### PR TITLE
Disambiguate Sentry environment between production and dev

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -31,7 +31,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applicationDidFinishLaunching(_ notification: Notification) {
         SentrySDK.start { options in
             options.dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"
+            #if DEBUG
+            options.environment = "development"
             options.debug = true
+            #else
+            options.environment = "production"
+            options.debug = false
+            #endif
             options.sendDefaultPii = true
         }
 


### PR DESCRIPTION
## Summary
- Set Sentry `environment` option to "development" for DEBUG builds and "production" for Release builds
- Disable Sentry `debug` logging in production builds (was always `true` before)

This allows filtering and distinguishing crash reports between development testing and real user issues in the Sentry dashboard.

## Test plan
- [ ] Build in Debug configuration and verify Sentry reports show `environment: development`
- [ ] Build in Release configuration and verify Sentry reports show `environment: production`