### PR TITLE
Align render loop with Ghostty

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -359,14 +359,6 @@ class TabManager: ObservableObject {
         selectedSurface?.searchState = nil
     }
 
-    func tickRender() {
-        guard let selectedTabId,
-              let tab = tabs.first(where: { $0.id == selectedTabId }) else { return }
-        for surface in tab.splitTree.map({ $0 }) {
-            surface.renderIfVisible()
-        }
-    }
-
     @discardableResult
     func addTab() -> Tab {
         let workingDirectory = preferredWorkingDirectoryForNewTab()


### PR DESCRIPTION
## Summary
- remove app-level display link/forced per-tick draws so rendering follows Ghostty wakeups
- stabilize ctrl-socket env path test with retry + prompt reset

## Testing
- ./scripts/reload.sh
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ssh cmux-vm 'cd /Users/cmux/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" build && pkill -x "cmuxterm DEV" || true && APP=$(find /Users/cmux/Library/Developer/Xcode/DerivedData -path "*/Build/Products/Debug/cmuxterm DEV.app" -print -quit) && open "$APP" && for i in {1..20}; do [ -S /tmp/cmuxterm.sock ] && break; sleep 0.5; done && python3 tests/test_update_timing.py && python3 tests/test_signals_auto.py && python3 tests/test_ctrl_socket.py && python3 tests/test_notifications.py'
