### PR TITLE
Release v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to cmuxterm are documented here.
 
+## [1.18.0] - 2026-02-06
+
+### Added
+- Sidebar metadata: see current directory, git branch, and listening ports for each terminal pane
+- Shell integration for bash and zsh to automatically report metadata to the sidebar
+
+### Fixed
+- Stale metadata no longer lingers after closing terminal panes
+
 ## [1.17.3] - 2025-02-05
 
 ### Fixed

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -554,7 +554,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.3;
+				MARKETING_VERSION = 1.18.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -583,7 +583,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -599,7 +599,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.3;
+				MARKETING_VERSION = 1.18.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -652,10 +652,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.17.3;
+				MARKETING_VERSION = 1.18.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,10 +669,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.17.3;
+				MARKETING_VERSION = 1.18.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/docs-site/content/docs/changelog.mdx
+++ b/docs-site/content/docs/changelog.mdx
@@ -5,6 +5,15 @@ description: Release notes and version history for cmuxterm
 
 All notable changes to cmuxterm are documented here.
 
+## [1.18.0] - 2026-02-06
+
+### Added
+- Sidebar metadata: see current directory, git branch, and listening ports for each terminal pane
+- Shell integration for bash and zsh to automatically report metadata to the sidebar
+
+### Fixed
+- Stale metadata no longer lingers after closing terminal panes
+
 ## [1.17.3] - 2025-02-05
 
 ### Fixed


### PR DESCRIPTION
## [1.18.0] - 2026-02-06

### Added
- Sidebar metadata: see current directory, git branch, and listening ports for each terminal pane
- Shell integration for bash and zsh to automatically report metadata to the sidebar

### Fixed
- Stale metadata no longer lingers after closing terminal panes