### PR TITLE
Fix zsh ZDOTDIR wrapper + log parsing for -- tokens

### DIFF
--- a/Resources/shell-integration/.zlogin
+++ b/Resources/shell-integration/.zlogin
@@ -1,4 +1,16 @@
 # cmuxterm ZDOTDIR wrapper — sources user's .zlogin
+_cmux_wrapper_zdotdir="${ZDOTDIR:-}"
 _cmux_real_zdotdir="${CMUX_ORIGINAL_ZDOTDIR:-$HOME}"
-[ -f "$_cmux_real_zdotdir/.zlogin" ] && source "$_cmux_real_zdotdir/.zlogin"
-unset _cmux_real_zdotdir
+if [ -f "$_cmux_real_zdotdir/.zlogin" ]; then
+    ZDOTDIR="$_cmux_real_zdotdir"
+    source "$_cmux_real_zdotdir/.zlogin"
+fi
+
+# Restore whatever ZDOTDIR was for the current shell.
+if [ -n "$_cmux_wrapper_zdotdir" ]; then
+    ZDOTDIR="$_cmux_wrapper_zdotdir"
+else
+    unset ZDOTDIR
+fi
+
+unset _cmux_real_zdotdir _cmux_wrapper_zdotdir

--- a/Resources/shell-integration/.zprofile
+++ b/Resources/shell-integration/.zprofile
@@ -1,4 +1,16 @@
 # cmuxterm ZDOTDIR wrapper — sources user's .zprofile
+_cmux_wrapper_zdotdir="${ZDOTDIR:-}"
 _cmux_real_zdotdir="${CMUX_ORIGINAL_ZDOTDIR:-$HOME}"
-[ -f "$_cmux_real_zdotdir/.zprofile" ] && source "$_cmux_real_zdotdir/.zprofile"
-unset _cmux_real_zdotdir
+if [ -f "$_cmux_real_zdotdir/.zprofile" ]; then
+    ZDOTDIR="$_cmux_real_zdotdir"
+    source "$_cmux_real_zdotdir/.zprofile"
+fi
+
+# Restore wrapper ZDOTDIR so zsh continues through our wrapper chain.
+if [ -n "$_cmux_wrapper_zdotdir" ]; then
+    ZDOTDIR="$_cmux_wrapper_zdotdir"
+else
+    unset ZDOTDIR
+fi
+
+unset _cmux_real_zdotdir _cmux_wrapper_zdotdir

--- a/Resources/shell-integration/.zshenv
+++ b/Resources/shell-integration/.zshenv
@@ -1,6 +1,28 @@
 # cmuxterm ZDOTDIR wrapper — sources user's .zshenv
-# NOTE: Do NOT restore ZDOTDIR here. It must stay pointed at our wrapper dir
-# so that zsh finds our .zshrc next. Restoration happens in .zshrc.
+#
+# zsh resolves startup files relative to $ZDOTDIR. We point $ZDOTDIR at this
+# wrapper directory so zsh loads our wrappers, but we must preserve the user's
+# semantics when sourcing their real files. In particular, many setups rely on
+# $ZDOTDIR inside early startup files, so source with ZDOTDIR temporarily
+# restored to the original value.
+_cmux_wrapper_zdotdir="${ZDOTDIR:-}"
 _cmux_real_zdotdir="${CMUX_ORIGINAL_ZDOTDIR:-$HOME}"
-[ -f "$_cmux_real_zdotdir/.zshenv" ] && source "$_cmux_real_zdotdir/.zshenv"
-unset _cmux_real_zdotdir
+if [ -f "$_cmux_real_zdotdir/.zshenv" ]; then
+    ZDOTDIR="$_cmux_real_zdotdir"
+    source "$_cmux_real_zdotdir/.zshenv"
+fi
+
+# For interactive shells, keep the wrapper chain intact so zsh loads our
+# .zprofile/.zshrc wrappers next. For non-interactive shells, leave ZDOTDIR
+# pointing at the real directory to avoid surprising script semantics.
+case $- in
+    *i*)
+        if [ -n "$_cmux_wrapper_zdotdir" ]; then
+            ZDOTDIR="$_cmux_wrapper_zdotdir"
+        else
+            unset ZDOTDIR
+        fi
+        ;;
+esac
+
+unset _cmux_real_zdotdir _cmux_wrapper_zdotdir

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -301,7 +301,7 @@ class TerminalController {
           set_status <key> <value> [--icon=X] [--color=#hex] - Set a status entry
           clear_status <key> [--tab=X] - Remove a status entry
           list_status [--tab=X]   - List all status entries
-          log <message> [--level=X] [--source=X] [--tab=X] - Append a log entry
+          log [--level=X] [--source=X] [--tab=X] -- <message> - Append a log entry
           clear_log [--tab=X]     - Clear log entries
           list_log [--limit=N] [--tab=X] - List log entries
           set_progress <0.0-1.0> [--label=X] [--tab=X] - Set progress bar
@@ -1189,7 +1189,7 @@ class TerminalController {
         guard tabManager != nil else { return "ERROR: TabManager not available" }
         let parsed = parseOptions(args)
         guard !parsed.positional.isEmpty else {
-            return "ERROR: Missing message — usage: log <message> [--level=X] [--source=X] [--tab=X]"
+            return "ERROR: Missing message — usage: log [--level=X] [--source=X] [--tab=X] -- <message>"
         }
         let message = parsed.positional.joined(separator: " ")
         let levelStr = parsed.options["level"] ?? "info"

--- a/tests/cmux.py
+++ b/tests/cmux.py
@@ -497,13 +497,17 @@ class cmux:
 
     def log(self, message: str, level: str = None, source: str = None, tab: str = None) -> None:
         """Append a sidebar log entry."""
-        cmd = f"log {message}"
+        # TerminalController.parseOptions treats any --* token as an option until
+        # a `--` separator. Put options first and then use `--` so messages can
+        # contain arbitrary tokens like `--force`.
+        cmd = "log"
         if level:
             cmd += f" --level={level}"
         if source:
             cmd += f" --source={source}"
         if tab:
             cmd += f" --tab={tab}"
+        cmd += f" -- {_quote_option_value(message)}"
         response = self._send_command(cmd)
         if not response.startswith("OK"):
             raise cmuxError(response)

--- a/tests/test_shell_zdotdir_wrapper.py
+++ b/tests/test_shell_zdotdir_wrapper.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Regression: zsh wrapper startup files must source user files with the *original*
+ZDOTDIR, not the wrapper directory.
+
+The cmuxterm zsh integration sets ZDOTDIR to the app's wrapper directory so zsh
+loads wrapper .zshenv/.zprofile/.zshrc. Those wrappers must temporarily restore
+ZDOTDIR while sourcing the user's real startup files so $ZDOTDIR semantics match
+normal zsh behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    wrapper_dir = root / "Resources" / "shell-integration"
+    if not (wrapper_dir / ".zshenv").exists():
+        print(f"SKIP: missing wrapper .zshenv at {wrapper_dir}")
+        return 0
+
+    base = Path("/tmp") / f"cmux_zdotdir_test_{os.getpid()}"
+    try:
+        if base.exists():
+            for child in base.iterdir():
+                try:
+                    child.unlink()
+                except Exception:
+                    pass
+        base.mkdir(parents=True, exist_ok=True)
+
+        orig = base / "orig"
+        orig.mkdir(parents=True, exist_ok=True)
+        seen_path = base / "seen.txt"
+
+        # User .zshenv that records the ZDOTDIR it sees.
+        (orig / ".zshenv").write_text(
+            'echo "$ZDOTDIR" > "$CMUX_ZDOTDIR_TEST_OUTPUT"\n',
+            encoding="utf-8",
+        )
+
+        env = dict(os.environ)
+        env["ZDOTDIR"] = str(wrapper_dir)
+        env["CMUX_ORIGINAL_ZDOTDIR"] = str(orig)
+        env["CMUX_ZDOTDIR_TEST_OUTPUT"] = str(seen_path)
+        env["CMUX_SHELL_INTEGRATION"] = "0"
+
+        # Non-interactive is enough: .zshenv is always sourced.
+        result = subprocess.run(
+            ["zsh", "-c", "true"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print("FAIL: zsh exited non-zero")
+            print(result.stderr.strip())
+            return 1
+
+        if not seen_path.exists():
+            print("FAIL: user .zshenv did not run (no output file created)")
+            return 1
+
+        seen = seen_path.read_text(encoding="utf-8").strip()
+        expected = str(orig)
+        if seen != expected:
+            print(f"FAIL: user .zshenv saw ZDOTDIR={seen!r}, expected {expected!r}")
+            return 1
+
+        print("PASS: zsh user startup files see original ZDOTDIR")
+        return 0
+
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sidebar_log_parsing.py
+++ b/tests/test_sidebar_log_parsing.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Regression: sidebar log messages must preserve tokens that start with `--`.
+
+TerminalController.parseOptions() treats `--*` tokens as options until a `--`
+separator. The log command must therefore send options before the message and
+use `--` so arbitrary message contents round-trip correctly.
+
+Run with a tagged instance to avoid unix socket conflicts:
+  CMUX_TAG=<tag> python3 tests/test_sidebar_log_parsing.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cmux import cmux, cmuxError  # noqa: E402
+
+
+def _assert_contains(text: str, needle: str) -> None:
+    if needle not in (text or ""):
+        raise AssertionError(f"Expected to find: {needle}\n\nGot:\n{text}")
+
+
+def main() -> int:
+    try:
+        with cmux() as client:
+            tab_id = client.new_tab()
+            client.select_tab(tab_id)
+            time.sleep(0.7)
+
+            client._send_command(f"clear_log --tab={tab_id}")
+
+            msg1 = "hello --force mid -- --level=not-an-option end"
+            client.log(msg1, level="warning", source="test", tab=tab_id)
+
+            msg2 = "--force starts-with-dashdash"
+            client.log(msg2, level="info", source="test", tab=tab_id)
+
+            time.sleep(0.2)
+            out = client._send_command(f"list_log --tab={tab_id} --limit=2")
+            _assert_contains(out, f"[warning] {msg1} (source=test)")
+            _assert_contains(out, f"[info] {msg2} (source=test)")
+
+            try:
+                client.close_tab(tab_id)
+            except Exception:
+                pass
+
+        print("PASS: log messages preserve `--*` tokens")
+        return 0
+
+    except (cmuxError, AssertionError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
Fixes two runtime correctness issues:

- zsh ZDOTDIR wrapper now temporarily restores the original ZDOTDIR while sourcing user startup files, then restores the wrapper dir only as needed for interactive shells.
- log command now sends options before the message and uses `--` + quoting so messages containing `--*` tokens round-trip correctly.

Tests:
- UTM VM: `./scripts/reload.sh --tag vm-tests` + `CMUX_TAG=vm-tests` ran Python suite including new regressions: `tests/test_sidebar_log_parsing.py`, `tests/test_shell_zdotdir_wrapper.py`.
- ctrl-enter keybind test still skips when Accessibility is blocked on the VM.