### PR TITLE
Release v1.19.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           brew update
           brew install zig
+          npm install --global create-dmg
 
       - name: Build GhosttyKit.xcframework
         run: |
@@ -137,6 +138,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
             echo "Missing notarization secrets (APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID)" >&2
@@ -158,13 +160,12 @@ jobs:
           xcrun stapler validate "$APP_PATH"
           spctl -a -vv --type execute "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
-          STAGING_DIR="$(mktemp -d)"
-          cp -R "$APP_PATH" "$STAGING_DIR/cmuxterm.app"
-          ln -s /Applications "$STAGING_DIR/Applications"
-          # hdiutil defaults to APFS for -srcfolder images (volume name becomes "Untitled" on mount).
-          # Force HFS+ so the mounted volume name is stable and Finder shows the contents reliably.
-          hdiutil create -fs HFS+ -volname "cmuxterm" -srcfolder "$STAGING_DIR" -ov -format UDZO "$DMG_RELEASE"
-          rm -rf "$STAGING_DIR"
+          # create-dmg generates a styled drag-to-install DMG (matches Ghostty's approach)
+          create-dmg \
+            --identity="$APPLE_SIGNING_IDENTITY" \
+            "$APP_PATH" \
+            ./
+          mv ./cmuxterm*.dmg "$DMG_RELEASE"
           DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
           DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
           DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to cmuxterm are documented here.
 
+## [1.19.1] - 2026-02-08
+
+### Fixed
+- Blank window on macOS 26 when background glass effect is enabled
+- "Copy Update Logs" showing empty logs in production builds
+
+### Changed
+- Clearer error when app needs to be moved to Applications before updating
+- DMG installer now shows drag-to-install window with Applications shortcut
+
 ## [1.19.0] - 2026-02-08
 
 ### Fixed
 - Blank window on macOS 26 caused by NSGlassEffectView wrapper
-- "Copy Update Logs" showing empty logs in production builds
 
 ## [1.18.0] - 2026-02-06
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -554,7 +554,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -583,7 +583,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -599,7 +599,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -652,10 +652,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,10 +669,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.19.0;
+				MARKETING_VERSION = 1.19.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -23,9 +23,8 @@ enum WindowGlassEffect {
 
         let bounds = contentView.bounds
 
-        // macOS 26+: Prefer NSGlassEffectView. Avoid re-parenting the SwiftUI NSHostingView via
-        // constraints (it can result in a blank content area). Keep the original content view
-        // on autoresizing masks and just insert it into the glass view.
+        // macOS 26+: Insert NSGlassEffectView as a background subview (never replace
+        // window.contentView — reparenting the SwiftUI hosting view causes blank content).
         if let glassClass = NSClassFromString("NSGlassEffectView") as? NSVisualEffectView.Type {
             let glassView = glassClass.init(frame: bounds)
             glassView.wantsLayer = true
@@ -39,13 +38,7 @@ enum WindowGlassEffect {
                 }
             }
 
-            window.contentView = glassView
-
-            contentView.wantsLayer = true
-            contentView.layer?.backgroundColor = NSColor.clear.cgColor
-            contentView.frame = glassView.bounds
-            contentView.autoresizingMask = [.width, .height]
-            glassView.addSubview(contentView)
+            contentView.addSubview(glassView, positioned: .below, relativeTo: contentView.subviews.first)
 
             objc_setAssociatedObject(window, &glassViewKey, glassView, .OBJC_ASSOCIATION_RETAIN)
             return

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -205,7 +205,7 @@ class UpdateViewModel: ObservableObject {
             case 1, 2, 3001, 3002:
                 return "Update Signature Error"
             case 1003, 1005:
-                return "App Location Issue"
+                return "Move to Applications"
             default:
                 break
             }

--- a/docs-site/content/docs/changelog.mdx
+++ b/docs-site/content/docs/changelog.mdx
@@ -5,11 +5,20 @@ description: Release notes and version history for cmuxterm
 
 All notable changes to cmuxterm are documented here.
 
+## [1.19.1] - 2026-02-08
+
+### Fixed
+- Blank window on macOS 26 when background glass effect is enabled
+- "Copy Update Logs" showing empty logs in production builds
+
+### Changed
+- Clearer error when app needs to be moved to Applications before updating
+- DMG installer now shows drag-to-install window with Applications shortcut
+
 ## [1.19.0] - 2026-02-08
 
 ### Fixed
 - Blank window on macOS 26 caused by NSGlassEffectView wrapper
-- "Copy Update Logs" showing empty logs in production builds
 
 ## [1.18.0] - 2026-02-06
 


### PR DESCRIPTION
## [1.19.1] - 2026-02-08

### Fixed
- Blank window on macOS 26 when background glass effect is enabled
- "Copy Update Logs" showing empty logs in production builds

### Changed
- Clearer error when app needs to be moved to Applications before updating
- DMG installer now shows drag-to-install window with Applications shortcut (using `create-dmg`)