### PR TITLE
Release v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,13 @@
 
 All notable changes to cmuxterm are documented here.
 
-## [1.19.4] - 2026-02-09
-
-### Fixed
-- Update pill never appearing due to constraint/sizing feedback loop
-
-## [1.19.3] - 2026-02-09
-
-### Fixed
-- Update status pill not rendering in toolbar due to zero-frame hosting view
-
-## [1.19.2] - 2026-02-09
-
-### Fixed
-- Update status pill not showing in production builds
-- Update errors appearing instantly without showing checking state first
-
-## [1.19.1] - 2026-02-08
+## [1.20.0] - 2026-02-09
 
 ### Fixed
 - Blank window on macOS 26 when background glass effect is enabled
-- "Copy Update Logs" showing empty logs in production builds
+- Update status pill not appearing in toolbar
+- Update errors appearing instantly without showing checking spinner first
+- "Copy Update Logs" showing empty logs
 
 ### Changed
 - Clearer error when app needs to be moved to Applications before updating

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -554,7 +554,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.4;
+				MARKETING_VERSION = 1.20.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -583,7 +583,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -599,7 +599,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.19.4;
+				MARKETING_VERSION = 1.20.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -652,10 +652,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.19.4;
+				MARKETING_VERSION = 1.20.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,10 +669,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.19.4;
+				MARKETING_VERSION = 1.20.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -79,12 +79,8 @@ private struct TitlebarAccessoryView: View {
     @ObservedObject var model: UpdateViewModel
 
     var body: some View {
-        #if DEBUG
         UpdatePill(model: model)
             .padding(.trailing, 8)
-        #else
-        EmptyView()
-        #endif
     }
 }
 

--- a/docs-site/content/docs/changelog.mdx
+++ b/docs-site/content/docs/changelog.mdx
@@ -5,27 +5,13 @@ description: Release notes and version history for cmuxterm
 
 All notable changes to cmuxterm are documented here.
 
-## [1.19.4] - 2026-02-09
-
-### Fixed
-- Update pill never appearing due to constraint/sizing feedback loop
-
-## [1.19.3] - 2026-02-09
-
-### Fixed
-- Update status pill not rendering in toolbar due to zero-frame hosting view
-
-## [1.19.2] - 2026-02-09
-
-### Fixed
-- Update status pill not showing in production builds
-- Update errors appearing instantly without showing checking state first
-
-## [1.19.1] - 2026-02-08
+## [1.20.0] - 2026-02-09
 
 ### Fixed
 - Blank window on macOS 26 when background glass effect is enabled
-- "Copy Update Logs" showing empty logs in production builds
+- Update status pill not appearing in toolbar
+- Update errors appearing instantly without showing checking spinner first
+- "Copy Update Logs" showing empty logs
 
 ### Changed
 - Clearer error when app needs to be moved to Applications before updating


### PR DESCRIPTION
## Summary
- Fix blank window on macOS 26 when background glass effect is enabled
- Fix update status pill not appearing in toolbar (removed #if DEBUG guards, fixed constraint feedback loop)
- Fix update errors appearing instantly without showing checking spinner first
- Fix "Copy Update Logs" showing empty logs
- Clearer error when app needs to be moved to Applications before updating
- DMG installer now shows drag-to-install window with Applications shortcut

## Test plan
- [ ] Verify update pill appears when checking for updates
- [ ] Verify update pill shows error state correctly
- [ ] Verify blank window fix on macOS 26
- [ ] Verify DMG layout looks correct