### PR TITLE
Release v1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to cmux are documented here.
 
+## [1.27.0] - 2026-02-11
+
+### Fixed
+- Muted traffic lights and toolbar items on macOS 14 (Sonoma) caused by `clipsToBounds` default change
+- Toolbar buttons (sidebar, notifications, new tab) disappearing after toggling sidebar with Cmd+B
+- Update check pill not appearing in titlebar on macOS 14 (Sonoma)
+
 ## [1.26.0] - 2026-02-11
 
 ### Fixed

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -554,7 +554,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.26.0;
+				MARKETING_VERSION = 1.27.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -583,7 +583,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -599,7 +599,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.26.0;
+				MARKETING_VERSION = 1.27.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -652,10 +652,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.26.0;
+				MARKETING_VERSION = 1.27.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmux.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -669,10 +669,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.26.0;
+				MARKETING_VERSION = 1.27.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmux.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/docs-site/content/docs/changelog.mdx
+++ b/docs-site/content/docs/changelog.mdx
@@ -5,6 +5,13 @@ description: Release notes and version history for cmux
 
 All notable changes to cmux are documented here.
 
+## [1.27.0] - 2026-02-11
+
+### Fixed
+- Muted traffic lights and toolbar items on macOS 14 (Sonoma) caused by `clipsToBounds` default change
+- Toolbar buttons (sidebar, notifications, new tab) disappearing after toggling sidebar with Cmd+B
+- Update check pill not appearing in titlebar on macOS 14 (Sonoma)
+
 ## [1.26.0] - 2026-02-11
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fix muted traffic lights and toolbar items on macOS 14 (Sonoma) caused by `clipsToBounds` default change
- Fix toolbar buttons (sidebar, notifications, new tab) disappearing after toggling sidebar with Cmd+B
- Fix update check pill not appearing in titlebar on macOS 14 (Sonoma)

## Details
macOS 14 (Sonoma) changed the default value of `NSView.clipsToBounds` from `YES` to `NO`. This caused:
1. Background blur/tint views to render beyond contentView bounds into the titlebar area, dimming traffic lights and toolbar items
2. NSTitlebarAccessoryViewController hosting views to clip incorrectly during layout transitions, causing them to disappear
3. Update pill accessory not rendering due to zero-size frames during layout

Fixes:
- Set `clipsToBounds = true` on blur, tint, and contentView for macOS 14+
- Set `clipsToBounds = true` on all titlebar accessory container/hosting views
- Add `ensureVisible()` on every layout pass to prevent accessories from being hidden
- Add zero-size guard in `updateSize()` to skip invalid frames
- Add sidebar toggle observer to revalidate and re-attach accessories after Cmd+B

## Test plan
- [ ] Verify traffic lights are vibrant on Sonoma when window is focused
- [ ] Verify toolbar buttons (sidebar, notifications, +) remain visible after Cmd+B
- [ ] Verify update check pill appears on Sonoma
- [ ] Verify no regression on Sequoia (15.x) and Tahoe (26.x)