### PR TITLE
Fix sidebar metadata commands failing in multi-window setups

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8661,7 +8661,15 @@ class TerminalController {
         guard let tabManager else { return nil }
         let parsed = parseOptions(args)
         if let tabArg = parsed.options["tab"], !tabArg.isEmpty {
-            return resolveTab(from: tabArg, tabManager: tabManager)
+            if let tab = resolveTab(from: tabArg, tabManager: tabManager) {
+                return tab
+            }
+            // The tab may belong to a different window — search all contexts.
+            if let uuid = UUID(uuidString: tabArg.trimmingCharacters(in: .whitespacesAndNewlines)),
+               let otherManager = AppDelegate.shared?.tabManagerFor(tabId: uuid) {
+                return otherManager.tabs.first(where: { $0.id == uuid })
+            }
+            return nil
         }
         guard let selectedId = tabManager.selectedTabId else { return nil }
         return tabManager.tabs.first(where: { $0.id == selectedId })


### PR DESCRIPTION
## Summary
- `resolveTabForReport` only searched the active window's tab manager, so `report_ports`, `report_git_branch`, `report_pwd`, `set_status`, etc. returned "Tab not found" when the shell's `--tab` UUID belonged to a different window
- Falls back to `AppDelegate.tabManagerFor(tabId:)` to search all window contexts, matching the pattern used by v2 API commands

## Test plan
- [ ] Open multiple cmux windows
- [ ] Start a dev server (e.g. `npm run dev`) in a non-focused window
- [ ] Verify ports appear in the sidebar for that window
- [ ] Verify git branch and pwd still update across windows