### PR TITLE
Fix socket accept loop not restarted after Sparkle update relaunch

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -424,6 +424,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        TerminalController.shared.stop()
         BrowserHistoryStore.shared.flushPendingSaves()
         PostHogAnalytics.shared.flush()
         notificationStore?.clearAll()

--- a/Sources/Update/UpdateDelegate.swift
+++ b/Sources/Update/UpdateDelegate.swift
@@ -87,6 +87,7 @@ extension UpdateDriver: SPUUpdaterDelegate {
     }
 
     func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        TerminalController.shared.stop()
         NSApp.invalidateRestorableState()
         for window in NSApp.windows {
             window.invalidateRestorableState()


### PR DESCRIPTION
## Summary

- After a Sparkle auto-update relaunches cmux, the control socket at `/tmp/cmux.sock` stops accepting connections — `cmux list-workspaces` fails and Claude Code's `SessionStart` hook breaks on every launch
- **Root cause**: `start()` early-returns when `isRunning == true` without checking if the accept loop thread is actually alive. If the thread died (race during relaunch teardown, `accept()` EBADF after fd invalidation), the socket stays bound but nobody accepts
- **Secondary issue**: `acceptLoop()` tight-spins on persistent `accept()` failure with no backoff or exit condition

## Changes

- Add `acceptLoopAlive` flag to track whether the accept loop thread is running
- Fix `start()` early-return to require `acceptLoopAlive` — dead thread triggers full socket re-creation
- `acceptLoop()` now breaks after 50 consecutive failures with 10ms backoff (instead of infinite tight-spin)
- Clean up socket in `applicationWillTerminate` and `updaterWillRelaunchApplication` for clean teardown before Sparkle relaunch

## Test plan

- [ ] Build and reload: `./scripts/reload.sh --tag fix-socket-relaunch`
- [ ] Verify socket works: `cmux --socket /tmp/cmux-debug-fix-socket-relaunch.sock list-workspaces`
- [ ] Kill accept loop (close server fd) and verify `start()` auto-recovers on next call
- [ ] Verify `acceptLoopAlive` flag correctly tracks thread state