### PR TITLE
Free stale surfaces and wire occlusion for background terminals

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -541,7 +541,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             for ws in ctx.tabManager.tabs {
                 for (panelId, panel) in ws.panels {
                     guard let terminal = panel as? TerminalPanel else { continue }
-                    if terminal.surface.surface == surface {
+                    if terminal.surface?.surface == surface {
                         return (ctx.windowId, ws.id, panelId, ctx.tabManager)
                     }
                 }
@@ -877,7 +877,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func sendTextWhenReady(_ text: String, to tab: Tab, attempt: Int = 0) {
         let maxAttempts = 60
-        if let terminalPanel = tab.focusedTerminalPanel, terminalPanel.surface.surface != nil {
+        if let terminalPanel = tab.focusedTerminalPanel, terminalPanel.surface?.surface != nil {
             terminalPanel.sendText(text)
             return
         }

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -14,18 +14,20 @@ struct TerminalPanelView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            GhosttyTerminalView(
-                terminalSurface: panel.surface,
-                isActive: isFocused,
-                isVisibleInUI: isVisibleInUI,
-                reattachToken: panel.viewReattachToken,
-                onFocus: { _ in onFocus() },
-                onTriggerFlash: onTriggerFlash
-            )
-            // Keep the NSViewRepresentable identity stable across bonsplit structural updates.
-            // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
-            .id(panel.id)
-            .background(Color.clear)
+            if let surface = panel.surface {
+                GhosttyTerminalView(
+                    terminalSurface: surface,
+                    isActive: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    reattachToken: panel.viewReattachToken,
+                    onFocus: { _ in onFocus() },
+                    onTriggerFlash: onTriggerFlash
+                )
+                // Keep the NSViewRepresentable identity stable across bonsplit structural updates.
+                // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
+                .id(panel.id)
+                .background(Color.clear)
+            }
 
             // Unfocused overlay
             if isSplit && !isFocused && appearance.unfocusedOverlayOpacity > 0 {
@@ -45,9 +47,10 @@ struct TerminalPanelView: View {
             }
 
             // Search overlay
-            if let searchState = panel.searchState {
+            if let searchState = panel.searchState,
+               let surface = panel.surface {
                 SurfaceSearchOverlay(
-                    surface: panel.surface,
+                    surface: surface,
                     searchState: searchState,
                     onClose: {
                         panel.searchState = nil

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2163,7 +2163,7 @@ class TerminalController {
             var refreshedCount = 0
             for panel in ws.panels.values {
                 if let terminalPanel = panel as? TerminalPanel {
-                    terminalPanel.surface.forceRefresh()
+                    terminalPanel.surface?.forceRefresh()
                     refreshedCount += 1
                 }
             }
@@ -2185,7 +2185,7 @@ class TerminalController {
             let items: [[String: Any]] = panels.enumerated().map { index, panel in
                 var inWindow: Any = NSNull()
                 if let tp = panel as? TerminalPanel {
-                    inWindow = tp.surface.isViewInWindow
+                    inWindow = tp.surface?.isViewInWindow ?? false
                 } else if let bp = panel as? BrowserPanel {
                     inWindow = bp.webView.window != nil
                 }
@@ -2252,7 +2252,7 @@ class TerminalController {
             // Ensure we present a new frame after injecting input so snapshot-based tests (and
             // socket-driven agents) can observe the updated terminal without requiring a focus
             // change to trigger a draw.
-            terminalPanel.surface.forceRefresh()
+            terminalPanel.surface?.forceRefresh()
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
         return result
@@ -2289,7 +2289,7 @@ class TerminalController {
                 result = .err(code: "invalid_params", message: "Unknown key", data: ["key": key])
                 return
             }
-            terminalPanel.surface.forceRefresh()
+            terminalPanel.surface?.forceRefresh()
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
         return result
@@ -6476,7 +6476,7 @@ class TerminalController {
 
             guard let panelId,
                   let terminalPanel = tab.terminalPanel(for: panelId),
-                  let surface = terminalPanel.surface.surface else {
+                  let surface = terminalPanel.surface?.surface else {
                 result = "ERROR: Terminal surface not found"
                 return
             }
@@ -7335,7 +7335,7 @@ class TerminalController {
             var cgImage = view.debugCopyIOSurfaceCGImage()
             if cgImage == nil {
                 // If the surface is mid-attach we may not have contents yet. Nudge a draw and retry once.
-                terminalPanel.surface.forceRefresh()
+                terminalPanel.surface?.forceRefresh()
                 cgImage = view.debugCopyIOSurfaceCGImage()
             }
             guard let cgImage else {
@@ -7524,7 +7524,7 @@ class TerminalController {
 	                        selectedTabId: selectedTabId,
 	                        panelId: panelId.uuidString,
 	                        panelType: tp.panelType.rawValue,
-	                        inWindow: tp.surface.isViewInWindow,
+	                        inWindow: tp.surface?.isViewInWindow ?? false,
 	                        hidden: isHiddenOrAncestorHidden(tp.hostedView),
 	                        viewFrame: viewRect,
 	                        splitViews: splitViews
@@ -7761,18 +7761,18 @@ class TerminalController {
     }
 
     private func waitForTerminalSurface(_ terminalPanel: TerminalPanel, waitUpTo timeout: TimeInterval = 0.6) -> ghostty_surface_t? {
-        if let surface = terminalPanel.surface.surface { return surface }
+        if let surface = terminalPanel.surface?.surface { return surface }
 
         // This can be transient during bonsplit tree restructuring when the SwiftUI
         // view is temporarily detached and then reattached (surface creation is
         // gated on view/window/bounds). Pump the runloop briefly to allow pending
         // attach retries to execute.
         let deadline = Date().addingTimeInterval(timeout)
-        while terminalPanel.surface.surface == nil && Date() < deadline {
+        while terminalPanel.surface?.surface == nil && Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
         }
 
-        return terminalPanel.surface.surface
+        return terminalPanel.surface?.surface
     }
 
     private func resolveSurface(from arg: String, tabManager: TabManager) -> ghostty_surface_t? {
@@ -9129,7 +9129,7 @@ class TerminalController {
             // (resets cached metrics so the Metal layer drawable resizes correctly)
             for panel in tab.panels.values {
                 if let terminalPanel = panel as? TerminalPanel {
-                    terminalPanel.surface.forceRefresh()
+                    terminalPanel.surface?.forceRefresh()
                     refreshedCount += 1
                 }
             }
@@ -9150,7 +9150,7 @@ class TerminalController {
                 let panelId = panel.id.uuidString
                 let type = panel.panelType.rawValue
                 if let tp = panel as? TerminalPanel {
-                    let inWindow = tp.surface.isViewInWindow
+                    let inWindow = tp.surface?.isViewInWindow ?? false
                     return "\(index): \(panelId) type=\(type) in_window=\(inWindow)"
                 } else if let bp = panel as? BrowserPanel {
                     let inWindow = bp.webView.window != nil


### PR DESCRIPTION
## Summary

- Fix stale Ghostty surfaces leaking memory by explicitly closing panels in `closeWorkspace()` and making `TerminalPanel.surface` optional so ARC can release resources
- Wire `ghostty_surface_set_occlusion` for background surfaces — both workspace-level (sidebar tabs) and bonsplit tab-level — so only visible terminals run CVDisplayLink + Metal draws
- Add double-free guard in `TerminalSurface.deinit` and harden `SHOW_CHILD_EXITED` handler with per-guard debug logging

## What stays the same

- ZStack with opacity(0/1) layout unchanged — all views remain mounted
- `keepAllAlive` bonsplit mode unchanged
- Terminal state (PTY, scrollback, processes) stays alive
- Switch latency: `setOcclusion(true)` resumes on next vsync (~16ms)

## Test plan

- [ ] Open 5+ workspace tabs, verify only active workspace's terminals render (check thread count / Activity Monitor)
- [ ] Switch between workspaces, verify instant switching with no visual glitch
- [ ] Open bonsplit tabs within a pane, verify background tabs stop rendering
- [ ] Close a workspace with multiple terminals, verify surfaces are freed (deinit fires)
- [ ] `tail -f /tmp/cmux-debug.log` to verify child_exited debug logging works
- [ ] Ctrl+D in a split terminal, verify panel closes cleanly
- [ ] Open browser panels alongside terminals, verify no regression