### PR TITLE
Fix infinite recursion crash in FileDropOverlayView.mouseDown

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -183,10 +183,15 @@ final class FileDropOverlayView: NSView {
 
     // MARK: Mouse forwarding – hide self so the event reaches views below.
 
+    private var isForwarding = false
+
     private func forwardEvent(_ event: NSEvent) {
+        guard !isForwarding else { return }
+        isForwarding = true
         isHidden = true
         window?.sendEvent(event)
         isHidden = false
+        isForwarding = false
     }
 
     override func mouseDown(with event: NSEvent) { forwardEvent(event) }


### PR DESCRIPTION
## Summary
- Fixes 6 crashes (Feb 18) + 4 hangs + 2 CPU resource violations (Feb 17) caused by infinite recursion in `FileDropOverlayView.forwardEvent()`
- The hide-send-unhide mouse forwarding pattern recurses because `NSWindow.sendEvent:` routes the event back to the same overlay view without re-doing hit testing
- Adds a simple `isForwarding` reentrancy guard to break the cycle

## Test plan
- [ ] Launch app, click around terminal splits — mouse events still pass through the overlay
- [ ] Drag files from Finder onto terminal splits — drops still work
- [ ] Verify no crashes in Console.app / crash reporter after extended use

🤖 Generated with [Claude Code](https://claude.com/claude-code)