### PR TITLE
Fix titlebar folder icon briefly enlarging on workspace switch

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2290,16 +2290,22 @@ private final class DraggableFolderNSView: NSView, NSDraggingSource {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 16, height: 16)
+    }
+
     private func setupImageView() {
         imageView = NSImageView()
-        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.imageScaling = .scaleProportionallyDown
         imageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(imageView)
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
             imageView.topAnchor.constraint(equalTo: topAnchor),
-            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 16),
+            imageView.heightAnchor.constraint(equalToConstant: 16),
         ])
         updateIcon()
     }


### PR DESCRIPTION
## Summary
- Add explicit 16x16 size constraints and `intrinsicContentSize` override to `DraggableFolderNSView` to prevent the icon from briefly rendering at its native image size during workspace switches
- Change image scaling from `.scaleProportionallyUpOrDown` to `.scaleProportionallyDown` since the icon never needs to scale up

## Test plan
- [ ] Switch between workspaces rapidly and verify the folder icon stays at 16x16