### PR TITLE
Fix release build lag on M1 by using universal xcframework target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
               exit 1
             fi
           fi
-          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native)
+          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false)
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
           test -d GhosttyKit.xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build GhosttyKit.xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Doptimize=ReleaseFast
           cd ..
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework


### PR DESCRIPTION
## Summary
- Remove `-Dxcframework-target=native` from CI and release workflows, defaulting to `universal`
- The self-hosted runner (M4 Mac Mini) was producing M4-tuned GhosttyKit binaries that caused menubar and right-click lag on M1 machines
- `universal` is ghostty's default and produces binaries that run well across all Apple Silicon chips

## Test plan
- [ ] Download release build on M1 Mac and verify no menubar/right-click lag
- [ ] Verify release build works on M3/M4 machines