### PR TITLE
Revert xcframework-target removal that broke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
               exit 1
             fi
           fi
-          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false)
+          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native)
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
           test -d GhosttyKit.xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build GhosttyKit.xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
           cd ..
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework


### PR DESCRIPTION
## Summary
- Restores `-Dxcframework-target=native` to CI and release workflows
- PR #86 incorrectly removed this flag thinking it controlled CPU microarchitecture, but it actually controls platform slices (native=macOS only, universal=macOS+iOS+sim)
- Without `native`, the build tries to compile iOS slices which fails due to missing Metal iOS toolchain on the runner