### PR TITLE
Fix browser opening new tabs on link click

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1558,8 +1558,8 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
 private class BrowserUIDelegate: NSObject, WKUIDelegate {
     var openInNewTab: ((URL) -> Void)?
 
-    /// Handle cmd+click / target=_blank links. Returning nil tells WebKit not to open a new window;
-    /// instead we navigate in the current webview.
+    /// Returning nil tells WebKit not to open a new window.
+    /// Cmd+click opens in a new tab; regular target=_blank navigates in-place.
     func webView(
         _ webView: WKWebView,
         createWebViewWith configuration: WKWebViewConfiguration,
@@ -1567,7 +1567,11 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         if let url = navigationAction.request.url {
-            webView.load(URLRequest(url: url))
+            if navigationAction.modifierFlags.contains(.command) {
+                openInNewTab?(url)
+            } else {
+                webView.load(URLRequest(url: url))
+            }
         }
         return nil
     }


### PR DESCRIPTION
## Summary
- Navigate `target=_blank` and `window.open()` links in the current webview instead of opening new browser tabs
- Fixes issue where clicking Google search results (and other sites using `target="_blank"`) always spawned a new tab
- Cmd+click still opens in a new tab for intentional use

## Test plan
- [ ] Open browser panel, go to Google, search, click a result — should navigate in-place
- [ ] Test sites that use `window.open()` — should navigate in-place
- [ ] Cmd+click a link — should still open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)