### PR TITLE
Fix menubar lag on M1 Macs by using universal xcframework target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               exit 1
             fi
           fi
-          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native)
+          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false)
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
           test -d GhosttyKit.xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build GhosttyKit.xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Doptimize=ReleaseFast
           cd ..
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework


### PR DESCRIPTION
## Summary
- Remove `-Dxcframework-target=native` from CI and release workflows, defaulting to `universal` (matching upstream ghostty)
- The `native` target produces a `macos-arm64` xcframework slice that causes Xcode to link the final binary differently (~70KB more `__text`), resulting in menubar and right-click lag on M1 Max
- The arm64 static libraries are byte-for-byte identical between native and universal — the difference is purely in how Xcode resolves the xcframework slice

## Test plan
- [x] Built Release locally with universal xcframework → menubar fast on M1 Max
- [x] Built Release locally with native xcframework → menubar laggy on M1 Max
- [x] Confirmed arm64 `.a` files are byte-identical between native and universal
- [ ] CI passes (universal build requires iOS SDK + Metal toolchain, both confirmed available on runner)