### PR TITLE
Fix split blackout during drag split and stabilize focus handoff

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1120,9 +1120,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     func attachToView(_ view: GhosttyNSView) {
-        #if DEBUG
-        print("[TerminalSurface] attachToView: \(id) attachedView=\(attachedView != nil) surface=\(surface != nil)")
-        #endif
+#if DEBUG
+        dlog(
+            "surface.attach surface=\(id.uuidString.prefix(5)) view=\(Unmanaged.passUnretained(view).toOpaque()) " +
+            "attached=\(attachedView != nil ? 1 : 0) hasSurface=\(surface != nil ? 1 : 0) inWindow=\(view.window != nil ? 1 : 0)"
+        )
+#endif
 
         // If already attached to this view, nothing to do.
         // Still re-assert the display id: during split close tree restructuring, the view can be
@@ -1130,9 +1133,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Ghostty's vsync-driven renderer depends on having a valid display id; if it is missing
         // or stale, the surface can appear visually frozen until a focus/visibility change.
         if attachedView === view && surface != nil {
-            #if DEBUG
-            print("[TerminalSurface] attachToView: same view and surface exists")
-            #endif
+#if DEBUG
+            dlog("surface.attach.reuse surface=\(id.uuidString.prefix(5)) view=\(Unmanaged.passUnretained(view).toOpaque())")
+#endif
             if let screen = view.window?.screen ?? NSScreen.main,
                let displayID = screen.displayID,
                displayID != 0,
@@ -1144,9 +1147,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         if let attachedView, attachedView !== view {
-            #if DEBUG
-            print("[TerminalSurface] attachToView: different view, returning")
-            #endif
+#if DEBUG
+            dlog(
+                "surface.attach.skip surface=\(id.uuidString.prefix(5)) reason=alreadyAttachedToDifferentView " +
+                "current=\(Unmanaged.passUnretained(attachedView).toOpaque()) new=\(Unmanaged.passUnretained(view).toOpaque())"
+            )
+#endif
             return
         }
 
@@ -1155,20 +1161,31 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // If surface doesn't exist yet, create it once the view is in a real window so
         // content scale and pixel geometry are derived from the actual backing context.
         if surface == nil {
-            guard view.window != nil else { return }
-            #if DEBUG
-            print("[TerminalSurface] attachToView: creating surface for \(id)")
-            #endif
+            guard view.window != nil else {
+#if DEBUG
+                dlog(
+                    "surface.attach.defer surface=\(id.uuidString.prefix(5)) reason=noWindow " +
+                    "bounds=\(String(format: "%.1fx%.1f", view.bounds.width, view.bounds.height))"
+                )
+#endif
+                return
+            }
+#if DEBUG
+            dlog("surface.attach.create surface=\(id.uuidString.prefix(5))")
+#endif
             createSurface(for: view)
-            #if DEBUG
-            print("[TerminalSurface] attachToView: after createSurface, surface=\(surface != nil)")
-            #endif
+#if DEBUG
+            dlog("surface.attach.create.done surface=\(id.uuidString.prefix(5)) hasSurface=\(surface != nil ? 1 : 0)")
+#endif
         } else if let screen = view.window?.screen ?? NSScreen.main,
                   let displayID = screen.displayID,
                   displayID != 0,
                   let s = surface {
             // Surface exists but we're (re)attaching after a view hierarchy move; ensure display id.
             ghostty_surface_set_display_id(s, displayID)
+#if DEBUG
+            dlog("surface.attach.displayId surface=\(id.uuidString.prefix(5)) display=\(displayID)")
+#endif
         }
     }
 
@@ -1536,6 +1553,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 	    private var lastScrollEventTime: CFTimeInterval = 0
     private var visibleInUI: Bool = true
     private var pendingSurfaceSize: CGSize?
+#if DEBUG
+    private var lastSizeSkipSignature: String?
+#endif
 
         // Visibility is used for focus gating, not for libghostty occlusion.
         fileprivate var isVisibleInUI: Bool { visibleInUI }
@@ -1640,6 +1660,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             NotificationCenter.default.removeObserver(windowObserver)
             self.windowObserver = nil
         }
+#if DEBUG
+        dlog(
+            "surface.view.windowMove surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
+            "inWindow=\(window != nil ? 1 : 0) bounds=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+            "pending=\(String(format: "%.1fx%.1f", pendingSurfaceSize?.width ?? 0, pendingSurfaceSize?.height ?? 0))"
+        )
+#endif
         guard let window else { return }
 
         // If the surface creation was deferred while detached, create/attach it now.
@@ -1700,14 +1727,62 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func updateSurfaceSize(size: CGSize? = nil) {
         guard let terminalSurface = terminalSurface else { return }
         let size = size ?? bounds.size
-        guard size.width > 0 && size.height > 0 else { return }
+        guard size.width > 0 && size.height > 0 else {
+#if DEBUG
+            let signature = "nonPositive-\(Int(size.width))x\(Int(size.height))"
+            if lastSizeSkipSignature != signature {
+                dlog(
+                    "surface.size.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=nonPositive size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                    "inWindow=\(window != nil ? 1 : 0)"
+                )
+                lastSizeSkipSignature = signature
+            }
+#endif
+            return
+        }
         pendingSurfaceSize = size
-        guard let window else { return }
+        guard let window else {
+#if DEBUG
+            let signature = "noWindow-\(Int(size.width))x\(Int(size.height))"
+            if lastSizeSkipSignature != signature {
+                dlog(
+                    "surface.size.defer surface=\(terminalSurface.id.uuidString.prefix(5)) reason=noWindow " +
+                    "size=\(String(format: "%.1fx%.1f", size.width, size.height))"
+                )
+                lastSizeSkipSignature = signature
+            }
+#endif
+            return
+        }
 
         // First principles: derive pixel size from AppKit's backing conversion for the current
         // window/screen. Avoid updating Ghostty while detached from a window.
         let backingSize = convertToBacking(NSRect(origin: .zero, size: size)).size
-        guard backingSize.width > 0, backingSize.height > 0 else { return }
+        guard backingSize.width > 0, backingSize.height > 0 else {
+#if DEBUG
+            let signature = "zeroBacking-\(Int(backingSize.width))x\(Int(backingSize.height))"
+            if lastSizeSkipSignature != signature {
+                dlog(
+                    "surface.size.defer surface=\(terminalSurface.id.uuidString.prefix(5)) reason=zeroBacking " +
+                    "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                    "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
+                )
+                lastSizeSkipSignature = signature
+            }
+#endif
+            return
+        }
+#if DEBUG
+        if lastSizeSkipSignature != nil {
+            dlog(
+                "surface.size.resume surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
+            )
+            lastSizeSkipSignature = nil
+        }
+#endif
         let xScale = backingSize.width / size.width
         let yScale = backingSize.height / size.height
         let layerScale = max(1.0, window.backingScaleFactor)
@@ -3939,16 +4014,21 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.desiredIsVisibleInUI = false
         coordinator.desiredPortalZPriority = 0
         coordinator.lastBoundHostId = nil
+        let hostedView = coordinator.hostedView
 #if DEBUG
-        if let hostedView = coordinator.hostedView {
+        if let hostedView {
             if let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
                 dlog(
                     "ws.swiftui.dismantle id=\(snapshot.id) dt=\(String(format: "%.2fms", dtMs)) " +
-                    "surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil")"
+                    "surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
+                    "inWindow=\(hostedView.window != nil ? 1 : 0)"
                 )
             } else {
-                dlog("ws.swiftui.dismantle id=none surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil")")
+                dlog(
+                    "ws.swiftui.dismantle id=none surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
+                    "inWindow=\(hostedView.window != nil ? 1 : 0)"
+                )
             }
         }
 #endif
@@ -3958,9 +4038,12 @@ struct GhosttyTerminalView: NSViewRepresentable {
             host.onGeometryChanged = nil
         }
 
-        coordinator.hostedView?.setVisibleInUI(false)
-        coordinator.hostedView?.setActive(false)
-        coordinator.hostedView?.setInactiveOverlay(color: .clear, opacity: 0, visible: false)
+        // SwiftUI can transiently dismantle/rebuild NSViewRepresentable instances during split
+        // tree updates. Do not force visible/active false here; that causes avoidable blackouts
+        // when the same hosted view is rebound moments later.
+        hostedView?.setFocusHandler(nil)
+        hostedView?.setTriggerFlashHandler(nil)
+        hostedView?.setDropZoneOverlay(zone: nil)
         coordinator.hostedView = nil
 
         nsView.subviews.forEach { $0.removeFromSuperview() }

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -114,6 +114,9 @@ final class TerminalPanel: Panel, ObservableObject {
 
     func focus() {
         surface.setFocus(true)
+        // `unfocus()` force-disables active state to stop stale retries from stealing focus.
+        // Re-enable it immediately for explicit focus requests (socket/UI) so ensureFocus can run.
+        hostedView.setActive(true)
         hostedView.ensureFocus(for: workspaceId, surfaceId: id)
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8403,8 +8403,14 @@ class TerminalController {
                 return
             }
 
+            // Programmatic WebView focus should win over stale omnibar focus state, especially
+            // after workspace switches where the blank-page omnibar auto-focus can re-trigger.
+            browserPanel.endSuppressWebViewFocusForAddressBar()
+            browserPanel.clearWebViewFocusSuppression()
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panelId)
+
             // Prevent omnibar auto-focus from immediately stealing first responder back.
-            browserPanel.suppressOmnibarAutofocus(for: 1.0)
+            browserPanel.suppressOmnibarAutofocus(for: 1.5)
 
             let webView = browserPanel.webView
             guard let window = webView.window else {
@@ -8418,6 +8424,15 @@ class TerminalController {
 
             window.makeFirstResponder(webView)
             if Self.responderChainContains(window.firstResponder, target: webView) {
+                // Some focus churn paths (workspace handoff / omnibar blur) can race this call.
+                // Reassert on the next runloop if another responder steals focus immediately.
+                DispatchQueue.main.async { [weak window, weak webView] in
+                    guard let window, let webView else { return }
+                    guard webView.window === window else { return }
+                    if !Self.responderChainContains(window.firstResponder, target: webView) {
+                        window.makeFirstResponder(webView)
+                    }
+                }
                 result = "OK"
             } else {
                 result = "ERROR: Focus did not move into web view"

--- a/tests_v2/test_split_flash_and_layout.py
+++ b/tests_v2/test_split_flash_and_layout.py
@@ -85,8 +85,47 @@ def _assert_selected_panels_healthy(payload: dict, *, min_wh: float = 80.0) -> N
                 )
 
 
+def _assert_no_transient_detach_or_hide(
+    c: cmux,
+    *,
+    duration_s: float = 1.0,
+    cadence_s: float = 0.005,
+    max_false_samples: int = 2,
+) -> None:
+    false_in_window: dict[str, int] = {}
+    hidden_true: dict[str, int] = {}
+    deadline = time.time() + duration_s
+
+    while time.time() < deadline:
+        rows = c.surface_health()
+        for row in rows:
+            if row.get("type") != "terminal":
+                continue
+            panel_id = (row.get("id") or "").lower()
+            if not panel_id:
+                continue
+            if row.get("in_window") is False:
+                false_in_window[panel_id] = false_in_window.get(panel_id, 0) + 1
+            if row.get("hidden") is True:
+                hidden_true[panel_id] = hidden_true.get(panel_id, 0) + 1
+        time.sleep(cadence_s)
+
+    detached = {k: v for k, v in false_in_window.items() if v > max_false_samples}
+    hidden = {k: v for k, v in hidden_true.items() if v > max_false_samples}
+    if detached or hidden:
+        raise cmuxError(
+            f"Transient detach/hide during split exceeds tolerance "
+            f"(detached={detached}, hidden={hidden})"
+        )
+
+
 def main() -> int:
     with cmux(SOCKET_PATH) as c:
+        # Run on a fresh workspace to avoid state carry-over from restored sessions.
+        test_workspace = c.new_workspace()
+        c.select_workspace(test_workspace)
+        time.sleep(0.2)
+
         # Baseline: a fresh counter, no flashes just from connecting.
         c.reset_empty_panel_count()
 
@@ -108,6 +147,36 @@ def main() -> int:
             raise cmuxError(f"Expected >= 2 panes after split, got {len(panes)}")
         _assert_selected_panels_healthy(after)
 
+        # Drag-to-split from a single-surface pane should also avoid EmptyPanelView flashes.
+        drag_workspace = c.new_workspace()
+        c.select_workspace(drag_workspace)
+        time.sleep(0.2)
+        drag_before = c.layout_debug()
+        _assert_selected_panels_healthy(drag_before)
+        drag_selected = drag_before.get("selectedPanels") or []
+        if not drag_selected:
+            raise cmuxError("layout_debug returned no selectedPanels for drag split setup")
+        drag_panel_id = drag_selected[0].get("panelId")
+        if not drag_panel_id:
+            raise cmuxError("drag split setup selected panel has no panelId")
+        drag_panes_before = len(drag_before.get("layout", {}).get("panes") or [])
+
+        c.reset_empty_panel_count()
+        c.drag_surface_to_split(drag_panel_id, "right")
+        _assert_no_transient_detach_or_hide(c)
+        time.sleep(0.4)
+        flashes = c.empty_panel_count()
+        if flashes != 0:
+            raise cmuxError(f"EmptyPanelView appeared during drag split (count={flashes})")
+
+        drag_after = c.layout_debug()
+        drag_panes_after = len(drag_after.get("layout", {}).get("panes") or [])
+        if drag_panes_after < drag_panes_before + 1:
+            raise cmuxError(
+                f"Expected drag split to add a pane: before={drag_panes_before} after={drag_panes_after}"
+            )
+        _assert_selected_panels_healthy(drag_after)
+
         # Browser split should also avoid EmptyPanelView flashes.
         c.reset_empty_panel_count()
         _browser_id = c.open_browser("https://example.com")
@@ -118,6 +187,9 @@ def main() -> int:
 
         after_browser = c.layout_debug()
         _assert_selected_panels_healthy(after_browser)
+
+        c.close_workspace(test_workspace)
+        time.sleep(0.1)
 
     print("PASS: split flash + layout bounds checks")
     return 0


### PR DESCRIPTION
## Summary
- reduce terminal portal reparent churn during split-tree updates to avoid transient detach/hide black frames
- keep hosted terminal views alive across transient SwiftUI dismantle/rebuild cycles and add focused DEBUG traces for attach/size/window transitions
- repair placeholder handling in drag-to-split so single-tab pane splits reuse placeholder identity instead of create+close churn
- harden browser/terminal focus handoff to avoid omnibar/webview responder races after workspace switches
- isolate split-flash regression tests in fresh workspaces and add drag-to-split coverage in both v1 and v2 test clients

## Validation
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag fix-focus-split-1-3
- on cmux-vm:
  - python3 tests/test_multi_workspace_focus.py
  - python3 tests/test_split_flash_and_layout.py
  - python3 tests_v2/test_split_flash_and_layout.py
