### PR TITLE
Fix update-channel regressions: nightly exit + older nightly filtering

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -444,6 +444,38 @@ final class UpdateChannelSettingsTests: XCTestCase {
         )
     }
 
+    func testStableDowngradeComparisonTreatsCurrentNightlyBuildAsOlderWhenHostIsLeftOperand() {
+        XCTAssertEqual(
+            UpdateChannelSettings.stableDowngradeComparisonOverride(
+                currentBuildVersion: "2026021901",
+                versionA: "2026021901",
+                versionB: "70"
+            ),
+            .orderedAscending
+        )
+    }
+
+    func testStableDowngradeComparisonTreatsCurrentNightlyBuildAsOlderWhenHostIsRightOperand() {
+        XCTAssertEqual(
+            UpdateChannelSettings.stableDowngradeComparisonOverride(
+                currentBuildVersion: "2026021901",
+                versionA: "70",
+                versionB: "2026021901"
+            ),
+            .orderedDescending
+        )
+    }
+
+    func testStableDowngradeComparisonDoesNotOverrideUnrelatedBuildComparisons() {
+        XCTAssertNil(
+            UpdateChannelSettings.stableDowngradeComparisonOverride(
+                currentBuildVersion: "2026021901",
+                versionA: "70",
+                versionB: "71"
+            )
+        )
+    }
+
     func testShouldOfferNightlyCandidateWhenSemanticVersionMatches() {
         XCTAssertTrue(
             UpdateChannelSettings.shouldOfferNightlyCandidate(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -444,34 +444,29 @@ final class UpdateChannelSettingsTests: XCTestCase {
         )
     }
 
-    func testStableDowngradeComparisonTreatsCurrentNightlyBuildAsOlderWhenHostIsLeftOperand() {
-        XCTAssertEqual(
-            UpdateChannelSettings.stableDowngradeComparisonOverride(
-                currentBuildVersion: "2026021901",
-                versionA: "2026021901",
-                versionB: "70"
-            ),
-            .orderedAscending
+    func testShouldOfferStableCandidateWhenCandidateBuildIsNewer() {
+        XCTAssertTrue(
+            UpdateChannelSettings.shouldOfferStableCandidate(
+                currentBuildVersion: "70",
+                candidateBuildVersion: "71"
+            )
         )
     }
 
-    func testStableDowngradeComparisonTreatsCurrentNightlyBuildAsOlderWhenHostIsRightOperand() {
-        XCTAssertEqual(
-            UpdateChannelSettings.stableDowngradeComparisonOverride(
+    func testShouldNotOfferStableCandidateWhenCandidateBuildIsOlder() {
+        XCTAssertFalse(
+            UpdateChannelSettings.shouldOfferStableCandidate(
                 currentBuildVersion: "2026021901",
-                versionA: "70",
-                versionB: "2026021901"
-            ),
-            .orderedDescending
+                candidateBuildVersion: "70"
+            )
         )
     }
 
-    func testStableDowngradeComparisonDoesNotOverrideUnrelatedBuildComparisons() {
-        XCTAssertNil(
-            UpdateChannelSettings.stableDowngradeComparisonOverride(
-                currentBuildVersion: "2026021901",
-                versionA: "70",
-                versionB: "71"
+    func testShouldNotOfferStableCandidateWhenCandidateBuildMatchesCurrent() {
+        XCTAssertFalse(
+            UpdateChannelSettings.shouldOfferStableCandidate(
+                currentBuildVersion: "70",
+                candidateBuildVersion: "70"
             )
         )
     }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -390,6 +390,59 @@ final class UpdateChannelSettingsTests: XCTestCase {
         XCTAssertTrue(resolved.isNightly)
         XCTAssertFalse(resolved.usedFallback)
     }
+
+    func testResolvedFeedReturnsToStableAfterNightlyPreferenceDisabled() {
+        let suiteName = "UpdateChannelSettingsTests.ToggleNightly.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: UpdateChannelSettings.includeNightlyBuildsKey)
+        let nightly = UpdateChannelSettings.resolvedFeedURLString(
+            infoFeedURL: "https://example.com/custom/appcast.xml",
+            defaults: defaults
+        )
+        XCTAssertEqual(nightly.url, UpdateChannelSettings.nightlyFeedURL)
+        XCTAssertTrue(nightly.isNightly)
+
+        defaults.set(false, forKey: UpdateChannelSettings.includeNightlyBuildsKey)
+        let stable = UpdateChannelSettings.resolvedFeedURLString(
+            infoFeedURL: "https://example.com/custom/appcast.xml",
+            defaults: defaults
+        )
+        XCTAssertEqual(stable.url, "https://example.com/custom/appcast.xml")
+        XCTAssertFalse(stable.isNightly)
+        XCTAssertFalse(stable.usedFallback)
+    }
+
+    func testShouldOfferStableDowngradeForNightlyBuildWhenNightlyDisabled() {
+        XCTAssertTrue(
+            UpdateChannelSettings.shouldOfferStableDowngrade(
+                includeNightlyBuilds: false,
+                currentShortVersion: "0.32.0-nightly.20260220"
+            )
+        )
+    }
+
+    func testShouldNotOfferStableDowngradeWhenNightlyChannelEnabled() {
+        XCTAssertFalse(
+            UpdateChannelSettings.shouldOfferStableDowngrade(
+                includeNightlyBuilds: true,
+                currentShortVersion: "0.32.0-nightly.20260220"
+            )
+        )
+    }
+
+    func testShouldNotOfferStableDowngradeForStableBuild() {
+        XCTAssertFalse(
+            UpdateChannelSettings.shouldOfferStableDowngrade(
+                includeNightlyBuilds: false,
+                currentShortVersion: "0.32.0"
+            )
+        )
+    }
 }
 
 final class WorkspaceReorderTests: XCTestCase {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -443,6 +443,33 @@ final class UpdateChannelSettingsTests: XCTestCase {
             )
         )
     }
+
+    func testShouldOfferNightlyCandidateWhenSemanticVersionMatches() {
+        XCTAssertTrue(
+            UpdateChannelSettings.shouldOfferNightlyCandidate(
+                currentShortVersion: "0.58.0",
+                candidateDisplayVersion: "0.58.0-nightly.20260220"
+            )
+        )
+    }
+
+    func testShouldOfferNightlyCandidateWhenSemanticVersionIsNewer() {
+        XCTAssertTrue(
+            UpdateChannelSettings.shouldOfferNightlyCandidate(
+                currentShortVersion: "0.58.0",
+                candidateDisplayVersion: "0.59.0-nightly.20260220"
+            )
+        )
+    }
+
+    func testShouldNotOfferNightlyCandidateWhenSemanticVersionIsOlder() {
+        XCTAssertFalse(
+            UpdateChannelSettings.shouldOfferNightlyCandidate(
+                currentShortVersion: "0.58.0",
+                candidateDisplayVersion: "0.56.0-nightly.20260220"
+            )
+        )
+    }
 }
 
 final class WorkspaceReorderTests: XCTestCase {


### PR DESCRIPTION
## Summary
- fix the nightly -> stable escape hatch by allowing stable appcast selection when the app is on a nightly build and nightly updates are disabled
- prevent nightly channel from suggesting older semantic versions (example: being on `0.58.x` and getting offered `0.56.x-nightly`)
- add regression coverage for both behaviors

## Why
Two bad update-channel edge cases were possible:
1. After installing nightly, disabling nightly could trap the user because Sparkle treated stable as older (`onNewerThanLatestVersion`).
2. Enabling nightly could offer a numerically older release series due nightly build-number ordering.

## What changed
### `Sources/Update/UpdateDelegate.swift`
- added semantic version parsing in `UpdateChannelSettings`
- added `shouldOfferNightlyCandidate(...)` guard
- expanded `bestValidUpdate(in:for:)` logic:
  - when nightly is OFF and current build is nightly: select latest stable item (enables leaving nightly)
  - when nightly is ON: only select appcast items whose semantic version is `>=` current semantic version
  - if nightly is ON and no eligible semantic candidate exists: return `SUAppcastItem.empty()` to avoid falling back to an older nightly suggestion

### `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`
- added regression tests for:
  - toggling nightly off returns to stable feed
  - stable downgrade offer logic for nightly-installed builds
  - nightly candidate selection when semantic version is equal/newer
  - nightly candidate rejection when semantic version is older (`0.58` current vs `0.56-nightly` candidate)

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/UpdateChannelSettingsTests test`
- `./scripts/reload.sh --tag fix-nightly-exit`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
