### PR TITLE
CLI: add --command flag to new-workspace

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -596,8 +596,10 @@ struct CMUXCLI {
             let response = try client.send(command: "new_workspace")
             print(response)
             if let commandText = commandOpt {
-                // Extract workspace ID from "OK <uuid>" response
-                let wsId = response.hasPrefix("OK ") ? String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines) : response.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard response.hasPrefix("OK ") else {
+                    throw CLIError(message: "new-workspace failed, cannot run --command")
+                }
+                let wsId = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
                 // Wait for shell to initialize
                 Thread.sleep(forTimeInterval: 0.5)
                 let text = unescapeSendText(commandText + "\\n")


### PR DESCRIPTION
## Summary
- Adds `--command <text>` flag to `cmux new-workspace` so it can run an initial command in the new terminal after creation
- Waits 500ms for shell to initialize before sending the command
- Uses existing `unescapeSendText` for escape sequence handling (`\n`, `\t`, etc.)

## Usage
```bash
cmux new-workspace --command "cd /path/to/project && claude"
```

## Test plan
- [ ] `cmux new-workspace` still works without `--command` (no regression)
- [ ] `cmux new-workspace --command "echo hello"` creates workspace and runs the command
- [ ] `cmux new-workspace --command "cd /tmp && ls"` correctly sends multi-part commands

Closes #120