### PR TITLE
Fix browser mouse back/forward and middle-click (#131)

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -107,6 +107,14 @@ struct BrowserPanelView: View {
         }) { _ in
             onRequestPanelFocus()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .webViewMiddleClickedLink).filter { [weak panel] note in
+            guard let webView = note.object as? CmuxWebView else { return false }
+            return webView === panel?.webView
+        }) { note in
+            if let url = note.userInfo?["url"] as? URL {
+                panel.openLinkInNewTab(url: url)
+            }
+        }
         .onAppear {
             UserDefaults.standard.register(defaults: [
                 BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2489,4 +2489,5 @@ extension Notification.Name {
     static let browserDidFocusAddressBar = Notification.Name("browserDidFocusAddressBar")
     static let browserDidBlurAddressBar = Notification.Name("browserDidBlurAddressBar")
     static let webViewDidReceiveClick = Notification.Name("webViewDidReceiveClick")
+    static let webViewMiddleClickedLink = Notification.Name("webViewMiddleClickedLink")
 }


### PR DESCRIPTION
## Summary
- Mouse back/forward side buttons (buttons 3/4) now navigate browser history via `goBack()`/`goForward()` overrides in `CmuxWebView`
- Middle-click (button 2) on links opens them in a new browser tab in the same pane
- Middle-click detection uses `document.elementFromPoint` JS hit-test, posts notification to `BrowserPanelView` which calls `openLinkInNewTab`

Fixes #131

## Test plan
- [ ] Click mouse back button in browser panel — should navigate back
- [ ] Click mouse forward button — should navigate forward  
- [ ] Middle-click a link — should open in new browser tab in same pane
- [ ] Middle-click non-link area — should do nothing (no crash)
- [ ] Regular left/right click behavior unchanged