### PR TITLE
Fix homebrew cask template: homepage and min macOS

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -84,14 +84,14 @@ jobs:
             url "https://github.com/manaflow-ai/cmux/releases/download/v#{version}/cmux-macos.dmg"
             name "cmux"
             desc "Lightweight native macOS terminal with vertical tabs for AI coding agents"
-            homepage "https://github.com/manaflow-ai/cmux"
+            homepage "https://cmux.dev"
 
             livecheck do
               url :url
               strategy :github_latest
             end
 
-            depends_on macos: ">= :ventura"
+            depends_on macos: ">= :sonoma"
 
             app "cmux.app"
 


### PR DESCRIPTION
## Summary
- Update homepage from GitHub repo URL to `cmux.dev`
- Update minimum macOS from Ventura to Sonoma (matches app binary requirement flagged by `brew audit`)

Fixes issues found while preparing submission to official homebrew-cask repo.