### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,112 @@
+name: Bug Report
+description: Report a bug in cmux
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the information below so we can reproduce and fix it.
+
+  - type: input
+    id: cmux-version
+    attributes:
+      label: cmux version
+      description: "Run `cmux --version` or check About cmux in the menu bar."
+      placeholder: "e.g. 0.3.2"
+    validations:
+      required: true
+
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      description: "Apple menu → About This Mac"
+      placeholder: "e.g. macOS 15.3 (Sequoia)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: chip
+    attributes:
+      label: Mac chip
+      options:
+        - Apple Silicon (M1/M2/M3/M4)
+        - Intel
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - Homebrew
+        - Direct download (DMG)
+        - Built from source
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: "A clear description of the bug."
+      placeholder: "What happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: "What did you expect to happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: "Minimal steps to reproduce the bug."
+      placeholder: |
+        1. Open cmux
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: shell-info
+    attributes:
+      label: Shell and environment
+      description: "Which shell are you using? Any relevant env config (oh-my-zsh, starship, tmux, etc.)?"
+      placeholder: "e.g. zsh with starship prompt, using tmux inside cmux"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or crash reports
+      description: |
+        If applicable, paste logs or crash reports. Crash reports are in `~/Library/Logs/DiagnosticReports/`.
+        You can also check `Console.app` for cmux-related messages.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recordings
+      description: "If applicable, add screenshots or recordings to help explain the problem."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: "Anything else that might be relevant (other apps running, display setup, accessibility features, etc.)."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/manaflow-ai/cmux/discussions
+    about: Ask questions and share ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: "What problem does this solve, or what's the motivation?"
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: "Describe the feature or behavior you'd like."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "Any alternative solutions or workarounds you've tried?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: "Screenshots, mockups, links to related issues, etc."
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds structured bug report template requiring cmux version, macOS version, chip type, install method, repro steps, and expected behavior
- Adds feature request template
- Disables blank issues to encourage structured reports

## Test plan
- [ ] Open https://github.com/manaflow-ai/cmux/issues/new/choose after merge and verify both templates render correctly