### PR TITLE
Run nightly workflow hourly instead of daily

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@ name: Nightly macOS build
 
 on:
   schedule:
-    # 09:30 UTC daily
-    - cron: "30 9 * * *"
+    # Every hour at :30. The 'decide' job skips if main has no new commits.
+    - cron: "30 * * * *"
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
The decide job already skips when main HEAD matches the nightly tag, so this only builds when there are actual changes. Users get nightly updates within an hour of merging to main instead of waiting for the next day.