### PR TITLE
Fix same-day nightly update detection in Sparkle

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,9 +180,14 @@ jobs:
           NIGHTLY_DATE=$(date -u +%Y%m%d)
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${BASE_MARKETING}-nightly.${NIGHTLY_DATE}" "$APP_PLIST"
 
-          # Build number: unique/monotonic per workflow run so same-day nightlies still
-          # compare as newer in Sparkle.
-          NIGHTLY_BUILD="${GITHUB_RUN_ID:-${NIGHTLY_DATE}000000}"
+          # Build number: unique/monotonic per workflow run attempt so same-day
+          # nightlies and reruns still compare as newer in Sparkle.
+          if [ -n "${GITHUB_RUN_ID:-}" ]; then
+            RUN_ATTEMPT="$(printf '%02d' "${GITHUB_RUN_ATTEMPT:-1}")"
+            NIGHTLY_BUILD="${GITHUB_RUN_ID}${RUN_ATTEMPT}"
+          else
+            NIGHTLY_BUILD="${NIGHTLY_DATE}000000"
+          fi
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${NIGHTLY_BUILD}" "$APP_PLIST"
 
           # Embed commit SHA for bug reports


### PR DESCRIPTION
## Summary
- fix nightly `CFBundleVersion` generation to be unique per workflow run
- replace static daily build number (`YYYYMMDD01`) with `GITHUB_RUN_ID` fallback logic
- keep nightly short version/date labeling unchanged

## Root Cause
Nightly builds were publishing the same Sparkle build version for every run on a given day (`YYYYMMDD01`). When a user installed an earlier nightly from the same day, Sparkle saw the latest appcast item with the same build version and reported "You’re up to date" even when the commit changed.

## Why this fixes it
`GITHUB_RUN_ID` is unique and monotonic for each GitHub Actions run, so every nightly publish now has a strictly newer Sparkle build version.

## Validation
- parsed `.github/workflows/nightly.yml` successfully after edit
- ran `./scripts/reload.sh --tag feat-nightly-unique-build-number` successfully in this worktree (warnings only)
