### PR TITLE
Allow HTTP connections in browser panel

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -92,6 +92,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 	<key>SUFeedURL</key>
 	<string>https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
## Summary
- Adds `NSAllowsArbitraryLoadsInWebContent` to Info.plist so the built-in browser can load non-HTTPS URLs (e.g. local dev servers on custom hostnames like `*.localtest.me`)
- This only affects WKWebView content; all other app networking (update checks, search suggestions, etc.) remains under strict App Transport Security

Fixes #180

## Test plan
- [x] Open browser panel and navigate to an HTTP URL on a non-localhost hostname (e.g. `http://foo.localtest.me:3000`)
- [x] Verify the page loads without ATS errors
- [x] Verify HTTPS URLs still work normally
- [x] Verify localhost HTTP URLs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)