### PR TITLE
Fix CLI symlink path in docs

### DIFF
--- a/web/app/docs/getting-started/page.tsx
+++ b/web/app/docs/getting-started/page.tsx
@@ -55,7 +55,7 @@ brew install --cask cmux`}</CodeBlock>
         it works automatically. To use the CLI from outside cmux, create a
         symlink:
       </p>
-      <CodeBlock lang="bash">{`sudo ln -sf "/Applications/cmux.app/Contents/MacOS/cmux" /usr/local/bin/cmux`}</CodeBlock>
+      <CodeBlock lang="bash">{`sudo ln -sf "/Applications/cmux.app/Contents/Resources/bin/cmux" /usr/local/bin/cmux`}</CodeBlock>
       <p>Then you can run commands like:</p>
       <CodeBlock lang="bash">{`cmux list-workspaces
 cmux notify --title "Build Complete" --body "Your build finished"`}</CodeBlock>


### PR DESCRIPTION
figure out how to fix this issue: The CLI symlinking command in the docs is wrong:
sudo ln -sf "/Applications/cmux.app/Contents/MacOS/cmux" /usr/local/bin/cmuxIt should be:
sudo ln -sf "/Applications/cmux.app/Contents/Resources/bin/cmux" /usr/local/bin/cmux