### PR TITLE
Fix sidebar branch not updating on repo change

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -100,9 +100,10 @@ _cmux_prompt_command() {
                 local first
                 first=$(git status --porcelain -uno 2>/dev/null | head -1)
                 [[ -n "$first" ]] && dirty_opt="--status=dirty"
-                _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID"
+                local qbranch="${branch//\"/\\\"}"
+                _cmux_send "report_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID $dirty_opt -- \"${qbranch}\""
             else
-                _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID"
+                _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
             fi
         } >/dev/null 2>&1 &
         _CMUX_GIT_JOB_PID=$!

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -236,9 +236,10 @@ _cmux_precmd() {
                     local first
                     first=$(git status --porcelain -uno 2>/dev/null | head -1)
                     [[ -n "$first" ]] && dirty_opt="--status=dirty"
-                    _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID"
+                    local qbranch="${branch//\"/\\\"}"
+                    _cmux_send "report_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID $dirty_opt -- \"${qbranch}\""
                 else
-                    _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID"
+                    _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                 fi
             } >/dev/null 2>&1 &!
             _CMUX_GIT_JOB_PID=$!

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6242,8 +6242,8 @@ class TerminalController {
           list_log [--limit=N] [--tab=X] - List log entries
           set_progress <0.0-1.0> [--label=X] [--tab=X] - Set progress bar
           clear_progress [--tab=X] - Clear progress bar
-          report_git_branch <branch> [--status=dirty] [--tab=X] - Report git branch
-          clear_git_branch [--tab=X] - Clear git branch
+          report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y] - Report git branch
+          clear_git_branch [--tab=X] [--panel=Y] - Clear git branch
           report_ports <port1> [port2...] [--tab=X] [--panel=Y] - Report listening ports
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
           ports_kick [--tab=X] [--panel=Y] - Request batched port scan for panel
@@ -9050,9 +9050,11 @@ class TerminalController {
     private func reportGitBranch(_ args: String) -> String {
         let parsed = parseOptions(args)
         guard let branch = parsed.positional.first else {
-            return "ERROR: Missing branch name — usage: report_git_branch <branch> [--status=dirty] [--tab=X]"
+            return "ERROR: Missing branch name — usage: report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y]"
         }
         let isDirty = parsed.options["status"]?.lowercased() == "dirty"
+        let branchState = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+        let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
 
         var result = "OK"
         DispatchQueue.main.sync {
@@ -9060,19 +9062,64 @@ class TerminalController {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
             }
-            tab.gitBranch = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+
+            if let panelArg {
+                let validSurfaceIds = Set(tab.panels.keys)
+                tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+                if panelArg.isEmpty {
+                    result = "ERROR: Missing panel id — usage: report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y]"
+                    return
+                }
+                guard let surfaceId = UUID(uuidString: panelArg) else {
+                    result = "ERROR: Invalid panel id '\(panelArg)'"
+                    return
+                }
+                guard validSurfaceIds.contains(surfaceId) else {
+                    result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+                    return
+                }
+                tab.updatePanelGitBranch(panelId: surfaceId, branchState: branchState)
+                return
+            }
+
+            tab.gitBranch = branchState
+            if let focusedSurfaceId = tab.focusedPanelId {
+                tab.updatePanelGitBranch(panelId: focusedSurfaceId, branchState: branchState)
+            }
         }
         return result
     }
 
     private func clearGitBranch(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
         var result = "OK"
         DispatchQueue.main.sync {
             guard let tab = resolveTabForReport(args) else {
-                result = "ERROR: Tab not found"
+                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
             }
-            tab.gitBranch = nil
+
+            if let panelArg {
+                let validSurfaceIds = Set(tab.panels.keys)
+                tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+                if panelArg.isEmpty {
+                    result = "ERROR: Missing panel id — usage: clear_git_branch [--tab=X] [--panel=Y]"
+                    return
+                }
+                guard let surfaceId = UUID(uuidString: panelArg) else {
+                    result = "ERROR: Invalid panel id '\(panelArg)'"
+                    return
+                }
+                guard validSurfaceIds.contains(surfaceId) else {
+                    result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+                    return
+                }
+                tab.updatePanelGitBranch(panelId: surfaceId, branchState: nil)
+                return
+            }
+
+            tab.clearPanelGitBranches()
         }
         return result
     }
@@ -9362,7 +9409,7 @@ class TerminalController {
             tab.statusEntries.removeAll()
             tab.logEntries.removeAll()
             tab.progress = nil
-            tab.gitBranch = nil
+            tab.clearPanelGitBranches()
             tab.surfaceListeningPorts.removeAll()
             tab.listeningPorts.removeAll()
         }

--- a/tests/cmux.py
+++ b/tests/cmux.py
@@ -561,13 +561,29 @@ class cmux:
         if not response.startswith("OK"):
             raise cmuxError(response)
 
-    def report_git_branch(self, branch: str, status: str = None, tab: str = None) -> None:
+    def report_git_branch(
+        self, branch: str, status: str = None, tab: str = None, panel: str = None
+    ) -> None:
         """Report git branch for sidebar display."""
-        cmd = f"report_git_branch {branch}"
+        cmd = "report_git_branch"
         if status:
             cmd += f" --status={status}"
         if tab:
             cmd += f" --tab={tab}"
+        if panel:
+            cmd += f" --panel={panel}"
+        cmd += f" -- {_quote_option_value(branch)}"
+        response = self._send_command(cmd)
+        if not response.startswith("OK"):
+            raise cmuxError(response)
+
+    def clear_git_branch(self, tab: str = None, panel: str = None) -> None:
+        """Clear sidebar git branch display."""
+        cmd = "clear_git_branch"
+        if tab:
+            cmd += f" --tab={tab}"
+        if panel:
+            cmd += f" --panel={panel}"
         response = self._send_command(cmd)
         if not response.startswith("OK"):
             raise cmuxError(response)

--- a/tests/test_sidebar_cwd_git.py
+++ b/tests/test_sidebar_cwd_git.py
@@ -195,6 +195,32 @@ def main() -> int:
             _send_cd_and_wait(client, other)
             _wait_for_git_branch(client, "none")
 
+            # Panel-scoped branch updates should only affect the focused panel.
+            client.new_split("right")
+            time.sleep(0.4)
+            surfaces = client.list_surfaces()
+            if len(surfaces) < 2:
+                raise AssertionError("Expected at least two surfaces after split")
+
+            first_surface = surfaces[0][1]
+            second_surface = surfaces[1][1]
+
+            client.focus_surface(first_surface)
+            client.report_git_branch("panel-one", status="clean", tab=new_tab_id, panel=first_surface)
+            _wait_for_git_branch(client, "panel-one")
+
+            client.report_git_branch("panel-two", status="clean", tab=new_tab_id, panel=second_surface)
+            _wait_for_git_branch(client, "panel-one")
+
+            client.focus_surface(second_surface)
+            _wait_for_git_branch(client, "panel-two")
+
+            client.clear_git_branch(tab=new_tab_id, panel=second_surface)
+            _wait_for_git_branch(client, "none")
+
+            client.focus_surface(first_surface)
+            _wait_for_git_branch(client, "panel-one")
+
             try:
                 client.close_tab(new_tab_id)
             except Exception:


### PR DESCRIPTION
Branch name in sidebar sometimes doesn't update correctly #19austinywang
opened 25 minutes ago
Member
DescriptionThe git branch name displayed in the sidebar tab sometimes does not update correctly when switching branches or navigating to a different repository directory.
Current behaviorThe branch name shown in the sidebar can become stale or fail to reflect the current branch after certain actions (e.g., git checkout, cd-ing into a different repo).
Expected behaviorThe sidebar branch name should always reflect the current git branch of the active working directory in the terminal.
Relevant codeSources/Workspace.swift — SidebarGitBranchState and @Published var gitBranchSources/TerminalController.swift — reportGitBranch / clearGitBranch socket commandsSources/ContentView.swift — TabItemView.branchDirectoryRow renderingThe flow is: shell reports the branch via the report_git_branch socket command → TerminalController updates tab.gitBranch → SwiftUI view reacts to the @Published change. The issue likely lies in the shell hook not firing reliably or the socket command not being sent in all cases where the branch changes. we need to fix this issue