### PR TITLE
Fix Cmd+Shift+, reload to keep titlebar colors in sync

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -288,9 +288,7 @@ class GhosttyApp {
 
         // Load default config (includes user config). If this fails hard (e.g. due to
         // invalid user config), ghostty_app_new may return nil; we fall back below.
-        ghostty_config_load_default_files(primaryConfig)
-        loadLegacyGhosttyConfigIfNeeded(primaryConfig)
-        ghostty_config_finalize(primaryConfig)
+        loadDefaultConfigFilesWithLegacyFallback(primaryConfig)
         updateDefaultBackground(from: primaryConfig)
 
         // Create runtime config with callbacks
@@ -458,6 +456,21 @@ class GhosttyApp {
         #endif
     }
 
+    private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
+        ghostty_config_load_default_files(config)
+        loadLegacyGhosttyConfigIfNeeded(config)
+        ghostty_config_finalize(config)
+    }
+
+    static func shouldLoadLegacyGhosttyConfig(
+        newConfigFileSize: Int?,
+        legacyConfigFileSize: Int?
+    ) -> Bool {
+        guard let newConfigFileSize, newConfigFileSize == 0 else { return false }
+        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
+        return true
+    }
+
     private func loadLegacyGhosttyConfigIfNeeded(_ config: ghostty_config_t) {
         #if os(macOS)
         // Ghostty 1.3+ prefers `config.ghostty`, but some users still have their real
@@ -475,8 +488,10 @@ class GhosttyApp {
             return size.intValue
         }
 
-        guard let newSize = fileSize(configNew), newSize == 0 else { return }
-        guard let legacySize = fileSize(configLegacy), legacySize > 0 else { return }
+        guard Self.shouldLoadLegacyGhosttyConfig(
+            newConfigFileSize: fileSize(configNew),
+            legacyConfigFileSize: fileSize(configLegacy)
+        ) else { return }
 
         configLegacy.path.withCString { path in
             ghostty_config_load_file(config, path)
@@ -512,8 +527,7 @@ class GhosttyApp {
         }
 
         guard let newConfig = ghostty_config_new() else { return }
-        ghostty_config_load_default_files(newConfig)
-        ghostty_config_finalize(newConfig)
+        loadDefaultConfigFilesWithLegacyFallback(newConfig)
         ghostty_app_update_config(app, newConfig)
         updateDefaultBackground(from: newConfig)
         DispatchQueue.main.async {
@@ -533,8 +547,7 @@ class GhosttyApp {
         }
 
         guard let newConfig = ghostty_config_new() else { return }
-        ghostty_config_load_default_files(newConfig)
-        ghostty_config_finalize(newConfig)
+        loadDefaultConfigFilesWithLegacyFallback(newConfig)
         ghostty_surface_update_config(surface, newConfig)
         ghostty_config_free(newConfig)
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -126,6 +126,42 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(rgb255(config.backgroundColor), RGB(red: 253, green: 246, blue: 227))
     }
 
+    func testLegacyConfigFallbackUsesLegacyFileWhenConfigGhosttyIsEmpty() {
+        XCTAssertTrue(
+            GhosttyApp.shouldLoadLegacyGhosttyConfig(
+                newConfigFileSize: 0,
+                legacyConfigFileSize: 42
+            )
+        )
+    }
+
+    func testLegacyConfigFallbackSkipsWhenNewFileMissingOrLegacyEmpty() {
+        XCTAssertFalse(
+            GhosttyApp.shouldLoadLegacyGhosttyConfig(
+                newConfigFileSize: nil,
+                legacyConfigFileSize: 42
+            )
+        )
+        XCTAssertFalse(
+            GhosttyApp.shouldLoadLegacyGhosttyConfig(
+                newConfigFileSize: 10,
+                legacyConfigFileSize: 42
+            )
+        )
+        XCTAssertFalse(
+            GhosttyApp.shouldLoadLegacyGhosttyConfig(
+                newConfigFileSize: 0,
+                legacyConfigFileSize: 0
+            )
+        )
+        XCTAssertFalse(
+            GhosttyApp.shouldLoadLegacyGhosttyConfig(
+                newConfigFileSize: 0,
+                legacyConfigFileSize: nil
+            )
+        )
+    }
+
     private func rgb255(_ color: NSColor) -> RGB {
         let srgb = color.usingColorSpace(.sRGB)!
         var red: CGFloat = 0


### PR DESCRIPTION
## Summary
- route config reload through the same Ghostty config load path used at startup
- apply legacy `config` fallback when `config.ghostty` exists but is empty during reloads
- add regression coverage for legacy fallback decision logic

## Why
When users keep Ghostty settings in the legacy `~/Library/Application Support/com.mitchellh.ghostty/config` file, app startup loaded those settings but `Cmd+Shift+,` reload did not. That could leave titlebar/background colors wrong until restart.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag ghosttykit-cache`
