### PR TITLE
Speed up setup.sh with commit-keyed GhosttyKit cache

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -16,13 +16,53 @@ if ! command -v zig &> /dev/null; then
     exit 1
 fi
 
-echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
-cd ghostty
-zig build -Demit-xcframework=true -Doptimize=ReleaseFast
-cd "$PROJECT_DIR"
+GHOSTTY_SHA="$(git -C ghostty rev-parse HEAD)"
+CACHE_ROOT="${CMUX_GHOSTTYKIT_CACHE_DIR:-$HOME/.cache/cmux/ghosttykit}"
+CACHE_DIR="$CACHE_ROOT/$GHOSTTY_SHA"
+CACHE_XCFRAMEWORK="$CACHE_DIR/GhosttyKit.xcframework"
+LOCAL_XCFRAMEWORK="$PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
+LOCK_DIR="$CACHE_ROOT/$GHOSTTY_SHA.lock"
+
+mkdir -p "$CACHE_ROOT"
+
+echo "==> Ghostty submodule commit: $GHOSTTY_SHA"
+
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    echo "==> Waiting for GhosttyKit cache lock for $GHOSTTY_SHA..."
+    sleep 1
+done
+trap 'rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
+
+if [ -d "$CACHE_XCFRAMEWORK" ]; then
+    echo "==> Reusing cached GhosttyKit.xcframework"
+else
+    if [ -d "$LOCAL_XCFRAMEWORK" ]; then
+        echo "==> Seeding cache from existing local GhosttyKit.xcframework"
+    else
+        echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
+        (
+            cd ghostty
+            zig build -Demit-xcframework=true -Doptimize=ReleaseFast
+        )
+    fi
+
+    SRC_XCFRAMEWORK="$LOCAL_XCFRAMEWORK"
+    if [ ! -d "$SRC_XCFRAMEWORK" ]; then
+        echo "Error: GhosttyKit.xcframework not found at $SRC_XCFRAMEWORK"
+        exit 1
+    fi
+
+    TMP_DIR="$(mktemp -d "$CACHE_ROOT/.ghosttykit-tmp.XXXXXX")"
+    mkdir -p "$CACHE_DIR"
+    cp -R "$SRC_XCFRAMEWORK" "$TMP_DIR/GhosttyKit.xcframework"
+    rm -rf "$CACHE_XCFRAMEWORK"
+    mv "$TMP_DIR/GhosttyKit.xcframework" "$CACHE_XCFRAMEWORK"
+    rmdir "$TMP_DIR"
+    echo "==> Cached GhosttyKit.xcframework at $CACHE_XCFRAMEWORK"
+fi
 
 echo "==> Creating symlink for GhosttyKit.xcframework..."
-ln -sf ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
+ln -sfn "$CACHE_XCFRAMEWORK" GhosttyKit.xcframework
 
 echo "==> Setup complete!"
 echo ""


### PR DESCRIPTION
## Summary
- cache `GhosttyKit.xcframework` under `~/.cache/cmux/ghosttykit/<ghostty-sha>`
- add per-commit lock handling so concurrent setup runs do not race
- symlink project `GhosttyKit.xcframework` to the cached artifact
- keep rebuild behavior only for cache misses/new ghostty SHAs

## Why
Fresh worktrees currently rebuild GhosttyKit every time `./scripts/setup.sh` runs. This makes setup slow even when the `ghostty` submodule commit is unchanged.

## Testing
- `bash -n scripts/setup.sh`
- `./scripts/setup.sh` in a fresh worktree: cache was reused for current `ghostty` SHA
