### PR TITLE
Fix Cmd+Enter being routed as browser reload in browser surfaces

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -96,6 +96,13 @@ func browserOmnibarSelectionDeltaForArrowNavigation(
     }
 }
 
+func browserOmnibarShouldSubmitOnReturn(flags: NSEvent.ModifierFlags) -> Bool {
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function])
+    return normalizedFlags == [] || normalizedFlags == [.shift]
+}
+
 enum BrowserZoomShortcutAction: Equatable {
     case zoomIn
     case zoomOut

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1970,6 +1970,8 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                 parent.onMoveSelection(-1)
                 return true
             case #selector(NSResponder.insertNewline(_:)):
+                let currentFlags = NSApp.currentEvent?.modifierFlags ?? []
+                guard browserOmnibarShouldSubmitOnReturn(flags: currentFlags) else { return false }
                 parent.onSubmit()
                 return true
             case #selector(NSResponder.cancelOperation(_:)):
@@ -2080,6 +2082,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 
             switch keyCode {
             case 36, 76: // Return / keypad Enter
+                guard browserOmnibarShouldSubmitOnReturn(flags: event.modifierFlags) else { return false }
                 parent.onSubmit()
                 return true
             case 53: // Escape

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -7,6 +7,13 @@ import WebKit
 /// the first responder.
 final class CmuxWebView: WKWebView {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Preserve Cmd+Return/Enter for web content (e.g. editors/forms). Do not
+        // route it through app/menu key equivalents, which can trigger unintended actions.
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags.contains(.command), event.keyCode == 36 || event.keyCode == 76 {
+            return false
+        }
+
         // Let the app menu handle key equivalents first (New Tab, Close Tab, tab switching, etc).
         if let menu = NSApp.mainMenu, menu.performKeyEquivalent(with: event) {
             return true

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -53,6 +53,18 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertTrue(spy.invoked)
     }
 
+    func testCmdReturnBypassesMenuRoutingWhenWebViewIsFirstResponder() {
+        let spy = ActionSpy()
+        installMenu(spy: spy, key: "\r", modifiers: [.command])
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let event = makeKeyDownEvent(key: "\r", modifiers: [.command], keyCode: 36) // kVK_Return
+        XCTAssertNotNil(event)
+
+        XCTAssertFalse(webView.performKeyEquivalent(with: event!))
+        XCTAssertFalse(spy.invoked)
+    }
+
     private func installMenu(spy: ActionSpy, key: String, modifiers: NSEvent.ModifierFlags) {
         let mainMenu = NSMenu()
 
@@ -189,6 +201,20 @@ final class BrowserOmnibarCommandNavigationTests: XCTestCase {
             ),
             1
         )
+    }
+}
+
+final class BrowserOmnibarReturnSubmitPolicyTests: XCTestCase {
+    func testReturnSubmitAllowsPlainAndShiftOnly() {
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: []))
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: [.shift]))
+    }
+
+    func testReturnSubmitRejectsCommandControlAndOption() {
+        XCTAssertFalse(browserOmnibarShouldSubmitOnReturn(flags: [.command]))
+        XCTAssertFalse(browserOmnibarShouldSubmitOnReturn(flags: [.control]))
+        XCTAssertFalse(browserOmnibarShouldSubmitOnReturn(flags: [.option]))
+        XCTAssertFalse(browserOmnibarShouldSubmitOnReturn(flags: [.command, .shift]))
     }
 }
 


### PR DESCRIPTION
## Summary
- stop routing Cmd+Return/Enter from `CmuxWebView.performKeyEquivalent` through app/menu shortcuts
- gate omnibar Return submit so only plain/Shift Return submits (not Cmd/Ctrl/Option modified Return)
- add regression tests for both WebView key-equivalent routing and omnibar Return submit policy

Fixes #144

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests -only-testing:cmuxTests/BrowserOmnibarReturnSubmitPolicyTests test`
- `./scripts/reload.sh --tag fix-cmd-enter-browser`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
