### PR TITLE
Add community section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Everything is scriptable through the CLI and socket API — create workspaces/ta
 
 cmux NIGHTLY is a separate app with its own bundle ID, so it runs alongside the stable version. Built automatically from the latest `main` commit and auto-updates via its own Sparkle feed.
 
+## Community
+
+- [Discord](https://discord.com/invite/QRxkhZgY)
+- [GitHub](https://github.com/manaflow-ai/cmux)
+- [X / Twitter](https://twitter.com/manaflowai)
+- [YouTube](https://www.youtube.com/channel/UCAa89_j-TWkrXfk9A3CbASw)
+- [LinkedIn](https://www.linkedin.com/company/manaflow-ai/)
+
 ## License
 
 This project is licensed under the GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`).


### PR DESCRIPTION
## Summary
- Adds a Community section to the bottom of the README (above License) with links to Discord, GitHub, X/Twitter, YouTube, and LinkedIn — matching the community page on the website

## Test plan
- [ ] Verify links render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)