### PR TITLE
Expose production read-screen capture-pane APIs

### DIFF
--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -830,6 +830,18 @@ class cmux:
         if panel is not None:
             sid = self._resolve_surface_id(panel)
             params["surface_id"] = sid
+        try:
+            res = self._call("surface.read_text", params) or {}
+            if "text" in res:
+                return str(res.get("text") or "")
+            b64 = str(res.get("base64") or "")
+            raw = base64.b64decode(b64) if b64 else b""
+            return raw.decode("utf-8", errors="replace")
+        except cmuxError as exc:
+            # Back-compat for older builds that only expose the debug method.
+            if "method_not_found" not in str(exc):
+                raise
+
         res = self._call("debug.terminal.read_text", params) or {}
         b64 = str(res.get("base64") or "")
         raw = base64.b64decode(b64) if b64 else b""

--- a/tests_v2/test_read_screen_capture_pane_parity.py
+++ b/tests_v2/test_read_screen_capture_pane_parity.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Regression: capture-pane parity via production read-screen APIs."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable, List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _wait_for(pred: Callable[[], bool], timeout_s: float = 5.0, step_s: float = 0.05) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if pred():
+            return
+        time.sleep(step_s)
+    raise cmuxError("Timed out waiting for condition")
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    fixed = os.path.expanduser("~/Library/Developer/Xcode/DerivedData/cmux-tests-v2/Build/Products/Debug/cmux")
+    if os.path.isfile(fixed) and os.access(fixed, os.X_OK):
+        return fixed
+
+    candidates = glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"), recursive=True)
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_cli(cli: str, args: List[str]) -> str:
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        merged = f"{proc.stdout}\n{proc.stderr}".strip()
+        raise cmuxError(f"CLI failed ({' '.join(cmd)}): {merged}")
+    return proc.stdout
+
+
+def main() -> int:
+    cli = _find_cli_binary()
+
+    with cmux(SOCKET_PATH) as c:
+        caps = c.capabilities() or {}
+        methods = set(caps.get("methods") or [])
+        _must("surface.read_text" in methods, f"Missing surface.read_text in capabilities: {sorted(methods)[:20]}")
+
+        created = c._call("workspace.create") or {}
+        ws_id = str(created.get("workspace_id") or "")
+        _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+        c._call("workspace.select", {"workspace_id": ws_id})
+
+        surfaces_payload = c._call("surface.list", {"workspace_id": ws_id}) or {}
+        surfaces = surfaces_payload.get("surfaces") or []
+        _must(bool(surfaces), f"Expected at least one surface in workspace: {surfaces_payload}")
+        surface_id = str(surfaces[0].get("id") or "")
+        _must(bool(surface_id), f"surface.list returned surface without id: {surfaces_payload}")
+
+        token = f"CMUX_READ_SCREEN_{int(time.time() * 1000)}"
+        c._call("surface.send_text", {
+            "workspace_id": ws_id,
+            "surface_id": surface_id,
+            "text": f"echo {token}\n",
+        })
+
+        def has_token() -> bool:
+            payload = c._call("surface.read_text", {"workspace_id": ws_id, "surface_id": surface_id}) or {}
+            return token in str(payload.get("text") or "")
+
+        _wait_for(has_token, timeout_s=5.0)
+
+        read_payload = c._call("surface.read_text", {"workspace_id": ws_id, "surface_id": surface_id}) or {}
+        text = str(read_payload.get("text") or "")
+        _must(token in text, f"surface.read_text missing token {token!r}: {read_payload}")
+
+        cli_text = _run_cli(cli, ["read-screen", "--workspace", ws_id, "--surface", surface_id])
+        _must(token in cli_text, f"cmux read-screen output missing token {token!r}: {cli_text!r}")
+
+        cli_text_scrollback = _run_cli(cli, ["read-screen", "--workspace", ws_id, "--surface", surface_id, "--scrollback", "--lines", "80"])
+        _must(token in cli_text_scrollback, f"cmux read-screen --scrollback output missing token {token!r}: {cli_text_scrollback!r}")
+
+        cli_json = _run_cli(cli, ["--json", "read-screen", "--workspace", ws_id, "--surface", surface_id])
+        payload = json.loads(cli_json or "{}")
+        _must(token in str(payload.get("text") or ""), f"cmux --json read-screen missing token {token!r}: {payload}")
+
+        invalid = subprocess.run(
+            [cli, "--socket", SOCKET_PATH, "read-screen", "--workspace", ws_id, "--surface", surface_id, "--lines", "0"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        invalid_output = f"{invalid.stdout}\n{invalid.stderr}"
+        _must(invalid.returncode != 0, "Expected read-screen --lines 0 to fail")
+        _must("--lines must be greater than 0" in invalid_output, f"Unexpected error for --lines 0: {invalid_output!r}")
+
+    print("PASS: production read-screen APIs expose capture-pane behavior")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- expose `read_screen` in production socket command routing and add `--scrollback` / `--lines` parsing
- add production v2 `surface.read_text` method and include it in `system.capabilities`
- add CLI `read-screen` command wired to `surface.read_text` with help/usage docs
- update `tests_v2` client text-read helper to prefer `surface.read_text` (with fallback)
- add regression test `tests_v2/test_read_screen_capture_pane_parity.py` covering capabilities + CLI behavior

## Issues
- fixes https://github.com/manaflow-ai/cmux/issues/152
- addresses the capture-pane parity item in https://github.com/manaflow-ai/cmux/issues/153

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `CMUX_TAG=issue-152-153-read-screen CMUX_SOCKET=/tmp/cmux-debug-issue-152-153-read-screen.sock CMUX_SOCKET_PATH=/tmp/cmux-debug-issue-152-153-read-screen.sock CMUXTERM_CLI=/tmp/cmux-issue-152-153-read-screen/Build/Products/Debug/cmux python3 tests_v2/test_read_screen_capture_pane_parity.py`
- `CMUX_TAG=issue-152-153-read-screen CMUX_SOCKET=/tmp/cmux-debug-issue-152-153-read-screen.sock CMUX_SOCKET_PATH=/tmp/cmux-debug-issue-152-153-read-screen.sock CMUXTERM_CLI=/tmp/cmux-issue-152-153-read-screen/Build/Products/Debug/cmux python3 tests/test_blank_screen.py`
