### PR TITLE
tmux compat: implement pane.resize via Bonsplit divider control

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2906,20 +2906,187 @@ class TerminalController {
         return result
     }
 
+    private enum V2PaneResizeDirection: String {
+        case left
+        case right
+        case up
+        case down
+
+        var splitOrientation: String {
+            switch self {
+            case .left, .right:
+                return "horizontal"
+            case .up, .down:
+                return "vertical"
+            }
+        }
+
+        /// A split controls the target pane's right/bottom edge when target is first child,
+        /// and left/top edge when target is second child.
+        var requiresPaneInFirstChild: Bool {
+            switch self {
+            case .right, .down:
+                return true
+            case .left, .up:
+                return false
+            }
+        }
+
+        /// Positive value moves divider toward second child (right/down).
+        var dividerDeltaSign: CGFloat {
+            requiresPaneInFirstChild ? 1 : -1
+        }
+    }
+
+    private struct V2PaneResizeCandidate {
+        let splitId: UUID
+        let orientation: String
+        let paneInFirstChild: Bool
+        let dividerPosition: CGFloat
+        let axisPixels: CGFloat
+    }
+
+    private struct V2PaneResizeTrace {
+        let containsTarget: Bool
+        let bounds: CGRect
+    }
+
+    private func v2PaneResizeCollectCandidates(
+        node: ExternalTreeNode,
+        targetPaneId: String,
+        candidates: inout [V2PaneResizeCandidate]
+    ) -> V2PaneResizeTrace {
+        switch node {
+        case .pane(let pane):
+            let bounds = CGRect(
+                x: pane.frame.x,
+                y: pane.frame.y,
+                width: pane.frame.width,
+                height: pane.frame.height
+            )
+            return V2PaneResizeTrace(containsTarget: pane.id == targetPaneId, bounds: bounds)
+
+        case .split(let split):
+            let first = v2PaneResizeCollectCandidates(
+                node: split.first,
+                targetPaneId: targetPaneId,
+                candidates: &candidates
+            )
+            let second = v2PaneResizeCollectCandidates(
+                node: split.second,
+                targetPaneId: targetPaneId,
+                candidates: &candidates
+            )
+
+            let combinedBounds = first.bounds.union(second.bounds)
+            let containsTarget = first.containsTarget || second.containsTarget
+
+            if containsTarget,
+               let splitUUID = UUID(uuidString: split.id) {
+                let orientation = split.orientation.lowercased()
+                let axisPixels: CGFloat = orientation == "horizontal"
+                    ? combinedBounds.width
+                    : combinedBounds.height
+                candidates.append(V2PaneResizeCandidate(
+                    splitId: splitUUID,
+                    orientation: orientation,
+                    paneInFirstChild: first.containsTarget,
+                    dividerPosition: CGFloat(split.dividerPosition),
+                    axisPixels: max(axisPixels, 1)
+                ))
+            }
+
+            return V2PaneResizeTrace(containsTarget: containsTarget, bounds: combinedBounds)
+        }
+    }
+
     private func v2PaneResize(params: [String: Any]) -> V2CallResult {
-        let direction = (v2String(params, "direction") ?? "").lowercased()
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        let directionRaw = (v2String(params, "direction") ?? "").lowercased()
         let amount = v2Int(params, "amount") ?? 1
-        guard ["left", "right", "up", "down"].contains(direction), amount > 0 else {
+        guard let direction = V2PaneResizeDirection(rawValue: directionRaw), amount > 0 else {
             return .err(code: "invalid_params", message: "direction must be one of left|right|up|down and amount must be > 0", data: nil)
         }
-        return .err(
-            code: "not_supported",
-            message: "pane.resize is not supported yet; Bonsplit does not currently expose a stable programmable divider API",
-            data: [
-                "direction": direction,
-                "amount": amount
-            ]
-        )
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to resize pane", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let paneUUID = v2UUID(params, "pane_id") ?? ws.bonsplitController.focusedPaneId?.id
+            guard let paneUUID else {
+                result = .err(code: "not_found", message: "No focused pane", data: nil)
+                return
+            }
+            guard ws.bonsplitController.allPaneIds.contains(where: { $0.id == paneUUID }) else {
+                result = .err(code: "not_found", message: "Pane not found", data: ["pane_id": paneUUID.uuidString])
+                return
+            }
+
+            let tree = ws.bonsplitController.treeSnapshot()
+            var candidates: [V2PaneResizeCandidate] = []
+            let trace = v2PaneResizeCollectCandidates(
+                node: tree,
+                targetPaneId: paneUUID.uuidString,
+                candidates: &candidates
+            )
+            guard trace.containsTarget else {
+                result = .err(code: "not_found", message: "Pane not found in split tree", data: ["pane_id": paneUUID.uuidString])
+                return
+            }
+
+            let orientationMatches = candidates.filter { $0.orientation == direction.splitOrientation }
+            guard !orientationMatches.isEmpty else {
+                result = .err(
+                    code: "invalid_state",
+                    message: "No \(direction.splitOrientation) split ancestor for pane",
+                    data: ["pane_id": paneUUID.uuidString, "direction": direction.rawValue]
+                )
+                return
+            }
+
+            guard let candidate = orientationMatches.first(where: { $0.paneInFirstChild == direction.requiresPaneInFirstChild }) else {
+                result = .err(
+                    code: "invalid_state",
+                    message: "Pane has no adjacent border in direction \(direction.rawValue)",
+                    data: ["pane_id": paneUUID.uuidString, "direction": direction.rawValue]
+                )
+                return
+            }
+
+            let delta = CGFloat(amount) / candidate.axisPixels
+            let requested = candidate.dividerPosition + (direction.dividerDeltaSign * delta)
+            let clamped = min(max(requested, 0.1), 0.9)
+            guard ws.bonsplitController.setDividerPosition(clamped, forSplit: candidate.splitId, fromExternal: true) else {
+                result = .err(
+                    code: "internal_error",
+                    message: "Failed to set split divider position",
+                    data: ["split_id": candidate.splitId.uuidString]
+                )
+                return
+            }
+
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "pane_id": paneUUID.uuidString,
+                "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
+                "split_id": candidate.splitId.uuidString,
+                "direction": direction.rawValue,
+                "amount": amount,
+                "old_divider_position": candidate.dividerPosition,
+                "new_divider_position": clamped
+            ])
+        }
+        return result
     }
 
     private func v2PaneSwap(params: [String: Any]) -> V2CallResult {


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/manaflow-ai/cmux/issues/153 to implement real `resize-pane` behavior.

This replaces the `pane.resize` `not_supported` stub with Bonsplit-backed divider movement:

- resolves target workspace/pane
- traverses Bonsplit tree (`treeSnapshot`) to find the nearest matching split edge for the resize direction
- applies proportional divider movement via `setDividerPosition`
- returns structured resize metadata (`split_id`, old/new divider position, etc.)

## Tests

Validated against a tagged build/socket:

- `CMUX_SOCKET=/tmp/cmux-debug-issue-153-resize-pane.sock CMUXTERM_CLI=/tmp/cmux-issue-153-resize-pane/Build/Products/Debug/cmux python3 tests_v2/test_read_screen_capture_pane_parity.py`
- `CMUX_SOCKET=/tmp/cmux-debug-issue-153-resize-pane.sock CMUXTERM_CLI=/tmp/cmux-issue-153-resize-pane/Build/Products/Debug/cmux python3 tests_v2/test_rename_window_workspace_parity.py`
- `CMUX_SOCKET=/tmp/cmux-debug-issue-153-resize-pane.sock CMUXTERM_CLI=/tmp/cmux-issue-153-resize-pane/Build/Products/Debug/cmux python3 tests_v2/test_tmux_compat_matrix.py`

`tests_v2/test_tmux_compat_matrix.py` was updated to assert `resize-pane` changes pane extent (width/height) instead of expecting failure.
