### PR TITLE
Fix top offset glitch on newly created windows

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -703,7 +703,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 460, height: 360),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )


### PR DESCRIPTION
## Summary
- include `.fullSizeContentView` in `createMainWindow` style mask so new windows start with correct titlebar/content geometry
- keep existing window decoration behavior unchanged
- add regression test to enforce `.fullSizeContentView` in `createMainWindow`

## Root Cause
- new windows were created without `.fullSizeContentView`, then the mask was inserted later from SwiftUI/window decoration flow
- this caused initial titlebar/content offset mismatch until a resize/layout cycle corrected geometry

## Validation
- ✅ `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- ⚠️ `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/MainWindowLayoutStyleTests test` is currently blocked by pre-existing `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` compile errors (`UpdateChannelSettings` missing)

## Manual check
- open a new window and confirm top/titlebar offset is correct immediately (no resize needed)
