### PR TITLE
Increase hit area for browser panel buttons

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -149,6 +149,7 @@ struct BrowserPanelView: View {
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     private let omnibarPillCornerRadius: CGFloat = 12
     private let addressBarButtonSize: CGFloat = 22
+    private let addressBarButtonHitSize: CGFloat = 32
     private let devToolsButtonIconSize: CGFloat = 11
 
     private var searchEngine: BrowserSearchEngine {
@@ -350,10 +351,10 @@ struct BrowserPanelView: View {
             }) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 12, weight: .medium))
-                    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+                    .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .disabled(!panel.canGoBack)
             .opacity(panel.canGoBack ? 1.0 : 0.4)
             .help("Go Back")
@@ -366,10 +367,10 @@ struct BrowserPanelView: View {
             }) {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .medium))
-                    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+                    .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .disabled(!panel.canGoForward)
             .opacity(panel.canGoForward ? 1.0 : 0.4)
             .help("Go Forward")
@@ -389,10 +390,10 @@ struct BrowserPanelView: View {
             }) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
                     .font(.system(size: 12, weight: .medium))
-                    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+                    .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
             .help(panel.isLoading ? "Stop" : "Reload")
         }
     }


### PR DESCRIPTION
The back, forward, and refresh buttons in the browser panel toolbar have small click targets, making them hard to hit accurately. The clickable area should be larger to improve usability, especially for quick navigation.
Expected behaviorButtons should have generous padding / hit areasShould be easy to click without precise aimingConsider making the entire button area (including padding) clickable, not just the iconCurrent behaviorClick targets are small, requiring precise mouse placementEasy to miss the button and click empty toolbar space insteadmake sure you clean up your commits and not to do anything in node_modules please.