### PR TITLE
Respect Ghostty window-inherit-working-directory for new workspaces

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -11,6 +11,7 @@ struct GhosttyConfig {
     var fontSize: CGFloat = 12
     var theme: String?
     var workingDirectory: String?
+    var windowInheritWorkingDirectory: Bool = true
     var scrollbackLimit: Int = 10000
     var unfocusedSplitOpacity: Double = 0.7
     var unfocusedSplitFill: NSColor?
@@ -94,6 +95,10 @@ struct GhosttyConfig {
                     theme = value
                 case "working-directory":
                     workingDirectory = value
+                case "window-inherit-working-directory":
+                    if let inherit = Self.parseBoolean(value) {
+                        windowInheritWorkingDirectory = inherit
+                    }
                 case "scrollback-limit":
                     if let limit = Int(value) {
                         scrollbackLimit = limit
@@ -356,6 +361,17 @@ struct GhosttyConfig {
         appendUniquePath("~/Library/Application Support/com.mitchellh.ghostty/themes/\(themeName)")
 
         return paths
+    }
+
+    private static func parseBoolean(_ value: String) -> Bool? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
     }
 
     private static func readConfigFile(at path: String) -> String? {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -45,6 +45,23 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertTrue(candidates.contains("iTerm2 Solarized Dark"))
     }
 
+    func testWindowInheritWorkingDirectoryParsesBooleanValues() {
+        var config = GhosttyConfig()
+        XCTAssertTrue(config.windowInheritWorkingDirectory)
+
+        config.parse("window-inherit-working-directory=false")
+        XCTAssertFalse(config.windowInheritWorkingDirectory)
+
+        config.parse("window-inherit-working-directory=on")
+        XCTAssertTrue(config.windowInheritWorkingDirectory)
+    }
+
+    func testWindowInheritWorkingDirectoryIgnoresInvalidValues() {
+        var config = GhosttyConfig()
+        config.parse("window-inherit-working-directory=maybe")
+        XCTAssertTrue(config.windowInheritWorkingDirectory)
+    }
+
     func testThemeSearchPathsIncludeXDGDataDirsThemes() {
         let pathA = "/tmp/cmux-theme-a"
         let pathB = "/tmp/cmux-theme-b"


### PR DESCRIPTION
## Summary
- parse Ghostty's `window-inherit-working-directory` setting in `GhosttyConfig`
- make `TabManager.addWorkspace()` respect this setting when choosing the startup cwd for new workspaces
- keep explicit `addWorkspace(workingDirectory:)` overrides unchanged
- add regression tests for config parsing and workspace cwd inheritance logic

## Verification
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag fix-working-dir-177`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- attempted: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyConfigTests -only-testing:cmuxTests/TabManagerWorkingDirectoryInheritanceTests test` (fails in existing `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` due unresolved `UpdateChannelSettings` under `cmux-unit`)

Issue: https://github.com/manaflow-ai/cmux/issues/177

Fixes #177
