### PR TITLE
Fix JavaScript alert/confirm/prompt dialogs in browser panel

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -217,6 +217,48 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
 }
 
 @MainActor
+final class BrowserJavaScriptDialogDelegateTests: XCTestCase {
+    func testBrowserPanelUIDelegateImplementsJavaScriptDialogSelectors() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        guard let uiDelegate = panel.webView.uiDelegate as? NSObject else {
+            XCTFail("Expected BrowserPanel webView.uiDelegate to be an NSObject")
+            return
+        }
+
+        XCTAssertTrue(
+            uiDelegate.responds(
+                to: #selector(
+                    WKUIDelegate.webView(
+                        _:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:
+                    )
+                )
+            ),
+            "Browser UI delegate must implement JavaScript alert handling"
+        )
+        XCTAssertTrue(
+            uiDelegate.responds(
+                to: #selector(
+                    WKUIDelegate.webView(
+                        _:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:
+                    )
+                )
+            ),
+            "Browser UI delegate must implement JavaScript confirm handling"
+        )
+        XCTAssertTrue(
+            uiDelegate.responds(
+                to: #selector(
+                    WKUIDelegate.webView(
+                        _:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:
+                    )
+                )
+            ),
+            "Browser UI delegate must implement JavaScript prompt handling"
+        )
+    }
+}
+
+@MainActor
 final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     private final class FakeInspector: NSObject {
         private(set) var showCount = 0


### PR DESCRIPTION
## Summary
- implement `WKUIDelegate` JavaScript dialog handlers in `BrowserUIDelegate` so `alert()`, `confirm()`, and `prompt()` are surfaced in cmux browser tabs
- present dialogs as sheets when a window is available, with a modal fallback
- add a regression test that asserts the browser panel UI delegate responds to all three WebKit JavaScript dialog selectors

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag feat-browser-alerts-prompts`
- attempted: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' test -only-testing:cmuxTests/BrowserJavaScriptDialogDelegateTests/testBrowserPanelUIDelegateImplementsJavaScriptDialogSelectors` (blocked by pre-existing `UpdateChannelSettings` compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`)
