### PR TITLE
Update Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ cmux NIGHTLY is a separate app with its own bundle ID, so it runs alongside the 
 
 ## Community
 
-- [Discord](https://discord.com/invite/QRxkhZgY)
+- [Discord](https://discord.gg/xsgFEVrWCZ)
 - [GitHub](https://github.com/manaflow-ai/cmux)
 - [X / Twitter](https://twitter.com/manaflowai)
 - [YouTube](https://www.youtube.com/channel/UCAa89_j-TWkrXfk9A3CbASw)

--- a/web/app/community/page.tsx
+++ b/web/app/community/page.tsx
@@ -54,7 +54,7 @@ export default function CommunityPage() {
 
         <div className="grid gap-4 sm:grid-cols-2">
           <CommunityLink
-            href="https://discord.com/invite/QRxkhZgY"
+            href="https://discord.gg/xsgFEVrWCZ"
             name="Discord"
             action="Join our Discord"
             description="Chat with the community, get help, and share feedback"

--- a/web/app/components/nav-links.tsx
+++ b/web/app/components/nav-links.tsx
@@ -57,7 +57,7 @@ export function SiteFooter() {
           GitHub
         </a>
         <a href="https://twitter.com/manaflowai" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Twitter</a>
-        <a href="https://discord.com/invite/QRxkhZgY" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Discord</a>
+        <a href="https://discord.gg/xsgFEVrWCZ" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Discord</a>
         <Link href="/privacy-policy" className="hover:text-foreground transition-colors">Privacy</Link>
         <Link href="/terms-of-service" className="hover:text-foreground transition-colors">Terms</Link>
         <Link href="/eula" className="hover:text-foreground transition-colors">EULA</Link>


### PR DESCRIPTION
## Summary
- Replace old Discord invite URL (`discord.com/invite/QRxkhZgY`) with new permanent link (`discord.gg/xsgFEVrWCZ`)
- Updated in `README.md`, `web/app/community/page.tsx`, and `web/app/components/nav-links.tsx`

## Test plan
- [ ] Verify all three Discord links resolve to the correct server