### PR TITLE
Enable Claude Code integration by default again

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2400,7 +2400,7 @@ enum AppearanceSettings {
 
 enum ClaudeCodeIntegrationSettings {
     static let hooksEnabledKey = "claudeCodeHooksEnabled"
-    static let defaultHooksEnabled = false
+    static let defaultHooksEnabled = true
 
     static func hooksEnabled(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: hooksEnabledKey) == nil {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -162,7 +162,7 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testClaudeCodeIntegrationDefaultsToDisabledWhenUnset() {
+    func testClaudeCodeIntegrationDefaultsToEnabledWhenUnset() {
         let suiteName = "cmux.tests.claude-hooks.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated user defaults suite")
@@ -173,7 +173,7 @@ final class GhosttyConfigTests: XCTestCase {
         }
 
         defaults.removeObject(forKey: ClaudeCodeIntegrationSettings.hooksEnabledKey)
-        XCTAssertFalse(ClaudeCodeIntegrationSettings.hooksEnabled(defaults: defaults))
+        XCTAssertTrue(ClaudeCodeIntegrationSettings.hooksEnabled(defaults: defaults))
     }
 
     func testClaudeCodeIntegrationRespectsStoredPreference() {


### PR DESCRIPTION
## Summary
- set `ClaudeCodeIntegrationSettings.defaultHooksEnabled` back to `true`
- update the corresponding unit test to assert default-on behavior when preference is unset

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyConfigTests test` ❌ (blocked by existing compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` referencing `UpdateChannelSettings`)
- `./scripts/reload.sh --tag claude-default-on` ✅