### PR TITLE
Ignore ambient CMUX_SOCKET_PATH in stable/nightly builds

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2540,7 +2540,7 @@ struct SettingsView: View {
                         SettingsCardDivider()
 
                         SettingsCardNote("Controls access to the local Unix socket for programmatic control. In \"cmux processes only\" mode, only processes spawned inside cmux terminals can connect.")
-                        SettingsCardNote("Overrides: CMUX_SOCKET_ENABLE, CMUX_SOCKET_MODE, and CMUX_SOCKET_PATH.")
+                        SettingsCardNote("Overrides: CMUX_SOCKET_ENABLE, CMUX_SOCKET_MODE, and CMUX_SOCKET_PATH (set CMUX_ALLOW_SOCKET_OVERRIDE=1 for stable/nightly builds).")
                     }
 
                     SettingsCard {


### PR DESCRIPTION
## Summary
- stop treating ambient `CMUX_SOCKET_PATH` as authoritative in stable/nightly channels
- add channel-aware socket defaults (`/tmp/cmux.sock`, `/tmp/cmux-nightly.sock`, `/tmp/cmux-staging.sock`, `/tmp/cmux-debug.sock`)
- only honor `CMUX_SOCKET_PATH` by default for debug/staging bundles (or when `CMUX_ALLOW_SOCKET_OVERRIDE=1` is explicitly set)
- add regression tests covering stable/nightly ignore behavior and override opt-in behavior
- update settings copy to document `CMUX_ALLOW_SOCKET_OVERRIDE=1` requirement in stable/nightly

## Why
Auto-updated nightly/stable apps were inheriting stale launchd `CMUX_SOCKET_PATH` values from prior tagged debug sessions (for example `/tmp/cmux-debug-issue-153-tmux-compat.sock`), causing stop hooks and CLI actions to target dead sockets.

## Testing
- `./scripts/reload.sh --tag socket-override-boundary` (build + launch succeeds)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' test` (fails due to pre-existing unresolved `UpdateChannelSettings` symbols in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`)
- direct socket-path probe via `swiftc Sources/SocketControlSettings.swift <temp-main.swift>` confirms:
  - stable ignores stale override and resolves to `/tmp/cmux.sock`
  - nightly ignores stale override and resolves to `/tmp/cmux-nightly.sock`
  - debug/staging tagged bundles still honor override
  - stable honors override only with `CMUX_ALLOW_SOCKET_OVERRIDE=1`
