### PR TITLE
Add Cmd+Shift+T reopen for closed browser panels

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -363,6 +363,11 @@ struct cmuxApp: App {
                     closeTabOrWindow()
                 }
                 .keyboardShortcut("w", modifiers: [.command, .shift])
+
+                Button("Reopen Closed Browser Panel") {
+                    _ = (AppDelegate.shared?.tabManager ?? tabManager).reopenMostRecentlyClosedBrowserPanel()
+                }
+                .keyboardShortcut("t", modifiers: [.command, .shift])
             }
 
             // Find

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -271,6 +271,44 @@ final class NotificationBurstCoalescerTests: XCTestCase {
     }
 }
 
+final class RecentlyClosedBrowserStackTests: XCTestCase {
+    func testPopReturnsEntriesInLIFOOrder() {
+        var stack = RecentlyClosedBrowserStack(capacity: 20)
+        stack.push(makeSnapshot(index: 1))
+        stack.push(makeSnapshot(index: 2))
+        stack.push(makeSnapshot(index: 3))
+
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 3)
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 2)
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 1)
+        XCTAssertNil(stack.pop())
+    }
+
+    func testPushDropsOldestEntriesWhenCapacityExceeded() {
+        var stack = RecentlyClosedBrowserStack(capacity: 3)
+        for index in 1...5 {
+            stack.push(makeSnapshot(index: index))
+        }
+
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 5)
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 4)
+        XCTAssertEqual(stack.pop()?.originalTabIndex, 3)
+        XCTAssertNil(stack.pop())
+    }
+
+    private func makeSnapshot(index: Int) -> ClosedBrowserPanelRestoreSnapshot {
+        ClosedBrowserPanelRestoreSnapshot(
+            workspaceId: UUID(),
+            url: URL(string: "https://example.com/\(index)"),
+            originalPaneId: UUID(),
+            originalTabIndex: index,
+            fallbackSplitOrientation: .horizontal,
+            fallbackSplitInsertFirst: false,
+            fallbackAnchorPaneId: UUID()
+        )
+    }
+}
+
 final class TabManagerNotificationOrderingSourceTests: XCTestCase {
     func testGhosttyDidSetTitleObserverDoesNotHopThroughTask() throws {
         let projectRoot = findProjectRoot()


### PR DESCRIPTION
## Summary
- add browser-only recently-closed snapshot capture in `Workspace` at close-time
- add capped (20) LIFO restore stack in `TabManager` and reopen logic that prefers the original pane, then split recreation fallback, then focused-pane fallback
- wire `Cmd+Shift+T` via menu action (`Reopen Closed Browser Panel`)
- add regression unit tests for LIFO/cap stack behavior

## Restore behavior
- if the original pane still exists, reopen in that pane and restore tab index
- if the pane collapsed, attempt to recreate the split side from captured parent split metadata
- if the original workspace is gone or placement data no longer applies, reopen in the currently focused pane

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/RecentlyClosedBrowserStackTests test` ❌ (pre-existing compile failures in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`: missing `UpdateChannelSettings` symbols)
- `./scripts/reload.sh --tag issue-244-cmd-shift-t` ✅

Closes https://github.com/manaflow-ai/cmux/issues/244
