### PR TITLE
Track cmux version/build in PostHog DAU events

### DIFF
--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -398,3 +398,51 @@ final class SocketControlSettingsTests: XCTestCase {
         )
     }
 }
+
+final class PostHogAnalyticsPropertiesTests: XCTestCase {
+    func testDailyActivePropertiesIncludeVersionAndBuild() {
+        let properties = PostHogAnalytics.dailyActiveProperties(
+            dayUTC: "2026-02-21",
+            reason: "didBecomeActive",
+            infoDictionary: [
+                "CFBundleShortVersionString": "0.31.0",
+                "CFBundleVersion": "230",
+            ]
+        )
+
+        XCTAssertEqual(properties["day_utc"] as? String, "2026-02-21")
+        XCTAssertEqual(properties["reason"] as? String, "didBecomeActive")
+        XCTAssertEqual(properties["app_version"] as? String, "0.31.0")
+        XCTAssertEqual(properties["app_build"] as? String, "230")
+    }
+
+    func testSuperPropertiesIncludePlatformVersionAndBuild() {
+        let properties = PostHogAnalytics.superProperties(
+            infoDictionary: [
+                "CFBundleShortVersionString": "0.31.0",
+                "CFBundleVersion": "230",
+            ]
+        )
+
+        XCTAssertEqual(properties["platform"] as? String, "cmuxterm")
+        XCTAssertEqual(properties["app_version"] as? String, "0.31.0")
+        XCTAssertEqual(properties["app_build"] as? String, "230")
+    }
+
+    func testPropertiesOmitVersionFieldsWhenUnavailable() {
+        let superProperties = PostHogAnalytics.superProperties(infoDictionary: [:])
+        XCTAssertEqual(superProperties["platform"] as? String, "cmuxterm")
+        XCTAssertNil(superProperties["app_version"])
+        XCTAssertNil(superProperties["app_build"])
+
+        let dailyProperties = PostHogAnalytics.dailyActiveProperties(
+            dayUTC: "2026-02-21",
+            reason: "activeTimer",
+            infoDictionary: [:]
+        )
+        XCTAssertEqual(dailyProperties["day_utc"] as? String, "2026-02-21")
+        XCTAssertEqual(dailyProperties["reason"] as? String, "activeTimer")
+        XCTAssertNil(dailyProperties["app_version"])
+        XCTAssertNil(dailyProperties["app_build"])
+    }
+}


### PR DESCRIPTION
## Summary
- register app version/build as PostHog super properties (`app_version`, `app_build`) alongside `platform=cmuxterm`
- include the same version/build properties on `cmux_daily_active` events so DAU can be broken down by release version over time (stacked area/AUC)
- add regression tests for PostHog property payload construction in `cmuxTests/GhosttyConfigTests.swift`

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/PostHogAnalyticsPropertiesTests test` ⚠️ blocked by existing unrelated compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` (`UpdateChannelSettings` not found)
