### PR TITLE
fix: disable Sentry HTTP client error capture for browser panels

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -311,6 +311,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             options.debug = false
             #endif
             options.sendDefaultPii = true
+            // Disable automatic HTTP client error capture — browser panels load
+            // user-visited sites whose HTTP errors (e.g. 500 for /favicon.ico)
+            // are not cmux bugs and create Sentry noise. See #241.
+            options.enableCaptureFailedRequests = false
         }
 
         if !isRunningUnderXCTest {


### PR DESCRIPTION
## Summary
Fixes #241

Browser panels load user-visited websites whose HTTP errors (e.g. HTTP 500 for `/favicon.ico` from a local dev server) are not cmux bugs. The Sentry Swift SDK captures these by default via `enableCaptureFailedRequests`, creating noise in Sentry (26 events on CMUXTERM-MACOS-3X).

## Changes
- Set `options.enableCaptureFailedRequests = false` in Sentry SDK configuration

## Why this approach?
The Sentry Swift SDK [automatically captures HTTP client errors](https://docs.sentry.io/platforms/apple/configuration/http-client-errors/) (status codes 500-599) by default. Since cmux embeds a browser (WKWebView) that loads arbitrary user URLs, these HTTP errors from external sites are expected and not actionable.

---
🤖 Generated with Claude Code