### PR TITLE
Hotfix TabContextAction switch exhaustiveness

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2461,9 +2461,8 @@ extension Workspace: BonsplitDelegate {
         case .markAsUnread:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             markPanelUnread(panelId)
-        case .markAsRead:
-            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
-            markPanelRead(panelId)
+        @unknown default:
+            break
         }
     }
 


### PR DESCRIPTION
## Summary
- fix post-merge build break from https://github.com/manaflow-ai/cmux/pull/257 by removing the stale `.markAsRead` case in `Workspace.splitTabBar(_:didRequestTabContextAction:for:inPane:)`
- add `@unknown default` so future Bonsplit `TabContextAction` additions do not break cmux compilation

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/TabManagerReopenClosedBrowserFocusTests test`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
