### PR TITLE
release: enforce immutable signed assets per tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,36 @@ jobs:
           fi
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
+      - name: Guard immutable release assets
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const requiredAssets = ['cmux-macos.dmg', 'appcast.xml'];
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              const assetNames = new Set((release.data.assets || []).map((asset) => asset.name));
+              const conflicts = requiredAssets.filter((asset) => assetNames.has(asset));
+              if (conflicts.length > 0) {
+                core.setFailed(
+                  `Release ${tag} already contains immutable assets (${conflicts.join(', ')}). ` +
+                  'Refusing to overwrite signed artifacts for an existing tag.'
+                );
+                return;
+              }
+              core.notice(`Release ${tag} exists but does not contain conflicting assets.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`Release ${tag} does not exist yet; safe to publish assets.`);
+                return;
+              }
+              throw error;
+            }
+
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
@@ -200,6 +230,7 @@ jobs:
             cmux-macos.dmg
             appcast.xml
           generate_release_notes: true
+          overwrite_files: false
 
       - name: Cleanup keychain
         if: always()


### PR DESCRIPTION
## Summary
- add a release workflow guard that fails if `cmux-macos.dmg` or `appcast.xml` already exists on the target tag
- explicitly keep `overwrite_files: false` in release upload
- harden `scripts/build-sign-upload.sh` to refuse overwriting existing signed assets unless `--allow-overwrite` is explicitly passed

## Why
Production release tags should be immutable once signed artifacts are published. Replacing artifacts for an existing tag can create Sparkle validation mismatches for clients that observe stale appcast content against newly replaced binaries.

These guards make accidental overwrite the default failure mode.

## Validation
- YAML parse check: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- script syntax check: `bash -n scripts/build-sign-upload.sh`
- local tagged reload build: `./scripts/reload.sh --tag feat-release-immutable-guards`
