### PR TITLE
Follow up PR 242: refresh browser under-page background on theme updates

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -514,25 +514,38 @@ struct BrowserPanelView: View {
     }
 
     private var webView: some View {
-        WebViewRepresentable(
-            panel: panel,
-            shouldAttachWebView: isVisibleInUI,
-            shouldFocusWebView: isFocused && !addressBarFocused,
-            isPanelFocused: isFocused,
-            portalZPriority: portalPriority
-        )
-            // Keep the representable identity stable across bonsplit structural updates.
-            // This reduces WKWebView reparenting churn (and the associated WebKit crashes).
-            .id(panel.id)
-            .contentShape(Rectangle())
-            .simultaneousGesture(TapGesture().onEnded {
-                // Chrome-like behavior: clicking web content while editing the
-                // omnibar should commit blur and revert transient edits.
-                if addressBarFocused {
-                    addressBarFocused = false
-                }
-            })
-            .zIndex(0)
+        Group {
+            if panel.shouldRenderWebView {
+                WebViewRepresentable(
+                    panel: panel,
+                    shouldAttachWebView: isVisibleInUI,
+                    shouldFocusWebView: isFocused && !addressBarFocused,
+                    isPanelFocused: isFocused,
+                    portalZPriority: portalPriority
+                )
+                // Keep the representable identity stable across bonsplit structural updates.
+                // This reduces WKWebView reparenting churn (and the associated WebKit crashes).
+                .id(panel.id)
+                .contentShape(Rectangle())
+                .simultaneousGesture(TapGesture().onEnded {
+                    // Chrome-like behavior: clicking web content while editing the
+                    // omnibar should commit blur and revert transient edits.
+                    if addressBarFocused {
+                        addressBarFocused = false
+                    }
+                })
+            } else {
+                Color(nsColor: GhosttyApp.shared.defaultBackgroundColor)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onRequestPanelFocus()
+                        if addressBarFocused {
+                            addressBarFocused = false
+                        }
+                    }
+            }
+        }
+        .zIndex(0)
     }
 
     private func triggerFocusFlashAnimation() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -241,13 +241,13 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
         XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.005)
     }
 
-    func testBrowserPanelThemedBlankHTMLIncludesMarkerAndResolvedBackground() {
-        let color = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 0.57)
+    func testBrowserPanelStartsAsNewTabWithoutLoadingAboutBlank() {
+        let panel = BrowserPanel(workspaceId: UUID())
 
-        let html = BrowserPanel.themedBlankHTML(backgroundColor: color)
-
-        XCTAssertTrue(html.contains("data-cmux-themed-blank=\"1\""))
-        XCTAssertTrue(html.contains("rgba(46, 74, 112, 0.570)"))
+        XCTAssertEqual(panel.displayTitle, "New tab")
+        XCTAssertFalse(panel.shouldRenderWebView)
+        XCTAssertNil(panel.webView.url)
+        XCTAssertNil(panel.currentURL)
     }
 }
 


### PR DESCRIPTION
## Summary
- Refresh `WKWebView.underPageBackgroundColor` when `.ghosttyDefaultBackgroundDidChange` fires so already-open browser panels track runtime theme/background updates
- Add a regression test that posts the background-change notification and verifies the browser under-page color updates
- Keep the titlebar border unchanged (per requested scope)

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/BrowserDeveloperToolsConfigurationTests/testBrowserPanelRefreshesUnderPageBackgroundColorWhenGhosttyBackgroundChanges test` (passes)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (passes)
- `./scripts/reload.sh --tag pr242-followup` (passes)

## Related
- Follow-up to: https://github.com/manaflow-ai/cmux/pull/242
- Addressed review thread: https://github.com/manaflow-ai/cmux/pull/242#discussion_r2835887672
