### PR TITLE
Fix Show HN blog summary phrasing

### DIFF
--- a/web/app/blog/page.tsx
+++ b/web/app/blog/page.tsx
@@ -12,7 +12,7 @@ const posts = [
     title: "Launching cmux on Show HN",
     date: "2026-02-21",
     summary:
-      "cmux hit the front page, went viral in Japan, and shipped 18 releases in 48 hours.",
+      "cmux hit #2 on Hacker News, got shared by Mitchell Hashimoto, and went viral in Japan.",
   },
   {
     slug: "introducing-cmux",


### PR DESCRIPTION
## Summary
- Update blog index summary for Show HN post to highlight hitting #2, Mitchell Hashimoto sharing it, and going viral in Japan

## Related
- Follow-up to https://github.com/manaflow-ai/cmux/pull/273