### PR TITLE
Fix community gap 16px, add China tweet to blog post

### DIFF
--- a/web/app/blog/show-hn-launch/page.tsx
+++ b/web/app/blog/show-hn-launch/page.tsx
@@ -159,7 +159,7 @@ export default function ShowHNLaunchPage() {
       </blockquote>
 
       <p>
-        Surprisingly, cmux went semi-viral in Japan!
+        Surprisingly, cmux went viral in Japan:
       </p>
 
       <Tweet id="2025129675262251026" />
@@ -170,6 +170,12 @@ export default function ShowHNLaunchPage() {
         Code in parallel. The waiting-for-input panel gets a blue frame, and
         it has its own notification system.&quot;
       </p>
+
+      <p>
+        And semi-viral in China:
+      </p>
+
+      <Tweet id="2024867449947275444" />
 
       <p>
         Another exciting thing was seeing people build on top of the cmux

--- a/web/app/components/spacing-control.tsx
+++ b/web/app/components/spacing-control.tsx
@@ -27,7 +27,7 @@ const defaults: DevValues = {
   featuresLh: 1.275,
   featuresPt: 12,
   featuresPb: 15,
-  communityGap: 6,
+  communityGap: 16,
   faqPt: 0,
   docsPt: 8,
 };

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -201,7 +201,7 @@ export default function Home() {
           <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
             Community
           </h2>
-          <ul data-dev="community-ul" className="text-[15px]" style={{ lineHeight: 1.5, display: "flex", flexDirection: "column", gap: 6 }}>
+          <ul data-dev="community-ul" className="text-[15px]" style={{ lineHeight: 1.5, display: "flex", flexDirection: "column", gap: 16 }}>
             {testimonials.map((t) => (
               <li key={t.url}>
                 <span>


### PR DESCRIPTION
## Summary
- Set community section gap to 16px (was 6px, missed in previous squash merge)
- Add dingyi tweet to Show HN blog post (semi-viral in China)
- Split "semi-viral in Japan" into "viral in Japan" + "semi-viral in China"