### PR TITLE
Add "Short Directory Name" sidebar setting

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1419,6 +1419,7 @@ private struct TabItemView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowStatusPills = true
+    @AppStorage("sidebarDirectoryShortName") private var sidebarDirectoryShortName = false
 
     var isActive: Bool {
         tabManager.selectedTabId == tab.id
@@ -1985,6 +1986,9 @@ private struct TabItemView: View {
         guard !trimmed.isEmpty else { return path }
         if trimmed == home {
             return "~"
+        }
+        if sidebarDirectoryShortName {
+            return (trimmed as NSString).lastPathComponent
         }
         if trimmed.hasPrefix(home + "/") {
             return "~" + trimmed.dropFirst(home.count)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2273,6 +2273,7 @@ struct SettingsView: View {
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
     @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
+    @AppStorage("sidebarDirectoryShortName") private var sidebarDirectoryShortName = false
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
     @State private var shortcutResetToken = UUID()
     @State private var topBlurOpacity: Double = 0
@@ -2345,6 +2346,18 @@ struct SettingsView: View {
                             subtitle: "Show unread count on app icon (Dock and Cmd+Tab)."
                         ) {
                             Toggle("", isOn: $notificationDockBadgeEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+                    }
+
+                    SettingsSectionHeader(title: "Sidebar")
+                    SettingsCard {
+                        SettingsCardRow(
+                            "Short Directory Name",
+                            subtitle: "Show only the last path component instead of the full path."
+                        ) {
+                            Toggle("", isOn: $sidebarDirectoryShortName)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }


### PR DESCRIPTION
Show only the last path component (e.g. `cmux` instead of `~/go/src/github.com/manaflow-ai/cmux`) when enabled in Settings > Sidebar.

This helps distinguish workspaces that share same directory tree. This is common for repos of the same company, for example.