### PR TITLE
Fix missing Applications drop target in release DMGs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           brew update
           brew install zig
-          npm install --global create-dmg
+          npm install --global create-dmg@8.0.0
 
       - name: Build GhosttyKit.xcframework
         run: |
@@ -274,7 +274,7 @@ jobs:
           xcrun stapler validate "$APP_PATH"
           spctl -a -vv --type execute "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
-          ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
+          CMUX_CREATE_DMG_REQUIRE_MODERN=1 ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
           DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
           DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
           DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -274,11 +274,7 @@ jobs:
           xcrun stapler validate "$APP_PATH"
           spctl -a -vv --type execute "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
-          create-dmg \
-            --identity="$APPLE_SIGNING_IDENTITY" \
-            "$APP_PATH" \
-            ./
-          mv ./"cmux NIGHTLY"*.dmg "$DMG_RELEASE" 2>/dev/null || mv ./cmux*.dmg "$DMG_RELEASE"
+          ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
           DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
           DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
           DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           brew update
           brew install zig
-          npm install --global create-dmg
+          npm install --global create-dmg@8.0.0
 
       - name: Download Metal Toolchain
         run: xcodebuild -downloadComponent MetalToolchain
@@ -166,7 +166,7 @@ jobs:
           xcrun stapler validate "$APP_PATH"
           spctl -a -vv --type execute "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
-          ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
+          CMUX_CREATE_DMG_REQUIRE_MODERN=1 ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
           DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
           DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
           DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,12 +166,7 @@ jobs:
           xcrun stapler validate "$APP_PATH"
           spctl -a -vv --type execute "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
-          # create-dmg generates a styled drag-to-install DMG
-          create-dmg \
-            --identity="$APPLE_SIGNING_IDENTITY" \
-            "$APP_PATH" \
-            ./
-          mv ./cmux*.dmg "$DMG_RELEASE"
+          ./scripts/create_release_dmg.sh "$APP_PATH" "$DMG_RELEASE" "$APPLE_SIGNING_IDENTITY"
           DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
           DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
           DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -53,9 +53,13 @@ APP_PATH="build/Build/Products/Release/cmux.app"
 # --- Pre-flight ---
 source ~/.secrets/cmuxterm.env
 export SPARKLE_PRIVATE_KEY
-for tool in zig xcodebuild create-dmg xcrun codesign ditto gh; do
+for tool in zig xcodebuild xcrun codesign ditto gh; do
   command -v "$tool" >/dev/null || { echo "MISSING: $tool" >&2; exit 1; }
 done
+if ! command -v create-dmg >/dev/null 2>&1 && ! command -v npx >/dev/null 2>&1; then
+  echo "MISSING: create-dmg or npx" >&2
+  exit 1
+fi
 echo "Pre-flight checks passed"
 
 # --- Build GhosttyKit (if needed) ---
@@ -107,7 +111,7 @@ echo "App notarized"
 # --- Create and notarize DMG ---
 echo "Creating DMG..."
 rm -f cmux-macos.dmg
-./scripts/create_release_dmg.sh "$APP_PATH" "cmux-macos.dmg" "$SIGN_HASH"
+CMUX_CREATE_DMG_REQUIRE_MODERN=1 ./scripts/create_release_dmg.sh "$APP_PATH" "cmux-macos.dmg" "$SIGN_HASH"
 echo "Notarizing DMG..."
 xcrun notarytool submit cmux-macos.dmg \
   --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -107,7 +107,7 @@ echo "App notarized"
 # --- Create and notarize DMG ---
 echo "Creating DMG..."
 rm -f cmux-macos.dmg
-create-dmg --codesign "$SIGN_HASH" cmux-macos.dmg "$APP_PATH"
+./scripts/create_release_dmg.sh "$APP_PATH" "cmux-macos.dmg" "$SIGN_HASH"
 echo "Notarizing DMG..."
 xcrun notarytool submit cmux-macos.dmg \
   --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait

--- a/scripts/create_release_dmg.sh
+++ b/scripts/create_release_dmg.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <app-path> <dmg-output-path> [signing-identity]" >&2
+  exit 1
+fi
+
+if ! command -v create-dmg >/dev/null 2>&1; then
+  echo "create-dmg is required but not found in PATH" >&2
+  exit 1
+fi
+
+APP_PATH="$1"
+DMG_OUTPUT="$2"
+SIGNING_IDENTITY="${3:-}"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "App not found: $APP_PATH" >&2
+  exit 1
+fi
+
+OUTPUT_DIR="$(dirname "$DMG_OUTPUT")"
+mkdir -p "$OUTPUT_DIR"
+
+cleanup_paths=()
+cleanup() {
+  local path
+  for path in "${cleanup_paths[@]}"; do
+    [ -n "$path" ] && rm -rf "$path"
+  done
+}
+trap cleanup EXIT
+
+detect_create_dmg_mode() {
+  local version_output major help_output
+
+  version_output="$(create-dmg --version 2>/dev/null || true)"
+  major="$(printf '%s\n' "$version_output" | sed -n 's/.* \([0-9][0-9]*\)\..*/\1/p' | head -n1)"
+  if [ -n "$major" ]; then
+    if [ "$major" -lt 2 ]; then
+      echo "legacy"
+    else
+      echo "modern"
+    fi
+    return
+  fi
+
+  help_output="$(create-dmg --help 2>&1 || true)"
+  if printf '%s\n' "$help_output" | grep -Fq "<output_name.dmg> <source_folder>"; then
+    echo "legacy"
+  else
+    echo "modern"
+  fi
+}
+
+create_dmg_legacy() {
+  local staging_dir app_name volume_name cmd
+  staging_dir="$(mktemp -d)"
+  cleanup_paths+=("$staging_dir")
+
+  cp -R "$APP_PATH" "$staging_dir/"
+  app_name="$(basename "$APP_PATH")"
+  volume_name="$(basename "$DMG_OUTPUT" .dmg)"
+
+  cmd=(
+    create-dmg
+    --volname "$volume_name"
+    --window-size 660 400
+    --icon-size 128
+    --icon "$app_name" 180 170
+    --hide-extension "$app_name"
+    --app-drop-link 480 170
+  )
+  if [ -n "$SIGNING_IDENTITY" ]; then
+    cmd+=(--codesign "$SIGNING_IDENTITY")
+  fi
+  cmd+=("$DMG_OUTPUT" "$staging_dir")
+
+  "${cmd[@]}"
+}
+
+create_dmg_modern() {
+  local temp_output_dir generated_dmg cmd
+  temp_output_dir="$(mktemp -d)"
+  cleanup_paths+=("$temp_output_dir")
+
+  cmd=(create-dmg --overwrite)
+  if [ -n "$SIGNING_IDENTITY" ]; then
+    cmd+=(--identity="$SIGNING_IDENTITY")
+  fi
+  cmd+=("$APP_PATH" "$temp_output_dir")
+
+  "${cmd[@]}"
+
+  generated_dmg="$(find "$temp_output_dir" -maxdepth 1 -type f -name '*.dmg' | head -n1)"
+  if [ -z "$generated_dmg" ]; then
+    echo "create-dmg did not produce a DMG file in $temp_output_dir" >&2
+    exit 1
+  fi
+
+  rm -f "$DMG_OUTPUT"
+  mv "$generated_dmg" "$DMG_OUTPUT"
+}
+
+case "$(detect_create_dmg_mode)" in
+  legacy)
+    create_dmg_legacy
+    ;;
+  modern)
+    create_dmg_modern
+    ;;
+  *)
+    echo "Unable to detect create-dmg mode" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_create_release_dmg.sh
+++ b/tests/test_create_release_dmg.sh
@@ -12,79 +12,183 @@ fi
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-mkdir -p "$TMPDIR/bin"
-cat > "$TMPDIR/bin/create-dmg" <<'EOF'
+BIN_WITH_NPX="$TMPDIR/bin-with-npx"
+BIN_NO_NPX="$TMPDIR/bin-no-npx"
+PATH_BASE="/usr/bin:/bin:/usr/sbin:/sbin"
+mkdir -p "$BIN_WITH_NPX" "$BIN_NO_NPX"
+
+cat > "$BIN_WITH_NPX/create-dmg" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
 if [ "${1:-}" = "--version" ]; then
-  if [ "${FAKE_MODE:-}" = "legacy" ]; then
-    echo "create-dmg 1.2.1"
+  echo "create-dmg ${FAKE_CREATE_DMG_VERSION:-8.0.0}"
+  exit 0
+fi
+
+if [ "${1:-}" = "--help" ]; then
+  if [ "${FAKE_CREATE_DMG_VERSION:-8.0.0}" = "1.2.1" ]; then
+    echo "Usage: create-dmg [options] <output_name.dmg> <source_folder>"
   else
-    echo "create-dmg 8.0.0"
+    echo "Usage: create-dmg <app> [destination]"
   fi
   exit 0
 fi
 
-printf '%s\n' "$*" >> "$FAKE_LOG"
+printf '%s\n' "$*" >> "$FAKE_CREATE_DMG_LOG"
 
-if [ "${FAKE_MODE:-}" = "legacy" ]; then
-  for arg in "$@"; do
-    if [[ "$arg" == *.dmg ]]; then
-      mkdir -p "$(dirname "$arg")"
-      : > "$arg"
-      exit 0
-    fi
-  done
-  echo "fake legacy create-dmg did not receive an output .dmg argument" >&2
+if printf '%s\n' "$*" | grep -Fq -- "--overwrite"; then
+  dest="${!#}"
+  mkdir -p "$dest"
+  : > "$dest/generated.dmg"
+  exit 0
+fi
+
+for arg in "$@"; do
+  if [[ "$arg" == *.dmg ]]; then
+    mkdir -p "$(dirname "$arg")"
+    : > "$arg"
+    exit 0
+  fi
+done
+
+echo "fake create-dmg did not receive a valid destination" >&2
+exit 1
+EOF
+
+cp "$BIN_WITH_NPX/create-dmg" "$BIN_NO_NPX/create-dmg"
+
+cat > "$BIN_WITH_NPX/npx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_NPX_LOG"
+
+if [ "${1:-}" != "--yes" ]; then
+  echo "expected --yes as first arg" >&2
+  exit 1
+fi
+
+if [[ "${2:-}" != create-dmg@* ]]; then
+  echo "expected create-dmg@<version> as second arg" >&2
   exit 1
 fi
 
 dest="${!#}"
 mkdir -p "$dest"
-: > "$dest/generated.dmg"
+: > "$dest/generated-via-npx.dmg"
 EOF
-chmod +x "$TMPDIR/bin/create-dmg"
+
+chmod +x "$BIN_WITH_NPX/create-dmg" "$BIN_NO_NPX/create-dmg" "$BIN_WITH_NPX/npx"
 
 APP_DIR="$TMPDIR/cmux.app"
 mkdir -p "$APP_DIR/Contents"
 
-run_case() {
-  local mode log_file output_path
-  mode="$1"
-  log_file="$TMPDIR/${mode}.log"
-  output_path="$TMPDIR/${mode}/cmux-macos.dmg"
+run_script() {
+  local output_path create_dmg_log npx_log
+  output_path="$1"
+  create_dmg_log="$2"
+  npx_log="$3"
+  shift 3
 
-  PATH="$TMPDIR/bin:$PATH" FAKE_MODE="$mode" FAKE_LOG="$log_file" \
-    "$SCRIPT" "$APP_DIR" "$output_path" "SIGNING-ID"
+  FAKE_CREATE_DMG_LOG="$create_dmg_log" \
+    FAKE_NPX_LOG="$npx_log" \
+    "$@" "$SCRIPT" "$APP_DIR" "$output_path" "SIGNING-ID"
+}
 
-  if [ ! -f "$output_path" ]; then
-    echo "FAIL: ${mode} mode did not produce $output_path"
+case_modern_binary() {
+  local output_path create_dmg_log npx_log
+  output_path="$TMPDIR/modern/cmux-macos.dmg"
+  create_dmg_log="$TMPDIR/modern-create-dmg.log"
+  npx_log="$TMPDIR/modern-npx.log"
+  : > "$create_dmg_log"
+  : > "$npx_log"
+
+  run_script "$output_path" "$create_dmg_log" "$npx_log" \
+    env PATH="$BIN_WITH_NPX:$PATH_BASE" FAKE_CREATE_DMG_VERSION="8.0.0"
+
+  [ -f "$output_path" ] || { echo "FAIL: modern binary case did not produce DMG"; exit 1; }
+  grep -F -- "--overwrite" "$create_dmg_log" >/dev/null || {
+    echo "FAIL: modern binary case did not use --overwrite"
     exit 1
-  fi
-
-  if [ "$mode" = "legacy" ]; then
-    grep -F -- "--app-drop-link 480 170" "$log_file" >/dev/null || {
-      echo "FAIL: legacy mode did not add Applications drop link"
-      exit 1
-    }
-    grep -F -- "--codesign SIGNING-ID" "$log_file" >/dev/null || {
-      echo "FAIL: legacy mode did not pass --codesign"
-      exit 1
-    }
-  else
-    grep -F -- "--overwrite" "$log_file" >/dev/null || {
-      echo "FAIL: modern mode did not pass --overwrite"
-      exit 1
-    }
-    grep -F -- "--identity=SIGNING-ID" "$log_file" >/dev/null || {
-      echo "FAIL: modern mode did not pass --identity"
-      exit 1
-    }
+  }
+  grep -F -- "--identity=SIGNING-ID" "$create_dmg_log" >/dev/null || {
+    echo "FAIL: modern binary case did not pass --identity"
+    exit 1
+  }
+  if [ -s "$npx_log" ]; then
+    echo "FAIL: modern binary case should not invoke npx"
+    exit 1
   fi
 }
 
-run_case legacy
-run_case modern
+case_legacy_promoted_to_modern() {
+  local output_path create_dmg_log npx_log
+  output_path="$TMPDIR/legacy-modernized/cmux-macos.dmg"
+  create_dmg_log="$TMPDIR/legacy-modernized-create-dmg.log"
+  npx_log="$TMPDIR/legacy-modernized-npx.log"
+  : > "$create_dmg_log"
+  : > "$npx_log"
 
-echo "PASS: create_release_dmg script handles legacy and modern create-dmg"
+  run_script "$output_path" "$create_dmg_log" "$npx_log" \
+    env PATH="$BIN_WITH_NPX:$PATH_BASE" FAKE_CREATE_DMG_VERSION="1.2.1" CMUX_CREATE_DMG_REQUIRE_MODERN=1
+
+  [ -f "$output_path" ] || { echo "FAIL: legacy modernized case did not produce DMG"; exit 1; }
+  grep -F -- "create-dmg@8.0.0" "$npx_log" >/dev/null || {
+    echo "FAIL: legacy modernized case did not invoke npx create-dmg@8.0.0"
+    exit 1
+  }
+  grep -F -- "--overwrite" "$npx_log" >/dev/null || {
+    echo "FAIL: legacy modernized case did not pass --overwrite through npx"
+    exit 1
+  }
+}
+
+case_legacy_fallback() {
+  local output_path create_dmg_log npx_log
+  output_path="$TMPDIR/legacy-fallback/cmux-macos.dmg"
+  create_dmg_log="$TMPDIR/legacy-fallback-create-dmg.log"
+  npx_log="$TMPDIR/legacy-fallback-npx.log"
+  : > "$create_dmg_log"
+  : > "$npx_log"
+
+  run_script "$output_path" "$create_dmg_log" "$npx_log" \
+    env PATH="$BIN_NO_NPX:$PATH_BASE" FAKE_CREATE_DMG_VERSION="1.2.1"
+
+  [ -f "$output_path" ] || { echo "FAIL: legacy fallback case did not produce DMG"; exit 1; }
+  grep -F -- "--app-drop-link 480 170" "$create_dmg_log" >/dev/null || {
+    echo "FAIL: legacy fallback case did not pass --app-drop-link"
+    exit 1
+  }
+  grep -F -- "--codesign SIGNING-ID" "$create_dmg_log" >/dev/null || {
+    echo "FAIL: legacy fallback case did not pass --codesign"
+    exit 1
+  }
+  if [ -s "$npx_log" ]; then
+    echo "FAIL: legacy fallback case should not invoke npx"
+    exit 1
+  fi
+}
+
+case_require_modern_without_npx_fails() {
+  local output_path create_dmg_log npx_log
+  output_path="$TMPDIR/require-modern-fail/cmux-macos.dmg"
+  create_dmg_log="$TMPDIR/require-modern-fail-create-dmg.log"
+  npx_log="$TMPDIR/require-modern-fail-npx.log"
+  : > "$create_dmg_log"
+  : > "$npx_log"
+
+  if run_script "$output_path" "$create_dmg_log" "$npx_log" \
+    env PATH="$BIN_NO_NPX:$PATH_BASE" FAKE_CREATE_DMG_VERSION="1.2.1" CMUX_CREATE_DMG_REQUIRE_MODERN=1 \
+    >/dev/null 2>&1; then
+    echo "FAIL: require modern without npx should fail"
+    exit 1
+  fi
+}
+
+case_modern_binary
+case_legacy_promoted_to_modern
+case_legacy_fallback
+case_require_modern_without_npx_fails
+
+echo "PASS: create_release_dmg script modern path and legacy fallback behavior"

--- a/tests/test_create_release_dmg.sh
+++ b/tests/test_create_release_dmg.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/create_release_dmg.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: missing executable script $SCRIPT"
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+cat > "$TMPDIR/bin/create-dmg" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  if [ "${FAKE_MODE:-}" = "legacy" ]; then
+    echo "create-dmg 1.2.1"
+  else
+    echo "create-dmg 8.0.0"
+  fi
+  exit 0
+fi
+
+printf '%s\n' "$*" >> "$FAKE_LOG"
+
+if [ "${FAKE_MODE:-}" = "legacy" ]; then
+  for arg in "$@"; do
+    if [[ "$arg" == *.dmg ]]; then
+      mkdir -p "$(dirname "$arg")"
+      : > "$arg"
+      exit 0
+    fi
+  done
+  echo "fake legacy create-dmg did not receive an output .dmg argument" >&2
+  exit 1
+fi
+
+dest="${!#}"
+mkdir -p "$dest"
+: > "$dest/generated.dmg"
+EOF
+chmod +x "$TMPDIR/bin/create-dmg"
+
+APP_DIR="$TMPDIR/cmux.app"
+mkdir -p "$APP_DIR/Contents"
+
+run_case() {
+  local mode log_file output_path
+  mode="$1"
+  log_file="$TMPDIR/${mode}.log"
+  output_path="$TMPDIR/${mode}/cmux-macos.dmg"
+
+  PATH="$TMPDIR/bin:$PATH" FAKE_MODE="$mode" FAKE_LOG="$log_file" \
+    "$SCRIPT" "$APP_DIR" "$output_path" "SIGNING-ID"
+
+  if [ ! -f "$output_path" ]; then
+    echo "FAIL: ${mode} mode did not produce $output_path"
+    exit 1
+  fi
+
+  if [ "$mode" = "legacy" ]; then
+    grep -F -- "--app-drop-link 480 170" "$log_file" >/dev/null || {
+      echo "FAIL: legacy mode did not add Applications drop link"
+      exit 1
+    }
+    grep -F -- "--codesign SIGNING-ID" "$log_file" >/dev/null || {
+      echo "FAIL: legacy mode did not pass --codesign"
+      exit 1
+    }
+  else
+    grep -F -- "--overwrite" "$log_file" >/dev/null || {
+      echo "FAIL: modern mode did not pass --overwrite"
+      exit 1
+    }
+    grep -F -- "--identity=SIGNING-ID" "$log_file" >/dev/null || {
+      echo "FAIL: modern mode did not pass --identity"
+      exit 1
+    }
+  fi
+}
+
+run_case legacy
+run_case modern
+
+echo "PASS: create_release_dmg script handles legacy and modern create-dmg"


### PR DESCRIPTION
## Summary
- add `scripts/create_release_dmg.sh` to build release DMGs with both legacy and modern `create-dmg` CLIs
- ensure legacy `create-dmg` invocations include an explicit Applications drop link (`--app-drop-link`) so drag-to-install UI is present
- route release/nightly workflows and `scripts/build-sign-upload.sh` through the new wrapper
- add `tests/test_create_release_dmg.sh` regression coverage for legacy and modern CLI modes

## Testing
- `./tests/test_create_release_dmg.sh` (pass)
- `bash -n scripts/create_release_dmg.sh tests/test_create_release_dmg.sh scripts/build-sign-upload.sh` (pass)

## Related
- Task: User report (Image #1): "new cmux -dmg doesn't have drag to applications"
