### PR TITLE
Improve light mode support across browser and app chrome

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -330,7 +330,7 @@ struct TitlebarControlsView: View {
                     if notificationStore.unreadCount > 0 {
                         Text("\(min(notificationStore.unreadCount, 99))")
                             .font(.system(size: max(8, config.badgeSize - 5), weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(Color(nsColor: .alternateSelectedControlTextColor))
                             .frame(width: config.badgeSize, height: config.badgeSize)
                             .background(
                                 Circle().fill(Color.accentColor)

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -128,7 +128,7 @@ class UpdateViewModel: ObservableObject {
         case .idle:
             return .secondary
         case .permissionRequest:
-            return .white
+            return .accentColor
         case .checking:
             return .secondary
         case .updateAvailable:
@@ -145,11 +145,11 @@ class UpdateViewModel: ObservableObject {
     var backgroundColor: Color {
         switch effectiveState {
         case .permissionRequest:
-            return Color(nsColor: NSColor.systemBlue.blended(withFraction: 0.3, of: .black) ?? .systemBlue)
+            return Color(nsColor: .controlAccentColor).opacity(0.18)
         case .updateAvailable:
             return .accentColor
         case .notFound:
-            return Color(nsColor: NSColor.systemBlue.blended(withFraction: 0.5, of: .black) ?? .systemBlue)
+            return Color(nsColor: .controlAccentColor).opacity(0.14)
         case .error:
             return .orange.opacity(0.2)
         default:
@@ -160,11 +160,11 @@ class UpdateViewModel: ObservableObject {
     var foregroundColor: Color {
         switch effectiveState {
         case .permissionRequest:
-            return .white
+            return .primary
         case .updateAvailable:
             return .white
         case .notFound:
-            return .white
+            return .primary
         case .error:
             return .orange
         default:

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -180,14 +180,23 @@ struct EmptyPanelView: View {
 
     private struct ShortcutHint: View {
         let text: String
+        @Environment(\.colorScheme) private var colorScheme
+
+        private var textColor: Color {
+            Color.primary.opacity(colorScheme == .dark ? 0.90 : 0.86)
+        }
+
+        private var backgroundColor: Color {
+            Color.primary.opacity(colorScheme == .dark ? 0.18 : 0.10)
+        }
 
         var body: some View {
             Text(text)
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .foregroundStyle(.white.opacity(0.9))
+                .foregroundStyle(textColor)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
-                .background(.white.opacity(0.18), in: Capsule())
+                .background(backgroundColor, in: Capsule())
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2431,6 +2431,7 @@ enum ClaudeCodeIntegrationSettings {
 struct SettingsView: View {
     private let contentTopInset: CGFloat = 8
     private let pickerColumnWidth: CGFloat = 196
+    @Environment(\.colorScheme) private var colorScheme
 
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
@@ -2454,6 +2455,40 @@ struct SettingsView: View {
     @State private var showClearBrowserHistoryConfirmation = false
     @State private var browserHistoryEntryCount: Int = 0
     @State private var browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText
+
+    private var topMaskBaseColors: [Color] {
+        if colorScheme == .dark {
+            return [
+                Color.black.opacity(0.9),
+                Color.black.opacity(0.64),
+                Color.black.opacity(0.36),
+                Color.clear
+            ]
+        }
+        return [
+            Color.white.opacity(0.90),
+            Color.white.opacity(0.64),
+            Color.white.opacity(0.32),
+            Color.clear
+        ]
+    }
+
+    private var topMaskDynamicColors: [Color] {
+        if colorScheme == .dark {
+            return [
+                Color.black.opacity(0.98),
+                Color.black.opacity(0.78),
+                Color.black.opacity(0.42),
+                Color.clear
+            ]
+        }
+        return [
+            Color.white.opacity(0.98),
+            Color.white.opacity(0.78),
+            Color.white.opacity(0.42),
+            Color.clear
+        ]
+    }
 
     private var selectedWorkspacePlacement: NewWorkspacePlacement {
         NewWorkspacePlacement(rawValue: newWorkspacePlacement) ?? WorkspacePlacementSettings.defaultPlacement
@@ -2814,12 +2849,7 @@ struct SettingsView: View {
                 AboutVisualEffectBackground(material: .underWindowBackground, blendingMode: .withinWindow)
                     .mask(
                         LinearGradient(
-                            colors: [
-                                Color.black.opacity(0.9),
-                                Color.black.opacity(0.64),
-                                Color.black.opacity(0.36),
-                                Color.clear
-                            ],
+                            colors: topMaskBaseColors,
                             startPoint: .top,
                             endPoint: .bottom
                         )
@@ -2829,12 +2859,7 @@ struct SettingsView: View {
                 AboutVisualEffectBackground(material: .underWindowBackground, blendingMode: .withinWindow)
                     .mask(
                         LinearGradient(
-                            colors: [
-                                Color.black.opacity(0.98),
-                                Color.black.opacity(0.78),
-                                Color.black.opacity(0.42),
-                                Color.clear
-                            ],
+                            colors: topMaskDynamicColors,
                             startPoint: .top,
                             endPoint: .bottom
                         )


### PR DESCRIPTION
## Summary
- make browser UI chrome honor light mode (address bar and web fallback surfaces)
- make embedded `WKWebView` explicitly follow app color scheme (`aqua` in light mode, `darkAqua` in dark mode)
- ensure browser under-page background is light in light mode while preserving dark-mode behavior
- improve omnibar suggestions popup styling for light mode (text, badges, highlight, border, overlay, shadow)
- replace remaining hardcoded dark-only sidebar/titlebar/settings accents with appearance-aware colors

## Files
- `Sources/Panels/BrowserPanelView.swift`
- `Sources/Panels/BrowserPanel.swift`
- `Sources/ContentView.swift`
- `Sources/cmuxApp.swift`
- `Sources/Update/UpdateViewModel.swift`
- `Sources/Update/UpdateTitlebarAccessory.swift`
- `Sources/WorkspaceContentView.swift`

## Validation
- `./scripts/reload.sh --tag light-mode-browser`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
