### PR TITLE
Fix stuck split resize cursor outside divider range

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -49,7 +49,7 @@ final class WindowBrowserHostView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if window == nil {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: false)
         }
         window?.invalidateCursorRects(for: self)
     }
@@ -111,7 +111,7 @@ final class WindowBrowserHostView: NSView {
     }
 
     override func mouseExited(with event: NSEvent) {
-        clearActiveDividerCursor()
+        clearActiveDividerCursor(restoreArrow: true)
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -180,22 +180,25 @@ final class WindowBrowserHostView: NSView {
 
     private func updateDividerCursor(at point: NSPoint) {
         if shouldPassThroughToSidebarResizer(at: point) {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: false)
             return
         }
 
         guard let nextKind = splitDividerCursorKind(at: point) else {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: true)
             return
         }
         activeDividerCursorKind = nextKind
         nextKind.cursor.set()
     }
 
-    private func clearActiveDividerCursor() {
+    private func clearActiveDividerCursor(restoreArrow: Bool) {
         guard activeDividerCursorKind != nil else { return }
         window?.invalidateCursorRects(for: self)
         activeDividerCursorKind = nil
+        if restoreArrow {
+            NSCursor.arrow.set()
+        }
     }
 
     private func splitDividerCursorKind(at point: NSPoint) -> DividerCursorKind? {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -51,7 +51,7 @@ final class WindowTerminalHostView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if window == nil {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: false)
         }
         window?.invalidateCursorRects(for: self)
     }
@@ -113,7 +113,7 @@ final class WindowTerminalHostView: NSView {
     }
 
     override func mouseExited(with event: NSEvent) {
-        clearActiveDividerCursor()
+        clearActiveDividerCursor(restoreArrow: true)
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -212,22 +212,25 @@ final class WindowTerminalHostView: NSView {
 
     private func updateDividerCursor(at point: NSPoint) {
         if shouldPassThroughToSidebarResizer(at: point) {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: false)
             return
         }
 
         guard let nextKind = splitDividerCursorKind(at: point) else {
-            clearActiveDividerCursor()
+            clearActiveDividerCursor(restoreArrow: true)
             return
         }
         activeDividerCursorKind = nextKind
         nextKind.cursor.set()
     }
 
-    private func clearActiveDividerCursor() {
+    private func clearActiveDividerCursor(restoreArrow: Bool) {
         guard activeDividerCursorKind != nil else { return }
         window?.invalidateCursorRects(for: self)
         activeDividerCursorKind = nil
+        if restoreArrow {
+            NSCursor.arrow.set()
+        }
     }
 
     private func splitDividerCursorKind(at point: NSPoint) -> DividerCursorKind? {


### PR DESCRIPTION
## Summary
- fix split divider resize cursor sticking after leaving divider hit zone
- update portal host cursor clear path to restore arrow only when appropriate
- preserve sidebar resize cursor behavior while preventing split hover cursor leakage

## Verification
- ./scripts/reload.sh --tag fix-border-resize
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build