### PR TITLE
Use Shift+Enter as linebreak instead of submit

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -100,7 +100,7 @@ func browserOmnibarShouldSubmitOnReturn(flags: NSEvent.ModifierFlags) -> Bool {
     let normalizedFlags = flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function])
-    return normalizedFlags == [] || normalizedFlags == [.shift]
+    return normalizedFlags == []
 }
 
 enum BrowserZoomShortcutAction: Equatable {


### PR DESCRIPTION
## Summary
- Changed `browserOmnibarShouldSubmitOnReturn()` so that only plain Enter submits the omnibar
- Shift+Enter no longer triggers submit, allowing it to act as a linebreak instead

## Change
In `Sources/AppDelegate.swift`, removed `|| normalizedFlags == [.shift]` from the submit condition so Shift+Enter passes through as a linebreak rather than triggering navigation/submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)