### PR TITLE
Add tab color feature to sidebar workspaces

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -632,6 +632,11 @@ class TabManager: ObservableObject {
         setCustomTitle(tabId: tabId, title: nil)
     }
 
+    func setTabColor(tabId: UUID, color: String?) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        tab.setCustomColor(color)
+    }
+
     func togglePin(tabId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let tab = tabs[index]

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -243,6 +243,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var title: String
     @Published var customTitle: String?
     @Published var isPinned: Bool = false
+    @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var currentDirectory: String
 
     /// Ordinal for CMUX_PORT range assignment (monotonically increasing per app session)
@@ -753,6 +754,10 @@ final class Workspace: Identifiable, ObservableObject {
         processTitle = title
         guard customTitle == nil else { return }
         self.title = title
+    }
+
+    func setCustomColor(_ hex: String?) {
+        customColor = hex
     }
 
     func setCustomTitle(_ title: String?) {


### PR DESCRIPTION
## Summary

- Adds a **Tab Color** submenu to the sidebar workspace right-click context menu with 16 curated dark colors (all luminance < 0.30, ensuring white text remains readable in all themes)
- The primary motivation is working across multiple projects simultaneously — coloring tabs by project makes it instant to visually locate the right workspace without reading the title
- Active tab gets a subtle 1.5pt `Color.primary` border overlay so the selected tab remains clearly identifiable even when custom colors are set

## Implementation

- `Workspace`: adds `@Published var customColor: String?` and `setCustomColor()` setter
- `TabManager`: adds `setTabColor(tabId:color:)` convenience method
- `ContentView`: `Color(hex:)` extension, `coloredCircleImage(hex:)` helper (renders bitmapped `NSImage` circles — required because macOS menus strip SwiftUI `foregroundColor` from SF Symbols), updated `backgroundColor` computed var (full/70%/35% opacity for active/inactive/multi-selected), "Tab Color" context menu submenu with "Clear Color" option