### PR TITLE
Add contributor credits to release skills

### DIFF
--- a/.claude/commands/release-local.md
+++ b/.claude/commands/release-local.md
@@ -9,19 +9,29 @@ Full end-to-end release built locally. Bumps version, updates changelog, tags, t
 - Get the current version from `GhosttyTabs.xcodeproj/project.pbxproj` (look for `MARKETING_VERSION`)
 - Bump the minor version unless the user specifies otherwise (e.g., 0.54.0 → 0.55.0)
 
-### 2. Gather changes since the last release
+### 2. Gather changes and contributors since the last release
 
 - Find the most recent git tag: `git describe --tags --abbrev=0`
 - Get commits since that tag: `git log --oneline <last-tag>..HEAD --no-merges`
 - **Filter for end-user visible changes only** — ignore developer tooling, CI, docs, tests
 - Categorize changes into: Added, Changed, Fixed, Removed
 - If there are no user-facing changes, ask the user if they still want to release
+- **Collect contributors:** For each PR referenced in the commits, get the author:
+  ```bash
+  gh pr view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+  ```
+- Also check for linked issue reporters (the person who filed the bug):
+  ```bash
+  gh issue view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+  ```
+- Build a deduplicated list of all contributor `@handle`s for the release
 
 ### 3. Update the changelog
 
 - Add a new section at the top of `CHANGELOG.md` with the new version and today's date
 - **Only include changes that affect the end-user experience**
 - Write clear, user-facing descriptions (not raw commit messages)
+- **Credit contributors inline** (see Contributor Credits below)
 - Also update `docs-site/content/docs/changelog.mdx` if it exists
 
 ### 4. Bump the version
@@ -72,3 +82,25 @@ If the script fails, run `say "cmux release failed"`.
 - Group by category: Added, Changed, Fixed, Removed
 - Be concise but descriptive
 - Focus on what the user experiences, not how it was implemented
+
+## Contributor Credits
+
+Credit the people who made each release happen. This builds community and encourages contributions.
+
+**Per-entry attribution** — append contributor credit after each changelog bullet:
+- For code contributions (PR author): `— thanks @user!`
+- For bug reports (issue reporter, if different from PR author): `— thanks @reporter for the report!`
+- Core team (`lawrencecchen`, `austinywang`) contributions get no per-entry callout — core work is the baseline
+
+**Summary section** — add a "Thanks to N contributors!" section at the bottom of each release:
+```markdown
+### Thanks to N contributors!
+
+- [@user1](https://github.com/user1)
+- [@user2](https://github.com/user2)
+```
+- List all contributors alphabetically by GitHub handle (including core team)
+- Link each handle to their GitHub profile
+- Include everyone: PR authors, issue reporters, anyone whose work is in the release
+
+**GitHub Release body** — when the release is published, the GitHub Release should also include the "Thanks to N contributors!" section with linked handles.

--- a/.claude/commands/release-nightly.md
+++ b/.claude/commands/release-nightly.md
@@ -13,16 +13,26 @@ End-to-end release via PR flow: bump version, update changelog, create PR, merge
 2. **Create a release branch**
    - Create branch: `git checkout -b release/vX.Y.Z`
 
-3. **Gather changes since the last release**
+3. **Gather changes and contributors since the last release**
    - Find the most recent git tag: `git describe --tags --abbrev=0`
    - Get commits since that tag: `git log --oneline <last-tag>..HEAD --no-merges`
    - **Filter for end-user visible changes only** - ignore developer tooling, CI, docs, tests
    - Categorize changes into: Added, Changed, Fixed, Removed
+   - **Collect contributors:** For each PR referenced in the commits, get the author:
+     ```bash
+     gh pr view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+     ```
+   - Also check for linked issue reporters (the person who filed the bug):
+     ```bash
+     gh issue view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+     ```
+   - Build a deduplicated list of all contributor `@handle`s for the release
 
 4. **Update the changelog**
    - Add a new section at the top of `CHANGELOG.md` with the new version and today's date
    - **Only include changes that affect the end-user experience**
    - Write clear, user-facing descriptions (not raw commit messages)
+   - **Credit contributors inline** (see Contributor Credits below)
    - Also update `docs-site/content/docs/changelog.mdx` if it exists
    - If there are no user-facing changes, ask the user if they still want to release
 
@@ -73,3 +83,25 @@ If the script fails, run `say "cmux release failed"`.
 - Test additions or fixes
 - Internal refactoring with no user-visible effect
 - Dependency updates (unless they fix a user-facing bug)
+
+## Contributor Credits
+
+Credit the people who made each release happen. This builds community and encourages contributions.
+
+**Per-entry attribution** — append contributor credit after each changelog bullet:
+- For code contributions (PR author): `— thanks @user!`
+- For bug reports (issue reporter, if different from PR author): `— thanks @reporter for the report!`
+- Core team (`lawrencecchen`, `austinywang`) contributions get no per-entry callout — core work is the baseline
+
+**Summary section** — add a "Thanks to N contributors!" section at the bottom of each release:
+```markdown
+### Thanks to N contributors!
+
+- [@user1](https://github.com/user1)
+- [@user2](https://github.com/user2)
+```
+- List all contributors alphabetically by GitHub handle (including core team)
+- Link each handle to their GitHub profile
+- Include everyone: PR authors, issue reporters, anyone whose work is in the release
+
+**GitHub Release body** — when the release is published, the GitHub Release should also include the "Thanks to N contributors!" section with linked handles.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -11,16 +11,26 @@ Prepare a new release for cmux. This command updates the changelog, bumps the ve
 2. **Create a release branch**
    - Create branch: `git checkout -b release/vX.Y.Z`
 
-3. **Gather changes since the last release**
+3. **Gather changes and contributors since the last release**
    - Find the most recent git tag: `git describe --tags --abbrev=0`
    - Get commits since that tag: `git log --oneline <last-tag>..HEAD --no-merges`
    - **Filter for end-user visible changes only** - ignore developer tooling, CI, docs, tests
    - Categorize changes into: Added, Changed, Fixed, Removed
+   - **Collect contributors:** For each PR referenced in the commits, get the author:
+     ```bash
+     gh pr view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+     ```
+   - Also check for linked issue reporters (the person who filed the bug):
+     ```bash
+     gh issue view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'
+     ```
+   - Build a deduplicated list of all contributor `@handle`s for the release
 
 4. **Update the changelog**
    - Add a new section at the top of `CHANGELOG.md` with the new version and today's date
    - **Only include changes that affect the end-user experience** - things users will see, feel, or interact with
    - Write clear, user-facing descriptions (not raw commit messages)
+   - **Credit contributors inline** (see Contributor Credits below)
    - Also update `docs-site/content/docs/changelog.mdx` with the same content
    - If there are no user-facing changes, ask the user if they still want to release
 
@@ -89,18 +99,47 @@ Prepare a new release for cmux. This command updates the changelog, bumps the ve
 - Focus on what the user experiences, not how it was implemented
 - Link to issues/PRs if relevant
 
+## Contributor Credits
+
+Credit the people who made each release happen. This builds community and encourages contributions.
+
+**Per-entry attribution** — append contributor credit after each changelog bullet:
+- For code contributions (PR author): `— thanks @user!`
+- For bug reports (issue reporter, if different from PR author): `— thanks @reporter for the report!`
+- Core team (`lawrencecchen`, `austinywang`) contributions get no per-entry callout — core work is the baseline
+
+**Summary section** — add a "Thanks to N contributors!" section at the bottom of each release:
+```markdown
+### Thanks to N contributors!
+
+- [@user1](https://github.com/user1)
+- [@user2](https://github.com/user2)
+```
+- List all contributors alphabetically by GitHub handle (including core team)
+- Link each handle to their GitHub profile
+- Include everyone: PR authors, issue reporters, anyone whose work is in the release
+
+**GitHub Release body** — when the release is published, the GitHub Release should also include the "Thanks to N contributors!" section with linked handles.
+
 ## Example Changelog Entry
 
 ```markdown
 ## [0.13.0] - 2025-01-30
 
 ### Added
-- New keyboard shortcut for quick tab switching
+- New keyboard shortcut for quick tab switching ([#42](https://github.com/manaflow-ai/cmux/pull/42)) — thanks @contributor!
 
 ### Fixed
-- Memory leak when closing split panes
-- Notification badges not clearing properly
+- Memory leak when closing split panes ([#38](https://github.com/manaflow-ai/cmux/pull/38)) — thanks @fixer!
+- Notification badges not clearing properly ([#35](https://github.com/manaflow-ai/cmux/pull/35)) — thanks @reporter for the report!
 
 ### Changed
-- Improved terminal rendering performance
+- Improved terminal rendering performance ([#40](https://github.com/manaflow-ai/cmux/pull/40))
+
+### Thanks to 4 contributors!
+
+- [@contributor](https://github.com/contributor)
+- [@fixer](https://github.com/fixer)
+- [@lawrencechen](https://github.com/lawrencechen)
+- [@reporter](https://github.com/reporter)
 ```

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -16,15 +16,18 @@ Run this workflow to prepare and publish a cmux release.
 2. Create a release branch:
 - `git checkout -b release/vX.Y.Z`
 
-3. Gather user-facing changes since the last tag:
+3. Gather user-facing changes and contributors since the last tag:
 - `git describe --tags --abbrev=0`
 - `git log --oneline <last-tag>..HEAD --no-merges`
 - Keep only end-user visible changes (features, bug fixes, UX/perf behavior).
+- **Collect contributors:** For each PR, get the author with `gh pr view <N> --repo manaflow-ai/cmux --json author --jq '.author.login'`. Also check linked issue reporters with `gh issue view <N> --json author --jq '.author.login'`.
+- Build a deduplicated list of all contributor `@handle`s.
 
 4. Update changelogs:
 - Update `CHANGELOG.md`.
 - Update `docs-site/content/docs/changelog.mdx`.
 - Use categories `Added`, `Changed`, `Fixed`, `Removed`.
+- **Credit contributors inline** (see Contributor Credits below).
 - If no user-facing changes exist, confirm with the user before continuing.
 
 5. Bump app version metadata:
@@ -63,3 +66,11 @@ Run this workflow to prepare and publish a cmux release.
 - Include only user-visible changes.
 - Exclude internal-only changes (CI, tests, docs-only edits, refactors without behavior changes).
 - Write concise user-facing bullets in present tense.
+
+## Contributor Credits
+
+Credit the people who made each release happen:
+
+- **Per-entry:** Append `— thanks @user!` for community code contributions. Use `— thanks @user for the report!` for bug reporters (when different from PR author). No callout for core team (`lawrencecchen`, `austinywang`) — core work is the baseline.
+- **Summary:** Add a `### Thanks to N contributors!` section at the bottom of each release with an alphabetical list of all `[@handle](https://github.com/handle)` links (including core team).
+- **GitHub Release body:** Include the same "Thanks to N contributors!" section with linked handles.


### PR DESCRIPTION
## Summary

- Release changelogs now credit contributors inline, inspired by [Bun's approach](https://bun.sh/blog)
- Per-entry `— thanks @user!` for community code contributions
- Per-entry `— thanks @user for the report!` for bug reporters
- `### Thanks to N contributors!` summary section at bottom of each release with linked GitHub handles
- Core team (`lawrencecchen`, `austinywang`) excluded from per-entry callouts — core work is the baseline, community contributions get the spotlight

Updates all four release skill files:
- `.claude/commands/release.md`
- `.claude/commands/release-local.md`
- `.claude/commands/release-nightly.md`
- `skills/release/SKILL.md`

## Test plan

- [ ] Run `/release` on the next release and verify contributor credits appear in the changelog
- [ ] Verify community contributors get per-entry callouts
- [ ] Verify core team members do not get per-entry callouts
- [ ] Verify the "Thanks to N contributors!" summary section is generated