### PR TITLE
Fix changelog page links rendering as raw text

### DIFF
--- a/web/app/docs/changelog/page.tsx
+++ b/web/app/docs/changelog/page.tsx
@@ -75,17 +75,24 @@ function parseChangelog(markdown: string): ChangelogVersion[] {
   return versions;
 }
 
-function InlineCode({ text }: { text: string }) {
-  const parts = text.split(/(`[^`]+`)/g);
+function InlineMarkdown({ text }: { text: string }) {
+  const parts = text.split(/(`[^`]+`|\[[^\]]+\]\([^)]+\))/g);
   return (
     <>
-      {parts.map((part, i) =>
-        part.startsWith("`") && part.endsWith("`") ? (
-          <code key={i}>{part.slice(1, -1)}</code>
-        ) : (
-          <span key={i}>{part}</span>
-        )
-      )}
+      {parts.map((part, i) => {
+        if (part.startsWith("`") && part.endsWith("`")) {
+          return <code key={i}>{part.slice(1, -1)}</code>;
+        }
+        const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+        if (linkMatch) {
+          return (
+            <a key={i} href={linkMatch[2]}>
+              {linkMatch[1]}
+            </a>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
     </>
   );
 }
@@ -115,7 +122,7 @@ export default function ChangelogPage() {
               <ul>
                 {section.items.map((item, j) => (
                   <li key={j}>
-                    <InlineCode text={item} />
+                    <InlineMarkdown text={item} />
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- The `InlineCode` component in `web/app/docs/changelog/page.tsx` only handled backtick code spans but ignored markdown links `[text](url)`
- PR/issue references like `[#225](https://github.com/manaflow-ai/cmux/pull/225)` were displayed as raw text instead of clickable `<a>` tags
- Renamed component to `InlineMarkdown` and extended the split regex to also capture markdown link syntax

## Testing
- Verified the regex correctly splits on both `` `code` `` and `[text](url)` patterns
- Links in the 0.60.0 changelog (and all other versions) will now render as clickable `<a>` elements

## Related
- Task: https://www.cmux.dev/docs/changelog — fix broken links