### PR TITLE
Fix terminal find overlay retain cycle

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3426,11 +3426,20 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
+        let tabId = terminalSurface.tabId
+        let surfaceId = terminalSurface.id
         let rootView = SurfaceSearchOverlay(
-            surface: terminalSurface,
+            tabId: tabId,
+            surfaceId: surfaceId,
             searchState: searchState,
-            onClose: { [weak self] in
-                self?.surfaceView.terminalSurface?.searchState = nil
+            onMoveFocusToTerminal: { [weak self] in
+                self?.moveFocus()
+            },
+            onNavigateSearch: { [weak terminalSurface] action in
+                _ = terminalSurface?.performBindingAction(action)
+            },
+            onClose: { [weak self, weak terminalSurface] in
+                terminalSurface?.searchState = nil
                 self?.moveFocus()
             }
         )

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -3275,6 +3275,27 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         XCTAssertFalse(hostedView.debugHasSearchOverlay())
     }
 
+    func testSearchOverlayMountDoesNotRetainTerminalSurface() {
+        weak var weakSurface: TerminalSurface?
+
+        let hostedView: GhosttySurfaceScrollView = {
+            let surface = TerminalSurface(
+                tabId: UUID(),
+                context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+                configTemplate: nil,
+                workingDirectory: nil
+            )
+            weakSurface = surface
+            let hostedView = surface.hostedView
+            hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "retain-check"))
+            return hostedView
+        }()
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        XCTAssertTrue(hostedView.debugHasSearchOverlay())
+        XCTAssertNil(weakSurface, "Mounted search overlay must not retain TerminalSurface")
+    }
+
     func testSearchOverlaySurvivesPortalRebindDuringSplitLikeChurn() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),


### PR DESCRIPTION
## Summary
- break the retain cycle between `TerminalSurface` and mounted terminal find overlay
- stop `SurfaceSearchOverlay` from strongly owning `TerminalSurface`; it now receives IDs plus callback closures
- wire overlay callbacks from `GhosttySurfaceScrollView.setSearchOverlay` using weak captures for `TerminalSurface`
- add a regression test that verifies mounting the overlay does not retain and leak `TerminalSurface`

## Why
A mounted search overlay previously retained `TerminalSurface` via:
`TerminalSurface -> hostedView -> searchOverlayHostingView -> SurfaceSearchOverlay -> TerminalSurface`

That could leak ghostty surfaces when a panel/workspace was closed while find was active.

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttySurfaceOverlayTests test`
