### PR TITLE
Fix theme toggle tracking system preference instead of selected theme

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #fafafa;
   --foreground: #171717;


### PR DESCRIPTION
## Summary
- Tailwind v4 defaults `dark:` utilities to `@media (prefers-color-scheme: dark)`, which means the theme toggle icons (`dark:block` / `dark:hidden`) always tracked the OS dark mode setting rather than the explicitly selected theme
- Added `@custom-variant dark (&:where(.dark, .dark *));` to align Tailwind's `dark:` modifier with the `next-themes` class-based strategy (`attribute="class"`)

## Testing
- `next build` passes
- Toggle sun/moon icons now respond to the `.dark` class on `<html>` (set by next-themes) rather than the OS preference
- Verify on the Vercel preview: toggle the theme button in the site header and confirm the icon flips

## Related
- Fixes https://github.com/manaflow-ai/cmux/issues/325