### PR TITLE
Settings: move Workspace Color Indicator into Workspace Colors

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2761,10 +2761,12 @@ struct SettingsView: View {
                             .pickerStyle(.menu)
                         }
 
-                        SettingsCardDivider()
+                    }
 
+                    SettingsSectionHeader(title: "Workspace Colors")
+                    SettingsCard {
                         SettingsCardRow(
-                            "Active Workspace Indicator",
+                            "Workspace Color Indicator",
                             controlWidth: pickerColumnWidth
                         ) {
                             Picker("", selection: sidebarIndicatorStyleSelection) {
@@ -2775,10 +2777,9 @@ struct SettingsView: View {
                             .labelsHidden()
                             .pickerStyle(.menu)
                         }
-                    }
 
-                    SettingsSectionHeader(title: "Workspace Colors")
-                    SettingsCard {
+                        SettingsCardDivider()
+
                         SettingsCardNote("Customize the workspace color palette used by Sidebar > Tab Color. \"Choose Custom Color...\" entries are persisted below.")
 
                         ForEach(Array(workspaceTabDefaultEntries.enumerated()), id: \.element.name) { index, entry in


### PR DESCRIPTION
## Summary
- rename settings label from "Active Workspace Indicator" to "Workspace Color Indicator"
- move the indicator style picker from the "App" section to the "Workspace Colors" section
- keep existing indicator style behavior unchanged

## Validation
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build