### PR TITLE
Default workspace color indicator to left rail

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -81,7 +81,7 @@ enum SidebarActiveTabIndicatorStyle: String, CaseIterable, Identifiable {
 
 enum SidebarActiveTabIndicatorSettings {
     static let styleKey = "sidebarActiveTabIndicatorStyle"
-    static let defaultStyle: SidebarActiveTabIndicatorStyle = .solidFill
+    static let defaultStyle: SidebarActiveTabIndicatorStyle = .leftRail
 
     static func resolvedStyle(rawValue: String?) -> SidebarActiveTabIndicatorStyle {
         guard let rawValue else { return defaultStyle }

--- a/tests/test_sidebar_indicator_default.py
+++ b/tests/test_sidebar_indicator_default.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Regression test for the default sidebar active workspace indicator style.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    tab_manager = repo_root / "Sources" / "TabManager.swift"
+
+    if not tab_manager.exists():
+        print(f"FAIL: Missing file {tab_manager}")
+        return 1
+
+    content = tab_manager.read_text(encoding="utf-8")
+    pattern = r"static let defaultStyle:\s*SidebarActiveTabIndicatorStyle\s*=\s*\.leftRail\b"
+
+    if re.search(pattern, content) is None:
+        rel = tab_manager.relative_to(repo_root)
+        print(f"FAIL: Expected default style `.leftRail` in {rel}")
+        return 1
+
+    print("PASS: sidebar indicator default style is left rail")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- change the default sidebar active workspace indicator style to Left Rail
- add a regression test script that fails if `SidebarActiveTabIndicatorSettings.defaultStyle` stops being `.leftRail`

## Testing
- `python3 tests/test_sidebar_indicator_default.py` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `./scripts/reload.sh --tag default-indicator-left-rail` (pass)

## Related
- Task: ensure default workspace color indicator is left rail
