### PR TITLE
Fix split zoom portal visibility with alpha-hidden pane trees

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -20,6 +20,17 @@ private func browserPortalDebugFrame(_ rect: NSRect) -> String {
 }
 #endif
 
+private func browserPortalIsEffectivelyHidden(_ view: NSView) -> Bool {
+    var node: NSView? = view
+    while let current = node {
+        if current.isHidden || current.alphaValue <= 0.001 {
+            return true
+        }
+        node = current.superview
+    }
+    return false
+}
+
 final class WindowBrowserHostView: NSView {
     private struct DividerRegion {
         let rectInWindow: NSRect
@@ -213,7 +224,7 @@ final class WindowBrowserHostView: NSView {
     }
 
     private static func dividerCursorKind(at windowPoint: NSPoint, in view: NSView) -> DividerCursorKind? {
-        guard !view.isHidden else { return nil }
+        guard !browserPortalIsEffectivelyHidden(view) else { return nil }
 
         if let splitView = view as? NSSplitView {
             let pointInSplit = splitView.convert(windowPoint, from: nil)
@@ -266,7 +277,7 @@ final class WindowBrowserHostView: NSView {
     }
 
     private static func collectSplitDividerRegions(in view: NSView, into result: inout [DividerRegion]) {
-        guard !view.isHidden else { return }
+        guard !browserPortalIsEffectivelyHidden(view) else { return }
 
         if let splitView = view as? NSSplitView {
             let dividerCount = max(0, splitView.arrangedSubviews.count - 1)
@@ -410,13 +421,7 @@ final class WindowBrowserPortal: NSObject {
     }
 
     private static func isHiddenOrAncestorHidden(_ view: NSView) -> Bool {
-        if view.isHidden { return true }
-        var current = view.superview
-        while let v = current {
-            if v.isHidden { return true }
-            current = v.superview
-        }
-        return false
+        browserPortalIsEffectivelyHidden(view)
     }
 
     private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.5) -> Bool {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -19,6 +19,17 @@ private func portalDebugFrame(_ rect: NSRect) -> String {
 }
 #endif
 
+private func terminalPortalIsEffectivelyHidden(_ view: NSView) -> Bool {
+    var node: NSView? = view
+    while let current = node {
+        if current.isHidden || current.alphaValue <= 0.001 {
+            return true
+        }
+        node = current.superview
+    }
+    return false
+}
+
 final class WindowTerminalHostView: NSView {
     private struct DividerRegion {
         let rectInWindow: NSRect
@@ -245,7 +256,7 @@ final class WindowTerminalHostView: NSView {
     }
 
     private static func dividerCursorKind(at windowPoint: NSPoint, in view: NSView) -> DividerCursorKind? {
-        guard !view.isHidden else { return nil }
+        guard !terminalPortalIsEffectivelyHidden(view) else { return nil }
 
         if let splitView = view as? NSSplitView {
             let pointInSplit = splitView.convert(windowPoint, from: nil)
@@ -300,7 +311,7 @@ final class WindowTerminalHostView: NSView {
     }
 
     private static func collectSplitDividerRegions(in view: NSView, into result: inout [DividerRegion]) {
-        guard !view.isHidden else { return }
+        guard !terminalPortalIsEffectivelyHidden(view) else { return }
 
         if let splitView = view as? NSSplitView {
             let dividerCount = max(0, splitView.arrangedSubviews.count - 1)
@@ -436,7 +447,7 @@ private final class SplitDividerOverlayView: NSView {
     }
 
     private func collectDividerSegments(in view: NSView, into result: inout [DividerSegment]) {
-        guard !view.isHidden else { return }
+        guard !terminalPortalIsEffectivelyHidden(view) else { return }
 
         if let splitView = view as? NSSplitView {
             let dividerCount = max(0, splitView.arrangedSubviews.count - 1)
@@ -625,13 +636,7 @@ final class WindowTerminalPortal: NSObject {
     }
 
     private static func isHiddenOrAncestorHidden(_ view: NSView) -> Bool {
-        if view.isHidden { return true }
-        var current = view.superview
-        while let v = current {
-            if v.isHidden { return true }
-            current = v.superview
-        }
-        return false
+        terminalPortalIsEffectivelyHidden(view)
     }
 
     private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.5) -> Bool {


### PR DESCRIPTION
## Summary
Fixes split-zoom regressions where browser panes could appear behind terminal panes and hidden split dividers could still be detected/rendered.

## Root cause
During zoom, Bonsplit keeps a background split tree mounted with `opacity(0)` for state propagation. Portal and divider traversal logic only checked `isHidden`, so alpha-hidden ancestors were still treated as visible.

## Changes
- `Sources/TerminalWindowPortal.swift`
  - Added `terminalPortalIsEffectivelyHidden(_:)` (checks `isHidden` or `alphaValue <= 0.001` through ancestors).
  - Reused it in divider hit-testing/collection and anchor-hidden checks.
- `Sources/BrowserWindowPortal.swift`
  - Added `browserPortalIsEffectivelyHidden(_:)` with same semantics.
  - Reused it in divider hit-testing/collection and anchor-hidden checks.

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -destination 'platform=macOS' build`
- `./scripts/reloadp.sh`
- Manual verification on macOS: split zoom with terminal/browser panes no longer shows stale portal content from non-zoom panes and divider artifacts are suppressed in zoom mode.

## Scope
- No behavior changes outside portal visibility/hit-testing for effectively hidden pane hierarchies.
