### PR TITLE
Ensure browser omnibar uses squircle styling

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -194,7 +194,9 @@ struct BrowserPanelView: View {
     @State private var omnibarPillFrame: CGRect = .zero
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     @State private var isBrowserThemeMenuPresented = false
-    private let omnibarPillCornerRadius: CGFloat = 12
+    // Keep this below half of the compact omnibar height so it reads as a squircle,
+    // not a capsule.
+    private let omnibarPillCornerRadius: CGFloat = 10
     private let addressBarButtonSize: CGFloat = 22
     private let addressBarButtonHitSize: CGFloat = 26
     private let addressBarVerticalPadding: CGFloat = 4

--- a/tests/test_browser_omnibar_compact_layout_regression.py
+++ b/tests/test_browser_omnibar_compact_layout_regression.py
@@ -71,9 +71,25 @@ def main() -> int:
             f"addressBarVerticalPadding regressed to {vertical_padding:g}; expected <= 4 for compact omnibar height"
         )
 
+    omnibar_corner_radius = parse_cgfloat_constant(view_source, "omnibarPillCornerRadius")
+    if omnibar_corner_radius is None:
+        failures.append("omnibarPillCornerRadius constant is missing")
+    elif omnibar_corner_radius > 10:
+        failures.append(
+            f"omnibarPillCornerRadius regressed to {omnibar_corner_radius:g}; expected <= 10 to keep a squircle profile"
+        )
+
     address_bar_block = extract_block(view_source, "private var addressBar: some View")
     if ".padding(.vertical, addressBarVerticalPadding)" not in address_bar_block:
         failures.append("addressBar no longer applies compact vertical padding via addressBarVerticalPadding")
+
+    omnibar_field_block = extract_block(view_source, "private var omnibarField: some View")
+    if omnibar_field_block.count(
+        "RoundedRectangle(cornerRadius: omnibarPillCornerRadius, style: .continuous)"
+    ) < 2:
+        failures.append(
+            "omnibarField no longer uses continuous rounded-rectangle background+stroke tied to omnibarPillCornerRadius"
+        )
 
     button_bar_block = extract_block(view_source, "private var addressBarButtonBar: some View")
     hit_frame_uses = button_bar_block.count("addressBarButtonHitSize")


### PR DESCRIPTION
## Summary
- reduce browser omnibar pill corner radius to keep a squircle profile in compact chrome
- add static regression checks for omnibar squircle corner radius and continuous rounded styling usage

## Testing
- `python3 tests/test_browser_omnibar_compact_layout_regression.py` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)

## Related
- Task: ensure browser omnibar is a squircle
