### PR TITLE
Follow-up PR331: sync settings fallback and non-focus split intent

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -153,6 +153,10 @@ enum BrowserLinkOpenSettings {
         return defaultInterceptTerminalOpenCommandInCmuxBrowser
     }
 
+    static func initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: UserDefaults = .standard) -> Bool {
+        interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+    }
+
     static func hostWhitelist(defaults: UserDefaults = .standard) -> [String] {
         let raw = defaults.string(forKey: browserHostWhitelistKey) ?? defaultBrowserHostWhitelist
         return raw

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2560,7 +2560,7 @@ struct SettingsView: View {
     @AppStorage(BrowserThemeSettings.modeKey) private var browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
     @AppStorage(BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey) private var openTerminalLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenTerminalLinksInCmuxBrowser
     @AppStorage(BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
-    private var interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser
+    private var interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue()
     @AppStorage(BrowserLinkOpenSettings.browserHostWhitelistKey) private var browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
     @AppStorage(BrowserInsecureHTTPSettings.allowlistKey) private var browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1987,6 +1987,35 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testBrowserSplitWithFocusFalseAllowsSubsequentExplicitFocusOnSplitPanel() {
+        let workspace = Workspace()
+        guard let originalFocusedPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial focused panel")
+            return
+        }
+
+        guard let browserSplitPanel = workspace.newBrowserSplit(
+            from: originalFocusedPanelId,
+            orientation: .horizontal,
+            focus: false
+        ) else {
+            XCTFail("Expected browser split panel to be created")
+            return
+        }
+
+        workspace.focusPanel(browserSplitPanel.id)
+
+        drainMainQueue()
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(
+            workspace.focusedPanelId,
+            browserSplitPanel.id,
+            "Expected explicit focus intent to keep the split panel focused"
+        )
+    }
+
     func testClosingFocusedSplitRestoresBranchForRemainingFocusedPanel() {
         let workspace = Workspace()
         guard let firstPanelId = workspace.focusedPanelId else {
@@ -4346,6 +4375,14 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
 
         defaults.set(true, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
         XCTAssertTrue(BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults))
+    }
+
+    func testSettingsInitialOpenCommandInterceptionValueFallsBackToLegacyLinkToggleWhenUnset() {
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        XCTAssertFalse(BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: defaults))
+
+        defaults.set(true, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        XCTAssertTrue(BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: defaults))
     }
 }
 


### PR DESCRIPTION
## Summary
- Initialize the Settings `browserInterceptTerminalOpenCommandInCmuxBrowser` toggle from a legacy-aware fallback value so upgraded installs reflect runtime behavior immediately.
- Cancel pending non-focus split reassertion when explicit focus intent targets the new split panel, preventing delayed focus steal.
- Add focused regressions for both behaviors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testBrowserSplitWithFocusFalsePreservesOriginalFocusedPanel -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testBrowserSplitWithFocusFalseRecoversFromDelayedStaleSelection -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testBrowserSplitWithFocusFalseAllowsSubsequentExplicitFocusOnSplitPanel -only-testing:cmuxTests/BrowserLinkOpenSettingsTests/testOpenCommandInterceptionFallsBackToLegacyLinkToggleWhenUnset -only-testing:cmuxTests/BrowserLinkOpenSettingsTests/testSettingsInitialOpenCommandInterceptionValueFallsBackToLegacyLinkToggleWhenUnset test` (passed)

## Related
- Task: https://github.com/manaflow-ai/cmux/pull/331
