### PR TITLE
feat: tmux-style pane maximize toggle via resize-pane -Z

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3445,10 +3445,20 @@ struct CMUXCLI {
             """
         case "resize-pane":
             return """
-            Usage: cmux resize-pane --pane <id|ref> [--workspace <id|ref>] (-L|-R|-U|-D) [--amount <n>]
+            Usage: cmux resize-pane --pane <id|ref> [--workspace <id|ref>] (-L|-R|-U|-D|-Z) [--amount <n>]
 
-            tmux-compatible pane resize command.
-            Note: currently returns not_supported until programmable divider resize is implemented.
+            tmux-compatible pane resize/zoom command.
+
+            Flags:
+              --pane <id|ref>        Target pane (default: focused pane)
+              --workspace <id|ref>   Target workspace (default: current workspace)
+              -L|-R|-U|-D            Resize pane left/right/up/down
+              -Z                     Toggle pane zoom (tmux maximize/restore)
+              --amount <n>           Resize amount for -L|-R|-U|-D (default: 1)
+
+            Example:
+              cmux resize-pane --pane pane:2 -R --amount 20
+              cmux resize-pane --pane pane:2 -Z
             """
         case "pipe-pane":
             return """
@@ -3945,17 +3955,44 @@ struct CMUXCLI {
         case "resize-pane":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
             let paneArg = optionValue(commandArgs, name: "--pane")
+            let hasZoomToggle = commandArgs.contains("-Z")
+            let directionFlags = ["-L", "-R", "-U", "-D"].filter { commandArgs.contains($0) }
             let amountArg = optionValue(commandArgs, name: "--amount")
+            if hasZoomToggle {
+                if !directionFlags.isEmpty || amountArg != nil {
+                    throw CLIError(message: "resize-pane: -Z cannot be combined with directional flags or --amount")
+                }
+
+                var params: [String: Any] = [:]
+                let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+                if let wsId { params["workspace_id"] = wsId }
+                let paneId = try normalizePaneHandle(paneArg, client: client, workspaceHandle: wsId, allowFocused: true)
+                if let paneId { params["pane_id"] = paneId }
+                let payload = try client.sendV2(method: "pane.zoom", params: params)
+                printV2Payload(
+                    payload,
+                    jsonOutput: jsonOutput,
+                    idFormat: idFormat,
+                    fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["pane"])
+                )
+                return
+            }
+
+            if directionFlags.count > 1 {
+                throw CLIError(message: "resize-pane: specify only one of -L|-R|-U|-D")
+            }
             let amount = Int(amountArg ?? "1") ?? 1
             if amount <= 0 {
                 throw CLIError(message: "--amount must be greater than 0")
             }
 
             let direction: String = {
-                if commandArgs.contains("-L") { return "left" }
-                if commandArgs.contains("-R") { return "right" }
-                if commandArgs.contains("-U") { return "up" }
-                if commandArgs.contains("-D") { return "down" }
+                if let flag = directionFlags.first {
+                    if flag == "-L" { return "left" }
+                    if flag == "-R" { return "right" }
+                    if flag == "-U" { return "up" }
+                    if flag == "-D" { return "down" }
+                }
                 return "right"
             }()
 
@@ -4979,7 +5016,7 @@ struct CMUXCLI {
 
           # tmux compatibility commands
           capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
-          resize-pane --pane <id|ref> [--workspace <id|ref>] (-L|-R|-U|-D) [--amount <n>]
+          resize-pane --pane <id|ref> [--workspace <id|ref>] (-L|-R|-U|-D|-Z) [--amount <n>]
           pipe-pane --command <shell-command> [--workspace <id|ref>] [--surface <id|ref>]
           wait-for [-S|--signal] <name> [--timeout <seconds>]
           swap-pane --pane <id|ref> --target-pane <id|ref> [--workspace <id|ref>]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1069,6 +1069,8 @@ class TerminalController {
             return v2Result(id: id, self.v2PaneCreate(params: params))
         case "pane.resize":
             return v2Result(id: id, self.v2PaneResize(params: params))
+        case "pane.zoom":
+            return v2Result(id: id, self.v2PaneZoom(params: params))
         case "pane.swap":
             return v2Result(id: id, self.v2PaneSwap(params: params))
         case "pane.break":
@@ -1373,6 +1375,7 @@ class TerminalController {
             "pane.surfaces",
             "pane.create",
             "pane.resize",
+            "pane.zoom",
             "pane.swap",
             "pane.break",
             "pane.join",
@@ -3704,6 +3707,49 @@ class TerminalController {
                 "surface_id": newPanelId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: newPanelId),
                 "type": panelType.rawValue
+            ])
+        }
+        return result
+    }
+
+    private func v2PaneZoom(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to toggle pane zoom", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let paneUUID = v2UUID(params, "pane_id") ?? ws.bonsplitController.focusedPaneId?.id
+            guard let paneUUID else {
+                result = .err(code: "not_found", message: "No focused pane", data: nil)
+                return
+            }
+            guard let paneId = ws.bonsplitController.allPaneIds.first(where: { $0.id == paneUUID }) else {
+                result = .err(code: "not_found", message: "Pane not found", data: ["pane_id": paneUUID.uuidString])
+                return
+            }
+            guard ws.bonsplitController.togglePaneZoom(paneId) else {
+                result = .err(code: "internal_error", message: "Failed to toggle pane zoom", data: ["pane_id": paneUUID.uuidString])
+                return
+            }
+
+            let zoomedPaneUUID = ws.bonsplitController.zoomedPaneId?.id
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "pane_id": paneId.id.uuidString,
+                "pane_ref": v2Ref(kind: .pane, uuid: paneId.id),
+                "zoomed": ws.bonsplitController.isZoomed,
+                "zoomed_pane_id": v2OrNull(zoomedPaneUUID?.uuidString),
+                "zoomed_pane_ref": v2Ref(kind: .pane, uuid: zoomedPaneUUID)
             ])
         }
         return result

--- a/docs/v2-api-migration.md
+++ b/docs/v2-api-migration.md
@@ -89,6 +89,7 @@ Panes:
 - [x] focus_pane -> `pane.focus`
 - [x] list_pane_surfaces -> `pane.surfaces`
 - [x] new_pane -> `pane.create`
+- [x] toggle pane zoom (tmux `resize-pane -Z`) -> `pane.zoom`
 
 Input:
 - [x] send / send_surface -> `surface.send_text`

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -775,6 +775,23 @@ class cmux:
             raise cmuxError(f"pane.last returned no pane_id: {res}")
         return str(pid)
 
+    def pane_zoom(
+        self,
+        pane: Union[str, int, None] = None,
+        workspace: Union[str, int, None] = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        wsid = self._resolve_workspace_id(workspace)
+        if wsid:
+            params["workspace_id"] = wsid
+        if pane is not None:
+            pid = self._resolve_pane_id(pane, workspace_id=wsid)
+            if not pid:
+                raise cmuxError(f"Invalid pane: {pane!r}")
+            params["pane_id"] = pid
+        res = self._call("pane.zoom", params) or {}
+        return dict(res)
+
     # ---------------------------------------------------------------------
     # Input
     # ---------------------------------------------------------------------

--- a/tests_v2/test_tmux_compat_matrix.py
+++ b/tests_v2/test_tmux_compat_matrix.py
@@ -133,6 +133,7 @@ def main() -> int:
             "workspace.next",
             "workspace.previous",
             "workspace.last",
+            "pane.zoom",
             "pane.swap",
             "pane.break",
             "pane.join",
@@ -252,6 +253,64 @@ def main() -> int:
         _wait_for(
             lambda: _pane_extent(c, resize_target, resize_axis) > pre_extent + 1.0,
             timeout_s=3.0,
+        )
+
+        focus_before_zoom = str((c.identify().get("focused") or {}).get("pane_id") or "")
+        _must(bool(focus_before_zoom), "identify should return focused pane before resize-pane -Z test")
+        zoom_target = next((pid for pid in current_panes if pid != focus_before_zoom), focus_before_zoom)
+
+        zoom_on = _run_cli(
+            cli,
+            ["--json", "--id-format", "both", "resize-pane", "--workspace", ws, "--pane", zoom_target, "-Z"],
+        )
+        zoom_on_payload = json.loads(zoom_on.stdout or "{}")
+        _must(bool(zoom_on_payload.get("zoomed")), f"resize-pane -Z should enable zoom: {zoom_on_payload!r}")
+        _must(
+            str(zoom_on_payload.get("zoomed_pane_id") or "") == zoom_target,
+            f"resize-pane -Z should zoom target pane={zoom_target}, got {zoom_on_payload!r}",
+        )
+        focus_after_zoom_on = str((c.identify().get("focused") or {}).get("pane_id") or "")
+        _must(
+            focus_after_zoom_on == focus_before_zoom,
+            f"resize-pane -Z should not steal focus (before={focus_before_zoom}, after={focus_after_zoom_on})",
+        )
+
+        zoom_off = _run_cli(
+            cli,
+            ["--json", "--id-format", "both", "resize-pane", "--workspace", ws, "--pane", zoom_target, "-Z"],
+        )
+        zoom_off_payload = json.loads(zoom_off.stdout or "{}")
+        _must(not bool(zoom_off_payload.get("zoomed")), f"Second resize-pane -Z should disable zoom: {zoom_off_payload!r}")
+        _must(
+            zoom_off_payload.get("zoomed_pane_id") in (None, ""),
+            f"Unzoomed state should not report zoomed_pane_id: {zoom_off_payload!r}",
+        )
+        focus_after_zoom_off = str((c.identify().get("focused") or {}).get("pane_id") or "")
+        _must(
+            focus_after_zoom_off == focus_before_zoom,
+            f"resize-pane -Z unzoom should not steal focus (before={focus_before_zoom}, after={focus_after_zoom_off})",
+        )
+
+        invalid_zoom_direction = _run_cli(
+            cli,
+            ["resize-pane", "--workspace", ws, "--pane", zoom_target, "-Z", "-L"],
+            expect_ok=False,
+        )
+        invalid_zoom_direction_output = f"{invalid_zoom_direction.stdout}\n{invalid_zoom_direction.stderr}".lower()
+        _must(
+            invalid_zoom_direction.returncode != 0 and "cannot be combined" in invalid_zoom_direction_output,
+            f"Expected resize-pane -Z -L to fail with conflict error, got: {invalid_zoom_direction_output!r}",
+        )
+
+        invalid_zoom_amount = _run_cli(
+            cli,
+            ["resize-pane", "--workspace", ws, "--pane", zoom_target, "-Z", "--amount", "10"],
+            expect_ok=False,
+        )
+        invalid_zoom_amount_output = f"{invalid_zoom_amount.stdout}\n{invalid_zoom_amount.stderr}".lower()
+        _must(
+            invalid_zoom_amount.returncode != 0 and "cannot be combined" in invalid_zoom_amount_output,
+            f"Expected resize-pane -Z --amount to fail with conflict error, got: {invalid_zoom_amount_output!r}",
         )
 
         buffer_token = f"TMUX_BUFFER_{stamp}"


### PR DESCRIPTION
## Summary
- add tmux-compatible `resize-pane -Z` in CLI to toggle pane maximize/restore
- add new v2 API method `pane.zoom` and include it in capabilities
- validate conflicting flags for `resize-pane -Z` (`-L|-R|-U|-D`, `--amount`)
- add v2 test helper `pane_zoom(...)`
- extend tmux compatibility matrix test with zoom toggle + negative cases
- update v2 migration docs mapping (`resize-pane -Z` -> `pane.zoom`)

## Linked issue
Closes #351

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `python3 -m py_compile tests_v2/test_tmux_compat_matrix.py tests_v2/cmux.py`
- `cd vendor/bonsplit && swift test`
- targeted smoke checks for `resize-pane -Z` and `pane.zoom` (toggle + no focus steal + conflict errors)

## Notes
- full `tests_v2/test_tmux_compat_matrix.py` currently fails at existing `next-window` expectation (unrelated to this change)
