### PR TITLE
Add command palette (Cmd+Shift+P)

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1450,7 +1450,11 @@ class TabManager: ObservableObject {
     }
 
     func focusTab(_ tabId: UUID, surfaceId: UUID? = nil, suppressFlash: Bool = false) {
-        guard tabs.contains(where: { $0.id == tabId }) else { return }
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        if let surfaceId, tab.panels[surfaceId] != nil {
+            // Keep selected-surface intent stable across selectedTabId didSet async restore.
+            lastFocusedPanelByTab[tabId] = surfaceId
+        }
         selectedTabId = tabId
         NotificationCenter.default.post(
             name: .ghosttyDidFocusTab,
@@ -1469,7 +1473,7 @@ class TabManager: ObservableObject {
         if let surfaceId {
             if !suppressFlash {
                 focusSurface(tabId: tabId, surfaceId: surfaceId)
-            } else if let tab = tabs.first(where: { $0.id == tabId }) {
+            } else {
                 tab.focusPanel(surfaceId)
             }
         }
@@ -3055,6 +3059,13 @@ enum ResizeDirection {
 }
 
 extension Notification.Name {
+    static let commandPaletteToggleRequested = Notification.Name("cmux.commandPaletteToggleRequested")
+    static let commandPaletteRequested = Notification.Name("cmux.commandPaletteRequested")
+    static let commandPaletteSwitcherRequested = Notification.Name("cmux.commandPaletteSwitcherRequested")
+    static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")
+    static let commandPaletteMoveSelection = Notification.Name("cmux.commandPaletteMoveSelection")
+    static let commandPaletteRenameInputInteractionRequested = Notification.Name("cmux.commandPaletteRenameInputInteractionRequested")
+    static let commandPaletteRenameInputDeleteBackwardRequested = Notification.Name("cmux.commandPaletteRenameInputDeleteBackwardRequested")
     static let ghosttyDidSetTitle = Notification.Name("ghosttyDidSetTitle")
     static let ghosttyDidFocusTab = Notification.Name("ghosttyDidFocusTab")
     static let ghosttyDidFocusSurface = Notification.Name("ghosttyDidFocusSurface")

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AppKit
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -102,6 +103,336 @@ final class WorkspaceManualUnreadTests: XCTestCase {
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: false,
                 isManuallyUnread: false
+            )
+        )
+    }
+}
+
+final class CommandPaletteFuzzyMatcherTests: XCTestCase {
+    func testExactMatchScoresHigherThanPrefixAndContains() {
+        let exact = CommandPaletteFuzzyMatcher.score(query: "rename tab", candidate: "rename tab")
+        let prefix = CommandPaletteFuzzyMatcher.score(query: "rename tab", candidate: "rename tab now")
+        let contains = CommandPaletteFuzzyMatcher.score(query: "rename tab", candidate: "command rename tab flow")
+
+        XCTAssertNotNil(exact)
+        XCTAssertNotNil(prefix)
+        XCTAssertNotNil(contains)
+        XCTAssertGreaterThan(exact ?? 0, prefix ?? 0)
+        XCTAssertGreaterThan(prefix ?? 0, contains ?? 0)
+    }
+
+    func testInitialismMatchReturnsScore() {
+        let score = CommandPaletteFuzzyMatcher.score(query: "ocdi", candidate: "open current directory in ide")
+        XCTAssertNotNil(score)
+        XCTAssertGreaterThan(score ?? 0, 0)
+    }
+
+    func testLongTokenLooseSubsequenceDoesNotMatch() {
+        let score = CommandPaletteFuzzyMatcher.score(query: "rename", candidate: "open current directory in ide")
+        XCTAssertNil(score)
+    }
+
+    func testStitchedWordPrefixMatchesRetabForRenameTab() {
+        let score = CommandPaletteFuzzyMatcher.score(query: "retab", candidate: "Rename Tab…")
+        XCTAssertNotNil(score)
+        XCTAssertGreaterThan(score ?? 0, 0)
+    }
+
+    func testRetabPrefersRenameTabOverDistantTabWord() {
+        let renameTabScore = CommandPaletteFuzzyMatcher.score(query: "retab", candidate: "Rename Tab…")
+        let reopenTabScore = CommandPaletteFuzzyMatcher.score(query: "retab", candidate: "Reopen Closed Browser Tab")
+
+        XCTAssertNotNil(renameTabScore)
+        XCTAssertNotNil(reopenTabScore)
+        XCTAssertGreaterThan(renameTabScore ?? 0, reopenTabScore ?? 0)
+    }
+
+    func testRenameScoresHigherThanUnrelatedCommand() {
+        let renameScore = CommandPaletteFuzzyMatcher.score(
+            query: "rename",
+            candidates: ["Rename Tab…", "Tab • Terminal 1", "rename", "tab", "title"]
+        )
+        let unrelatedScore = CommandPaletteFuzzyMatcher.score(
+            query: "rename",
+            candidates: [
+                "Open Current Directory in IDE",
+                "Terminal • Terminal 1",
+                "terminal",
+                "directory",
+                "open",
+                "ide",
+                "code",
+                "default app"
+            ]
+        )
+
+        XCTAssertNotNil(renameScore)
+        XCTAssertNotNil(unrelatedScore)
+        XCTAssertGreaterThan(renameScore ?? 0, unrelatedScore ?? 0)
+    }
+
+    func testTokenMatchingRequiresAllTokens() {
+        let match = CommandPaletteFuzzyMatcher.score(
+            query: "rename workspace",
+            candidates: ["Rename Workspace", "Workspace settings"]
+        )
+        let miss = CommandPaletteFuzzyMatcher.score(
+            query: "rename workspace",
+            candidates: ["Rename Tab", "Tab settings"]
+        )
+
+        XCTAssertNotNil(match)
+        XCTAssertNil(miss)
+    }
+
+    func testEmptyQueryReturnsZeroScore() {
+        let score = CommandPaletteFuzzyMatcher.score(query: "   ", candidate: "anything")
+        XCTAssertEqual(score, 0)
+    }
+
+    func testMatchCharacterIndicesForContainsMatch() {
+        let indices = CommandPaletteFuzzyMatcher.matchCharacterIndices(
+            query: "workspace",
+            candidate: "New Workspace"
+        )
+        XCTAssertTrue(indices.contains(4))
+        XCTAssertTrue(indices.contains(12))
+        XCTAssertFalse(indices.contains(0))
+    }
+
+    func testMatchCharacterIndicesForSubsequenceMatch() {
+        let indices = CommandPaletteFuzzyMatcher.matchCharacterIndices(
+            query: "nws",
+            candidate: "New Workspace"
+        )
+        XCTAssertTrue(indices.contains(0))
+        XCTAssertTrue(indices.contains(2))
+        XCTAssertTrue(indices.contains(8))
+    }
+
+    func testMatchCharacterIndicesForStitchedWordPrefixMatch() {
+        let indices = CommandPaletteFuzzyMatcher.matchCharacterIndices(
+            query: "retab",
+            candidate: "Rename Tab…"
+        )
+        XCTAssertTrue(indices.contains(0))
+        XCTAssertTrue(indices.contains(1))
+        XCTAssertTrue(indices.contains(7))
+        XCTAssertTrue(indices.contains(8))
+        XCTAssertTrue(indices.contains(9))
+    }
+}
+
+final class CommandPaletteSwitcherSearchIndexerTests: XCTestCase {
+    func testKeywordsIncludeDirectoryBranchAndPortMetadata() {
+        let metadata = CommandPaletteSwitcherSearchMetadata(
+            directories: ["/Users/example/dev/cmuxterm-hq/worktrees/feat-cmd-palette"],
+            branches: ["feature/cmd-palette-indexing"],
+            ports: [3000, 9222]
+        )
+
+        let keywords = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["workspace", "switch"],
+            metadata: metadata
+        )
+
+        XCTAssertTrue(keywords.contains("/Users/example/dev/cmuxterm-hq/worktrees/feat-cmd-palette"))
+        XCTAssertTrue(keywords.contains("feat-cmd-palette"))
+        XCTAssertTrue(keywords.contains("feature/cmd-palette-indexing"))
+        XCTAssertTrue(keywords.contains("cmd-palette-indexing"))
+        XCTAssertTrue(keywords.contains("3000"))
+        XCTAssertTrue(keywords.contains(":9222"))
+    }
+
+    func testFuzzyMatcherMatchesDirectoryBranchAndPortMetadata() {
+        let metadata = CommandPaletteSwitcherSearchMetadata(
+            directories: ["/tmp/cmuxterm/worktrees/issue-123-switcher-search"],
+            branches: ["fix/switcher-metadata"],
+            ports: [4317]
+        )
+
+        let candidates = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["workspace"],
+            metadata: metadata
+        )
+
+        XCTAssertNotNil(CommandPaletteFuzzyMatcher.score(query: "switcher-search", candidates: candidates))
+        XCTAssertNotNil(CommandPaletteFuzzyMatcher.score(query: "switcher-metadata", candidates: candidates))
+        XCTAssertNotNil(CommandPaletteFuzzyMatcher.score(query: "4317", candidates: candidates))
+    }
+
+    func testWorkspaceDetailOmitsSplitDirectoryAndBranchTokens() {
+        let metadata = CommandPaletteSwitcherSearchMetadata(
+            directories: ["/Users/example/dev/cmuxterm-hq/worktrees/feat-cmd-palette"],
+            branches: ["feature/cmd-palette-indexing"],
+            ports: [3000]
+        )
+
+        let keywords = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["workspace"],
+            metadata: metadata,
+            detail: .workspace
+        )
+
+        XCTAssertTrue(keywords.contains("/Users/example/dev/cmuxterm-hq/worktrees/feat-cmd-palette"))
+        XCTAssertTrue(keywords.contains("feature/cmd-palette-indexing"))
+        XCTAssertTrue(keywords.contains("3000"))
+        XCTAssertFalse(keywords.contains("feat-cmd-palette"))
+        XCTAssertFalse(keywords.contains("cmd-palette-indexing"))
+    }
+
+    func testSurfaceDetailOutranksWorkspaceDetailForPathToken() {
+        let metadata = CommandPaletteSwitcherSearchMetadata(
+            directories: ["/tmp/worktrees/cmux"],
+            branches: ["feature/cmd-palette"],
+            ports: []
+        )
+
+        let workspaceKeywords = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["workspace"],
+            metadata: metadata,
+            detail: .workspace
+        )
+        let surfaceKeywords = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["surface"],
+            metadata: metadata,
+            detail: .surface
+        )
+
+        let workspaceScore = try XCTUnwrap(
+            CommandPaletteFuzzyMatcher.score(query: "cmux", candidates: workspaceKeywords)
+        )
+        let surfaceScore = try XCTUnwrap(
+            CommandPaletteFuzzyMatcher.score(query: "cmux", candidates: surfaceKeywords)
+        )
+
+        XCTAssertGreaterThan(
+            surfaceScore,
+            workspaceScore,
+            "Surface rows should rank ahead of workspace rows for directory-token matches."
+        )
+    }
+}
+
+@MainActor
+final class CommandPaletteRequestRoutingTests: XCTestCase {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    func testRequestedWindowTargetsOnlyMatchingObservedWindow() {
+        let windowA = makeWindow()
+        let windowB = makeWindow()
+
+        XCTAssertTrue(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: windowA,
+                requestedWindow: windowA,
+                keyWindow: windowA,
+                mainWindow: windowA
+            )
+        )
+        XCTAssertFalse(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: windowB,
+                requestedWindow: windowA,
+                keyWindow: windowA,
+                mainWindow: windowA
+            )
+        )
+    }
+
+    func testNilRequestedWindowFallsBackToKeyWindow() {
+        let key = makeWindow()
+        let other = makeWindow()
+
+        XCTAssertTrue(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: key,
+                requestedWindow: nil,
+                keyWindow: key,
+                mainWindow: nil
+            )
+        )
+        XCTAssertFalse(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: other,
+                requestedWindow: nil,
+                keyWindow: key,
+                mainWindow: nil
+            )
+        )
+    }
+
+    func testNilRequestedAndKeyFallsBackToMainWindow() {
+        let main = makeWindow()
+        let other = makeWindow()
+
+        XCTAssertTrue(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: main,
+                requestedWindow: nil,
+                keyWindow: nil,
+                mainWindow: main
+            )
+        )
+        XCTAssertFalse(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: other,
+                requestedWindow: nil,
+                keyWindow: nil,
+                mainWindow: main
+            )
+        )
+    }
+
+    func testNoObservedWindowNeverHandlesRequest() {
+        XCTAssertFalse(
+            ContentView.shouldHandleCommandPaletteRequest(
+                observedWindow: nil,
+                requestedWindow: makeWindow(),
+                keyWindow: makeWindow(),
+                mainWindow: makeWindow()
+            )
+        )
+    }
+}
+
+final class CommandPaletteBackNavigationTests: XCTestCase {
+    func testBackspaceOnEmptyRenameInputReturnsToCommandList() {
+        XCTAssertTrue(
+            ContentView.commandPaletteShouldPopRenameInputOnDelete(
+                renameDraft: "",
+                modifiers: []
+            )
+        )
+    }
+
+    func testBackspaceWithRenameTextDoesNotReturnToCommandList() {
+        XCTAssertFalse(
+            ContentView.commandPaletteShouldPopRenameInputOnDelete(
+                renameDraft: "Terminal 1",
+                modifiers: []
+            )
+        )
+    }
+
+    func testModifiedBackspaceDoesNotReturnToCommandList() {
+        XCTAssertFalse(
+            ContentView.commandPaletteShouldPopRenameInputOnDelete(
+                renameDraft: "",
+                modifiers: [.control]
+            )
+        )
+        XCTAssertFalse(
+            ContentView.commandPaletteShouldPopRenameInputOnDelete(
+                renameDraft: "",
+                modifiers: [.command]
             )
         )
     }

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -918,6 +918,27 @@ class cmux:
     def activate_app(self) -> None:
         self._call("debug.app.activate")
 
+    def open_command_palette_rename_tab_input(self, window_id: Optional[str] = None) -> None:
+        params: Dict[str, Any] = {}
+        if window_id is not None:
+            params["window_id"] = str(window_id)
+        self._call("debug.command_palette.rename_tab.open", params)
+
+    def command_palette_results(self, window_id: str, limit: int = 20) -> dict:
+        res = self._call(
+            "debug.command_palette.results",
+            {"window_id": str(window_id), "limit": int(limit)},
+        ) or {}
+        return dict(res)
+
+    def command_palette_rename_select_all(self) -> bool:
+        res = self._call("debug.command_palette.rename_input.select_all") or {}
+        return bool(res.get("enabled"))
+
+    def set_command_palette_rename_select_all(self, enabled: bool) -> bool:
+        res = self._call("debug.command_palette.rename_input.select_all", {"enabled": bool(enabled)}) or {}
+        return bool(res.get("enabled"))
+
     def is_terminal_focused(self, panel: Union[str, int]) -> bool:
         sid = self._resolve_surface_id(panel)
         res = self._call("debug.terminal.is_focused", {"surface_id": sid}) or {}

--- a/tests_v2/test_command_palette_backspace_go_back.py
+++ b/tests_v2/test_command_palette_backspace_go_back.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Regression test: backspace on empty rename input returns to command list.
+
+Coverage:
+- First backspace clears selected rename text.
+- Second backspace on empty rename input navigates back to command list mode.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s=4.0, interval_s=0.05, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client, window_id):
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client, window_id):
+    return client.command_palette_results(window_id, limit=20)
+
+
+def _rename_selection(client, window_id):
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _int_or(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _open_rename_input(client, window_id):
+    client.activate_app()
+    client.focus_window(window_id)
+    time.sleep(0.1)
+
+    if _palette_visible(client, window_id):
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="command palette failed to close before setup",
+        )
+
+    client.open_command_palette_rename_tab_input(window_id=window_id)
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="command palette failed to open",
+    )
+    _wait_until(
+        lambda: str(_palette_results(client, window_id).get("mode") or "") == "rename_input",
+        message="command palette did not enter rename input mode",
+    )
+
+
+def main():
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+        window_id = client.current_window()
+
+        original_select_all = client.command_palette_rename_select_all()
+
+        try:
+            client.set_command_palette_rename_select_all(True)
+            _open_rename_input(client, window_id)
+
+            _wait_until(
+                lambda: bool(_rename_selection(client, window_id).get("focused")),
+                message="rename input did not focus",
+            )
+
+            selection = _rename_selection(client, window_id)
+            text_length = _int_or(selection.get("text_length"), 0)
+            selection_location = _int_or(selection.get("selection_location"), -1)
+            selection_length = _int_or(selection.get("selection_length"), -1)
+            if not (
+                text_length > 0
+                and selection_location in (-1, 0)
+                and selection_length == text_length
+            ):
+                raise cmuxError(
+                    "rename input was not select-all on open: "
+                    f"text_length={text_length} selection=({selection_location}, {selection_length})"
+                )
+
+            client._call(
+                "debug.command_palette.rename_input.delete_backward",
+                {"window_id": window_id},
+            )
+
+            first_backspace_cleared = False
+            last_selection = {}
+            for _ in range(40):
+                last_selection = _rename_selection(client, window_id)
+                if _int_or(last_selection.get("text_length"), -1) == 0:
+                    first_backspace_cleared = True
+                    break
+                time.sleep(0.05)
+            if not first_backspace_cleared:
+                raise cmuxError(
+                    "first backspace did not clear rename input: "
+                    f"selection={last_selection} results={_palette_results(client, window_id)}"
+                )
+            after_first = _palette_results(client, window_id)
+            if str(after_first.get("mode") or "") != "rename_input":
+                raise cmuxError(f"palette exited rename mode too early after first backspace: {after_first}")
+
+            client._call(
+                "debug.command_palette.rename_input.delete_backward",
+                {"window_id": window_id},
+            )
+
+            _wait_until(
+                lambda: str(_palette_results(client, window_id).get("mode") or "") == "commands",
+                message="second backspace on empty input did not return to commands mode",
+            )
+
+            if not _palette_visible(client, window_id):
+                raise cmuxError("palette closed unexpectedly instead of navigating back to command list")
+
+        finally:
+            try:
+                client.set_command_palette_rename_select_all(original_select_all)
+            except Exception:
+                pass
+
+            if _palette_visible(client, window_id):
+                client._call("debug.command_palette.toggle", {"window_id": window_id})
+                _wait_until(
+                    lambda: not _palette_visible(client, window_id),
+                    message="command palette failed to close during cleanup",
+                )
+
+    print("PASS: backspace on empty rename input navigates back to command list")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_focus.py
+++ b/tests_v2/test_command_palette_focus.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Regression test: opening the command palette must move focus away from terminal.
+
+Why: if terminal remains first responder under the palette, typing goes into the shell
+instead of the palette search field.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _focused_surface_id(client: cmux) -> str:
+    surfaces = client.list_surfaces()
+    for _, sid, focused in surfaces:
+        if focused:
+            return sid
+    raise cmuxError(f"No focused surface in list_surfaces: {surfaces}")
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    res = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(res.get("visible"))
+
+
+def _wait_until(predicate, timeout_s: float = 3.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def main() -> int:
+    token = "CMUX_PALETTE_FOCUS_PROBE_9412"
+    restore_token = "CMUX_PALETTE_RESTORE_PROBE_7731"
+
+    with cmux(SOCKET_PATH) as client:
+        client.new_workspace()
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        panel_id = _focused_surface_id(client)
+        _wait_until(
+            lambda: client.is_terminal_focused(panel_id),
+            timeout_s=5.0,
+            message=f"terminal never became focused for panel {panel_id}",
+        )
+
+        pre_text = client.read_terminal_text(panel_id)
+
+        # Open palette via debug method and assert terminal focus drops.
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: _palette_visible(client, window_id),
+            timeout_s=3.0,
+            message="command palette did not open",
+        )
+
+        # Typing now should target palette input, not the terminal.
+        client.simulate_type(token)
+        time.sleep(0.15)
+        post_text = client.read_terminal_text(panel_id)
+
+        if token in post_text and token not in pre_text:
+            raise cmuxError("typed probe text leaked into terminal while palette is open")
+
+        # Close palette and ensure focus returns to previously-focused terminal.
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            timeout_s=3.0,
+            message="command palette did not close",
+        )
+
+        client.simulate_type(restore_token)
+        time.sleep(0.15)
+        restore_text = client.read_terminal_text(panel_id)
+        if restore_token not in restore_text:
+            raise cmuxError("terminal did not receive typing after closing command palette")
+
+    print("PASS: command palette steals and restores terminal focus")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_focus_lock_workspace_spawn.py
+++ b/tests_v2/test_command_palette_focus_lock_workspace_spawn.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Regression test: command palette focus must remain stable while a new workspace shell spawns.
+
+Why: when a terminal steals first responder during workspace bootstrap, the command-palette
+search field can re-focus with full selection, so the next keystroke replaces the whole query.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 5.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _palette_input_selection(client: cmux, window_id: str) -> dict:
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _close_palette_if_open(client: cmux, window_id: str) -> None:
+    if _palette_visible(client, window_id):
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="command palette failed to close",
+        )
+
+
+def _assert_caret_at_end(selection: dict, context: str) -> None:
+    if not selection.get("focused"):
+        raise cmuxError(f"{context}: palette input is not focused")
+    text_length = int(selection.get("text_length") or 0)
+    selection_location = int(selection.get("selection_location") or 0)
+    selection_length = int(selection.get("selection_length") or 0)
+    if selection_location != text_length or selection_length != 0:
+        raise cmuxError(
+            f"{context}: expected caret-at-end, got location={selection_location}, "
+            f"length={selection_length}, text_length={text_length}"
+        )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        _close_palette_if_open(client, window_id)
+        workspace_count_before = len(client.list_workspaces(window_id=window_id))
+
+        client.simulate_shortcut("cmd+shift+p")
+        _wait_until(
+            lambda: _palette_visible(client, window_id),
+            message="cmd+shift+p did not open command palette",
+        )
+        _wait_until(
+            lambda: str(_palette_results(client, window_id).get("mode") or "") == "commands",
+            message="palette did not open in commands mode",
+        )
+
+        selection = _palette_input_selection(client, window_id)
+        _assert_caret_at_end(selection, "initial state")
+
+        client.new_workspace(window_id=window_id)
+        _wait_until(
+            lambda: len(client.list_workspaces(window_id=window_id)) >= workspace_count_before + 1,
+            message="workspace.create did not add a new workspace",
+        )
+
+        # Sample across shell bootstrap; focus and caret should stay stable.
+        sample_deadline = time.time() + 2.0
+        while time.time() < sample_deadline:
+            selection = _palette_input_selection(client, window_id)
+            _assert_caret_at_end(selection, "after workspace spawn")
+            time.sleep(0.01)
+
+        client.simulate_type("focuslock")
+        _wait_until(
+            lambda: str(_palette_results(client, window_id).get("mode") or "") == "commands",
+            message="typing after workspace spawn switched palette out of commands mode",
+        )
+        _wait_until(
+            lambda: "focuslock" in str(_palette_results(client, window_id).get("query") or "").lower(),
+            message="typing after workspace spawn did not append into command query",
+        )
+
+    print("PASS: command palette keeps focus/caret during workspace shell spawn")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_fuzzy_ranking.py
+++ b/tests_v2/test_command_palette_fuzzy_ranking.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Regression test: command palette fuzzy ranking for rename commands.
+
+Validates:
+- Typing `rename` is captured by the palette query.
+- The top-ranked command is a rename command.
+- Pressing Enter opens rename input (instead of running an unrelated command).
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+RENAME_COMMAND_IDS = {"palette.renameTab", "palette.renameWorkspace"}
+
+
+def _wait_until(predicate, timeout_s=5.0, interval_s=0.05, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _rename_input_selection(client: cmux, window_id: str) -> dict:
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 10) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        time.sleep(0.2)
+
+        _set_palette_visible(client, window_id, False)
+        _set_palette_visible(client, window_id, True)
+
+        # Force command mode query regardless transient field-editor selection state.
+        time.sleep(0.2)
+        client.simulate_shortcut("cmd+a")
+        client.simulate_type(">rename")
+        _wait_until(
+            lambda: "rename" in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="palette query did not update to 'rename'",
+        )
+
+        payload = _palette_results(client, window_id, limit=12)
+        rows = payload.get("results") or []
+        if not rows:
+            raise cmuxError(f"palette returned no results for rename query: {payload}")
+
+        top = rows[0] or {}
+        top_id = str(top.get("command_id") or "")
+        top_title = str(top.get("title") or "")
+        if top_id not in RENAME_COMMAND_IDS:
+            titles = [str(row.get("title") or "") for row in rows]
+            raise cmuxError(
+                f"unexpected top result for 'rename': id={top_id!r} title={top_title!r} results={titles}"
+            )
+
+        client.simulate_shortcut("cmd+a")
+        client.simulate_type(">retab")
+        _wait_until(
+            lambda: "retab" in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="palette query did not update to 'retab'",
+        )
+
+        retab_payload = _palette_results(client, window_id, limit=12)
+        retab_rows = retab_payload.get("results") or []
+        if not retab_rows:
+            raise cmuxError(f"palette returned no results for retab query: {retab_payload}")
+        top_retabs = [str(row.get("command_id") or "") for row in retab_rows[:3]]
+        if "palette.renameTab" not in top_retabs:
+            raise cmuxError(
+                f"'retab' did not rank Rename Tab near top: top3={top_retabs} rows={retab_rows}"
+            )
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: _palette_visible(client, window_id)
+            and bool(_rename_input_selection(client, window_id).get("focused")),
+            message="Enter did not open rename input for top rename result",
+        )
+
+        _set_palette_visible(client, window_id, False)
+
+    print("PASS: command palette fuzzy ranking prioritizes rename commands")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_modes.py
+++ b/tests_v2/test_command_palette_modes.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Regression test: VSCode-like command palette modes.
+
+Validates:
+- Cmd+Shift+P opens commands mode (leading '>' semantics).
+- Cmd+P opens workspace/tab switcher mode.
+- Repeating Cmd+Shift+P or Cmd+P toggles visibility (open/close).
+- Switcher search can jump to another workspace by pressing Enter.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 5.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _palette_input_selection(client: cmux, window_id: str) -> dict:
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _wait_for_palette_input_caret_at_end(
+    client: cmux,
+    window_id: str,
+    expected_text_length: int,
+    message: str,
+    timeout_s: float = 1.2,
+) -> None:
+    def _matches() -> bool:
+        selection = _palette_input_selection(client, window_id)
+        if not selection.get("focused"):
+            return False
+        text_length = int(selection.get("text_length") or 0)
+        selection_location = int(selection.get("selection_location") or 0)
+        selection_length = int(selection.get("selection_length") or 0)
+        return (
+            text_length == expected_text_length
+            and selection_location == expected_text_length
+            and selection_length == 0
+        )
+
+    _wait_until(_matches, timeout_s=timeout_s, message=message)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        timeout_s=3.0,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        ws_a = client.new_workspace(window_id=window_id)
+        client.select_workspace(ws_a)
+        client.rename_workspace("alpha-workspace", workspace=ws_a)
+
+        ws_b = client.new_workspace(window_id=window_id)
+        client.select_workspace(ws_b)
+        client.rename_workspace("bravo-workspace", workspace=ws_b)
+
+        client.select_workspace(ws_a)
+        _wait_until(
+            lambda: client.current_workspace() == ws_a,
+            message="failed to select workspace alpha before switcher jump",
+        )
+
+        _set_palette_visible(client, window_id, False)
+
+        # Cmd+P: switcher mode.
+        client.simulate_shortcut("cmd+p")
+        _wait_until(
+            lambda: _palette_visible(client, window_id),
+            message="cmd+p did not open command palette",
+        )
+        _wait_until(
+            lambda: str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+            message="cmd+p did not open switcher mode",
+        )
+
+        time.sleep(0.2)
+        client.simulate_type("bravo")
+        _wait_until(
+            lambda: "bravo" in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="switcher query did not include bravo",
+        )
+        switched_rows = (_palette_results(client, window_id, limit=12).get("results") or [])
+        if not switched_rows:
+            raise cmuxError("switcher returned no rows for workspace query")
+        top_id = str((switched_rows[0] or {}).get("command_id") or "")
+        if not top_id.startswith("switcher."):
+            raise cmuxError(f"expected switcher row on top for cmd+p query, got: {switched_rows[0]}")
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="palette did not close after selecting switcher row",
+        )
+        _wait_until(
+            lambda: client.current_workspace() == ws_b,
+            message="Enter on switcher result did not move to target workspace",
+        )
+
+        # Cmd+Shift+P: commands mode.
+        client.simulate_shortcut("cmd+shift+p")
+        _wait_until(
+            lambda: _palette_visible(client, window_id),
+            message="cmd+shift+p did not open command palette",
+        )
+        _wait_until(
+            lambda: str(_palette_results(client, window_id).get("mode") or "") == "commands",
+            message="cmd+shift+p did not open commands mode",
+        )
+        _wait_for_palette_input_caret_at_end(
+            client,
+            window_id,
+            expected_text_length=1,
+            message="cmd+shift+p should prefill '>' with caret at end (not selected)",
+        )
+
+        command_rows = (_palette_results(client, window_id, limit=8).get("results") or [])
+        if not command_rows:
+            raise cmuxError("commands mode returned no rows")
+        top_command_id = str((command_rows[0] or {}).get("command_id") or "")
+        if not top_command_id.startswith("palette."):
+            raise cmuxError(f"expected command row in commands mode, got: {command_rows[0]}")
+
+        # Repeating either shortcut should toggle visibility.
+        client.simulate_shortcut("cmd+shift+p")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="second cmd+shift+p did not close the command palette",
+        )
+
+        client.simulate_shortcut("cmd+p")
+        _wait_until(
+            lambda: _palette_visible(client, window_id)
+            and str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+            message="cmd+p did not reopen switcher mode after toggle-close",
+        )
+        client.simulate_shortcut("cmd+p")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="second cmd+p did not close the command palette",
+        )
+
+    print("PASS: command palette cmd+p/cmd+shift+p open correct modes and toggle on repeat")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_navigation_keys.py
+++ b/tests_v2/test_command_palette_navigation_keys.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Regression test: command palette list navigation keys.
+
+Validates:
+- Down: ArrowDown, Ctrl+N, Ctrl+J
+- Up: ArrowUp, Ctrl+P, Ctrl+K
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(
+    predicate,
+    timeout_s: float = 4.0,
+    interval_s: float = 0.05,
+    message: str = "timeout",
+) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    res = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(res.get("visible"))
+
+
+def _palette_selected_index(client: cmux, window_id: str) -> int:
+    res = client._call("debug.command_palette.selection", {"window_id": window_id}) or {}
+    return int(res.get("selected_index") or 0)
+
+
+def _has_focused_surface(client: cmux) -> bool:
+    try:
+        return any(bool(row[2]) for row in client.list_surfaces())
+    except Exception:
+        return False
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def _open_palette_with_query(client: cmux, window_id: str, query: str) -> None:
+    _set_palette_visible(client, window_id, False)
+    _set_palette_visible(client, window_id, True)
+    client.simulate_type(query)
+    _wait_until(
+        lambda: _palette_selected_index(client, window_id) == 0,
+        message="palette selected index did not reset to zero",
+    )
+
+
+def _assert_move(client: cmux, window_id: str, combo: str, start_index: int, expected_index: int) -> None:
+    _open_palette_with_query(client, window_id, "new")
+    for _ in range(start_index):
+        client.simulate_shortcut("down")
+    _wait_until(
+        lambda: _palette_selected_index(client, window_id) == start_index,
+        message=f"failed to seed start index {start_index}",
+    )
+
+    client.simulate_shortcut(combo)
+    _wait_until(
+        lambda: _palette_visible(client, window_id)
+        and _palette_selected_index(client, window_id) == expected_index,
+        message=f"{combo} did not move selection from {start_index} to {expected_index}",
+    )
+
+
+def _assert_can_navigate_past_ten_results(client: cmux, window_id: str) -> None:
+    _open_palette_with_query(client, window_id, "")
+
+    for _ in range(12):
+        client.simulate_shortcut("down")
+
+    _wait_until(
+        lambda: _palette_visible(client, window_id)
+        and _palette_selected_index(client, window_id) >= 10,
+        message="selection did not move past index 9 (results may be capped)",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+        client.new_workspace()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        # Isolate this test to one window so stale palettes in other windows
+        # cannot steal navigation notifications.
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+        _wait_until(
+            lambda: _has_focused_surface(client),
+            timeout_s=5.0,
+            message="no focused surface available for command palette context",
+        )
+
+        for combo in ("down", "ctrl+n", "ctrl+j"):
+            _assert_move(client, window_id, combo, start_index=0, expected_index=1)
+
+        for combo in ("up", "ctrl+p", "ctrl+k"):
+            _assert_move(client, window_id, combo, start_index=1, expected_index=0)
+
+        _assert_can_navigate_past_ten_results(client, window_id)
+
+        _set_palette_visible(client, window_id, False)
+
+    print("PASS: command palette navigation keys and uncapped result navigation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_rename_enter.py
+++ b/tests_v2/test_command_palette_rename_enter.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Regression test: command-palette rename flow responds to Enter.
+
+Coverage:
+- Enter in rename input applies the new tab name and closes the palette.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s=4.0, interval_s=0.05, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client, window_id):
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _rename_input_selection(client, window_id):
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _focused_pane_id(client):
+    panes = client.list_panes()
+    focused = [row for row in panes if bool(row[3])]
+    if not focused:
+        raise cmuxError(f"no focused pane: {panes}")
+    return str(focused[0][1])
+
+
+def _selected_surface_title(client, pane_id):
+    rows = client.list_pane_surfaces(pane_id)
+    selected = [row for row in rows if bool(row[3])]
+    if not selected:
+        raise cmuxError(f"no selected surface in pane {pane_id}: {rows}")
+    return str(selected[0][2])
+
+
+def main():
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        time.sleep(0.2)
+
+        pane_id = _focused_pane_id(client)
+        rename_to = f"rename-enter-{int(time.time())}"
+
+        client.open_command_palette_rename_tab_input(window_id=window_id)
+        _wait_until(
+            lambda: _palette_visible(client, window_id),
+            message="command palette did not open",
+        )
+        _wait_until(
+            lambda: bool(_rename_input_selection(client, window_id).get("focused")),
+            message="rename input did not focus",
+        )
+
+        client.simulate_type(rename_to)
+        time.sleep(0.1)
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="Enter did not apply rename and close palette",
+        )
+
+        new_title = _selected_surface_title(client, pane_id)
+        if new_title != rename_to:
+            raise cmuxError(f"rename not applied: expected '{rename_to}', got '{new_title}'")
+
+    print("PASS: command-palette rename flow accepts Enter in input")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_rename_select_all.py
+++ b/tests_v2/test_command_palette_rename_select_all.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Regression test: command-palette rename input keeps select-all on interaction.
+
+Coverage:
+- With select-all setting enabled, rename input selects all existing text
+  immediately and stays selected after interaction.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s=4.0, interval_s=0.05, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client, window_id):
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _rename_input_selection(client, window_id):
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _rename_select_all_setting(client):
+    payload = client._call("debug.command_palette.rename_input.select_all", {}) or {}
+    return bool(payload.get("enabled"))
+
+
+def _set_rename_select_all_setting(client, enabled):
+    payload = client._call(
+        "debug.command_palette.rename_input.select_all",
+        {"enabled": bool(enabled)},
+    ) or {}
+    return bool(payload.get("enabled"))
+
+
+def _wait_for_rename_selection(
+    client,
+    window_id,
+    expect_select_all,
+    message,
+    timeout_s=0.6,
+):
+    def _matches():
+        selection = _rename_input_selection(client, window_id)
+        if not selection.get("focused"):
+            return False
+        text_length = int(selection.get("text_length") or 0)
+        selection_location = int(selection.get("selection_location") or 0)
+        selection_length = int(selection.get("selection_length") or 0)
+        if expect_select_all:
+            return text_length > 0 and selection_location == 0 and selection_length == text_length
+        return selection_location == text_length and selection_length == 0
+
+    _wait_until(_matches, timeout_s=timeout_s, message=message)
+
+
+def _exercise_rename_selection_setting(
+    client,
+    window_id,
+    expect_select_all,
+    cycles,
+    label,
+):
+    for cycle in range(cycles):
+        _open_rename_tab_input(client, window_id)
+        _wait_for_rename_selection(
+            client,
+            window_id,
+            expect_select_all=expect_select_all,
+            timeout_s=0.4,
+            message=(
+                f"{label}: rename input not ready with expected selection "
+                f"on open (cycle {cycle + 1}/{cycles})"
+            ),
+        )
+        client._call("debug.command_palette.rename_input.interact", {"window_id": window_id})
+        _wait_for_rename_selection(
+            client,
+            window_id,
+            expect_select_all=expect_select_all,
+            timeout_s=0.6,
+            message=(
+                f"{label}: rename input selection changed after interaction "
+                f"(cycle {cycle + 1}/{cycles})"
+            ),
+        )
+
+        if _palette_visible(client, window_id):
+            client._call("debug.command_palette.toggle", {"window_id": window_id})
+            _wait_until(
+                lambda: not _palette_visible(client, window_id),
+                message=f"{label}: command palette failed to close (cycle {cycle + 1}/{cycles})",
+            )
+
+
+def _open_rename_tab_input(client, window_id):
+    client.activate_app()
+    client.focus_window(window_id)
+    time.sleep(0.1)
+
+    if _palette_visible(client, window_id):
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="command palette failed to close before setup",
+        )
+
+    client.open_command_palette_rename_tab_input(window_id=window_id)
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="command palette failed to open rename-tab input",
+    )
+
+
+def main():
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        original_select_all = _rename_select_all_setting(client)
+
+        workspace_id = client.new_workspace()
+        client.select_workspace(workspace_id)
+        client.rename_workspace("SeedName", workspace_id)
+        time.sleep(0.25)
+        window_id = client.current_window()
+
+        try:
+            stress_cycles = 8
+
+            # ON: immediate select-all and interaction-preserved select-all.
+            _set_rename_select_all_setting(client, True)
+            _exercise_rename_selection_setting(
+                client,
+                window_id,
+                expect_select_all=True,
+                cycles=stress_cycles,
+                label="select-all enabled",
+            )
+
+            # OFF: immediate caret-at-end and interaction-preserved caret-at-end.
+            _set_rename_select_all_setting(client, False)
+            _exercise_rename_selection_setting(
+                client,
+                window_id,
+                expect_select_all=False,
+                cycles=stress_cycles,
+                label="select-all disabled",
+            )
+
+        finally:
+            try:
+                _set_rename_select_all_setting(client, original_select_all)
+            except Exception:
+                pass
+            if _palette_visible(client, window_id):
+                client._call("debug.command_palette.toggle", {"window_id": window_id})
+                _wait_until(
+                    lambda: not _palette_visible(client, window_id),
+                    message="command palette failed to close during cleanup",
+                )
+
+    print("PASS: command-palette rename input obeys select-all setting (on/off)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_search_action_sync.py
+++ b/tests_v2/test_command_palette_search_action_sync.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Regression test: command-palette search updates rows and executed action in sync.
+
+Why: if query replacement doesn't fully refresh the result list, the top row text
+can lag behind the action executed on Enter.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s=4.0, interval_s=0.05, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client, window_id):
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _set_palette_visible(client, window_id, visible):
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"command palette did not become visible={visible}",
+    )
+
+
+def _palette_results(client, window_id, limit=10):
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _palette_input_selection(client, window_id):
+    # Shared field-editor probe used by other command palette regressions.
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def main():
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        time.sleep(0.2)
+
+        _set_palette_visible(client, window_id, False)
+        _set_palette_visible(client, window_id, True)
+        _wait_until(
+            lambda: bool(_palette_input_selection(client, window_id).get("focused")),
+            message="palette search input did not focus",
+        )
+
+        client.simulate_shortcut("cmd+a")
+        client.simulate_type(">open")
+        _wait_until(
+            lambda: "open" in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="palette query did not become 'open'",
+        )
+
+        before = _palette_results(client, window_id, limit=8)
+        before_rows = before.get("results") or []
+        if not before_rows:
+            raise cmuxError(f"no results for 'open': {before}")
+        if str(before_rows[0].get("command_id") or "") != "palette.terminalOpenDirectory":
+            raise cmuxError(f"unexpected top command for 'open': {before_rows[0]}")
+
+        client.simulate_shortcut("cmd+a")
+        client.simulate_type(">rename")
+        _wait_until(
+            lambda: "rename" in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="palette query did not become 'rename' after replacement",
+        )
+        after = _palette_results(client, window_id, limit=8)
+        after_rows = after.get("results") or []
+        if not after_rows:
+            raise cmuxError(f"no results for 'rename' after replacement: {after}")
+        top_after = str(after_rows[0].get("command_id") or "")
+        if top_after not in {"palette.renameWorkspace", "palette.renameTab"}:
+            raise cmuxError(f"top result did not update to rename command after replacement: {after_rows[0]}")
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: bool(_palette_input_selection(client, window_id).get("focused")),
+            message="Enter did not trigger renamed top command input",
+        )
+
+        _set_palette_visible(client, window_id, False)
+
+    print("PASS: command-palette search replacement keeps row text/action in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_search_typing_stability.py
+++ b/tests_v2/test_command_palette_search_typing_stability.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Regression test: command-palette search typing should not reset selection.
+
+Why: if focus-lock logic repeatedly re-focuses the text field, typing behaves
+like Cmd+A is being spammed and each character replaces the previous query.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s=4.0, interval_s=0.04, message="timeout"):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client, window_id):
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_input_selection(client, window_id):
+    # Uses the shared field-editor probe; works for search and rename modes.
+    return client._call("debug.command_palette.rename_input.selection", {"window_id": window_id}) or {}
+
+
+def _wait_for_input_state(client, window_id, expected_text_length, message, timeout_s=0.8):
+    def _matches():
+        selection = _palette_input_selection(client, window_id)
+        if not selection.get("focused"):
+            return False
+        text_length = int(selection.get("text_length") or 0)
+        selection_location = int(selection.get("selection_location") or 0)
+        selection_length = int(selection.get("selection_length") or 0)
+        return (
+            text_length == expected_text_length
+            and selection_location == expected_text_length
+            and selection_length == 0
+        )
+
+    _wait_until(_matches, timeout_s=timeout_s, message=message)
+
+
+def _close_palette_if_open(client, window_id):
+    if _palette_visible(client, window_id):
+        client._call("debug.command_palette.toggle", {"window_id": window_id})
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="command palette failed to close",
+        )
+
+
+def _open_palette(client, window_id):
+    _close_palette_if_open(client, window_id)
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="command palette failed to open",
+    )
+    _wait_for_input_state(
+        client,
+        window_id,
+        expected_text_length=0,
+        message="search input did not focus with empty query",
+    )
+
+
+def main():
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+
+        # Keep a single active window for deterministic first-responder behavior.
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        probe = "typingstability"
+        cycles = 4
+        for cycle in range(cycles):
+            _open_palette(client, window_id)
+            for idx, ch in enumerate(probe, start=1):
+                client.simulate_type(ch)
+                _wait_for_input_state(
+                    client,
+                    window_id,
+                    expected_text_length=idx,
+                    timeout_s=0.7,
+                    message=(
+                        f"search typing did not accumulate at cycle {cycle + 1}/{cycles}, "
+                        f"char {idx}/{len(probe)}"
+                    ),
+                )
+            _close_palette_if_open(client, window_id)
+
+    print("PASS: command-palette search typing accumulates text without select-all churn")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_switcher_cross_workspace_surface_focus.py
+++ b/tests_v2/test_command_palette_switcher_cross_workspace_surface_focus.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Regression test: cmd+p switcher surface selection across workspaces must focus that surface.
+
+Why: switching workspaces with an explicit target surface could be overridden by stale
+per-workspace remembered focus, leaving the destination workspace selected but the wrong
+surface focused.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 6.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def _open_switcher(client: cmux, window_id: str) -> None:
+    _set_palette_visible(client, window_id, False)
+    client.simulate_shortcut("cmd+p")
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="cmd+p did not open switcher",
+    )
+    _wait_until(
+        lambda: str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+        message="cmd+p did not open switcher mode",
+    )
+
+
+def _rename_surface(client: cmux, surface_id: str, title: str) -> None:
+    client._call(
+        "surface.action",
+        {
+            "surface_id": surface_id,
+            "action": "rename",
+            "title": title,
+        },
+    )
+
+
+def _current_surface_id(client: cmux, workspace_id: str) -> str:
+    payload = client._call("surface.current", {"workspace_id": workspace_id}) or {}
+    return str(payload.get("surface_id") or "")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        ws_a = client.new_workspace(window_id=window_id)
+        client.select_workspace(ws_a)
+        client.rename_workspace("source-workspace", workspace=ws_a)
+
+        ws_b = client.new_workspace(window_id=window_id)
+        client.select_workspace(ws_b)
+        client.rename_workspace("target-workspace", workspace=ws_b)
+        time.sleep(0.2)
+
+        right_surface_id = client.new_split("right")
+        time.sleep(0.2)
+
+        payload = client._call("surface.list", {"workspace_id": ws_b}) or {}
+        rows = payload.get("surfaces") or []
+        if len(rows) < 2:
+            raise cmuxError(f"expected at least two surfaces after split: {payload}")
+
+        left_surface_id = ""
+        for row in rows:
+            sid = str(row.get("id") or "")
+            if sid and sid != right_surface_id:
+                left_surface_id = sid
+                break
+        if not left_surface_id:
+            raise cmuxError(f"failed to resolve left surface id: {payload}")
+
+        token = f"cmdp-crossws-{int(time.time() * 1000)}"
+        _rename_surface(client, right_surface_id, token)
+        time.sleep(0.2)
+
+        client.focus_surface(left_surface_id)
+        _wait_until(
+            lambda: _current_surface_id(client, ws_b).lower() == left_surface_id.lower(),
+            message="failed to prime remembered focus on non-target surface",
+        )
+
+        client.select_workspace(ws_a)
+        _wait_until(
+            lambda: client.current_workspace() == ws_a,
+            message="failed to return to source workspace before cmd+p navigation",
+        )
+
+        _open_switcher(client, window_id)
+        client.simulate_type(token)
+        _wait_until(
+            lambda: token in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="switcher query did not update to target token",
+        )
+
+        target_command_id = f"switcher.surface.{ws_b.lower()}.{right_surface_id.lower()}"
+        _wait_until(
+            lambda: str(((_palette_results(client, window_id, limit=24).get("results") or [{}])[0] or {}).get("command_id") or "") == target_command_id,
+            message="target surface row did not become top switcher result",
+        )
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="palette did not close after selecting cross-workspace surface row",
+        )
+        _wait_until(
+            lambda: client.current_workspace() == ws_b,
+            message="Enter on switcher surface row did not move to target workspace",
+        )
+        _wait_until(
+            lambda: _current_surface_id(client, ws_b).lower() == right_surface_id.lower(),
+            message="Enter on cross-workspace switcher surface row did not focus target surface",
+        )
+
+        client.close_workspace(ws_b)
+        client.close_workspace(ws_a)
+
+    print("PASS: cmd+p switcher focuses selected surface after cross-workspace navigation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_switcher_renamed_surface.py
+++ b/tests_v2/test_command_palette_switcher_renamed_surface.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Regression test: cmd+p switcher should search and navigate to renamed surfaces.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 6.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def _open_switcher(client: cmux, window_id: str) -> None:
+    _set_palette_visible(client, window_id, False)
+    client.simulate_shortcut("cmd+p")
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="cmd+p did not open switcher",
+    )
+    _wait_until(
+        lambda: str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+        message="cmd+p did not open switcher mode",
+    )
+
+
+def _rename_surface(client: cmux, surface_id: str, title: str) -> None:
+    client._call(
+        "surface.action",
+        {
+            "surface_id": surface_id,
+            "action": "rename",
+            "title": title,
+        },
+    )
+
+
+def _current_surface_id(client: cmux, workspace_id: str) -> str:
+    payload = client._call("surface.current", {"workspace_id": workspace_id}) or {}
+    return str(payload.get("surface_id") or "")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        time.sleep(0.2)
+
+        right_surface_id = client.new_split("right")
+        time.sleep(0.2)
+
+        payload = client._call("surface.list", {"workspace_id": workspace_id}) or {}
+        rows = payload.get("surfaces") or []
+        if len(rows) < 2:
+            raise cmuxError(f"expected at least two surfaces after split: {payload}")
+
+        left_surface_id = ""
+        for row in rows:
+            sid = str(row.get("id") or "")
+            if sid and sid != right_surface_id:
+                left_surface_id = sid
+                break
+        if not left_surface_id:
+            raise cmuxError(f"failed to resolve left surface id: {payload}")
+
+        token = f"renamed-surface-{int(time.time() * 1000)}"
+        _rename_surface(client, right_surface_id, token)
+        time.sleep(0.2)
+
+        client.focus_surface(left_surface_id)
+        time.sleep(0.2)
+
+        _open_switcher(client, window_id)
+        client.simulate_type(token)
+        _wait_until(
+            lambda: token in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="switcher query did not update to renamed surface token",
+        )
+
+        result_rows = (_palette_results(client, window_id, limit=24).get("results") or [])
+        if not result_rows:
+            raise cmuxError("switcher returned no rows for renamed surface query")
+
+        top_row = result_rows[0] or {}
+        top_id = str(top_row.get("command_id") or "")
+        top_title = str(top_row.get("title") or "")
+        if not top_id.startswith("switcher.surface."):
+            raise cmuxError(
+                f"expected renamed surface row on top, got top={top_id!r} rows={result_rows}"
+            )
+        if top_title != token:
+            raise cmuxError(
+                f"expected top surface row title to match renamed title {token!r}, got {top_title!r}"
+            )
+
+        client.simulate_shortcut("enter")
+        _wait_until(
+            lambda: not _palette_visible(client, window_id),
+            message="palette did not close after selecting renamed surface row",
+        )
+
+        _wait_until(
+            lambda: _current_surface_id(client, workspace_id).lower() == right_surface_id.lower(),
+            message="Enter on renamed surface switcher row did not focus target surface",
+        )
+
+        client.close_workspace(workspace_id)
+
+    print("PASS: cmd+p switcher searches and navigates renamed surfaces")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_switcher_surface_precedence.py
+++ b/tests_v2/test_command_palette_switcher_surface_precedence.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Regression test: switcher should prioritize matching surfaces over workspace rows.
+
+Why: workspace rows used to index metadata from all surfaces, so a path-token query
+could rank the workspace row above the actual surface row (because of stable rank
+tie-breaks), making Enter jump to workspace instead of the intended surface.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 6.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def _open_switcher(client: cmux, window_id: str) -> None:
+    _set_palette_visible(client, window_id, False)
+    client.simulate_shortcut("cmd+p")
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="cmd+p did not open switcher",
+    )
+    _wait_until(
+        lambda: str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+        message="cmd+p did not open switcher mode",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        client.rename_workspace("workspace-no-token", workspace=workspace_id)
+        time.sleep(0.2)
+
+        right_surface_id = client.new_split("right")
+        time.sleep(0.2)
+
+        payload = client._call("surface.list", {"workspace_id": workspace_id}) or {}
+        rows = payload.get("surfaces") or []
+        if len(rows) < 2:
+            raise cmuxError(f"expected at least two surfaces after split: {payload}")
+
+        left_surface_id = ""
+        for row in rows:
+            sid = str(row.get("id") or "")
+            if sid and sid != right_surface_id:
+                left_surface_id = sid
+                break
+        if not left_surface_id:
+            raise cmuxError(f"failed to resolve left surface id: {payload}")
+
+        token = f"cmdp-switcher-target-{int(time.time() * 1000)}"
+        target_dir = f"/tmp/{token}"
+
+        client.send_surface(left_surface_id, "cd /tmp\n")
+        client.send_surface(
+            right_surface_id,
+            f"mkdir -p {target_dir} && cd {target_dir}\n",
+        )
+        client.focus_surface(left_surface_id)
+        time.sleep(0.8)
+
+        _open_switcher(client, window_id)
+        client.simulate_type(token)
+        _wait_until(
+            lambda: token in str(_palette_results(client, window_id).get("query") or "").strip().lower(),
+            message="switcher query did not update to target token",
+        )
+
+        def _has_surface_match() -> bool:
+            result_rows = (_palette_results(client, window_id, limit=24).get("results") or [])
+            return any(str((row or {}).get("command_id") or "").startswith("switcher.surface.") for row in result_rows)
+
+        _wait_until(
+            _has_surface_match,
+            timeout_s=8.0,
+            message="switcher results never produced a matching surface row for token query",
+        )
+
+        result_rows = (_palette_results(client, window_id, limit=24).get("results") or [])
+        if not result_rows:
+            raise cmuxError("switcher returned no rows for token query")
+
+        top_id = str((result_rows[0] or {}).get("command_id") or "")
+        if not top_id.startswith("switcher.surface."):
+            raise cmuxError(f"expected a surface row on top for token query, got top={top_id!r} rows={result_rows}")
+
+        workspace_matches = [
+            str((row or {}).get("command_id") or "")
+            for row in result_rows
+            if str((row or {}).get("command_id") or "").startswith("switcher.workspace.")
+        ]
+        if workspace_matches:
+            raise cmuxError(
+                f"workspace row should not match a non-focused surface path token; workspace matches={workspace_matches} rows={result_rows}"
+            )
+
+        _set_palette_visible(client, window_id, False)
+        client.close_workspace(workspace_id)
+
+    print("PASS: switcher ranks matching surface rows ahead of workspace rows for path-token queries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_switcher_type_labels.py
+++ b/tests_v2/test_command_palette_switcher_type_labels.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Regression test: cmd+p switcher rows expose right-side type labels.
+
+Expected trailing labels:
+- switcher.workspace.* => Workspace
+- switcher.surface.* => Surface
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 6.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _palette_results(client: cmux, window_id: str, limit: int = 20) -> dict:
+    return client.command_palette_results(window_id=window_id, limit=limit)
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        message=f"palette visibility did not become {visible}",
+    )
+
+
+def _open_switcher(client: cmux, window_id: str) -> None:
+    _set_palette_visible(client, window_id, False)
+    client.simulate_shortcut("cmd+p")
+    _wait_until(
+        lambda: _palette_visible(client, window_id),
+        message="cmd+p did not open switcher",
+    )
+    _wait_until(
+        lambda: str(_palette_results(client, window_id).get("mode") or "") == "switcher",
+        message="cmd+p did not open switcher mode",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_id = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_id:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_id)
+        client.activate_app()
+        time.sleep(0.2)
+
+        workspace_id = client.new_workspace(window_id=window_id)
+        client.select_workspace(workspace_id)
+        token = f"switchertype{int(time.time() * 1000)}"
+        client.rename_workspace(token, workspace=workspace_id)
+        _ = client.new_split("right")
+        time.sleep(0.3)
+
+        _open_switcher(client, window_id)
+        client.simulate_type(token)
+        _wait_until(
+            lambda: token in str(_palette_results(client, window_id, limit=60).get("query") or "").strip().lower(),
+            message="switcher query did not update to workspace token",
+        )
+
+        rows = (_palette_results(client, window_id, limit=60).get("results") or [])
+        if not rows:
+            raise cmuxError("switcher returned no rows for token query")
+
+        workspace_rows = [
+            row for row in rows
+            if str((row or {}).get("command_id") or "").startswith("switcher.workspace.")
+        ]
+        surface_rows = [
+            row for row in rows
+            if str((row or {}).get("command_id") or "").startswith("switcher.surface.")
+        ]
+
+        if not workspace_rows:
+            raise cmuxError(f"expected workspace rows for switcher query: rows={rows}")
+        if not surface_rows:
+            raise cmuxError(f"expected surface rows for switcher query: rows={rows}")
+
+        bad_workspace = [row for row in workspace_rows if str((row or {}).get("trailing_label") or "") != "Workspace"]
+        if bad_workspace:
+            raise cmuxError(f"workspace rows missing 'Workspace' trailing label: {bad_workspace}")
+
+        bad_surface = [row for row in surface_rows if str((row or {}).get("trailing_label") or "") != "Surface"]
+        if bad_surface:
+            raise cmuxError(f"surface rows missing 'Surface' trailing label: {bad_surface}")
+
+        _set_palette_visible(client, window_id, False)
+        client.close_workspace(workspace_id)
+
+    print("PASS: cmd+p switcher rows report Workspace/Surface trailing labels")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_command_palette_window_scope.py
+++ b/tests_v2/test_command_palette_window_scope.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Regression test: command palette should open only in the active window.
+
+Why: if command-palette toggle is broadcast to all windows, inactive windows can
+end up with an open palette that steals focus once they become key.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 5.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _palette_visible(client: cmux, window_id: str) -> bool:
+    res = client._call("debug.command_palette.visible", {"window_id": window_id}) or {}
+    return bool(res.get("visible"))
+
+
+def _set_palette_visible(client: cmux, window_id: str, visible: bool) -> None:
+    if _palette_visible(client, window_id) == visible:
+        return
+    client._call("debug.command_palette.toggle", {"window_id": window_id})
+    _wait_until(
+        lambda: _palette_visible(client, window_id) == visible,
+        timeout_s=3.0,
+        message=f"palette in {window_id} did not become {visible}",
+    )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+        w1 = client.current_window()
+        w2 = client.new_window()
+        time.sleep(0.25)
+
+        ws1 = client.new_workspace(window_id=w1)
+        ws2 = client.new_workspace(window_id=w2)
+        time.sleep(0.25)
+        _set_palette_visible(client, w1, False)
+        _set_palette_visible(client, w2, False)
+
+        # Open palette in window1 and verify window2 remains untouched.
+        client._call("debug.command_palette.toggle", {"window_id": w1})
+        _wait_until(
+            lambda: _palette_visible(client, w1),
+            timeout_s=3.0,
+            message="window1 command palette did not open",
+        )
+        if _palette_visible(client, w2):
+            raise cmuxError("window2 palette became visible when toggling window1")
+
+        # Closing window1 palette should not affect window2.
+        client._call("debug.command_palette.toggle", {"window_id": w1})
+        _wait_until(
+            lambda: not _palette_visible(client, w1),
+            timeout_s=3.0,
+            message="window1 command palette did not close",
+        )
+
+        # Mirror the same check in the other direction.
+        client._call("debug.command_palette.toggle", {"window_id": w2})
+        _wait_until(
+            lambda: _palette_visible(client, w2),
+            timeout_s=3.0,
+            message="window2 command palette did not open",
+        )
+        if _palette_visible(client, w1):
+            raise cmuxError("window1 palette became visible when toggling window2")
+        client._call("debug.command_palette.toggle", {"window_id": w2})
+        _wait_until(
+            lambda: not _palette_visible(client, w2),
+            timeout_s=3.0,
+            message="window2 command palette did not close",
+        )
+
+    print("PASS: command palette is scoped to active window")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_shortcut_window_scope.py
+++ b/tests_v2/test_shortcut_window_scope.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Regression test: app shortcuts must apply to the focused window only.
+
+Covers:
+- Cmd+B (toggle sidebar) should only affect the active window.
+- Cmd+T (new terminal tab/surface) should only affect the active window.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_until(predicate, timeout_s: float = 4.0, interval_s: float = 0.05, message: str = "timeout") -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(interval_s)
+    raise cmuxError(message)
+
+
+def _sidebar_visible(client: cmux, window_id: str) -> bool:
+    payload = client._call("debug.sidebar.visible", {"window_id": window_id}) or {}
+    return bool(payload.get("visible"))
+
+
+def _surface_count(client: cmux, workspace_id: str) -> int:
+    payload = client._call("surface.list", {"workspace_id": workspace_id}) or {}
+    return len(payload.get("surfaces") or [])
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        window_a = client.current_window()
+        window_b = client.new_window()
+        time.sleep(0.25)
+
+        workspace_a = client.new_workspace(window_id=window_a)
+        workspace_b = client.new_workspace(window_id=window_b)
+        time.sleep(0.25)
+
+        client.focus_window(window_a)
+        client.activate_app()
+        time.sleep(0.2)
+
+        a_before = _sidebar_visible(client, window_a)
+        b_before = _sidebar_visible(client, window_b)
+
+        client.simulate_shortcut("cmd+b")
+        _wait_until(
+            lambda: _sidebar_visible(client, window_a) != a_before,
+            message="Cmd+B did not toggle sidebar in active window A",
+        )
+        a_after = _sidebar_visible(client, window_a)
+        b_after = _sidebar_visible(client, window_b)
+        if b_after != b_before:
+            raise cmuxError("Cmd+B in window A incorrectly toggled sidebar in window B")
+
+        client.focus_window(window_b)
+        client.activate_app()
+        time.sleep(0.2)
+
+        client.simulate_shortcut("cmd+b")
+        _wait_until(
+            lambda: _sidebar_visible(client, window_b) != b_after,
+            message="Cmd+B did not toggle sidebar in active window B",
+        )
+        if _sidebar_visible(client, window_a) != a_after:
+            raise cmuxError("Cmd+B in window B incorrectly toggled sidebar in window A")
+
+        client.focus_window(window_a)
+        client.activate_app()
+        time.sleep(0.2)
+        client.select_workspace(workspace_a)
+        time.sleep(0.1)
+
+        count_a_before = _surface_count(client, workspace_a)
+        count_b_before = _surface_count(client, workspace_b)
+
+        client.simulate_shortcut("cmd+t")
+        _wait_until(
+            lambda: _surface_count(client, workspace_a) == count_a_before + 1,
+            message="Cmd+T did not create a new surface in active window A",
+        )
+
+        count_b_after = _surface_count(client, workspace_b)
+        if count_b_after != count_b_before:
+            raise cmuxError("Cmd+T in window A incorrectly created a surface in window B")
+
+    print("PASS: window-scoped shortcuts stay in the active window (Cmd+B, Cmd+T)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a VS Code-style command palette triggered by Cmd+Shift+P
- Fuzzy search across actions, workspaces, and surfaces
- Keyboard navigation (arrow keys, Enter, Escape)
- Rename mode for workspaces/surfaces
- Window-scoped results

Closes https://github.com/manaflow-ai/cmux/issues/133

## Test plan
- [ ] Press Cmd+Shift+P to open the palette
- [ ] Type to fuzzy search actions
- [ ] Arrow keys to navigate, Enter to select
- [ ] Escape to dismiss
- [ ] Test rename mode
- [ ] Verify palette is scoped to current window