### PR TITLE
Add current working directory to panel metadata in TerminalController

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2712,6 +2712,7 @@ class TerminalController {
                     "type": panel.panelType.rawValue,
                     "title": ws.panelTitle(panelId: panel.id) ?? panel.displayTitle,
                     "focused": panel.id == focusedSurfaceId,
+                    "cwd": v2OrNull(ws.panelDirectories[panel.id]),
                     "pane_id": v2OrNull(paneUUID?.uuidString),
                     "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
                     "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),


### PR DESCRIPTION
Add current working directory to panel metadata in TerminalController (for use in list-panels cli command)

Personally I found myself in need of it when scripting IDE keybinds to open an existing terminal window of the project directory.