### PR TITLE
Fix stale split dividers persisting after workspace switch

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1661,6 +1661,10 @@ struct ContentView: View {
         // (to avoid blackouts during transient bonsplit dismantles). Hiding here
         // prevents stale portal-hosted terminals from covering browser panes.
         if let retiring, let workspace = tabManager.tabs.first(where: { $0.id == retiring }) {
+            // Ensure any lingering Bonsplit AppKit views (notably split dividers) are
+            // hidden before unmount. SwiftUI can occasionally leave stale NSView-backed
+            // split chrome visible for one workspace switch after teardown.
+            workspace.bonsplitController.isInteractive = false
             workspace.hideAllTerminalPortalViews()
         }
 


### PR DESCRIPTION
## Summary
- Disable Bonsplit interactivity on the retiring workspace before hiding terminal portal views
- Fixes stale NSView-backed split divider chrome occasionally remaining visible after workspace switch

## Test plan
- [ ] Open multiple workspaces with split panes
- [ ] Switch between workspaces and verify no lingering dividers appear
- [ ] Close splits and switch workspaces to confirm clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)