### PR TITLE
Fix browser workspace focus handoff lag

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3070,6 +3070,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator: Coordinator,
         generation: Int
     ) {
+        let retryInterval: TimeInterval = 1.0 / 60.0
         // Don't schedule multiple overlapping retries.
         guard coordinator.attachRetryWorkItem == nil else { return }
 
@@ -3102,7 +3103,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 // Be generous here: bonsplit structural updates can keep a representable
                 // container off-window longer than a few seconds under load.
                 if coordinator.attachRetryCount < 400 {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval) {
                         scheduleAttachRetry(
                             webView,
                             panel: panel,
@@ -3139,7 +3140,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         coordinator.attachRetryWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + retryInterval, execute: work)
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -45,6 +45,9 @@ final class CmuxWebView: WKWebView {
             return false
         }
         let result = super.becomeFirstResponder()
+        if result {
+            NotificationCenter.default.post(name: .browserDidBecomeFirstResponderWebView, object: self)
+        }
 #if DEBUG
         let eventType = NSApp.currentEvent.map { String(describing: $0.type) } ?? "nil"
         dlog(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3113,6 +3113,7 @@ extension Notification.Name {
     static let ghosttyDidFocusTab = Notification.Name("ghosttyDidFocusTab")
     static let ghosttyDidFocusSurface = Notification.Name("ghosttyDidFocusSurface")
     static let ghosttyDidBecomeFirstResponderSurface = Notification.Name("ghosttyDidBecomeFirstResponderSurface")
+    static let browserDidBecomeFirstResponderWebView = Notification.Name("browserDidBecomeFirstResponderWebView")
     static let browserFocusAddressBar = Notification.Name("browserFocusAddressBar")
     static let browserMoveOmnibarSelection = Notification.Name("browserMoveOmnibarSelection")
     static let browserDidExitAddressBar = Notification.Name("browserDidExitAddressBar")


### PR DESCRIPTION
## Summary
- keep only the selected workspace input-active during workspace handoff so retiring browser panels cannot steal first responder
- complete workspace handoff when browser focus is confirmed via WKWebView first-responder and browser address-bar focus notifications
- speed up browser attach retries from 50ms to frame-rate cadence (1/60s) to reduce delayed focus completion when returning to browser workspaces

## Validation
- ./scripts/reload.sh --tag fix-browser-workspace-handoff
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build