### PR TITLE
Fix Caps Lock preventing browser omnibar Enter submit

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1123,6 +1123,25 @@ final class BrowserOmnibarCommandNavigationTests: XCTestCase {
         )
     }
 
+    func testArrowNavigationDeltaIgnoresCapsLockModifier() {
+        XCTAssertEqual(
+            browserOmnibarSelectionDeltaForArrowNavigation(
+                hasFocusedAddressBar: true,
+                flags: [.capsLock],
+                keyCode: 126
+            ),
+            -1
+        )
+        XCTAssertEqual(
+            browserOmnibarSelectionDeltaForArrowNavigation(
+                hasFocusedAddressBar: true,
+                flags: [.capsLock],
+                keyCode: 125
+            ),
+            1
+        )
+    }
+
     func testCommandNavigationDeltaRequiresFocusedAddressBarAndCommandOrControlOnly() {
         XCTAssertNil(
             browserOmnibarSelectionDeltaForCommandNavigation(
@@ -1175,6 +1194,33 @@ final class BrowserOmnibarCommandNavigationTests: XCTestCase {
             ),
             1
         )
+    }
+
+    func testCommandNavigationDeltaIgnoresCapsLockModifier() {
+        XCTAssertEqual(
+            browserOmnibarSelectionDeltaForCommandNavigation(
+                hasFocusedAddressBar: true,
+                flags: [.control, .capsLock],
+                chars: "n"
+            ),
+            1
+        )
+        XCTAssertEqual(
+            browserOmnibarSelectionDeltaForCommandNavigation(
+                hasFocusedAddressBar: true,
+                flags: [.command, .capsLock],
+                chars: "p"
+            ),
+            -1
+        )
+    }
+
+    func testSubmitOnReturnIgnoresCapsLockModifier() {
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: []))
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: [.shift]))
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: [.capsLock]))
+        XCTAssertTrue(browserOmnibarShouldSubmitOnReturn(flags: [.shift, .capsLock]))
+        XCTAssertFalse(browserOmnibarShouldSubmitOnReturn(flags: [.command, .capsLock]))
     }
 }
 


### PR DESCRIPTION
## Summary\n- normalize browser omnibar modifier handling to treat Caps Lock as non-semantic\n- ensure Enter/Return submit works with Caps Lock enabled\n- keep omnibar Cmd/Ctrl+N/P and arrow-key selection logic consistent under Caps Lock\n- add regression tests for Caps Lock on submit and omnibar navigation\n\n## Testing\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/BrowserOmnibarCommandNavigationTests test\n- ./scripts/reload.sh --tag issue-379-capslock-enter\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build\n\nFixes #379