### PR TITLE
Fix sidebar max-width regression with a 1/3 window cap

### DIFF
--- a/cmuxUITests/SidebarResizeUITests.swift
+++ b/cmuxUITests/SidebarResizeUITests.swift
@@ -35,4 +35,31 @@ final class SidebarResizeUITests: XCTestCase {
         XCTAssertLessThanOrEqual(leftDelta, -40, "Expected drag-left to move resizer left")
         XCTAssertGreaterThanOrEqual(leftDelta, -122, "Resizer moved farther than requested drag-left offset")
     }
+
+    func testSidebarResizerHasMaximumWidthCap() {
+        let app = XCUIApplication()
+        app.launch()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0))
+
+        let elements = app.descendants(matching: .any)
+        let resizer = elements["SidebarResizer"]
+        XCTAssertTrue(resizer.waitForExistence(timeout: 5.0))
+
+        let start = resizer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let farRight = start.withOffset(CGVector(dx: 5000, dy: 0))
+        start.press(forDuration: 0.1, thenDragTo: farRight)
+
+        let windowFrame = window.frame
+        let remainingWidth = max(0, windowFrame.maxX - resizer.frame.maxX)
+        let minimumExpectedRemaining = windowFrame.width * 0.45
+
+        XCTAssertGreaterThanOrEqual(
+            remainingWidth,
+            minimumExpectedRemaining,
+            "Expected sidebar max-width clamp to leave substantial terminal width. " +
+            "remaining=\(remainingWidth), window=\(windowFrame.width)"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- restore sidebar max-width enforcement using live window/content width rather than screen width
- cap sidebar width to one-third of the available window width while preserving the existing 186px minimum
- clamp existing sidebar width on layout/window resize so stale oversized values cannot persist
- add a UI regression test that drags the sidebar far right and asserts substantial terminal width remains

## Testing
- ./scripts/reload.sh --tag fix-sidebar-max-width
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -only-testing:cmuxUITests/SidebarResizeUITests build-for-testing

Fixes #391