### PR TITLE
Fix actions routing to wrong window (#360)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -665,6 +665,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func preferredMainWindowContextForServiceWorkspace() -> MainWindowContext? {
+        activeMainWindowContext()
+    }
+
+    /// Resolves the main-window context for the currently active window.
+    /// If a specific window is provided it is checked first, then NSApp.keyWindow,
+    /// then NSApp.mainWindow, and finally any available context as a fallback.
+    /// Use this instead of the cached `tabManager`/`sidebarState` pointers so that
+    /// actions target the correct window in multi-window configurations.
+    private func activeMainWindowContext(for window: NSWindow? = nil) -> MainWindowContext? {
+        if let window = window,
+           isMainTerminalWindow(window),
+           let context = mainWindowContexts[ObjectIdentifier(window)] {
+            return context
+        }
+
         if let keyWindow = NSApp.keyWindow,
            isMainTerminalWindow(keyWindow),
            let context = mainWindowContexts[ObjectIdentifier(keyWindow)] {
@@ -678,6 +693,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         return mainWindowContexts.values.first
+    }
+
+    /// Convenience: the TabManager for the currently active main window.
+    var activeTabManager: TabManager? {
+        activeMainWindowContext()?.tabManager
+    }
+
+    /// Convenience: the SidebarState for the currently active main window.
+    var activeSidebarState: SidebarState? {
+        activeMainWindowContext()?.sidebarState
     }
 
     @discardableResult
@@ -1678,6 +1703,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Resolve the active window's context at event time so shortcuts
+        // operate on the correct window in multi-window configurations.
+        let ctx = activeMainWindowContext()
+        let tabManager = ctx?.tabManager
+        let sidebarState = ctx?.sidebarState
+
         // Keep keyboard routing deterministic after split close/reparent transitions:
         // before processing shortcuts, converge first responder with the focused terminal panel.
         if isControlD {
@@ -1957,7 +1988,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     private func focusBrowserAddressBar(panelId: UUID) -> Bool {
-        guard let tabManager,
+        guard let tabManager = activeTabManager,
               let workspace = tabManager.selectedWorkspace,
               let panel = workspace.browserPanel(for: panelId) else {
             return false
@@ -2071,7 +2102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func performSplitShortcut(direction: SplitDirection) -> Bool {
-        tabManager?.createSplit(direction: direction)
+        activeTabManager?.createSplit(direction: direction)
 #if DEBUG
         recordGotoSplitSplitIfNeeded(direction: direction)
 #endif
@@ -2080,7 +2111,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func performBrowserSplitShortcut(direction: SplitDirection) -> Bool {
-        guard let panelId = tabManager?.createBrowserSplit(direction: direction) else { return false }
+        guard let panelId = activeTabManager?.createBrowserSplit(direction: direction) else { return false }
         _ = focusBrowserAddressBar(panelId: panelId)
         return true
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -576,7 +576,7 @@ struct ContentView: View {
         TitlebarControlsView(
             notificationStore: TerminalNotificationStore.shared,
             viewModel: fullscreenControlsViewModel,
-            onToggleSidebar: { AppDelegate.shared?.sidebarState?.toggle() },
+            onToggleSidebar: { _ = AppDelegate.shared?.activeSidebarState?.toggle() },
             onToggleNotifications: { [fullscreenControlsViewModel] in
                 AppDelegate.shared?.toggleNotificationsPopover(
                     animated: true,

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -590,9 +590,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
     init(notificationStore: TerminalNotificationStore) {
         self.notificationStore = notificationStore
-        let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
+        let toggleSidebar = { _ = AppDelegate.shared?.activeSidebarState?.toggle() }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
-        let newTab = { _ = AppDelegate.shared?.tabManager?.addTab() }
+        let newTab = { _ = AppDelegate.shared?.activeTabManager?.addTab() }
 
         hostingView = NonDraggableHostingView(
             rootView: TitlebarControlsView(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -339,7 +339,7 @@ struct cmuxApp: App {
                 .keyboardShortcut("n", modifiers: [.command, .shift])
 
                 Button("New Workspace") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).addTab()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).addTab()
                 }
             }
 
@@ -365,81 +365,81 @@ struct cmuxApp: App {
             CommandGroup(after: .textEditing) {
                 Menu("Find") {
                     Button("Find…") {
-                        (AppDelegate.shared?.tabManager ?? tabManager).startSearch()
+                        (AppDelegate.shared?.activeTabManager ?? tabManager).startSearch()
                     }
                     .keyboardShortcut("f", modifiers: .command)
 
                     Button("Find Next") {
-                        (AppDelegate.shared?.tabManager ?? tabManager).findNext()
+                        (AppDelegate.shared?.activeTabManager ?? tabManager).findNext()
                     }
                     .keyboardShortcut("g", modifiers: .command)
 
                     Button("Find Previous") {
-                        (AppDelegate.shared?.tabManager ?? tabManager).findPrevious()
+                        (AppDelegate.shared?.activeTabManager ?? tabManager).findPrevious()
                     }
                     .keyboardShortcut("g", modifiers: [.command, .shift])
 
                     Divider()
 
                     Button("Hide Find Bar") {
-                        (AppDelegate.shared?.tabManager ?? tabManager).hideFind()
+                        (AppDelegate.shared?.activeTabManager ?? tabManager).hideFind()
                     }
                     .keyboardShortcut("f", modifiers: [.command, .shift])
-                    .disabled(!((AppDelegate.shared?.tabManager ?? tabManager).isFindVisible))
+                    .disabled(!((AppDelegate.shared?.activeTabManager ?? tabManager).isFindVisible))
 
                     Divider()
 
                     Button("Use Selection for Find") {
-                        (AppDelegate.shared?.tabManager ?? tabManager).searchSelection()
+                        (AppDelegate.shared?.activeTabManager ?? tabManager).searchSelection()
                     }
                     .keyboardShortcut("e", modifiers: .command)
-                    .disabled(!((AppDelegate.shared?.tabManager ?? tabManager).canUseSelectionForFind))
+                    .disabled(!((AppDelegate.shared?.activeTabManager ?? tabManager).canUseSelectionForFind))
                 }
             }
 
             // Tab navigation
             CommandGroup(after: .toolbar) {
                 Button("Toggle Sidebar") {
-                    sidebarState.toggle()
+                    (AppDelegate.shared?.activeSidebarState ?? sidebarState).toggle()
                 }
 
                 Divider()
 
                 Button("Next Surface") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).selectNextSurface()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).selectNextSurface()
                 }
 
                 Button("Previous Surface") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).selectPreviousSurface()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).selectPreviousSurface()
                 }
 
                 Button("Back") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).focusedBrowserPanel?.goBack()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).focusedBrowserPanel?.goBack()
                 }
                 .keyboardShortcut("[", modifiers: .command)
 
                 Button("Forward") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).focusedBrowserPanel?.goForward()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).focusedBrowserPanel?.goForward()
                 }
                 .keyboardShortcut("]", modifiers: .command)
 
                 Button("Reload Page") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).focusedBrowserPanel?.reload()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).focusedBrowserPanel?.reload()
                 }
                 .keyboardShortcut("r", modifiers: .command)
 
                 Button("Zoom In") {
-                    _ = (AppDelegate.shared?.tabManager ?? tabManager).zoomInFocusedBrowser()
+                    _ = (AppDelegate.shared?.activeTabManager ?? tabManager).zoomInFocusedBrowser()
                 }
                 .keyboardShortcut("=", modifiers: .command)
 
                 Button("Zoom Out") {
-                    _ = (AppDelegate.shared?.tabManager ?? tabManager).zoomOutFocusedBrowser()
+                    _ = (AppDelegate.shared?.activeTabManager ?? tabManager).zoomOutFocusedBrowser()
                 }
                 .keyboardShortcut("-", modifiers: .command)
 
                 Button("Actual Size") {
-                    _ = (AppDelegate.shared?.tabManager ?? tabManager).resetZoomFocusedBrowser()
+                    _ = (AppDelegate.shared?.activeTabManager ?? tabManager).resetZoomFocusedBrowser()
                 }
                 .keyboardShortcut("0", modifiers: .command)
 
@@ -448,11 +448,11 @@ struct cmuxApp: App {
                 }
 
                 Button("Next Workspace") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).selectNextTab()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).selectNextTab()
                 }
 
                 Button("Previous Workspace") {
-                    (AppDelegate.shared?.tabManager ?? tabManager).selectPreviousTab()
+                    (AppDelegate.shared?.activeTabManager ?? tabManager).selectPreviousTab()
                 }
 
                 Divider()
@@ -478,7 +478,7 @@ struct cmuxApp: App {
                 // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
                 ForEach(1...9, id: \.self) { number in
                     Button("Workspace \(number)") {
-                        let manager = (AppDelegate.shared?.tabManager ?? tabManager)
+                        let manager = (AppDelegate.shared?.activeTabManager ?? tabManager)
                         if let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: number, workspaceCount: manager.tabs.count) {
                             manager.selectTab(at: targetIndex)
                         }
@@ -660,11 +660,11 @@ struct cmuxApp: App {
             window.performClose(nil)
             return
         }
-        (AppDelegate.shared?.tabManager ?? tabManager).closeCurrentPanelWithConfirmation()
+        (AppDelegate.shared?.activeTabManager ?? tabManager).closeCurrentPanelWithConfirmation()
     }
 
     private func closeTabOrWindow() {
-        (AppDelegate.shared?.tabManager ?? tabManager).closeCurrentTabWithConfirmation()
+        (AppDelegate.shared?.activeTabManager ?? tabManager).closeCurrentTabWithConfirmation()
     }
 
     private func showNotificationsPopover() {


### PR DESCRIPTION
## Summary
- add `activeMainWindowContext()` helper that resolves the correct window's TabManager/SidebarState from `NSApp.keyWindow` at call time instead of relying on cached pointers updated via `didBecomeKeyNotification`
- fix `handleCustomShortcut` (all ~30 shortcut actions), titlebar "+" button, sidebar toggle, menu commands, split shortcuts, and browser address bar focus to use the new resolver
- add `activeTabManager` / `activeSidebarState` convenience properties for external callers
- refactor `preferredMainWindowContextForServiceWorkspace()` to delegate to the new shared helper

## Testing
- `./scripts/reload.sh --tag fix-wrong-window`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`

Fixes #360