### PR TITLE
Make browser omnibar suggestions popup and row highlights squircle

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2626,6 +2626,7 @@ private struct OmnibarSuggestionsView: View {
     let searchSuggestionsEnabled: Bool
     let onCommit: (OmnibarSuggestion) -> Void
     let onHighlight: (Int) -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     // Keep radii below half of the smallest rendered heights so this keeps a
     // squircle silhouette instead of auto-clamping into a capsule.
@@ -2683,6 +2684,101 @@ private struct OmnibarSuggestionsView: View {
         contentHeight > maxPopupHeight
     }
 
+    private var listTextColor: Color {
+        switch colorScheme {
+        case .light:
+            return Color(nsColor: .labelColor)
+        case .dark:
+            return Color.white.opacity(0.9)
+        @unknown default:
+            return Color(nsColor: .labelColor)
+        }
+    }
+
+    private var badgeTextColor: Color {
+        switch colorScheme {
+        case .light:
+            return Color(nsColor: .secondaryLabelColor)
+        case .dark:
+            return Color.white.opacity(0.72)
+        @unknown default:
+            return Color(nsColor: .secondaryLabelColor)
+        }
+    }
+
+    private var badgeBackgroundColor: Color {
+        switch colorScheme {
+        case .light:
+            return Color.black.opacity(0.06)
+        case .dark:
+            return Color.white.opacity(0.08)
+        @unknown default:
+            return Color.black.opacity(0.06)
+        }
+    }
+
+    private var rowHighlightColor: Color {
+        switch colorScheme {
+        case .light:
+            return Color.black.opacity(0.07)
+        case .dark:
+            return Color.white.opacity(0.12)
+        @unknown default:
+            return Color.black.opacity(0.07)
+        }
+    }
+
+    private var popupOverlayGradientColors: [Color] {
+        switch colorScheme {
+        case .light:
+            return [
+                Color.white.opacity(0.55),
+                Color.white.opacity(0.2),
+            ]
+        case .dark:
+            return [
+                Color.black.opacity(0.26),
+                Color.black.opacity(0.14),
+            ]
+        @unknown default:
+            return [
+                Color.white.opacity(0.55),
+                Color.white.opacity(0.2),
+            ]
+        }
+    }
+
+    private var popupBorderGradientColors: [Color] {
+        switch colorScheme {
+        case .light:
+            return [
+                Color.white.opacity(0.65),
+                Color.black.opacity(0.12),
+            ]
+        case .dark:
+            return [
+                Color.white.opacity(0.22),
+                Color.white.opacity(0.06),
+            ]
+        @unknown default:
+            return [
+                Color.white.opacity(0.65),
+                Color.black.opacity(0.12),
+            ]
+        }
+    }
+
+    private var popupShadowColor: Color {
+        switch colorScheme {
+        case .light:
+            return Color.black.opacity(0.18)
+        case .dark:
+            return Color.black.opacity(0.45)
+        @unknown default:
+            return Color.black.opacity(0.18)
+        }
+    }
+
     @ViewBuilder
     private var rowsView: some View {
         VStack(spacing: rowSpacing) {
@@ -2696,18 +2792,18 @@ private struct OmnibarSuggestionsView: View {
                 HStack(spacing: 6) {
                         Text(item.listText)
                             .font(.system(size: 11))
-                            .foregroundStyle(Color.white.opacity(0.9))
+                            .foregroundStyle(listTextColor)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         if let badge = item.trailingBadgeText {
                             Text(badge)
                                 .font(.system(size: 9.5, weight: .medium))
-                                .foregroundStyle(Color.white.opacity(0.72))
+                                .foregroundStyle(badgeTextColor)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 2)
                                 .background(
                                     RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                        .fill(Color.white.opacity(0.08))
+                                        .fill(badgeBackgroundColor)
                                 )
                         }
                         Spacer(minLength: 0)
@@ -2723,7 +2819,7 @@ private struct OmnibarSuggestionsView: View {
                         RoundedRectangle(cornerRadius: rowHighlightCornerRadius, style: .continuous)
                             .fill(
                                 idx == selectedIndex
-                                    ? Color.white.opacity(0.12)
+                                    ? rowHighlightColor
                                     : Color.clear
                             )
                     )
@@ -2778,10 +2874,7 @@ private struct OmnibarSuggestionsView: View {
                     RoundedRectangle(cornerRadius: popupCornerRadius, style: .continuous)
                         .fill(
                             LinearGradient(
-                                colors: [
-                                    Color.black.opacity(0.26),
-                                    Color.black.opacity(0.14),
-                                ],
+                                colors: popupOverlayGradientColors,
                                 startPoint: .top,
                                 endPoint: .bottom
                             )
@@ -2792,10 +2885,7 @@ private struct OmnibarSuggestionsView: View {
             RoundedRectangle(cornerRadius: popupCornerRadius, style: .continuous)
                 .stroke(
                     LinearGradient(
-                        colors: [
-                            Color.white.opacity(0.22),
-                            Color.white.opacity(0.06),
-                        ],
+                        colors: popupBorderGradientColors,
                         startPoint: .top,
                         endPoint: .bottom
                     ),
@@ -2803,7 +2893,7 @@ private struct OmnibarSuggestionsView: View {
                 )
         )
         .clipShape(RoundedRectangle(cornerRadius: popupCornerRadius, style: .continuous))
-        .shadow(color: Color.black.opacity(0.45), radius: 20, y: 10)
+        .shadow(color: popupShadowColor, radius: 20, y: 10)
         .contentShape(RoundedRectangle(cornerRadius: popupCornerRadius, style: .continuous))
         .accessibilityElement(children: .contain)
         .accessibilityRespondsToUserInteraction(true)


### PR DESCRIPTION
## Summary
- make the browser omnibar suggestions popup use a squircle silhouette by reducing the popup corner radius below clamp limits
- make each suggestion row highlight render as a squircle (not a capsule) and align hit-testing/clip shape with the popup geometry

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `./scripts/reload.sh --tag omnibar-squircle` (pass; app launched)

## Issues
- Related: task request "make the browser address suggestions popover a squircle. and the highlight for each line a squircle too."
