### PR TITLE
Fix browser tab favicon showing stale icon from previous page

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1647,6 +1647,9 @@ final class BrowserPanel: Panel, ObservableObject {
             faviconTask?.cancel()
             faviconTask = nil
             lastFaviconURLString = nil
+            // Clear the previous page's favicon so it never persists across navigations.
+            // The loading spinner covers this gap; didFinish will fetch the new favicon.
+            faviconPNGData = nil
             loadingGeneration &+= 1
             loadingEndWorkItem?.cancel()
             loadingEndWorkItem = nil
@@ -2526,6 +2529,10 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         NSLog("BrowserPanel navigation failed: %@", error.localizedDescription)
+        // Treat committed-navigation failures the same as provisional ones so
+        // the stale favicon/title from the previous page is cleared.
+        let failedURL = webView.url?.absoluteString ?? ""
+        didFailNavigation?(webView, failedURL)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {

--- a/tests/test_browser_favicon_navigation_regression.py
+++ b/tests/test_browser_favicon_navigation_regression.py
@@ -69,6 +69,13 @@ def main() -> int:
         failures.append("handleWebViewLoadingChanged() no longer cancels stale favicon tasks")
     if "lastFaviconURLString = nil" not in loading_block:
         failures.append("handleWebViewLoadingChanged() no longer resets favicon URL cache on new loads")
+    if "faviconPNGData = nil" not in loading_block:
+        failures.append("handleWebViewLoadingChanged() no longer clears stale favicon data on new loads")
+
+    # Committed-navigation failures (didFail) must also clear stale favicon/title.
+    did_fail_block = extract_block(panel_source, "func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error)")
+    if "didFailNavigation?" not in did_fail_block:
+        failures.append("didFail (committed navigation failure) does not call didFailNavigation to clear stale state")
 
     if failures:
         print("FAIL: browser favicon navigation regression guard failed")


### PR DESCRIPTION
## Summary

- Clear `faviconPNGData` when a new navigation starts (`handleWebViewLoadingChanged(true)`) so the previous page's favicon never persists across navigations. The loading spinner covers the visual gap until `didFinish` fetches the new favicon.
- Wire committed-navigation failures (`didFail`) through the same `didFailNavigation` cleanup path as provisional failures, so stale favicon/title is always cleared on any navigation failure.
- Extend the regression test to guard both new invariants.

## Root cause

When navigating from Page A to Page B, `handleWebViewLoadingChanged(true)` cancelled the old favicon task and invalidated the generation counter, but **never cleared `faviconPNGData`**. If the new page's favicon fetch failed (no favicon, 404, timeout, etc.), the old favicon from Page A persisted permanently. Additionally, `didFail` (committed navigation failure) only logged without clearing stale state.

Closes https://github.com/manaflow-ai/cmux/issues/404

## Test plan

- [ ] Navigate from a site with a favicon (e.g. GitHub) to one without — should show globe, not the old favicon
- [ ] Navigate between sites with different favicons — should always reflect the current page
- [ ] Back/forward navigation — favicon should update correctly
- [ ] Reload a page — favicon should reappear after reload
- [ ] `python3 tests/test_browser_favicon_navigation_regression.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)