### PR TITLE
Fix keyboard shortcuts for Dvorak and alternate layouts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3429,12 +3429,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
-        // Control-key combos can produce control characters (e.g. Ctrl+H => backspace),
-        // so fall back to keyCode matching for common printable keys.
+        // Primary matching: use the layout-aware character from charactersIgnoringModifiers.
+        // This respects Dvorak, Colemak, and other alternate keyboard layouts.
         if let chars = event.charactersIgnoringModifiers?.lowercased(), chars == shortcutKey {
             return true
         }
-        if let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
+
+        // Control-key combos can produce control characters (e.g. Ctrl+H => backspace),
+        // so fall back to keyCode matching ONLY when Control is pressed.
+        if flags.contains(.control), let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode
         }
         return false


### PR DESCRIPTION
## Current Behavior

Given I use Dvorak
When I try to cmd-c for `copy`, or cmd-d for `split`
Then it does the wrong thing

## Desired Behavior
When I cmd-c
Then it should `copy`

---

## Summary

- Fixes keyboard shortcuts matching physical key positions instead of logical characters on Dvorak, Colemak, and other alternate keyboard layouts
- On Dvorak, pressing Command+C (to copy) was triggering Command+I (notifications) because the physical "I" key produces "c"

## Root Cause

The `matchShortcut()` function in `AppDelegate.swift` had an unconditional keyCode fallback that matched physical key positions when character matching failed. This was originally added to handle Control-key combos that produce control characters (e.g., Ctrl+H → backspace), but it was being applied to all shortcuts.

## Fix

Restrict the keyCode fallback to only apply when the Control modifier is pressed, allowing `charactersIgnoringModifiers` to correctly match the logical character for all other shortcuts.

## Test plan

- [x] Tested on Dvorak keyboard layout
- [x] Command+C now correctly copies (instead of opening notifications)
- [x] Command+I opens notifications (when pressing the Dvorak key that produces "i")
- [x] Cmd+Ctrl+W still closes window (Control fallback preserved)

🤖 Generated with [Claude Code](https://claude.ai/code)