### PR TITLE
Fix ASCII diagram font rendering on concepts page

### DIFF
--- a/web/app/components/code-block.tsx
+++ b/web/app/components/code-block.tsx
@@ -60,7 +60,9 @@ export async function CodeBlock({
             : undefined
         }
       >
-        <code>{children}</code>
+        <code style={variant === "ascii" ? { fontFamily: "inherit" } : undefined}>
+          {children}
+        </code>
       </pre>
     </div>
   );

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -163,6 +163,7 @@ body {
   background: none;
   padding: 0;
   font-size: 1em;
+  font-family: inherit;
 }
 
 /* Shiki dual theme */


### PR DESCRIPTION
## Summary
- Use system monospace fonts (Menlo, Monaco, Consolas, Courier New) for `variant="ascii"` code blocks instead of Geist Mono
- Geist Mono renders box-drawing characters (`┌─┐│└┘┬┴├┤`) at double width, breaking alignment in the visual example on the [concepts page](https://cmux.dev/docs/concepts)
- System mono fonts handle box-drawing characters at correct single-column width

## Testing
- `npm run build` in `web/` passes
- Verify the ASCII diagram at https://cmux.dev/docs/concepts renders with aligned borders on the Vercel preview

## Related
- Page: https://cmux.dev/docs/concepts