### PR TITLE
Fix double-click titlebar zoom on browser panel side

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -117,6 +117,9 @@ final class WindowBrowserHostView: NSView {
     override func hitTest(_ point: NSPoint) -> NSView? {
         updateDividerCursor(at: point)
 
+        if shouldPassThroughToTitlebar(at: point) {
+            return nil
+        }
         if shouldPassThroughToSidebarResizer(at: point) {
             return nil
         }
@@ -125,6 +128,14 @@ final class WindowBrowserHostView: NSView {
         }
         let hitView = super.hitTest(point)
         return hitView === self ? nil : hitView
+    }
+
+    private func shouldPassThroughToTitlebar(at point: NSPoint) -> Bool {
+        guard let window else { return false }
+        // Window-level portal hosts sit above SwiftUI content. Never intercept
+        // hits that land in the native titlebar region.
+        let windowPoint = convert(point, to: nil)
+        return windowPoint.y >= (window.contentLayoutRect.maxY - 0.5)
     }
 
     private func shouldPassThroughToSidebarResizer(at point: NSPoint) -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5241,8 +5241,8 @@ struct VerticalTabsSidebar: View {
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
-                    // Double-click the sidebar title-bar area to zoom the
-                    // window, matching the panel top-bar behaviour.
+                    // Double-click the sidebar title-bar area to trigger the
+                    // standard macOS titlebar action (zoom/minimize).
                     DoubleClickZoomView()
                         .frame(height: trafficLightPadding)
                 }
@@ -7492,11 +7492,10 @@ private struct DoubleClickZoomView: NSViewRepresentable {
         override var mouseDownCanMoveWindow: Bool { true }
         override func hitTest(_ point: NSPoint) -> NSView? { self }
         override func mouseDown(with event: NSEvent) {
-            if event.clickCount == 2 {
-                window?.zoom(nil)
-            } else {
-                super.mouseDown(with: event)
+            if event.clickCount == 2, performStandardTitlebarDoubleClick(window: window) {
+                return
             }
+            super.mouseDown(with: event)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **BrowserWindowPortal**: `WindowBrowserHostView.hitTest()` now passes through hits landing in the native titlebar region, so the browser portal no longer swallows titlebar interactions
- **WindowDragHandleView**: `windowDragHandleShouldCaptureHit` now only lets titlebar-overlay views block capture (not underlay browser/webview layers); added `performStandardTitlebarDoubleClick()` that reads `AppleActionOnDoubleClick` to respect the user's macOS preference (zoom, minimize, or none)
- **ContentView**: `DoubleClickZoomView` uses the shared helper instead of hardcoded `window?.zoom(nil)`

Closes https://github.com/manaflow-ai/cmux/issues/422

## Test plan

- [ ] Double-click the titlebar above a browser panel — window should zoom/minimize per macOS preference
- [ ] Double-click the titlebar above a terminal panel — same behavior (no regression)
- [ ] Double-click the sidebar titlebar area — same behavior
- [ ] Change macOS "Double-click a window's title bar to" setting between Zoom/Minimize/None — all three should work
- [ ] Drag the window by the titlebar on the browser side — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)