### PR TITLE
Fix workspace move socket focus-intent policy

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -25,6 +25,7 @@ class TerminalController {
     private static let focusIntentV1Commands: Set<String> = [
         "focus_window",
         "select_workspace",
+        "move_workspace_to_window",
         "focus_surface",
         "focus_pane",
         "focus_surface_by_panel",
@@ -36,6 +37,7 @@ class TerminalController {
     private static let focusIntentV2Methods: Set<String> = [
         "window.focus",
         "workspace.select",
+        "workspace.move_to_window",
         "workspace.next",
         "workspace.previous",
         "workspace.last",


### PR DESCRIPTION
## Summary
- treat `workspace.move_to_window` (v2) as a focus-intent socket command
- treat `move_workspace_to_window` (v1) as a focus-intent socket command
- ensure `focus=true` during workspace moves can activate/attach destination workspace surfaces (prevents `in_window=false` stale state after move)

## Testing
- `python3 -u tests_v2/test_windows_api.py` (before fix) -> failed with `Expected all moved surfaces to be in_window=true`
- `python3 -u tests_v2/test_surface_move_reorder_api.py` -> PASS
- `python3 -u tests_v2/test_windows_api.py` (after fix) -> PASS
- targeted 2x2 grid case: `test_multiple_splits_responsive` from `tests_v2/test_tab_dragging.py` -> PASS (`All 4 terminals responsive after multiple splits`)

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/402
