### PR TITLE
Fix sidebar titlebar drag and double-click passthrough

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -133,9 +133,13 @@ final class WindowBrowserHostView: NSView {
     private func shouldPassThroughToTitlebar(at point: NSPoint) -> Bool {
         guard let window else { return false }
         // Window-level portal hosts sit above SwiftUI content. Never intercept
-        // hits that land in the native titlebar region.
+        // hits that land in native titlebar space or the custom titlebar strip
+        // we reserve directly under it for window drag/double-click behaviors.
         let windowPoint = convert(point, to: nil)
-        return windowPoint.y >= (window.contentLayoutRect.maxY - 0.5)
+        let nativeTitlebarHeight = window.frame.height - window.contentLayoutRect.height
+        let customTitlebarBandHeight = max(28, min(72, nativeTitlebarHeight))
+        let interactionBandMinY = window.contentLayoutRect.maxY - customTitlebarBandHeight - 0.5
+        return windowPoint.y >= interactionBandMinY
     }
 
     private func shouldPassThroughToSidebarResizer(at point: NSPoint) -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5241,9 +5241,9 @@ struct VerticalTabsSidebar: View {
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
-                    // Double-click the sidebar title-bar area to trigger the
-                    // standard macOS titlebar action (zoom/minimize).
-                    DoubleClickZoomView()
+                    // Match native titlebar behavior in the sidebar top strip:
+                    // drag-to-move and double-click action (zoom/minimize).
+                    WindowDragHandleView()
                         .frame(height: trafficLightPadding)
                 }
                 .background(Color.clear)
@@ -7476,27 +7476,6 @@ private struct SidebarTabDropDelegate: DropDelegate {
         guard let indicator else { return "nil" }
         let tabText = indicator.tabId.map { String($0.uuidString.prefix(5)) } ?? "end"
         return "\(tabText):\(indicator.edge == .top ? "top" : "bottom")"
-    }
-}
-
-/// AppKit-level double-click handler for the sidebar title-bar area.
-/// Uses NSView hit-testing so it isn't swallowed by the SwiftUI ScrollView underneath.
-private struct DoubleClickZoomView: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        DoubleClickZoomNSView()
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {}
-
-    private final class DoubleClickZoomNSView: NSView {
-        override var mouseDownCanMoveWindow: Bool { true }
-        override func hitTest(_ point: NSPoint) -> NSView? { self }
-        override func mouseDown(with event: NSEvent) {
-            if event.clickCount == 2, performStandardTitlebarDoubleClick(window: window) {
-                return
-            }
-            super.mouseDown(with: event)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the sidebar top-strip overlay with `WindowDragHandleView` so drag-to-move and titlebar double-click behavior are handled uniformly
- widen browser portal passthrough so the custom titlebar interaction band under the native titlebar is not intercepted
- remove the now-redundant local `DoubleClickZoomView` implementation from `ContentView.swift`

## Validation
- `./scripts/reload.sh --tag pr-titlebar-issues`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`