### PR TITLE
Fix terminal render recovery after split topology churn

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1914,6 +1914,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return
         }
 
+        // Reassert display id on topology churn (split close/reparent) before forcing a refresh.
+        // This avoids a first-run stuck-vsync state where Ghostty believes vsync is active
+        // but callbacks have not resumed for the current display.
+        if let displayID = (view.window?.screen ?? NSScreen.main)?.displayID,
+           displayID != 0 {
+            ghostty_surface_set_display_id(surface, displayID)
+        }
+
         view.forceRefreshSurface()
         ghostty_surface_refresh(surface)
     }


### PR DESCRIPTION
## Summary
- make terminal geometry reconciliation resilient to split close/reparent churn by running bounded follow-up passes when views are detached, unsized, or surfaces are not yet attached
- coalesce repeated reconcile requests while a pass is in-flight so late topology/layout updates are not dropped
- reassert Ghostty display id before forceRefresh redraws so vsync callbacks resume correctly after reparent transitions

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag fix-terminal-render-split`
