### PR TITLE
Sidebar double-click adds workspace at end

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5903,7 +5903,7 @@ private struct SidebarEmptyArea: View {
             .contentShape(Rectangle())
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .onTapGesture(count: 2) {
-                tabManager.addTab()
+                tabManager.addWorkspace(placementOverride: .end)
                 if let selectedId = tabManager.selectedTabId {
                     selectedTabIds = [selectedId]
                     lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -758,7 +758,11 @@ class TabManager: ObservableObject {
     }
 
     @discardableResult
-    func addWorkspace(workingDirectory overrideWorkingDirectory: String? = nil, select: Bool = true) -> Workspace {
+    func addWorkspace(
+        workingDirectory overrideWorkingDirectory: String? = nil,
+        select: Bool = true,
+        placementOverride: NewWorkspacePlacement? = nil
+    ) -> Workspace {
         sentryBreadcrumb("workspace.create", data: ["tabCount": tabs.count + 1])
         let workingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory) ?? preferredWorkingDirectoryForNewTab()
         let inheritedConfig = inheritedTerminalConfigForNewWorkspace()
@@ -771,7 +775,7 @@ class TabManager: ObservableObject {
             configTemplate: inheritedConfig
         )
         wireClosedBrowserTracking(for: newWorkspace)
-        let insertIndex = newTabInsertIndex()
+        let insertIndex = newTabInsertIndex(placementOverride: placementOverride)
         if insertIndex >= 0 && insertIndex <= tabs.count {
             tabs.insert(newWorkspace, at: insertIndex)
         } else {
@@ -836,8 +840,8 @@ class TabManager: ObservableObject {
         return trimmed.isEmpty ? nil : normalized
     }
 
-    private func newTabInsertIndex() -> Int {
-        let placement = WorkspacePlacementSettings.current()
+    private func newTabInsertIndex(placementOverride: NewWorkspacePlacement? = nil) -> Int {
+        let placement = placementOverride ?? WorkspacePlacementSettings.current()
         let pinnedCount = tabs.filter { $0.isPinned }.count
         let selectedIndex = selectedTabId.flatMap { tabId in
             tabs.firstIndex(where: { $0.id == tabId })


### PR DESCRIPTION
## Summary
- make sidebar empty-area double-click create the new workspace at the end of the workspace list
- keep default `addWorkspace()` placement behavior unchanged for keyboard shortcut and command palette flows
- add regression tests for explicit end placement and for default-placement parity

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/WorkspaceCreationPlacementTests test` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `./scripts/reload.sh --tag sidebar-dblclick-end` (pass)

## Issues
- Related task: task-sidebar-double-click-new-workspace-at-end (plain-text HQ request, no GitHub issue URL provided)
