### PR TITLE
Guard nil surface in TerminalSurface.forceRefresh

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1988,6 +1988,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         view.forceRefreshSurface()
+        guard let surface = surface else { return }
         ghostty_surface_refresh(surface)
     }
 


### PR DESCRIPTION
## Summary
- guard `surface` right before `ghostty_surface_refresh` in `TerminalSurface.forceRefresh()`
- avoid calling into Ghostty refresh when split close/reparent churn has temporarily detached or cleared the backing surface

## Testing
- `./scripts/reload.sh --tag pr-force-refresh-guard`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
