### PR TITLE
Fix Cmd+N workspace shortcut when browser panel is focused

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2984,7 +2984,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func shortcutEventHasAddressableWindow(_ event: NSEvent?) -> Bool {
         guard let event else { return false }
-        return event.window != nil || event.windowNumber >= 0
+        // NSEvent.windowNumber can be 0 for responder-chain events that are not
+        // actually bound to an NSWindow (notably some WebKit key paths).
+        return event.window != nil || event.windowNumber > 0
     }
 
     private func mainWindowContext(
@@ -3007,7 +3009,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return context
         }
 
-        if event.windowNumber >= 0,
+        if event.windowNumber > 0,
            let numberedWindow = NSApp.window(withWindowNumber: event.windowNumber),
            let context = contextForMainTerminalWindow(numberedWindow) {
             #if DEBUG
@@ -3022,7 +3024,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return context
         }
 
-        if event.windowNumber >= 0,
+        if event.windowNumber > 0,
            let context = mainWindowContexts.values.first(where: { candidate in
                let window = candidate.window ?? windowForMainWindowId(candidate.windowId)
                return window?.windowNumber == event.windowNumber


### PR DESCRIPTION
## Summary
- fix shortcut routing so events with `windowNumber == 0` are not treated as window-addressable
- allow browser-originated Cmd shortcuts to fall back to active main-window context routing
- restore Cmd+N new-workspace behavior when focus is in WKWebView

## Changes
- update `shortcutEventHasAddressableWindow` to require a real event window (`event.window != nil || event.windowNumber > 0`)
- update `mainWindowContext(forShortcutEvent:)` checks from `>= 0` to `> 0` for numbered-window lookup

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag browser-cmd-n`

Fixes #452
