### PR TITLE
Fix flaky browser context-menu downloads and target selection

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -641,6 +641,40 @@ final class CmuxWebViewContextMenuTests: XCTestCase {
 
         XCTAssertFalse(menu.items.contains { $0.title == "Open Link in Default Browser" })
     }
+
+    func testWillOpenMenuHooksDownloadImageToDiskMenuVariant() {
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let menu = NSMenu()
+        let originalTarget = NSObject()
+        let originalAction = NSSelectorFromString("downloadImageToDisk:")
+        let downloadItem = NSMenuItem(title: "Download Image As...", action: originalAction, keyEquivalent: "")
+        downloadItem.identifier = NSUserInterfaceItemIdentifier("WKMenuItemIdentifierDownloadImageToDisk")
+        downloadItem.target = originalTarget
+        menu.addItem(downloadItem)
+
+        webView.willOpenMenu(menu, with: makeRightMouseDownEvent())
+
+        XCTAssertTrue(downloadItem.target === webView)
+        XCTAssertNotNil(downloadItem.action)
+        XCTAssertNotEqual(downloadItem.action, originalAction)
+    }
+
+    func testWillOpenMenuHooksDownloadLinkedFileToDiskMenuVariant() {
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let menu = NSMenu()
+        let originalTarget = NSObject()
+        let originalAction = NSSelectorFromString("downloadLinkToDisk:")
+        let downloadItem = NSMenuItem(title: "Download Linked File As...", action: originalAction, keyEquivalent: "")
+        downloadItem.identifier = NSUserInterfaceItemIdentifier("WKMenuItemIdentifierDownloadLinkToDisk")
+        downloadItem.target = originalTarget
+        menu.addItem(downloadItem)
+
+        webView.willOpenMenu(menu, with: makeRightMouseDownEvent())
+
+        XCTAssertTrue(downloadItem.target === webView)
+        XCTAssertNotNil(downloadItem.action)
+        XCTAssertNotEqual(downloadItem.action, originalAction)
+    }
 }
 
 final class BrowserDevToolsButtonDebugSettingsTests: XCTestCase {


### PR DESCRIPTION
## Summary\n- fix flaky browser context menu downloads for `Download Linked File` and `Download Image`\n- add structured DEBUG tracing (`browser.ctxdl.*`) with trace IDs for menu hook, URL resolution, request/response, save prompt, and fallback paths\n- improve URL resolution for image/link detection at context-menu point (elementsFromPoint chain, nested images, data attrs, background-image, open shadow roots)\n- add direct `data:` URL download support (decode + save panel)\n- normalize Google redirect links (`imgurl`/`url`/`q`) before download\n- harden image target selection to avoid false positives (favicons/page URLs) and remove weak-candidate auto-download fallback that caused wrong downloads\n\n## Verification\n- ./scripts/reload.sh --tag debug-download-context\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build\n- manual reproduction on Google Images with repeated right-click downloads; validated via `browser.ctxdl` logs\n\nCloses #459