### PR TITLE
Require a tag to launch cmux DEV

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -35,6 +35,10 @@ struct cmuxApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {
+        if SocketControlSettings.shouldBlockUntaggedDebugLaunch() {
+            Self.terminateForMissingLaunchTag()
+        }
+
         Self.configureGhosttyEnvironment()
 
         let startupAppearance = AppearanceSettings.resolvedMode()
@@ -56,6 +60,14 @@ struct cmuxApp: App {
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
         appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState)
+    }
+
+    private static func terminateForMissingLaunchTag() -> Never {
+        let message = "error: refusing to launch untagged cmux DEV; start with ./scripts/reload.sh --tag <name> (or set CMUX_TAG for test harnesses)"
+        fputs("\(message)\n", stderr)
+        fflush(stderr)
+        NSLog("%@", message)
+        Darwin.exit(64)
     }
 
     private static func configureGhosttyEnvironment() {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -691,6 +691,56 @@ final class SocketControlSettingsTests: XCTestCase {
             "/tmp/cmux-staging.sock"
         )
     }
+
+    func testUntaggedDebugBundleBlockedWithoutLaunchTag() {
+        XCTAssertTrue(
+            SocketControlSettings.shouldBlockUntaggedDebugLaunch(
+                environment: [:],
+                bundleIdentifier: "com.cmuxterm.app.debug",
+                isDebugBuild: true
+            )
+        )
+    }
+
+    func testUntaggedDebugBundleAllowedWithLaunchTag() {
+        XCTAssertFalse(
+            SocketControlSettings.shouldBlockUntaggedDebugLaunch(
+                environment: ["CMUX_TAG": "tests-v1"],
+                bundleIdentifier: "com.cmuxterm.app.debug",
+                isDebugBuild: true
+            )
+        )
+    }
+
+    func testTaggedDebugBundleAllowedWithoutLaunchTag() {
+        XCTAssertFalse(
+            SocketControlSettings.shouldBlockUntaggedDebugLaunch(
+                environment: [:],
+                bundleIdentifier: "com.cmuxterm.app.debug.tests-v1",
+                isDebugBuild: true
+            )
+        )
+    }
+
+    func testReleaseBuildIgnoresLaunchTagGate() {
+        XCTAssertFalse(
+            SocketControlSettings.shouldBlockUntaggedDebugLaunch(
+                environment: [:],
+                bundleIdentifier: "com.cmuxterm.app.debug",
+                isDebugBuild: false
+            )
+        )
+    }
+
+    func testXCTestLaunchIgnoresLaunchTagGate() {
+        XCTAssertFalse(
+            SocketControlSettings.shouldBlockUntaggedDebugLaunch(
+                environment: ["XCTestConfigurationFilePath": "/tmp/fake.xctestconfiguration"],
+                bundleIdentifier: "com.cmuxterm.app.debug",
+                isDebugBuild: true
+            )
+        )
+    }
 }
 
 final class PostHogAnalyticsPropertiesTests: XCTestCase {

--- a/scripts/run-tests-v1.sh
+++ b/scripts/run-tests-v1.sh
@@ -13,6 +13,7 @@ cd "$(dirname "$0")/.."
 
 DERIVED_DATA_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-tests-v1"
 APP="$DERIVED_DATA_PATH/Build/Products/Debug/cmux DEV.app"
+RUN_TAG="tests-v1"
 
 echo "== build =="
 # Work around stale explicit-module cache artifacts (notably Sentry headers) that can
@@ -51,7 +52,7 @@ launch_and_wait() {
   defaults write com.cmuxterm.app.debug socketControlMode -string full >/dev/null 2>&1 || true
 
   # Launch directly with UI test mode enabled so startup follows deterministic test codepaths.
-  CMUX_UI_TEST_MODE=1 "$APP/Contents/MacOS/cmux DEV" >/dev/null 2>&1 &
+  CMUX_TAG="$RUN_TAG" CMUX_UI_TEST_MODE=1 "$APP/Contents/MacOS/cmux DEV" >/dev/null 2>&1 &
 
   SOCK=""
   for _ in {1..120}; do
@@ -70,7 +71,7 @@ launch_and_wait() {
   export CMUX_SOCKET="$SOCK"
 
   # Ensure LaunchServices has a visible/main window attached for rendering checks.
-  open "$APP" >/dev/null 2>&1 || true
+  CMUX_TAG="$RUN_TAG" open "$APP" >/dev/null 2>&1 || true
   sleep 0.5
 
   echo "== wait ready =="

--- a/scripts/run-tests-v2.sh
+++ b/scripts/run-tests-v2.sh
@@ -13,6 +13,7 @@ cd "$(dirname "$0")/.."
 
 DERIVED_DATA_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-tests-v2"
 APP="$DERIVED_DATA_PATH/Build/Products/Debug/cmux DEV.app"
+RUN_TAG="tests-v2"
 
 echo "== build =="
 # Work around stale explicit-module cache artifacts (notably Sentry headers) that can
@@ -51,7 +52,7 @@ launch_and_wait() {
   defaults write com.cmuxterm.app.debug socketControlMode -string full >/dev/null 2>&1 || true
 
   # Launch directly with UI test mode enabled so startup follows deterministic test codepaths.
-  CMUX_UI_TEST_MODE=1 "$APP/Contents/MacOS/cmux DEV" >/dev/null 2>&1 &
+  CMUX_TAG="$RUN_TAG" CMUX_UI_TEST_MODE=1 "$APP/Contents/MacOS/cmux DEV" >/dev/null 2>&1 &
 
   SOCK=""
   for _ in {1..120}; do
@@ -70,7 +71,7 @@ launch_and_wait() {
   export CMUX_SOCKET="$SOCK"
 
   # Ensure LaunchServices has a visible/main window attached for rendering checks.
-  open "$APP" >/dev/null 2>&1 || true
+  CMUX_TAG="$RUN_TAG" open "$APP" >/dev/null 2>&1 || true
   sleep 0.5
 
   echo "== wait ready =="


### PR DESCRIPTION
## Summary
- block untagged `cmux DEV` startup for `com.cmuxterm.app.debug` unless a launch tag is present
- keep unit-test host startup working by bypassing the launch gate under XCTest environments
- add regression coverage for tagged/untagged launch behavior and update VM test runners to provide `CMUX_TAG`

## Testing
- `bash -n scripts/run-tests-v1.sh scripts/run-tests-v2.sh`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyConfigTests test` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/SocketControlSettingsTests test` ✅

## Issues
- Related: Task summary from HQ session: ensure it's not possible to start cmux DEV without a tag
