### PR TITLE
Fix SPM binary artifact cache collision on self-hosted runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,16 +124,9 @@ jobs:
 
       - name: Clear SPM cache
         run: |
-          rm -rf ~/Library/Caches/org.swift.swiftpm
-          rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
-
-      - name: Configure SwiftPM cache
-        run: |
           set -euo pipefail
-          CACHE_DIR="${RUNNER_TEMP}/swiftpm-cache/${GITHUB_RUN_ID}"
-          rm -rf "$CACHE_DIR"
-          mkdir -p "$CACHE_DIR"
-          echo "SWIFTPM_CACHE_PATH=$CACHE_DIR" >> "$GITHUB_ENV"
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm"
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData/GhosttyTabs-*"
 
       - name: Derive Sparkle public key from private key
         env:
@@ -149,6 +142,7 @@ jobs:
 
       - name: Build app (Release)
         run: |
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
           xcodebuild -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
       - name: Inject nightly identity and metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,17 +119,9 @@ jobs:
       - name: Clear SPM cache
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
-          rm -rf ~/Library/Caches/org.swift.swiftpm
-          rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
-
-      - name: Configure SwiftPM cache
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
-        run: |
           set -euo pipefail
-          CACHE_DIR="${RUNNER_TEMP}/swiftpm-cache/${GITHUB_RUN_ID}"
-          rm -rf "$CACHE_DIR"
-          mkdir -p "$CACHE_DIR"
-          echo "SWIFTPM_CACHE_PATH=$CACHE_DIR" >> "$GITHUB_ENV"
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm"
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData/GhosttyTabs-*"
 
       - name: Derive Sparkle public key from private key
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -147,6 +139,7 @@ jobs:
       - name: Build app (Release)
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
           xcodebuild -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO build
 
       - name: Inject Sparkle keys into Info.plist


### PR DESCRIPTION
## Summary
- Fix nightly/release builds failing with `already exists in file system` error when SPM tries to download the Sentry xcframework binary artifact
- Use `$HOME` instead of `~` for reliable path expansion in the GitHub Actions runner shell
- Remove unused `Configure SwiftPM cache` step (`SWIFTPM_CACHE_PATH` only controls SPM's repository clone cache, not binary artifact downloads)
- Clear artifact cache immediately before `xcodebuild` to eliminate any window for cache re-creation

## Test plan
- [ ] Trigger a nightly build via `workflow_dispatch` and verify it passes package resolution
- [ ] Verify release workflow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)