### PR TITLE
Release v0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to cmux are documented here.
 
+## [0.61.0] - 2026-02-25
+
+### Added
+- Command palette (Cmd+Shift+P) with update actions and all-window switcher results ([#358](https://github.com/manaflow-ai/cmux/pull/358), [#361](https://github.com/manaflow-ai/cmux/pull/361))
+- Split actions and shortcut hints in terminal context menus
+- Cross-window tab and workspace move UI with improved destination focus behavior
+- Sidebar pull request metadata rows and workspace PR open actions
+- Workspace color schemes and left-rail workspace indicator settings ([#324](https://github.com/manaflow-ai/cmux/pull/324), [#329](https://github.com/manaflow-ai/cmux/pull/329), [#332](https://github.com/manaflow-ai/cmux/pull/332))
+- URL open-wrapper routing into the embedded browser ([#332](https://github.com/manaflow-ai/cmux/pull/332))
+- Cmd+Q quit warning with suppression toggle ([#295](https://github.com/manaflow-ai/cmux/pull/295))
+- `cmux --version` output now includes commit metadata
+
+### Changed
+- Added light mode and unified theme refresh across app surfaces ([#258](https://github.com/manaflow-ai/cmux/pull/258)) — thanks @ijpatricio for the report!
+- Browser link middle-click handling now uses native WebKit behavior ([#416](https://github.com/manaflow-ai/cmux/pull/416))
+- Settings-window actions now route through a single command-palette/settings flow
+- Sentry upgraded with tracing, breadcrumbs, and dSYM upload support ([#366](https://github.com/manaflow-ai/cmux/pull/366))
+
+### Fixed
+- Startup split hang when pressing Cmd+D then Ctrl+D early after launch ([#364](https://github.com/manaflow-ai/cmux/pull/364))
+- Browser focus handoff and click-to-focus regressions in mixed terminal/browser workspaces ([#381](https://github.com/manaflow-ai/cmux/pull/381), [#355](https://github.com/manaflow-ai/cmux/pull/355))
+- Caps Lock handling in browser omnibar keyboard paths ([#382](https://github.com/manaflow-ai/cmux/pull/382))
+- Embedded browser deeplink URL scheme handling ([#392](https://github.com/manaflow-ai/cmux/pull/392))
+- Sidebar resize cap regression ([#393](https://github.com/manaflow-ai/cmux/pull/393))
+- Terminal zoom inheritance for new splits, surfaces, and workspaces ([#384](https://github.com/manaflow-ai/cmux/pull/384))
+- Terminal find overlay layering across split and portal-hosted layouts
+- Titlebar drag and double-click zoom handling on browser-side panes
+- Stale browser favicon and window-title updates after navigation
+
+### Thanks to 3 contributors!
+- [@austinywang](https://github.com/austinywang)
+- [@ijpatricio](https://github.com/ijpatricio)
+- [@lawrencecchen](https://github.com/lawrencecchen)
+
 ## [0.60.0] - 2026-02-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ git commit -m "Update ghostty submodule"
 Use the `/release` command to prepare a new release. This will:
 1. Determine the new version (bumps minor by default)
 2. Gather commits since the last tag and update the changelog
-3. Update `CHANGELOG.md` and `docs-site/content/docs/changelog.mdx`
+3. Update `CHANGELOG.md` (the docs changelog page at `web/app/docs/changelog/page.tsx` reads from it)
 4. Run `./scripts/bump-version.sh` to update both versions
 5. Commit, tag, and push
 
@@ -194,4 +194,4 @@ Notes:
 - The release asset is `cmux-macos.dmg` attached to the tag.
 - README download button points to `releases/latest/download/cmux-macos.dmg`.
 - Versioning: bump the minor version for updates unless explicitly asked otherwise.
-- Changelog: always update both `CHANGELOG.md` and the docs-site version.
+- Changelog: update `CHANGELOG.md`; docs changelog is rendered from it.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -730,7 +730,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -739,7 +739,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -769,7 +769,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -778,7 +778,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -844,10 +844,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -861,10 +861,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -878,10 +878,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -897,10 +897,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 72;
+				CURRENT_PROJECT_VERSION = 73;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.61.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -25,7 +25,7 @@ Run this workflow to prepare and publish a cmux release.
 
 4. Update changelogs:
 - Update `CHANGELOG.md`.
-- Update `docs-site/content/docs/changelog.mdx`.
+- Do not edit a separate docs changelog file; `web/app/docs/changelog/page.tsx` renders from `CHANGELOG.md`.
 - Use categories `Added`, `Changed`, `Fixed`, `Removed`.
 - **Credit contributors inline** (see Contributor Credits below).
 - If no user-facing changes exist, confirm with the user before continuing.


### PR DESCRIPTION
## Summary
- Bump app version to `0.61.0` and build number to `73`.
- Add the `0.61.0` release notes to `CHANGELOG.md` with Added/Changed/Fixed sections.
- Update release instructions to reflect current docs behavior (`web/app/docs/changelog/page.tsx` renders from `CHANGELOG.md`, no `docs-site` path).

## Highlights
- Added command palette improvements, terminal split context-menu actions, cross-window tab/workspace move UX, and sidebar PR metadata features.
- Changed theme handling with light mode and unified refresh behavior, plus native WebKit middle-click link handling.
- Fixed split startup hang, browser focus handoff regressions, omnibar Caps Lock handling, deeplink URL handling, sidebar resize cap regression, and terminal zoom inheritance.

## Contributors
### Thanks to 3 contributors!
- [@austinywang](https://github.com/austinywang)
- [@ijpatricio](https://github.com/ijpatricio)
- [@lawrencecchen](https://github.com/lawrencecchen)
