### PR TITLE
Expand v0.61.0 contributor credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,13 @@ All notable changes to cmux are documented here.
 - Titlebar drag and double-click zoom handling on browser-side panes
 - Stale browser favicon and window-title updates after navigation
 
-### Thanks to 3 contributors!
+### Thanks to 7 contributors!
 - [@austinywang](https://github.com/austinywang)
+- [@avisser](https://github.com/avisser)
+- [@gnguralnick](https://github.com/gnguralnick)
 - [@ijpatricio](https://github.com/ijpatricio)
+- [@jperkin](https://github.com/jperkin)
+- [@jungcome7](https://github.com/jungcome7)
 - [@lawrencecchen](https://github.com/lawrencecchen)
 
 ## [0.60.0] - 2026-02-21


### PR DESCRIPTION
## Summary
- Expand the `0.61.0` changelog contributor credits from 3 to 7 handles.
- Include contributors from both release windows (`v0.59.0..v0.60.0` and `v0.60.0..v0.61.0`) as requested.

## Context
- Follow-up to https://github.com/manaflow-ai/cmux/pull/470.
