### PR TITLE
Add programmatic OG image generation

### DIFF
--- a/web/app/blog/introducing-cmux/page.tsx
+++ b/web/app/blog/introducing-cmux/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     url: "https://cmux.dev/blog/introducing-cmux",
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "Introducing cmux",
     description:
       "A native macOS terminal built on Ghostty, designed for running multiple AI coding agents side by side.",

--- a/web/app/blog/show-hn-launch/page.tsx
+++ b/web/app/blog/show-hn-launch/page.tsx
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
     url: "https://cmux.dev/blog/show-hn-launch",
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "Launching cmux on Show HN",
     description:
       "cmux launched on Hacker News, hit #2, went viral in Japan, and people started building extensions on the CLI.",

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     type: "website",
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "cmux — The terminal built for multitasking",
     description:
       "Native macOS terminal for AI coding agents. Works with Claude Code, Codex, OpenCode, Gemini CLI, Kiro, Aider, and any CLI tool.",

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,87 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "cmux — The terminal built for multitasking";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          backgroundImage:
+            "radial-gradient(ellipse 80% 50% at 50% 0%, #1a1a3e 0%, transparent 60%)",
+          padding: "60px 80px",
+        }}
+      >
+        {/* Prompt chevron + name */}
+        <div style={{ display: "flex", alignItems: "baseline" }}>
+          <div
+            style={{
+              fontSize: 96,
+              fontWeight: 700,
+              color: "#22d3ee",
+            }}
+          >
+            {">"}
+          </div>
+          <div
+            style={{
+              fontSize: 96,
+              fontWeight: 700,
+              color: "#ededed",
+              marginLeft: 20,
+              letterSpacing: "-0.03em",
+            }}
+          >
+            cmux
+          </div>
+        </div>
+
+        {/* Gradient accent line */}
+        <div
+          style={{
+            width: 120,
+            height: 3,
+            backgroundImage: "linear-gradient(90deg, #22d3ee, #3b82f6)",
+            marginTop: 24,
+            marginBottom: 24,
+            borderRadius: 2,
+          }}
+        />
+
+        {/* Tagline */}
+        <div
+          style={{
+            fontSize: 32,
+            color: "#a3a3a3",
+            lineHeight: 1.4,
+          }}
+        >
+          The terminal built for multitasking
+        </div>
+
+        {/* URL */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 48,
+            right: 80,
+            fontSize: 22,
+            color: "#404040",
+            letterSpacing: "0.05em",
+          }}
+        >
+          cmux.dev
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";


### PR DESCRIPTION
## Summary
- Add `opengraph-image.tsx` using Next.js file convention + `next/og` `ImageResponse` to generate branded OG images at build time
- Dark background with subtle radial gradient, cyan `>` chevron matching the logo, "cmux" title, gradient accent line, tagline, and `cmux.dev` URL
- Re-export as `twitter-image.tsx` so Twitter/X gets the same image
- Upgrade twitter card from `summary` to `summary_large_image` across root layout and both blog posts

## Testing
- `npx next build` passes — both `/opengraph-image` and `/twitter-image` routes appear in the build output
- Generated PNG verified visually (1200x630, dark branded image)
- All `og:image`, `twitter:image`, width/height/alt meta tags present in generated HTML

## Related
- Task: Add programmatic OG image generation for the cmux website