### PR TITLE
Alias Cmd+Shift+R to rename-tab command palette

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4560,8 +4560,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .renameWorkspace)) {
-            _ = promptRenameSelectedWorkspace()
-            return true
+            return requestRenameWorkspaceViaCommandPalette(
+                preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            )
         }
 
         if normalizedFlags == [.command, .option], (chars == "t" || event.keyCode == 17) {
@@ -5246,6 +5247,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @discardableResult
     func handleBrowserSurfaceKeyEquivalent(_ event: NSEvent) -> Bool {
         handleCustomShortcut(event: event)
+    }
+
+    @discardableResult
+    func requestRenameWorkspaceViaCommandPalette(preferredWindow: NSWindow? = nil) -> Bool {
+        let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        NotificationCenter.default.post(name: .commandPaletteRenameWorkspaceRequested, object: targetWindow)
+        return true
     }
 
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2213,6 +2213,17 @@ struct ContentView: View {
             openCommandPaletteRenameTabInput()
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRenameWorkspaceRequested)) { notification in
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ) else { return }
+            openCommandPaletteRenameWorkspaceInput()
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteMoveSelection)) { notification in
             guard isCommandPalettePresented else { return }
             guard case .commands = commandPaletteMode else { return }
@@ -4325,6 +4336,13 @@ struct ContentView: View {
             presentCommandPalette(initialQuery: Self.commandPaletteCommandsPrefix)
         }
         beginRenameTabFlow()
+    }
+
+    private func openCommandPaletteRenameWorkspaceInput() {
+        if !isCommandPalettePresented {
+            presentCommandPalette(initialQuery: Self.commandPaletteCommandsPrefix)
+        }
+        beginRenameWorkspaceFlow()
     }
 
     static func shouldHandleCommandPaletteRequest(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3414,6 +3414,7 @@ extension Notification.Name {
     static let commandPaletteRequested = Notification.Name("cmux.commandPaletteRequested")
     static let commandPaletteSwitcherRequested = Notification.Name("cmux.commandPaletteSwitcherRequested")
     static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")
+    static let commandPaletteRenameWorkspaceRequested = Notification.Name("cmux.commandPaletteRenameWorkspaceRequested")
     static let commandPaletteMoveSelection = Notification.Name("cmux.commandPaletteMoveSelection")
     static let commandPaletteRenameInputInteractionRequested = Notification.Name("cmux.commandPaletteRenameInputInteractionRequested")
     static let commandPaletteRenameInputDeleteBackwardRequested = Notification.Name("cmux.commandPaletteRenameInputDeleteBackwardRequested")

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -538,7 +538,7 @@ struct cmuxApp: App {
                 }
 
                 splitCommandButton(title: "Rename Workspace…", shortcut: renameWorkspaceMenuShortcut) {
-                    _ = AppDelegate.shared?.promptRenameSelectedWorkspace()
+                    _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
                 }
 
                 Divider()


### PR DESCRIPTION
## Summary
- Alias `Cmd+Shift+R` to the same rename-tab command palette request used by `Cmd+R`.
- Move the default `Rename Workspace` shortcut from `Cmd+Shift+R` to `Cmd+Ctrl+R` to avoid shortcut/menu conflicts.
- Add regression coverage for the alias path and update shortcut default metadata tests.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/AppDelegateShortcutRoutingTests -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests test` (passed)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (passed)
- `./scripts/reload.sh --tag cmd-shift-r-alias` (passed)

## Issues
- Related: task request "make cmd+shift+r shortcut show the same command pallette thing as cmd+r" (no GitHub issue URL provided)
