### PR TITLE
Fix titlebar icons invisible when sidebar closed with dark Ghostty theme in light macOS

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -479,7 +479,9 @@ struct TitlebarControlsView: View {
             .background(ShortcutHintPillBackground())
     }
 
-    private var iconForegroundColor: Color {
+    private var iconForegroundColor: Color? {
+        let sidebarVisible = AppDelegate.shared?.sidebarState?.isVisible ?? false
+        guard !sidebarVisible else { return nil }
         let bg = GhosttyApp.shared.defaultBackgroundColor
         return bg.isLightColor
             ? Color.black.opacity(0.55)
@@ -488,10 +490,16 @@ struct TitlebarControlsView: View {
 
     @ViewBuilder
     private func iconLabel(systemName: String, config: TitlebarControlsStyleConfig) -> some View {
-        let icon = Image(systemName: systemName)
+        let baseIcon = Image(systemName: systemName)
             .font(.system(size: config.iconSize, weight: .semibold))
-            .foregroundColor(iconForegroundColor)
             .frame(width: config.buttonSize, height: config.buttonSize)
+        let icon = Group {
+            if let color = iconForegroundColor {
+                baseIcon.foregroundColor(color)
+            } else {
+                baseIcon
+            }
+        }
 
         if config.buttonBackground {
             icon

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -479,11 +479,18 @@ struct TitlebarControlsView: View {
             .background(ShortcutHintPillBackground())
     }
 
+    private var iconForegroundColor: Color {
+        let bg = GhosttyApp.shared.defaultBackgroundColor
+        return bg.isLightColor
+            ? Color.black.opacity(0.55)
+            : Color.white.opacity(0.65)
+    }
+
     @ViewBuilder
     private func iconLabel(systemName: String, config: TitlebarControlsStyleConfig) -> some View {
         let icon = Image(systemName: systemName)
             .font(.system(size: config.iconSize, weight: .semibold))
-            .foregroundStyle(.secondary)
+            .foregroundColor(iconForegroundColor)
             .frame(width: config.buttonSize, height: config.buttonSize)
 
         if config.buttonBackground {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -483,6 +483,7 @@ struct TitlebarControlsView: View {
     private func iconLabel(systemName: String, config: TitlebarControlsStyleConfig) -> some View {
         let icon = Image(systemName: systemName)
             .font(.system(size: config.iconSize, weight: .semibold))
+            .foregroundStyle(.secondary)
             .frame(width: config.buttonSize, height: config.buttonSize)
 
         if config.buttonBackground {


### PR DESCRIPTION
## Problem

When using a dark Ghostty theme (e.g. Cursor Dark `#141414`) with macOS light system appearance and the sidebar **closed**, the three titlebar icons (sidebar toggle, bell, plus) are invisible — they're dark/black (from macOS light appearance) on a dark titlebar background (from Ghostty theme).

The titlebar background correctly derives its color from the Ghostty theme, but the icons have no explicit foreground color, so they inherit from the macOS system appearance.

## Solution

When the sidebar is **closed**, derive icon color from `GhosttyApp.shared.defaultBackgroundColor.isLightColor`:
- Dark Ghostty theme → light icons
- Light Ghostty theme → dark icons

When the sidebar is **open**, leave icons unchanged — they use the default system appearance color, which is correct since the sidebar background comes from the system theme, not Ghostty.

## Test plan
- [ ] Dark Ghostty theme + light macOS + sidebar **closed** → icons should be light/visible
- [ ] Dark Ghostty theme + light macOS + sidebar **open** → icons use default system color
- [ ] Dark Ghostty theme + dark macOS + sidebar closed → icons light/visible
- [ ] Light Ghostty theme + sidebar closed → icons dark/visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)