### PR TITLE
Reduce 0.61.0 Sentry crash and telemetry regressions

### DIFF
--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -254,11 +254,13 @@ func windowDragHandleShouldCaptureHit(_ point: NSPoint, in dragHandleView: NSVie
         }
     }
 
+    let siblingSnapshot = Array(superview.subviews.reversed())
+
     #if DEBUG
-    let siblingCount = superview.subviews.count
+    let siblingCount = siblingSnapshot.count
     #endif
 
-    for sibling in superview.subviews.reversed() {
+    for sibling in siblingSnapshot {
         guard sibling !== dragHandleView else { continue }
         guard !sibling.isHidden, sibling.alphaValue > 0 else { continue }
 


### PR DESCRIPTION
## Summary
- Make titlebar drag-handle hit testing reentrant-safe and iterate over a stable sibling snapshot so hit-test reentrancy/mutation does not trigger Swift access-conflict aborts.
- Remove `NSTextView.delegate` probing from `NSWindow.cmux_makeFirstResponder` webview ownership checks to avoid unsafe-unretained delegate traps while responder chains are tearing down.
- Reduce Sentry event noise for 0.61.0 by disabling failed-request capture recursion, increasing app-hang timeout, and throttling scroll-lag warning captures behind sustained-lag + cooldown heuristics.
- Add regression tests for delegate-lookup safety, drag-handle stability under mutating sibling hit-tests, and scroll-lag capture heuristics.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests -only-testing:cmuxTests/GhosttyConfigTests test` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅

## Issues
- Related: https://manaflow.sentry.io/issues/?project=cmuxterm-macos&query=is%3Aunresolved+release%3A*0.61*
- Related task source: `/Users/lawrencechen/fun/cmuxterm-hq/sentry-0.61.0-issues.md`
