### PR TITLE
Fix Escape key propagation from command palette and alerts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -739,6 +739,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var commandPaletteSnapshotByWindowId: [UUID: CommandPaletteDebugSnapshot] = [:]
     private var pendingCommandPaletteRequestByWindowId: [UUID: TimeInterval] = [:]
     private let commandPaletteRequestGraceInterval: TimeInterval = 0.75
+    private var commandPaletteDismissFollowupEscapeSuppressionWindowId: UUID?
+    private var commandPaletteDismissFollowupEscapeSuppressionDeadline: TimeInterval = 0
+    private let commandPaletteDismissFollowupEscapeSuppressionInterval: TimeInterval = 0.75
     private var shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = false
 
     var updateViewModel: UpdateViewModel {
@@ -2254,6 +2257,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func clearPendingCommandPaletteRequest(for window: NSWindow?) {
         guard let window, let windowId = mainWindowId(for: window) else { return }
         pendingCommandPaletteRequestByWindowId.removeValue(forKey: windowId)
+    }
+
+    private func armCommandPaletteDismissFollowupEscapeSuppression(for window: NSWindow) {
+        guard let windowId = mainWindowId(for: window) else {
+            clearCommandPaletteDismissFollowupEscapeSuppression()
+            return
+        }
+        commandPaletteDismissFollowupEscapeSuppressionWindowId = windowId
+        commandPaletteDismissFollowupEscapeSuppressionDeadline =
+            ProcessInfo.processInfo.systemUptime + commandPaletteDismissFollowupEscapeSuppressionInterval
+    }
+
+    private func clearCommandPaletteDismissFollowupEscapeSuppression() {
+        commandPaletteDismissFollowupEscapeSuppressionWindowId = nil
+        commandPaletteDismissFollowupEscapeSuppressionDeadline = 0
+    }
+
+    private func shouldConsumeCommandPaletteDismissFollowupEscape(
+        event: NSEvent,
+        commandPaletteTargetWindow: NSWindow?
+    ) -> Bool {
+        guard event.keyCode == 53, !event.isARepeat else { return false }
+        let normalizedFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        guard normalizedFlags.isEmpty else { return false }
+        guard let suppressedWindowId = commandPaletteDismissFollowupEscapeSuppressionWindowId else { return false }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now <= commandPaletteDismissFollowupEscapeSuppressionDeadline else {
+            clearCommandPaletteDismissFollowupEscapeSuppression()
+            return false
+        }
+
+        guard let targetWindow = commandPaletteTargetWindow ?? mainWindowForShortcutEvent(event),
+              let targetWindowId = mainWindowId(for: targetWindow),
+              targetWindowId == suppressedWindowId else {
+            return false
+        }
+
+        clearCommandPaletteDismissFollowupEscapeSuppression()
+        return true
     }
 
     func shouldBlockFirstResponderChangeWhileCommandPaletteVisible(
@@ -4315,6 +4359,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if !event.isARepeat {
             shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = false
+            if !isPlainEscape {
+                clearCommandPaletteDismissFollowupEscapeSuppression()
+            }
         }
         if isPlainEscape, event.isARepeat, shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss {
             return true
@@ -4375,6 +4422,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             NotificationCenter.default.post(name: .commandPaletteDismissRequested, object: paletteWindow)
             clearPendingCommandPaletteRequest(for: paletteWindow)
             shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
+            armCommandPaletteDismissFollowupEscapeSuppression(for: paletteWindow)
             return true
         }
 
@@ -4390,6 +4438,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
                 return true
             }
+        }
+
+        if isPlainEscape,
+           shouldConsumeCommandPaletteDismissFollowupEscape(
+               event: event,
+               commandPaletteTargetWindow: commandPaletteTargetWindow
+           ) {
+            return true
         }
 
         if NSApp.modalWindow != nil || sheetWindowForEscapeEvent(event) != nil {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4326,7 +4326,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isPlainEscape,
            commandPaletteVisibleInTargetWindow,
            let paletteWindow = commandPaletteTargetWindow {
-            NotificationCenter.default.post(name: .commandPaletteToggleRequested, object: paletteWindow)
+            NotificationCenter.default.post(name: .commandPaletteDismissRequested, object: paletteWindow)
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -737,6 +737,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
     private var commandPaletteSelectionByWindowId: [UUID: Int] = [:]
     private var commandPaletteSnapshotByWindowId: [UUID: CommandPaletteDebugSnapshot] = [:]
+    private var pendingCommandPaletteRequestByWindowId: [UUID: TimeInterval] = [:]
+    private let commandPaletteRequestGraceInterval: TimeInterval = 0.75
     private var shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = false
 
     var updateViewModel: UpdateViewModel {
@@ -2197,6 +2199,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func setCommandPaletteVisible(_ visible: Bool, for window: NSWindow) {
         guard let windowId = mainWindowId(for: window) else { return }
         commandPaletteVisibilityByWindowId[windowId] = visible
+        if visible {
+            pendingCommandPaletteRequestByWindowId.removeValue(forKey: windowId)
+        }
     }
 
     func isCommandPaletteVisible(windowId: UUID) -> Bool {
@@ -2224,6 +2229,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func isCommandPaletteVisible(for window: NSWindow) -> Bool {
         guard let windowId = mainWindowId(for: window) else { return false }
         return commandPaletteVisibilityByWindowId[windowId] ?? false
+    }
+
+    private func notePendingCommandPaletteRequest(for window: NSWindow?) {
+        guard let window, let windowId = mainWindowId(for: window) else { return }
+        pendingCommandPaletteRequestByWindowId[windowId] = ProcessInfo.processInfo.systemUptime
+    }
+
+    private func isCommandPaletteRequestPending(for window: NSWindow) -> Bool {
+        guard let windowId = mainWindowId(for: window),
+              let requestTimestamp = pendingCommandPaletteRequestByWindowId[windowId] else {
+            return false
+        }
+
+        let age = ProcessInfo.processInfo.systemUptime - requestTimestamp
+        if age <= commandPaletteRequestGraceInterval {
+            return true
+        }
+
+        pendingCommandPaletteRequestByWindowId.removeValue(forKey: windowId)
+        return false
+    }
+
+    private func clearPendingCommandPaletteRequest(for window: NSWindow?) {
+        guard let window, let windowId = mainWindowId(for: window) else { return }
+        pendingCommandPaletteRequestByWindowId.removeValue(forKey: windowId)
     }
 
     func shouldBlockFirstResponderChangeWhileCommandPaletteVisible(
@@ -4335,11 +4365,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let commandPaletteVisibleInTargetWindow = commandPaletteTargetWindow.map {
             isCommandPaletteVisible(for: $0)
         } ?? false
+        let commandPaletteRequestPendingInTargetWindow = commandPaletteTargetWindow.map {
+            isCommandPaletteRequestPending(for: $0)
+        } ?? false
 
         if isPlainEscape,
-           commandPaletteVisibleInTargetWindow,
+           (commandPaletteVisibleInTargetWindow || commandPaletteRequestPendingInTargetWindow),
            let paletteWindow = commandPaletteTargetWindow {
             NotificationCenter.default.post(name: .commandPaletteDismissRequested, object: paletteWindow)
+            clearPendingCommandPaletteRequest(for: paletteWindow)
             shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
             return true
         }
@@ -4381,6 +4415,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isCommandP {
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             NotificationCenter.default.post(name: .commandPaletteSwitcherRequested, object: targetWindow)
+            notePendingCommandPaletteRequest(for: targetWindow)
             return true
         }
 
@@ -4388,6 +4423,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isCommandShiftP {
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             NotificationCenter.default.post(name: .commandPaletteRequested, object: targetWindow)
+            notePendingCommandPaletteRequest(for: targetWindow)
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -737,6 +737,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
     private var commandPaletteSelectionByWindowId: [UUID: Int] = [:]
     private var commandPaletteSnapshotByWindowId: [UUID: CommandPaletteDebugSnapshot] = [:]
+    private var shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = false
 
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
@@ -4280,6 +4281,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isControlOnly = hasControl && !hasCommand && !hasOption
         let controlDChar = chars == "d" || event.characters == "\u{04}"
         let isControlD = isControlOnly && (controlDChar || event.keyCode == 2)
+        let isPlainEscape = normalizedFlags.isEmpty && event.keyCode == 53
+
+        if !event.isARepeat {
+            shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = false
+        }
+        if isPlainEscape, event.isARepeat, shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss {
+            return true
+        }
 #if DEBUG
         if isControlD {
             writeChildExitKeyboardProbe(
@@ -4314,10 +4323,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 closeButton.performClick(nil)
                 return true
             }
+            if isPlainEscape {
+                _ = closeConfirmationPanel.performKeyEquivalent(with: event)
+                shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
+                return true
+            }
             return false
         }
 
-        let isPlainEscape = normalizedFlags.isEmpty && event.keyCode == 53
         let commandPaletteTargetWindow = commandPaletteWindowForShortcutEvent(event)
         let commandPaletteVisibleInTargetWindow = commandPaletteTargetWindow.map {
             isCommandPaletteVisible(for: $0)
@@ -4327,17 +4340,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            commandPaletteVisibleInTargetWindow,
            let paletteWindow = commandPaletteTargetWindow {
             NotificationCenter.default.post(name: .commandPaletteDismissRequested, object: paletteWindow)
+            shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
             return true
         }
 
         if isPlainEscape {
             if let modalWindow = NSApp.modalWindow {
                 _ = modalWindow.performKeyEquivalent(with: event)
+                shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
                 return true
             }
 
             if let sheetWindow = sheetWindowForEscapeEvent(event) {
                 _ = sheetWindow.performKeyEquivalent(with: event)
+                shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
                 return true
             }
         }
@@ -4402,6 +4418,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // When the notifications popover is open, Escape should dismiss it immediately.
         if flags.isEmpty, event.keyCode == 53, titlebarAccessoryController.dismissNotificationsPopoverIfShown() {
+            shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4445,6 +4445,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                event: event,
                commandPaletteTargetWindow: commandPaletteTargetWindow
            ) {
+            shouldSuppressRepeatedPlainEscapeAfterOverlayDismiss = true
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4273,6 +4273,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Most shortcuts below use keyCode fallbacks, so treat nil as "" rather than bailing out.
         let chars = (event.charactersIgnoringModifiers ?? "").lowercased()
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
         let hasControl = flags.contains(.control)
         let hasCommand = flags.contains(.command)
         let hasOption = flags.contains(.option)
@@ -4316,15 +4317,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        if NSApp.modalWindow != nil || NSApp.keyWindow?.attachedSheet != nil {
-            return false
-        }
-
-        let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
+        let isPlainEscape = normalizedFlags.isEmpty && event.keyCode == 53
         let commandPaletteTargetWindow = commandPaletteWindowForShortcutEvent(event)
         let commandPaletteVisibleInTargetWindow = commandPaletteTargetWindow.map {
             isCommandPaletteVisible(for: $0)
         } ?? false
+
+        if isPlainEscape,
+           commandPaletteVisibleInTargetWindow,
+           let paletteWindow = commandPaletteTargetWindow {
+            NotificationCenter.default.post(name: .commandPaletteToggleRequested, object: paletteWindow)
+            return true
+        }
+
+        if isPlainEscape {
+            if let modalWindow = NSApp.modalWindow {
+                _ = modalWindow.performKeyEquivalent(with: event)
+                return true
+            }
+
+            if let sheetWindow = sheetWindowForEscapeEvent(event) {
+                _ = sheetWindow.performKeyEquivalent(with: event)
+                return true
+            }
+        }
+
+        if NSApp.modalWindow != nil || sheetWindowForEscapeEvent(event) != nil {
+            return false
+        }
 
         if let delta = commandPaletteSelectionDeltaForKeyboardNavigation(
             flags: event.modifierFlags,
@@ -4863,6 +4883,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         #endif
 
         return false
+    }
+
+    private func sheetWindowForEscapeEvent(_ event: NSEvent) -> NSWindow? {
+        if let eventWindow = event.window, eventWindow.sheetParent != nil {
+            return eventWindow
+        }
+        if let sheet = NSApp.keyWindow?.attachedSheet {
+            return sheet
+        }
+        if let sheet = NSApp.mainWindow?.attachedSheet {
+            return sheet
+        }
+        return NSApp.windows.compactMap { $0.attachedSheet }.first(where: { $0.isVisible })
     }
 
     private func shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: SplitDirection) -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2180,6 +2180,18 @@ struct ContentView: View {
             toggleCommandPalette()
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteDismissRequested)) { notification in
+            guard isCommandPalettePresented else { return }
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ) else { return }
+            dismissCommandPalette()
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRequested)) { notification in
             let requestedWindow = notification.object as? NSWindow
             guard Self.shouldHandleCommandPaletteRequest(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3411,6 +3411,7 @@ enum ResizeDirection {
 
 extension Notification.Name {
     static let commandPaletteToggleRequested = Notification.Name("cmux.commandPaletteToggleRequested")
+    static let commandPaletteDismissRequested = Notification.Name("cmux.commandPaletteDismissRequested")
     static let commandPaletteRequested = Notification.Name("cmux.commandPaletteRequested")
     static let commandPaletteSwitcherRequested = Notification.Name("cmux.commandPaletteSwitcherRequested")
     static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -6,6 +6,15 @@ import XCTest
 @testable import cmux
 #endif
 
+private final class EscapeTrackingSheetPanel: NSPanel {
+    private(set) var performKeyEquivalentCallCount = 0
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        performKeyEquivalentCallCount += 1
+        return true
+    }
+}
+
 @MainActor
 final class AppDelegateShortcutRoutingTests: XCTestCase {
     func testCmdNUsesEventWindowContextWhenActiveManagerIsStale() {
@@ -368,6 +377,108 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         wait(for: [workspaceExpectation, renameTabExpectation], timeout: 1.0)
         XCTAssertEqual(observedWorkspaceWindow?.windowNumber, window.windowNumber)
+    }
+
+    func testEscapeDismissesVisibleCommandPaletteAndConsumesEvent() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        appDelegate.setCommandPaletteVisible(true, for: window)
+        defer { appDelegate.setCommandPaletteVisible(false, for: window) }
+
+        let dismissExpectation = expectation(description: "Expected command palette toggle request on Escape")
+        var observedWindow: NSWindow?
+        let token = NotificationCenter.default.addObserver(
+            forName: .commandPaletteToggleRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            observedWindow = notification.object as? NSWindow
+            dismissExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        guard let event = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [dismissExpectation], timeout: 1.0)
+        XCTAssertEqual(observedWindow?.windowNumber, window.windowNumber)
+    }
+
+    func testEscapeIsForwardedToAttachedSheetAndConsumed() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        let sheet = EscapeTrackingSheetPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 140),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.beginSheet(sheet)
+        defer {
+            if sheet.sheetParent != nil {
+                window.endSheet(sheet)
+            }
+            sheet.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: sheet.windowNumber
+        ) else {
+            XCTFail("Failed to construct Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(sheet.performKeyEquivalentCallCount, 1)
     }
 
     func testCmdDigitDoesNotFallbackToOtherWindowWhenEventWindowContextIsMissing() {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -779,6 +779,78 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 #endif
     }
 
+    func testRepeatedEscapeAfterConsumedFollowupEscapeIsConsumed() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        appDelegate.setCommandPaletteVisible(true, for: window)
+
+        guard let initialEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct initial Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: initialEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        guard let followupEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct follow-up Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: followupEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        guard let repeatedEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: true
+        ) else {
+            XCTFail("Failed to construct repeated Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: repeatedEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+    }
+
     func testRepeatedEscapeWithoutOverlayStillFallsThrough() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -501,6 +501,90 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(sheet.performKeyEquivalentCallCount, 1)
     }
 
+    func testEscapeImmediatelyAfterCmdPSwitcherRequestConsumesBeforeVisibilitySync() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+        appDelegate.setCommandPaletteVisible(false, for: window)
+        defer { appDelegate.setCommandPaletteVisible(false, for: window) }
+
+        let switcherExpectation = expectation(description: "Expected command palette switcher request")
+        var switcherWindow: NSWindow?
+        let switcherToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteSwitcherRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            switcherWindow = notification.object as? NSWindow
+            switcherExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(switcherToken) }
+
+        guard let commandPEvent = makeKeyDownEvent(
+            key: "p",
+            modifiers: [.command],
+            keyCode: 35,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+P event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: commandPEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        wait(for: [switcherExpectation], timeout: 1.0)
+        XCTAssertEqual(switcherWindow?.windowNumber, window.windowNumber)
+
+        // Simulate the race where palette visibility has not yet synced when Escape arrives.
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        let dismissExpectation = expectation(description: "Expected command palette dismiss request on immediate Escape")
+        var dismissWindow: NSWindow?
+        let dismissToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteDismissRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            dismissWindow = notification.object as? NSWindow
+            dismissExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(dismissToken) }
+
+        guard let escapeEvent = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: escapeEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [dismissExpectation], timeout: 1.0)
+        XCTAssertEqual(dismissWindow?.windowNumber, window.windowNumber)
+    }
+
     func testRepeatedEscapeAfterCommandPaletteDismissIsConsumed() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -585,6 +585,90 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(dismissWindow?.windowNumber, window.windowNumber)
     }
 
+    func testEscapeImmediatelyAfterCmdShiftPRequestConsumesBeforeVisibilitySync() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+        appDelegate.setCommandPaletteVisible(false, for: window)
+        defer { appDelegate.setCommandPaletteVisible(false, for: window) }
+
+        let requestExpectation = expectation(description: "Expected command palette request")
+        var requestWindow: NSWindow?
+        let requestToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            requestWindow = notification.object as? NSWindow
+            requestExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(requestToken) }
+
+        guard let commandShiftPEvent = makeKeyDownEvent(
+            key: "p",
+            modifiers: [.command, .shift],
+            keyCode: 35,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+P event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: commandShiftPEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        wait(for: [requestExpectation], timeout: 1.0)
+        XCTAssertEqual(requestWindow?.windowNumber, window.windowNumber)
+
+        // Simulate the race where palette visibility has not yet synced when Escape arrives.
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        let dismissExpectation = expectation(description: "Expected command palette dismiss request on immediate Escape")
+        var dismissWindow: NSWindow?
+        let dismissToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteDismissRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            dismissWindow = notification.object as? NSWindow
+            dismissExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(dismissToken) }
+
+        guard let escapeEvent = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: escapeEvent))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [dismissExpectation], timeout: 1.0)
+        XCTAssertEqual(dismissWindow?.windowNumber, window.windowNumber)
+    }
+
     func testRepeatedEscapeAfterCommandPaletteDismissIsConsumed() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -635,6 +719,61 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
 #if DEBUG
         XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: repeatedEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+    }
+
+    func testNonRepeatedFollowupEscapeAfterCommandPaletteDismissIsConsumed() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        appDelegate.setCommandPaletteVisible(true, for: window)
+
+        guard let initialEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct initial Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: initialEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        guard let followupEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct follow-up Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: followupEscape))
 #else
         XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -15,6 +15,15 @@ private final class EscapeTrackingSheetPanel: NSPanel {
     }
 }
 
+private final class EscapeTrackingCloseConfirmationPanel: NSPanel {
+    private(set) var performKeyEquivalentCallCount = 0
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        performKeyEquivalentCallCount += 1
+        return true
+    }
+}
+
 @MainActor
 final class AppDelegateShortcutRoutingTests: XCTestCase {
     func testCmdNUsesEventWindowContextWhenActiveManagerIsStale() {
@@ -492,6 +501,153 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(sheet.performKeyEquivalentCallCount, 1)
     }
 
+    func testRepeatedEscapeAfterCommandPaletteDismissIsConsumed() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        appDelegate.setCommandPaletteVisible(true, for: window)
+
+        guard let initialEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct initial Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: initialEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        guard let repeatedEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: true
+        ) else {
+            XCTFail("Failed to construct repeated Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: repeatedEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+    }
+
+    func testRepeatedEscapeWithoutOverlayStillFallsThrough() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        guard let firstEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct first Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: firstEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        guard let repeatedEscape = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: window.windowNumber,
+            isARepeat: true
+        ) else {
+            XCTFail("Failed to construct repeated Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: repeatedEscape))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+    }
+
+    func testEscapeIsForwardedToCloseConfirmationPanelAndConsumed() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let panel = EscapeTrackingCloseConfirmationPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 140),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 140))
+        let label = NSTextField(labelWithString: "Close tab?")
+        label.frame = NSRect(x: 16, y: 90, width: 200, height: 24)
+        contentView.addSubview(label)
+        panel.contentView = contentView
+        panel.makeKeyAndOrderFront(nil)
+        defer { panel.orderOut(nil) }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "\u{1B}",
+            modifiers: [],
+            keyCode: 53,
+            windowNumber: panel.windowNumber,
+            isARepeat: false
+        ) else {
+            XCTFail("Failed to construct Escape event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(panel.performKeyEquivalentCallCount, 1)
+    }
+
     func testCmdDigitDoesNotFallbackToOtherWindowWhenEventWindowContextIsMissing() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -645,7 +801,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         key: String,
         modifiers: NSEvent.ModifierFlags,
         keyCode: UInt16,
-        windowNumber: Int
+        windowNumber: Int,
+        isARepeat: Bool = false
     ) -> NSEvent? {
         NSEvent.keyEvent(
             with: .keyDown,
@@ -656,7 +813,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             context: nil,
             characters: key,
             charactersIgnoringModifiers: key,
-            isARepeat: false,
+            isARepeat: isARepeat,
             keyCode: keyCode
         )
     }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -398,10 +398,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         appDelegate.setCommandPaletteVisible(true, for: window)
         defer { appDelegate.setCommandPaletteVisible(false, for: window) }
 
-        let dismissExpectation = expectation(description: "Expected command palette toggle request on Escape")
+        let dismissExpectation = expectation(description: "Expected command palette dismiss request on Escape")
         var observedWindow: NSWindow?
         let token = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -409,6 +409,17 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             dismissExpectation.fulfill()
         }
         defer { NotificationCenter.default.removeObserver(token) }
+
+        let toggleExpectation = expectation(description: "Escape should not route through toggle notification")
+        toggleExpectation.isInverted = true
+        let toggleToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteToggleRequested,
+            object: nil,
+            queue: nil
+        ) { _ in
+            toggleExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(toggleToken) }
 
         guard let event = makeKeyDownEvent(
             key: "\u{1B}",
@@ -426,7 +437,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
 
-        wait(for: [dismissExpectation], timeout: 1.0)
+        wait(for: [dismissExpectation, toggleExpectation], timeout: 1.0)
         XCTAssertEqual(observedWindow?.windowNumber, window.windowNumber)
     }
 

--- a/cmuxUITests/MultiWindowNotificationsUITests.swift
+++ b/cmuxUITests/MultiWindowNotificationsUITests.swift
@@ -23,6 +23,7 @@ final class MultiWindowNotificationsUITests: XCTestCase {
 
     func testNotificationsRouteToCorrectWindow() {
         let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
         app.launchEnvironment["CMUX_UI_TEST_MULTI_WINDOW_NOTIF_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_MULTI_WINDOW_NOTIF_PATH"] = dataPath
         app.launch()
@@ -106,6 +107,7 @@ final class MultiWindowNotificationsUITests: XCTestCase {
 
     func testNotificationsPopoverCanCloseViaShortcutAndEscape() {
         let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
         app.launchEnvironment["CMUX_UI_TEST_MULTI_WINDOW_NOTIF_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_MULTI_WINDOW_NOTIF_PATH"] = dataPath
         app.launch()
@@ -139,6 +141,7 @@ final class MultiWindowNotificationsUITests: XCTestCase {
 
     func testEmptyNotificationsPopoverBlocksTerminalTyping() {
         let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launch()
         app.activate()
@@ -300,5 +303,164 @@ final class MultiWindowNotificationsUITests: XCTestCase {
             return nil
         }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+}
+
+final class CommandPaletteEscapeLeakUITests: XCTestCase {
+    private var socketPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        socketPath = "/tmp/cmux-ui-test-socket-\(UUID().uuidString).sock"
+        try? FileManager.default.removeItem(atPath: socketPath)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        super.tearDown()
+    }
+
+    func testCmdPThenEscapeDoesNotLeakToTerminal() {
+        runCommandPaletteEscapeLeakCheck(
+            label: "cmd_p",
+            openPalette: { app in
+                app.typeKey("p", modifierFlags: [.command])
+            }
+        )
+    }
+
+    func testCmdShiftPThenEscapeDoesNotLeakToTerminal() {
+        runCommandPaletteEscapeLeakCheck(
+            label: "cmd_shift_p",
+            openPalette: { app in
+                app.typeKey("p", modifierFlags: [.command, .shift])
+            }
+        )
+    }
+
+    private func runCommandPaletteEscapeLeakCheck(
+        label: String,
+        openPalette: (XCUIApplication) -> Void
+    ) {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launch()
+        app.activate()
+
+        XCTAssertTrue(waitForWindowCount(atLeast: 1, app: app, timeout: 8.0), "Expected at least one app window")
+        XCTAssertTrue(waitForSocketPong(timeout: 8.0), "Expected control socket to respond")
+
+        let token = "CMUX_ESC_PROBE_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8))"
+        let startMarker = "\(token)_START"
+
+        // Ensure we're at a clean prompt first.
+        _ = socketCommand("send_key ctrl-c")
+        _ = socketCommand("send echo \(startMarker)\\n")
+        _ = socketCommand("send cat -v\\n")
+
+        XCTAssertTrue(
+            waitForTerminalTextContains(startMarker, timeout: 3.0),
+            "Expected probe start marker to be visible before shortcut test"
+        )
+
+        openPalette(app)
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+        RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+
+        _ = socketCommand("send_key ctrl-c")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        guard let terminalText = readCurrentTerminalText() else {
+            XCTFail("Expected terminal text from control socket")
+            return
+        }
+
+        XCTAssertFalse(
+            terminalText.contains("^["),
+            """
+            Expected Escape after command palette shortcut to not leak to terminal.
+            scenario=\(label)
+            terminalText=\(terminalText)
+            """
+        )
+    }
+
+    private func waitForWindowCount(atLeast count: Int, app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if app.windows.count >= count { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return app.windows.count >= count
+    }
+
+    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if socketCommand("ping") == "PONG" {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return socketCommand("ping") == "PONG"
+    }
+
+    private func waitForTerminalTextContains(_ marker: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let text = readCurrentTerminalText(), text.contains(marker) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return readCurrentTerminalText()?.contains(marker) ?? false
+    }
+
+    private func socketCommand(_ cmd: String) -> String? {
+        let nc = "/usr/bin/nc"
+        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: nc)
+        proc.arguments = ["-U", socketPath, "-w", "2"]
+
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardInput = inPipe
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+
+        do {
+            try proc.run()
+        } catch {
+            return nil
+        }
+
+        if let data = (cmd + "\n").data(using: .utf8) {
+            inPipe.fileHandleForWriting.write(data)
+        }
+        inPipe.fileHandleForWriting.closeFile()
+
+        proc.waitUntilExit()
+
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
+        if let first = outStr.split(separator: "\n", maxSplits: 1).first {
+            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let trimmed = outStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func readCurrentTerminalText() -> String? {
+        guard let response = socketCommand("read_terminal_text"), response.hasPrefix("OK ") else {
+            return nil
+        }
+        let encoded = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = Data(base64Encoded: encoded) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }


### PR DESCRIPTION
## Summary
- consume plain Escape in app-level shortcut routing when command palette is visible and dismiss the palette immediately
- forward Escape to active modal windows/attached sheets and consume it so Escape does not propagate into terminal input
- add regression tests for command-palette dismiss routing and attached-sheet Escape forwarding

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/AppDelegateShortcutRoutingTests test` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `./scripts/reload.sh --tag escape-no-propagation-r1` (pass)

## Issues
- Task reference: "when we do escape on cmdpallete as well as various alerts that pop up, i think it propagates to the terminal itself. this is undesirable."
- Related: N/A
