### PR TITLE
Avoid main-thread session autosave persistence writes

### DIFF
--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -363,6 +363,42 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testSessionAutosaveTickPolicySkipsWhenTerminating() {
+        XCTAssertTrue(
+            AppDelegate.shouldRunSessionAutosaveTick(isTerminatingApp: false)
+        )
+        XCTAssertFalse(
+            AppDelegate.shouldRunSessionAutosaveTick(isTerminatingApp: true)
+        )
+    }
+
+    func testSessionSnapshotSynchronousWritePolicy() {
+        XCTAssertFalse(
+            AppDelegate.shouldWriteSessionSnapshotSynchronously(
+                isTerminatingApp: false,
+                includeScrollback: false
+            )
+        )
+        XCTAssertFalse(
+            AppDelegate.shouldWriteSessionSnapshotSynchronously(
+                isTerminatingApp: false,
+                includeScrollback: true
+            )
+        )
+        XCTAssertFalse(
+            AppDelegate.shouldWriteSessionSnapshotSynchronously(
+                isTerminatingApp: true,
+                includeScrollback: false
+            )
+        )
+        XCTAssertTrue(
+            AppDelegate.shouldWriteSessionSnapshotSynchronously(
+                isTerminatingApp: true,
+                includeScrollback: true
+            )
+        )
+    }
+
     func testResolvedWindowFramePrefersSavedDisplayIdentity() {
         let savedFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
         let savedDisplay = SessionDisplaySnapshot(


### PR DESCRIPTION
## Summary
- move autosave persistence writes off the main queue onto a dedicated utility queue
- keep synchronous snapshot writes only for termination paths that include scrollback
- pre-encode persisted window geometry in the snapshot path and write it alongside snapshot persistence
- skip autosave timer ticks once termination starts
- add regression tests for autosave tick and sync-write policy helpers in cmuxTests/SessionPersistenceTests.swift

## Sentry issues
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-EA
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-DT

## Validation
- ./scripts/test-unit.sh -only-testing:cmuxTests/SessionPersistenceTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag sentry-ea-dt-async-r1
