### PR TITLE
Cache Ghostty config loads to avoid render-path file IO

### DIFF
--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -117,6 +117,7 @@ struct WorkspaceContentView: View {
             syncBonsplitNotificationBadges()
         }
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+            GhosttyConfig.invalidateLoadCache()
             refreshGhosttyAppearanceConfig(reason: "ghosttyConfigDidReload")
         }
         .onChange(of: colorScheme) { oldValue, newValue in
@@ -175,7 +176,7 @@ struct WorkspaceContentView: View {
     static func resolveGhosttyAppearanceConfig(
         reason: String = "unspecified",
         backgroundOverride: NSColor? = nil,
-        loadConfig: () -> GhosttyConfig = GhosttyConfig.load,
+        loadConfig: () -> GhosttyConfig = { GhosttyConfig.load() },
         defaultBackground: () -> NSColor = { GhosttyApp.shared.defaultBackgroundColor }
     ) -> GhosttyConfig {
         var next = loadConfig()


### PR DESCRIPTION
## Summary
- add an in-memory, color-scheme-aware cache for `GhosttyConfig.load` to avoid repeated file reads on hot SwiftUI render paths
- invalidate that cache when `.ghosttyConfigDidReload` fires so config edits still apply promptly
- keep behavior intact for theme resolution by loading/caching separately for light and dark preferences
- add regression tests for cache reuse and explicit cache invalidation

## Sentry issue
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-A7

## Validation
- ./scripts/test-unit.sh -only-testing:cmuxTests/GhosttyConfigTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag sentry-a7-config-cache-r1
