### PR TITLE
perf: reduce sidebar tab-item hot-path recomputation

### DIFF
--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -7,6 +7,38 @@ import AppKit
 @testable import cmux
 #endif
 
+final class SidebarPathFormatterTests: XCTestCase {
+    func testShortenedPathReplacesExactHomeDirectory() {
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "~"
+        )
+    }
+
+    func testShortenedPathReplacesHomeDirectoryPrefix() {
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example/projects/cmux",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "~/projects/cmux"
+        )
+    }
+
+    func testShortenedPathLeavesExternalPathUnchanged() {
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/tmp/cmux",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "/tmp/cmux"
+        )
+    }
+}
+
 final class GhosttyConfigTests: XCTestCase {
     private struct RGB: Equatable {
         let red: Int


### PR DESCRIPTION
## Summary
- add SidebarPathFormatter with a cached home-directory path and shared path-shortening logic
- avoid repeated computed-property evaluation inside TabItemView.body by precomputing branch and directory rows once per render
- reuse shared path formatting in branch-directory and directory-summary derivation
- add regression tests for exact-home, home-prefix, and external-path formatting

## Sentry
- addresses CMUXTERM-MACOS-FT
- addresses CMUXTERM-MACOS-PF

## Validation
- ./scripts/test-unit.sh -only-testing:cmuxTests/SidebarPathFormatterTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag sentry-ft-sidebar-path-r1
