### PR TITLE
Allow Cmd shortcuts during IME composition

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2748,10 +2748,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
               fr === self || fr.isDescendant(of: self) else { return false }
         guard let surface = ensureSurfaceReadyForInput() else { return false }
 
-        // If the IME is composing (marked text present), don't intercept key
-        // events for bindings — let them flow through to keyDown so the input
-        // method can process them normally.
-        if hasMarkedText() {
+        // If the IME is composing (marked text present) and the key has no Cmd
+        // modifier, don't intercept — let it flow through to keyDown so the input
+        // method can process it normally. Cmd-based shortcuts should still work
+        // during composition since Cmd is never part of IME input sequences.
+        if hasMarkedText(), !event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) {
             return false
         }
 


### PR DESCRIPTION
## Summary
- Cmd-based keyboard shortcuts (Cmd+T, Cmd+Shift+L, etc.) were blocked while any IME had active composition (marked text)
- Affected all CJK input methods: Chinese Pinyin, Japanese Hiragana/Katakana, Korean Jamo, Vietnamese Telex, etc.
- Fixed by exempting Cmd-modified events from the three IME bypass points in the key event chain, since Cmd is a system modifier never consumed by IME input sequences

## Test plan
- [ ] Switch to Chinese Simplified Pinyin IME, focus a terminal, press Cmd+Shift+L → browser panel opens
- [ ] Type partial pinyin (e.g. "niha"), then press Cmd+T → new tab opens, composition preserved
- [ ] Switch to Japanese Hiragana IME, type partial kana, press Cmd+N → new workspace opens
- [ ] Switch to Korean IME, type partial jamo, press Cmd+D → pane closes
- [ ] Verify normal IME composition (typing, candidate selection, commit) still works for all languages
- [ ] Verify Cmd+C/V/X copy-paste still works during composition

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)