### PR TITLE
avoid command-palette overlay subview-copy hot path

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6223,6 +6223,42 @@ final class WindowMoveSuppressionHitPathTests: XCTestCase {
 }
 
 @MainActor
+final class CommandPaletteOverlayPromotionPolicyTests: XCTestCase {
+    func testShouldPromoteWhenBecomingVisible() {
+        XCTAssertTrue(
+            CommandPaletteOverlayPromotionPolicy.shouldPromote(
+                previouslyVisible: false,
+                isVisible: true
+            )
+        )
+    }
+
+    func testShouldNotPromoteWhenAlreadyVisible() {
+        XCTAssertFalse(
+            CommandPaletteOverlayPromotionPolicy.shouldPromote(
+                previouslyVisible: true,
+                isVisible: true
+            )
+        )
+    }
+
+    func testShouldNotPromoteWhenHidden() {
+        XCTAssertFalse(
+            CommandPaletteOverlayPromotionPolicy.shouldPromote(
+                previouslyVisible: true,
+                isVisible: false
+            )
+        )
+        XCTAssertFalse(
+            CommandPaletteOverlayPromotionPolicy.shouldPromote(
+                previouslyVisible: false,
+                isVisible: false
+            )
+        )
+    }
+}
+
+@MainActor
 final class GhosttySurfaceOverlayTests: XCTestCase {
     func testInactiveOverlayVisibilityTracksRequestedState() {
         let hostedView = GhosttySurfaceScrollView(


### PR DESCRIPTION
## Summary
- avoid `themeFrame.subviews` scans in the command-palette overlay install/update hot path
- only re-promote the command-palette overlay container when visibility transitions from hidden to visible
- keep install idempotent while preserving overlay promotion behavior when opening the palette
- add regression tests for the overlay-promotion policy transitions

## Sentry
- addresses CMUXTERM-MACOS-M9

## Validation
- ./scripts/test-unit.sh -only-testing:cmuxTests/CommandPaletteOverlayPromotionPolicyTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag sentry-m9-overlay-guard-r1
