### PR TITLE
guard devtools auto-restore from first-responder crash path

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2150,7 +2150,12 @@ extension BrowserPanel {
             dlog("browser.devtools refresh.forceShowWhenHidden panel=\(id.uuidString.prefix(5)) \(debugDeveloperToolsStateSummary())")
         }
         #endif
-        inspector.cmuxCallVoid(selector: selector)
+        // WebKit inspector "show" can trigger transient first-responder churn while
+        // panel attachment is still stabilizing. Keep this auto-restore path from
+        // mutating first responder so AppKit doesn't walk tearing-down responder chains.
+        cmuxWithWindowFirstResponderBypass {
+            inspector.cmuxCallVoid(selector: selector)
+        }
         preferredDeveloperToolsVisible = true
         let visibleAfterShow = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
         if visibleAfterShow {


### PR DESCRIPTION
## Summary
- add a scoped first-responder bypass used by the `NSWindow.makeFirstResponder` swizzle
- wrap Browser DevTools auto-restore `show` calls in that bypass to avoid responder-chain churn during split/attach retries
- add regression coverage for bypass behavior in window first-responder guard tests

## Sentry
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-J6
- related: https://manaflow.sentry.io/issues/CMUXTERM-MACOS-J5
- related: https://manaflow.sentry.io/issues/CMUXTERM-MACOS-PH

## Validation
- `./scripts/test-unit.sh -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testWindowFirstResponderBypassBlocksSwizzledMakeFirstResponder -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testWindowFirstResponderGuardResolvesTrackedWebViewForFieldEditorResponder test`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag sentry-j6-first-responder-r1`
