### PR TITLE
reuse terminal portal installation target on sync hot path

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -717,7 +717,8 @@ final class WindowTerminalPortal: NSObject {
     @discardableResult
     private func ensureInstalled() -> Bool {
         guard let window else { return false }
-        guard let (container, reference) = installationTarget(for: window) else { return false }
+        guard let (container, reference) = installedTargetIfStillValid(for: window) ?? installationTarget(for: window)
+        else { return false }
 
         if hostView.superview !== container ||
             installedContainerView !== container ||
@@ -753,6 +754,22 @@ final class WindowTerminalPortal: NSObject {
         ensureDividerOverlayOnTop()
 
         return true
+    }
+
+    private func installedTargetIfStillValid(for window: NSWindow) -> (container: NSView, reference: NSView)? {
+        guard let container = installedContainerView,
+              let reference = installedReferenceView else {
+            return nil
+        }
+
+        guard hostView.superview === container,
+              container.window === window,
+              reference.window === window,
+              reference.superview === container else {
+            return nil
+        }
+
+        return (container, reference)
     }
 
     private func installationTarget(for window: NSWindow) -> (container: NSView, reference: NSView)? {


### PR DESCRIPTION
## Summary
- avoid repeated `window.contentView` lookups during terminal portal anchor synchronizes by reusing the already-installed `(container, reference)` target when still valid
- keep existing install/reinstall behavior when the host/reference/container relationship changes
- add regression coverage that counts `contentView` getter reads and verifies repeated `synchronizeHostedViewForAnchor` calls do not re-read `window.contentView`

## Sentry
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-FW

## Validation
- `./scripts/test-unit.sh -only-testing:cmuxTests/TerminalWindowPortalLifecycleTests/testSynchronizeReusesInstalledTargetWithoutRepeatedContentViewLookup -only-testing:cmuxTests/TerminalWindowPortalLifecycleTests/testTerminalViewAtWindowPointResolvesPortalHostedSurface test`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag sentry-fw-portal-cache-r1`
