### PR TITLE
Reduce autosave snapshot churn for unchanged state

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3315,6 +3315,47 @@ class TabManager: ObservableObject {
 }
 
 extension TabManager {
+    func sessionAutosaveFingerprint() -> Int {
+        var hasher = Hasher()
+        hasher.combine(selectedTabId)
+        hasher.combine(tabs.count)
+
+        for workspace in tabs.prefix(SessionPersistencePolicy.maxWorkspacesPerWindow) {
+            hasher.combine(workspace.id)
+            hasher.combine(workspace.focusedPanelId)
+            hasher.combine(workspace.currentDirectory)
+            hasher.combine(workspace.customTitle ?? "")
+            hasher.combine(workspace.customColor ?? "")
+            hasher.combine(workspace.isPinned)
+            hasher.combine(workspace.panels.count)
+            hasher.combine(workspace.statusEntries.count)
+            hasher.combine(workspace.metadataBlocks.count)
+            hasher.combine(workspace.logEntries.count)
+            hasher.combine(workspace.panelDirectories.count)
+            hasher.combine(workspace.panelTitles.count)
+            hasher.combine(workspace.panelPullRequests.count)
+            hasher.combine(workspace.panelGitBranches.count)
+            hasher.combine(workspace.surfaceListeningPorts.count)
+
+            if let progress = workspace.progress {
+                hasher.combine(Int((progress.value * 1000).rounded()))
+                hasher.combine(progress.label)
+            } else {
+                hasher.combine(-1)
+            }
+
+            if let gitBranch = workspace.gitBranch {
+                hasher.combine(gitBranch.branch)
+                hasher.combine(gitBranch.isDirty)
+            } else {
+                hasher.combine("")
+                hasher.combine(false)
+            }
+        }
+
+        return hasher.finalize()
+    }
+
     func sessionSnapshot(includeScrollback: Bool) -> SessionTabManagerSnapshot {
         let workspaceSnapshots = tabs
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -399,6 +399,60 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testUnchangedAutosaveFingerprintSkipsWithinStalenessWindow() {
+        let now = Date()
+        XCTAssertTrue(
+            AppDelegate.shouldSkipSessionAutosaveForUnchangedFingerprint(
+                isTerminatingApp: false,
+                includeScrollback: false,
+                previousFingerprint: 1234,
+                currentFingerprint: 1234,
+                lastPersistedAt: now.addingTimeInterval(-5),
+                now: now,
+                maximumAutosaveSkippableInterval: 60
+            )
+        )
+    }
+
+    func testUnchangedAutosaveFingerprintDoesNotSkipAfterStalenessWindow() {
+        let now = Date()
+        XCTAssertFalse(
+            AppDelegate.shouldSkipSessionAutosaveForUnchangedFingerprint(
+                isTerminatingApp: false,
+                includeScrollback: false,
+                previousFingerprint: 1234,
+                currentFingerprint: 1234,
+                lastPersistedAt: now.addingTimeInterval(-120),
+                now: now,
+                maximumAutosaveSkippableInterval: 60
+            )
+        )
+    }
+
+    func testUnchangedAutosaveFingerprintNeverSkipsTerminatingOrScrollbackWrites() {
+        let now = Date()
+        XCTAssertFalse(
+            AppDelegate.shouldSkipSessionAutosaveForUnchangedFingerprint(
+                isTerminatingApp: true,
+                includeScrollback: false,
+                previousFingerprint: 1234,
+                currentFingerprint: 1234,
+                lastPersistedAt: now.addingTimeInterval(-1),
+                now: now
+            )
+        )
+        XCTAssertFalse(
+            AppDelegate.shouldSkipSessionAutosaveForUnchangedFingerprint(
+                isTerminatingApp: false,
+                includeScrollback: true,
+                previousFingerprint: 1234,
+                currentFingerprint: 1234,
+                lastPersistedAt: now.addingTimeInterval(-1),
+                now: now
+            )
+        )
+    }
+
     func testResolvedWindowFramePrefersSavedDisplayIdentity() {
         let savedFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
         let savedDisplay = SessionDisplaySnapshot(


### PR DESCRIPTION
## Summary\n- add a lightweight autosave fingerprint for window + workspace state\n- skip periodic autosave ticks when fingerprint is unchanged, with a 60s max skip window\n- keep non-autosave snapshot call sites unchanged\n- add regression tests for the autosave-skip policy\n\n## Sentry\n- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-RF\n- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-H4\n\n## Validation\n- ./scripts/test-unit.sh -only-testing:cmuxTests/SessionPersistenceTests/testUnchangedAutosaveFingerprintSkipsWithinStalenessWindow -only-testing:cmuxTests/SessionPersistenceTests/testUnchangedAutosaveFingerprintDoesNotSkipAfterStalenessWindow -only-testing:cmuxTests/SessionPersistenceTests/testUnchangedAutosaveFingerprintNeverSkipsTerminatingOrScrollbackWrites -only-testing:cmuxTests/SessionPersistenceTests/testSessionSnapshotSynchronousWritePolicy test\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build\n- ./scripts/reload.sh --tag sentry-rf-autosave-r1\n