### PR TITLE
Cache sidebar drop type + shortcut hint metrics

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6081,6 +6081,45 @@ final class WindowDragHandleHitTests: XCTestCase {
     }
 }
 
+#if DEBUG
+@MainActor
+final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        SidebarWorkspaceShortcutHintMetrics.resetCacheForTesting()
+    }
+
+    override func tearDown() {
+        SidebarWorkspaceShortcutHintMetrics.resetCacheForTesting()
+        super.tearDown()
+    }
+
+    func testHintWidthCachesRepeatedMeasurements() {
+        XCTAssertEqual(SidebarWorkspaceShortcutHintMetrics.measurementCountForTesting(), 0)
+
+        let first = SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘1")
+        XCTAssertGreaterThan(first, 0)
+        XCTAssertEqual(SidebarWorkspaceShortcutHintMetrics.measurementCountForTesting(), 1)
+
+        let second = SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘1")
+        XCTAssertEqual(second, first)
+        XCTAssertEqual(SidebarWorkspaceShortcutHintMetrics.measurementCountForTesting(), 1)
+
+        _ = SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘2")
+        XCTAssertEqual(SidebarWorkspaceShortcutHintMetrics.measurementCountForTesting(), 2)
+    }
+
+    func testSlotWidthAppliesMinimumAndDebugInset() {
+        let nilLabelWidth = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: nil, debugXOffset: 999)
+        XCTAssertEqual(nilLabelWidth, 28)
+
+        let base = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
+        let widened = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 10)
+        XCTAssertGreaterThan(widened, base)
+    }
+}
+#endif
+
 @MainActor
 final class DraggableFolderHitTests: XCTestCase {
     func testFolderHitTestReturnsContainerWhenInsideBounds() {


### PR DESCRIPTION
## Summary
- switch sidebar and bonsplit `.onDrop(of:)` call sites to cached `UTType` arrays instead of per-render string identifiers
- add `SidebarWorkspaceShortcutHintMetrics` to memoize shortcut hint width measurements used by `TabItemView`
- add regression tests for width-cache behavior and slot-width sizing semantics

## Sentry
- Fixes CMUXTERM-MACOS-GA (https://manaflow.sentry.io/issues/CMUXTERM-MACOS-GA)
- Fixes CMUXTERM-MACOS-JG (https://manaflow.sentry.io/issues/CMUXTERM-MACOS-JG)

## Validation
- `./scripts/test-unit.sh -only-testing:cmuxTests/SidebarWorkspaceShortcutHintMetricsTests test`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag sentry-ga-jg-drop-hint-r1`
