### PR TITLE
Skip drag-handle capture when current event is unavailable

### DIFF
--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -8,7 +8,7 @@ private func windowDragHandleFormatPoint(_ point: NSPoint) -> String {
 
 private func windowDragHandleShouldDeferHitCapture(for eventType: NSEvent.EventType?) -> Bool {
     switch eventType {
-    case .mouseMoved?, .cursorUpdate?:
+    case nil, .mouseMoved?, .cursorUpdate?:
         return true
     default:
         return false

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -5973,6 +5973,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         let point = NSPoint(x: 180, y: 18)
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .mouseMoved))
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .cursorUpdate))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: nil))
         XCTAssertTrue(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown))
     }
 


### PR DESCRIPTION
## Summary
- treat `eventType == nil` as passive in `windowDragHandleShouldDeferHitCapture`
- keep capture enabled for explicit pointer intent (`.leftMouseDown`) only
- extend `WindowDragHandleHitTests` to assert nil-event hit tests do not capture the drag handle

## Why
- hardens titlebar drag-handle hit testing for non-interaction AppKit hit-test passes where `NSApp.currentEvent` is unavailable
- reduces risk in the cursor/update structural-hit-test path seen in:
  - https://manaflow.sentry.io/issues/CMUXTERM-MACOS-AF
  - https://manaflow.sentry.io/issues/CMUXTERM-MACOS-A8

## Validation
- `./scripts/test-unit.sh -only-testing:cmuxTests/WindowDragHandleHitTests test`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag sentry-af-passive-hit-r1`
