### PR TITLE
Add cmux_hourly_active event for hourly retention

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -950,6 +950,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let env = ProcessInfo.processInfo.environment
         if !isRunningUnderXCTest(env) {
             PostHogAnalytics.shared.trackDailyActive(reason: "didBecomeActive")
+            PostHogAnalytics.shared.trackHourlyActive(reason: "didBecomeActive")
         }
 
         guard let tabManager, let notificationStore else { return }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -943,6 +943,35 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         XCTAssertEqual(properties["app_build"] as? String, "230")
     }
 
+    func testHourlyActivePropertiesIncludeVersionAndBuild() {
+        let properties = PostHogAnalytics.hourlyActiveProperties(
+            hourUTC: "2026-02-21T14",
+            reason: "didBecomeActive",
+            infoDictionary: [
+                "CFBundleShortVersionString": "0.31.0",
+                "CFBundleVersion": "230",
+            ]
+        )
+
+        XCTAssertEqual(properties["hour_utc"] as? String, "2026-02-21T14")
+        XCTAssertEqual(properties["reason"] as? String, "didBecomeActive")
+        XCTAssertEqual(properties["app_version"] as? String, "0.31.0")
+        XCTAssertEqual(properties["app_build"] as? String, "230")
+    }
+
+    func testHourlyPropertiesOmitVersionFieldsWhenUnavailable() {
+        let properties = PostHogAnalytics.hourlyActiveProperties(
+            hourUTC: "2026-02-21T14",
+            reason: "activeTimer",
+            infoDictionary: [:]
+        )
+
+        XCTAssertEqual(properties["hour_utc"] as? String, "2026-02-21T14")
+        XCTAssertEqual(properties["reason"] as? String, "activeTimer")
+        XCTAssertNil(properties["app_version"])
+        XCTAssertNil(properties["app_build"])
+    }
+
     func testPropertiesOmitVersionFieldsWhenUnavailable() {
         let superProperties = PostHogAnalytics.superProperties(infoDictionary: [:])
         XCTAssertEqual(superProperties["platform"] as? String, "cmuxterm")


### PR DESCRIPTION
## Summary

- Adds `cmux_hourly_active` PostHog event that fires at most once per UTC hour, deduped via UserDefaults key `posthog.lastActiveHourUTC`
- Fires from `applicationDidBecomeActive` and the existing 30-minute timer — no timer interval changes needed
- No `flush()` after hourly events (batches naturally; only daily DAU needs eager delivery)
- Adds `hourlyActiveProperties` static method following existing testable pattern

## Why

`cmux_daily_active` deduplicates by UTC date, so PostHog hourly retention cohorts show 0s. This companion event provides intra-day signal (~144K events/month at 200 DAU).

## Test plan

- [ ] New unit tests: `testHourlyActivePropertiesIncludeVersionAndBuild`, `testHourlyPropertiesOmitVersionFieldsWhenUnavailable`
- [ ] Existing daily-active tests still pass (no regressions)
- [ ] Manual: `CMUX_POSTHOG_ENABLE=1` debug build → verify `cmux_hourly_active` in PostHog live events