### PR TITLE
Add X/Twitter and Discord badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 </p>
 
 <p align="center">
+  <a href="https://x.com/manaflowai"><img src="https://img.shields.io/badge/@manaflow-555?logo=x" alt="X / Twitter" /></a>
+  <a href="https://discord.gg/xsgFEVrWCZ"><img src="https://img.shields.io/badge/Discord-555?logo=discord" alt="Discord" /></a>
+</p>
+
+<p align="center">
   <img src="./docs/assets/main-first-image.png" alt="cmux screenshot" width="900" />
 </p>
 


### PR DESCRIPTION
## Summary
- Adds X/Twitter and Discord shield.io badges below the language selector in README

## Testing
- Visual check on GitHub rendered README

## Related
- Task: Add social media badges to README header