### PR TITLE
Fix mic permission prompt support for codex voice transcription

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,6 +26,8 @@
 	<string></string>
 	<key>NSMainStoryboardFile</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>A program running within cmux would like to use your microphone.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSServices</key>

--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 </dict>

--- a/tests/test_microphone_access_metadata.py
+++ b/tests/test_microphone_access_metadata.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Regression test: cmux advertises and allows microphone access."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def load_plist(path: Path, failures: list[str]) -> dict:
+    if not path.exists():
+        failures.append(f"Missing expected file: {path}")
+        return {}
+    with path.open("rb") as f:
+        return plistlib.load(f)
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    failures: list[str] = []
+
+    info = load_plist(repo_root / "Resources" / "Info.plist", failures)
+    entitlements = load_plist(repo_root / "cmux.entitlements", failures)
+
+    mic_usage = info.get("NSMicrophoneUsageDescription")
+    if not isinstance(mic_usage, str) or not mic_usage.strip():
+        failures.append(
+            "Resources/Info.plist must define a non-empty NSMicrophoneUsageDescription"
+        )
+    elif mic_usage.strip() != "A program running within cmux would like to use your microphone.":
+        failures.append(
+            "Resources/Info.plist NSMicrophoneUsageDescription should match the Ghostty-style wording"
+        )
+
+    if entitlements.get("com.apple.security.device.audio-input") is not True:
+        failures.append(
+            "cmux.entitlements must set com.apple.security.device.audio-input to true"
+        )
+
+    if failures:
+        print("FAIL: microphone access metadata regression(s) detected")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: microphone usage description and entitlement are present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `NSMicrophoneUsageDescription` to `Resources/Info.plist` using Ghostty-style wording so macOS can show the mic permission prompt for terminal tools
- add `com.apple.security.device.audio-input = true` to `cmux.entitlements` so hardened-runtime signed nightly/release apps are allowed to request microphone access
- add regression test `tests/test_microphone_access_metadata.py` to assert both keys stay present

## Testing
- `python3 tests/test_microphone_access_metadata.py` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)

## Issues
- Related: Task from HQ session (2026-02-26): "codex v0.105.0 recently added support for voice transcription. however, microphone access approval window is not showing in cmux. giving approval separately to ghostty doesn't work :("
