### PR TITLE
Add Cmd+Enter fullscreen shortcut

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -302,6 +302,17 @@ func shouldDispatchBrowserReturnViaFirstResponderKeyDown(
     return keyCode == 36 || keyCode == 76
 }
 
+func shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+    flags: NSEvent.ModifierFlags,
+    keyCode: UInt16
+) -> Bool {
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    guard normalizedFlags == [.command] else { return false }
+    return keyCode == 36 || keyCode == 76
+}
+
 func commandPaletteSelectionDeltaForKeyboardNavigation(
     flags: NSEvent.ModifierFlags,
     chars: String,
@@ -4571,6 +4582,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if normalizedFlags == [.command, .shift],
            (chars == "," || chars == "<" || event.keyCode == 43) {
             GhosttyApp.shared.reloadConfiguration(source: "shortcut.cmd_shift_comma")
+            return true
+        }
+
+        if shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+            flags: event.modifierFlags,
+            keyCode: event.keyCode
+        ) {
+            guard let targetWindow = mainWindowForShortcutEvent(event) else {
+                return false
+            }
+            targetWindow.toggleFullScreen(nil)
             return true
         }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1934,6 +1934,68 @@ final class BrowserReturnKeyDownRoutingTests: XCTestCase {
     }
 }
 
+final class FullScreenShortcutTests: XCTestCase {
+    func testMatchesCommandReturn() {
+        XCTAssertTrue(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command],
+                keyCode: 36
+            )
+        )
+    }
+
+    func testMatchesCommandKeypadEnterWithNumericPadFlag() {
+        XCTAssertTrue(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command, .numericPad],
+                keyCode: 76
+            )
+        )
+    }
+
+    func testIgnoresCapsLockForCommandEnter() {
+        XCTAssertTrue(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command, .capsLock],
+                keyCode: 36
+            )
+        )
+    }
+
+    func testRejectsNonEnterKeyCodes() {
+        XCTAssertFalse(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command],
+                keyCode: 13
+            )
+        )
+    }
+
+    func testRejectsAdditionalModifiers() {
+        XCTAssertFalse(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command, .shift],
+                keyCode: 36
+            )
+        )
+        XCTAssertFalse(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [.command, .control],
+                keyCode: 36
+            )
+        )
+    }
+
+    func testRejectsWhenCommandIsMissing() {
+        XCTAssertFalse(
+            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+                flags: [],
+                keyCode: 36
+            )
+        )
+    }
+}
+
 final class BrowserZoomShortcutActionTests: XCTestCase {
     func testZoomInSupportsEqualsAndPlusVariants() {
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
- add a `Cmd+Enter` shortcut in app-level shortcut routing to toggle fullscreen for the active main terminal window
- support both Return and keypad Enter key codes and normalize modifier flags to avoid false matches
- add regression tests for the fullscreen shortcut matcher helper

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/FullScreenShortcutTests test` (fails due pre-existing compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` about `hostWindowAttached` argument labels)
- `./scripts/reload.sh --tag cmd-enter-fullscreen` (pass)

## Issues
- Related task: ghostty has cmd+enter to go fullscreen we need to add the same thing
