### PR TITLE
CLI: harden socket send path and add SIGPIPE telemetry breadcrumbs

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -453,6 +453,7 @@ private enum SocketPasswordResolver {
 
 final class SocketClient {
     private let path: String
+    private let telemetry: CLISocketSentryTelemetry?
     private var socketFD: Int32 = -1
     private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
     private static let responseTimeoutSeconds: TimeInterval = {
@@ -465,8 +466,9 @@ final class SocketClient {
         return defaultResponseTimeoutSeconds
     }()
 
-    init(path: String) {
+    fileprivate init(path: String, telemetry: CLISocketSentryTelemetry? = nil) {
         self.path = path
+        self.telemetry = telemetry
     }
 
     func connect() throws {
@@ -518,11 +520,35 @@ final class SocketClient {
     func send(command: String) throws -> String {
         guard socketFD >= 0 else { throw CLIError(message: "Not connected") }
         let payload = command + "\n"
-        try payload.withCString { ptr in
-            let sent = Darwin.write(socketFD, ptr, strlen(ptr))
-            if sent < 0 {
-                throw CLIError(message: "Failed to write to socket")
+        let commandSummary = Self.commandSummary(command)
+        telemetry?.breadcrumb(
+            "socket.send.attempt",
+            data: ["command_summary": commandSummary]
+        )
+
+        let payloadBytes = Array(payload.utf8)
+        var written = 0
+        while written < payloadBytes.count {
+            let sent = payloadBytes.withUnsafeBytes { rawBuffer -> Int in
+                guard let base = rawBuffer.baseAddress else { return -1 }
+                return Darwin.write(socketFD, base.advanced(by: written), payloadBytes.count - written)
             }
+            if sent <= 0 {
+                let code = errno
+                let errorDescription = String(cString: strerror(code))
+                telemetry?.breadcrumb(
+                    "socket.send.write.failure",
+                    data: [
+                        "command_summary": commandSummary,
+                        "errno": Int(code),
+                        "errno_description": errorDescription,
+                        "bytes_written": written,
+                        "bytes_total": payloadBytes.count
+                    ]
+                )
+                throw CLIError(message: "Failed to write to socket (\(code): \(errorDescription))")
+            }
+            written += sent
         }
 
         var data = Data()
@@ -533,36 +559,109 @@ final class SocketClient {
             var pollFD = pollfd(fd: socketFD, events: Int16(POLLIN), revents: 0)
             let ready = poll(&pollFD, 1, 100)
             if ready < 0 {
-                throw CLIError(message: "Socket read error")
+                let code = errno
+                let errorDescription = String(cString: strerror(code))
+                telemetry?.breadcrumb(
+                    "socket.send.poll.failure",
+                    data: [
+                        "command_summary": commandSummary,
+                        "errno": Int(code),
+                        "errno_description": errorDescription
+                    ]
+                )
+                throw CLIError(message: "Socket read error (\(code): \(errorDescription))")
             }
             if ready == 0 {
                 if sawNewline {
                     break
                 }
                 if Date().timeIntervalSince(start) > Self.responseTimeoutSeconds {
-                    throw CLIError(message: "Command timed out")
+                    telemetry?.breadcrumb(
+                        "socket.send.timeout",
+                        data: [
+                            "command_summary": commandSummary,
+                            "timeout_seconds": Self.responseTimeoutSeconds,
+                            "received_bytes": data.count
+                        ]
+                    )
+                    throw CLIError(message: "Command timed out after \(Self.responseTimeoutSeconds)s")
                 }
                 continue
             }
 
             var buffer = [UInt8](repeating: 0, count: 8192)
             let count = Darwin.read(socketFD, &buffer, buffer.count)
-            if count <= 0 {
+            if count < 0 {
+                let code = errno
+                let errorDescription = String(cString: strerror(code))
+                telemetry?.breadcrumb(
+                    "socket.send.read.failure",
+                    data: [
+                        "command_summary": commandSummary,
+                        "errno": Int(code),
+                        "errno_description": errorDescription,
+                        "received_bytes": data.count
+                    ]
+                )
+                throw CLIError(message: "Socket read error (\(code): \(errorDescription))")
+            }
+            if count == 0 {
+                if !sawNewline {
+                    telemetry?.breadcrumb(
+                        "socket.send.read.eof",
+                        data: [
+                            "command_summary": commandSummary,
+                            "received_bytes": data.count
+                        ]
+                    )
+                    throw CLIError(message: "Socket closed before response completed")
+                }
                 break
             }
             data.append(buffer, count: count)
-            if data.contains(UInt8(0x0A)) {
+            if buffer[..<count].contains(UInt8(0x0A)) {
                 sawNewline = true
             }
         }
 
         guard var response = String(data: data, encoding: .utf8) else {
+            telemetry?.breadcrumb(
+                "socket.send.invalid_utf8",
+                data: [
+                    "command_summary": commandSummary,
+                    "received_bytes": data.count
+                ]
+            )
             throw CLIError(message: "Invalid UTF-8 response")
         }
         if response.hasSuffix("\n") {
             response.removeLast()
         }
         return response
+    }
+
+    private static func commandSummary(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "<empty>" }
+
+        if trimmed.lowercased().hasPrefix("auth ") {
+            return "auth <redacted>"
+        }
+
+        if trimmed.first == "{",
+           let jsonData = trimmed.data(using: .utf8),
+           let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: []),
+           let payload = jsonObject as? [String: Any] {
+            let method = (payload["method"] as? String) ?? "unknown"
+            let id = (payload["id"] as? String) ?? "unknown"
+            return "jsonrpc method=\(method) id=\(id)"
+        }
+
+        if let commandVerb = trimmed.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true).first {
+            return String(commandVerb)
+        }
+
+        return trimmed
     }
 
     func sendV2(method: String, params: [String: Any] = [:]) throws -> [String: Any] {
@@ -698,7 +797,7 @@ struct CMUXCLI {
             }
         }
 
-        let client = SocketClient(path: socketPath)
+        let client = SocketClient(path: socketPath, telemetry: cliTelemetry)
         cliTelemetry.breadcrumb(
             "socket.connect.attempt",
             data: ["command": command]
@@ -714,10 +813,18 @@ struct CMUXCLI {
         defer { client.close() }
 
         if let socketPassword = SocketPasswordResolver.resolve(explicit: socketPasswordArg) {
-            let authResponse = try client.send(command: "auth \(socketPassword)")
-            if authResponse.hasPrefix("ERROR:"),
-               !authResponse.contains("Unknown command 'auth'") {
-                throw CLIError(message: authResponse)
+            cliTelemetry.breadcrumb("socket.auth.attempt")
+            do {
+                let authResponse = try client.send(command: "auth \(socketPassword)")
+                if authResponse.hasPrefix("ERROR:"),
+                   !authResponse.contains("Unknown command 'auth'") {
+                    throw CLIError(message: authResponse)
+                }
+                cliTelemetry.breadcrumb("socket.auth.success")
+            } catch {
+                cliTelemetry.breadcrumb("socket.auth.failure")
+                cliTelemetry.captureError(stage: "socket_auth", error: error)
+                throw error
             }
         }
 
@@ -729,7 +836,8 @@ struct CMUXCLI {
             _ = try client.sendV2(method: "window.focus", params: ["window_id": normalizedWindow])
         }
 
-        switch command {
+        do {
+            switch command {
         case "ping":
             let response = try sendV1Command("ping", client: client)
             print(response)
@@ -1491,6 +1599,16 @@ struct CMUXCLI {
         default:
             print(usage())
             throw CLIError(message: "Unknown command: \(command)")
+            }
+        } catch {
+            if command != "claude-hook" {
+                cliTelemetry.breadcrumb(
+                    "command.dispatch.failure",
+                    data: ["command": command]
+                )
+                cliTelemetry.captureError(stage: "command_dispatch", error: error)
+            }
+            throw error
         }
     }
 

--- a/tests/test_cli_sigpipe_breadcrumbs_regression.py
+++ b/tests/test_cli_sigpipe_breadcrumbs_regression.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Regression test: CLI should survive broken pipes and emit send breadcrumbs."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def require(content: str, needle: str, message: str, failures: list[str]) -> None:
+    if needle not in content:
+        failures.append(message)
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    cli_path = repo_root / "CLI" / "cmux.swift"
+    if not cli_path.exists():
+        print(f"FAIL: missing expected file: {cli_path}")
+        return 1
+
+    content = cli_path.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    require(
+        content,
+        "_ = signal(SIGPIPE, SIG_IGN)",
+        "CLI main must ignore SIGPIPE so socket write failures return errors instead of terminating the process",
+        failures,
+    )
+    require(
+        content,
+        "let client = SocketClient(path: socketPath, telemetry: cliTelemetry)",
+        "SocketClient should receive CLI telemetry for per-command send breadcrumbs",
+        failures,
+    )
+    require(
+        content,
+        '"socket.send.write.failure"',
+        "Socket send write failures should emit breadcrumbs",
+        failures,
+    )
+    require(
+        content,
+        '"socket.send.timeout"',
+        "Socket send timeouts should emit breadcrumbs",
+        failures,
+    )
+    require(
+        content,
+        '"socket.send.read.failure"',
+        "Socket read failures should emit breadcrumbs",
+        failures,
+    )
+    require(
+        content,
+        'if trimmed.lowercased().hasPrefix("auth ") {\n            return "auth <redacted>"',
+        "Socket command summaries must redact auth payloads",
+        failures,
+    )
+    require(
+        content,
+        'cliTelemetry.captureError(stage: "command_dispatch", error: error)',
+        "Command dispatch failures should be captured for non-claude-hook commands",
+        failures,
+    )
+
+    if failures:
+        print("FAIL: CLI SIGPIPE/breadcrumb regression(s) detected")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: CLI SIGPIPE handling and send breadcrumbs are wired")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ignore `SIGPIPE` in the CLI process so broken socket pipes return structured errors instead of terminating the CLI process
- wire CLI telemetry into `SocketClient` and add breadcrumbs for send/write/poll/read/timeout/EOF/UTF-8 decode failures
- redact auth payloads in command summaries while still recording useful JSON-RPC method/id context
- capture non-`claude-hook` command-dispatch failures with `command_dispatch` stage context
- add regression test coverage in `tests/test_cli_sigpipe_breadcrumbs_regression.py`

## Sentry
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-EV/
- https://manaflow.sentry.io/issues/CMUXTERM-MACOS-G5/

## Verification
- `python3 tests/test_cli_socket_sentry_scope.py`
- `python3 tests/test_cli_sigpipe_breadcrumbs_regression.py`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-cli -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag sentry-061-cli-sigpipe-r1`
