### PR TITLE
Fix focus-follows-mouse pane focus switching

### DIFF
--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -960,3 +960,77 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         XCTAssertNil(dailyProperties["app_build"])
     }
 }
+
+final class GhosttyMouseFocusTests: XCTestCase {
+    func testShouldRequestFirstResponderForMouseFocusWhenEnabledAndWindowIsActive() {
+        XCTAssertTrue(
+            GhosttyNSView.shouldRequestFirstResponderForMouseFocus(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false,
+                visibleInUI: true,
+                hasUsableGeometry: true,
+                hiddenInHierarchy: false
+            )
+        )
+    }
+
+    func testShouldNotRequestFirstResponderWhenFocusFollowsMouseDisabled() {
+        XCTAssertFalse(
+            GhosttyNSView.shouldRequestFirstResponderForMouseFocus(
+                focusFollowsMouseEnabled: false,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false,
+                visibleInUI: true,
+                hasUsableGeometry: true,
+                hiddenInHierarchy: false
+            )
+        )
+    }
+
+    func testShouldNotRequestFirstResponderDuringMouseDrag() {
+        XCTAssertFalse(
+            GhosttyNSView.shouldRequestFirstResponderForMouseFocus(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 1,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false,
+                visibleInUI: true,
+                hasUsableGeometry: true,
+                hiddenInHierarchy: false
+            )
+        )
+    }
+
+    func testShouldNotRequestFirstResponderWhenViewCannotSafelyReceiveFocus() {
+        XCTAssertFalse(
+            GhosttyNSView.shouldRequestFirstResponderForMouseFocus(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false,
+                visibleInUI: true,
+                hasUsableGeometry: false,
+                hiddenInHierarchy: false
+            )
+        )
+        XCTAssertFalse(
+            GhosttyNSView.shouldRequestFirstResponderForMouseFocus(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false,
+                visibleInUI: true,
+                hasUsableGeometry: true,
+                hiddenInHierarchy: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- honor Ghostty `focus-follows-mouse` by requesting first-responder focus when the pointer enters or moves within a terminal surface under safe conditions (active app/key window, no mouse drag, visible/usable geometry)
- add guard logic helper and regression unit tests for focus-on-hover decision paths

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyMouseFocusTests test` ⚠️ fails in existing test code (`cmuxTests/CmuxWebViewKeyEquivalentTests.swift`: `Extra argument 'hostWindowAttached' in call`), unrelated to this change

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/501
