### PR TITLE
Add active-pane full-screen toggle hotkey

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4945,6 +4945,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .togglePaneZoom)) {
+            _ = tabManager?.toggleFocusedPaneFullscreen()
+            return true
+        }
+
         // Surface navigation (legacy Ctrl+Tab support)
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: false, option: false, control: true)) {
             tabManager?.selectNextSurface()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1385,6 +1385,7 @@ struct ContentView: View {
         static let workspaceHasCustomName = "workspace.hasCustomName"
         static let workspaceShouldPin = "workspace.shouldPin"
         static let workspaceHasPullRequests = "workspace.hasPullRequests"
+        static let workspacePaneZoomed = "workspace.paneZoomed"
 
         static let hasFocusedPanel = "panel.hasFocus"
         static let panelName = "panel.name"
@@ -3315,6 +3316,8 @@ struct ContentView: View {
             return .splitRight
         case "palette.terminalSplitDown":
             return .splitDown
+        case "palette.togglePaneFullScreen":
+            return .togglePaneZoom
         default:
             return nil
         }
@@ -3371,6 +3374,7 @@ struct ContentView: View {
                 CommandPaletteContextKeys.workspaceHasPullRequests,
                 !workspace.sidebarPullRequestsInDisplayOrder().isEmpty
             )
+            snapshot.setBool(CommandPaletteContextKeys.workspacePaneZoomed, workspace.isPaneZoomed)
         }
 
         if let panelContext = focusedPanelContext {
@@ -3928,6 +3932,19 @@ struct ContentView: View {
                 when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
             )
         )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.togglePaneFullScreen",
+                title: { context in
+                    context.bool(CommandPaletteContextKeys.workspacePaneZoomed)
+                        ? "Restore Pane Layout"
+                        : "Toggle Pane Full Screen"
+                },
+                subtitle: constant("Pane Layout"),
+                keywords: ["pane", "split", "zoom", "fullscreen", "maximize"],
+                when: { $0.bool(CommandPaletteContextKeys.hasFocusedPanel) }
+            )
+        )
 
         return contributions
     }
@@ -4162,6 +4179,11 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.terminalSplitBrowserDown") {
             _ = tabManager.createBrowserSplit(direction: .down)
+        }
+        registry.register(commandId: "palette.togglePaneFullScreen") {
+            if !tabManager.toggleFocusedPaneFullscreen() {
+                NSSound.beep()
+            }
         }
     }
 

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -32,6 +32,7 @@ enum KeyboardShortcutSettings {
         case splitDown
         case splitBrowserRight
         case splitBrowserDown
+        case togglePaneZoom
 
         // Panels
         case openBrowser
@@ -65,6 +66,7 @@ enum KeyboardShortcutSettings {
             case .splitDown: return "Split Down"
             case .splitBrowserRight: return "Split Browser Right"
             case .splitBrowserDown: return "Split Browser Down"
+            case .togglePaneZoom: return "Toggle Pane Full Screen"
             case .openBrowser: return "Open Browser"
             case .toggleBrowserDeveloperTools: return "Toggle Browser Developer Tools"
             case .showBrowserJavaScriptConsole: return "Show Browser JavaScript Console"
@@ -93,6 +95,7 @@ enum KeyboardShortcutSettings {
             case .splitDown: return "shortcut.splitDown"
             case .splitBrowserRight: return "shortcut.splitBrowserRight"
             case .splitBrowserDown: return "shortcut.splitBrowserDown"
+            case .togglePaneZoom: return "shortcut.togglePaneZoom"
             case .nextSurface: return "shortcut.nextSurface"
             case .prevSurface: return "shortcut.prevSurface"
             case .newSurface: return "shortcut.newSurface"
@@ -144,6 +147,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "d", command: true, shift: false, option: true, control: false)
             case .splitBrowserDown:
                 return StoredShortcut(key: "d", command: true, shift: true, option: true, control: false)
+            case .togglePaneZoom:
+                return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
             case .nextSurface:
                 return StoredShortcut(key: "]", command: true, shift: true, option: false, control: false)
             case .prevSurface:
@@ -222,6 +227,7 @@ enum KeyboardShortcutSettings {
     static func splitDownShortcut() -> StoredShortcut { shortcut(for: .splitDown) }
     static func splitBrowserRightShortcut() -> StoredShortcut { shortcut(for: .splitBrowserRight) }
     static func splitBrowserDownShortcut() -> StoredShortcut { shortcut(for: .splitBrowserDown) }
+    static func togglePaneZoomShortcut() -> StoredShortcut { shortcut(for: .togglePaneZoom) }
 
     static func nextSurfaceShortcut() -> StoredShortcut { shortcut(for: .nextSurface) }
     static func prevSurfaceShortcut() -> StoredShortcut { shortcut(for: .prevSurface) }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1858,6 +1858,12 @@ class TabManager: ObservableObject {
         selectedWorkspace?.newTerminalSurfaceInFocusedPane(focus: true)
     }
 
+    /// Toggle focused-pane fullscreen (zoom) in the selected workspace.
+    @discardableResult
+    func toggleFocusedPaneFullscreen() -> Bool {
+        selectedWorkspace?.toggleSplitZoom() ?? false
+    }
+
     // MARK: - Split Creation
 
     /// Create a new split in the current tab
@@ -2011,10 +2017,10 @@ class TabManager: ObservableObject {
         return false
     }
 
-    /// Toggle zoom on a panel - bonsplit doesn't have zoom support
+    /// Toggle zoom on a panel within a workspace.
     func toggleSplitZoom(tabId: UUID, surfaceId: UUID) -> Bool {
-        // Bonsplit doesn't have zoom support
-        return false
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return false }
+        return tab.toggleSplitZoom(from: surfaceId)
     }
 
     /// Close a surface/panel

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -972,6 +972,22 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
+    private struct PaneZoomState {
+        let paneId: PaneID
+        let splitDividerPositions: [UUID: CGFloat]
+    }
+    private enum PaneZoomPathBranch {
+        case first
+        case second
+    }
+    private struct PaneZoomPathStep {
+        let split: ExternalSplitNode
+        let branch: PaneZoomPathBranch
+    }
+    private static let paneZoomCollapsedDividerPosition: CGFloat = 0
+    private static let paneZoomExpandedDividerPosition: CGFloat = 1
+    private var paneZoomState: PaneZoomState?
+    var isPaneZoomed: Bool { paneZoomState != nil }
 
     var focusedSurfaceId: UUID? { focusedPanelId }
     var surfaceDirectories: [UUID: String] {
@@ -1838,6 +1854,10 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         focus: Bool = true
     ) -> TerminalPanel? {
+        if paneZoomState != nil {
+            _ = restorePaneZoomState()
+        }
+
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
         var sourcePaneId: PaneID?
@@ -1980,6 +2000,10 @@ final class Workspace: Identifiable, ObservableObject {
         url: URL? = nil,
         focus: Bool = true
     ) -> BrowserPanel? {
+        if paneZoomState != nil {
+            _ = restorePaneZoomState()
+        }
+
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
         var sourcePaneId: PaneID?
@@ -2898,6 +2922,120 @@ final class Workspace: Identifiable, ObservableObject {
     func newTerminalSurfaceInFocusedPane(focus: Bool? = nil) -> TerminalPanel? {
         guard let focusedPaneId = bonsplitController.focusedPaneId else { return nil }
         return newTerminalSurface(inPane: focusedPaneId, focus: focus)
+    }
+
+    /// Toggle focused-pane fullscreen (zoomed pane layout) for this workspace.
+    @discardableResult
+    func toggleSplitZoom(from panelId: UUID? = nil) -> Bool {
+        guard let targetPane = targetPaneForZoom(panelId: panelId) else { return false }
+
+        if let state = paneZoomState {
+            if state.paneId == targetPane {
+                return restorePaneZoomState()
+            }
+            _ = restorePaneZoomState()
+            return applyPaneZoom(to: targetPane)
+        }
+
+        return applyPaneZoom(to: targetPane)
+    }
+
+    private func targetPaneForZoom(panelId: UUID?) -> PaneID? {
+        if let panelId, let paneId = paneId(forPanelId: panelId) {
+            return paneId
+        }
+        return bonsplitController.focusedPaneId
+    }
+
+    @discardableResult
+    private func applyPaneZoom(to paneId: PaneID) -> Bool {
+        let tree = bonsplitController.treeSnapshot()
+        guard let path = paneZoomPath(toPaneId: paneId.id.uuidString, in: tree) else { return false }
+        guard !path.isEmpty else { return true }
+
+        var splitDividerPositions: [UUID: CGFloat] = [:]
+        collectPaneZoomSplitDividerPositions(in: tree, into: &splitDividerPositions)
+
+        for step in path.reversed() {
+            guard let splitId = UUID(uuidString: step.split.id) else { continue }
+            let dividerPosition = step.branch == .first
+                ? Self.paneZoomExpandedDividerPosition
+                : Self.paneZoomCollapsedDividerPosition
+            _ = bonsplitController.setDividerPosition(dividerPosition, forSplit: splitId, fromExternal: true)
+        }
+
+        paneZoomState = PaneZoomState(paneId: paneId, splitDividerPositions: splitDividerPositions)
+
+        if bonsplitController.focusedPaneId != paneId {
+            bonsplitController.focusPane(paneId)
+        }
+        if let tabId = bonsplitController.selectedTab(inPane: paneId)?.id {
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        }
+        return true
+    }
+
+    @discardableResult
+    private func restorePaneZoomState() -> Bool {
+        guard let state = paneZoomState else { return false }
+        paneZoomState = nil
+
+        var restoredAny = false
+        for (splitId, dividerPosition) in state.splitDividerPositions {
+            if bonsplitController.setDividerPosition(dividerPosition, forSplit: splitId, fromExternal: true) {
+                restoredAny = true
+            }
+        }
+        return restoredAny || state.splitDividerPositions.isEmpty
+    }
+
+    private func clearPaneZoomState() {
+        paneZoomState = nil
+    }
+
+    private func maybeClearPaneZoomStateForCurrentTree() {
+        guard let state = paneZoomState else { return }
+        guard bonsplitController.allPaneIds.contains(state.paneId) else {
+            paneZoomState = nil
+            return
+        }
+        for splitId in state.splitDividerPositions.keys where !bonsplitController.findSplit(splitId) {
+            paneZoomState = nil
+            return
+        }
+    }
+
+    private func paneZoomPath(toPaneId paneId: String, in node: ExternalTreeNode) -> [PaneZoomPathStep]? {
+        switch node {
+        case .pane(let pane):
+            return pane.id == paneId ? [] : nil
+        case .split(let split):
+            if var path = paneZoomPath(toPaneId: paneId, in: split.first) {
+                path.append(PaneZoomPathStep(split: split, branch: .first))
+                return path
+            }
+            if var path = paneZoomPath(toPaneId: paneId, in: split.second) {
+                path.append(PaneZoomPathStep(split: split, branch: .second))
+                return path
+            }
+            return nil
+        }
+    }
+
+    private func collectPaneZoomSplitDividerPositions(
+        in node: ExternalTreeNode,
+        into output: inout [UUID: CGFloat]
+    ) {
+        switch node {
+        case .pane:
+            return
+        case .split(let split):
+            if let splitId = UUID(uuidString: split.id) {
+                output[splitId] = CGFloat(split.dividerPosition)
+            }
+            collectPaneZoomSplitDividerPositions(in: split.first, into: &output)
+            collectPaneZoomSplitDividerPositions(in: split.second, into: &output)
+        }
     }
 
     // MARK: - Flash/Notification Support
@@ -3825,6 +3963,8 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {
+        clearPaneZoomState()
+
         let closedPanelIds = pendingPaneClosePanelIds.removeValue(forKey: paneId.id) ?? []
         let shouldScheduleFocusReconcile = !isDetachingCloseTransaction
 
@@ -3881,6 +4021,8 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didSplitPane originalPane: PaneID, newPane: PaneID, orientation: SplitOrientation) {
+        clearPaneZoomState()
+
 #if DEBUG
         let panelKindForTab: (TabID) -> String = { tabId in
             guard let panelId = self.panelIdFromSurfaceId(tabId),
@@ -4111,6 +4253,7 @@ extension Workspace: BonsplitDelegate {
 
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {
         _ = snapshot
+        maybeClearPaneZoomStateForCurrentTree()
         scheduleTerminalGeometryReconcile()
         if !isDetachingCloseTransaction {
             scheduleFocusReconcile()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -25,6 +25,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.prevSidebarTab.defaultsKey) private var prevWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.splitRight.defaultsKey) private var splitRightShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.splitDown.defaultsKey) private var splitDownShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.togglePaneZoom.defaultsKey) private var togglePaneZoomShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.toggleBrowserDeveloperTools.defaultsKey)
     private var toggleBrowserDeveloperToolsShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.showBrowserJavaScriptConsole.defaultsKey)
@@ -559,6 +560,10 @@ struct cmuxApp: App {
                     performBrowserSplitFromMenu(direction: .down)
                 }
 
+                splitCommandButton(title: "Toggle Pane Full Screen", shortcut: togglePaneZoomMenuShortcut) {
+                    _ = activeTabManager.toggleFocusedPaneFullscreen()
+                }
+
                 Divider()
 
                 // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
@@ -709,6 +714,13 @@ struct cmuxApp: App {
         decodeShortcut(
             from: splitBrowserDownShortcutData,
             fallback: KeyboardShortcutSettings.Action.splitBrowserDown.defaultShortcut
+        )
+    }
+
+    private var togglePaneZoomMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: togglePaneZoomShortcutData,
+            fallback: KeyboardShortcutSettings.Action.togglePaneZoom.defaultShortcut
         )
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1187,6 +1187,18 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         XCTAssertTrue(prevShortcut.eventModifiers.contains(.control))
     }
 
+    func testTogglePaneFullScreenShortcutDefaultsAndMetadata() {
+        XCTAssertEqual(KeyboardShortcutSettings.Action.togglePaneZoom.label, "Toggle Pane Full Screen")
+        XCTAssertEqual(KeyboardShortcutSettings.Action.togglePaneZoom.defaultsKey, "shortcut.togglePaneZoom")
+
+        let shortcut = KeyboardShortcutSettings.Action.togglePaneZoom.defaultShortcut
+        XCTAssertEqual(shortcut.key, "m")
+        XCTAssertTrue(shortcut.command)
+        XCTAssertTrue(shortcut.shift)
+        XCTAssertFalse(shortcut.option)
+        XCTAssertFalse(shortcut.control)
+    }
+
     func testMenuItemKeyEquivalentHandlesArrowAndTabKeys() {
         XCTAssertNotNil(StoredShortcut(key: "←", command: true, shift: false, option: false, control: false).menuItemKeyEquivalent)
         XCTAssertNotNil(StoredShortcut(key: "→", command: true, shift: false, option: false, control: false).menuItemKeyEquivalent)
@@ -3147,6 +3159,56 @@ final class TabManagerSurfaceCreationTests: XCTestCase {
             browserPanelId,
             "Expected browser surface to be appended at end in the reused top-right pane"
         )
+    }
+}
+
+@MainActor
+final class WorkspacePaneZoomTests: XCTestCase {
+    func testToggleSplitZoomExpandsFocusedPaneAndRestoresLayout() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let leftPanelId = workspace.focusedPanelId,
+              let rightPanel = workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal),
+              let targetPaneId = workspace.paneId(forPanelId: rightPanel.id),
+              let siblingPaneId = workspace.bonsplitController.allPaneIds.first(where: { $0 != targetPaneId }) else {
+            XCTFail("Expected split workspace setup")
+            return
+        }
+
+        workspace.bonsplitController.setContainerFrame(CGRect(x: 0, y: 0, width: 1200, height: 800))
+
+        let beforeSnapshot = workspace.bonsplitController.layoutSnapshot()
+        guard let targetWidthBefore = beforeSnapshot.panes.first(where: { $0.paneId == targetPaneId.id.uuidString })?.frame.width,
+              let siblingWidthBefore = beforeSnapshot.panes.first(where: { $0.paneId == siblingPaneId.id.uuidString })?.frame.width else {
+            XCTFail("Expected pane widths before zoom")
+            return
+        }
+
+        XCTAssertTrue(manager.toggleSplitZoom(tabId: workspace.id, surfaceId: rightPanel.id))
+        XCTAssertTrue(workspace.isPaneZoomed)
+
+        let zoomedSnapshot = workspace.bonsplitController.layoutSnapshot()
+        guard let targetWidthZoomed = zoomedSnapshot.panes.first(where: { $0.paneId == targetPaneId.id.uuidString })?.frame.width,
+              let siblingWidthZoomed = zoomedSnapshot.panes.first(where: { $0.paneId == siblingPaneId.id.uuidString })?.frame.width else {
+            XCTFail("Expected pane widths after zoom")
+            return
+        }
+
+        XCTAssertGreaterThan(targetWidthZoomed, targetWidthBefore)
+        XCTAssertLessThan(siblingWidthZoomed, siblingWidthBefore)
+
+        XCTAssertTrue(manager.toggleSplitZoom(tabId: workspace.id, surfaceId: rightPanel.id))
+        XCTAssertFalse(workspace.isPaneZoomed)
+
+        let restoredSnapshot = workspace.bonsplitController.layoutSnapshot()
+        guard let targetWidthRestored = restoredSnapshot.panes.first(where: { $0.paneId == targetPaneId.id.uuidString })?.frame.width,
+              let siblingWidthRestored = restoredSnapshot.panes.first(where: { $0.paneId == siblingPaneId.id.uuidString })?.frame.width else {
+            XCTFail("Expected pane widths after restoring zoom")
+            return
+        }
+
+        XCTAssertEqual(targetWidthRestored, targetWidthBefore, accuracy: 0.5)
+        XCTAssertEqual(siblingWidthRestored, siblingWidthBefore, accuracy: 0.5)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a new configurable shortcut action, `Toggle Pane Full Screen` (default: `cmd+shift+m`), and wire it through key handling, menus, and command palette
- implement workspace-level pane zoom toggle by maximizing the focused pane across split ancestry and restoring the exact prior divider layout on toggle-off
- hook existing Ghostty `toggle_split_zoom` action support in `TabManager` to the new Bonsplit-backed implementation
- add regression tests for shortcut metadata/defaults and split zoom expand/restore behavior

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests test` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/WorkspacePaneZoomTests test` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `./scripts/reload.sh --tag pane-fullscreen-hotkey-r2` (pass)

## Issues
- Task reference: plain-text request in HQ session: "I'd love to have hotkey to full screen my active pane."
- Related: none
