### PR TITLE
Add low-risk theme load/resolve breadcrumbs for E4 triage

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -246,17 +246,19 @@ struct GhosttyConfig {
         }
 
         let durationMs = Int(((CFAbsoluteTimeGetCurrent() - startedAt) * 1000).rounded())
-        sentryBreadcrumb(
-            "ghostty.theme.load.miss",
-            category: "config",
-            data: [
-                "requested_theme": name,
-                "resolved_theme": resolvedThemeName,
-                "candidate_count": candidateNames.count,
-                "path_count": pathCount,
-                "duration_ms": durationMs
-            ]
-        )
+        if durationMs >= 150 {
+            sentryBreadcrumb(
+                "ghostty.theme.load.miss",
+                category: "config",
+                data: [
+                    "requested_theme": name,
+                    "resolved_theme": resolvedThemeName,
+                    "candidate_count": candidateNames.count,
+                    "path_count": pathCount,
+                    "duration_ms": durationMs
+                ]
+            )
+        }
     }
 
     static func currentColorSchemePreference(
@@ -400,7 +402,9 @@ struct GhosttyConfig {
             let expanded = NSString(string: resourcesRoot).expandingTildeInPath
             guard !expanded.isEmpty else { return }
             appendUniquePath(
-                appendPathComponents(expanded, ["themes", themeName])
+                URL(fileURLWithPath: expanded)
+                    .appendingPathComponent("themes/\(themeName)")
+                    .path
             )
         }
 
@@ -408,18 +412,20 @@ struct GhosttyConfig {
         appendThemePath(in: environment["GHOSTTY_RESOURCES_DIR"])
 
         // 2) App bundle resources.
-        if let bundlePath = bundleResourceURL?.path {
-            appendUniquePath(
-                appendPathComponents(bundlePath, ["ghostty", "themes", themeName])
-            )
-        }
+        appendUniquePath(
+            bundleResourceURL?
+                .appendingPathComponent("ghostty/themes/\(themeName)")
+                .path
+        )
 
         // 3) Data dirs (Ghostty installs themes under share/ghostty/themes).
         if let xdgDataDirs = environment["XDG_DATA_DIRS"] {
             for dataDir in xdgDataDirs.split(separator: ":").map(String.init) {
                 guard !dataDir.isEmpty else { continue }
                 appendUniquePath(
-                    appendPathComponents(dataDir, ["ghostty", "themes", themeName])
+                    URL(fileURLWithPath: dataDir)
+                        .appendingPathComponent("ghostty/themes/\(themeName)")
+                        .path
                 )
             }
         }
@@ -430,14 +436,6 @@ struct GhosttyConfig {
         appendUniquePath("~/Library/Application Support/com.mitchellh.ghostty/themes/\(themeName)")
 
         return paths
-    }
-
-    private static func appendPathComponents(_ basePath: String, _ components: [String]) -> String {
-        var path = NSString(string: basePath).expandingTildeInPath
-        for component in components {
-            path = (path as NSString).appendingPathComponent(component)
-        }
-        return path
     }
 
     private static func readConfigFile(at path: String) -> String? {

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -209,22 +209,54 @@ struct GhosttyConfig {
         bundleResourceURL: URL?,
         preferredColorScheme: ColorSchemePreference? = nil
     ) {
+        let startedAt = CFAbsoluteTimeGetCurrent()
         let resolvedThemeName = Self.resolveThemeName(
             from: name,
             preferredColorScheme: preferredColorScheme ?? Self.currentColorSchemePreference()
         )
-        for candidateName in Self.themeNameCandidates(from: resolvedThemeName) {
+        let candidateNames = Self.themeNameCandidates(from: resolvedThemeName)
+        var pathCount = 0
+        for candidateName in candidateNames {
             for path in Self.themeSearchPaths(
                 forThemeName: candidateName,
                 environment: environment,
                 bundleResourceURL: bundleResourceURL
             ) {
+                pathCount += 1
                 if let contents = try? String(contentsOfFile: path, encoding: .utf8) {
                     parse(contents)
+                    let durationMs = Int(((CFAbsoluteTimeGetCurrent() - startedAt) * 1000).rounded())
+                    if durationMs >= 150 {
+                        sentryBreadcrumb(
+                            "ghostty.theme.load.slow",
+                            category: "config",
+                            data: [
+                                "requested_theme": name,
+                                "resolved_theme": resolvedThemeName,
+                                "matched_candidate": candidateName,
+                                "candidate_count": candidateNames.count,
+                                "path_count": pathCount,
+                                "duration_ms": durationMs
+                            ]
+                        )
+                    }
                     return
                 }
             }
         }
+
+        let durationMs = Int(((CFAbsoluteTimeGetCurrent() - startedAt) * 1000).rounded())
+        sentryBreadcrumb(
+            "ghostty.theme.load.miss",
+            category: "config",
+            data: [
+                "requested_theme": name,
+                "resolved_theme": resolvedThemeName,
+                "candidate_count": candidateNames.count,
+                "path_count": pathCount,
+                "duration_ms": durationMs
+            ]
+        )
     }
 
     static func currentColorSchemePreference(
@@ -368,9 +400,7 @@ struct GhosttyConfig {
             let expanded = NSString(string: resourcesRoot).expandingTildeInPath
             guard !expanded.isEmpty else { return }
             appendUniquePath(
-                URL(fileURLWithPath: expanded)
-                    .appendingPathComponent("themes/\(themeName)")
-                    .path
+                appendPathComponents(expanded, ["themes", themeName])
             )
         }
 
@@ -378,20 +408,18 @@ struct GhosttyConfig {
         appendThemePath(in: environment["GHOSTTY_RESOURCES_DIR"])
 
         // 2) App bundle resources.
-        appendUniquePath(
-            bundleResourceURL?
-                .appendingPathComponent("ghostty/themes/\(themeName)")
-                .path
-        )
+        if let bundlePath = bundleResourceURL?.path {
+            appendUniquePath(
+                appendPathComponents(bundlePath, ["ghostty", "themes", themeName])
+            )
+        }
 
         // 3) Data dirs (Ghostty installs themes under share/ghostty/themes).
         if let xdgDataDirs = environment["XDG_DATA_DIRS"] {
             for dataDir in xdgDataDirs.split(separator: ":").map(String.init) {
                 guard !dataDir.isEmpty else { continue }
                 appendUniquePath(
-                    URL(fileURLWithPath: dataDir)
-                        .appendingPathComponent("ghostty/themes/\(themeName)")
-                        .path
+                    appendPathComponents(dataDir, ["ghostty", "themes", themeName])
                 )
             }
         }
@@ -402,6 +430,14 @@ struct GhosttyConfig {
         appendUniquePath("~/Library/Application Support/com.mitchellh.ghostty/themes/\(themeName)")
 
         return paths
+    }
+
+    private static func appendPathComponents(_ basePath: String, _ components: [String]) -> String {
+        var path = NSString(string: basePath).expandingTildeInPath
+        for component in components {
+            path = (path as NSString).appendingPathComponent(component)
+        }
+        return path
     }
 
     private static func readConfigFile(at path: String) -> String? {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3703,6 +3703,11 @@ final class GhosttySurfaceScrollView: NSView {
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
+
+    var portalSurfaceId: UUID? {
+        surfaceView.terminalSurface?.id
+    }
+
 #if DEBUG
     private var lastDropZoneOverlayLogSignature: String?
 	    private static var flashCounts: [UUID: Int] = [:]
@@ -3807,7 +3812,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     var debugSurfaceId: UUID? {
-        surfaceView.terminalSurface?.id
+        portalSurfaceId
     }
 #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4704,6 +4704,77 @@ final class GhosttySurfaceScrollView: NSView {
             isFirstResponder: isFirstResponder
         )
     }
+
+    private static func debugShortSurfaceId(_ id: UUID?) -> String {
+        guard let id else { return "nil" }
+        return String(id.uuidString.prefix(5))
+    }
+
+    private static func debugAgeText(since timestamp: CFTimeInterval) -> String {
+        guard timestamp > 0 else { return "na" }
+        let ageMs = max(0, (CACurrentMediaTime() - timestamp) * 1000)
+        return String(format: "%.1fms", ageMs)
+    }
+
+    private func debugViewDepth(maxDepth: Int = 128) -> Int {
+        var depth = 0
+        var current: NSView? = self
+        while let view = current, depth < maxDepth {
+            depth += 1
+            current = view.superview
+        }
+        return depth
+    }
+
+    private func debugIsPortalHosted() -> Bool {
+        var current: NSView? = self
+        while let view = current {
+            if view is WindowTerminalHostView { return true }
+            current = view.superview
+        }
+        return false
+    }
+
+    private func debugSuperviewChain(limit: Int = 8) -> String {
+        var parts: [String] = []
+        var current: NSView? = self
+        var remaining = limit
+        while let view = current, remaining > 0 {
+            parts.append(String(describing: type(of: view)))
+            current = view.superview
+            remaining -= 1
+        }
+        if current != nil {
+            parts.append("...")
+        }
+        return parts.joined(separator: ">")
+    }
+
+    func debugLifecycleSummary() -> String {
+        let stats = debugRenderStats()
+        let frameText = String(format: "%.1fx%.1f@%.1f,%.1f", frame.width, frame.height, frame.minX, frame.minY)
+        let boundsText = String(format: "%.1fx%.1f", bounds.width, bounds.height)
+        let layerKey = stats.layerContentsKey.count > 16
+            ? String(stats.layerContentsKey.prefix(16))
+            : stats.layerContentsKey
+        let dropZone = activeDropZone.map { String(describing: $0) } ?? "none"
+
+        return
+            "ghost.surface=\(Self.debugShortSurfaceId(debugSurfaceId)) " +
+            "portal=\(debugIsPortalHosted() ? 1 : 0) depth=\(debugViewDepth()) " +
+            "inWindow=\(stats.inWindow ? 1 : 0) window=\(window?.windowNumber ?? -1) " +
+            "hostHidden=\(isHidden ? 1 : 0) surfaceHidden=\(surfaceView.isHidden ? 1 : 0) " +
+            "visibleFlag=\(surfaceView.isVisibleInUI ? 1 : 0) active=\(stats.isActive ? 1 : 0) " +
+            "firstResponder=\(stats.isFirstResponder ? 1 : 0) desiredFocus=\(stats.desiredFocus ? 1 : 0) " +
+            "frame=\(frameText) bounds=\(boundsText) " +
+            "draw=\(stats.drawCount)/\(Self.debugAgeText(since: stats.lastDrawTime)) " +
+            "present=\(stats.presentCount)/\(Self.debugAgeText(since: stats.lastPresentTime)) " +
+            "metal=\(stats.metalDrawableCount)/\(Self.debugAgeText(since: stats.metalLastDrawableTime)) " +
+            "layer=\(stats.layerClass) key=\(layerKey) " +
+            "dropZone=\(dropZone) dropHidden=\(dropZoneOverlayView.isHidden ? 1 : 0) " +
+            "ringHidden=\(notificationRingOverlayView.isHidden ? 1 : 0) " +
+            "chain=\(debugSuperviewChain())"
+    }
 #endif
 
 #if DEBUG
@@ -5462,17 +5533,23 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let hostedView = coordinator.hostedView
 #if DEBUG
         if let hostedView {
+            let modelState =
+                AppDelegate.shared?.tabManager?.debugSurfaceDriftSummary(surfaceId: hostedView.debugSurfaceId)
+                ?? "surfaceState=tabManager_missing"
+            let ghostState = hostedView.debugLifecycleSummary()
             if let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
                 dlog(
                     "ws.swiftui.dismantle id=\(snapshot.id) dt=\(String(format: "%.2fms", dtMs)) " +
                     "surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
-                    "inWindow=\(hostedView.window != nil ? 1 : 0)"
+                    "inWindow=\(hostedView.window != nil ? 1 : 0) " +
+                    "\(ghostState) \(modelState)"
                 )
             } else {
                 dlog(
                     "ws.swiftui.dismantle id=none surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
-                    "inWindow=\(hostedView.window != nil ? 1 : 0)"
+                    "inWindow=\(hostedView.window != nil ? 1 : 0) " +
+                    "\(ghostState) \(modelState)"
                 )
             }
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1309,6 +1309,12 @@ class TabManager: ObservableObject {
         guard tab.panels[surfaceId] != nil else { return }
 
 #if DEBUG
+        debugLogSurfaceDrift(
+            event: "closeRuntime.begin",
+            tabId: tabId,
+            surfaceId: surfaceId,
+            extra: "panelsBefore=\(tab.panels.count)"
+        )
         dlog(
             "surface.close.runtime tab=\(tabId.uuidString.prefix(5)) " +
             "surface=\(surfaceId.uuidString.prefix(5)) panelsBefore=\(tab.panels.count)"
@@ -1325,6 +1331,12 @@ class TabManager: ObservableObject {
             "surface.close.runtime.done tab=\(tabId.uuidString.prefix(5)) " +
             "surface=\(surfaceId.uuidString.prefix(5)) closed=\(closed ? 1 : 0) panelsAfter=\(tab.panels.count)"
         )
+        debugLogSurfaceDrift(
+            event: "closeRuntime.end",
+            tabId: tabId,
+            surfaceId: surfaceId,
+            extra: "closed=\(closed ? 1 : 0) panelsAfter=\(tab.panels.count)"
+        )
 #endif
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
     }
@@ -1338,6 +1350,12 @@ class TabManager: ObservableObject {
         guard tab.panels[surfaceId] != nil else { return }
 
 #if DEBUG
+        debugLogSurfaceDrift(
+            event: "childExited.begin",
+            tabId: tabId,
+            surfaceId: surfaceId,
+            extra: "panels=\(tab.panels.count) workspaces=\(tabs.count)"
+        )
         dlog(
             "surface.close.childExited tab=\(tabId.uuidString.prefix(5)) " +
             "surface=\(surfaceId.uuidString.prefix(5)) panels=\(tab.panels.count) workspaces=\(tabs.count)"
@@ -1348,6 +1366,14 @@ class TabManager: ObservableObject {
         // semantics (and close the window when it was the last workspace).
         if tab.panels.count <= 1 {
             if tabs.count <= 1 {
+#if DEBUG
+                debugLogSurfaceDrift(
+                    event: "childExited.lastPanel.lastWorkspace",
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    extra: "route=windowClose"
+                )
+#endif
                 if let app = AppDelegate.shared {
                     app.notificationStore?.clearNotifications(forTabId: tabId)
                     app.closeMainWindowContainingTabId(tabId)
@@ -1356,11 +1382,27 @@ class TabManager: ObservableObject {
                     closeRuntimeSurface(tabId: tabId, surfaceId: surfaceId)
                 }
             } else {
+#if DEBUG
+                debugLogSurfaceDrift(
+                    event: "childExited.lastPanel.multiWorkspace",
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    extra: "route=closeWorkspace"
+                )
+#endif
                 closeWorkspace(tab)
             }
             return
         }
 
+#if DEBUG
+        debugLogSurfaceDrift(
+            event: "childExited.routeRuntimeClose",
+            tabId: tabId,
+            surfaceId: surfaceId,
+            extra: "panels=\(tab.panels.count)"
+        )
+#endif
         closeRuntimeSurface(tabId: tabId, surfaceId: surfaceId)
     }
 
@@ -1817,6 +1859,73 @@ class TabManager: ObservableObject {
 
     private static func debugMsText(_ ms: Double) -> String {
         String(format: "%.2fms", ms)
+    }
+
+    private static func debugShortIdentifier(_ id: String?) -> String {
+        guard let id, !id.isEmpty else { return "nil" }
+        if let uuid = UUID(uuidString: id) {
+            return debugShortWorkspaceId(uuid)
+        }
+        return String(id.prefix(5))
+    }
+
+    private static func debugFrameSummary(_ frame: PixelRect) -> String {
+        String(format: "%.0fx%.0f@%.0f,%.0f", frame.width, frame.height, frame.x, frame.y)
+    }
+
+    private func debugWorkspaceContainingSurface(_ surfaceId: UUID) -> Workspace? {
+        tabs.first(where: { $0.panels[surfaceId] != nil })
+    }
+
+    func debugHasSurfaceModel(surfaceId: UUID) -> Bool {
+        debugWorkspaceContainingSurface(surfaceId) != nil
+    }
+
+    func debugSurfaceDriftSummary(surfaceId: UUID?) -> String {
+        guard let surfaceId else {
+            return
+                "surface=nil model=missing " +
+                "selectedWs=\(Self.debugShortWorkspaceId(selectedTabId)) workspaces=\(tabs.count)"
+        }
+
+        let surfaceShort = Self.debugShortWorkspaceId(surfaceId)
+        guard let workspace = debugWorkspaceContainingSurface(surfaceId) else {
+            return
+                "surface=\(surfaceShort) model=missing " +
+                "selectedWs=\(Self.debugShortWorkspaceId(selectedTabId)) workspaces=\(tabs.count)"
+        }
+
+        let layout = workspace.bonsplitController.layoutSnapshot()
+        let paneState = layout.panes.map { pane in
+            let selected = Self.debugShortIdentifier(pane.selectedTabId)
+            let tabsText = pane.tabIds.map(Self.debugShortIdentifier).joined(separator: ",")
+            return
+                "\(Self.debugShortIdentifier(pane.paneId)){" +
+                "sel=\(selected)," +
+                "tabs=\(tabsText.isEmpty ? "-" : tabsText)," +
+                "frame=\(Self.debugFrameSummary(pane.frame))}"
+        }.joined(separator: ";")
+        let panel = workspace.panels[surfaceId]
+        let panelType = panel?.panelType.rawValue ?? "missing"
+        let ghostSummary = (panel as? TerminalPanel)?.hostedView.debugLifecycleSummary() ?? "ghost=na"
+
+        return
+            "surface=\(surfaceShort) model=present " +
+            "ws=\(Self.debugShortWorkspaceId(workspace.id)) selectedWs=\(selectedTabId == workspace.id ? 1 : 0) " +
+            "panelType=\(panelType) " +
+            "\(workspace.debugBonsplitStateSummary(highlightPanelId: surfaceId)) " +
+            "layoutFocusedPane=\(Self.debugShortIdentifier(layout.focusedPaneId)) " +
+            "layoutPanes=\(paneState.isEmpty ? "none" : paneState) " +
+            "\(ghostSummary)"
+    }
+
+    func debugLogSurfaceDrift(event: String, tabId: UUID?, surfaceId: UUID?, extra: String = "") {
+        let extraSuffix = extra.isEmpty ? "" : " \(extra)"
+        dlog(
+            "surface.drift event=\(event) tab=\(Self.debugShortWorkspaceId(tabId)) " +
+            "surface=\(Self.debugShortWorkspaceId(surfaceId))\(extraSuffix) " +
+            "\(debugSurfaceDriftSummary(surfaceId: surfaceId))"
+        )
     }
 #endif
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1877,8 +1877,12 @@ class TabManager: ObservableObject {
         tabs.first(where: { $0.panels[surfaceId] != nil })
     }
 
+    func hasSurfaceModel(surfaceId: UUID) -> Bool {
+        tabs.contains(where: { $0.panels[surfaceId] != nil })
+    }
+
     func debugHasSurfaceModel(surfaceId: UUID) -> Bool {
-        debugWorkspaceContainingSurface(surfaceId) != nil
+        hasSurfaceModel(surfaceId: surfaceId)
     }
 
     func debugSurfaceDriftSummary(surfaceId: UUID?) -> String {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1186,11 +1186,28 @@ final class WindowTerminalPortal: NSObject {
         return true
     }
 
+    private func isHostedViewBackedByModel(_ hostedView: GhosttySurfaceScrollView) -> Bool {
+        guard let surfaceId = hostedView.portalSurfaceId else { return false }
+        guard let tabManager = AppDelegate.shared?.tabManager else { return true }
+        return tabManager.hasSurfaceModel(surfaceId: surfaceId)
+    }
+
     private func synchronizeHostedView(withId hostedId: ObjectIdentifier) {
         guard ensureInstalled() else { return }
         guard var entry = entriesByHostedId[hostedId] else { return }
         guard let hostedView = entry.hostedView else {
             entriesByHostedId.removeValue(forKey: hostedId)
+            return
+        }
+        if !isHostedViewBackedByModel(hostedView) {
+#if DEBUG
+            dlog(
+                "portal.sync.drop hosted=\(portalDebugToken(hostedView)) " +
+                "reason=modelMissing"
+            )
+#endif
+            hostedView.isHidden = true
+            detachHostedView(withId: hostedId)
             return
         }
         guard let anchorView = entry.anchorView, let window else {
@@ -1638,6 +1655,27 @@ enum TerminalWindowPortalRegistry {
         }
     }
 
+    private static func isHostedViewBackedByModel(_ hostedView: GhosttySurfaceScrollView) -> Bool {
+        guard let surfaceId = hostedView.portalSurfaceId else { return false }
+        guard let tabManager = AppDelegate.shared?.tabManager else { return true }
+        return tabManager.hasSurfaceModel(surfaceId: surfaceId)
+    }
+
+    private static func dropModelMissingBinding(hostedView: GhosttySurfaceScrollView, reason: String) {
+        let hostedId = ObjectIdentifier(hostedView)
+        if let windowId = hostedToWindowId.removeValue(forKey: hostedId) {
+            portalsByWindowId[windowId]?.detachHostedView(withId: hostedId)
+        }
+        hostedView.isHidden = true
+#if DEBUG
+        let surface = hostedView.portalSurfaceId?.uuidString.prefix(5) ?? "nil"
+        dlog(
+            "portal.bind.skip hosted=\(portalDebugToken(hostedView)) " +
+            "surface=\(surface) reason=modelMissing context=\(reason)"
+        )
+#endif
+    }
+
     private static func portal(for window: NSWindow) -> WindowTerminalPortal {
         if let existing = objc_getAssociatedObject(window, &cmuxWindowTerminalPortalKey) as? WindowTerminalPortal {
             portalsByWindowId[ObjectIdentifier(window)] = existing
@@ -1654,6 +1692,10 @@ enum TerminalWindowPortalRegistry {
 
     static func bind(hostedView: GhosttySurfaceScrollView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
         guard let window = anchorView.window else { return }
+        guard isHostedViewBackedByModel(hostedView) else {
+            dropModelMissingBinding(hostedView: hostedView, reason: "bind")
+            return
+        }
 
         let windowId = ObjectIdentifier(window)
         let hostedId = ObjectIdentifier(hostedView)
@@ -1694,6 +1736,11 @@ enum TerminalWindowPortalRegistry {
     /// Called when a bind is deferred (host not yet in window) to prevent stale
     /// portal syncs from hiding a view that is about to become visible.
     static func updateEntryVisibility(for hostedView: GhosttySurfaceScrollView, visibleInUI: Bool) {
+        guard isHostedViewBackedByModel(hostedView) else {
+            dropModelMissingBinding(hostedView: hostedView, reason: "updateEntryVisibility")
+            return
+        }
+
         let hostedId = ObjectIdentifier(hostedView)
         guard let windowId = hostedToWindowId[hostedId],
               let portal = portalsByWindowId[windowId] else { return }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -556,6 +556,7 @@ final class WindowTerminalPortal: NSObject {
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
+    private var lastLoggedModelDriftSignatureByHostedId: [ObjectIdentifier: String] = [:]
 #endif
 
     private struct Entry {
@@ -864,6 +865,39 @@ final class WindowTerminalPortal: NSObject {
             "host=\(portalDebugFrameInWindow(hostView)) anchor=\(portalDebugFrameInWindow(anchorView))"
         )
     }
+
+    private func logModelDriftIfNeeded(
+        hostedId: ObjectIdentifier,
+        hostedView: GhosttySurfaceScrollView,
+        entry: Entry,
+        anchorView: NSView?,
+        reason: String,
+        targetFrame: NSRect
+    ) {
+        guard let surfaceId = hostedView.debugSurfaceId else { return }
+        guard let tabManager = AppDelegate.shared?.tabManager else {
+            lastLoggedModelDriftSignatureByHostedId.removeValue(forKey: hostedId)
+            return
+        }
+        guard !tabManager.debugHasSurfaceModel(surfaceId: surfaceId) else {
+            lastLoggedModelDriftSignatureByHostedId.removeValue(forKey: hostedId)
+            return
+        }
+
+        let signature =
+            "\(reason)|\(entry.visibleInUI ? 1 : 0)|\(hostedView.isHidden ? 1 : 0)|" +
+            "\(portalDebugFrame(targetFrame))|\(portalDebugToken(anchorView))"
+        guard lastLoggedModelDriftSignatureByHostedId[hostedId] != signature else { return }
+        lastLoggedModelDriftSignatureByHostedId[hostedId] = signature
+
+        dlog(
+            "portal.model.drift hosted=\(portalDebugToken(hostedView)) " +
+            "surface=\(surfaceId.uuidString.prefix(5)) reason=\(reason) " +
+            "entryVisible=\(entry.visibleInUI ? 1 : 0) hostedHidden=\(hostedView.isHidden ? 1 : 0) " +
+            "anchor=\(portalDebugToken(anchorView)) frame=\(portalDebugFrame(targetFrame)) " +
+            "\(tabManager.debugSurfaceDriftSummary(surfaceId: surfaceId))"
+        )
+    }
 #endif
 
     /// Convert an anchor view's bounds to window coordinates while honoring ancestor clipping.
@@ -920,14 +954,21 @@ final class WindowTerminalPortal: NSObject {
 
     func detachHostedView(withId hostedId: ObjectIdentifier) {
         guard let entry = entriesByHostedId.removeValue(forKey: hostedId) else { return }
+#if DEBUG
+        lastLoggedModelDriftSignatureByHostedId.removeValue(forKey: hostedId)
+#endif
         if let anchor = entry.anchorView {
             hostedByAnchorId.removeValue(forKey: ObjectIdentifier(anchor))
         }
 #if DEBUG
         let hadSuperview = (entry.hostedView?.superview === hostView) ? 1 : 0
+        let modelState =
+            AppDelegate.shared?.tabManager?.debugSurfaceDriftSummary(surfaceId: entry.hostedView?.debugSurfaceId)
+            ?? "surfaceState=tabManager_missing"
         dlog(
             "portal.detach hosted=\(portalDebugToken(entry.hostedView)) " +
-            "anchor=\(portalDebugToken(entry.anchorView)) hadSuperview=\(hadSuperview)"
+            "anchor=\(portalDebugToken(entry.anchorView)) hadSuperview=\(hadSuperview) " +
+            "\(modelState)"
         )
 #endif
         if let hostedView = entry.hostedView, hostedView.superview === hostView {
@@ -1434,6 +1475,14 @@ final class WindowTerminalPortal: NSObject {
             "target=\(portalDebugFrame(targetFrame)) hide=\(shouldHide ? 1 : 0) " +
             "entryVisible=\(entry.visibleInUI ? 1 : 0) hostedHidden=\(hostedView.isHidden ? 1 : 0) " +
             "hostBounds=\(portalDebugFrame(hostBounds))"
+        )
+        logModelDriftIfNeeded(
+            hostedId: hostedId,
+            hostedView: hostedView,
+            entry: entry,
+            anchorView: anchorView,
+            reason: shouldHide ? "syncHidden" : "syncVisible",
+            targetFrame: targetFrame
         )
 #endif
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1216,6 +1216,70 @@ final class Workspace: Identifiable, ObservableObject {
         let ms = (ProcessInfo.processInfo.systemUptime - start) * 1000
         return String(format: "%.2f", ms)
     }
+
+    private static func debugShortUUID(_ id: UUID?) -> String {
+        guard let id else { return "nil" }
+        return String(id.uuidString.prefix(5))
+    }
+
+    private static func debugShortIdentifier(_ id: String?) -> String {
+        guard let id, !id.isEmpty else { return "nil" }
+        if let uuid = UUID(uuidString: id) {
+            return debugShortUUID(uuid)
+        }
+        return String(id.prefix(5))
+    }
+
+    private static func debugFrameSummary(_ frame: PixelRect) -> String {
+        String(format: "%.0fx%.0f@%.0f,%.0f", frame.width, frame.height, frame.x, frame.y)
+    }
+
+    private func debugTreeSummary(_ node: ExternalTreeNode) -> String {
+        switch node {
+        case .pane(let pane):
+            let tabCount = pane.tabs.count
+            return
+                "p(\(Self.debugShortIdentifier(pane.id)):" +
+                "sel=\(Self.debugShortIdentifier(pane.selectedTabId)):" +
+                "n=\(tabCount))"
+        case .split(let split):
+            let orientation = split.orientation == "horizontal" ? "h" : "v"
+            return
+                "\(orientation)(\(debugTreeSummary(split.first))|\(debugTreeSummary(split.second)))"
+        }
+    }
+
+    func debugBonsplitStateSummary(highlightPanelId: UUID? = nil) -> String {
+        let layout = bonsplitController.layoutSnapshot()
+        let tree = debugTreeSummary(bonsplitController.treeSnapshot())
+        let highlightTabId = highlightPanelId
+            .flatMap(surfaceIdFromPanelId)?
+            .uuid
+            .uuidString
+            .lowercased()
+
+        let paneState = layout.panes.map { pane in
+            let selected = Self.debugShortIdentifier(pane.selectedTabId)
+            let tabs = pane.tabIds.map(Self.debugShortIdentifier).joined(separator: ",")
+            let isHighlighted = highlightTabId.map { tabId in
+                pane.tabIds.contains { $0.caseInsensitiveCompare(tabId) == .orderedSame }
+            } ?? false
+            let marker = isHighlighted ? "*" : ""
+            return
+                "\(marker)\(Self.debugShortIdentifier(pane.paneId)){" +
+                "sel=\(selected)," +
+                "tabs=\(tabs.isEmpty ? "-" : tabs)," +
+                "frame=\(Self.debugFrameSummary(pane.frame))}"
+        }.joined(separator: ";")
+
+        return
+            "ws=\(Self.debugShortUUID(id)) " +
+            "focusedPane=\(Self.debugShortIdentifier(layout.focusedPaneId)) " +
+            "focusedPanel=\(Self.debugShortUUID(focusedPanelId)) " +
+            "panels=\(panels.count) panes=\(layout.panes.count) " +
+            "paneState=\(paneState.isEmpty ? "none" : paneState) " +
+            "tree=\(tree)"
+    }
 #endif
 
     func panelIdFromSurfaceId(_ surfaceId: TabID) -> UUID? {
@@ -3659,6 +3723,16 @@ extension Workspace: BonsplitDelegate {
         #endif
 
         let panel = panels[panelId]
+#if DEBUG
+        let panelType = panel?.panelType.rawValue ?? "missing"
+        let ghostStateBeforeClose = (panel as? TerminalPanel)?.hostedView.debugLifecycleSummary() ?? "ghost=na"
+        dlog(
+            "surface.close.delegate.begin ws=\(id.uuidString.prefix(5)) " +
+            "tab=\(tabId.uuid.uuidString.prefix(5)) panel=\(panelId.uuidString.prefix(5)) " +
+            "pane=\(pane.id.uuidString.prefix(5)) isDetaching=\(isDetaching ? 1 : 0) panelType=\(panelType) " +
+            "\(debugBonsplitStateSummary(highlightPanelId: panelId)) \(ghostStateBeforeClose)"
+        )
+#endif
 
         if isDetaching, let panel {
             let browserPanel = panel as? BrowserPanel
@@ -3703,6 +3777,14 @@ extension Workspace: BonsplitDelegate {
         if lastTerminalConfigInheritancePanelId == panelId {
             lastTerminalConfigInheritancePanelId = nil
         }
+#if DEBUG
+        dlog(
+            "surface.close.delegate.end ws=\(id.uuidString.prefix(5)) " +
+            "tab=\(tabId.uuid.uuidString.prefix(5)) panel=\(panelId.uuidString.prefix(5)) " +
+            "remainingPanels=\(panels.count) remainingPanes=\(bonsplitController.allPaneIds.count) " +
+            "\(debugBonsplitStateSummary(highlightPanelId: nil))"
+        )
+#endif
 
         // Keep the workspace invariant for normal close paths.
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -177,8 +177,14 @@ struct WorkspaceContentView: View {
         reason: String = "unspecified",
         backgroundOverride: NSColor? = nil,
         loadConfig: () -> GhosttyConfig = { GhosttyConfig.load() },
-        defaultBackground: () -> NSColor = { GhosttyApp.shared.defaultBackgroundColor }
+        defaultBackground: () -> NSColor = { GhosttyApp.shared.defaultBackgroundColor },
+        currentTime: () -> TimeInterval = { CFAbsoluteTimeGetCurrent() },
+        slowThresholdMs: Double = 120,
+        emitBreadcrumb: (_ message: String, _ category: String, _ data: [String: Any]) -> Void = { message, category, data in
+            sentryBreadcrumb(message, category: category, data: data)
+        }
     ) -> GhosttyConfig {
+        let startedAt = currentTime()
         var next = loadConfig()
         let loadedBackgroundHex = next.backgroundColor.hexString()
         let defaultBackgroundHex: String
@@ -194,6 +200,23 @@ struct WorkspaceContentView: View {
         }
 
         next.backgroundColor = resolvedBackground
+        let elapsedMs = max(0, (currentTime() - startedAt) * 1000)
+        if elapsedMs >= slowThresholdMs {
+            emitBreadcrumb(
+                "theme.resolve.slow",
+                "config",
+                [
+                    "reason": reason,
+                    "duration_ms": Int(elapsedMs.rounded()),
+                    "theme": next.theme ?? "nil",
+                    "loaded_background": loadedBackgroundHex,
+                    "default_background": defaultBackgroundHex,
+                    "final_background": next.backgroundColor.hexString(),
+                    "used_background_override": backgroundOverride != nil,
+                    "thread": Thread.isMainThread ? "main" : "background"
+                ]
+            )
+        }
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme resolve reason=\(reason) loadedBg=\(loadedBackgroundHex) overrideBg=\(backgroundOverride?.hexString() ?? "nil") defaultBg=\(defaultBackgroundHex) finalBg=\(next.backgroundColor.hexString()) theme=\(next.theme ?? "nil")"

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -989,3 +989,56 @@ final class PostHogAnalyticsPropertiesTests: XCTestCase {
         XCTAssertNil(dailyProperties["app_build"])
     }
 }
+
+final class WorkspaceContentViewThemeResolveTests: XCTestCase {
+    func testResolveGhosttyAppearanceConfigEmitsSlowBreadcrumbWhenThresholdExceeded() {
+        var timestamps: [TimeInterval] = [100.0, 100.25]
+        var breadcrumbs: [(message: String, category: String, data: [String: Any])] = []
+
+        let resolved = WorkspaceContentView.resolveGhosttyAppearanceConfig(
+            reason: "unit-test",
+            loadConfig: {
+                var config = GhosttyConfig()
+                config.theme = "Builtin Solarized Dark"
+                config.backgroundColor = NSColor(hex: "#111111")!
+                return config
+            },
+            defaultBackground: { NSColor(hex: "#222222")! },
+            currentTime: { timestamps.removeFirst() },
+            slowThresholdMs: 100,
+            emitBreadcrumb: { message, category, data in
+                breadcrumbs.append((message, category, data))
+            }
+        )
+
+        XCTAssertEqual(breadcrumbs.count, 1)
+        XCTAssertEqual(breadcrumbs.first?.message, "theme.resolve.slow")
+        XCTAssertEqual(breadcrumbs.first?.category, "config")
+        XCTAssertEqual(breadcrumbs.first?.data["reason"] as? String, "unit-test")
+        XCTAssertEqual(breadcrumbs.first?.data["duration_ms"] as? Int, 250)
+        XCTAssertEqual(breadcrumbs.first?.data["theme"] as? String, "Builtin Solarized Dark")
+        XCTAssertEqual(resolved.backgroundColor.hexString(), "#222222")
+    }
+
+    func testResolveGhosttyAppearanceConfigSkipsBreadcrumbWhenBelowThreshold() {
+        var timestamps: [TimeInterval] = [200.0, 200.05]
+        var breadcrumbCount = 0
+
+        _ = WorkspaceContentView.resolveGhosttyAppearanceConfig(
+            reason: "fast-path",
+            loadConfig: {
+                var config = GhosttyConfig()
+                config.backgroundColor = NSColor(hex: "#111111")!
+                return config
+            },
+            defaultBackground: { NSColor(hex: "#333333")! },
+            currentTime: { timestamps.removeFirst() },
+            slowThresholdMs: 120,
+            emitBreadcrumb: { _, _, _ in
+                breadcrumbCount += 1
+            }
+        )
+
+        XCTAssertEqual(breadcrumbCount, 0)
+    }
+}

--- a/tests/test_terminal_portal_model_drift_regression.py
+++ b/tests/test_terminal_portal_model_drift_regression.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Static regression guards for portal/model drift protection.
+
+This checks the invariant that portal binding/sync is model-authoritative:
+if a terminal surface is no longer present in TabManager, stale SwiftUI/AppKit
+callbacks must not be able to re-show it as an overlay.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path(__file__).resolve().parents[1]
+
+
+def extract_block(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        raise ValueError(f"Missing signature: {signature}")
+    brace_start = source.find("{", start)
+    if brace_start < 0:
+        raise ValueError(f"Missing opening brace for: {signature}")
+
+    depth = 0
+    for idx in range(brace_start, len(source)):
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start : idx + 1]
+    raise ValueError(f"Unbalanced braces for: {signature}")
+
+
+def main() -> int:
+    root = repo_root()
+    failures: list[str] = []
+
+    tab_manager_source = (root / "Sources" / "TabManager.swift").read_text(encoding="utf-8")
+    portal_source = (root / "Sources" / "TerminalWindowPortal.swift").read_text(encoding="utf-8")
+    terminal_view_source = (root / "Sources" / "GhosttyTerminalView.swift").read_text(encoding="utf-8")
+
+    if "func hasSurfaceModel(surfaceId: UUID) -> Bool" not in tab_manager_source:
+        failures.append("TabManager is missing hasSurfaceModel(surfaceId:) model lookup helper")
+
+    if "var portalSurfaceId: UUID?" not in terminal_view_source:
+        failures.append("GhosttySurfaceScrollView is missing portalSurfaceId for model checks")
+
+    sync_block = extract_block(portal_source, "private func synchronizeHostedView(withId hostedId: ObjectIdentifier)")
+    for required in [
+        "if !isHostedViewBackedByModel(hostedView)",
+        "reason=modelMissing",
+        "detachHostedView(withId: hostedId)",
+    ]:
+        if required not in sync_block:
+            failures.append(f"synchronizeHostedView() missing model-drift guard: {required}")
+
+    registry_bind_block = extract_block(
+        portal_source,
+        "static func bind(hostedView: GhosttySurfaceScrollView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0)",
+    )
+    if "guard isHostedViewBackedByModel(hostedView) else" not in registry_bind_block:
+        failures.append("TerminalWindowPortalRegistry.bind() missing model-authoritative guard")
+    if 'dropModelMissingBinding(hostedView: hostedView, reason: "bind")' not in registry_bind_block:
+        failures.append("TerminalWindowPortalRegistry.bind() missing model-missing cleanup path")
+
+    registry_visibility_block = extract_block(
+        portal_source,
+        "static func updateEntryVisibility(for hostedView: GhosttySurfaceScrollView, visibleInUI: Bool)",
+    )
+    if "guard isHostedViewBackedByModel(hostedView) else" not in registry_visibility_block:
+        failures.append("updateEntryVisibility() missing model-authoritative guard")
+
+    if failures:
+        print("FAIL: portal/model drift regression guards failed")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("PASS: portal/model drift guards are in place")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- targets Sentry issue https://manaflow.sentry.io/issues/CMUXTERM-MACOS-E4/
- add `ghostty.theme.load.slow` breadcrumb with candidate/path counts and timing when theme load takes `>=150ms`
- add `ghostty.theme.load.miss` breadcrumb only for slow misses (`>=150ms`) to reduce noise
- emit `theme.resolve.slow` breadcrumb in `WorkspaceContentView.resolveGhosttyAppearanceConfig` for expensive config resolution
- add unit coverage for slow breadcrumb emission in `WorkspaceContentViewThemeResolveTests`
- keep theme path resolution behavior unchanged from `main` (reverted path-join refactor after regression report during dogfooding)

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS" -only-testing:cmuxTests/WorkspaceContentViewThemeResolveTests test` *(currently blocked by unrelated compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`: extra argument `hostWindowAttached` in call)*
- `./scripts/reload.sh --tag sentry-061-e4-theme-r2`
