### PR TITLE
Fix title update fan-out causing main-thread hangs

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1198,7 +1198,6 @@ struct ContentView: View {
     @State private var selectedTabIds: Set<UUID> = []
     @State private var mountedWorkspaceIds: [UUID] = []
     @State private var lastSidebarSelectionIndex: Int? = nil
-    @State private var titlebarText: String = ""
     @State private var isFullScreen: Bool = false
     @State private var observedWindow: NSWindow?
     @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
@@ -1208,7 +1207,6 @@ struct ContentView: View {
     @State private var workspaceHandoffFallbackTask: Task<Void, Never>?
     @State private var titlebarThemeGeneration: UInt64 = 0
     @State private var sidebarDraggedTabId: UUID?
-    @State private var titlebarTextUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
     @State private var sidebarResizerCursorReleaseWorkItem: DispatchWorkItem?
     @State private var sidebarResizerPointerMonitor: Any?
     @State private var isResizerBandActive = false
@@ -1870,7 +1868,7 @@ struct ContentView: View {
                     DraggableFolderIcon(directory: directory)
                 }
 
-                Text(titlebarText)
+                Text(tabManager.selectedCommandTitle)
                     .font(.system(size: 13, weight: .bold))
                     .foregroundColor(fakeTitlebarTextColor)
                     .lineLimit(1)
@@ -1892,26 +1890,6 @@ struct ContentView: View {
             Rectangle()
                 .fill(Color(nsColor: .separatorColor))
                 .frame(height: 1)
-        }
-    }
-
-    private func updateTitlebarText() {
-        guard let selectedId = tabManager.selectedTabId,
-              let tab = tabManager.tabs.first(where: { $0.id == selectedId }) else {
-            if !titlebarText.isEmpty {
-                titlebarText = ""
-            }
-            return
-        }
-        let title = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        if titlebarText != title {
-            titlebarText = title
-        }
-    }
-
-    private func scheduleTitlebarTextRefresh() {
-        titlebarTextUpdateCoalescer.signal {
-            updateTitlebarText()
         }
     }
 
@@ -2041,7 +2019,6 @@ struct ContentView: View {
                 selectedTabIds = [selectedId]
                 lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
             }
-            updateTitlebarText()
         })
 
         view = AnyView(view.onChange(of: tabManager.selectedTabId) { newValue in
@@ -2063,7 +2040,6 @@ struct ContentView: View {
                 selectedTabIds = [newValue]
                 lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == newValue }
             }
-            updateTitlebarText()
         })
 
         view = AnyView(view.onChange(of: tabManager.isWorkspaceCycleHot) { _ in
@@ -2084,22 +2060,14 @@ struct ContentView: View {
             reconcileMountedWorkspaceIds()
         })
 
-        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidSetTitle)) { notification in
-            guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
-                  tabId == tabManager.selectedTabId else { return }
-            scheduleTitlebarTextRefresh()
-        })
-
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidFocusTab)) { _ in
             sidebarSelectionState.selection = .tabs
-            scheduleTitlebarTextRefresh()
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidFocusSurface)) { notification in
             guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
                   tabId == tabManager.selectedTabId else { return }
             completeWorkspaceHandoffIfNeeded(focusedTabId: tabId, reason: "focus")
-            scheduleTitlebarTextRefresh()
         })
 
         view = AnyView(view.onChange(of: titlebarThemeGeneration) { oldValue, newValue in

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1177,15 +1177,12 @@ class GhosttyApp {
             if let tabId = surfaceView.tabId,
                let surfaceId = surfaceView.terminalSurface?.id {
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: .ghosttyDidSetTitle,
-                        object: surfaceView,
-                        userInfo: [
-                            GhosttyNotificationKey.tabId: tabId,
-                            GhosttyNotificationKey.surfaceId: surfaceId,
-                            GhosttyNotificationKey.title: title,
-                        ]
-                    )
+                    let appDelegate = AppDelegate.shared
+                    if let tabManager = appDelegate?.tabManagerFor(tabId: tabId) {
+                        tabManager.handleGhosttySetTitle(tabId: tabId, surfaceId: surfaceId, title: title)
+                    } else if let tabManager = appDelegate?.tabManager {
+                        tabManager.handleGhosttySetTitle(tabId: tabId, surfaceId: surfaceId, title: title)
+                    }
                 }
             }
             return true

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -564,6 +564,7 @@ class TabManager: ObservableObject {
 
     @Published var tabs: [Workspace] = []
     @Published private(set) var isWorkspaceCycleHot: Bool = false
+    @Published private(set) var selectedCommandTitle: String = ""
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -616,6 +617,9 @@ class TabManager: ObservableObject {
     private var observers: [NSObjectProtocol] = []
     private var suppressFocusFlash = false
     private var lastFocusedPanelByTab: [UUID: UUID] = [:]
+    private var selectedWorkspaceTitleObserver: AnyCancellable?
+    private var observedSelectedWorkspaceId: UUID?
+    private var selectedCommandTitleCancellables = Set<AnyCancellable>()
     private struct PanelTitleUpdateKey: Hashable {
         let tabId: UUID
         let panelId: UUID
@@ -650,19 +654,6 @@ class TabManager: ObservableObject {
     init(initialWorkingDirectory: String? = nil) {
         addWorkspace(workingDirectory: initialWorkingDirectory)
         observers.append(NotificationCenter.default.addObserver(
-            forName: .ghosttyDidSetTitle,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            MainActor.assumeIsolated { [weak self] in
-                guard let self else { return }
-                guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID else { return }
-                guard let surfaceId = notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else { return }
-                guard let title = notification.userInfo?[GhosttyNotificationKey.title] as? String else { return }
-                enqueuePanelTitleUpdate(tabId: tabId, panelId: surfaceId, title: title)
-            }
-        })
-        observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidFocusSurface,
             object: nil,
             queue: .main
@@ -674,6 +665,8 @@ class TabManager: ObservableObject {
                 markPanelReadOnFocusIfActive(tabId: tabId, panelId: surfaceId)
             }
         })
+        bindSelectedCommandTitle()
+        syncSelectedWorkspaceTitleSubscription()
 
 #if DEBUG
         setupUITestFocusShortcutsIfNeeded()
@@ -700,6 +693,46 @@ class TabManager: ObservableObject {
     var selectedWorkspace: Workspace? {
         guard let selectedTabId else { return nil }
         return tabs.first(where: { $0.id == selectedTabId })
+    }
+
+    func handleGhosttySetTitle(tabId: UUID, surfaceId: UUID, title: String) {
+        enqueuePanelTitleUpdate(tabId: tabId, panelId: surfaceId, title: title)
+    }
+
+    private func bindSelectedCommandTitle() {
+        $selectedTabId
+            .combineLatest($tabs)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _, _ in
+                self?.syncSelectedWorkspaceTitleSubscription()
+            }
+            .store(in: &selectedCommandTitleCancellables)
+    }
+
+    private func syncSelectedWorkspaceTitleSubscription() {
+        guard let workspace = selectedWorkspace else {
+            selectedWorkspaceTitleObserver = nil
+            observedSelectedWorkspaceId = nil
+            updateSelectedCommandTitle(from: "")
+            return
+        }
+
+        if observedSelectedWorkspaceId != workspace.id {
+            observedSelectedWorkspaceId = workspace.id
+            selectedWorkspaceTitleObserver = workspace.$title
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] title in
+                    self?.updateSelectedCommandTitle(from: title)
+                }
+        }
+
+        updateSelectedCommandTitle(from: workspace.title)
+    }
+
+    private func updateSelectedCommandTitle(from title: String) {
+        let normalized = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard selectedCommandTitle != normalized else { return }
+        selectedCommandTitle = normalized
     }
 
     // Keep selectedTab as convenience alias

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -10,6 +10,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
 
     private var commandLabels: [ObjectIdentifier: NSTextField] = [:]
     private var observers: [NSObjectProtocol] = []
+    private var cancellables = Set<AnyCancellable>()
     private let focusedCommandUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
 
     override init() {
@@ -24,33 +25,25 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
 
     func start(tabManager: TabManager) {
         self.tabManager = tabManager
+        bindTabManager()
         attachToExistingWindows()
         installObservers()
         scheduleFocusedCommandTextUpdate()
     }
 
+    private func bindTabManager() {
+        cancellables.removeAll()
+        tabManager?.$selectedCommandTitle
+            .receive(on: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.scheduleFocusedCommandTextUpdate()
+            }
+            .store(in: &cancellables)
+    }
+
     private func installObservers() {
         let center = NotificationCenter.default
-        observers.append(center.addObserver(
-            forName: .ghosttyDidSetTitle,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.scheduleFocusedCommandTextUpdate()
-            }
-        })
-
-        observers.append(center.addObserver(
-            forName: .ghosttyDidFocusTab,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.scheduleFocusedCommandTextUpdate()
-            }
-        })
-
         observers.append(center.addObserver(
             forName: NSWindow.didBecomeMainNotification,
             object: nil,
@@ -91,14 +84,8 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
 
     private func updateFocusedCommandText() {
         guard let tabManager else { return }
-        let text: String
-        if let selectedId = tabManager.selectedTabId,
-           let tab = tabManager.tabs.first(where: { $0.id == selectedId }) {
-            let title = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
-            text = title.isEmpty ? "Cmd: —" : "Cmd: \(title)"
-        } else {
-            text = "Cmd: —"
-        }
+        let title = tabManager.selectedCommandTitle
+        let text = title.isEmpty ? "Cmd: —" : "Cmd: \(title)"
 
         for label in commandLabels.values {
             if label.stringValue != text {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -531,35 +531,53 @@ final class RecentlyClosedBrowserStackTests: XCTestCase {
 }
 
 final class TabManagerNotificationOrderingSourceTests: XCTestCase {
-    func testGhosttyDidSetTitleObserverDoesNotHopThroughTask() throws {
+    func testTabManagerRoutesGhosttyTitleUpdatesThroughDedicatedHandler() throws {
         let projectRoot = findProjectRoot()
         let tabManagerURL = projectRoot.appendingPathComponent("Sources/TabManager.swift")
         let source = try String(contentsOf: tabManagerURL, encoding: .utf8)
 
-        guard let titleObserverStart = source.range(of: "forName: .ghosttyDidSetTitle"),
-              let focusObserverStart = source.range(
-                of: "forName: .ghosttyDidFocusSurface",
-                range: titleObserverStart.upperBound..<source.endIndex
+        guard let handlerStart = source.range(of: "func handleGhosttySetTitle("),
+              let bindStart = source.range(
+                of: "private func bindSelectedCommandTitle()",
+                range: handlerStart.upperBound..<source.endIndex
               ) else {
-            XCTFail("Failed to locate TabManager notification observer block in Sources/TabManager.swift")
+            XCTFail("Failed to locate handleGhosttySetTitle block in Sources/TabManager.swift")
             return
         }
 
-        let block = String(source[titleObserverStart.lowerBound..<focusObserverStart.lowerBound])
-        XCTAssertFalse(
-            block.contains("Task {"),
-            """
-            The .ghosttyDidSetTitle observer must update model state in the notification callback.
-            Using Task can reorder updates and leave titlebar/toolbar one event behind.
-            """
-        )
-        XCTAssertTrue(
-            block.contains("MainActor.assumeIsolated"),
-            "Expected .ghosttyDidSetTitle observer to run synchronously on MainActor."
-        )
+        let block = String(source[handlerStart.lowerBound..<bindStart.lowerBound])
         XCTAssertTrue(
             block.contains("enqueuePanelTitleUpdate"),
-            "Expected .ghosttyDidSetTitle observer to enqueue panel title updates."
+            "Expected handleGhosttySetTitle to enqueue panel title updates."
+        )
+    }
+
+    func testGhosttySetTitleActionRoutesToOwningTabManager() throws {
+        let projectRoot = findProjectRoot()
+        let viewURL = projectRoot.appendingPathComponent("Sources/GhosttyTerminalView.swift")
+        let source = try String(contentsOf: viewURL, encoding: .utf8)
+
+        guard let actionStart = source.range(of: "case GHOSTTY_ACTION_SET_TITLE:"),
+              let nextCaseStart = source.range(
+                of: "case GHOSTTY_ACTION_PWD:",
+                range: actionStart.upperBound..<source.endIndex
+              ) else {
+            XCTFail("Failed to locate GHOSTTY_ACTION_SET_TITLE block in Sources/GhosttyTerminalView.swift")
+            return
+        }
+
+        let block = String(source[actionStart.lowerBound..<nextCaseStart.lowerBound])
+        XCTAssertTrue(
+            block.contains("tabManagerFor(tabId: tabId)"),
+            "Expected GHOSTTY_ACTION_SET_TITLE to route updates to the owning TabManager."
+        )
+        XCTAssertTrue(
+            block.contains("handleGhosttySetTitle"),
+            "Expected GHOSTTY_ACTION_SET_TITLE to use TabManager.handleGhosttySetTitle."
+        )
+        XCTAssertFalse(
+            block.contains("NotificationCenter.default.post"),
+            "Expected GHOSTTY_ACTION_SET_TITLE to avoid NotificationCenter fan-out."
         )
     }
 


### PR DESCRIPTION
## Summary
- route `GHOSTTY_ACTION_SET_TITLE` directly to the owning `TabManager` instead of posting `.ghosttyDidSetTitle` notifications
- add `TabManager.selectedCommandTitle` and keep it synced to the selected workspace title
- bind titlebar (`ContentView`) and toolbar (`WindowToolbarController`) to `selectedCommandTitle`, removing duplicated notification handlers
- update source-level regression tests to assert direct routing and prevent notification fan-out regressions

## Testing
- `./scripts/reload.sh --tag fix-issue230`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/TabManagerNotificationOrderingSourceTests test`

Fixes #230
