### PR TITLE
Browser panels: focus follows mouse on hover

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -348,6 +348,21 @@ struct BrowserPanelView: View {
 #endif
             onRequestPanelFocus()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveHover).filter { [weak panel] note in
+            // Only handle hover intents from our own webview.
+            guard let webView = note.object as? CmuxWebView else { return false }
+            return webView === panel?.webView
+        }) { _ in
+            guard !isFocused else { return }
+#if DEBUG
+            dlog(
+                "browser.focus.hoverIntent panel=\(panel.id.uuidString.prefix(5)) " +
+                "isFocused=\(isFocused ? 1 : 0) " +
+                "addressFocused=\(addressBarFocused ? 1 : 0)"
+            )
+#endif
+            onRequestPanelFocus()
+        }
         .onAppear {
             UserDefaults.standard.register(defaults: [
                 BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -58,11 +58,54 @@ final class CmuxWebView: WKWebView {
     /// Guard against background panes stealing first responder (e.g. page autofocus).
     /// BrowserPanelView updates this as pane focus state changes.
     var allowsFirstResponderAcquisition: Bool = true
+    private var trackingArea: NSTrackingArea?
     private var pointerFocusAllowanceDepth: Int = 0
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
     }
     var debugPointerFocusAllowanceDepth: Int { pointerFocusAllowanceDepth }
+
+    static func shouldRequestPanelFocusForMouseHover(
+        focusFollowsMouseEnabled: Bool,
+        pressedMouseButtons: Int,
+        appIsActive: Bool,
+        windowIsKey: Bool,
+        alreadyFirstResponder: Bool
+    ) -> Bool {
+        guard focusFollowsMouseEnabled else { return false }
+        guard pressedMouseButtons == 0 else { return false }
+        guard appIsActive, windowIsKey else { return false }
+        guard !alreadyFirstResponder else { return false }
+        return true
+    }
+
+    override func updateTrackingAreas() {
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+
+        let options: NSTrackingArea.Options = [
+            .inVisibleRect,
+            .activeAlways,
+            .mouseMoved,
+            .mouseEnteredAndExited,
+        ]
+        let next = NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil)
+        addTrackingArea(next)
+        trackingArea = next
+
+        super.updateTrackingAreas()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        maybeNotifyPanelHoverFocusIntent()
+        super.mouseMoved(with: event)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        maybeNotifyPanelHoverFocusIntent()
+        super.mouseEntered(with: event)
+    }
 
     override func becomeFirstResponder() -> Bool {
         guard allowsFirstResponderAcquisitionEffective else {
@@ -172,6 +215,39 @@ final class CmuxWebView: WKWebView {
         withPointerFocusAllowance {
             super.mouseDown(with: event)
         }
+    }
+
+    private func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var responder = start
+        var hops = 0
+        while let current = responder, hops < 64 {
+            if current === target { return true }
+            responder = current.nextResponder
+            hops += 1
+        }
+        return false
+    }
+
+    private func maybeNotifyPanelHoverFocusIntent() {
+        guard let window else { return }
+        let alreadyFirstResponder = responderChainContains(window.firstResponder, target: self)
+        let shouldRequest = Self.shouldRequestPanelFocusForMouseHover(
+            focusFollowsMouseEnabled: GhosttyApp.shared.focusFollowsMouseEnabled(),
+            pressedMouseButtons: NSEvent.pressedMouseButtons,
+            appIsActive: NSApp.isActive,
+            windowIsKey: window.isKeyWindow,
+            alreadyFirstResponder: alreadyFirstResponder
+        )
+        guard shouldRequest else { return }
+
+#if DEBUG
+        dlog(
+            "browser.focus.hoverIntent web=\(ObjectIdentifier(self)) " +
+            "policy=\(allowsFirstResponderAcquisition ? 1 : 0) " +
+            "pointerDepth=\(pointerFocusAllowanceDepth)"
+        )
+#endif
+        NotificationCenter.default.post(name: .webViewDidReceiveHover, object: self)
     }
 
     // MARK: - Mouse back/forward buttons

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3470,4 +3470,5 @@ extension Notification.Name {
     static let browserDidFocusAddressBar = Notification.Name("browserDidFocusAddressBar")
     static let browserDidBlurAddressBar = Notification.Name("browserDidBlurAddressBar")
     static let webViewDidReceiveClick = Notification.Name("webViewDidReceiveClick")
+    static let webViewDidReceiveHover = Notification.Name("webViewDidReceiveHover")
 }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1063,3 +1063,50 @@ final class GhosttyMouseFocusTests: XCTestCase {
         )
     }
 }
+
+final class BrowserMouseFocusTests: XCTestCase {
+    func testShouldRequestPanelFocusForMouseHoverWhenEnabledAndWindowIsActive() {
+        XCTAssertTrue(
+            CmuxWebView.shouldRequestPanelFocusForMouseHover(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false
+            )
+        )
+    }
+
+    func testShouldNotRequestPanelFocusForMouseHoverWhenDisabled() {
+        XCTAssertFalse(
+            CmuxWebView.shouldRequestPanelFocusForMouseHover(
+                focusFollowsMouseEnabled: false,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false
+            )
+        )
+    }
+
+    func testShouldNotRequestPanelFocusForMouseHoverDuringDragOrWhenAlreadyFocused() {
+        XCTAssertFalse(
+            CmuxWebView.shouldRequestPanelFocusForMouseHover(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 1,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: false
+            )
+        )
+        XCTAssertFalse(
+            CmuxWebView.shouldRequestPanelFocusForMouseHover(
+                focusFollowsMouseEnabled: true,
+                pressedMouseButtons: 0,
+                appIsActive: true,
+                windowIsKey: true,
+                alreadyFirstResponder: true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add browser hover intent notification from CmuxWebView when Ghostty `focus_follows_mouse` is enabled
- wire BrowserPanelView to request panel focus on hover intent (matching terminal behavior)
- add regression tests for hover-focus guard logic

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/BrowserMouseFocusTests test` *(currently fails in existing `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` due `hostWindowAttached` argument mismatch before test execution)*

Related context: https://github.com/manaflow-ai/cmux/issues/501
