### PR TITLE
Switch fullscreen default to Cmd+Ctrl+F

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -302,15 +302,17 @@ func shouldDispatchBrowserReturnViaFirstResponderKeyDown(
     return keyCode == 36 || keyCode == 76
 }
 
-func shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+func shouldToggleMainWindowFullScreenForCommandControlFShortcut(
     flags: NSEvent.ModifierFlags,
+    chars: String,
     keyCode: UInt16
 ) -> Bool {
     let normalizedFlags = flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function, .capsLock])
-    guard normalizedFlags == [.command] else { return false }
-    return keyCode == 36 || keyCode == 76
+    guard normalizedFlags == [.command, .control] else { return false }
+    let normalizedChars = chars.lowercased()
+    return normalizedChars == "f" || keyCode == 3
 }
 
 func commandPaletteSelectionDeltaForKeyboardNavigation(
@@ -4586,8 +4588,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+        if shouldToggleMainWindowFullScreenForCommandControlFShortcut(
             flags: event.modifierFlags,
+            chars: chars,
             keyCode: event.keyCode
         ) {
             guard let targetWindow = mainWindowForShortcutEvent(event) else {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3354,6 +3354,8 @@ struct ContentView: View {
             return "⌘⇧F"
         case "palette.terminalUseSelectionForFind":
             return "⌘E"
+        case "palette.toggleFullScreen":
+            return "\u{2303}\u{2318}F"
         default:
             return nil
         }
@@ -3493,6 +3495,14 @@ struct ContentView: View {
                 title: constant("Close Window"),
                 subtitle: constant("Window"),
                 keywords: ["close", "window"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.toggleFullScreen",
+                title: constant("Toggle Full Screen"),
+                subtitle: constant("Window"),
+                keywords: ["fullscreen", "full", "screen", "window", "toggle"]
             )
         )
         contributions.append(
@@ -3961,6 +3971,13 @@ struct ContentView: View {
                 return
             }
             window.performClose(nil)
+        }
+        registry.register(commandId: "palette.toggleFullScreen") {
+            guard let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else {
+                NSSound.beep()
+                return
+            }
+            window.toggleFullScreen(nil)
         }
         registry.register(commandId: "palette.reopenClosedBrowserTab") {
             _ = tabManager.reopenMostRecentlyClosedBrowserPanel()

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1935,62 +1935,79 @@ final class BrowserReturnKeyDownRoutingTests: XCTestCase {
 }
 
 final class FullScreenShortcutTests: XCTestCase {
-    func testMatchesCommandReturn() {
+    func testMatchesCommandControlF() {
         XCTAssertTrue(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [.command],
-                keyCode: 36
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control],
+                chars: "f",
+                keyCode: 3
             )
         )
     }
 
-    func testMatchesCommandKeypadEnterWithNumericPadFlag() {
+    func testMatchesCommandControlFFromKeyCodeWhenCharsAreUnavailable() {
         XCTAssertTrue(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [.command, .numericPad],
-                keyCode: 76
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control],
+                chars: "",
+                keyCode: 3
             )
         )
     }
 
-    func testIgnoresCapsLockForCommandEnter() {
+    func testIgnoresCapsLockForCommandControlF() {
         XCTAssertTrue(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [.command, .capsLock],
-                keyCode: 36
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control, .capsLock],
+                chars: "f",
+                keyCode: 3
             )
         )
     }
 
-    func testRejectsNonEnterKeyCodes() {
+    func testRejectsWhenControlIsMissing() {
         XCTAssertFalse(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
                 flags: [.command],
-                keyCode: 13
+                chars: "f",
+                keyCode: 3
             )
         )
     }
 
     func testRejectsAdditionalModifiers() {
         XCTAssertFalse(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [.command, .shift],
-                keyCode: 36
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control, .shift],
+                chars: "f",
+                keyCode: 3
             )
         )
         XCTAssertFalse(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [.command, .control],
-                keyCode: 36
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control, .option],
+                chars: "f",
+                keyCode: 3
             )
         )
     }
 
     func testRejectsWhenCommandIsMissing() {
         XCTAssertFalse(
-            shouldToggleMainWindowFullScreenForCommandEnterShortcut(
-                flags: [],
-                keyCode: 36
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.control],
+                chars: "f",
+                keyCode: 3
+            )
+        )
+    }
+
+    func testRejectsNonFKey() {
+        XCTAssertFalse(
+            shouldToggleMainWindowFullScreenForCommandControlFShortcut(
+                flags: [.command, .control],
+                chars: "r",
+                keyCode: 15
             )
         )
     }


### PR DESCRIPTION
## Summary
- switch app-level fullscreen shortcut handling from Cmd+Enter to Cmd+Ctrl+F (including normalized modifier handling)
- add `Toggle Full Screen` to the Command Palette (`Cmd+Shift+P`) with a `⌃⌘F` shortcut hint and handler
- update fullscreen shortcut regression tests for the new default behavior

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/FullScreenShortcutTests test` (fails due pre-existing compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift` about extra `hostWindowAttached` arguments)
- `./scripts/reload.sh --tag cmd-ctrl-f-fullscreen` (pass)

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/517
