### PR TITLE
feat: Add Intel (x86_64) Mac support via universal binary builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Build GhosttyKit.xcframework
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
           cd ..
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
           cd ghostty
-          zig build -Demit-xcframework=true -Demit-macos-app=false -Doptimize=ReleaseFast
+          zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
           cd ..
           rm -rf GhosttyKit.xcframework
           cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -836,6 +836,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = cmux;
 				PRODUCT_MODULE_NAME = cmux_cli;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -796,7 +796,7 @@
 					"-framework",
 					Carbon,
 				);
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.app;
 				PRODUCT_NAME = cmux;
 				SPARKLE_PUBLIC_KEY = "avjcgKibf1FTvhIjLBxhd+0HSpsXU4D0IGlVk8cgqRc=";

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -61,7 +61,7 @@ echo "Pre-flight checks passed"
 # --- Build GhosttyKit (if needed) ---
 if [ ! -d "GhosttyKit.xcframework" ]; then
   echo "Building GhosttyKit..."
-  cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=native -Doptimize=ReleaseFast && cd ..
+  cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast && cd ..
   rm -rf GhosttyKit.xcframework
   cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
 else

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -59,13 +59,23 @@ done
 echo "Pre-flight checks passed"
 
 # --- Build GhosttyKit (if needed) ---
+# Always rebuild if the existing xcframework is missing the x86_64 slice,
+# which happens when setup.sh seeds a native-only (arm64) build.
+NEED_BUILD="false"
 if [ ! -d "GhosttyKit.xcframework" ]; then
-  echo "Building GhosttyKit..."
+  NEED_BUILD="true"
+elif [ ! -d "GhosttyKit.xcframework/macos-arm64_x86_64" ]; then
+  echo "GhosttyKit.xcframework exists but is not universal, rebuilding..."
+  NEED_BUILD="true"
+fi
+
+if [ "$NEED_BUILD" = "true" ]; then
+  echo "Building universal GhosttyKit..."
   cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast && cd ..
   rm -rf GhosttyKit.xcframework
   cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
 else
-  echo "GhosttyKit.xcframework exists, skipping build"
+  echo "GhosttyKit.xcframework exists and is universal, skipping build"
 fi
 
 # --- Build app (Release, unsigned) ---


### PR DESCRIPTION
## Summary

Fixes #293 — cmux currently ships as arm64-only, preventing installation on Intel Macs.

This PR makes **3 minimal changes** to produce a **Universal Binary** (arm64 + x86_64):

1. **GhosttyKit.xcframework**: Build with `-Dxcframework-target=universal` instead of `native`/unspecified in all release & nightly build paths
2. **Xcode project**: Set `ONLY_ACTIVE_ARCH = NO` for the main app Release configuration so Xcode compiles Swift code for both architectures

### Files changed (4 files, 4 lines)

| File | Change |
|------|--------|
| `scripts/build-sign-upload.sh:64` | `-Dxcframework-target=native` → `universal` |
| `.github/workflows/release.yml:117` | Added `-Dxcframework-target=universal` (was missing) |
| `.github/workflows/nightly.yml:123` | `-Dxcframework-target=native` → `universal` |
| `GhosttyTabs.xcodeproj/project.pbxproj:799` | `ONLY_ACTIVE_ARCH = YES` → `NO` (Release config only) |

### What was NOT changed (by design)

- **`scripts/setup.sh`**: Keeps no explicit xcframework-target — builds for the developer's native architecture (works on both Intel and Apple Silicon for local dev)
- **Debug configurations**: Keep `ONLY_ACTIVE_ARCH = YES` for fast dev builds
- **Test target configs**: Keep `ONLY_ACTIVE_ARCH = YES`

### Why this works

- Ghostty's Zig build system already supports `-Dxcframework-target=universal`, which cross-compiles both arm64 and x86_64 slices into the xcframework (Ghostty itself ships as a Universal Binary)
- Zig handles cross-compilation natively — no additional CI runners or toolchains needed
- The self-hosted CI runner (Apple Silicon) can cross-compile x86_64 via Zig
- All Swift/AppKit code is architecture-agnostic — no arch-specific code exists in cmux
- Code signing, notarization, and Sparkle updates work identically with universal binaries

### Verification

After building, the output can be verified with:
```bash
lipo -archs build/Build/Products/Release/cmux.app/Contents/MacOS/cmux
# Expected: arm64 x86_64

lipo -archs GhosttyKit.xcframework/macos-arm64_x86_64/GhosttyKit.framework/GhosttyKit
# Expected: arm64 x86_64
```

## Test plan

- [ ] CI builds successfully with universal GhosttyKit.xcframework
- [ ] Release DMG contains universal binary (both arm64 and x86_64 slices)
- [ ] App launches on Apple Silicon Mac
- [ ] App launches on Intel Mac (ideally real hardware or x86_64 VM)
- [ ] Embedded CLI (`Contents/Resources/bin/cmux`) is also universal
- [ ] Code signing and notarization pass
- [ ] Sparkle update from current arm64-only build to new universal build works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build workflows and scripts updated to produce universal xcframeworks by default, with logic to rebuild when slices are missing.
  * Release build configurations adjusted to disable "only active architecture" for Release builds.
* **Bug Fixes**
  * Improved build reliability and messaging around skipping or forcing framework rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->