### PR TITLE
Fix workspace rename when selection is missing with single workspace

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4455,8 +4455,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func promptRenameSelectedWorkspace() -> Bool {
         guard let tabManager,
-              let tabId = tabManager.selectedTabId,
-              let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
+              let tab = tabManager.selectedWorkspaceForUserAction() else {
             NSSound.beep()
             return false
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3364,7 +3364,7 @@ struct ContentView: View {
     private func commandPaletteContextSnapshot() -> CommandPaletteContextSnapshot {
         var snapshot = CommandPaletteContextSnapshot()
 
-        if let workspace = tabManager.selectedWorkspace {
+        if let workspace = tabManager.selectedWorkspaceForUserAction() {
             snapshot.setBool(CommandPaletteContextKeys.hasWorkspace, true)
             snapshot.setString(CommandPaletteContextKeys.workspaceName, workspaceDisplayName(workspace))
             snapshot.setBool(CommandPaletteContextKeys.workspaceHasCustomName, workspace.customTitle != nil)
@@ -4021,14 +4021,14 @@ struct ContentView: View {
             beginRenameWorkspaceFlow()
         }
         registry.register(commandId: "palette.clearWorkspaceName") {
-            guard let workspace = tabManager.selectedWorkspace else {
+            guard let workspace = tabManager.selectedWorkspaceForUserAction() else {
                 NSSound.beep()
                 return
             }
             tabManager.clearCustomTitle(tabId: workspace.id)
         }
         registry.register(commandId: "palette.toggleWorkspacePin") {
-            guard let workspace = tabManager.selectedWorkspace else {
+            guard let workspace = tabManager.selectedWorkspaceForUserAction() else {
                 NSSound.beep()
                 return
             }
@@ -4662,7 +4662,7 @@ struct ContentView: View {
     }
 
     private func beginRenameWorkspaceFlow() {
-        guard let workspace = tabManager.selectedWorkspace else {
+        guard let workspace = tabManager.selectedWorkspaceForUserAction() else {
             NSSound.beep()
             return
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -702,6 +702,17 @@ class TabManager: ObservableObject {
         return tabs.first(where: { $0.id == selectedTabId })
     }
 
+    /// Returns the selected workspace for user-triggered workspace commands.
+    /// If selection is temporarily missing but there is exactly one workspace,
+    /// treat that sole workspace as the command target.
+    func selectedWorkspaceForUserAction() -> Workspace? {
+        if let selectedWorkspace {
+            return selectedWorkspace
+        }
+        guard tabs.count == 1 else { return nil }
+        return tabs.first
+    }
+
     // Keep selectedTab as convenience alias
     var selectedTab: Workspace? { selectedWorkspace }
 

--- a/cmuxTests/TabManagerWorkspaceSelectionFallbackTests.swift
+++ b/cmuxTests/TabManagerWorkspaceSelectionFallbackTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class TabManagerWorkspaceSelectionFallbackTests: XCTestCase {
+    func testSelectedWorkspaceForUserActionUsesSelectedWorkspace() {
+        let manager = TabManager()
+        let secondWorkspace = manager.addWorkspace()
+
+        XCTAssertEqual(manager.selectedWorkspace?.id, secondWorkspace.id)
+        XCTAssertEqual(manager.selectedWorkspaceForUserAction()?.id, secondWorkspace.id)
+    }
+
+    func testSelectedWorkspaceForUserActionFallsBackToSoleWorkspace() {
+        let manager = TabManager()
+        guard let soleWorkspace = manager.tabs.first else {
+            XCTFail("Expected one initial workspace")
+            return
+        }
+
+        manager.selectedTabId = nil
+
+        XCTAssertNil(manager.selectedWorkspace)
+        XCTAssertEqual(manager.selectedWorkspaceForUserAction()?.id, soleWorkspace.id)
+    }
+
+    func testSelectedWorkspaceForUserActionFallsBackWhenSelectionIsStale() {
+        let manager = TabManager()
+        guard let soleWorkspace = manager.tabs.first else {
+            XCTFail("Expected one initial workspace")
+            return
+        }
+
+        manager.selectedTabId = UUID()
+
+        XCTAssertNil(manager.selectedWorkspace)
+        XCTAssertEqual(manager.selectedWorkspaceForUserAction()?.id, soleWorkspace.id)
+    }
+
+    func testSelectedWorkspaceForUserActionDoesNotGuessWhenMultipleWorkspacesExist() {
+        let manager = TabManager()
+        _ = manager.addWorkspace()
+
+        manager.selectedTabId = nil
+
+        XCTAssertNil(manager.selectedWorkspace)
+        XCTAssertNil(manager.selectedWorkspaceForUserAction())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a rename edge case where `Rename Workspace` could fail (beep/no-op) when there is exactly one workspace and the explicit selected workspace id is temporarily missing or stale.

## Root Cause
Workspace rename flows relied on `selectedWorkspace`, which returns `nil` when `selectedTabId` is `nil` or invalid.
In single-workspace state, there is still an obvious rename target, but the action had no fallback.

## Changes
- Added `TabManager.selectedWorkspaceForUserAction()`:
  - Returns `selectedWorkspace` when available.
  - Falls back to the sole workspace when `tabs.count == 1`.
  - Does not guess when multiple workspaces exist.
- Updated workspace-command paths to use this fallback:
  - Command palette workspace context snapshot
  - `palette.renameWorkspace`
  - `palette.clearWorkspaceName`
  - `palette.toggleWorkspacePin`
  - AppDelegate rename prompt path (`promptRenameSelectedWorkspace`)
- Added regression tests:
  - `cmuxTests/TabManagerWorkspaceSelectionFallbackTests.swift`
  - Covers selected, single-workspace fallback, stale selection fallback, and multi-workspace no-guess behavior.

## Behavior
- Single workspace: rename now works even if explicit selection state is missing.
- Multiple workspaces: unchanged behavior (still requires explicit selection).

## Verification
- Manual: reproduced the issue and confirmed rename now works in single-workspace mode.
- Added focused unit tests for fallback selection behavior.