### PR TITLE
Align modifier flagsChanged behavior with Ghostty

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
+					F8000000A1B2C3D4E5F60718 /* GhosttyModifierFlagsChangedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* GhosttyModifierFlagsChangedTests.swift */; };
 			/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -210,9 +211,10 @@
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
-				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
-				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
-				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
+					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
+					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+					F8000001A1B2C3D4E5F60718 /* GhosttyModifierFlagsChangedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyModifierFlagsChangedTests.swift; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -425,6 +427,7 @@
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
+					F8000001A1B2C3D4E5F60718 /* GhosttyModifierFlagsChangedTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -634,6 +637,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+					F8000000A1B2C3D4E5F60718 /* GhosttyModifierFlagsChangedTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2791,6 +2791,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     func clearIMEPointForTesting() {
         imePointOverrideForTesting = nil
     }
+
+    // Test-only helper to assert modifier press/release inference for flagsChanged.
+    func flagsChangedActionForTesting(event: NSEvent) -> ghostty_input_action_e? {
+        flagsChangedAction(for: event)
+    }
 #endif
 
 #if DEBUG
@@ -3145,8 +3150,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
+        guard let action = flagsChangedAction(for: event) else { return }
+
         var keyEvent = ghostty_input_key_s()
-        keyEvent.action = GHOSTTY_ACTION_PRESS
+        keyEvent.action = action
         keyEvent.keycode = UInt32(event.keyCode)
         keyEvent.mods = modsFromEvent(event)
         keyEvent.consumed_mods = GHOSTTY_MODS_NONE
@@ -3155,8 +3162,48 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = ghostty_surface_key(surface, keyEvent)
     }
 
+    private func flagsChangedAction(for event: NSEvent) -> ghostty_input_action_e? {
+        if hasMarkedText() { return nil }
+
+        let modifierMask: UInt32
+        switch event.keyCode {
+        case 0x39: modifierMask = GHOSTTY_MODS_CAPS.rawValue
+        case 0x38, 0x3C: modifierMask = GHOSTTY_MODS_SHIFT.rawValue
+        case 0x3B, 0x3E: modifierMask = GHOSTTY_MODS_CTRL.rawValue
+        case 0x3A, 0x3D: modifierMask = GHOSTTY_MODS_ALT.rawValue
+        case 0x37, 0x36: modifierMask = GHOSTTY_MODS_SUPER.rawValue
+        default: return nil
+        }
+
+        let mods = modsFromEvent(event)
+        var action = GHOSTTY_ACTION_RELEASE
+
+        if (mods.rawValue & modifierMask) != 0 {
+            let sidePressed: Bool
+            switch event.keyCode {
+            case 0x3C:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+            case 0x3E:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
+            case 0x3D:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
+            case 0x36:
+                sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
+            default:
+                sidePressed = true
+            }
+
+            if sidePressed {
+                action = GHOSTTY_ACTION_PRESS
+            }
+        }
+
+        return action
+    }
+
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
         var mods = GHOSTTY_MODS_NONE.rawValue
+        if event.modifierFlags.contains(.capsLock) { mods |= GHOSTTY_MODS_CAPS.rawValue }
         if event.modifierFlags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
         if event.modifierFlags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
         if event.modifierFlags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }

--- a/cmuxTests/GhosttyModifierFlagsChangedTests.swift
+++ b/cmuxTests/GhosttyModifierFlagsChangedTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class GhosttyModifierFlagsChangedTests: XCTestCase {
+    func testLeftShiftPressMapsToPressAction() {
+        let view = GhosttyNSView(frame: .zero)
+        let event = makeFlagsChangedEvent(keyCode: 0x38, modifierFlags: [.shift])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertEqual(action, GHOSTTY_ACTION_PRESS)
+    }
+
+    func testLeftShiftReleaseMapsToReleaseAction() {
+        let view = GhosttyNSView(frame: .zero)
+        let event = makeFlagsChangedEvent(keyCode: 0x38, modifierFlags: [])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertEqual(action, GHOSTTY_ACTION_RELEASE)
+    }
+
+    func testRightShiftReleaseWhileLeftStillHeldMapsToReleaseAction() {
+        let view = GhosttyNSView(frame: .zero)
+        let event = makeFlagsChangedEvent(keyCode: 0x3C, modifierFlags: [.shift])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertEqual(action, GHOSTTY_ACTION_RELEASE)
+    }
+
+    func testRightShiftPressWithDeviceMaskMapsToPressAction() {
+        let view = GhosttyNSView(frame: .zero)
+        let rightShiftMask = NSEvent.ModifierFlags(rawValue: UInt(NX_DEVICERSHIFTKEYMASK))
+        let event = makeFlagsChangedEvent(keyCode: 0x3C, modifierFlags: [.shift, rightShiftMask])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertEqual(action, GHOSTTY_ACTION_PRESS)
+    }
+
+    func testFlagsChangedIgnoredDuringMarkedTextComposition() {
+        let view = GhosttyNSView(frame: .zero)
+        view.setMarkedText(
+            "한",
+            selectedRange: NSRange(location: 0, length: 1),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        let event = makeFlagsChangedEvent(keyCode: 0x38, modifierFlags: [.shift])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertNil(action)
+    }
+
+    func testUnknownModifierKeyCodeReturnsNilAction() {
+        let view = GhosttyNSView(frame: .zero)
+        let event = makeFlagsChangedEvent(keyCode: 0x00, modifierFlags: [])
+        let action = view.flagsChangedActionForTesting(event: event)
+        XCTAssertNil(action)
+    }
+
+    private func makeFlagsChangedEvent(keyCode: UInt16, modifierFlags: NSEvent.ModifierFlags) -> NSEvent {
+        guard let event = NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: keyCode
+        ) else {
+            fatalError("Failed to create flagsChanged event")
+        }
+        return event
+    }
+}


### PR DESCRIPTION
## Summary
- align `GhosttyNSView.flagsChanged` with Ghostty's modifier semantics so modifier transitions emit accurate press/release events (including right-side modifier handling and IME composition bypass)
- include Caps Lock in `modsFromEvent` so modifier state mirrors Ghostty behavior
- add `GhosttyModifierFlagsChangedTests` regression coverage and wire it into the `cmuxTests` target

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyModifierFlagsChangedTests test` (fails due pre-existing compile errors in `cmuxTests/CmuxWebViewKeyEquivalentTests.swift`: extra argument `hostWindowAttached` in call; new regression test file compiles and is included in target)
- `./scripts/reload.sh --tag voice-space-release` (pass)

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/516
- Related: https://github.com/ghostty-org/ghostty/pull/8492
- Related: https://github.com/ghostty-org/ghostty/pull/9488
- Related: https://github.com/ghostty-org/ghostty/pull/9605
