### PR TITLE
Include current_directory and custom_color in list-workspaces output

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1999,7 +1999,9 @@ class TerminalController {
                     "index": index,
                     "title": ws.title,
                     "selected": ws.id == tabManager.selectedTabId,
-                    "pinned": ws.isPinned
+                    "pinned": ws.isPinned,
+                    "current_directory": v2OrNull(ws.currentDirectory),
+                    "custom_color": v2OrNull(ws.customColor)
                 ]
             }
         }


### PR DESCRIPTION
## Summary
- Add `current_directory` and `custom_color` fields to the `workspace.list` (list-workspaces) JSON response
- Enables CLI-based workspace sorting by working directory and color inspection

## Motivation
The `list-workspaces` command currently returns `id`, `ref`, `index`, `title`, `selected`, and `pinned` — but not the workspace's working directory or tab color. Both are already tracked by the `Workspace` model (`currentDirectory` and `customColor` properties) but not exposed via the socket API.

This is useful for:
- **Sorting workspaces** by project/directory (e.g., grouping work repos together)
- **Inspecting tab colors** programmatically (e.g., verifying color was set correctly)

## Change
Two fields added to each workspace entry in the `workspace.list` response:

```json
{
  "current_directory": "/Users/me/project" | null,
  "custom_color": "#1565C0" | null
}
```

## Test plan
- [ ] `cmux list-workspaces --json` includes `current_directory` for workspaces with a known directory
- [ ] `cmux list-workspaces --json` includes `custom_color` for workspaces with a tab color set
- [ ] Both fields are `null` when not set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace listings now include current directory and custom color information for each workspace, enabling enhanced metadata visibility and customization tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->