### PR TITLE
Fix find overlay invisible after portal overflow fix

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4057,6 +4057,7 @@ final class GhosttySurfaceScrollView: NSView {
         }
         notificationRingOverlayView.frame = bounds
         flashOverlayView.frame = bounds
+        searchOverlayHostingView?.frame = bounds
         updateNotificationRingPath()
         updateFlashPath()
         synchronizeScrollView()
@@ -4175,26 +4176,16 @@ final class GhosttySurfaceScrollView: NSView {
             overlay.rootView = rootView
             if overlay.superview !== self {
                 overlay.removeFromSuperview()
-                addSubview(overlay)
-                NSLayoutConstraint.activate([
-                    overlay.topAnchor.constraint(equalTo: topAnchor),
-                    overlay.bottomAnchor.constraint(equalTo: bottomAnchor),
-                    overlay.leadingAnchor.constraint(equalTo: leadingAnchor),
-                    overlay.trailingAnchor.constraint(equalTo: trailingAnchor),
-                ])
+                overlay.frame = bounds
+                addSubview(overlay, positioned: .above, relativeTo: nil)
             }
             return
         }
 
         let overlay = NSHostingView(rootView: rootView)
-        overlay.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(overlay)
-        NSLayoutConstraint.activate([
-            overlay.topAnchor.constraint(equalTo: topAnchor),
-            overlay.bottomAnchor.constraint(equalTo: bottomAnchor),
-            overlay.leadingAnchor.constraint(equalTo: leadingAnchor),
-            overlay.trailingAnchor.constraint(equalTo: trailingAnchor),
-        ])
+        overlay.frame = bounds
+        overlay.autoresizingMask = [.width, .height]
+        addSubview(overlay, positioned: .above, relativeTo: nil)
         searchOverlayHostingView = overlay
     }
 


### PR DESCRIPTION
## Summary

- Fix terminal find overlay (Cmd+F) being invisible after the portal overflow fix (4bc3da6)
- Switch from Auto Layout constraints to frame-based layout for the search overlay NSHostingView

Closes #158

## Root cause

The portal overflow fix added `wantsLayer = true` + `masksToBounds = true` to `GhosttySurfaceScrollView`. This broke Auto Layout constraint resolution for the `NSHostingView` search overlay in the portal-hosted layer-backed context — the overlay was added and focused (search worked when typing) but rendered with zero visual output.

## Fix

Switch to frame-based layout matching how all other overlay views (`inactiveOverlayView`, `flashOverlayView`, etc.) work in `GhosttySurfaceScrollView`:
- Use `autoresizingMask` + explicit `frame = bounds` instead of Auto Layout constraints
- Sync frame in `synchronizeGeometryAndContent()` alongside other overlays
- Use `addSubview(positioned: .above, relativeTo: nil)` for correct z-ordering

## Test plan

- [ ] Cmd+F shows find bar in terminal panel
- [ ] Typing in find bar highlights matches in terminal
- [ ] Find bar persists across pane resize
- [ ] Find bar appears correctly in split panes
- [ ] Cmd+Shift+F hides find bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)