### PR TITLE
Fix _cmux_fix_path to strip Contents/MacOS from PATH

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -240,11 +240,15 @@ _cmux_install_prompt_command() {
 # may prepend other dirs that push our wrapper behind the system claude binary.
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
-        local bin_dir="${GHOSTTY_BIN_DIR%/MacOS}"
-        bin_dir="${bin_dir}/Resources/bin"
+        local base_dir="${GHOSTTY_BIN_DIR%/MacOS}"
+        local bin_dir="${base_dir}/Resources/bin"
         if [[ -d "$bin_dir" ]]; then
+            # Remove existing Resources/bin and Contents/MacOS entries,
+            # then prepend Resources/bin. Contents/MacOS contains the GUI
+            # app binary which must not shadow the CLI wrapper.
             local new_path=":${PATH}:"
             new_path="${new_path//:${bin_dir}:/:}"
+            new_path="${new_path//:${GHOSTTY_BIN_DIR}:/:}"
             new_path="${new_path#:}"
             new_path="${new_path%:}"
             PATH="${bin_dir}:${new_path}"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -373,12 +373,15 @@ _cmux_precmd() {
 # We fix this once on first prompt (after all init files have run).
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
-        local bin_dir="${GHOSTTY_BIN_DIR%/MacOS}"
-        bin_dir="${bin_dir}/Resources/bin"
+        local base_dir="${GHOSTTY_BIN_DIR%/MacOS}"
+        local bin_dir="${base_dir}/Resources/bin"
         if [[ -d "$bin_dir" ]]; then
-            # Remove existing entry and re-prepend.
+            # Remove existing Resources/bin and Contents/MacOS entries,
+            # then prepend Resources/bin. Contents/MacOS contains the GUI
+            # app binary which must not shadow the CLI wrapper.
             local -a parts=("${(@s/:/)PATH}")
             parts=("${(@)parts:#$bin_dir}")
+            parts=("${(@)parts:#${GHOSTTY_BIN_DIR}}")
             PATH="${bin_dir}:${(j/:/)parts}"
         fi
     fi


### PR DESCRIPTION
## Summary

- Strip `GHOSTTY_BIN_DIR` (`Contents/MacOS`) from PATH in `_cmux_fix_path` for both bash and zsh
- Prevents the GUI app binary from being resolved as the `cmux` CLI tool

Closes #553

## Root cause

Ghostty's `Exec.zig` appends the executable directory (`Contents/MacOS`) to PATH and sets `GHOSTTY_BIN_DIR`. This is intentional in upstream Ghostty where the same binary handles both GUI and CLI (`ghostty +action`). cmux uses separate binaries — `Contents/MacOS/cmux` (SwiftUI app, `cmuxApp`) and `Contents/Resources/bin/cmux` (CLI tool built from `CLI/cmux.swift`, `cmux-cli` target).

In v0.61.0, the shell integration `_cmux_fix_path` prepends `Resources/bin` to the front of PATH but does not remove `Contents/MacOS`. If PATH is reordered (e.g., by macOS `path_helper`, user shell config) or shell integration is bypassed (non-interactive shells), `cmux` resolves to the GUI binary, which launches a GUI process instead of handling CLI commands.

## Fix

In `_cmux_fix_path`, also remove `GHOSTTY_BIN_DIR` from PATH before prepending `Resources/bin`. The GUI app binary has no reason to be on PATH.

**bash** (`cmux-bash-integration.bash`):
```bash
new_path="${new_path//:${GHOSTTY_BIN_DIR}:/:}"
```

**zsh** (`cmux-zsh-integration.zsh`):
```zsh
parts=("${(@)parts:#${GHOSTTY_BIN_DIR}}")
```

## Test plan

- [ ] `echo "$PATH" | tr ':' '\n' | grep 'Contents/MacOS'` returns no output (stripped)
- [ ] `echo "$PATH" | tr ':' '\n' | grep 'Contents/Resources/bin'` shows the CLI directory
- [ ] `which cmux` resolves to `Contents/Resources/bin/cmux`
- [ ] `cmux identify --json` returns valid JSON
- [ ] Verified in both zsh and bash