### PR TITLE
docs: add full OpenCode integration via opencode-cmux npm package

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -108,22 +108,142 @@ notify = ["bash", "~/.local/bin/codex-notify.sh"]
 
 ### OpenCode Plugin
 
-Create `.opencode/plugins/cmux-notify.js`:
+The easiest way to get full cmux integration in OpenCode is via the
+[`opencode-cmux`](https://www.npmjs.com/package/opencode-cmux) npm package.
+
+Add to `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "plugin": ["opencode-cmux"]
+}
+```
+
+OpenCode will download the package automatically on next start. This covers all events
+out of the box: session status (busy/idle/error), subagent detection, permission requests,
+and question prompts — with sidebar status pills and desktop notifications.
+
+#### What it does
+
+| Event | cmux action |
+|---|---|
+| Session starts working | Sidebar status: "working" (amber, terminal icon) |
+| Session completes (primary) | Desktop notification + log + clear status |
+| Session completes (subagent) | Log only — no notification spam |
+| Session error | Desktop notification + log + clear status |
+| Permission requested | Desktop notification + sidebar status: "waiting" (red) |
+| AI has a question (`ask` tool) | Desktop notification + sidebar status: "question" (purple) |
+
+#### Inline plugin (for customization)
+
+If you prefer to inline the plugin or customize the behavior, create
+`~/.config/opencode/plugins/cmux.js`:
 
 ```javascript
-export const CmuxNotificationPlugin = async ({ $, }) => {
-  const notify = async (title, body) => {
+import { existsSync } from "node:fs";
+
+function isInCmux() {
+  return (
+    existsSync(process.env.CMUX_SOCKET_PATH ?? "/tmp/cmux.sock") ||
+    !!process.env.CMUX_WORKSPACE_ID
+  );
+}
+
+async function notify($, opts) {
+  if (!isInCmux()) return;
+  try {
+    const args = ["--title", opts.title];
+    if (opts.subtitle) args.push("--subtitle", opts.subtitle);
+    if (opts.body) args.push("--body", opts.body);
+    await $`cmux notify ${args}`.quiet().nothrow();
+  } catch {}
+}
+
+async function setStatus($, key, text, opts) {
+  if (!isInCmux()) return;
+  try {
+    const args = [key, text];
+    if (opts?.icon) args.push("--icon", opts.icon);
+    if (opts?.color) args.push("--color", opts.color);
+    await $`cmux set-status ${args}`.quiet().nothrow();
+  } catch {}
+}
+
+async function clearStatus($, key) {
+  if (!isInCmux()) return;
+  try {
+    await $`cmux clear-status ${key}`.quiet().nothrow();
+  } catch {}
+}
+
+async function log($, message, opts) {
+  if (!isInCmux()) return;
+  try {
+    const args = [];
+    if (opts?.level) args.push("--level", opts.level === "warn" ? "warning" : opts.level);
+    if (opts?.source) args.push("--source", opts.source);
+    args.push("--", message);
+    await $`cmux log ${args}`.quiet().nothrow();
+  } catch {}
+}
+
+export default async ({ client, $ }) => {
+  async function fetchSession(sessionID) {
     try {
-      await $`command -v cmux && cmux notify --title ${title} --body ${body}`;
+      const result = await client.session.get({ path: { id: sessionID } });
+      return result.data ?? null;
     } catch {
-      await $`osascript -e ${"display notification \"" + body + "\" with title \"" + title + "\""}`;
+      return null;
     }
-  };
+  }
 
   return {
-    event: async ({ event }) => {
-      if (event.type === "session.idle") {
-        await notify("OpenCode", "Session idle");
+    async event({ event }) {
+      if (event.type === "session.status") {
+        const { sessionID, status } = event.properties;
+
+        if (status.type === "busy") {
+          await setStatus($, "opencode", "working", { icon: "terminal", color: "#f59e0b" });
+          return;
+        }
+
+        if (status.type === "idle") {
+          const session = await fetchSession(sessionID);
+          const title = session?.title ?? sessionID;
+
+          if (!session?.parentID) {
+            // Primary session — notify + clear status
+            await notify($, { title: `Done: ${title}` });
+            await log($, `Done: ${title}`, { level: "success", source: "opencode" });
+            await clearStatus($, "opencode");
+          } else {
+            // Subagent — log only to avoid notification spam
+            await log($, `Subagent finished: ${title}`, { level: "info", source: "opencode" });
+          }
+          return;
+        }
+      }
+
+      if (event.type === "session.error") {
+        const sessionID = event.properties.sessionID;
+        const session = sessionID ? await fetchSession(sessionID) : null;
+        const title = session?.title ?? sessionID ?? "unknown session";
+
+        await notify($, { title: `Error: ${title}` });
+        await log($, `Error in session: ${title}`, { level: "error", source: "opencode" });
+        await clearStatus($, "opencode");
+      }
+    },
+
+    async "permission.ask"(input) {
+      await notify($, { title: "Needs your permission", subtitle: input.title });
+      await setStatus($, "opencode", "waiting", { icon: "lock", color: "#ef4444" });
+    },
+
+    async "tool.execute.before"(input) {
+      if (input.tool === "ask") {
+        await notify($, { title: "Has a question" });
+        await setStatus($, "opencode", "question", { icon: "help-circle", color: "#a855f7" });
       }
     },
   };
@@ -137,13 +257,18 @@ cmux sets these in child shells:
 | Variable | Description |
 |----------|-------------|
 | `CMUX_SOCKET_PATH` | Path to control socket |
-| `CMUX_TAB_ID` | UUID of the current tab |
-| `CMUX_PANEL_ID` | UUID of the current panel |
+| `CMUX_WORKSPACE_ID` | UUID of the current workspace |
+| `CMUX_SURFACE_ID` | UUID of the current surface/panel |
+| `CMUX_TAB_ID` | UUID of the current tab (legacy name for `CMUX_WORKSPACE_ID`) |
+| `CMUX_PANEL_ID` | UUID of the current panel (legacy name for `CMUX_SURFACE_ID`) |
 
 ## CLI Commands
 
 ```
 cmux notify --title <text> [--subtitle <text>] [--body <text>] [--tab <id|index>] [--panel <id|index>]
+cmux set-status <key> <text> [--icon <name>] [--color <#hex>]
+cmux clear-status <key>
+cmux log <message> [--level info|success|error|warning] [--source <name>]
 cmux list-notifications
 cmux clear-notifications
 cmux ping
@@ -151,6 +276,6 @@ cmux ping
 
 ## Best Practices
 
-1. **Always check availability first** - Use `command -v cmux` before calling
+1. **Always check availability first** - Use `command -v cmux` before calling, or check `CMUX_WORKSPACE_ID`
 2. **Provide fallbacks** - Use `|| osascript` for macOS fallback
 3. **Keep notifications concise** - Title should be brief, use body for details


### PR DESCRIPTION
## Summary
The existing OpenCode section in `docs/notifications.md` was a minimal placeholder — it only handled `session.idle` with a basic `cmux notify` call and didn't use `set-status`, `clear-status`, or `log`.
This PR replaces it with a complete, tested integration.
## Changes
**`docs/notifications.md`**
- **OpenCode section**: replaced placeholder snippet with full integration
  - Primary install path: [`opencode-cmux`](https://www.npmjs.com/package/opencode-cmux) npm package (one line in `opencode.json`)
  - Full inline JS plugin for users who want to customize, covering all 6 event cases:
    - Session busy → sidebar status "working" (amber)
    - Session idle, primary → notification + log + clear status
    - Session idle, subagent → log only (no notification spam)
    - Session error → notification + log + clear status
    - `permission.ask` hook → notification + sidebar status "waiting" (red)
    - `tool.execute.before` (`ask` tool) → notification + sidebar status "question" (purple)
  - Proper `isInCmux()` detection (socket file + `CMUX_WORKSPACE_ID`)
  - All shell calls use `.quiet().nothrow()` — plugin never crashes OpenCode
- **CLI Commands section**: added `set-status`, `clear-status`, and `log`
- **Environment Variables table**: added `CMUX_WORKSPACE_ID` and `CMUX_SURFACE_ID` (current names), kept `CMUX_TAB_ID`/`CMUX_PANEL_ID` as legacy
- **Best Practices**: added `CMUX_WORKSPACE_ID` as alternative detection method
## Testing
The `opencode-cmux` package was built, tested locally via symlink, then published to npm and verified working with OpenCode v1.x against cmux v0.61.0.