### PR TITLE
Fix keyboard shortcuts on non-QWERTY layouts (Dvorak, Colemak, etc.)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -312,7 +312,7 @@ func shouldToggleMainWindowFullScreenForCommandControlFShortcut(
         .subtracting([.numericPad, .function, .capsLock])
     guard normalizedFlags == [.command, .control] else { return false }
     let normalizedChars = chars.lowercased()
-    return normalizedChars == "f" || keyCode == 3
+    return normalizedChars == "f" || KeyboardLayout.character(forKeyCode: keyCode) == "f"
 }
 
 func commandPaletteSelectionDeltaForKeyboardNavigation(
@@ -335,10 +335,12 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
 
     if normalizedFlags == [.control] {
         // Control modifiers can surface as either printable chars or ASCII control chars.
-        if keyCode == 45 || normalizedChars == "n" || normalizedChars == "\u{0e}" { return 1 }    // Ctrl+N
-        if keyCode == 35 || normalizedChars == "p" || normalizedChars == "\u{10}" { return -1 }   // Ctrl+P
-        if keyCode == 38 || normalizedChars == "j" || normalizedChars == "\u{0a}" { return 1 }    // Ctrl+J
-        if keyCode == 40 || normalizedChars == "k" || normalizedChars == "\u{0b}" { return -1 }   // Ctrl+K
+        // Use layout-aware keyCode translation as a fallback instead of hardcoded ANSI keyCodes.
+        let layoutChar = KeyboardLayout.character(forKeyCode: keyCode)
+        if normalizedChars == "n" || normalizedChars == "\u{0e}" || layoutChar == "n" { return 1 }    // Ctrl+N
+        if normalizedChars == "p" || normalizedChars == "\u{10}" || layoutChar == "p" { return -1 }   // Ctrl+P
+        if normalizedChars == "j" || normalizedChars == "\u{0a}" || layoutChar == "j" { return 1 }    // Ctrl+J
+        if normalizedChars == "k" || normalizedChars == "\u{0b}" || layoutChar == "k" { return -1 }   // Ctrl+K
     }
 
     return nil
@@ -416,15 +418,16 @@ func browserZoomShortcutAction(
 
     guard hasOnlyCommandAndOptionalShift else { return nil }
 
-    if key == "=" || key == "+" || keyCode == 24 || keyCode == 69 { // kVK_ANSI_Equal / kVK_ANSI_KeypadPlus
+    let layoutChar = KeyboardLayout.character(forKeyCode: keyCode)
+    if key == "=" || key == "+" || layoutChar == "=" || keyCode == 69 { // kVK_ANSI_KeypadPlus
         return .zoomIn
     }
 
-    if key == "-" || key == "_" || keyCode == 27 || keyCode == 78 { // kVK_ANSI_Minus / kVK_ANSI_KeypadMinus
+    if key == "-" || key == "_" || layoutChar == "-" || keyCode == 78 { // kVK_ANSI_KeypadMinus
         return .zoomOut
     }
 
-    if key == "0" || keyCode == 29 || keyCode == 82 { // kVK_ANSI_0 / kVK_ANSI_Keypad0
+    if key == "0" || layoutChar == "0" || keyCode == 82 { // kVK_ANSI_Keypad0
         return .reset
     }
 
@@ -4493,7 +4496,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let hasOption = flags.contains(.option)
         let isControlOnly = hasControl && !hasCommand && !hasOption
         let controlDChar = chars == "d" || event.characters == "\u{04}"
-        let isControlD = isControlOnly && (controlDChar || event.keyCode == 2)
+            || KeyboardLayout.character(forKeyCode: event.keyCode) == "d"
+        let isControlD = isControlOnly && controlDChar
 #if DEBUG
         if isControlD {
             writeChildExitKeyboardProbe(
@@ -4556,14 +4560,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        let isCommandP = normalizedFlags == [.command] && (chars == "p" || event.keyCode == 35)
+        let isCommandP = normalizedFlags == [.command] && chars == "p"
         if isCommandP {
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             NotificationCenter.default.post(name: .commandPaletteSwitcherRequested, object: targetWindow)
             return true
         }
 
-        let isCommandShiftP = normalizedFlags == [.command, .shift] && (chars == "p" || event.keyCode == 35)
+        let isCommandShiftP = normalizedFlags == [.command, .shift] && chars == "p"
         if isCommandShiftP {
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             NotificationCenter.default.post(name: .commandPaletteRequested, object: targetWindow)
@@ -4583,7 +4587,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return handleQuitShortcutWarning()
         }
         if normalizedFlags == [.command, .shift],
-           (chars == "," || chars == "<" || event.keyCode == 43) {
+           (chars == "," || chars == "<") {
             GhosttyApp.shared.reloadConfiguration(source: "shortcut.cmd_shift_comma")
             return true
         }
@@ -4795,7 +4799,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
 
-        if normalizedFlags == [.command, .option], (chars == "t" || event.keyCode == 17) {
+        if normalizedFlags == [.command, .option], chars == "t" {
             if let targetWindow = event.window ?? NSApp.keyWindow ?? NSApp.mainWindow,
                targetWindow.identifier?.rawValue == "cmux.settings" {
                 targetWindow.performClose(nil)
@@ -4816,7 +4820,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Cmd+W must close the focused panel even if first-responder momentarily lags on a
         // browser NSTextView during split focus transitions.
-        if normalizedFlags == [.command], (chars == "w" || event.keyCode == 13) {
+        if normalizedFlags == [.command], chars == "w" {
             if let targetWindow = event.window ?? NSApp.keyWindow ?? NSApp.mainWindow,
                targetWindow.identifier?.rawValue == "cmux.settings" {
                 targetWindow.performClose(nil)
@@ -5331,10 +5335,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let chars = (event.charactersIgnoringModifiers ?? "").lowercased()
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if flags == [.command, .option] {
-            if chars == "i" || event.keyCode == 34 {
+            if chars == "i" {
                 return "toggle.literal"
             }
-            if chars == "c" || event.keyCode == 8 {
+            if chars == "c" {
                 return "console.literal"
             }
         }
@@ -5555,84 +5559,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .subtracting([.numericPad, .function])
         guard flags == shortcut.modifierFlags else { return false }
 
-        // NSEvent.charactersIgnoringModifiers preserves Shift for some symbol keys
-        // (e.g. Shift+] can yield "}" instead of "]"), so match brackets by keyCode.
         let shortcutKey = shortcut.key.lowercased()
+
+        // NSEvent.charactersIgnoringModifiers preserves Shift for some symbol keys
+        // (e.g. Shift+] can yield "}" instead of "]"), so for bracket shortcuts also
+        // accept the shifted variant.
         if shortcutKey == "[" || shortcutKey == "]" {
-            switch event.keyCode {
-            case 33: // kVK_ANSI_LeftBracket
-                return shortcutKey == "["
-            case 30: // kVK_ANSI_RightBracket
-                return shortcutKey == "]"
-            default:
-                return false
+            if let chars = event.charactersIgnoringModifiers?.lowercased() {
+                if chars == shortcutKey { return true }
+                // Accept shifted variants: "{" for "[", "}" for "]"
+                if shortcutKey == "[" && chars == "{" { return true }
+                if shortcutKey == "]" && chars == "}" { return true }
             }
+            // Fall through to layout-aware keyCode translation below.
         }
 
-        // Control-key combos can produce control characters (e.g. Ctrl+H => backspace),
-        // so fall back to keyCode matching for common printable keys.
         if let chars = event.charactersIgnoringModifiers?.lowercased(), chars == shortcutKey {
             return true
         }
-        if let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
-            return event.keyCode == expectedKeyCode
+        // Control-key combos can produce control characters (e.g. Ctrl+H => backspace)
+        // instead of the base letter. Fall back to a layout-aware keyCode translation
+        // so this works correctly on non-QWERTY layouts (Dvorak, Colemak, etc.).
+        if let translated = KeyboardLayout.character(forKeyCode: event.keyCode), translated == shortcutKey {
+            return true
         }
         return false
     }
 
-    private func keyCodeForShortcutKey(_ key: String) -> UInt16? {
-        // Matches macOS ANSI key codes. This is intentionally limited to keys we
-        // support in StoredShortcut/ghostty trigger translation.
-        switch key {
-        case "a": return 0   // kVK_ANSI_A
-        case "s": return 1   // kVK_ANSI_S
-        case "d": return 2   // kVK_ANSI_D
-        case "f": return 3   // kVK_ANSI_F
-        case "h": return 4   // kVK_ANSI_H
-        case "g": return 5   // kVK_ANSI_G
-        case "z": return 6   // kVK_ANSI_Z
-        case "x": return 7   // kVK_ANSI_X
-        case "c": return 8   // kVK_ANSI_C
-        case "v": return 9   // kVK_ANSI_V
-        case "b": return 11  // kVK_ANSI_B
-        case "q": return 12  // kVK_ANSI_Q
-        case "w": return 13  // kVK_ANSI_W
-        case "e": return 14  // kVK_ANSI_E
-        case "r": return 15  // kVK_ANSI_R
-        case "y": return 16  // kVK_ANSI_Y
-        case "t": return 17  // kVK_ANSI_T
-        case "1": return 18  // kVK_ANSI_1
-        case "2": return 19  // kVK_ANSI_2
-        case "3": return 20  // kVK_ANSI_3
-        case "4": return 21  // kVK_ANSI_4
-        case "6": return 22  // kVK_ANSI_6
-        case "5": return 23  // kVK_ANSI_5
-        case "=": return 24  // kVK_ANSI_Equal
-        case "9": return 25  // kVK_ANSI_9
-        case "7": return 26  // kVK_ANSI_7
-        case "-": return 27  // kVK_ANSI_Minus
-        case "8": return 28  // kVK_ANSI_8
-        case "0": return 29  // kVK_ANSI_0
-        case "o": return 31  // kVK_ANSI_O
-        case "u": return 32  // kVK_ANSI_U
-        case "i": return 34  // kVK_ANSI_I
-        case "p": return 35  // kVK_ANSI_P
-        case "l": return 37  // kVK_ANSI_L
-        case "j": return 38  // kVK_ANSI_J
-        case "'": return 39  // kVK_ANSI_Quote
-        case "k": return 40  // kVK_ANSI_K
-        case ";": return 41  // kVK_ANSI_Semicolon
-        case "\\": return 42 // kVK_ANSI_Backslash
-        case ",": return 43  // kVK_ANSI_Comma
-        case "/": return 44  // kVK_ANSI_Slash
-        case "n": return 45  // kVK_ANSI_N
-        case "m": return 46  // kVK_ANSI_M
-        case ".": return 47  // kVK_ANSI_Period
-        case "`": return 50  // kVK_ANSI_Grave
-        default:
-            return nil
-        }
-    }
+    // keyCodeForShortcutKey was removed — it mapped logical characters to physical
+    // ANSI keyCodes, which only works on QWERTY. Use KeyboardLayout.character(forKeyCode:)
+    // for layout-aware translation instead.
 
     /// Match arrow key shortcuts using keyCode
     /// Arrow keys include .numericPad and .function in their modifierFlags, so strip those before comparing.

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -11,4 +11,37 @@ class KeyboardLayout {
 
         return nil
     }
+
+    /// Translate a physical keyCode to the character it produces under the current keyboard layout
+    /// (without any modifier keys applied). Returns `nil` when no translation is available.
+    static func character(forKeyCode keyCode: UInt16) -> String? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+              let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+
+        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+        guard let bytes = CFDataGetBytePtr(layoutData) else { return nil }
+        let keyboardLayout = bytes.withMemoryRebound(to: UCKeyboardLayout.self, capacity: 1) { $0 }
+
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+
+        let status = UCKeyTranslate(
+            keyboardLayout,
+            keyCode,
+            UInt16(kUCKeyActionDisplay),
+            0,  // no modifiers
+            UInt32(LMGetKbdType()),
+            UInt32(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            chars.count,
+            &length,
+            &chars
+        )
+
+        guard status == noErr, length > 0 else { return nil }
+        return String(utf16CodeUnits: chars, count: length).lowercased()
+    }
 }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -348,34 +348,40 @@ struct StoredShortcut: Codable, Equatable {
     }
 
     private static func storedKey(from event: NSEvent) -> String? {
-        // Prefer keyCode mapping so shifted symbol keys (e.g. "}") record as "]".
+        // Layout-independent keys: always use keyCode for these.
         switch event.keyCode {
         case 123: return "←" // left arrow
         case 124: return "→" // right arrow
         case 125: return "↓" // down arrow
         case 126: return "↑" // up arrow
         case 48: return "\t" // tab
-        case 33: return "["  // kVK_ANSI_LeftBracket
-        case 30: return "]"  // kVK_ANSI_RightBracket
-        case 27: return "-"  // kVK_ANSI_Minus
-        case 24: return "="  // kVK_ANSI_Equal
-        case 43: return ","  // kVK_ANSI_Comma
-        case 47: return "."  // kVK_ANSI_Period
-        case 44: return "/"  // kVK_ANSI_Slash
-        case 41: return ";"  // kVK_ANSI_Semicolon
-        case 39: return "'"  // kVK_ANSI_Quote
-        case 50: return "`"  // kVK_ANSI_Grave
-        case 42: return "\\" // kVK_ANSI_Backslash
         default:
             break
         }
 
+        // For character-producing keys, use layout-aware translation so the recorded
+        // shortcut matches the character the user sees, not the physical key position.
+        // This ensures correct behavior on non-QWERTY layouts (Dvorak, Colemak, etc.).
+        // UCKeyTranslate gives us the unshifted character, which normalizes shifted
+        // symbol keys (e.g. "}" records as "]").
+        if let layoutChar = KeyboardLayout.character(forKeyCode: event.keyCode) {
+            let ch = layoutChar.first
+            if ch != nil && (ch!.isLetter || ch!.isNumber) {
+                return layoutChar
+            }
+            // Accept symbol characters that are valid shortcut keys.
+            let validSymbols: Set<Character> = ["[", "]", "-", "=", ",", ".", "/", ";", "'", "`", "\\"]
+            if let ch, validSymbols.contains(ch) {
+                return layoutChar
+            }
+        }
+
+        // Fallback to charactersIgnoringModifiers for any remaining cases.
         guard let chars = event.charactersIgnoringModifiers?.lowercased(),
               let char = chars.first else {
             return nil
         }
 
-        // Allow letters/numbers; everything else should be handled by keyCode mapping above.
         if char.isLetter || char.isNumber {
             return String(char)
         }


### PR DESCRIPTION
## Summary

Keyboard shortcuts break on non-QWERTY layouts because the app uses hardcoded ANSI `keyCode` values (physical key positions) as fallbacks. On Dvorak for example:

- **Cmd+, closes a tab** instead of opening Settings, because `,` sits on the physical W key (keyCode 13) and the `Cmd+W` handler matches via `event.keyCode == 13`
- **Cmd+C doesn't copy**, because C sits on the physical J key (keyCode 38) and may get intercepted by a different shortcut's keyCode fallback

### Root cause

`NSEvent.keyCode` represents the *physical* key position (ANSI/QWERTY layout). `NSEvent.charactersIgnoringModifiers` gives the *logical* character for the current layout. The code correctly checks `charactersIgnoringModifiers` first, but falls back to hardcoded QWERTY keyCodes — which fires the wrong shortcut on alternative layouts.

### Fix

- Added `KeyboardLayout.character(forKeyCode:)` — uses `UCKeyTranslate` to translate a physical keyCode to the character it produces under the **current** keyboard layout
- Replaced `keyCodeForShortcutKey()` (a static QWERTY char→keyCode map) with the layout-aware helper in `matchShortcut()`
- Removed hardcoded `event.keyCode == N` fallbacks from `handleCustomShortcut()` for Cmd+W, Cmd+P, Cmd+Shift+P, Cmd+Shift+,, Cmd+Option+T
- Fixed Ctrl+D, Ctrl+N/P/J/K (command palette navigation), Cmd+Ctrl+F (fullscreen), and browser zoom shortcuts to use layout-aware fallbacks
- Fixed `storedKey(from:)` in `KeyboardShortcutSettings` to record the logical character for the current layout instead of assuming ANSI key positions
- Layout-independent keys (arrows, Tab, Escape, Return, keypad keys) still correctly use keyCode since their identity doesn't change between layouts

## Test plan

- [ ] On QWERTY: verify all shortcuts still work as before (Cmd+W, Cmd+P, Cmd+C/V/X, Cmd+,, Cmd+Shift+,, Cmd+Ctrl+F, Cmd+=/-, Ctrl+N/P/J/K in command palette)
- [ ] On Dvorak: verify Cmd+, opens Settings (not close tab), Cmd+C copies, Cmd+W closes tab (physical comma key, which produces W on Dvorak)
- [ ] On Dvorak: verify custom shortcut recording captures the logical character, not the physical position
- [ ] Verify Ctrl+D still correctly detected for terminal exit handling
- [ ] Verify keypad shortcuts (+/-/0) still work for browser zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)