### PR TITLE
Fix crash when hovering over notification icon in titlebar

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -749,7 +749,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         label: "com.cmuxterm.app.launchServicesRegistration",
         qos: .utility
     )
-    private static func enqueueLaunchServicesRegistrationWork(_ work: @escaping @Sendable () -> Void) {
+    nonisolated private static func enqueueLaunchServicesRegistrationWork(_ work: @escaping @Sendable () -> Void) {
         launchServicesRegistrationQueue.async(execute: work)
     }
     private var lastSessionAutosaveFingerprint: Int?

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -8,7 +8,7 @@ private func windowDragHandleFormatPoint(_ point: NSPoint) -> String {
 
 private func windowDragHandleShouldDeferHitCapture(for eventType: NSEvent.EventType?) -> Bool {
     switch eventType {
-    case nil, .mouseMoved?, .cursorUpdate?:
+    case nil, .mouseMoved?, .mouseEntered?, .mouseExited?, .cursorUpdate?, .appKitDefined?, .systemDefined?:
         return true
     default:
         return false

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6122,7 +6122,11 @@ final class WindowDragHandleHitTests: XCTestCase {
 
         let point = NSPoint(x: 180, y: 18)
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .mouseMoved))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .mouseEntered))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .mouseExited))
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .cursorUpdate))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .appKitDefined))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .systemDefined))
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: nil))
         XCTAssertTrue(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown))
     }


### PR DESCRIPTION
## Summary
- Fix crash caused by `WindowDragHandleView` capturing `mouseEntered`, `mouseExited`, `appKitDefined`, and `systemDefined` events that should be deferred — these tracking/system events were incorrectly handled as click-like events on Sonoma and Sequoia, causing a crash when hovering over the notification bell or other titlebar controls
- Fix build warning by marking `enqueueLaunchServicesRegistrationWork` as `nonisolated` since it only dispatches to a background queue

Closes #537

## Test plan
- [x] Verified build succeeds locally
- [x] Launched tagged debug app (`./scripts/reload.sh --tag fix-537-notif-hover`)
- [ ] Tested hover interactions on notification bell — no crash
- [ ] Verify on both Sonoma and Sequoia

🤖 Generated with [Claude Code](https://claude.com/claude-code)