### PR TITLE
Gate browser JS eval behind capability check in allowAll mode

### DIFF
--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -166,6 +166,13 @@ struct SocketControlSettings {
     static let launchTagEnvKey = "CMUX_TAG"
     static let baseDebugBundleIdentifier = "com.cmuxterm.app.debug"
 
+    /// When `true`, socket clients in `allowAll` mode can execute arbitrary JavaScript
+    /// via `browser.eval`, `browser.addscript`, and `browser.addinitscript`.
+    /// In other modes (cmuxOnly, automation, password), browser JS eval is always permitted
+    /// because those modes already enforce meaningful access control.
+    static let allowBrowserJSEvalInOpenAccessKey = "socketAllowBrowserJSEvalInOpenAccess"
+    static let defaultAllowBrowserJSEvalInOpenAccess = false
+
     private static func normalizeMode(_ raw: String) -> String {
         raw
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -147,6 +147,23 @@ class TerminalController {
         requested && socketCommandAllowsInAppFocusMutations()
     }
 
+    /// Commands that execute arbitrary client-supplied JavaScript (`browser.eval`,
+    /// `browser.addscript`, `browser.addinitscript`) are always allowed in modes
+    /// with meaningful access control (cmuxOnly, automation, password).  In `allowAll`
+    /// mode they are blocked by default — the user must explicitly opt in via Settings.
+    private static let browserJSEvalMethods: Set<String> = [
+        "browser.eval",
+        "browser.addscript",
+        "browser.addinitscript",
+    ]
+
+    private func isBrowserJSEvalAllowed() -> Bool {
+        guard accessMode == .allowAll else { return true }
+        return UserDefaults.standard.bool(
+            forKey: SocketControlSettings.allowBrowserJSEvalInOpenAccessKey
+        )
+    }
+
     private func v2MaybeFocusWindow(for tabManager: TabManager) {
         guard socketCommandAllowsInAppFocusMutations(),
               let windowId = v2ResolveWindowId(tabManager: tabManager) else { return }
@@ -1583,11 +1600,16 @@ class TerminalController {
         ])
 #endif
 
+        if !isBrowserJSEvalAllowed() {
+            methods.removeAll { Self.browserJSEvalMethods.contains($0) }
+        }
+
         return [
             "protocol": "cmux-socket",
             "version": 2,
             "socket_path": socketPath,
             "access_mode": accessMode.rawValue,
+            "browser_js_eval_allowed": isBrowserJSEvalAllowed(),
             "methods": methods.sorted()
         ]
     }
@@ -5169,6 +5191,13 @@ class TerminalController {
     }
 
     private func v2BrowserEval(params: [String: Any]) -> V2CallResult {
+        guard isBrowserJSEvalAllowed() else {
+            return .err(
+                code: "capability_disabled",
+                message: "browser.eval is disabled in full open access mode. Enable 'Allow browser JS eval in open access' in Settings > Automation.",
+                data: ["capability": "browser_js_eval", "access_mode": accessMode.rawValue]
+            )
+        }
         guard let script = v2String(params, "script") else {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }
@@ -7603,6 +7632,13 @@ class TerminalController {
     }
 
     private func v2BrowserAddInitScript(params: [String: Any]) -> V2CallResult {
+        guard isBrowserJSEvalAllowed() else {
+            return .err(
+                code: "capability_disabled",
+                message: "browser.addinitscript is disabled in full open access mode. Enable 'Allow browser JS eval in open access' in Settings > Automation.",
+                data: ["capability": "browser_js_eval", "access_mode": accessMode.rawValue]
+            )
+        }
         guard let script = v2String(params, "script") ?? v2String(params, "content") else {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }
@@ -7626,6 +7662,13 @@ class TerminalController {
     }
 
     private func v2BrowserAddScript(params: [String: Any]) -> V2CallResult {
+        guard isBrowserJSEvalAllowed() else {
+            return .err(
+                code: "capability_disabled",
+                message: "browser.addscript is disabled in full open access mode. Enable 'Allow browser JS eval in open access' in Settings > Automation.",
+                data: ["capability": "browser_js_eval", "access_mode": accessMode.rawValue]
+            )
+        }
         guard let script = v2String(params, "script") ?? v2String(params, "content") else {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2620,6 +2620,8 @@ struct SettingsView: View {
 
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
+    @AppStorage(SocketControlSettings.allowBrowserJSEvalInOpenAccessKey)
+    private var allowBrowserJSEvalInOpenAccess = SocketControlSettings.defaultAllowBrowserJSEvalInOpenAccess
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
@@ -3095,6 +3097,18 @@ struct SettingsView: View {
                         }
                         if selectedSocketControlMode == .allowAll {
                             SettingsCardDivider()
+                            SettingsCardRow(
+                                "Allow Browser JS Eval",
+                                subtitle: allowBrowserJSEvalInOpenAccess
+                                    ? "Socket clients can execute arbitrary JavaScript in browser tabs via browser.eval, browser.addscript, and browser.addinitscript."
+                                    : "Arbitrary JavaScript execution via socket is blocked. Structured browser commands (click, type, snapshot, etc.) still work."
+                            ) {
+                                Toggle("", isOn: $allowBrowserJSEvalInOpenAccess)
+                                    .labelsHidden()
+                                    .controlSize(.small)
+                                    .accessibilityIdentifier("SettingsAllowBrowserJSEvalToggle")
+                            }
+                            SettingsCardDivider()
                             Text("Warning: Full open access makes the control socket world-readable/writable on this Mac and disables auth checks. Use only for local debugging.")
                                 .font(.caption)
                                 .foregroundStyle(.red)
@@ -3469,6 +3483,7 @@ struct SettingsView: View {
     private func resetAllSettings() {
         appearanceMode = AppearanceSettings.defaultMode.rawValue
         socketControlMode = SocketControlSettings.defaultMode.rawValue
+        allowBrowserJSEvalInOpenAccess = SocketControlSettings.defaultAllowBrowserJSEvalInOpenAccess
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled


### PR DESCRIPTION
## Summary

- Adds a capability layer that blocks `browser.eval`, `browser.addscript`, and `browser.addinitscript` when socket mode is `allowAll` (full open access), preventing arbitrary JavaScript execution in WKWebView by unauthorized local processes
- Adds a new "Allow Browser JS Eval" toggle in Settings > Automation (shown only in `allowAll` mode) for users who need this capability and accept the risk
- `system.capabilities` response now includes `browser_js_eval_allowed` flag and conditionally excludes gated methods from the methods list
- No behavior change for `cmuxOnly`, `automation`, or `password` modes — these already enforce meaningful access control

## Test plan

- [ ] Build and launch in `allowAll` mode, verify `browser.eval` returns `capability_disabled` error
- [ ] Toggle "Allow Browser JS Eval" ON in Settings, verify `browser.eval` works
- [ ] Toggle OFF, verify blocked again
- [ ] Verify `browser.click`, `browser.type`, `browser.snapshot` etc. still work in `allowAll` mode regardless of toggle
- [ ] Verify `browser.eval` works normally in `cmuxOnly` mode (no capability gate)
- [ ] Verify `system.capabilities` excludes gated methods when toggle is OFF in `allowAll` mode
- [ ] Verify Settings reset restores the toggle to OFF

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)