### PR TITLE
Fix frozen blank launch state from session restore race (#399)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2056,6 +2056,50 @@ struct ContentView: View {
                 lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
             }
             updateTitlebarText()
+
+            // Startup recovery (#399): if session restore or a race condition leaves the
+            // view in a broken state (empty tabs, no selection, unmounted workspaces),
+            // detect and recover after a short delay.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak tabManager] in
+                guard let tabManager else { return }
+                var didRecover = false
+
+                // Ensure there is at least one workspace.
+                if tabManager.tabs.isEmpty {
+                    tabManager.addWorkspace()
+                    didRecover = true
+                }
+
+                // Ensure selectedTabId points to an existing workspace.
+                if tabManager.selectedTabId == nil || !tabManager.tabs.contains(where: { $0.id == tabManager.selectedTabId }) {
+                    tabManager.selectedTabId = tabManager.tabs.first?.id
+                    didRecover = true
+                }
+
+                // Ensure mountedWorkspaceIds is populated.
+                if mountedWorkspaceIds.isEmpty || !mountedWorkspaceIds.contains(where: { id in tabManager.tabs.contains { $0.id == id } }) {
+                    reconcileMountedWorkspaceIds()
+                    didRecover = true
+                }
+
+                // Ensure sidebar selection is valid.
+                if selectedTabIds.isEmpty, let selectedId = tabManager.selectedTabId {
+                    selectedTabIds = [selectedId]
+                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                    didRecover = true
+                }
+
+                if didRecover {
+#if DEBUG
+                    dlog("startup.recovery tabCount=\(tabManager.tabs.count) selected=\(tabManager.selectedTabId?.uuidString.prefix(8) ?? "nil") mounted=\(mountedWorkspaceIds.count)")
+#endif
+                    sentryBreadcrumb("startup.recovery", data: [
+                        "tabCount": tabManager.tabs.count,
+                        "selectedTabId": tabManager.selectedTabId?.uuidString ?? "nil",
+                        "mountedCount": mountedWorkspaceIds.count
+                    ])
+                }
+            }
         })
 
         view = AnyView(view.onChange(of: tabManager.selectedTabId) { newValue in

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3374,7 +3374,7 @@ extension TabManager {
             unwireClosedBrowserTracking(for: tab)
         }
 
-        tabs.removeAll(keepingCapacity: false)
+        // Clear non-@Published state without touching tabs/selectedTabId yet.
         lastFocusedPanelByTab.removeAll()
         pendingPanelTitleUpdates.removeAll()
         tabHistory.removeAll()
@@ -3387,6 +3387,10 @@ extension TabManager {
         selectionSideEffectsGeneration &+= 1
         recentlyClosedBrowsers = RecentlyClosedBrowserStack(capacity: 20)
 
+        // Build the new workspace list locally to avoid intermediate @Published
+        // emissions (empty tabs, nil selectedTabId) that can leave SwiftUI's
+        // mountedWorkspaceIds empty and cause a frozen blank launch state (#399).
+        var newTabs: [Workspace] = []
         let workspaceSnapshots = snapshot.workspaces
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
         for workspaceSnapshot in workspaceSnapshots {
@@ -3399,20 +3403,30 @@ extension TabManager {
             )
             workspace.restoreSessionSnapshot(workspaceSnapshot)
             wireClosedBrowserTracking(for: workspace)
-            tabs.append(workspace)
+            newTabs.append(workspace)
         }
 
-        if tabs.isEmpty {
-            _ = addWorkspace(select: false)
+        if newTabs.isEmpty {
+            let ordinal = Self.nextPortOrdinal
+            Self.nextPortOrdinal += 1
+            let fallback = Workspace(title: "Terminal 1", portOrdinal: ordinal)
+            wireClosedBrowserTracking(for: fallback)
+            newTabs.append(fallback)
         }
 
-        selectedTabId = nil
+        // Determine selection before mutating @Published properties.
+        let newSelectedId: UUID?
         if let selectedWorkspaceIndex = snapshot.selectedWorkspaceIndex,
-           tabs.indices.contains(selectedWorkspaceIndex) {
-            selectedTabId = tabs[selectedWorkspaceIndex].id
+           newTabs.indices.contains(selectedWorkspaceIndex) {
+            newSelectedId = newTabs[selectedWorkspaceIndex].id
         } else {
-            selectedTabId = tabs.first?.id
+            newSelectedId = newTabs.first?.id
         }
+
+        // Single atomic assignment of @Published properties so SwiftUI observers
+        // never see an intermediate state with empty tabs or nil selection.
+        tabs = newTabs
+        selectedTabId = newSelectedId
 
         if let selectedTabId {
             NotificationCenter.default.post(


### PR DESCRIPTION
## Summary
- **Root cause**: `TabManager.restoreSessionSnapshot` modified `@Published` properties (`tabs`, `selectedTabId`) through multiple intermediate states — `tabs.removeAll()` followed by individual appends, then `selectedTabId = nil` then reassignment. SwiftUI's `onReceive(tabManager.$tabs)` could observe the intermediate empty state, causing `mountedWorkspaceIds` to become empty and leaving the terminal content area blank.
- **Fix 1 — Atomic restore**: Build the new workspace list in a local variable and assign `tabs` and `selectedTabId` in a single batch, so SwiftUI observers never see an intermediate empty state.
- **Fix 2 — Startup recovery timer**: 500ms after `ContentView.onAppear`, verify that tabs are non-empty, `selectedTabId` is valid, `mountedWorkspaceIds` is populated, and sidebar selection is set. If any check fails, trigger recovery. Logs a Sentry breadcrumb when recovery fires for diagnostics.

## Test plan
- [x] Build succeeds (`xcodebuild ... build`)
- [x] App launches normally via `./scripts/reload.sh --tag fix-399-frozen-launch`
- [ ] Verify session restore works correctly (quit app with multiple workspaces, relaunch)
- [ ] Verify new workspace creation still works (Cmd+T)
- [ ] Verify no frozen blank state on repeated launch/quit cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)