### PR TITLE
Fix use-after-free crash in ghostty_surface_refresh after wake

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3079,7 +3079,9 @@ final class Workspace: Identifiable, ObservableObject {
             }
 
             hostedView.reconcileGeometryNow()
-            if hasSurface {
+            // Re-check surface after reconcileGeometryNow() which can trigger AppKit
+            // layout and view lifecycle changes that free surfaces (#432).
+            if terminalPanel.surface.surface != nil {
                 terminalPanel.surface.forceRefresh()
             } else if isAttached && hasUsableBounds {
                 terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()


### PR DESCRIPTION
## Summary

Fixes #432 — crash (`EXC_BAD_ACCESS / KERN_INVALID_ADDRESS at ghostty_surface_refresh`) during geometry reconcile after wake-from-sleep.

- **Re-read `self.surface` before each ghostty C call** in `forceRefresh()` instead of using a stale captured local from the initial guard. The old code captured `surface` once at the top and reused it across `ghostty_surface_set_display_id` and `ghostty_surface_refresh`, but AppKit layout triggered by `forceRefreshSurface()` can invalidate the surface between calls.
- **Nil out `self.surface` in `deinit`** before scheduling the async `ghostty_surface_free` Task. This ensures any in-flight closures (geometry reconcile dispatched via `DispatchQueue.main.async`) that read `self.surface` will see nil and bail out, rather than passing a freed pointer.
- **Re-check surface validity in `reconcileTerminalGeometryPass()`** after `reconcileGeometryNow()` instead of relying on the `hasSurface` variable captured before the reconcile, which can trigger AppKit layout that frees surfaces.

## Test plan

- [ ] Build and launch with `./scripts/reload.sh --tag fix-432-surface-refresh`
- [ ] Put machine to sleep and wake — verify no crash in `ghostty_surface_refresh`
- [ ] Close/split panes rapidly during wake — verify geometry reconcile completes without crash
- [ ] Verify terminal rendering works normally after wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)