### PR TITLE
Fix crash on launch: exclusive access violation in drag handle hit test

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6075,7 +6075,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(dragHandle)
 
         XCTAssertTrue(
-            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle),
+            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle, eventType: .leftMouseDown),
             "Empty titlebar space should drag the window"
         )
     }
@@ -6089,10 +6089,10 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(folderIconHost)
 
         XCTAssertFalse(
-            windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle),
+            windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle, eventType: .leftMouseDown),
             "Interactive titlebar controls should receive the mouse event"
         )
-        XCTAssertTrue(windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle))
+        XCTAssertTrue(windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle, eventType: .leftMouseDown))
     }
 
     func testDragHandleIgnoresHiddenSiblingWhenResolvingHit() {
@@ -6104,7 +6104,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         hidden.isHidden = true
         container.addSubview(hidden)
 
-        XCTAssertTrue(windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle))
+        XCTAssertTrue(windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle, eventType: .leftMouseDown))
     }
 
     func testDragHandleDoesNotCaptureOutsideBounds() {
@@ -6112,7 +6112,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         let dragHandle = NSView(frame: container.bounds)
         container.addSubview(dragHandle)
 
-        XCTAssertFalse(windowDragHandleShouldCaptureHit(NSPoint(x: 240, y: 18), in: dragHandle))
+        XCTAssertFalse(windowDragHandleShouldCaptureHit(NSPoint(x: 240, y: 18), in: dragHandle, eventType: .leftMouseDown))
     }
 
     func testDragHandleSkipsCaptureForPassivePointerEvents() {
@@ -6141,7 +6141,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(passiveHost)
 
         XCTAssertTrue(
-            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle),
+            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle, eventType: .leftMouseDown),
             "Passive host wrappers should not block titlebar drag capture"
         )
     }
@@ -6157,7 +6157,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(passiveHost)
 
         XCTAssertFalse(
-            windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle),
+            windowDragHandleShouldCaptureHit(NSPoint(x: 14, y: 14), in: dragHandle, eventType: .leftMouseDown),
             "Interactive controls inside passive host wrappers should still receive hits"
         )
     }
@@ -6202,7 +6202,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         nestedContainer.addSubview(nestedDragHandle)
 
         XCTAssertFalse(
-            windowDragHandleShouldCaptureHit(point, in: nestedDragHandle),
+            windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown),
             "Nested window drag handle should be blocked by top-hit titlebar container"
         )
 
@@ -6210,11 +6210,11 @@ final class WindowDragHandleHitTests: XCTestCase {
         let probe = PassThroughProbeView(frame: outerContainer.bounds)
         probe.autoresizingMask = [.width, .height]
         probe.onHitTest = {
-            nestedCaptureResult = windowDragHandleShouldCaptureHit(point, in: nestedDragHandle)
+            nestedCaptureResult = windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown)
         }
         outerContainer.addSubview(probe)
 
-        _ = windowDragHandleShouldCaptureHit(point, in: outerDragHandle)
+        _ = windowDragHandleShouldCaptureHit(point, in: outerDragHandle, eventType: .leftMouseDown)
 
         XCTAssertEqual(
             nestedCaptureResult,
@@ -6233,7 +6233,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(mutatingSibling)
 
         XCTAssertTrue(
-            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle),
+            windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle, eventType: .leftMouseDown),
             "Subview mutations during hit testing should not crash or break drag-handle capture"
         )
     }


### PR DESCRIPTION
## Summary

Fixes #490 — crash on launch with a Swift exclusive access violation in `windowDragHandleShouldCaptureHit`.

- **Root cause:** During app launch, `mouseMoved` events trigger `hitTest` on the drag handle while SwiftUI is performing a layout pass. The previous blacklist approach in `windowDragHandleShouldDeferHitCapture` only blocked `mouseMoved`, `cursorUpdate`, and `nil` event types, but `NSApp.currentEvent` can be a different event type (e.g., an activation event) when the actual `mouseMoved` is being routed. This lets the function proceed to `contentView.hitTest()`, which re-enters SwiftUI views whose state is being modified — triggering the exclusive access violation.
- **Fix:** Switch from a blacklist to a whitelist — only `leftMouseDown` (the sole event the drag handle handles) proceeds with the full view-hierarchy walk. All other event types bail out immediately. Also moves the deferred-event check to the very first line of `windowDragHandleShouldCaptureHit` so no view state is touched before the guard fires.
- **Tests:** Updated all `WindowDragHandleHitTests` to pass explicit `eventType: .leftMouseDown` instead of relying on `NSApp.currentEvent?.type` (which was fragile in test environments).

## Test plan

- [x] Build succeeds (`xcodebuild -scheme cmux -configuration Debug build`)
- [x] App launches without crash via `./scripts/reload.sh --tag fix-490-drag-handle-crash`
- [ ] Verify on macOS Sonoma (the reporter's OS) that the crash no longer occurs when launching from Finder/Dock
- [ ] Run `WindowDragHandleHitTests` on VM to confirm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Acknowledgements

- Thanks to @andrewcummings for filing #490 with detailed repro + stack analysis, and for sharing additional edge-case findings in #550.
- Thanks to @dragonhuntr for the related passive-event hardening work in #550.
- Thanks to @lawrencecchen for prior drag-handle exclusivity hardening in #508.
