### PR TITLE
Fix notification bell hover crash

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -200,7 +200,7 @@ struct TitlebarControlButton<Content: View>: View {
     @State private var isHovering = false
 
     var body: some View {
-        Button(action: action) {
+        let baseButton = Button(action: action) {
             content()
                 .frame(width: config.buttonSize, height: config.buttonSize)
                 .contentShape(Rectangle())
@@ -209,7 +209,12 @@ struct TitlebarControlButton<Content: View>: View {
         .frame(width: config.buttonSize, height: config.buttonSize)
         .contentShape(Rectangle())
         .background(hoverBackground)
-        .onHover { isHovering = $0 }
+
+        if titlebarControlsShouldTrackButtonHover(config: config) {
+            baseButton.onHover { isHovering = $0 }
+        } else {
+            baseButton
+        }
     }
 
     @ViewBuilder
@@ -341,7 +346,7 @@ struct TitlebarControlsView: View {
                 .frame(width: config.buttonSize, height: config.buttonSize)
             }
             .accessibilityIdentifier("titlebarControl.showNotifications")
-            .overlay(NotificationsAnchorView { viewModel.notificationsAnchorView = $0 }.allowsHitTesting(false))
+            .background(NotificationsAnchorView { viewModel.notificationsAnchorView = $0 })
             .accessibilityLabel("Notifications")
             .help(KeyboardShortcutSettings.Action.showNotifications.tooltip("Show notifications"))
 
@@ -661,6 +666,10 @@ struct TitlebarControlsLayoutSnapshot: Equatable {
     let contentSize: NSSize
     let containerHeight: CGFloat
     let yOffset: CGFloat
+}
+
+func titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyleConfig) -> Bool {
+    config.hoverBackground
 }
 
 func titlebarControlsShouldScheduleForViewSizeChange(

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -263,6 +263,16 @@ final class TitlebarControlsSizingPolicyTests: XCTestCase {
     }
 }
 
+final class TitlebarControlsHoverPolicyTests: XCTestCase {
+    func testHoverTrackingOnlyEnabledForHoverBackgroundStyles() {
+        XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.classic.config))
+        XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.compact.config))
+        XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.roomy.config))
+        XCTAssertTrue(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.pillGroup.config))
+        XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.softButtons.config))
+    }
+}
+
 /// Regression test: ensure new terminal windows are born in full-size content mode so
 /// titlebar/content offsets are correct before the first resize.
 final class MainWindowLayoutStyleTests: XCTestCase {


### PR DESCRIPTION
## Summary

- Only enable `.onHover` tracking on `TitlebarControlButton` when the style has `hoverBackground` enabled (e.g. `pillGroup`). Styles without a visible hover background no longer install the tracking area, preventing the crash on notification-bell hover.
- Switch the notifications anchor from `.overlay` to `.background` so AppKit hit-testing no longer conflicts with the popover anchor view.
- Add regression test (`TitlebarControlsHoverPolicyTests`) verifying hover tracking is only enabled for styles that use hover backgrounds.

## Test plan

- [ ] Hover over the notification bell icon in all titlebar styles (classic, compact, roomy, pillGroup, softButtons) -- no crash
- [ ] Notification popover still opens correctly when clicking the bell
- [ ] `TitlebarControlsHoverPolicyTests` passes

Fixes https://github.com/manaflow-ai/cmux/issues/537