### PR TITLE
Fix equalize splits no-op

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1385,6 +1385,7 @@ struct ContentView: View {
         static let workspaceHasCustomName = "workspace.hasCustomName"
         static let workspaceShouldPin = "workspace.shouldPin"
         static let workspaceHasPullRequests = "workspace.hasPullRequests"
+        static let workspaceHasSplits = "workspace.hasSplits"
 
         static let hasFocusedPanel = "panel.hasFocus"
         static let panelName = "panel.name"
@@ -3373,6 +3374,10 @@ struct ContentView: View {
                 CommandPaletteContextKeys.workspaceHasPullRequests,
                 !workspace.sidebarPullRequestsInDisplayOrder().isEmpty
             )
+            snapshot.setBool(
+                CommandPaletteContextKeys.workspaceHasSplits,
+                workspace.bonsplitController.allPaneIds.count > 1
+            )
         }
 
         if let panelContext = focusedPanelContext {
@@ -3938,6 +3943,15 @@ struct ContentView: View {
                 when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
             )
         )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.equalizeSplits",
+                title: constant("Equalize Splits"),
+                subtitle: workspaceSubtitle,
+                keywords: ["split", "equalize", "balance", "divider", "layout"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
 
         return contributions
     }
@@ -4179,6 +4193,13 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.terminalSplitBrowserDown") {
             _ = tabManager.createBrowserSplit(direction: .down)
+        }
+        registry.register(commandId: "palette.equalizeSplits") {
+            guard let workspace = tabManager.selectedWorkspace,
+                  tabManager.equalizeSplits(tabId: workspace.id) else {
+                NSSound.beep()
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Implement `equalizeSplits` in `TabManager` by recursively walking the bonsplit tree and setting every divider position to 0.5 (previously was a stub that always returned `false`)
- Register `palette.equalizeSplits` command in the command palette with a `workspaceHasSplits` precondition so it only appears when there are multiple panes
- Add regression test that creates a nested split layout, skews dividers, equalizes, and verifies all positions are 0.5

Fixes https://github.com/manaflow-ai/cmux/issues/571

## Test plan

- [ ] Open a workspace with 2+ splits, run "Equalize Splits" from the command palette, verify all dividers snap to equal sizes
- [ ] Verify the command does not appear in the palette when there is only a single pane
- [ ] Nested splits (3+ panes) should all equalize recursively