### PR TITLE
Replace keychain password storage with file-based storage

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
+					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 			/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -213,6 +214,7 @@
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -425,6 +427,7 @@
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
+					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -634,6 +637,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -56,6 +56,7 @@ struct cmuxApp: App {
             defaults.set(legacy ? SocketControlMode.cmuxOnly.rawValue : SocketControlMode.off.rawValue,
                          forKey: SocketControlSettings.appStorageKey)
         }
+        SocketControlPasswordStore.migrateLegacyKeychainPasswordIfNeeded(defaults: defaults)
         migrateSidebarAppearanceDefaultsIfNeeded(defaults: defaults)
 
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
@@ -2751,7 +2752,7 @@ struct SettingsView: View {
         do {
             try SocketControlPasswordStore.savePassword(trimmed)
             socketPasswordDraft = ""
-            socketPasswordStatusMessage = "Password saved to keychain."
+            socketPasswordStatusMessage = "Password saved."
             socketPasswordStatusIsError = false
         } catch {
             socketPasswordStatusMessage = "Failed to save password (\(error.localizedDescription))."
@@ -3063,7 +3064,7 @@ struct SettingsView: View {
                             SettingsCardRow(
                                 "Socket Password",
                                 subtitle: hasSocketPasswordConfigured
-                                    ? "Stored in login keychain."
+                                    ? "Stored in Application Support."
                                     : "No password set. External clients will be blocked until one is configured."
                             ) {
                                 HStack(spacing: 8) {

--- a/cmuxTests/SocketControlPasswordStoreTests.swift
+++ b/cmuxTests/SocketControlPasswordStoreTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SocketControlPasswordStoreTests: XCTestCase {
+    func testSaveLoadAndClearRoundTripUsesFileStorage() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("socket-password.txt", isDirectory: false)
+
+        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+
+        try SocketControlPasswordStore.savePassword("hunter2", fileURL: fileURL)
+        XCTAssertEqual(try SocketControlPasswordStore.loadPassword(fileURL: fileURL), "hunter2")
+        XCTAssertTrue(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+
+        try SocketControlPasswordStore.clearPassword(fileURL: fileURL)
+        XCTAssertNil(try SocketControlPasswordStore.loadPassword(fileURL: fileURL))
+        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+    }
+
+    func testConfiguredPasswordPrefersEnvironmentOverStoredFile() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("socket-password.txt", isDirectory: false)
+        try SocketControlPasswordStore.savePassword("stored-secret", fileURL: fileURL)
+
+        let environment = [SocketControlSettings.socketPasswordEnvKey: "env-secret"]
+        let configured = SocketControlPasswordStore.configuredPassword(
+            environment: environment,
+            fileURL: fileURL
+        )
+        XCTAssertEqual(configured, "env-secret")
+    }
+
+    func testDefaultPasswordFileURLUsesCmuxAppSupportPath() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let resolved = SocketControlPasswordStore.defaultPasswordFileURL(appSupportDirectory: tempDir)
+        XCTAssertEqual(
+            resolved?.path,
+            tempDir.appendingPathComponent("cmux", isDirectory: true)
+                .appendingPathComponent("socket-control-password", isDirectory: false).path
+        )
+    }
+
+    func testLegacyKeychainMigrationCopiesPasswordDeletesLegacyAndRunsOnlyOnce() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("socket-password.txt", isDirectory: false)
+        let defaultsSuiteName = "cmux-socket-password-migration-tests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: defaultsSuiteName) else {
+            XCTFail("Expected isolated UserDefaults suite for migration test")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+
+        var lookupCount = 0
+        var deleteCount = 0
+
+        SocketControlPasswordStore.migrateLegacyKeychainPasswordIfNeeded(
+            defaults: defaults,
+            fileURL: fileURL,
+            loadLegacyPassword: {
+                lookupCount += 1
+                return "legacy-secret"
+            },
+            deleteLegacyPassword: {
+                deleteCount += 1
+                return true
+            }
+        )
+
+        XCTAssertEqual(try SocketControlPasswordStore.loadPassword(fileURL: fileURL), "legacy-secret")
+        XCTAssertEqual(lookupCount, 1)
+        XCTAssertEqual(deleteCount, 1)
+
+        SocketControlPasswordStore.migrateLegacyKeychainPasswordIfNeeded(
+            defaults: defaults,
+            fileURL: fileURL,
+            loadLegacyPassword: {
+                lookupCount += 1
+                return "new-value"
+            },
+            deleteLegacyPassword: {
+                deleteCount += 1
+                return true
+            }
+        )
+
+        XCTAssertEqual(lookupCount, 1)
+        XCTAssertEqual(deleteCount, 1)
+        XCTAssertEqual(try SocketControlPasswordStore.loadPassword(fileURL: fileURL), "legacy-secret")
+    }
+}


### PR DESCRIPTION
## Summary

- Moves socket control password from macOS login keychain to `~/Library/Application Support/cmux/socket-control-password` (0600 perms, 0700 directory)
- Eliminates the system keychain prompt that interrupts users on first launch or after keychain changes
- One-time migration on app launch copies any existing keychain password to the file, deletes the keychain entry, and records a migration version in UserDefaults
- CLI `SocketPasswordResolver` updated to read from the file path instead of keychain
- `Security` framework import is now conditional (`#if canImport(Security)`)

## Test plan

- [x] `SocketControlPasswordStoreTests` covering round-trip save/load/clear, env-over-file priority, path resolution, and migration behavior
- [ ] Verify existing keychain password is migrated on first launch after update
- [ ] Verify new password save/load works from Settings UI
- [ ] Verify CLI `--password` and `CMUX_SOCKET_PASSWORD` env var still take precedence

Fixes https://github.com/manaflow-ai/cmux/issues/541