### PR TITLE
Fix terminal blink/lag when splitting or closing panes

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4947,22 +4947,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             dlog("shortcut.action name=splitRight \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            if shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: .right) {
-                return true
-            }
-            _ = performSplitShortcut(direction: .right)
-            return true
+            return performSplitShortcutWithTransientFocusRecovery(direction: .right)
         }
 
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .splitDown)) {
 #if DEBUG
             dlog("shortcut.action name=splitDown \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            if shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: .down) {
-                return true
-            }
-            _ = performSplitShortcut(direction: .down)
-            return true
+            return performSplitShortcutWithTransientFocusRecovery(direction: .down)
         }
 
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .splitBrowserRight)) {
@@ -5132,6 +5124,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             "frame=\(String(format: "%.1fx%.1f", hostedSize.width, hostedSize.height))"
         )
 #endif
+        return true
+    }
+
+    @discardableResult
+    private func performSplitShortcutWithTransientFocusRecovery(direction: SplitDirection) -> Bool {
+        guard shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: direction) else {
+            return performSplitShortcut(direction: direction)
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard !self.shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: direction) else { return }
+#if DEBUG
+            let directionLabel: String
+            switch direction {
+            case .left: directionLabel = "left"
+            case .right: directionLabel = "right"
+            case .up: directionLabel = "up"
+            case .down: directionLabel = "down"
+            }
+            dlog("split.shortcut retry dir=\(directionLabel) reason=postFocusReconcile")
+#endif
+            _ = self.performSplitShortcut(direction: direction)
+        }
         return true
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2215,6 +2215,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var cellSize: CGSize = .zero
     var desiredFocus: Bool = false
     var suppressingReparentFocus: Bool = false
+    var reparentFocusSuppressionGeneration: UInt64 = 0
     var tabId: UUID?
     var onFocus: (() -> Void)?
     var onTriggerFlash: (() -> Void)?
@@ -2693,6 +2694,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // becomeFirstResponder. Suppress onFocus + ghostty_surface_set_focus to prevent
             // the old view from stealing focus and creating model/surface divergence.
             if suppressingReparentFocus {
+                suppressingReparentFocus = false
 #if DEBUG
                 dlog("focus.firstResponder SUPPRESSED (reparent) surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil")")
 #endif
@@ -4652,10 +4654,29 @@ final class GhosttySurfaceScrollView: NSView {
         }
     }
 
+    private func scheduleReparentFocusSuppressionClear(generation: UInt64, remainingPasses: Int = 2) {
+        guard remainingPasses > 0 else {
+            guard surfaceView.reparentFocusSuppressionGeneration == generation else { return }
+            surfaceView.suppressingReparentFocus = false
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.scheduleReparentFocusSuppressionClear(
+                generation: generation,
+                remainingPasses: remainingPasses - 1
+            )
+        }
+    }
+
     /// Suppress the surface view's onFocus callback and ghostty_surface_set_focus during
-    /// SwiftUI reparenting (programmatic splits). Call clearSuppressReparentFocus() after layout settles.
+    /// SwiftUI reparenting (programmatic splits). Clear automatically after the next couple
+    /// of main-queue turns to avoid long fixed-time suppression windows.
     func suppressReparentFocus() {
+        surfaceView.reparentFocusSuppressionGeneration &+= 1
+        let generation = surfaceView.reparentFocusSuppressionGeneration
         surfaceView.suppressingReparentFocus = true
+        scheduleReparentFocusSuppressionClear(generation: generation)
     }
 
     func clearSuppressReparentFocus() {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -539,11 +539,9 @@ final class WindowTerminalPortal: NSObject {
     private static let minimumRevealWidth: CGFloat = 24
     private static let minimumRevealHeight: CGFloat = 18
     private static let transientRecoveryRetryBudget: Int = 12
-#if CMUX_ISSUE_483_PORTAL_RECOVERY
+    // Keep portal-hosted terminals visible through brief split/close reparent geometry churn.
+    // Hiding immediately on transient tiny/offscreen states causes one-frame blink/blackout.
     private static let transientRecoveryEnabled = true
-#else
-    private static let transientRecoveryEnabled = false
-#endif
 
     private weak var window: NSWindow?
     private let hostView = WindowTerminalHostView(frame: .zero)
@@ -1022,6 +1020,11 @@ final class WindowTerminalPortal: NSObject {
 
         _ = synchronizeHostFrameToReference()
 
+        let canPreserveExistingFrameOnSeedMiss =
+            previousEntry != nil &&
+            hostedView.superview === hostView &&
+            ((previousEntry?.visibleInUI ?? false) || visibleInUI)
+
         // Seed frame/bounds before entering the window so a freshly reparented
         // surface doesn't do a transient 800x600 size update on viewDidMoveToWindow.
         if let seededFrame = seededFrameInHost(for: anchorView),
@@ -1032,6 +1035,17 @@ final class WindowTerminalPortal: NSObject {
             hostedView.frame = seededFrame
             hostedView.bounds = NSRect(origin: .zero, size: seededFrame.size)
             CATransaction.commit()
+        } else if canPreserveExistingFrameOnSeedMiss {
+            // During split/close tree mutations, SwiftUI can temporarily report unsettled anchor
+            // geometry while the hosted terminal should remain visible. Preserve the current frame
+            // and hidden state; synchronizeHostedView will reconcile to the new geometry shortly.
+#if DEBUG
+            dlog(
+                "portal.bind.deferSeed hosted=\(portalDebugToken(hostedView)) " +
+                "anchor=\(portalDebugToken(anchorView)) frame=\(portalDebugFrame(hostedView.frame)) " +
+                "hidden=\(hostedView.isHidden ? 1 : 0)"
+            )
+#endif
         } else {
             // If anchor geometry is still unsettled, keep this hidden/zero-sized until
             // synchronizeHostedView resolves a valid target frame on the next layout tick.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1900,9 +1900,6 @@ final class Workspace: Identifiable, ObservableObject {
         if focus {
             previousHostedView?.suppressReparentFocus()
             focusPanel(newPanel.id, previousHostedView: previousHostedView)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                previousHostedView?.clearSuppressReparentFocus()
-            }
         } else {
             preserveFocusAfterNonFocusSplit(
                 preferredPanelId: previousFocusedPanelId,
@@ -1910,6 +1907,7 @@ final class Workspace: Identifiable, ObservableObject {
                 previousHostedView: previousHostedView
             )
         }
+        scheduleTerminalGeometryReconcile(runImmediately: true)
 
         return newPanel
     }
@@ -2026,9 +2024,6 @@ final class Workspace: Identifiable, ObservableObject {
         if focus {
             previousHostedView?.suppressReparentFocus()
             focusPanel(browserPanel.id)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                previousHostedView?.clearSuppressReparentFocus()
-            }
         } else {
             preserveFocusAfterNonFocusSplit(
                 preferredPanelId: previousFocusedPanelId,
@@ -2036,6 +2031,7 @@ final class Workspace: Identifiable, ObservableObject {
                 previousHostedView: previousHostedView
             )
         }
+        scheduleTerminalGeometryReconcile(runImmediately: true)
 
         installBrowserPanelSubscription(browserPanel)
 
@@ -2661,6 +2657,28 @@ final class Workspace: Identifiable, ObservableObject {
             allowPreviousHostedView: true
         )
 
+        scheduleDeferredNonFocusSplitFocusReassert(
+            generation: generation,
+            preferredPanelId: preferredPanelId,
+            splitPanelId: splitPanelId,
+            previousHostedView: previousHostedView,
+            remainingPasses: 1
+        )
+    }
+
+    private func scheduleDeferredNonFocusSplitFocusReassert(
+        generation: UInt64,
+        preferredPanelId: UUID,
+        splitPanelId: UUID,
+        previousHostedView: GhosttySurfaceScrollView?,
+        remainingPasses: Int
+    ) {
+        guard remainingPasses > 0 else {
+            scheduleFocusReconcile()
+            clearNonFocusSplitFocusReassert(generation: generation)
+            return
+        }
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.reassertFocusAfterNonFocusSplit(
@@ -2670,19 +2688,13 @@ final class Workspace: Identifiable, ObservableObject {
                 previousHostedView: previousHostedView,
                 allowPreviousHostedView: false
             )
-
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.reassertFocusAfterNonFocusSplit(
-                    generation: generation,
-                    preferredPanelId: preferredPanelId,
-                    splitPanelId: splitPanelId,
-                    previousHostedView: previousHostedView,
-                    allowPreviousHostedView: false
-                )
-                self.scheduleFocusReconcile()
-                self.clearNonFocusSplitFocusReassert(generation: generation)
-            }
+            self.scheduleDeferredNonFocusSplitFocusReassert(
+                generation: generation,
+                preferredPanelId: preferredPanelId,
+                splitPanelId: splitPanelId,
+                previousHostedView: previousHostedView,
+                remainingPasses: remainingPasses - 1
+            )
         }
     }
 
@@ -3112,15 +3124,23 @@ final class Workspace: Identifiable, ObservableObject {
         geometryReconcileNeedsRerun = false
     }
 
-    private func scheduleTerminalGeometryReconcile() {
+    private func scheduleTerminalGeometryReconcile(runImmediately: Bool = false) {
+        if runImmediately {
+            let needsFollowUpPass = reconcileTerminalGeometryPass()
+            if needsFollowUpPass {
+                geometryReconcileNeedsRerun = true
+            }
+        }
+
         guard !geometryReconcileScheduled else {
             geometryReconcileNeedsRerun = true
             return
         }
         geometryReconcileScheduled = true
+        let deferredPassCount = runImmediately ? 3 : 4
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.runScheduledTerminalGeometryReconcile(remainingPasses: 4)
+            self.runScheduledTerminalGeometryReconcile(remainingPasses: deferredPassCount)
         }
     }
 
@@ -3647,7 +3667,7 @@ extension Workspace: BonsplitDelegate {
             #if DEBUG
             NSLog("[Workspace] didCloseTab: no panelId for tabId")
             #endif
-            scheduleTerminalGeometryReconcile()
+            scheduleTerminalGeometryReconcile(runImmediately: true)
             if !isDetaching {
                 scheduleFocusReconcile()
             }
@@ -3709,7 +3729,7 @@ extension Workspace: BonsplitDelegate {
         // prune the source workspace/window after the tab is attached elsewhere.
         if panels.isEmpty {
             if isDetaching {
-                scheduleTerminalGeometryReconcile()
+                scheduleTerminalGeometryReconcile(runImmediately: true)
                 return
             }
 
@@ -3720,7 +3740,7 @@ extension Workspace: BonsplitDelegate {
                 bonsplitController.selectTab(replacementTabId)
                 applyTabSelection(tabId: replacementTabId, inPane: replacementPane)
             }
-            scheduleTerminalGeometryReconcile()
+            scheduleTerminalGeometryReconcile(runImmediately: true)
             scheduleFocusReconcile()
             return
         }
@@ -3743,7 +3763,7 @@ extension Workspace: BonsplitDelegate {
         if bonsplitController.allPaneIds.contains(pane) {
             normalizePinnedTabs(in: pane)
         }
-        scheduleTerminalGeometryReconcile()
+        scheduleTerminalGeometryReconcile(runImmediately: true)
         if !isDetaching {
             scheduleFocusReconcile()
         }
@@ -3801,7 +3821,7 @@ extension Workspace: BonsplitDelegate {
 #endif
         normalizePinnedTabs(in: source)
         normalizePinnedTabs(in: destination)
-        scheduleTerminalGeometryReconcile()
+        scheduleTerminalGeometryReconcile(runImmediately: true)
         if !isDetachingCloseTransaction {
             scheduleFocusReconcile()
         }
@@ -3858,7 +3878,7 @@ extension Workspace: BonsplitDelegate {
             }
         }
 
-        scheduleTerminalGeometryReconcile()
+        scheduleTerminalGeometryReconcile(runImmediately: true)
         if shouldScheduleFocusReconcile {
             scheduleFocusReconcile()
         }
@@ -3911,7 +3931,7 @@ extension Workspace: BonsplitDelegate {
         guard !isProgrammaticSplit else {
             normalizePinnedTabs(in: originalPane)
             normalizePinnedTabs(in: newPane)
-            scheduleTerminalGeometryReconcile()
+            scheduleTerminalGeometryReconcile(runImmediately: true)
             return
         }
 
@@ -3992,7 +4012,7 @@ extension Workspace: BonsplitDelegate {
             }
             normalizePinnedTabs(in: originalPane)
             normalizePinnedTabs(in: newPane)
-            scheduleTerminalGeometryReconcile()
+            scheduleTerminalGeometryReconcile(runImmediately: true)
             return
         }
 
@@ -4053,7 +4073,7 @@ extension Workspace: BonsplitDelegate {
             if self.bonsplitController.focusedPaneId == newPane {
                 self.bonsplitController.selectTab(newTabId)
             }
-            self.scheduleTerminalGeometryReconcile()
+            self.scheduleTerminalGeometryReconcile(runImmediately: true)
             self.scheduleFocusReconcile()
         }
     }
@@ -4111,7 +4131,7 @@ extension Workspace: BonsplitDelegate {
 
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {
         _ = snapshot
-        scheduleTerminalGeometryReconcile()
+        scheduleTerminalGeometryReconcile(runImmediately: true)
         if !isDetachingCloseTransaction {
             scheduleFocusReconcile()
         }


### PR DESCRIPTION
## Summary\n- keep portal-hosted terminals visible during transient split-tree reparent/geometry churn instead of forcing hide/zero on seed misses\n- replace fixed 50ms reparent-focus suppression with generation/runloop-based clearing to avoid timing-sensitive focus steal/drop windows\n- tighten split/close geometry reconciliation by running an immediate pass on split/close/didChangeGeometry paths\n- replace nested triple deferred non-focus split reassertion with bounded deferred reassert scheduling\n- make Cmd+D/Cmd+Shift+D split shortcuts auto-retry once after transient focus-state suppression instead of dropping the action\n\n## Testing\n- ./scripts/setup.sh\n- ./scripts/reload.sh --tag fix-issue-456\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build\n\nCloses #456