### PR TITLE
Fix #553: filter Contents/MacOS from shell PATH fixup

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -236,15 +236,17 @@ _cmux_install_prompt_command() {
     fi
 }
 
-# Ensure Resources/bin is at the front of PATH. Shell init (.bashrc/.bash_profile)
-# may prepend other dirs that push our wrapper behind the system claude binary.
+# Ensure Resources/bin is at the front of PATH, and remove the app's
+# Contents/MacOS entry so the GUI cmux binary cannot shadow the CLI cmux.
+# Shell init (.bashrc/.bash_profile) may prepend other dirs after launch.
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
-        local bin_dir="${GHOSTTY_BIN_DIR%/MacOS}"
-        bin_dir="${bin_dir}/Resources/bin"
+        local gui_dir="${GHOSTTY_BIN_DIR%/}"
+        local bin_dir="${gui_dir%/MacOS}/Resources/bin"
         if [[ -d "$bin_dir" ]]; then
             local new_path=":${PATH}:"
             new_path="${new_path//:${bin_dir}:/:}"
+            new_path="${new_path//:${gui_dir}:/:}"
             new_path="${new_path#:}"
             new_path="${new_path%:}"
             PATH="${bin_dir}:${new_path}"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -368,17 +368,19 @@ _cmux_precmd() {
     fi
 }
 
-# Ensure Resources/bin is at the front of PATH. Shell init (.zprofile/.zshrc)
-# may prepend other dirs that push our wrapper behind the system claude binary.
+# Ensure Resources/bin is at the front of PATH, and remove the app's
+# Contents/MacOS entry so the GUI cmux binary cannot shadow the CLI cmux.
+# Shell init (.zprofile/.zshrc) may prepend other dirs after launch.
 # We fix this once on first prompt (after all init files have run).
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
-        local bin_dir="${GHOSTTY_BIN_DIR%/MacOS}"
-        bin_dir="${bin_dir}/Resources/bin"
+        local gui_dir="${GHOSTTY_BIN_DIR%/}"
+        local bin_dir="${gui_dir%/MacOS}/Resources/bin"
         if [[ -d "$bin_dir" ]]; then
-            # Remove existing entry and re-prepend.
+            # Remove existing entries and re-prepend the CLI bin dir.
             local -a parts=("${(@s/:/)PATH}")
             parts=("${(@)parts:#$bin_dir}")
+            parts=("${(@)parts:#$gui_dir}")
             PATH="${bin_dir}:${(j/:/)parts}"
         fi
     fi


### PR DESCRIPTION
## Summary
- update zsh integration `_cmux_fix_path` to remove both `Contents/MacOS` and duplicate `Resources/bin` entries before prepending `Resources/bin`
- update bash integration `_cmux_fix_path` with the same filtering behavior
- ensure the CLI `cmux` in `Resources/bin` always takes precedence over the GUI app binary on PATH

## Validation
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `./scripts/reload.sh --tag fix-issue-553-gui-shadow`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`

## Acknowledgement
- Thanks to @apollo880 for independently identifying the same root cause and proposing a fix in #554.

Fixes #553
