### PR TITLE
Fix selected workspace status color contrast

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7470,6 +7470,11 @@ private struct SidebarMetadataEntryRow: View {
     }
 
     private var foregroundColor: Color {
+        if isActive,
+           let raw = entry.color,
+           Color(hex: raw) != nil {
+            return Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 0.95))
+        }
         if let raw = entry.color, let explicit = Color(hex: raw) {
             return explicit
         }


### PR DESCRIPTION
## Summary
- fix sidebar status entry contrast when a workspace row is selected
- render explicitly-colored status entries in selected rows with high-contrast white text/icon
- preserves existing explicit status colors for unselected rows

## Why
Statuses like "Needs input" and "Running" used blue text, which blended into the blue selected-workspace background.

Closes #572

## Validation
- ./scripts/reload.sh --tag issue-572
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build