### PR TITLE
Restore lazy keychain reads for socket password

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -459,7 +459,7 @@ class TerminalController {
         guard lowered == "auth" || lowered.hasPrefix("auth ") else {
             return nil
         }
-        guard SocketControlPasswordStore.hasConfiguredPassword() else {
+        guard SocketControlPasswordStore.hasConfiguredPassword(allowLazyKeychainFallback: true) else {
             return "ERROR: Password mode is enabled but no socket password is configured in Settings."
         }
 
@@ -472,7 +472,7 @@ class TerminalController {
         guard !provided.isEmpty else {
             return "ERROR: Missing password. Usage: auth <password>"
         }
-        guard SocketControlPasswordStore.verify(password: provided) else {
+        guard SocketControlPasswordStore.verify(password: provided, allowLazyKeychainFallback: true) else {
             return "ERROR: Invalid password"
         }
         authenticated = true
@@ -496,7 +496,7 @@ class TerminalController {
             return v2Error(id: id, code: "invalid_params", message: "auth.login requires params.password")
         }
 
-        guard SocketControlPasswordStore.hasConfiguredPassword() else {
+        guard SocketControlPasswordStore.hasConfiguredPassword(allowLazyKeychainFallback: true) else {
             return v2Error(
                 id: id,
                 code: "auth_unconfigured",
@@ -504,7 +504,7 @@ class TerminalController {
             )
         }
 
-        guard SocketControlPasswordStore.verify(password: provided) else {
+        guard SocketControlPasswordStore.verify(password: provided, allowLazyKeychainFallback: true) else {
             return v2Error(id: id, code: "auth_failed", message: "Invalid password")
         }
         authenticated = true


### PR DESCRIPTION
## Summary

- Add a cached lazy keychain fallback to `SocketControlPasswordStore` so authentication paths in `TerminalController` can transparently read a legacy keychain password without blocking on every request
- The keychain is read at most once per process; the result is cached behind an `NSLock`
- File-based and environment passwords still take priority over the keychain fallback
- Add comprehensive tests covering caching behavior, nil caching, priority ordering, and single-read guarantees

Closes https://github.com/manaflow-ai/cmux/issues/579