### PR TITLE
Remove not_supported commands and legacy aliases from --help

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5372,16 +5372,7 @@ struct CMUXCLI {
           browser addinitscript <script>
           browser addscript <script>
           browser addstyle <css>
-          browser viewport <width> <height>      (returns not_supported on WKWebView)
-          browser geolocation|geo <lat> <lon>    (returns not_supported on WKWebView)
-          browser offline <true|false>           (returns not_supported on WKWebView)
-          browser trace <start|stop> [path]      (returns not_supported on WKWebView)
-          browser network <route|unroute|requests> [...] (returns not_supported on WKWebView)
-          browser screencast <start|stop>        (returns not_supported on WKWebView)
-          browser input <mouse|keyboard|touch>   (returns not_supported on WKWebView)
           browser identify [--surface <id|ref|index>]
-
-          (legacy browser aliases still supported: open-browser, navigate, browser-back, browser-forward, browser-reload, get-url)
           help
 
         Environment:


### PR DESCRIPTION
## Summary
- Remove 7 browser subcommands that always return `not_supported` on WKWebView from help output
- Remove legacy browser alias notice from help
- Command handlers remain in code for backwards compatibility

Closes https://github.com/manaflow-ai/cmux/issues/593

## Test plan
- [ ] Run `cmux help` — verify no `not_supported` lines appear
- [ ] Run `cmux browser viewport 1920 1080` — should still return `not_supported` (handler kept)
- [ ] Run `cmux open-browser http://example.com` — legacy alias still works