### PR TITLE
Fix interaction crash in titlebar drag hit-testing

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -747,11 +747,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         label: "com.cmuxterm.app.sessionPersistence",
         qos: .utility
     )
-    private static let launchServicesRegistrationQueue = DispatchQueue(
+    private nonisolated static let launchServicesRegistrationQueue = DispatchQueue(
         label: "com.cmuxterm.app.launchServicesRegistration",
         qos: .utility
     )
-    private static func enqueueLaunchServicesRegistrationWork(_ work: @escaping @Sendable () -> Void) {
+    private nonisolated static func enqueueLaunchServicesRegistrationWork(_ work: @escaping @Sendable () -> Void) {
         launchServicesRegistrationQueue.async(execute: work)
     }
     private var lastSessionAutosaveFingerprint: Int?


### PR DESCRIPTION
## Summary
Fix crash-on-interaction reported in #587 by removing a re-entrant titlebar hit-testing path that could trigger Swift exclusivity failure on user input.

## Root cause
`windowDragHandleShouldCaptureHit` performed a window-level `contentView.hitTest(...)` while already in the drag-handle/input hit-test flow.
On Sequoia 15.1 with cmux 0.61, this could re-enter AppKit/SwiftUI responder traversal and terminate with `Fatal access conflict detected` during mouse/keyboard interaction.

## Changes
- `Sources/WindowDragHandleView.swift`
  - Removed top-hit resolution state (`WindowDragHandleHitTestState` and associated object key for `topHitResolutionDepth`).
  - Removed window-level `contentView.hitTest(...)` probing branch.
  - Kept deterministic sibling-based hit-testing for drag-handle capture decisions.
- `Sources/AppDelegate.swift`
  - Marked launch services registration queue + scheduler helper as `nonisolated` to satisfy actor-isolation at the static default-argument callsite and keep Debug builds passing under current toolchain.

## Validation
- `./scripts/reload.sh --tag fix-587-interaction-crash` -> `BUILD SUCCEEDED`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` -> `BUILD SUCCEEDED`
- Manual interaction path (mouse + keyboard) no longer causes immediate termination.

## Scope
- No API/protocol/config changes.
- Behavior change is limited to titlebar drag-handle hit-test strategy (remove re-entrant top-hit probing).

Fixes #587
