### PR TITLE
Add telemetry opt-out setting

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -372,14 +372,16 @@ class GhosttyApp {
                 lastReportedUptime: lastScrollLagReportUptime,
                 cooldown: scrollLagReportCooldownSeconds
             ) {
-                SentrySDK.capture(message: "Scroll lag detected") { scope in
-                    scope.setLevel(.warning)
-                    scope.setContext(value: [
-                        "samples": samples,
-                        "avg_ms": String(format: "%.2f", avgLag),
-                        "max_ms": String(format: "%.2f", maxLag),
-                        "threshold_ms": threshold
-                    ], key: "scroll_lag")
+                if TelemetrySettings.enabledForCurrentLaunch {
+                    SentrySDK.capture(message: "Scroll lag detected") { scope in
+                        scope.setLevel(.warning)
+                        scope.setContext(value: [
+                            "samples": samples,
+                            "avg_ms": String(format: "%.2f", avgLag),
+                            "max_ms": String(format: "%.2f", maxLag),
+                            "threshold_ms": threshold
+                        ], key: "scroll_lag")
+                    }
                 }
                 lastScrollLagReportUptime = nowUptime
             }

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -19,6 +19,7 @@ final class PostHogAnalytics {
     private var activeCheckTimer: Timer?
 
     private var isEnabled: Bool {
+        guard TelemetrySettings.enabledForCurrentLaunch else { return false }
 #if DEBUG
         // Avoid polluting production analytics while iterating locally.
         return ProcessInfo.processInfo.environment["CMUX_POSTHOG_ENABLE"] == "1"

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -2,6 +2,7 @@ import Sentry
 
 /// Add a Sentry breadcrumb for user-action context in hang/crash reports.
 func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String: Any]? = nil) {
+    guard TelemetrySettings.enabledForCurrentLaunch else { return }
     let crumb = Breadcrumb(level: .info, category: category)
     crumb.message = message
     crumb.data = data

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -414,6 +414,37 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertFalse(ClaudeCodeIntegrationSettings.hooksEnabled(defaults: defaults))
     }
 
+    func testTelemetryDefaultsToEnabledWhenUnset() {
+        let suiteName = "cmux.tests.telemetry.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated user defaults suite")
+            return
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.removeObject(forKey: TelemetrySettings.sendAnonymousTelemetryKey)
+        XCTAssertTrue(TelemetrySettings.isEnabled(defaults: defaults))
+    }
+
+    func testTelemetryRespectsStoredPreference() {
+        let suiteName = "cmux.tests.telemetry.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated user defaults suite")
+            return
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(true, forKey: TelemetrySettings.sendAnonymousTelemetryKey)
+        XCTAssertTrue(TelemetrySettings.isEnabled(defaults: defaults))
+
+        defaults.set(false, forKey: TelemetrySettings.sendAnonymousTelemetryKey)
+        XCTAssertFalse(TelemetrySettings.isEnabled(defaults: defaults))
+    }
+
     private func rgb255(_ color: NSColor) -> RGB {
         let srgb = color.usingColorSpace(.sRGB)!
         var red: CGFloat = 0


### PR DESCRIPTION
## Summary

- Adds "Send anonymous telemetry" toggle in Settings (under General section)
- Disables Sentry crash reporting and PostHog analytics when turned off
- Setting is frozen at launch, shows restart hint when changed
- Restart hint correctly clears if user toggles back to launch-time value

Closes https://github.com/manaflow-ai/cmux/issues/607

## Test plan

- [ ] Open Settings, verify "Send anonymous telemetry" toggle appears
- [ ] Toggle off, verify "Change takes effect on next launch" subtitle appears
- [ ] Toggle back on, verify subtitle reverts to default copy
- [ ] Restart with telemetry off, verify no Sentry/PostHog calls in Console.app
- [ ] "Reset all settings" resets toggle to default (on)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Send anonymous telemetry" toggle in Settings to control telemetry data collection. Telemetry can be enabled or disabled, with changes taking effect on the next app launch. Telemetry is enabled by default.

* **Tests**
  * Added unit tests for telemetry settings configuration and preference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->