### PR TITLE
Remove duplicate telemetry assignment in resetAllSettings

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3530,7 +3530,6 @@ struct SettingsView: View {
         socketPasswordDraft = ""
         socketPasswordStatusMessage = nil
         socketPasswordStatusIsError = false
-        sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         KeyboardShortcutSettings.resetAll()
         WorkspaceTabColorSettings.reset()
         reloadWorkspaceTabColorSettings()


### PR DESCRIPTION
## Summary

Removes the duplicate `sendAnonymousTelemetry` reset at line 3533 in `resetAllSettings`. The same assignment already exists at line 3505 earlier in the function.

Addresses review comment on https://github.com/manaflow-ai/cmux/pull/610#discussion_r2016254938.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry preferences now persist when resetting all settings, rather than reverting to default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->