### PR TITLE
Fix use-after-free in ghostty_surface_refresh after sleep/wake

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3083,8 +3083,10 @@ final class Workspace: Identifiable, ObservableObject {
             // layout and view lifecycle changes that free surfaces (#432).
             if terminalPanel.surface.surface != nil {
                 terminalPanel.surface.forceRefresh()
-            } else if isAttached && hasUsableBounds {
+            }
+            if terminalPanel.surface.surface == nil, isAttached && hasUsableBounds {
                 terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()
+                needsFollowUpPass = true
             }
         }
 
@@ -3139,7 +3141,8 @@ final class Workspace: Identifiable, ObservableObject {
                 panel.hostedView.reconcileGeometryNow()
                 if panel.surface.surface != nil {
                     panel.surface.forceRefresh()
-                } else {
+                }
+                if panel.surface.surface == nil {
                     panel.surface.requestBackgroundSurfaceStartIfNeeded()
                 }
             }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6695,6 +6695,49 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         XCTAssertFalse(hostedView.debugHasSearchOverlay())
     }
 
+    func testForceRefreshNoopsAfterSurfaceReleaseDuringGeometryReconcile() throws {
+#if DEBUG
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        hostedView.reconcileGeometryNow()
+        surface.releaseSurfaceForTesting()
+        XCTAssertNil(surface.surface, "Surface should be nil after test release helper")
+
+        hostedView.reconcileGeometryNow()
+        surface.forceRefresh()
+        XCTAssertNil(surface.surface, "Force refresh should no-op when runtime surface is nil")
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
+
     func testSearchOverlayMountDoesNotRetainTerminalSurface() {
         weak var weakSurface: TerminalSurface?
 


### PR DESCRIPTION
## Summary
- Add nil guard in `forceRefresh()` to prevent dereferencing freed surface pointer after `forceRefreshSurface()` triggers layout that frees the surface
- Split `else if` chains in `Workspace.swift` into separate `if` statements so `requestBackgroundSurfaceStartIfNeeded()` runs when the surface is freed during refresh (recovery path)
- Add `releaseSurfaceForTesting()` helper (`#if DEBUG`) and regression test

Closes https://github.com/manaflow-ai/cmux/issues/432

## Test plan
- [ ] Sleep 30s, wake, verify no crash and terminals redraw
- [ ] Sleep 5min, wake, verify no crash
- [ ] Close lid, reopen, verify no crash
- [ ] Run unit tests: `xcodebuild test -only-testing:cmuxTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface refresh handling to ensure correct references are maintained during terminal topology changes, preventing potential interactions with freed surfaces.
  * Enhanced background surface startup logic for more consistent behavior.

* **Tests**
  * Added regression test to verify refresh behavior maintains stability when runtime surfaces are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->