### PR TITLE
Fix drag-handle crash on launch from stale foreign-window events

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6128,7 +6128,7 @@ final class WindowDragHandleHitTests: XCTestCase {
 
     private final class ReentrantDragHandleView: NSView {
         override func hitTest(_ point: NSPoint) -> NSView? {
-            let shouldCapture = windowDragHandleShouldCaptureHit(point, in: self, eventType: .leftMouseDown)
+            let shouldCapture = windowDragHandleShouldCaptureHit(point, in: self, eventType: .leftMouseDown, eventWindow: self.window)
             return shouldCapture ? self : nil
         }
     }
@@ -6189,6 +6189,67 @@ final class WindowDragHandleHitTests: XCTestCase {
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .cursorUpdate))
         XCTAssertFalse(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: nil))
         XCTAssertTrue(windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown))
+    }
+
+    func testDragHandleSkipsForeignLeftMouseDownDuringLaunch() {
+        let point = NSPoint(x: 180, y: 18)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 36),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let container = NSView(frame: contentView.bounds)
+        container.autoresizingMask = [.width, .height]
+        contentView.addSubview(container)
+
+        let dragHandle = NSView(frame: container.bounds)
+        dragHandle.autoresizingMask = [.width, .height]
+        container.addSubview(dragHandle)
+
+        let foreignWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 36),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { foreignWindow.orderOut(nil) }
+
+        XCTAssertFalse(
+            windowDragHandleShouldCaptureHit(
+                point,
+                in: dragHandle,
+                eventType: .leftMouseDown,
+                eventWindow: nil
+            ),
+            "Launch activation events without a matching window should not trigger drag-handle hierarchy walk"
+        )
+
+        XCTAssertFalse(
+            windowDragHandleShouldCaptureHit(
+                point,
+                in: dragHandle,
+                eventType: .leftMouseDown,
+                eventWindow: foreignWindow
+            ),
+            "Left mouse-down events for a different window should be treated as passive"
+        )
+
+        XCTAssertTrue(
+            windowDragHandleShouldCaptureHit(
+                point,
+                in: dragHandle,
+                eventType: .leftMouseDown,
+                eventWindow: window
+            ),
+            "Left mouse-down events for this window should still capture empty titlebar space"
+        )
     }
 
     func testPassiveHostingTopHitClassification() {
@@ -6266,7 +6327,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         nestedContainer.addSubview(nestedDragHandle)
 
         XCTAssertFalse(
-            windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown),
+            windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown, eventWindow: nestedWindow),
             "Nested window drag handle should be blocked by top-hit titlebar container"
         )
 
@@ -6274,11 +6335,11 @@ final class WindowDragHandleHitTests: XCTestCase {
         let probe = PassThroughProbeView(frame: outerContainer.bounds)
         probe.autoresizingMask = [.width, .height]
         probe.onHitTest = {
-            nestedCaptureResult = windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown)
+            nestedCaptureResult = windowDragHandleShouldCaptureHit(point, in: nestedDragHandle, eventType: .leftMouseDown, eventWindow: nestedWindow)
         }
         outerContainer.addSubview(probe)
 
-        _ = windowDragHandleShouldCaptureHit(point, in: outerDragHandle, eventType: .leftMouseDown)
+        _ = windowDragHandleShouldCaptureHit(point, in: outerDragHandle, eventType: .leftMouseDown, eventWindow: outerWindow)
 
         XCTAssertEqual(
             nestedCaptureResult,
@@ -6325,7 +6386,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         container.addSubview(dragHandle)
 
         XCTAssertTrue(
-            windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown),
+            windowDragHandleShouldCaptureHit(point, in: dragHandle, eventType: .leftMouseDown, eventWindow: window),
             "Reentrant same-window top-hit resolution should not trigger exclusivity crashes"
         )
     }
@@ -7770,7 +7831,6 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
     func testImmediateStateUpdateAllowedWhenHostNotInWindow() {
         XCTAssertTrue(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
-                hostWindowAttached: false,
                 hostedViewHasSuperview: true,
                 isBoundToCurrentHost: false
             )
@@ -7780,7 +7840,6 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
     func testImmediateStateUpdateAllowedWhenBoundToCurrentHost() {
         XCTAssertTrue(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
-                hostWindowAttached: true,
                 hostedViewHasSuperview: true,
                 isBoundToCurrentHost: true
             )
@@ -7790,7 +7849,6 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
     func testImmediateStateUpdateSkippedForStaleHostBoundElsewhere() {
         XCTAssertFalse(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
-                hostWindowAttached: true,
                 hostedViewHasSuperview: true,
                 isBoundToCurrentHost: false
             )
@@ -7800,7 +7858,6 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
     func testImmediateStateUpdateAllowedWhenUnboundAndNotAttachedAnywhere() {
         XCTAssertTrue(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
-                hostWindowAttached: true,
                 hostedViewHasSuperview: false,
                 isBoundToCurrentHost: false
             )


### PR DESCRIPTION
## Summary
- Add window-identity check to `windowDragHandleShouldCaptureHit` so stale `leftMouseDown` events from other apps (Finder, Dock) during launch don't trigger the SwiftUI hierarchy walk while initial layout is mutating (exclusive-access violation)
- Add `NSLock` to `WindowDragHandleBreadcrumbLimiter` for thread safety
- Add regression test for nil/foreign/matching eventWindow scenarios
- Fix `shouldApplyImmediateHostedStateUpdate` test call sites (removed stale `hostWindowAttached:` param)

Closes https://github.com/manaflow-ai/cmux/issues/490

## Test plan
- [ ] Launch app with mouse hovering over window area (was crash scenario)
- [ ] Launch from Dock, Spotlight, terminal
- [ ] Verify drag-handle still works for normal clicks after launch
- [ ] Run unit tests: `xcodebuild test -only-testing:cmuxTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety and memory management in window drag operations to enhance stability.
  * Enhanced hit-testing accuracy for drag capture across multiple window scenarios.

* **Tests**
  * Updated tests to validate window-aware drag behavior and reentrancy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->