### PR TITLE
Disable Sentry sendDefaultPii to match anonymous telemetry label

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -850,7 +850,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 options.environment = "production"
                 options.debug = false
                 #endif
-                options.sendDefaultPii = true
+                options.sendDefaultPii = false
 
                 // Performance tracing (10% of transactions)
                 options.tracesSampleRate = 0.1


### PR DESCRIPTION
One-liner follow-up to #610. The telemetry opt-out PR re-indented the Sentry config but kept `sendDefaultPii = true`, which auto-collects usernames, emails, and IPs. This contradicts the "Send anonymous telemetry" label in Settings. Sets it to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated telemetry default settings to prevent sending personally identifiable information by default across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->