### PR TITLE
Add Tower to command palette Open Directory targets

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -49,6 +49,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case xcode
     case androidStudio
     case zed
+    case tower
 
     struct DetectionEnvironment {
         let homeDirectoryPath: String
@@ -100,6 +101,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return "Open Current Directory in Android Studio"
         case .zed:
             return "Open Current Directory in Zed"
+        case .tower:
+            return "Open Current Directory in Tower"
         }
     }
 
@@ -130,6 +133,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["android", "studio"]
         case .zed:
             return common + ["zed"]
+        case .tower:
+            return common + ["tower", "git", "client"]
         }
     }
 
@@ -205,6 +210,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
                 "/Applications/Zed Preview.app",
                 "/Applications/Zed Nightly.app",
             ]
+        case .tower:
+            return ["/Applications/Tower.app"]
         }
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -4628,6 +4628,11 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertTrue(TerminalDirectoryOpenTarget.iterm2.isAvailable(in: env))
     }
 
+    func testTowerDetected() {
+        let env = environment(existingPaths: ["/Applications/Tower.app"])
+        XCTAssertTrue(TerminalDirectoryOpenTarget.tower.isAvailable(in: env))
+    }
+
     func testCommandPaletteShortcutsExcludeGenericIDEEntry() {
         let targets = TerminalDirectoryOpenTarget.commandPaletteShortcutTargets
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteTitle == "Open Current Directory in IDE" }))


### PR DESCRIPTION
## Summary
- Adds Tower (Git client) as an Open Directory target in the command palette
- Auto-detected at `/Applications/Tower.app` (also checks `~/Applications/`)
- Keywords: tower, git, client
- Regression test for Tower detection included

Follows the same pattern as VS Code, Cursor, Zed, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening the current directory in Tower application
  * Tower now appears in the command palette with searchable keywords ("tower", "git", "client")

* **Tests**
  * Added test coverage for Tower application detection and availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->