### PR TITLE
Add "Open Folder…" command to open a workspace at a chosen directory

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3504,6 +3504,15 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.openRepository",
+                title: constant("Open Folder…"),
+                subtitle: constant("Workspace"),
+                shortcutHint: "⌘O",
+                keywords: ["open", "folder", "repository", "project", "directory"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.newTerminalTab",
                 title: constant("New Tab (Terminal)"),
                 subtitle: constant("Tab"),
@@ -4003,6 +4012,17 @@ struct ContentView: View {
     private func registerCommandPaletteHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
         registry.register(commandId: "palette.newWorkspace") {
             tabManager.addWorkspace()
+        }
+        registry.register(commandId: "palette.openRepository") {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            panel.title = "Open Folder"
+            panel.prompt = "Open"
+            if panel.runModal() == .OK, let url = panel.url {
+                tabManager.addWorkspace(workingDirectory: url.path)
+            }
         }
         registry.register(commandId: "palette.newWindow") {
             AppDelegate.shared?.openNewMainWindow(nil)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -384,6 +384,30 @@ struct cmuxApp: App {
                         activeTabManager.addTab()
                     }
                 }
+
+                splitCommandButton(
+                    title: "Open Folder…",
+                    shortcut: StoredShortcut(key: "o", command: true, shift: false, option: false, control: false)
+                ) {
+                    let panel = NSOpenPanel()
+                    panel.canChooseFiles = false
+                    panel.canChooseDirectories = true
+                    panel.allowsMultipleSelection = false
+                    panel.title = "Open Folder"
+                    panel.prompt = "Open"
+                    if panel.runModal() == .OK, let url = panel.url {
+                        if let appDelegate = AppDelegate.shared {
+                            if appDelegate.addWorkspaceInPreferredMainWindow(
+                                workingDirectory: url.path,
+                                debugSource: "menu.openFolder"
+                            ) == nil {
+                                appDelegate.openNewMainWindow(nil)
+                            }
+                        } else {
+                            activeTabManager.addWorkspace(workingDirectory: url.path)
+                        }
+                    }
+                }
             }
 
             // Close tab/workspace


### PR DESCRIPTION
## Summary
- Adds a native folder picker (`NSOpenPanel`) accessible from the **Command Palette** (⌘⇧P → "Open Folder…") and the **File menu** with **⌘O** shortcut
- Selecting a folder opens a new workspace at that path
- Follows existing patterns for command palette contributions, handlers, and menu items

## Files Changed
- `Sources/ContentView.swift` — command palette contribution + handler
- `Sources/cmuxApp.swift` — menu bar entry with ⌘O

## Test plan
- [ ] Open Command Palette (⌘⇧P) → type "Open Folder" → verify it appears and opens NSOpenPanel
- [ ] Select a folder → verify new workspace opens at that path
- [ ] Use File menu → "Open Folder…" (⌘O) → same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open Folder…" command accessible via Command Palette (shortcut: ⌘O) and menu under New Tab/New Window group
  * Opens directory selection dialog and creates new workspace with selected folder
  * Keywords include: open, folder, repository, project, directory for improved discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->