### PR TITLE
Rename 'tab color' to 'workspace color' in UI strings

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6792,7 +6792,7 @@ private struct TabItemView: View {
                 }
             }
 
-            Menu("Tab Color") {
+            Menu("Workspace Color") {
                 if tab.customColor != nil {
                     Button {
                         applyTabColor(nil, targetIds: targetIds)
@@ -7401,7 +7401,7 @@ private struct TabItemView: View {
 
     private func promptCustomColor(targetIds: [UUID]) {
         let alert = NSAlert()
-        alert.messageText = "Custom Tab Color"
+        alert.messageText = "Custom Workspace Color"
         alert.informativeText = "Enter a hex color in the format #RRGGBB."
 
         let seed = tab.customColor ?? WorkspaceTabColorSettings.customColors().first ?? ""

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -312,7 +312,7 @@ struct cmuxApp: App {
                     appDelegate.openDebugScrollbackTab(nil)
                 }
 
-                Button("Open Workspaces for All Tab Colors") {
+                Button("Open Workspaces for All Workspace Colors") {
                     appDelegate.openDebugColorComparisonWorkspaces(nil)
                 }
 
@@ -2996,7 +2996,7 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
-                        SettingsCardNote("Customize the workspace color palette used by Sidebar > Tab Color. \"Choose Custom Color...\" entries are persisted below.")
+                        SettingsCardNote("Customize the workspace color palette used by Sidebar > Workspace Color. \"Choose Custom Color...\" entries are persisted below.")
 
                         ForEach(Array(workspaceTabDefaultEntries.enumerated()), id: \.element.name) { index, entry in
                             if index > 0 {


### PR DESCRIPTION
## Summary
- Renames all user-facing "tab color" strings to "workspace color" for consistency
- Context menu: "Tab Color" → "Workspace Color"
- Custom color alert: "Custom Tab Color" → "Custom Workspace Color"
- Debug menu: "Open Workspaces for All Tab Colors" → "Open Workspaces for All Workspace Colors"
- Settings note: "Sidebar > Tab Color" → "Sidebar > Workspace Color"

No internal identifiers changed, only user-visible strings.

Closes https://github.com/manaflow-ai/cmux/issues/635

## Test plan
- [ ] Right-click workspace tab → menu says "Workspace Color"
- [ ] "Choose Custom Color..." dialog says "Custom Workspace Color"
- [ ] Settings card note references "Sidebar > Workspace Color"