### PR TITLE
Add 'Flash Focused Panel' to command palette

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3362,6 +3362,8 @@ struct ContentView: View {
             return .splitDown
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
+        case "palette.triggerFlash":
+            return .triggerFlash
         default:
             return nil
         }
@@ -3589,6 +3591,14 @@ struct ContentView: View {
                 title: constant("Toggle Sidebar"),
                 subtitle: constant("Layout"),
                 keywords: ["toggle", "sidebar", "layout"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.triggerFlash",
+                title: constant("Flash Focused Panel"),
+                subtitle: constant("View"),
+                keywords: ["flash", "highlight", "focus", "panel"]
             )
         )
         contributions.append(
@@ -4080,6 +4090,9 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.toggleSidebar") {
             sidebarState.toggle()
+        }
+        registry.register(commandId: "palette.triggerFlash") {
+            tabManager.triggerFocusFlash()
         }
         registry.register(commandId: "palette.showNotifications") {
             AppDelegate.shared?.toggleNotificationsPopover(animated: false)


### PR DESCRIPTION
## Summary
- Adds "Flash Focused Panel" as a command palette entry (Cmd+Shift+P → type "flash")
- Wired to the same `triggerFocusFlash()` that Cmd+Shift+H uses
- Shortcut hint reads from KeyboardShortcutSettings (stays in sync with custom bindings)

Closes https://github.com/manaflow-ai/cmux/issues/633

## Test plan
- [ ] Cmd+Shift+P → type "flash" → "Flash Focused Panel" appears with ⌘⇧H hint
- [ ] Selecting it flashes the accent-color border on the focused panel
- [ ] Remapping Cmd+Shift+H in Settings updates the palette hint