### PR TITLE
Decouple glass effect from sidebar blend mode

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1831,7 +1831,7 @@ struct ContentView: View {
     // Background glass settings
     @AppStorage("bgGlassTintHex") private var bgGlassTintHex = "#000000"
     @AppStorage("bgGlassTintOpacity") private var bgGlassTintOpacity = 0.03
-    @AppStorage("bgGlassEnabled") private var bgGlassEnabled = true
+    @AppStorage("bgGlassEnabled") private var bgGlassEnabled = false
     @AppStorage("debugTitlebarLeadingExtra") private var debugTitlebarLeadingExtra: Double = 0
 
     @State private var titlebarLeadingInset: CGFloat = 12
@@ -2435,8 +2435,7 @@ struct ContentView: View {
             // Background glass: skip on macOS 26+ where NSGlassEffectView can cause blank
             // or incorrectly tinted SwiftUI content. Keep native window rendering there so
             // Ghostty theme colors remain authoritative.
-            if sidebarBlendMode == SidebarBlendModeOption.behindWindow.rawValue
-                && bgGlassEnabled
+            if bgGlassEnabled
                 && !WindowGlassEffect.isAvailable {
                 window.isOpaque = false
                 window.backgroundColor = .clear

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12,9 +12,8 @@ import IOSurface
 #if os(macOS)
 private func cmuxShouldUseTransparentBackgroundWindow() -> Bool {
     let defaults = UserDefaults.standard
-    let sidebarBlendMode = defaults.string(forKey: "sidebarBlendMode") ?? "withinWindow"
-    let bgGlassEnabled = defaults.object(forKey: "bgGlassEnabled") as? Bool ?? true
-    return sidebarBlendMode == "behindWindow" && bgGlassEnabled && !WindowGlassEffect.isAvailable
+    let bgGlassEnabled = defaults.object(forKey: "bgGlassEnabled") as? Bool ?? false
+    return bgGlassEnabled && !WindowGlassEffect.isAvailable
 }
 #endif
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1290,7 +1290,7 @@ private enum DebugWindowConfigSnapshot {
         """
 
         let backgroundPayload = """
-        bgGlassEnabled=\(boolValue(defaults, key: "bgGlassEnabled", fallback: true))
+        bgGlassEnabled=\(boolValue(defaults, key: "bgGlassEnabled", fallback: false))
         bgGlassMaterial=\(stringValue(defaults, key: "bgGlassMaterial", fallback: "hudWindow"))
         bgGlassTintHex=\(stringValue(defaults, key: "bgGlassTintHex", fallback: "#000000"))
         bgGlassTintOpacity=\(String(format: "%.2f", doubleValue(defaults, key: "bgGlassTintOpacity", fallback: 0.03)))
@@ -2347,7 +2347,7 @@ private struct BackgroundDebugView: View {
     @AppStorage("bgGlassTintHex") private var bgGlassTintHex = "#000000"
     @AppStorage("bgGlassTintOpacity") private var bgGlassTintOpacity = 0.03
     @AppStorage("bgGlassMaterial") private var bgGlassMaterial = "hudWindow"
-    @AppStorage("bgGlassEnabled") private var bgGlassEnabled = true
+    @AppStorage("bgGlassEnabled") private var bgGlassEnabled = false
 
     var body: some View {
         ScrollView {


### PR DESCRIPTION
## Summary

- Remove `sidebarBlendMode == "behindWindow"` requirement from glass effect checks in `GhosttyTerminalView.swift` and `ContentView.swift`
- Change `bgGlassEnabled` default from `true` to `false` (opt-in instead of silently enabled)

The glass/blur effect was gated behind `sidebarBlendMode == "behindWindow"`, but that defaults to `"withinWindow"`, making the feature effectively unreachable. This decouples the two settings so glass works independently when explicitly enabled.

## How to use

1. `defaults write com.cmuxterm.app bgGlassEnabled -bool true`
2. Set `background-opacity = 0.5` in `~/.config/ghostty/config`
3. Restart cmux — terminal shows frosted glass effect behind text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Background glass visual effect is now disabled by default, resulting in a different initial visual presentation of the application.
  * Refined the activation mechanism for the glass effect fallback feature, making it operate independently of other display-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->