### PR TITLE
Add sidebar font size setting (Small/Default/Large/Extra Large)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6339,6 +6339,7 @@ private struct TabItemView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
+    @AppStorage(SidebarFontSizeSettings.key) private var sidebarFontSizeRaw = SidebarFontSizeSettings.defaultSize.rawValue
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var activeTabIndicatorStyleRaw = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
 
@@ -6356,6 +6357,10 @@ private struct TabItemView: View {
 
     private var activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
         SidebarActiveTabIndicatorSettings.resolvedStyle(rawValue: activeTabIndicatorStyleRaw)
+    }
+
+    private var sidebarFontSize: SidebarFontSize {
+        SidebarFontSize(rawValue: sidebarFontSizeRaw) ?? .default
     }
 
     private var titleFontWeight: Font.Weight {
@@ -6455,7 +6460,7 @@ private struct TabItemView: View {
                         Circle()
                             .fill(activeUnreadBadgeFillColor)
                         Text("\(unreadCount)")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(.system(size: sidebarFontSize.badgeSize, weight: .semibold))
                             .foregroundColor(.white)
                     }
                     .frame(width: 16, height: 16)
@@ -6463,12 +6468,12 @@ private struct TabItemView: View {
 
                 if tab.isPinned {
                     Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.system(size: sidebarFontSize.badgeSize, weight: .semibold))
                         .foregroundColor(activeSecondaryColor(0.8))
                 }
 
                 Text(tab.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(.system(size: sidebarFontSize.titleSize, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -6483,7 +6488,7 @@ private struct TabItemView: View {
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
                         Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .medium))
+                            .font(.system(size: sidebarFontSize.badgeSize, weight: .medium))
                             .foregroundColor(activeSecondaryColor(0.7))
                     }
                     .buttonStyle(.plain)
@@ -6496,7 +6501,7 @@ private struct TabItemView: View {
                         Text(workspaceShortcutLabel)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(.system(size: sidebarFontSize.metadataSize, weight: .semibold, design: .rounded))
                             .monospacedDigit()
                             .foregroundColor(activePrimaryTextColor)
                             .padding(.horizontal, 6)
@@ -6515,7 +6520,7 @@ private struct TabItemView: View {
 
             if let subtitle = latestNotificationSubtitle {
                 Text(subtitle)
-                    .font(.system(size: 10))
+                    .font(.system(size: sidebarFontSize.metadataSize))
                     .foregroundColor(activeSecondaryColor(0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -6589,7 +6594,7 @@ private struct TabItemView: View {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, branchLinesContainBranch {
                                 Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: 9))
+                                    .font(.system(size: sidebarFontSize.badgeSize))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
@@ -6597,7 +6602,7 @@ private struct TabItemView: View {
                                     HStack(spacing: 3) {
                                         if let branch = line.branch {
                                             Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: sidebarFontSize.branchSize, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -6610,7 +6615,7 @@ private struct TabItemView: View {
                                         }
                                         if let directory = line.directory {
                                             Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: sidebarFontSize.branchSize, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -6624,11 +6629,11 @@ private struct TabItemView: View {
                     HStack(spacing: 3) {
                         if sidebarShowGitBranch && gitBranchSummaryText != nil && sidebarShowGitBranchIcon {
                             Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
+                                .font(.system(size: sidebarFontSize.badgeSize))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(.system(size: sidebarFontSize.branchSize, design: .monospaced))
                             .foregroundColor(activeSecondaryColor(0.75))
                             .lineLimit(1)
                             .truncationMode(.tail)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -51,6 +51,73 @@ enum WorkspaceAutoReorderSettings {
     }
 }
 
+enum SidebarFontSize: String, CaseIterable, Identifiable {
+    case small
+    case `default`
+    case large
+    case extraLarge
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .small: return "Small"
+        case .default: return "Default"
+        case .large: return "Large"
+        case .extraLarge: return "Extra Large"
+        }
+    }
+
+    var titleSize: CGFloat {
+        switch self {
+        case .small: return 11
+        case .default: return 12.5
+        case .large: return 14
+        case .extraLarge: return 16
+        }
+    }
+
+    var metadataSize: CGFloat {
+        switch self {
+        case .small: return 9
+        case .default: return 10
+        case .large: return 11
+        case .extraLarge: return 12
+        }
+    }
+
+    var badgeSize: CGFloat {
+        switch self {
+        case .small: return 8
+        case .default: return 9
+        case .large: return 10
+        case .extraLarge: return 11
+        }
+    }
+
+    var branchSize: CGFloat {
+        switch self {
+        case .small: return 9
+        case .default: return 10
+        case .large: return 11
+        case .extraLarge: return 12
+        }
+    }
+}
+
+enum SidebarFontSizeSettings {
+    static let key = "sidebarFontSize"
+    static let defaultSize: SidebarFontSize = .default
+
+    static func current(defaults: UserDefaults = .standard) -> SidebarFontSize {
+        guard let raw = defaults.string(forKey: key),
+              let size = SidebarFontSize(rawValue: raw) else {
+            return defaultSize
+        }
+        return size
+    }
+}
+
 enum SidebarBranchLayoutSettings {
     static let key = "sidebarBranchVerticalLayout"
     static let defaultVerticalLayout = true

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2656,6 +2656,7 @@ struct SettingsView: View {
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+    @AppStorage(SidebarFontSizeSettings.key) private var sidebarFontSize = SidebarFontSizeSettings.defaultSize.rawValue
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
@@ -2894,6 +2895,21 @@ struct SettingsView: View {
                             Picker("", selection: $sidebarBranchVerticalLayout) {
                                 Text("Vertical").tag(true)
                                 Text("Inline").tag(false)
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            "Sidebar Font Size",
+                            subtitle: "Adjust text size for workspace names and metadata."
+                        ) {
+                            Picker("", selection: $sidebarFontSize) {
+                                ForEach(SidebarFontSize.allCases) { size in
+                                    Text(size.displayName).tag(size.rawValue)
+                                }
                             }
                             .labelsHidden()
                             .pickerStyle(.menu)
@@ -3516,6 +3532,7 @@ struct SettingsView: View {
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
         newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+        sidebarFontSize = SidebarFontSizeSettings.defaultSize.rawValue
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
         sidebarShowBranchDirectory = true


### PR DESCRIPTION
New setting in Settings > Sidebar that scales workspace titles, metadata, badges, branch/directory text, and icons proportionally.

PS: Thanks for your software - it is awesome. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sidebar font size customization with four size options: small, default, large, and extra-large.
  * Font size preference is persistent and applies to badges, titles, metadata, and branch/directory labels in the sidebar.
  * New "Sidebar Font Size" setting available in the settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->