### PR TITLE
Split CI: depot for unit tests, Xcode Cloud for UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,7 @@ jobs:
   tests:
     # Never run self-hosted jobs for fork pull requests.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
-    concurrency:
-      group: self-hosted-build
-      cancel-in-progress: false
+    runs-on: depot-macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -69,23 +66,31 @@ jobs:
           xcodebuild -version
           xcrun --sdk macosx --show-sdk-path
 
-      - name: Download Metal Toolchain
-        run: xcodebuild -downloadComponent MetalToolchain
-
-      - name: Build GhosttyKit.xcframework
+      - name: Download pre-built GhosttyKit.xcframework
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if ! command -v zig >/dev/null 2>&1; then
-            if command -v brew >/dev/null 2>&1; then
-              brew install zig
-            else
-              echo "zig is required to build GhosttyKit.xcframework. Install zig and retry." >&2
+          GHOSTTY_SHA=$(git -C ghostty rev-parse HEAD)
+          TAG="xcframework-$GHOSTTY_SHA"
+          URL="https://github.com/manaflow-ai/ghostty/releases/download/$TAG/GhosttyKit.xcframework.tar.gz"
+          echo "Downloading xcframework for ghostty $GHOSTTY_SHA"
+          MAX_RETRIES=30
+          RETRY_DELAY=20
+          for i in $(seq 1 $MAX_RETRIES); do
+            if curl -fSL -o GhosttyKit.xcframework.tar.gz "$URL"; then
+              echo "Download succeeded on attempt $i"
+              break
+            fi
+            if [ "$i" -eq "$MAX_RETRIES" ]; then
+              echo "Failed to download xcframework after $MAX_RETRIES attempts" >&2
               exit 1
             fi
-          fi
-          (cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false)
-          rm -rf GhosttyKit.xcframework
-          cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
+            echo "Attempt $i/$MAX_RETRIES failed, retrying in ${RETRY_DELAY}s..."
+            sleep $RETRY_DELAY
+          done
+          tar xzf GhosttyKit.xcframework.tar.gz
+          rm GhosttyKit.xcframework.tar.gz
           test -d GhosttyKit.xcframework
 
       - name: Clean DerivedData
@@ -113,8 +118,4 @@ jobs:
               exit 1
             fi
           fi
-
-      - name: Run UI tests
-        run: |
-          set -euo pipefail
-          xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" -only-testing:cmuxUITests/UpdatePillUITests test
+          # UI tests run on Xcode Cloud (not depot)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,10 @@
 name: Nightly macOS build
 
 on:
+  push:
+    branches: [main]
   schedule:
-    # Every hour at :30. The 'decide' job skips if main has no new commits.
+    # Hourly safety net. The 'decide' job skips if main has no new commits.
     - cron: "30 * * * *"
   workflow_dispatch:
     inputs:
@@ -11,6 +13,10 @@ on:
         required: false
         default: false
         type: boolean
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -81,10 +87,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: self-hosted
-    concurrency:
-      group: self-hosted-build
-      cancel-in-progress: false
+    runs-on: depot-macos-latest
     steps:
       - name: Checkout main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
+++ b/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
@@ -7,7 +7,7 @@
       </BuildActionEntry>
     </BuildActionEntries>
   </BuildAction>
-  <TestAction buildConfiguration="Release" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+  <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
     <Testables>
       <TestableReference skipped="NO">
         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="CB450DF0F0B3839599082C4D" BuildableName="cmuxUITests.xctest" BlueprintName="cmuxUITests" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression test for https://github.com/manaflow-ai/cmux/issues/385.
-# Ensures self-hosted UI tests are never run for fork pull requests.
+# Ensures tests are never run for fork pull requests on non-public runners.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -9,7 +9,7 @@ WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 EXPECTED_IF="if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository"
 
 if ! grep -Fq "$EXPECTED_IF" "$WORKFLOW_FILE"; then
-  echo "FAIL: Missing fork pull_request guard for ui-tests in $WORKFLOW_FILE"
+  echo "FAIL: Missing fork pull_request guard for tests in $WORKFLOW_FILE"
   echo "Expected line:"
   echo "  $EXPECTED_IF"
   exit 1
@@ -18,12 +18,12 @@ fi
 if ! awk '
   /^  tests:/ { in_tests=1; next }
   in_tests && /^  [^[:space:]]/ { in_tests=0 }
-  in_tests && /runs-on: self-hosted/ { saw_self_hosted=1 }
+  in_tests && /runs-on: depot-macos/ { saw_depot=1 }
   in_tests && /github.event.pull_request.head.repo.full_name == github.repository/ { saw_guard=1 }
-  END { exit !(saw_self_hosted && saw_guard) }
+  END { exit !(saw_depot && saw_guard) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: tests block must keep both self-hosted and fork guard"
+  echo "FAIL: tests block must keep both depot-macos runner and fork guard"
   exit 1
 fi
 
-echo "PASS: tests self-hosted fork guard is present"
+echo "PASS: tests fork guard is present"


### PR DESCRIPTION
## Summary

- **ci.yml**: Remove UI test step and Metal Toolchain download. Switch `runs-on` from `self-hosted` to `depot-macos-latest`. Download pre-built GhosttyKit.xcframework instead of building from source (same curl+retry pattern as `ci_post_clone.sh`). Unit tests only (~2-3 min).
- **nightly.yml**: Add `push: [main]` trigger so every merge builds a nightly immediately. Add top-level `concurrency: { group: nightly, cancel-in-progress: true }` so rapid merges cancel stale runs. Switch from `self-hosted` to `depot-macos-latest`.
- **test_ci_self_hosted_guard.sh**: Update awk pattern to check for `depot-macos` instead of `self-hosted`.

UI tests move to Xcode Cloud (manual setup in Xcode, `ci_post_clone.sh` hook already merged in PR #447).

## Test plan

- [ ] Verify depot `tests` job runs unit tests only and passes quickly
- [ ] After Xcode Cloud setup: verify it picks up PRs and runs full test suite
- [ ] Merge to main, verify nightly triggers automatically
- [ ] Merge two PRs quickly, verify first nightly is cancelled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD to use optimized macOS runners and simplified concurrency.
  * Switched to downloading a pre-built framework with robust retry logic and token support.
  * Moved depot UI test execution to Xcode Cloud.

* **Tests**
  * Adjusted CI guard and nightly triggers to align with the new runner and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->