### PR TITLE
Precompute panel ordering to reduce sidebar scroll lag

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1622,19 +1622,25 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    func sidebarGitBranchesInDisplayOrder() -> [SidebarGitBranchState] {
+    func sidebarGitBranchesInDisplayOrder(orderedPanelIds: [UUID]) -> [SidebarGitBranchState] {
         SidebarBranchOrdering
             .orderedUniqueBranches(
-                orderedPanelIds: sidebarOrderedPanelIds(),
+                orderedPanelIds: orderedPanelIds,
                 panelBranches: panelGitBranches,
                 fallbackBranch: gitBranch
             )
             .map { SidebarGitBranchState(branch: $0.name, isDirty: $0.isDirty) }
     }
 
-    func sidebarBranchDirectoryEntriesInDisplayOrder() -> [SidebarBranchOrdering.BranchDirectoryEntry] {
+    func sidebarGitBranchesInDisplayOrder() -> [SidebarGitBranchState] {
+        sidebarGitBranchesInDisplayOrder(orderedPanelIds: sidebarOrderedPanelIds())
+    }
+
+    func sidebarBranchDirectoryEntriesInDisplayOrder(
+        orderedPanelIds: [UUID]
+    ) -> [SidebarBranchOrdering.BranchDirectoryEntry] {
         SidebarBranchOrdering.orderedUniqueBranchDirectoryEntries(
-            orderedPanelIds: sidebarOrderedPanelIds(),
+            orderedPanelIds: orderedPanelIds,
             panelBranches: panelGitBranches,
             panelDirectories: panelDirectories,
             defaultDirectory: currentDirectory,
@@ -1642,12 +1648,20 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    func sidebarPullRequestsInDisplayOrder() -> [SidebarPullRequestState] {
+    func sidebarBranchDirectoryEntriesInDisplayOrder() -> [SidebarBranchOrdering.BranchDirectoryEntry] {
+        sidebarBranchDirectoryEntriesInDisplayOrder(orderedPanelIds: sidebarOrderedPanelIds())
+    }
+
+    func sidebarPullRequestsInDisplayOrder(orderedPanelIds: [UUID]) -> [SidebarPullRequestState] {
         SidebarBranchOrdering.orderedUniquePullRequests(
-            orderedPanelIds: sidebarOrderedPanelIds(),
+            orderedPanelIds: orderedPanelIds,
             panelPullRequests: panelPullRequests,
             fallbackPullRequest: pullRequest
         )
+    }
+
+    func sidebarPullRequestsInDisplayOrder() -> [SidebarPullRequestState] {
+        sidebarPullRequestsInDisplayOrder(orderedPanelIds: sidebarOrderedPanelIds())
     }
 
     func sidebarStatusEntriesInDisplayOrder() -> [SidebarStatusEntry] {


### PR DESCRIPTION
## Summary
- Sidebar body was calling `sidebarOrderedPanelIds()` multiple times per render (branches, directories, pull requests each called it independently)
- Now computes ordered panel IDs once at the top of body and passes through to all derived functions
- Converts computed properties to functions accepting precomputed panel order

Closes https://github.com/manaflow-ai/cmux/issues/655

## Test plan
- [ ] Open 20+ workspaces, scroll sidebar rapidly, verify reduced lag
- [ ] Verify branch, directory, and pull request displays still render correctly
- [ ] Run unit tests (precomputed vs non-precomputed equivalence test)