### PR TITLE
Defer browser view hierarchy mutations to prevent Auto Layout recursion

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2981,6 +2981,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         weak var panel: BrowserPanel?
         weak var webView: WKWebView?
         var attachRetryWorkItem: DispatchWorkItem?
+        var deferredHierarchyMutationWorkItem: DispatchWorkItem?
         var attachRetryCount: Int = 0
         var attachGeneration: Int = 0
         var usesWindowPortal: Bool = false
@@ -3139,6 +3140,24 @@ struct WebViewRepresentable: NSViewRepresentable {
         host.onGeometryChanged = nil
     }
 
+    private static func cancelDeferredHierarchyMutation(coordinator: Coordinator) {
+        coordinator.deferredHierarchyMutationWorkItem?.cancel()
+        coordinator.deferredHierarchyMutationWorkItem = nil
+    }
+
+    private static func scheduleDeferredHierarchyMutation(
+        coordinator: Coordinator,
+        _ mutation: @escaping () -> Void
+    ) {
+        cancelDeferredHierarchyMutation(coordinator: coordinator)
+        let work = DispatchWorkItem {
+            coordinator.deferredHierarchyMutationWorkItem = nil
+            mutation()
+        }
+        coordinator.deferredHierarchyMutationWorkItem = work
+        DispatchQueue.main.async(execute: work)
+    }
+
     private func updateUsingWindowPortal(_ nsView: NSView, context: Context, webView: WKWebView) {
         guard let host = nsView as? HostContainerView else { return }
 
@@ -3263,6 +3282,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         let retryInterval: TimeInterval = 1.0 / 60.0
         // Don't schedule multiple overlapping retries.
         guard coordinator.attachRetryWorkItem == nil else { return }
+        cancelDeferredHierarchyMutation(coordinator: coordinator)
 
         let work = DispatchWorkItem { [weak host, weak webView] in
             coordinator.attachRetryWorkItem = nil
@@ -3335,8 +3355,9 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         let webView = panel.webView
-        context.coordinator.panel = panel
-        context.coordinator.webView = webView
+        let coordinator = context.coordinator
+        coordinator.panel = panel
+        coordinator.webView = webView
         Self.applyWebViewFirstResponderPolicy(
             panel: panel,
             webView: webView,
@@ -3345,7 +3366,8 @@ struct WebViewRepresentable: NSViewRepresentable {
 
         let shouldUseWindowPortal = panel.shouldPreserveWebViewAttachmentDuringTransientHide()
         if shouldUseWindowPortal {
-            context.coordinator.usesWindowPortal = true
+            coordinator.usesWindowPortal = true
+            Self.cancelDeferredHierarchyMutation(coordinator: coordinator)
             Self.clearPortalCallbacks(for: nsView)
             updateUsingWindowPortal(nsView, context: context, webView: webView)
             Self.applyFocus(
@@ -3358,10 +3380,10 @@ struct WebViewRepresentable: NSViewRepresentable {
             return
         }
 
-        if context.coordinator.usesWindowPortal {
+        if coordinator.usesWindowPortal {
             BrowserWindowPortalRegistry.detach(webView: webView)
-            context.coordinator.usesWindowPortal = false
-            context.coordinator.lastPortalHostId = nil
+            coordinator.usesWindowPortal = false
+            coordinator.lastPortalHostId = nil
         }
         Self.clearPortalCallbacks(for: nsView)
 
@@ -3390,8 +3412,8 @@ struct WebViewRepresentable: NSViewRepresentable {
             Self.logDevToolsState(
                 panel,
                 event: "detach.beforeSync",
-                generation: context.coordinator.attachGeneration,
-                retryCount: context.coordinator.attachRetryCount,
+                generation: coordinator.attachGeneration,
+                retryCount: coordinator.attachRetryCount,
                 details: Self.attachContext(webView: webView, host: nsView)
             )
             #endif
@@ -3400,54 +3422,60 @@ struct WebViewRepresentable: NSViewRepresentable {
             Self.logDevToolsState(
                 panel,
                 event: "detach.afterSync",
-                generation: context.coordinator.attachGeneration,
-                retryCount: context.coordinator.attachRetryCount,
+                generation: coordinator.attachGeneration,
+                retryCount: coordinator.attachRetryCount,
                 details: Self.attachContext(webView: webView, host: nsView)
             )
             #endif
-            context.coordinator.attachRetryWorkItem?.cancel()
-            context.coordinator.attachRetryWorkItem = nil
-            context.coordinator.attachRetryCount = 0
-            context.coordinator.attachGeneration += 1
+            coordinator.attachRetryWorkItem?.cancel()
+            coordinator.attachRetryWorkItem = nil
+            coordinator.attachRetryCount = 0
+            coordinator.attachGeneration += 1
+            let generation = coordinator.attachGeneration
+            Self.scheduleDeferredHierarchyMutation(coordinator: coordinator) { [weak nsView, weak webView] in
+                guard coordinator.attachGeneration == generation else { return }
+                guard let nsView, let webView else { return }
 
-            // Resign focus if WebKit currently owns first responder.
-            if let window = webView.window ?? nsView.window {
-                let state = Self.firstResponderResignState(window.firstResponder, webView: webView)
-                if state.needsResign {
-                    #if DEBUG
-                    Self.logDevToolsState(
-                        panel,
-                        event: "detach.resignFirstResponder",
-                        generation: context.coordinator.attachGeneration,
-                        retryCount: context.coordinator.attachRetryCount,
-                        details: Self.attachContext(webView: webView, host: nsView) + " " + state.flags
-                    )
-                    #endif
-                    window.makeFirstResponder(nil)
+                // Resign focus if WebKit currently owns first responder.
+                if let window = webView.window ?? nsView.window {
+                    let state = Self.firstResponderResignState(window.firstResponder, webView: webView)
+                    if state.needsResign {
+                        #if DEBUG
+                        Self.logDevToolsState(
+                            panel,
+                            event: "detach.resignFirstResponder",
+                            generation: generation,
+                            retryCount: coordinator.attachRetryCount,
+                            details: Self.attachContext(webView: webView, host: nsView) + " " + state.flags
+                        )
+                        #endif
+                        window.makeFirstResponder(nil)
+                    }
                 }
-            }
 
-            if webView.superview != nil {
-                webView.removeFromSuperview()
+                if webView.superview != nil {
+                    webView.removeFromSuperview()
+                }
+                nsView.subviews.forEach { $0.removeFromSuperview() }
+                #if DEBUG
+                Self.logDevToolsState(
+                    panel,
+                    event: "detach.done",
+                    generation: generation,
+                    retryCount: coordinator.attachRetryCount,
+                    details: Self.attachContext(webView: webView, host: nsView)
+                )
+                #endif
             }
-            nsView.subviews.forEach { $0.removeFromSuperview() }
-            #if DEBUG
-            Self.logDevToolsState(
-                panel,
-                event: "detach.done",
-                generation: context.coordinator.attachGeneration,
-                retryCount: context.coordinator.attachRetryCount,
-                details: Self.attachContext(webView: webView, host: nsView)
-            )
-            #endif
             return
         }
 
         if webView.superview !== nsView {
             // Cancel any pending retry; we'll reschedule if needed.
-            context.coordinator.attachRetryWorkItem?.cancel()
-            context.coordinator.attachRetryWorkItem = nil
-            context.coordinator.attachGeneration += 1
+            coordinator.attachRetryWorkItem?.cancel()
+            coordinator.attachRetryWorkItem = nil
+            coordinator.attachGeneration += 1
+            let generation = coordinator.attachGeneration
 
             if let window = webView.window ?? nsView.window {
                 let state = Self.firstResponderResignState(window.firstResponder, webView: webView)
@@ -3456,8 +3484,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     Self.logDevToolsState(
                         panel,
                         event: "attach.reparent.resignFirstResponder.begin",
-                        generation: context.coordinator.attachGeneration,
-                        retryCount: context.coordinator.attachRetryCount,
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
                         details: Self.attachContext(webView: webView, host: nsView) + " " + state.flags
                     )
                     #endif
@@ -3466,8 +3494,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     Self.logDevToolsState(
                         panel,
                         event: "attach.reparent.resignFirstResponder.end",
-                        generation: context.coordinator.attachGeneration,
-                        retryCount: context.coordinator.attachRetryCount,
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
                         details: Self.attachContext(webView: webView, host: nsView) + " " + state.flags + " resigned=\(resigned ? 1 : 0)"
                     )
                     #endif
@@ -3483,8 +3511,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     Self.logDevToolsState(
                         panel,
                         event: "attach.defer.requestRefresh",
-                        generation: context.coordinator.attachGeneration,
-                        retryCount: context.coordinator.attachRetryCount,
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
                         details: Self.attachContext(webView: webView, host: nsView)
                     )
                     #endif
@@ -3493,8 +3521,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                 Self.logDevToolsState(
                     panel,
                     event: "attach.defer.offWindow",
-                    generation: context.coordinator.attachGeneration,
-                    retryCount: context.coordinator.attachRetryCount,
+                    generation: generation,
+                    retryCount: coordinator.attachRetryCount,
                     details: Self.attachContext(webView: webView, host: nsView)
                 )
                 #endif
@@ -3502,37 +3530,54 @@ struct WebViewRepresentable: NSViewRepresentable {
                     webView,
                     panel: panel,
                     to: nsView,
-                    coordinator: context.coordinator,
-                    generation: context.coordinator.attachGeneration
+                    coordinator: coordinator,
+                    generation: generation
                 )
             } else {
-                #if DEBUG
-                Self.logDevToolsState(
-                    panel,
-                    event: "attach.immediate.begin",
-                    generation: context.coordinator.attachGeneration,
-                    retryCount: context.coordinator.attachRetryCount,
-                    details: Self.attachContext(webView: webView, host: nsView)
-                )
-                #endif
-                Self.attachWebView(webView, to: nsView)
-                panel.restoreDeveloperToolsAfterAttachIfNeeded()
-                #if DEBUG
-                Self.logDevToolsState(
-                    panel,
-                    event: "attach.immediate",
-                    generation: context.coordinator.attachGeneration,
-                    retryCount: context.coordinator.attachRetryCount,
-                    details: Self.attachContext(webView: webView, host: nsView)
-                )
-                #endif
+                Self.scheduleDeferredHierarchyMutation(coordinator: coordinator) { [weak nsView, weak webView] in
+                    guard coordinator.attachGeneration == generation else { return }
+                    guard let nsView, let webView else { return }
+
+                    guard nsView.window != nil else {
+                        Self.scheduleAttachRetry(
+                            webView,
+                            panel: panel,
+                            to: nsView,
+                            coordinator: coordinator,
+                            generation: generation
+                        )
+                        return
+                    }
+
+                    #if DEBUG
+                    Self.logDevToolsState(
+                        panel,
+                        event: "attach.immediate.begin",
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
+                        details: Self.attachContext(webView: webView, host: nsView)
+                    )
+                    #endif
+                    Self.attachWebView(webView, to: nsView)
+                    panel.restoreDeveloperToolsAfterAttachIfNeeded()
+                    #if DEBUG
+                    Self.logDevToolsState(
+                        panel,
+                        event: "attach.immediate",
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
+                        details: Self.attachContext(webView: webView, host: nsView)
+                    )
+                    #endif
+                }
             }
         } else {
             // Already attached; no need for any pending retry.
-            context.coordinator.attachRetryWorkItem?.cancel()
-            context.coordinator.attachRetryWorkItem = nil
-            context.coordinator.attachRetryCount = 0
-            context.coordinator.attachGeneration += 1
+            coordinator.attachRetryWorkItem?.cancel()
+            coordinator.attachRetryWorkItem = nil
+            coordinator.attachRetryCount = 0
+            coordinator.attachGeneration += 1
+            Self.cancelDeferredHierarchyMutation(coordinator: coordinator)
             let hadPendingRefresh = panel.hasPendingDeveloperToolsRefreshAfterAttach()
             panel.restoreDeveloperToolsAfterAttachIfNeeded()
             #if DEBUG
@@ -3540,16 +3585,16 @@ struct WebViewRepresentable: NSViewRepresentable {
                 Self.logDevToolsState(
                     panel,
                     event: "attach.alreadyAttached.consumePendingRefresh",
-                    generation: context.coordinator.attachGeneration,
-                    retryCount: context.coordinator.attachRetryCount,
+                    generation: coordinator.attachGeneration,
+                    retryCount: coordinator.attachRetryCount,
                     details: Self.attachContext(webView: webView, host: nsView)
                 )
             }
             Self.logDevToolsState(
                 panel,
                 event: "attach.alreadyAttached",
-                generation: context.coordinator.attachGeneration,
-                retryCount: context.coordinator.attachRetryCount,
+                generation: coordinator.attachGeneration,
+                retryCount: coordinator.attachRetryCount,
                 details: Self.attachContext(webView: webView, host: nsView)
             )
             #endif
@@ -3612,6 +3657,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         coordinator.attachRetryWorkItem?.cancel()
         coordinator.attachRetryWorkItem = nil
+        cancelDeferredHierarchyMutation(coordinator: coordinator)
         coordinator.attachRetryCount = 0
         coordinator.attachGeneration += 1
         clearPortalCallbacks(for: nsView)
@@ -3681,18 +3727,24 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         if webView.superview === nsView {
-            webView.removeFromSuperview()
-            #if DEBUG
-            if let panel {
-                logDevToolsState(
-                    panel,
-                    event: "dismantle.detached",
-                    generation: coordinator.attachGeneration,
-                    retryCount: coordinator.attachRetryCount,
-                    details: attachContext(webView: webView, host: nsView)
-                )
+            let generation = coordinator.attachGeneration
+            scheduleDeferredHierarchyMutation(coordinator: coordinator) { [weak webView, weak nsView] in
+                guard coordinator.attachGeneration == generation else { return }
+                guard let webView, let nsView else { return }
+                guard webView.superview === nsView else { return }
+                webView.removeFromSuperview()
+                #if DEBUG
+                if let panel {
+                    logDevToolsState(
+                        panel,
+                        event: "dismantle.detached",
+                        generation: generation,
+                        retryCount: coordinator.attachRetryCount,
+                        details: attachContext(webView: webView, host: nsView)
+                    )
+                }
+                #endif
             }
-            #endif
         }
     }
 }

--- a/tests/test_browser_panel_stability.py
+++ b/tests/test_browser_panel_stability.py
@@ -153,6 +153,57 @@ def test_focus_panes_with_loaded_browser(client: cmux) -> tuple[bool, str]:
     return True, "Rapid focus_pane loop with loaded browser did not crash"
 
 
+def test_workspace_switch_with_browser_surface(client: cmux) -> tuple[bool, str]:
+    browser_workspace_id = client.new_workspace()
+    terminal_workspace_id = None
+
+    try:
+        client.select_workspace(browser_workspace_id)
+        time.sleep(0.5)
+
+        browser_id = client.new_surface(panel_type="browser", url="https://example.com")
+        time.sleep(1.2)
+        ensure_webview_focused(client, browser_id, timeout_s=2.0)
+
+        terminal_workspace_id = client.new_workspace()
+        client.select_workspace(terminal_workspace_id)
+        time.sleep(0.3)
+
+        # Repeatedly switch between a browser-active workspace and a terminal workspace.
+        # This reproduces the workspace-switch path that used to trigger Auto Layout recursion.
+        for i in range(120):
+            client.select_workspace(browser_workspace_id)
+            time.sleep(0.03)
+
+            if i % 4 == 0:
+                client.focus_surface(browser_id)
+                client.focus_webview(browser_id)
+
+            client.select_workspace(terminal_workspace_id)
+            time.sleep(0.03)
+
+            if i % 12 == 0 and not client.ping():
+                return False, f"Ping failed during workspace switch loop (i={i})"
+
+        client.select_workspace(browser_workspace_id)
+        time.sleep(0.1)
+        ensure_webview_focused(client, browser_id, timeout_s=1.2)
+        if not client.ping():
+            return False, "Ping failed after workspace switch loop"
+
+        return True, "Repeated workspace switching with browser-active tab did not crash"
+    finally:
+        if terminal_workspace_id is not None:
+            try:
+                client.close_workspace(terminal_workspace_id)
+            except Exception:
+                pass
+        try:
+            client.close_workspace(browser_workspace_id)
+        except Exception:
+            pass
+
+
 def run_tests() -> int:
     print("=" * 60)
     print("cmux Browser Panel Stability Test")
@@ -165,6 +216,7 @@ def run_tests() -> int:
     tests = [
         ("open_browser then new_surface loop", test_open_browser_then_new_surface_loop),
         ("focus panes with loaded browser", test_focus_panes_with_loaded_browser),
+        ("workspace switching with browser surface", test_workspace_switch_with_browser_surface),
     ]
 
     passed = 0

--- a/tests_v2/test_browser_panel_stability.py
+++ b/tests_v2/test_browser_panel_stability.py
@@ -153,6 +153,57 @@ def test_focus_panes_with_loaded_browser(client: cmux) -> tuple[bool, str]:
     return True, "Rapid focus_pane loop with loaded browser did not crash"
 
 
+def test_workspace_switch_with_browser_surface(client: cmux) -> tuple[bool, str]:
+    browser_workspace_id = client.new_workspace()
+    terminal_workspace_id = None
+
+    try:
+        client.select_workspace(browser_workspace_id)
+        time.sleep(0.5)
+
+        browser_id = client.new_surface(panel_type="browser", url="https://example.com")
+        time.sleep(1.2)
+        ensure_webview_focused(client, browser_id, timeout_s=2.0)
+
+        terminal_workspace_id = client.new_workspace()
+        client.select_workspace(terminal_workspace_id)
+        time.sleep(0.3)
+
+        # Repeatedly switch between a browser-active workspace and a terminal workspace.
+        # This reproduces the workspace-switch path that used to trigger Auto Layout recursion.
+        for i in range(120):
+            client.select_workspace(browser_workspace_id)
+            time.sleep(0.03)
+
+            if i % 4 == 0:
+                client.focus_surface(browser_id)
+                client.focus_webview(browser_id)
+
+            client.select_workspace(terminal_workspace_id)
+            time.sleep(0.03)
+
+            if i % 12 == 0 and not client.ping():
+                return False, f"Ping failed during workspace switch loop (i={i})"
+
+        client.select_workspace(browser_workspace_id)
+        time.sleep(0.1)
+        ensure_webview_focused(client, browser_id, timeout_s=1.2)
+        if not client.ping():
+            return False, "Ping failed after workspace switch loop"
+
+        return True, "Repeated workspace switching with browser-active tab did not crash"
+    finally:
+        if terminal_workspace_id is not None:
+            try:
+                client.close_workspace(terminal_workspace_id)
+            except Exception:
+                pass
+        try:
+            client.close_workspace(browser_workspace_id)
+        except Exception:
+            pass
+
+
 def run_tests() -> int:
     print("=" * 60)
     print("cmux Browser Panel Stability Test")
@@ -165,6 +216,7 @@ def run_tests() -> int:
     tests = [
         ("open_browser then new_surface loop", test_open_browser_then_new_surface_loop),
         ("focus panes with loaded browser", test_focus_panes_with_loaded_browser),
+        ("workspace switching with browser surface", test_workspace_switch_with_browser_surface),
     ]
 
     passed = 0


### PR DESCRIPTION
## Summary
- macOS 26 Tahoe enforces stricter Auto Layout validation, crashing with EXC_BREAKPOINT when addSubview/removeFromSuperview is called during a layout pass
- Wraps attach/detach/dismantle view hierarchy mutations in `scheduleDeferredHierarchyMutation` (DispatchQueue.main.async) with generation guards to prevent stale mutations
- Adds regression test that rapidly switches between browser and terminal workspaces 120 times

Closes https://github.com/manaflow-ai/cmux/issues/653

## Test plan
- [ ] Switch between browser-active and terminal workspaces rapidly on macOS 26
- [ ] Verify no crash (was EXC_BREAKPOINT/SIGTRAP previously)
- [ ] Verify browser panels still attach/detach correctly during normal tab switching
- [ ] Verify DevTools restoration still works after workspace switch