### PR TITLE
Fix Cmd+plus zoom on non-US keyboard layouts

### DIFF
--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -11,4 +11,36 @@ class KeyboardLayout {
 
         return nil
     }
+
+    /// Translate a physical keyCode to the unmodified character under the current keyboard layout.
+    static func character(forKeyCode keyCode: UInt16) -> String? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+              let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+
+        let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+        guard let bytes = CFDataGetBytePtr(layoutData) else { return nil }
+        let keyboardLayout = UnsafeRawPointer(bytes).assumingMemoryBound(to: UCKeyboardLayout.self)
+
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+
+        let status = UCKeyTranslate(
+            keyboardLayout,
+            keyCode,
+            UInt16(kUCKeyActionDisplay),
+            0,
+            UInt32(LMGetKbdType()),
+            UInt32(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            chars.count,
+            &length,
+            &chars
+        )
+
+        guard status == noErr, length > 0 else { return nil }
+        return String(utf16CodeUnits: chars, count: length).lowercased()
+    }
 }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2045,6 +2045,26 @@ final class BrowserZoomShortcutActionTests: XCTestCase {
         )
     }
 
+    func testZoomInSupportsShiftedLiteralFromDifferentPhysicalKey() {
+        XCTAssertEqual(
+            browserZoomShortcutAction(
+                flags: [.command, .shift],
+                chars: ";",
+                keyCode: 41,
+                literalChars: "+"
+            ),
+            .zoomIn
+        )
+
+        XCTAssertNil(
+            browserZoomShortcutAction(
+                flags: [.command, .shift],
+                chars: ";",
+                keyCode: 41
+            )
+        )
+    }
+
     func testZoomRequiresCommandWithoutOptionOrControl() {
         XCTAssertNil(browserZoomShortcutAction(flags: [], chars: "=", keyCode: 24))
         XCTAssertNil(browserZoomShortcutAction(flags: [.command, .option], chars: "=", keyCode: 24))
@@ -2105,6 +2125,18 @@ final class BrowserZoomShortcutRoutingPolicyTests: XCTestCase {
                 flags: [.command],
                 chars: "n",
                 keyCode: 45
+            )
+        )
+    }
+
+    func testRoutesForShiftedLiteralZoomShortcut() {
+        XCTAssertTrue(
+            shouldRouteTerminalFontZoomShortcutToGhostty(
+                firstResponderIsGhostty: true,
+                flags: [.command, .shift],
+                chars: ";",
+                keyCode: 41,
+                literalChars: "+"
             )
         )
     }


### PR DESCRIPTION
## Summary
- fix zoom shortcut matching to consider both `charactersIgnoringModifiers`, literal `event.characters`, and the current keyboard-layout character for the pressed key code
- route shifted literal zoom shortcuts (for example layouts where `+` comes from a non-`=` physical key) to both browser zoom and terminal font zoom paths
- add regression tests for shifted-literal `Cmd+Shift` zoom-in routing and keep zoom shortcut matching gated behind command-modifier checks for hot-path performance

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests test` (pass)

## Issues
- Related: task-jis-cmd-plus-zoom-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Browser zoom shortcuts now work reliably across different keyboard layouts by recognizing both physical key positions and literal character inputs.
* Enhanced zoom shortcut matching to consider keyboard layout variations and shifted key combinations.

## Tests
* Added test cases to verify browser zoom shortcuts function correctly with shifted modifiers and alternative physical keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->