### PR TITLE
Fix CI unit-test failures from transient SwiftPM artifact resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Validate create-dmg version pinning
         run: ./tests/test_ci_create_dmg_pinned.sh
 
+      - name: Validate unit-test SwiftPM retry guard
+        run: ./tests/test_ci_unit_test_spm_retry.sh
+
   web-typecheck:
     runs-on: ubuntu-latest
     defaults:
@@ -96,13 +99,31 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
+          run_unit_tests() {
+            xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug \
+              -destination "platform=macOS" test 2>&1
+          }
+
           # xcodebuild exits 65 even for expected failures (XCTExpectFailure).
           # Capture output and fail only if there are unexpected failures.
           set +e
-          OUTPUT=$(xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug \
-            -destination "platform=macOS" test 2>&1)
+          OUTPUT=$(run_unit_tests)
           EXIT_CODE=$?
           set -e
+
+          # SwiftPM binary artifact resolution can occasionally fail on self-hosted
+          # runners with "Could not resolve package dependencies". Retry once after
+          # clearing SwiftPM/DerivedData caches to recover from transient corruption.
+          if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | grep -q "Could not resolve package dependencies"; then
+            echo "SwiftPM package resolution failed, clearing caches and retrying once"
+            rm -rf ~/Library/Caches/org.swift.swiftpm
+            rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
+            set +e
+            OUTPUT=$(run_unit_tests)
+            EXIT_CODE=$?
+            set -e
+          fi
+
           echo "$OUTPUT"
           if [ "$EXIT_CODE" -ne 0 ]; then
             SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)

--- a/tests/test_ci_unit_test_spm_retry.sh
+++ b/tests/test_ci_unit_test_spm_retry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Regression test for CI unit-test SwiftPM dependency flake handling.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
+
+REQUIRED_PATTERNS=(
+  "run_unit_tests()"
+  "Could not resolve package dependencies"
+  "rm -rf ~/Library/Caches/org.swift.swiftpm"
+  "OUTPUT=\$(run_unit_tests)"
+)
+
+for pattern in "${REQUIRED_PATTERNS[@]}"; do
+  if ! grep -Fq "$pattern" "$WORKFLOW_FILE"; then
+    echo "FAIL: Missing pattern in ci.yml: $pattern"
+    exit 1
+  fi
+done
+
+echo "PASS: CI unit-test SwiftPM retry guard is present"


### PR DESCRIPTION
## Summary
- make the CI unit-test step retry once when xcodebuild fails with "Could not resolve package dependencies"
- clear SwiftPM + DerivedData caches before retry to recover from stale/missing binary artifact state
- add a workflow guard regression script so this retry behavior stays in `.github/workflows/ci.yml`

## Why
This fixes the failure seen in run https://github.com/manaflow-ai/cmux/actions/runs/22516948209/job/65236024084 where unit tests failed due to a missing Sparkle artifact path during package resolution.

## Validation
- `./tests/test_ci_unit_test_spm_retry.sh`
- `./tests/test_ci_self_hosted_guard.sh`
- `./tests/test_ci_create_dmg_pinned.sh`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `./scripts/reload.sh --tag fix-ci-swiftpm-artifact-retry`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline reliability with automatic retry logic for unit tests. When SwiftPM dependency resolution fails, caches are cleared and tests retry automatically.

* **Tests**
  * Added validation test to verify CI workflow contains required SwiftPM retry handling patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->