### PR TITLE
Add configurable Cmd+Shift/Option+Shift override for sidebar PR links

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4214,8 +4214,9 @@ struct ContentView: View {
             tabManager.selectPreviousSurface()
         }
         registry.register(commandId: "palette.openWorkspacePullRequests") {
+            let modifierFlags = NSEvent.modifierFlags
             DispatchQueue.main.async {
-                if !openWorkspacePullRequestsInConfiguredBrowser() {
+                if !openWorkspacePullRequestsInConfiguredBrowser(modifierFlags: modifierFlags) {
                     NSSound.beep()
                 }
             }
@@ -4884,13 +4885,18 @@ struct ContentView: View {
         return NSWorkspace.shared.open(url)
     }
 
-    private func openWorkspacePullRequestsInConfiguredBrowser() -> Bool {
+    private func openWorkspacePullRequestsInConfiguredBrowser(
+        modifierFlags: NSEvent.ModifierFlags = NSEvent.modifierFlags
+    ) -> Bool {
         guard let workspace = tabManager.selectedWorkspace else { return false }
         let pullRequests = workspace.sidebarPullRequestsInDisplayOrder()
         guard !pullRequests.isEmpty else { return false }
 
+        let shouldOpenInCmuxBrowser = BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+            modifierFlags: modifierFlags
+        )
         var openedCount = 0
-        if openSidebarPullRequestLinksInCmuxBrowser {
+        if shouldOpenInCmuxBrowser {
             for pullRequest in pullRequests {
                 if tabManager.openBrowser(url: pullRequest.url, insertAtEnd: true) != nil {
                     openedCount += 1
@@ -7054,9 +7060,9 @@ private struct TabItemView: View {
         selection = .tabs
     }
 
-    private func updateSelection() {
+    private func updateSelection(modifierFlags: NSEvent.ModifierFlags = NSEvent.modifierFlags) {
         #if DEBUG
-        let mods = NSEvent.modifierFlags
+        let mods = modifierFlags
         var modStr = ""
         if mods.contains(.command) { modStr += "cmd " }
         if mods.contains(.shift) { modStr += "shift " }
@@ -7064,7 +7070,7 @@ private struct TabItemView: View {
         if mods.contains(.control) { modStr += "ctrl " }
         dlog("sidebar.select workspace=\(tab.id.uuidString.prefix(5)) modifiers=\(modStr.isEmpty ? "none" : modStr.trimmingCharacters(in: .whitespaces))")
         #endif
-        let modifiers = NSEvent.modifierFlags
+        let modifiers = modifierFlags
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
 
@@ -7310,8 +7316,12 @@ private struct TabItemView: View {
     }
 
     private func openPullRequestLink(_ url: URL) {
-        updateSelection()
-        if openSidebarPullRequestLinksInCmuxBrowser {
+        let openModifierFlags = NSEvent.modifierFlags
+        updateSelection(modifierFlags: [])
+        let shouldOpenInCmuxBrowser = BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+            modifierFlags: openModifierFlags
+        )
+        if shouldOpenInCmuxBrowser {
             if tabManager.openBrowser(
                 inWorkspace: tab.id,
                 url: url,

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -127,6 +127,43 @@ enum BrowserThemeSettings {
     }
 }
 
+enum BrowserLinkModifierBehavior: String, CaseIterable, Identifiable {
+    case commandShiftOpensCmuxOptionShiftOpensDefault
+    case commandShiftOpensDefaultOptionShiftOpensCmux
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .commandShiftOpensCmuxOptionShiftOpensDefault:
+            return "Cmd+Shift -> cmux, Option+Shift -> Default"
+        case .commandShiftOpensDefaultOptionShiftOpensCmux:
+            return "Cmd+Shift -> Default, Option+Shift -> cmux"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .commandShiftOpensCmuxOptionShiftOpensDefault:
+            return "Cmd+Shift forces cmux browser, Option+Shift forces your default browser."
+        case .commandShiftOpensDefaultOptionShiftOpensCmux:
+            return "Cmd+Shift forces your default browser, Option+Shift forces cmux browser."
+        }
+    }
+
+    func opensInCmuxBrowser(for modifierFlags: NSEvent.ModifierFlags) -> Bool? {
+        let normalizedFlags = modifierFlags.intersection([.command, .shift, .option, .control])
+        switch normalizedFlags {
+        case [.command, .shift]:
+            return self == .commandShiftOpensCmuxOptionShiftOpensDefault
+        case [.option, .shift]:
+            return self == .commandShiftOpensDefaultOptionShiftOpensCmux
+        default:
+            return nil
+        }
+    }
+}
+
 enum BrowserLinkOpenSettings {
     static let openTerminalLinksInCmuxBrowserKey = "browserOpenTerminalLinksInCmuxBrowser"
     static let defaultOpenTerminalLinksInCmuxBrowser: Bool = true
@@ -136,6 +173,9 @@ enum BrowserLinkOpenSettings {
 
     static let interceptTerminalOpenCommandInCmuxBrowserKey = "browserInterceptTerminalOpenCommandInCmuxBrowser"
     static let defaultInterceptTerminalOpenCommandInCmuxBrowser: Bool = true
+
+    static let linkModifierBehaviorKey = "browserLinkModifierBehavior"
+    static let defaultLinkModifierBehavior: BrowserLinkModifierBehavior = .commandShiftOpensCmuxOptionShiftOpensDefault
 
     static let browserHostWhitelistKey = "browserHostWhitelist"
     static let defaultBrowserHostWhitelist: String = ""
@@ -169,6 +209,38 @@ enum BrowserLinkOpenSettings {
 
     static func initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: UserDefaults = .standard) -> Bool {
         interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+    }
+
+    static func linkModifierBehavior(for rawValue: String?) -> BrowserLinkModifierBehavior {
+        guard let rawValue,
+              let behavior = BrowserLinkModifierBehavior(rawValue: rawValue) else {
+            return defaultLinkModifierBehavior
+        }
+        return behavior
+    }
+
+    static func linkModifierBehavior(defaults: UserDefaults = .standard) -> BrowserLinkModifierBehavior {
+        linkModifierBehavior(for: defaults.string(forKey: linkModifierBehaviorKey))
+    }
+
+    static func linkModifierOverrideOpensInCmuxBrowser(
+        modifierFlags: NSEvent.ModifierFlags,
+        defaults: UserDefaults = .standard
+    ) -> Bool? {
+        linkModifierBehavior(defaults: defaults).opensInCmuxBrowser(for: modifierFlags)
+    }
+
+    static func shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+        modifierFlags: NSEvent.ModifierFlags,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if let modifierOverride = linkModifierOverrideOpensInCmuxBrowser(
+            modifierFlags: modifierFlags,
+            defaults: defaults
+        ) {
+            return modifierOverride
+        }
+        return openSidebarPullRequestLinksInCmuxBrowser(defaults: defaults)
     }
 
     static func hostWhitelist(defaults: UserDefaults = .standard) -> [String] {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2674,6 +2674,8 @@ struct SettingsView: View {
     @AppStorage(BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey) private var openTerminalLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenTerminalLinksInCmuxBrowser
     @AppStorage(BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
     private var interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue()
+    @AppStorage(BrowserLinkOpenSettings.linkModifierBehaviorKey)
+    private var linkModifierBehavior = BrowserLinkOpenSettings.defaultLinkModifierBehavior.rawValue
     @AppStorage(BrowserLinkOpenSettings.browserHostWhitelistKey) private var browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
     @AppStorage(BrowserInsecureHTTPSettings.allowlistKey) private var browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
@@ -2737,6 +2739,19 @@ struct SettingsView: View {
             get: { browserThemeMode },
             set: { newValue in
                 browserThemeMode = BrowserThemeSettings.mode(for: newValue).rawValue
+            }
+        )
+    }
+
+    private var selectedLinkModifierBehavior: BrowserLinkModifierBehavior {
+        BrowserLinkOpenSettings.linkModifierBehavior(for: linkModifierBehavior)
+    }
+
+    private var linkModifierBehaviorSelection: Binding<String> {
+        Binding(
+            get: { selectedLinkModifierBehavior.rawValue },
+            set: { newValue in
+                linkModifierBehavior = BrowserLinkOpenSettings.linkModifierBehavior(for: newValue).rawValue
             }
         )
     }
@@ -2958,6 +2973,22 @@ struct SettingsView: View {
                             Toggle("", isOn: $openSidebarPullRequestLinksInCmuxBrowser)
                                 .labelsHidden()
                                 .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            "Sidebar PR Link Modifier Override",
+                            subtitle: selectedLinkModifierBehavior.summary,
+                            controlWidth: pickerColumnWidth
+                        ) {
+                            Picker("", selection: linkModifierBehaviorSelection) {
+                                ForEach(BrowserLinkModifierBehavior.allCases) { behavior in
+                                    Text(behavior.displayName).tag(behavior.rawValue)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
                         }
 
                         SettingsCardDivider()
@@ -3479,6 +3510,7 @@ struct SettingsView: View {
         .onAppear {
             BrowserHistoryStore.shared.loadIfNeeded()
             browserThemeMode = BrowserThemeSettings.mode(defaults: .standard).rawValue
+            linkModifierBehavior = BrowserLinkOpenSettings.linkModifierBehavior(defaults: .standard).rawValue
             browserHistoryEntryCount = BrowserHistoryStore.shared.entries.count
             browserInsecureHTTPAllowlistDraft = browserInsecureHTTPAllowlist
             reloadWorkspaceTabColorSettings()
@@ -3534,6 +3566,7 @@ struct SettingsView: View {
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
         openTerminalLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenTerminalLinksInCmuxBrowser
         interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser
+        linkModifierBehavior = BrowserLinkOpenSettings.defaultLinkModifierBehavior.rawValue
         browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
         browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
         browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7636,6 +7636,129 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         defaults.set(true, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
         XCTAssertTrue(BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: defaults))
     }
+
+    func testLinkModifierBehaviorDefaultsToCommandShiftCmux() {
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierBehavior(defaults: defaults),
+            .commandShiftOpensCmuxOptionShiftOpensDefault
+        )
+    }
+
+    func testLinkModifierBehaviorUsesStoredValue() {
+        defaults.set(
+            BrowserLinkModifierBehavior.commandShiftOpensDefaultOptionShiftOpensCmux.rawValue,
+            forKey: BrowserLinkOpenSettings.linkModifierBehaviorKey
+        )
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierBehavior(defaults: defaults),
+            .commandShiftOpensDefaultOptionShiftOpensCmux
+        )
+    }
+
+    func testLinkModifierOverrideMatchesConfiguredBehavior() {
+        defaults.set(
+            BrowserLinkModifierBehavior.commandShiftOpensCmuxOptionShiftOpensDefault.rawValue,
+            forKey: BrowserLinkOpenSettings.linkModifierBehaviorKey
+        )
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.command, .shift],
+                defaults: defaults
+            ),
+            true
+        )
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.option, .shift],
+                defaults: defaults
+            ),
+            false
+        )
+
+        defaults.set(
+            BrowserLinkModifierBehavior.commandShiftOpensDefaultOptionShiftOpensCmux.rawValue,
+            forKey: BrowserLinkOpenSettings.linkModifierBehaviorKey
+        )
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.command, .shift],
+                defaults: defaults
+            ),
+            false
+        )
+        XCTAssertEqual(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.option, .shift],
+                defaults: defaults
+            ),
+            true
+        )
+    }
+
+    func testLinkModifierOverrideIgnoresUnconfiguredModifierSets() {
+        XCTAssertNil(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.shift],
+                defaults: defaults
+            )
+        )
+        XCTAssertNil(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.command],
+                defaults: defaults
+            )
+        )
+        XCTAssertNil(
+            BrowserLinkOpenSettings.linkModifierOverrideOpensInCmuxBrowser(
+                modifierFlags: [.command, .shift, .control],
+                defaults: defaults
+            )
+        )
+    }
+
+    func testShouldOpenSidebarPullRequestLinkInCmuxBrowserFallsBackToToggleWhenNoOverrideModifier() {
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
+        XCTAssertFalse(
+            BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+                modifierFlags: [],
+                defaults: defaults
+            )
+        )
+
+        defaults.set(true, forKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
+        XCTAssertTrue(
+            BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+                modifierFlags: [],
+                defaults: defaults
+            )
+        )
+    }
+
+    func testShouldOpenSidebarPullRequestLinkInCmuxBrowserUsesModifierOverride() {
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
+        defaults.set(
+            BrowserLinkModifierBehavior.commandShiftOpensCmuxOptionShiftOpensDefault.rawValue,
+            forKey: BrowserLinkOpenSettings.linkModifierBehaviorKey
+        )
+        XCTAssertTrue(
+            BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+                modifierFlags: [.command, .shift],
+                defaults: defaults
+            )
+        )
+
+        defaults.set(true, forKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
+        defaults.set(
+            BrowserLinkModifierBehavior.commandShiftOpensDefaultOptionShiftOpensCmux.rawValue,
+            forKey: BrowserLinkOpenSettings.linkModifierBehaviorKey
+        )
+        XCTAssertFalse(
+            BrowserLinkOpenSettings.shouldOpenSidebarPullRequestLinkInCmuxBrowser(
+                modifierFlags: [.command, .shift],
+                defaults: defaults
+            )
+        )
+    }
 }
 
 final class TerminalOpenURLTargetResolutionTests: XCTestCase {


### PR DESCRIPTION
## Summary
- add a configurable modifier override for sidebar pull request links with two modes:
  - Cmd+Shift -> cmux browser, Option+Shift -> default browser
  - Cmd+Shift -> default browser, Option+Shift -> cmux browser
- add settings UI under App settings (next to the sidebar PR link destination toggle)
- route sidebar PR link opens and the "Open Workspace Pull Requests" command through the same override logic
- preserve link-open override semantics without triggering unintended multi-select/range selection side effects
- add/rename regression tests for BrowserLinkOpenSettings modifier behavior and fallback paths

## Validation
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -derivedDataPath /tmp/cmux-dd-task-cmd-shift-browser-open-setting -destination 'platform=macOS' -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -derivedDataPath /tmp/cmux-dd-task-cmd-shift-browser-open-setting -destination 'platform=macOS' build
- codex review --uncommitted (clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new "Sidebar PR Link Modifier Override" setting allowing users to configure which modifier key combination (Cmd+Shift or Option+Shift) opens pull request links in the cmux browser versus the default browser.

* **Tests**
  * Added tests validating modifier key configuration, storage, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->