### PR TITLE
Add workspace close TERM/KILL fallback with reentrancy guards

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
+					F9000000A1B2C3D4E5F60718 /* WorkspaceCloseResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* WorkspaceCloseResultTests.swift */; };
 			/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -215,6 +216,7 @@
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
+				F9000001A1B2C3D4E5F60718 /* WorkspaceCloseResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCloseResultTests.swift; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -428,6 +430,7 @@
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
+					F9000001A1B2C3D4E5F60718 /* WorkspaceCloseResultTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -638,6 +641,7 @@
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+					F9000000A1B2C3D4E5F60718 /* WorkspaceCloseResultTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -973,24 +973,28 @@ class TabManager: ObservableObject {
         return trimmed
     }
 
-    func closeWorkspace(_ workspace: Workspace) {
-        guard tabs.count > 1 else { return }
+    @discardableResult
+    func closeWorkspace(_ workspace: Workspace) -> Bool {
+        guard tabs.count > 1 else { return false }
+        guard teardownWorkspacePanels(workspace) else { return false }
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         unwireClosedBrowserTracking(for: workspace)
 
-        if let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
-            tabs.remove(at: index)
-
-            if selectedTabId == workspace.id {
-                // Keep the "focused index" stable when possible:
-                // - If we closed workspace i and there is still a workspace at index i, focus it (the one that moved up).
-                // - Otherwise (we closed the last workspace), focus the new last workspace (i-1).
-                let newIndex = min(index, max(0, tabs.count - 1))
-                selectedTabId = tabs[newIndex].id
-            }
+        guard let index = tabs.firstIndex(where: { $0.id == workspace.id }) else {
+            return false
         }
+        tabs.remove(at: index)
+
+        if selectedTabId == workspace.id {
+            // Keep the "focused index" stable when possible:
+            // - If we closed workspace i and there is still a workspace at index i, focus it (the one that moved up).
+            // - Otherwise (we closed the last workspace), focus the new last workspace (i-1).
+            let newIndex = min(index, max(0, tabs.count - 1))
+            selectedTabId = tabs[newIndex].id
+        }
+        return true
     }
 
     /// Detach a workspace from this window without closing its panels.
@@ -1166,6 +1170,32 @@ class TabManager: ObservableObject {
         return "Untitled Tab"
     }
 
+    /// Tears down all panels in the workspace, logging and recording telemetry on partial failure.
+    /// Returns `true` if all panels closed successfully, `false` otherwise.
+    private func teardownWorkspacePanels(_ workspace: Workspace) -> Bool {
+        let teardown = workspace.closeAllPanelsForWorkspaceClose()
+#if DEBUG
+        if !teardown.allClosed {
+            dlog(
+                "workspace.close.teardown.partial workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "requested=\(teardown.requestedCount) closed=\(teardown.closedCount) failed=\(teardown.failedPanelIds.count)"
+            )
+        }
+#endif
+        guard teardown.allClosed else {
+            sentryBreadcrumb(
+                "workspace.close.teardown.partial",
+                data: [
+                    "requested": teardown.requestedCount,
+                    "closed": teardown.closedCount,
+                    "failed": teardown.failedPanelIds.count
+                ]
+            )
+            return false
+        }
+        return true
+    }
+
     private func closeWorkspaceIfRunningProcess(_ workspace: Workspace) {
         let willCloseWindow = tabs.count <= 1
         if workspaceNeedsConfirmClose(workspace),
@@ -1177,6 +1207,7 @@ class TabManager: ObservableObject {
             return
         }
         if tabs.count <= 1 {
+            guard teardownWorkspacePanels(workspace) else { return }
             // Last workspace in this window: close the window (Cmd+Shift+W behavior).
             AppDelegate.shared?.closeMainWindowContainingTabId(workspace.id)
         } else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2452,26 +2452,26 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
         }
 
-        var found = false
+        var result: V2CallResult = .err(code: "not_found", message: "Workspace not found", data: [
+            "workspace_id": wsId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
+        ])
         v2MainSync {
-            if let ws = tabManager.tabs.first(where: { $0.id == wsId }) {
-                tabManager.closeWorkspace(ws)
-                found = true
+            guard let ws = tabManager.tabs.first(where: { $0.id == wsId }) else { return }
+            guard !ws.isWorkspaceClosingTransaction else {
+                result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+                return
             }
-        }
-
-        let windowId = v2ResolveWindowId(tabManager: tabManager)
-        return found
-            ? .ok([
+            tabManager.closeWorkspace(ws)
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
                 "window_id": v2OrNull(windowId?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: windowId),
                 "workspace_id": wsId.uuidString,
                 "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
             ])
-            : .err(code: "not_found", message: "Workspace not found", data: [
-                "workspace_id": wsId.uuidString,
-                "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
-            ])
+        }
+        return result
     }
     private func v2WorkspaceMoveToWindow(params: [String: Any]) -> V2CallResult {
         guard let wsId = v2UUID(params, "workspace_id") else {
@@ -3089,6 +3089,25 @@ class TerminalController {
         return tabManager.tabs.first(where: { $0.id == wsId })
     }
 
+    /// Resolves the target workspace and guards against mid-close mutations.
+    /// Sets `result` to the appropriate error and returns `nil` if the workspace
+    /// is not found or is currently being torn down.
+    private func v2ResolveActiveWorkspace(
+        params: [String: Any],
+        tabManager: TabManager,
+        result: inout V2CallResult
+    ) -> Workspace? {
+        guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+            result = .err(code: "not_found", message: "Workspace not found", data: nil)
+            return nil
+        }
+        guard !ws.isWorkspaceClosingTransaction else {
+            result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+            return nil
+        }
+        return ws
+    }
+
     private func v2SurfaceList(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -3223,10 +3242,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create split", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
@@ -3276,10 +3292,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create surface", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
@@ -3331,10 +3344,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to close surface", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
 
             let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
             guard let surfaceId else {
@@ -3495,6 +3505,10 @@ class TerminalController {
                 targetPane = ws.bonsplitController.focusedPaneId ?? ws.bonsplitController.allPaneIds.first
             }
 
+            if sourceWorkspace.isWorkspaceClosingTransaction || targetWorkspace.isWorkspaceClosingTransaction {
+                result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+                return
+            }
             guard let destinationPane = targetPane else {
                 result = .err(code: "not_found", message: "No destination pane", data: nil)
                 return
@@ -4250,10 +4264,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create pane", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
             guard let focusedPanelId = ws.focusedPanelId else {
@@ -10782,8 +10793,9 @@ class TerminalController {
 
         var success = false
         DispatchQueue.main.sync {
-            if let tab = tabManager.tabs.first(where: { $0.id == uuid }) {
-                tabManager.closeTab(tab)
+            if let tab = tabManager.tabs.first(where: { $0.id == uuid }),
+               !tab.isWorkspaceClosingTransaction {
+                tabManager.closeWorkspace(tab)
                 success = true
             }
         }
@@ -12844,6 +12856,10 @@ class TerminalController {
         DispatchQueue.main.sync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
+                return
+            }
+            guard !tab.isWorkspaceClosingTransaction else {
+                result = "ERROR: Workspace is closing"
                 return
             }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2462,7 +2462,14 @@ class TerminalController {
                 result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
                 return
             }
-            tabManager.closeWorkspace(ws)
+            let closed = tabManager.closeWorkspace(ws)
+            guard closed else {
+                result = .err(code: "close_failed", message: "Failed to close workspace", data: [
+                    "workspace_id": wsId.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
+                ])
+                return
+            }
             let windowId = v2ResolveWindowId(tabManager: tabManager)
             result = .ok([
                 "window_id": v2OrNull(windowId?.uuidString),
@@ -10795,8 +10802,7 @@ class TerminalController {
         DispatchQueue.main.sync {
             if let tab = tabManager.tabs.first(where: { $0.id == uuid }),
                !tab.isWorkspaceClosingTransaction {
-                tabManager.closeWorkspace(tab)
-                success = true
+                success = tabManager.closeWorkspace(tab)
             }
         }
         return success ? "OK" : "ERROR: Tab not found"

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2263,11 +2263,12 @@ final class Workspace: Identifiable, ObservableObject {
 
         let processInfos = ttyProcessInfos(forTTY: ttyName)
         let appPid = Int32(ProcessInfo.processInfo.processIdentifier)
+        let appPgid = getpgrp()
         let trackedPids = Set(processInfos.map(\.pid).filter { $0 > 1 && $0 != appPid })
         var targetProcessGroups = Set(
             processInfos
                 .map(\.processGroupId)
-                .filter { $0 > 1 && $0 != appPid }
+                .filter { $0 > 1 && $0 != appPgid }
         )
         guard !trackedPids.isEmpty, !targetProcessGroups.isEmpty else {
 #if DEBUG
@@ -2287,7 +2288,7 @@ final class Workspace: Identifiable, ObservableObject {
                 refreshedInfos
                     .filter { remainingPids.contains($0.pid) }
                     .map(\.processGroupId)
-                    .filter { $0 > 1 }
+                    .filter { $0 > 1 && $0 != appPgid }
             )
             if !targetProcessGroups.isEmpty {
                 signalProcessGroups(targetProcessGroups, signal: SIGKILL)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2212,10 +2212,8 @@ final class Workspace: Identifiable, ObservableObject {
 
             // Fallback path: if close did not complete in time, terminate processes tied to the
             // panel's TTY and retry close once more before declaring failure.
-            let fallbackSignaled = forceTerminateTerminalProcessesForWorkspaceClose(panelId: panelId)
-            if fallbackSignaled {
-                _ = closePanel(panelId, force: true)
-            }
+            _ = forceTerminateTerminalProcessesForWorkspaceClose(panelId: panelId)
+            _ = closePanel(panelId, force: true)
 
             if waitForPanelClose(panelId, timeout: 0.6) {
                 closedCount += 1

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4,6 +4,7 @@ import AppKit
 import Bonsplit
 import Combine
 import CoreText
+import Darwin
 
 func cmuxSurfaceContextName(_ context: ghostty_surface_context_e) -> String {
     switch context {
@@ -1211,6 +1212,25 @@ final class Workspace: Identifiable, ObservableObject {
     private var pendingDetachedSurfaces: [TabID: DetachedSurfaceTransfer] = [:]
     private var activeDetachCloseTransactions: Int = 0
     private var isDetachingCloseTransaction: Bool { activeDetachCloseTransactions > 0 }
+    private var activeWorkspaceCloseTransactions: Int = 0
+    var isWorkspaceClosingTransaction: Bool { activeWorkspaceCloseTransactions > 0 }
+
+    /// Result payload for deterministic workspace-close teardown.
+    struct WorkspaceCloseResult {
+        let requestedCount: Int
+        let closedCount: Int
+        let failedPanelIds: [UUID]
+
+        var allClosed: Bool {
+            failedPanelIds.isEmpty && closedCount == requestedCount
+        }
+    }
+
+    /// Process identity snapshot for a terminal session discovered via `ps`.
+    private struct TTYProcessInfo {
+        let pid: Int32
+        let processGroupId: Int32
+    }
 
 #if DEBUG
     private func debugElapsedMs(since start: TimeInterval) -> String {
@@ -2158,6 +2178,211 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
         return closed
+    }
+
+    /// Closes all panels as part of a workspace-close operation.
+    /// This avoids relying on workspace deallocation timing for terminal process teardown.
+    func closeAllPanelsForWorkspaceClose() -> WorkspaceCloseResult {
+        let requestedPanelIds = panels.keys.sorted(by: { $0.uuidString < $1.uuidString })
+        guard !requestedPanelIds.isEmpty else {
+            return WorkspaceCloseResult(requestedCount: 0, closedCount: 0, failedPanelIds: [])
+        }
+
+        activeWorkspaceCloseTransactions += 1
+        defer { activeWorkspaceCloseTransactions -= 1 }
+
+        var closedCount = 0
+        var failedPanelIds: [UUID] = []
+
+        for panelId in requestedPanelIds {
+            if panels[panelId] == nil {
+                closedCount += 1
+                continue
+            }
+
+            guard closePanel(panelId, force: true) else {
+                failedPanelIds.append(panelId)
+                continue
+            }
+
+            if waitForPanelClose(panelId, timeout: 0.6) {
+                closedCount += 1
+                continue
+            }
+
+            // Fallback path: if close did not complete in time, terminate processes tied to the
+            // panel's TTY and retry close once more before declaring failure.
+            let fallbackSignaled = forceTerminateTerminalProcessesForWorkspaceClose(panelId: panelId)
+            if fallbackSignaled {
+                _ = closePanel(panelId, force: true)
+            }
+
+            if waitForPanelClose(panelId, timeout: 0.6) {
+                closedCount += 1
+            } else {
+                failedPanelIds.append(panelId)
+            }
+        }
+
+#if DEBUG
+        dlog(
+            "workspace.close.teardown workspace=\(id.uuidString.prefix(5)) " +
+            "requested=\(requestedPanelIds.count) closed=\(closedCount) failed=\(failedPanelIds.count)"
+        )
+#endif
+
+        return WorkspaceCloseResult(
+            requestedCount: requestedPanelIds.count,
+            closedCount: closedCount,
+            failedPanelIds: failedPanelIds
+        )
+    }
+
+    /// Waits for a panel to be removed from the workspace maps.
+    private func waitForPanelClose(_ panelId: UUID, timeout: TimeInterval) -> Bool {
+        let closeDeadline = Date().addingTimeInterval(timeout)
+        while panels[panelId] != nil && Date() < closeDeadline {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        return panels[panelId] == nil
+    }
+
+    /// Best-effort process fallback for terminal panels that failed to close via Bonsplit.
+    /// Uses the panel's tracked TTY to locate and terminate the process group.
+    private func forceTerminateTerminalProcessesForWorkspaceClose(panelId: UUID) -> Bool {
+        guard panels[panelId] is TerminalPanel else {
+            return false
+        }
+        guard let ttyName = normalizedTTYName(surfaceTTYNames[panelId]) else {
+#if DEBUG
+            dlog(
+                "workspace.close.kill.skip workspace=\(id.uuidString.prefix(5)) " +
+                "panel=\(panelId.uuidString.prefix(5)) reason=missing_tty"
+            )
+#endif
+            return false
+        }
+
+        let processInfos = ttyProcessInfos(forTTY: ttyName)
+        let appPid = Int32(ProcessInfo.processInfo.processIdentifier)
+        let trackedPids = Set(processInfos.map(\.pid).filter { $0 > 1 && $0 != appPid })
+        var targetProcessGroups = Set(
+            processInfos
+                .map(\.processGroupId)
+                .filter { $0 > 1 && $0 != appPid }
+        )
+        guard !trackedPids.isEmpty, !targetProcessGroups.isEmpty else {
+#if DEBUG
+            dlog(
+                "workspace.close.kill.skip workspace=\(id.uuidString.prefix(5)) " +
+                "panel=\(panelId.uuidString.prefix(5)) tty=\(ttyName) reason=no_targets"
+            )
+#endif
+            return false
+        }
+
+        signalProcessGroups(targetProcessGroups, signal: SIGTERM)
+        var remainingPids = waitForProcessesToExit(trackedPids, timeout: 1.0)
+        if !remainingPids.isEmpty {
+            let refreshedInfos = ttyProcessInfos(forTTY: ttyName)
+            targetProcessGroups = Set(
+                refreshedInfos
+                    .filter { remainingPids.contains($0.pid) }
+                    .map(\.processGroupId)
+                    .filter { $0 > 1 }
+            )
+            if !targetProcessGroups.isEmpty {
+                signalProcessGroups(targetProcessGroups, signal: SIGKILL)
+            }
+            remainingPids = waitForProcessesToExit(remainingPids, timeout: 1.0)
+        }
+
+#if DEBUG
+        dlog(
+            "workspace.close.kill workspace=\(id.uuidString.prefix(5)) panel=\(panelId.uuidString.prefix(5)) " +
+            "tty=\(ttyName) tracked=\(trackedPids.count) remaining=\(remainingPids.count)"
+        )
+#endif
+        return remainingPids.isEmpty
+    }
+
+    /// Normalizes shell-reported TTY names for `ps -t` usage.
+    private func normalizedTTYName(_ rawTTY: String?) -> String? {
+        guard let rawTTY else { return nil }
+        let trimmed = rawTTY.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("/dev/") {
+            let shortName = String(trimmed.dropFirst("/dev/".count))
+            return shortName.isEmpty ? nil : shortName
+        }
+        return trimmed
+    }
+
+    /// Enumerates process IDs and process groups attached to the given TTY.
+    private func ttyProcessInfos(forTTY ttyName: String) -> [TTYProcessInfo] {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-t", ttyName, "-o", "pid=,pgid="]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+
+        let deadline = Date().addingTimeInterval(5.0)
+        while process.isRunning && Date() < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        guard !process.isRunning, process.terminationStatus == 0 else { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8), !output.isEmpty else {
+            return []
+        }
+
+        var result: [TTYProcessInfo] = []
+        for line in output.split(whereSeparator: \.isNewline) {
+            let parts = line.split(whereSeparator: \.isWhitespace)
+            guard parts.count >= 2,
+                  let pid = Int32(parts[0]),
+                  let pgid = Int32(parts[1]) else {
+                continue
+            }
+            result.append(TTYProcessInfo(pid: pid, processGroupId: pgid))
+        }
+        return result
+    }
+
+    /// Sends a POSIX signal to each process group.
+    private func signalProcessGroups(_ processGroups: Set<Int32>, signal: Int32) {
+        for processGroupId in processGroups where processGroupId > 1 {
+            _ = Darwin.kill(-processGroupId, signal)
+        }
+    }
+
+    /// Waits for all processes in `pids` to exit and returns those still alive.
+    private func waitForProcessesToExit(_ pids: Set<Int32>, timeout: TimeInterval) -> Set<Int32> {
+        guard !pids.isEmpty else { return [] }
+        let deadline = Date().addingTimeInterval(timeout)
+        var remaining = pids
+        while !remaining.isEmpty && Date() < deadline {
+            remaining = remaining.filter { isProcessAlive($0) }
+            if !remaining.isEmpty {
+                _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+        }
+        return remaining
+    }
+
+    /// Returns true if a process is still alive.
+    private func isProcessAlive(_ pid: Int32) -> Bool {
+        if Darwin.kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
     }
 
     func paneId(forPanelId panelId: UUID) -> PaneID? {
@@ -3759,7 +3984,7 @@ extension Workspace: BonsplitDelegate {
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can
         // prune the source workspace/window after the tab is attached elsewhere.
         if panels.isEmpty {
-            if isDetaching {
+            if isDetaching || isWorkspaceClosingTransaction {
                 scheduleTerminalGeometryReconcile()
                 return
             }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -3701,6 +3701,44 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
 }
 
 @MainActor
+final class TabManagerWorkspaceCloseTeardownTests: XCTestCase {
+    func testCloseWorkspaceTearsDownAllPanelsBeforeRemoval() {
+        let manager = TabManager()
+        guard let workspaceToClose = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
+            return
+        }
+
+        // Add extra surfaces so teardown must close more than one panel.
+        _ = workspaceToClose.newTerminalSurfaceInFocusedPane(focus: false)
+        _ = manager.openBrowser(url: URL(string: "https://example.com/workspace-close-teardown"))
+        drainMainQueue()
+        XCTAssertGreaterThanOrEqual(workspaceToClose.panels.count, 2)
+
+        let survivingWorkspace = manager.addWorkspace()
+        XCTAssertEqual(manager.selectedTabId, survivingWorkspace.id)
+
+        manager.closeWorkspace(workspaceToClose)
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertFalse(manager.tabs.contains(where: { $0.id == workspaceToClose.id }))
+        XCTAssertTrue(
+            workspaceToClose.panels.isEmpty,
+            "Expected removed workspace panels to be torn down deterministically"
+        )
+    }
+
+    private func drainMainQueue() {
+        let expectation = expectation(description: "drain main queue")
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+@MainActor
 final class WorkspacePanelGitBranchTests: XCTestCase {
     private func drainMainQueue() {
         let expectation = expectation(description: "drain main queue")

--- a/cmuxTests/WorkspaceCloseResultTests.swift
+++ b/cmuxTests/WorkspaceCloseResultTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests for `Workspace.WorkspaceCloseResult.allClosed`, which gates whether a workspace
+/// is removed from the tab list after teardown. The `allClosed == false` path causes
+/// `teardownWorkspacePanels` to abort the close and leave the workspace visible.
+final class WorkspaceCloseResultTests: XCTestCase {
+
+    // MARK: - allClosed == true
+
+    func testAllClosedWhenAllPanelsSucceeded() {
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: 3,
+            closedCount: 3,
+            failedPanelIds: []
+        )
+        XCTAssertTrue(result.allClosed)
+    }
+
+    func testAllClosedWhenNoPanelsRequested() {
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: 0,
+            closedCount: 0,
+            failedPanelIds: []
+        )
+        XCTAssertTrue(result.allClosed)
+    }
+
+    // MARK: - allClosed == false
+
+    func testNotAllClosedWhenFailedPanelIdsNonEmpty() {
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: 2,
+            closedCount: 1,
+            failedPanelIds: [UUID()]
+        )
+        XCTAssertFalse(result.allClosed)
+    }
+
+    func testNotAllClosedWhenClosedCountUnderRequestedWithNoFailedIds() {
+        // Partial close recorded via closedCount mismatch alone (no failedPanelIds entry).
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: 3,
+            closedCount: 2,
+            failedPanelIds: []
+        )
+        XCTAssertFalse(result.allClosed)
+    }
+
+    func testNotAllClosedWhenFailedIdsNonEmptyEvenIfCountsMatch() {
+        // closedCount == requestedCount but a panel ID is recorded as failed.
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: 2,
+            closedCount: 2,
+            failedPanelIds: [UUID()]
+        )
+        XCTAssertFalse(result.allClosed)
+    }
+
+    func testNotAllClosedWhenAllPanelsFailed() {
+        let ids = [UUID(), UUID(), UUID()]
+        let result = Workspace.WorkspaceCloseResult(
+            requestedCount: ids.count,
+            closedCount: 0,
+            failedPanelIds: ids
+        )
+        XCTAssertFalse(result.allClosed)
+    }
+}

--- a/tests/test_close_workspace_kills_processes.py
+++ b/tests/test_close_workspace_kills_processes.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Regression test: closing a workspace must tear down terminal processes.
+
+Scenario:
+1. Create a workspace with two terminal surfaces.
+2. Start a long-running process in each surface and capture its PID.
+3. Close that workspace.
+
+Expected:
+- The workspace is removed.
+- All captured PIDs are no longer alive shortly after close.
+"""
+
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+def _wait_until(predicate, timeout_s: float = 5.0, interval_s: float = 0.05) -> bool:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return True
+        time.sleep(interval_s)
+    return predicate()
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Treat as alive if we can see the PID but cannot signal it.
+        return True
+    return True
+
+
+def _wait_file(path: Path, timeout_s: float = 5.0) -> bool:
+    return _wait_until(lambda: path.exists() and path.read_text(encoding="utf-8").strip() != "", timeout_s=timeout_s)
+
+
+def _start_probe_process(client: cmux, surface_id: str, pid_file: Path) -> int:
+    pid_file.unlink(missing_ok=True)
+    command = f"sh -lc 'echo $$ > {pid_file}; exec sleep 600'\n"
+    client.send_surface(surface_id, command)
+    if not _wait_file(pid_file, timeout_s=6.0):
+        raise cmuxError(f"Timed out waiting for PID file: {pid_file}")
+    return int(pid_file.read_text(encoding="utf-8").strip())
+
+
+def main() -> int:
+    pid_files: list[Path] = []
+    tracked_pids: list[int] = []
+    workspace_id: str | None = None
+
+    try:
+        with cmux() as client:
+            if not client.ping():
+                raise cmuxError("Socket ping failed")
+
+            workspace_id = client.new_workspace()
+            client.select_workspace(workspace_id)
+            time.sleep(0.25)
+
+            client.new_split("right")
+            time.sleep(0.35)
+
+            surfaces = client.list_surfaces()
+            if len(surfaces) < 2:
+                raise cmuxError(f"Expected >=2 surfaces, got {len(surfaces)} ({surfaces})")
+
+            for index, (_, surface_id, _) in enumerate(surfaces[:2]):
+                pid_file = Path(f"/tmp/cmux_wsclose_pid_{os.getpid()}_{index}.txt")
+                pid_files.append(pid_file)
+                pid = _start_probe_process(client, surface_id, pid_file)
+                tracked_pids.append(pid)
+
+            client.close_workspace(workspace_id)
+            workspace_closed = _wait_until(
+                lambda: all(ws[1] != workspace_id for ws in client.list_workspaces()),
+                timeout_s=3.0,
+                interval_s=0.05,
+            )
+            if not workspace_closed:
+                raise cmuxError(f"Expected workspace to be removed after close: {workspace_id}")
+
+            not_alive = _wait_until(
+                lambda: all(not _process_alive(pid) for pid in tracked_pids),
+                timeout_s=6.0,
+                interval_s=0.1,
+            )
+            if not not_alive:
+                alive = [pid for pid in tracked_pids if _process_alive(pid)]
+                raise cmuxError(f"Expected terminal processes to exit after workspace close, still alive: {alive}")
+    finally:
+        for pid in tracked_pids:
+            if _process_alive(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except OSError:
+                    pass
+        for path in pid_files:
+            path.unlink(missing_ok=True)
+
+    print("PASS: workspace close tears down terminal processes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_close_workspace_kills_processes.py
+++ b/tests/test_close_workspace_kills_processes.py
@@ -15,6 +15,7 @@ Expected:
 import os
 import signal
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -77,7 +78,9 @@ def main() -> int:
                 raise cmuxError(f"Expected >=2 surfaces, got {len(surfaces)} ({surfaces})")
 
             for index, (_, surface_id, _) in enumerate(surfaces[:2]):
-                pid_file = Path(f"/tmp/cmux_wsclose_pid_{os.getpid()}_{index}.txt")
+                fd, name = tempfile.mkstemp(prefix="cmux_wsclose_pid_", suffix=".txt")
+                os.close(fd)
+                pid_file = Path(name)
                 pid_files.append(pid_file)
                 pid = _start_probe_process(client, surface_id, pid_file)
                 tracked_pids.append(pid)


### PR DESCRIPTION
When closing a workspace whose terminal processes don't exit within 0.6s, fall back to SIGTERM → SIGKILL escalation per panel before removing the workspace from the tab list. This prevents orphaned shell processes when closing workspaces with long-running commands.

Teardown flow (closeAllPanelsForWorkspaceClose):
- For each panel: closePanel → wait 0.6s → SIGTERM process groups → wait 1s → SIGKILL remaining → wait 1s → retry closePanel
- Returns WorkspaceCloseResult with per-panel success/failure tracking
- Gate workspace removal on full teardown (allClosed == true)

Main-thread responsiveness:
- All waits use RunLoop drain (10ms ticks) instead of blocking calls so the UI stays responsive during teardown
- ttyProcessInfos uses process.isRunning + RunLoop spin instead of the blocking waitUntilExit()

Reentrancy protection:
- Widen isWorkspaceClosingTransaction to internal
- Guard all mutating socket handlers (V1 and V2) against mid-teardown workspace mutations — surface.create/close/split/move, workspace.close, pane.create all return invalid_state if the workspace is being closed
- Extract v2ResolveActiveWorkspace helper combining workspace resolution with the closing-transaction guard

Refactoring:
- Extract teardownWorkspacePanels helper in TabManager (eliminates duplicated teardown + logging block in closeWorkspace and closeWorkspaceIfRunningProcess)
- Inline processGroupsForPIDs at its sole call site — the caller already knows the target TTY, no need to scan all workspace TTYs
- Collapse identical isDetaching / isWorkspaceClosingTransaction branches in didCloseTab
- Remove unused force parameter from closeAllPanelsForWorkspaceClose

Tests:
- WorkspaceCloseResultTests: unit tests for allClosed computed property covering success, partial failure, and edge cases
- test_close_workspace_kills_processes.py: integration test verifying processes are terminated when closing a workspace via socket

Fixes #629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures workspaces tear down all panels before removal.
  * Improves termination of lingering terminal processes during workspace shutdown.
  * Prevents operations from proceeding during workspace-close transitions, yielding more consistent error outcomes.

* **Tests**
  * Added tests validating workspace teardown semantics and that terminal processes are killed when a workspace is closed.
  * Added unit tests covering workspace-close result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->