### PR TITLE
Fix window.open() and target=_blank not opening in new tab

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3239,10 +3239,8 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         for navigationAction: WKNavigationAction,
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
-        let hasRecentMiddleClickIntent = CmuxWebView.hasRecentMiddleClickIntent(for: webView)
         // createWebViewWith is only called when the page requests a new window,
         // so always treat as new-tab intent regardless of modifiers/button.
-        let shouldOpenInNewTab = true
 #if DEBUG
         let currentEventType = NSApp.currentEvent.map { String(describing: $0.type) } ?? "nil"
         let currentEventButton = NSApp.currentEvent.map { String($0.buttonNumber) } ?? "nil"
@@ -3251,8 +3249,7 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
             "browser.nav.createWebView navType=\(navType) button=\(navigationAction.buttonNumber) " +
             "mods=\(navigationAction.modifierFlags.rawValue) targetNil=\(navigationAction.targetFrame == nil ? 1 : 0) " +
             "eventType=\(currentEventType) eventButton=\(currentEventButton) " +
-            "recentMiddleIntent=\(hasRecentMiddleClickIntent ? 1 : 0) " +
-            "openInNewTab=\(shouldOpenInNewTab ? 1 : 0)"
+            "openInNewTab=1"
         )
 #endif
         if let url = navigationAction.request.url {
@@ -3267,25 +3264,19 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
                 return nil
             }
             if let requestNavigation {
-                let intent: BrowserInsecureHTTPNavigationIntent =
-                    shouldOpenInNewTab ? .newTab : .currentTab
+                let intent: BrowserInsecureHTTPNavigationIntent = .newTab
 #if DEBUG
                 dlog(
-                    "browser.nav.createWebView.action kind=requestNavigation intent=\(intent == .newTab ? "newTab" : "currentTab") " +
+                    "browser.nav.createWebView.action kind=requestNavigation intent=newTab " +
                     "url=\(url.absoluteString)"
                 )
 #endif
                 requestNavigation(navigationAction.request, intent)
-            } else if shouldOpenInNewTab {
+            } else {
 #if DEBUG
                 dlog("browser.nav.createWebView.action kind=openInNewTab url=\(url.absoluteString)")
 #endif
                 openInNewTab?(url)
-            } else {
-#if DEBUG
-                dlog("browser.nav.createWebView.action kind=loadInPlace url=\(url.absoluteString)")
-#endif
-                webView.load(navigationAction.request)
             }
         }
         return nil


### PR DESCRIPTION
## Summary

- `createWebViewWith` is only called when the page requests a new window (`window.open()`, `target=_blank`). Always open in a new tab regardless of modifier keys/mouse button, since programmatic calls have no user gesture.
- Fix insecure HTTP navigation path to treat `targetFrame == nil` as new-tab intent, consistent with the secure path.

Closes #606

## Test plan

- [ ] Open a page that calls `window.open()` — verify it opens in a new tab
- [ ] Click a `target=_blank` link — verify it opens in a new tab
- [ ] Cmd+click a regular link — verify it still opens in a new tab
- [ ] Middle-click a regular link — verify it still opens in a new tab
- [ ] Navigate to an insecure HTTP URL via `window.open()` — verify the insecure HTTP prompt shows with new-tab intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Navigation now consistently treats links without a target frame as “open in new tab”, avoiding unexpected in-place loads.
  * Blocked insecure navigations and new-window requests are opened in new tabs instead of loading in the current view, improving navigation predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->