### PR TITLE
Fix display-pass crash from isHidden toggle in debug hit test

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -633,9 +633,8 @@ final class FileDropOverlayView: NSView {
               let themeFrame = contentView.superview else { return "-" }
 
         let pointInTheme = themeFrame.convert(currentEvent.locationInWindow, from: nil)
-        isHidden = true
-        defer { isHidden = false }
-
+        // Don't toggle isHidden here — it triggers setNeedsDisplay which can
+        // exceed AppKit's display-pass limit during cursor-update display cycles.
         guard let hit = themeFrame.hitTest(pointInTheme) else { return "nil" }
         var chain: [String] = []
         var current: NSView? = hit


### PR DESCRIPTION
Toggling isHidden during a display cycle calls _setHidden:setNeedsDisplay:, which posts another window-needs-display and pushes the pass count past AppKit's per-cycle limit, causing an NSException crash near resize handles.

Remove the isHidden toggle from debugTopHitViewForCurrentEvent(); the hit test now returns the overlay itself when it is the topmost view, which is acceptable for debug logging purposes.

Fixes #697 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed performance issue in hit-testing where unnecessary state changes could exceed AppKit's display-pass limit during cursor-update cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->