### PR TITLE
Add Ghostty terminal theme picker in Settings

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -104,6 +104,17 @@ struct GhosttyConfig {
             }
         }
 
+        // cmux theme override takes precedence over ghostty config
+        if let override = TerminalThemeSettings.effectiveThemeName() {
+            let available = Self.availableThemeNames(
+                environment: ProcessInfo.processInfo.environment,
+                bundleResourceURL: Bundle.main.resourceURL
+            )
+            if available.contains(override) {
+                config.theme = override
+            }
+        }
+
         // Load theme if specified
         if let themeName = config.theme {
             config.loadTheme(
@@ -407,6 +418,54 @@ struct GhosttyConfig {
         appendUniquePath("~/Library/Application Support/com.mitchellh.ghostty/themes/\(themeName)")
 
         return paths
+    }
+
+    /// Returns sorted list of available Ghostty theme names by scanning theme directories.
+    static func availableThemeNames(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleResourceURL: URL? = Bundle.main.resourceURL
+    ) -> [String] {
+        var themeDirs: [String] = []
+
+        func appendDir(_ path: String?) {
+            guard let path else { return }
+            let expanded = NSString(string: path).expandingTildeInPath
+            guard !expanded.isEmpty, !themeDirs.contains(expanded) else { return }
+            themeDirs.append(expanded)
+        }
+
+        if let resourcesDir = environment["GHOSTTY_RESOURCES_DIR"] {
+            appendDir(URL(fileURLWithPath: resourcesDir).appendingPathComponent("themes").path)
+        }
+        appendDir(bundleResourceURL?.appendingPathComponent("ghostty/themes").path)
+        if let xdgDataDirs = environment["XDG_DATA_DIRS"] {
+            for dataDir in xdgDataDirs.split(separator: ":").map(String.init) {
+                guard !dataDir.isEmpty else { continue }
+                appendDir(URL(fileURLWithPath: dataDir).appendingPathComponent("ghostty/themes").path)
+            }
+        }
+        appendDir("/Applications/Ghostty.app/Contents/Resources/ghostty/themes")
+        appendDir("~/.config/ghostty/themes")
+        appendDir("~/Library/Application Support/com.mitchellh.ghostty/themes")
+
+        let fm = FileManager.default
+        var seen = Set<String>()
+        var names: [String] = []
+
+        for dir in themeDirs {
+            guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { continue }
+            for entry in entries {
+                guard !entry.hasPrefix("."), !seen.contains(entry) else { continue }
+                let fullPath = (dir as NSString).appendingPathComponent(entry)
+                var isDirectory: ObjCBool = false
+                guard fm.fileExists(atPath: fullPath, isDirectory: &isDirectory), !isDirectory.boolValue else { continue }
+                seen.insert(entry)
+                names.append(entry)
+            }
+        }
+
+        names.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        return names
     }
 
     private static func readConfigFile(at path: String) -> String? {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -626,7 +626,25 @@ class GhosttyApp {
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
         ghostty_config_load_default_files(config)
         loadLegacyGhosttyConfigIfNeeded(config)
+        loadCmuxThemeOverrideIfNeeded(config)
         ghostty_config_finalize(config)
+    }
+
+    private func loadCmuxThemeOverrideIfNeeded(_ config: ghostty_config_t) {
+        guard let themeName = TerminalThemeSettings.effectiveThemeName() else { return }
+        let available = GhosttyConfig.availableThemeNames()
+        guard available.contains(themeName) else { return }
+        let tmpPath = "/tmp/cmux-theme-override-\(UUID().uuidString).conf"
+        let content = "theme = \(themeName)\n"
+        do {
+            try content.write(toFile: tmpPath, atomically: true, encoding: .utf8)
+            tmpPath.withCString { path in
+                ghostty_config_load_file(config, path)
+            }
+            try FileManager.default.removeItem(atPath: tmpPath)
+        } catch {
+            NSLog("cmux: failed to apply theme override: %@", error.localizedDescription)
+        }
     }
 
     static func shouldLoadLegacyGhosttyConfig(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2655,6 +2655,22 @@ enum AppIconSettings {
     }
 }
 
+enum TerminalThemeSettings {
+    static let themeKey = "terminalTheme"
+
+    /// Returns the user-selected theme name, or nil if no override (use ghostty config).
+    /// Validates the stored value contains only safe characters (alphanumeric, hyphens,
+    /// underscores, spaces, dots, parens) to prevent path traversal or config injection.
+    static func effectiveThemeName(defaults: UserDefaults = .standard) -> String? {
+        guard let raw = defaults.string(forKey: themeKey) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. ()"))
+        guard trimmed.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return trimmed
+    }
+}
+
 enum QuitWarningSettings {
     static let warnBeforeQuitKey = "warnBeforeQuitShortcut"
     static let defaultWarnBeforeQuit = true
@@ -2761,6 +2777,8 @@ struct SettingsView: View {
     @State private var socketPasswordStatusMessage: String?
     @State private var socketPasswordStatusIsError = false
     @State private var telemetryValueAtLaunch = TelemetrySettings.enabledForCurrentLaunch
+    @AppStorage(TerminalThemeSettings.themeKey) private var terminalTheme = ""
+    @State private var availableThemes: [String] = []
     @State private var workspaceTabDefaultEntries = WorkspaceTabColorSettings.defaultPaletteWithOverrides()
     @State private var workspaceTabCustomColors = WorkspaceTabColorSettings.customColors()
 
@@ -3067,6 +3085,24 @@ struct SettingsView: View {
                             Toggle("", isOn: $sidebarShowMetadata)
                                 .labelsHidden()
                                 .controlSize(.small)
+                        }
+                    }
+
+                    SettingsSectionHeader(title: "Terminal")
+                    SettingsCard {
+                        SettingsCardRow(
+                            "Terminal Theme",
+                            subtitle: "Overrides the theme in your Ghostty config.",
+                            controlWidth: pickerColumnWidth
+                        ) {
+                            Picker("", selection: $terminalTheme) {
+                                Text("Default (Ghostty Config)").tag("")
+                                ForEach(availableThemes, id: \.self) { name in
+                                    Text(name).tag(name)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
                         }
                     }
 
@@ -3547,12 +3583,17 @@ struct SettingsView: View {
             browserHistoryEntryCount = BrowserHistoryStore.shared.entries.count
             browserInsecureHTTPAllowlistDraft = browserInsecureHTTPAllowlist
             reloadWorkspaceTabColorSettings()
+            availableThemes = GhosttyConfig.availableThemeNames()
         }
         .onChange(of: browserInsecureHTTPAllowlist) { oldValue, newValue in
             // Keep draft in sync with external changes unless the user has local unsaved edits.
             if browserInsecureHTTPAllowlistDraft == oldValue {
                 browserInsecureHTTPAllowlistDraft = newValue
             }
+        }
+        .onChange(of: terminalTheme) { _ in
+            GhosttyConfig.invalidateLoadCache()
+            GhosttyApp.shared.reloadConfiguration(source: "settings.terminalTheme")
         }
         .onReceive(BrowserHistoryStore.shared.$entries) { entries in
             browserHistoryEntryCount = entries.count
@@ -3618,6 +3659,7 @@ struct SettingsView: View {
         sidebarShowLog = true
         sidebarShowProgress = true
         sidebarShowMetadata = true
+        terminalTheme = ""
         showOpenAccessConfirmation = false
         pendingOpenAccessMode = nil
         socketPasswordDraft = ""


### PR DESCRIPTION
## Summary

- Adds a "Terminal Theme" picker to Settings that lists all available Ghostty themes
- Scans bundled themes, Ghostty.app resources, and user theme directories (`~/.config/ghostty/themes`)
- Selected theme overrides the ghostty config `theme` setting; "Default" falls back to user's ghostty config

## How it works

`TerminalThemeSettings` stores a single theme name in UserDefaults. On config load, if a theme is set, it writes a temp `theme = <name>` config file and loads it via `ghostty_config_load_file` — overriding whatever the user's ghostty config specifies.

## Test plan

- [ ] Open Settings → "Terminal Theme" picker shows available Ghostty themes
- [ ] Pick a theme → terminal colors update immediately
- [ ] Switch app appearance Light↔Dark → terminal keeps the selected theme, only chrome changes
- [ ] Set to "Default (Ghostty Config)" → falls back to ghostty config

## Test
<img width="1196" height="798" alt="Screenshot 2026-02-28 at 2 12 59 p m" src="https://github.com/user-attachments/assets/e53f7204-014f-4187-bc84-4637c8872615" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal theme customization in Settings with a new "Terminal" section and theme picker.
  * Theme selection persists, is applied immediately, and survives app sessions.
  * Available themes are discovered from multiple locations, deduplicated, sorted, and shown in the picker.
  * Theme list is populated when Settings opens and changes trigger an immediate configuration reload to apply the selected theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->