### PR TITLE
Fade in GitHub stars badge and reduce right padding

### DIFF
--- a/web/app/components/github-stars.tsx
+++ b/web/app/components/github-stars.tsx
@@ -33,7 +33,7 @@ export function GitHubStarsBadge() {
       onClick={() =>
         posthog.capture("cmuxterm_github_clicked", { location: "stars_badge" })
       }
-      className="inline-flex items-center gap-1.5 pr-2 text-sm text-muted hover:text-foreground transition-colors"
+      className="inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in"
     >
       <svg
         width="16"

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -75,6 +75,15 @@ body {
   animation: blink 1s step-end infinite;
 }
 
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fade-in 500ms ease-out;
+}
+
 /* Docs prose styles — in @layer base so Tailwind utilities can override */
 @layer base {
   .docs-content h1 {


### PR DESCRIPTION
## Summary
- GitHub stars badge fades in over 500ms instead of appearing abruptly
- Reduced right padding from `pr-2` to `pr-1`

## Testing
- Verify on Vercel preview: stars badge should smoothly fade in on page load
- Check right padding looks tighter

## Related
- Task: header GitHub stars fade-in + padding adjustment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing adjustments for UI components
  * Introduced fade-in animation effect to enhance visual transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->