### PR TITLE
Fix Ghostty conditional theme parsing to respect macOS system appearance

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -53,7 +53,7 @@ struct GhosttyConfig {
         useCache: Bool = true,
         loadFromDisk: (_ preferredColorScheme: ColorSchemePreference) -> GhosttyConfig = Self.loadFromDisk
     ) -> GhosttyConfig {
-        let resolvedColorScheme = preferredColorScheme ?? currentColorSchemePreference()
+        let resolvedColorScheme = preferredColorScheme ?? currentSystemColorSchemePreference()
         if useCache, let cached = cachedLoad(for: resolvedColorScheme) {
             return cached
         }
@@ -211,7 +211,7 @@ struct GhosttyConfig {
     ) {
         let resolvedThemeName = Self.resolveThemeName(
             from: name,
-            preferredColorScheme: preferredColorScheme ?? Self.currentColorSchemePreference()
+            preferredColorScheme: preferredColorScheme ?? Self.currentSystemColorSchemePreference()
         )
         for candidateName in Self.themeNameCandidates(from: resolvedThemeName) {
             for path in Self.themeSearchPaths(
@@ -230,8 +230,19 @@ struct GhosttyConfig {
     static func currentColorSchemePreference(
         appAppearance: NSAppearance? = NSApp?.effectiveAppearance
     ) -> ColorSchemePreference {
-        let bestMatch = appAppearance?.bestMatch(from: [.darkAqua, .aqua])
+        guard let bestMatch = appAppearance?.bestMatch(from: [.darkAqua, .aqua]) else {
+            return currentSystemColorSchemePreference()
+        }
         return bestMatch == .darkAqua ? .dark : .light
+    }
+
+    static func currentSystemColorSchemePreference(
+        appleInterfaceStyle: String? = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+    ) -> ColorSchemePreference {
+        let style = appleInterfaceStyle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return style == "dark" ? .dark : .light
     }
 
     static func resolveThemeName(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -64,6 +64,33 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(resolved, "Builtin Solarized Dark")
     }
 
+    func testResolveThemeNamePrefersLightEntryForDarkThenLightPairedTheme() {
+        let resolved = GhosttyConfig.resolveThemeName(
+            from: "dark:Builtin Solarized Dark,light:Builtin Solarized Light",
+            preferredColorScheme: .light
+        )
+
+        XCTAssertEqual(resolved, "Builtin Solarized Light")
+    }
+
+    func testCurrentSystemColorSchemePreferenceUsesDarkAppleInterfaceStyle() {
+        XCTAssertEqual(
+            GhosttyConfig.currentSystemColorSchemePreference(appleInterfaceStyle: "Dark"),
+            .dark
+        )
+    }
+
+    func testCurrentSystemColorSchemePreferenceDefaultsToLightWithoutDarkStyle() {
+        XCTAssertEqual(
+            GhosttyConfig.currentSystemColorSchemePreference(appleInterfaceStyle: nil),
+            .light
+        )
+        XCTAssertEqual(
+            GhosttyConfig.currentSystemColorSchemePreference(appleInterfaceStyle: "Light"),
+            .light
+        )
+    }
+
     func testThemeNameCandidatesIncludeBuiltinAliasForms() {
         let candidates = GhosttyConfig.themeNameCandidates(from: "Builtin Solarized Light")
         XCTAssertEqual(candidates.first, "Builtin Solarized Light")


### PR DESCRIPTION
## Summary
- resolve Ghostty config `theme=` conditionals using macOS system appearance (`AppleInterfaceStyle`) when no explicit color scheme is provided
- keep app-appearance resolution for existing runtime appearance-sync logic, but fall back to system appearance when app appearance is unavailable
- add unit coverage for `dark:...,light:...` ordering and system appearance resolution

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag fix-theme-conditional-706
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttyConfigTests test

Fixes #706


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system color scheme detection to better respect OS-level dark/light mode preferences.
  * Enhanced theme resolution logic with more reliable fallback to system settings when no explicit preference is set.

* **Tests**
  * Added test coverage for theme resolution precedence and system color scheme detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->