### PR TITLE
Move Build GhosttyKit to Depot runners

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -8,12 +8,9 @@ on:
 
 jobs:
   build-ghosttykit:
-    # Never run self-hosted jobs for fork pull requests.
+    # Never run Depot jobs for fork pull requests (avoid billing on external PRs).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
-    concurrency:
-      group: self-hosted-build
-      cancel-in-progress: false
+    runs-on: depot-macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Moves `build-ghosttykit` from `self-hosted` to `depot-macos-latest`
- Removes the `self-hosted-build` concurrency group (no longer competing with CI tests for the Mac Mini)
- Most runs are no-ops (xcframework release already exists), so they finish in seconds on Depot
- Fixes the red X cancellation that happens when CI tests and build-ghosttykit both trigger on the same push to main

## Testing
- The PR's own CI run will validate this works on Depot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->