### PR TITLE
Fix: use policy constants for minimum window size instead of hardcoded 800×600

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2036,7 +2036,7 @@ struct ContentView: View {
                             .padding(.top, 4)
                     }
                 }
-                .frame(minWidth: 800, minHeight: 600)
+                .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
                 .background(Color.clear)
         )
 


### PR DESCRIPTION
## Problem

`ContentView.body` had a hardcoded `.frame(minWidth: 800, minHeight: 600)` applied to the root view since the initial commit. This prevents users from resizing the window narrower than 800px, even when the sidebar is hidden and the terminal content fits comfortably in a much smaller footprint.

## Fix

Replace the magic numbers with the existing `SessionPersistencePolicy` constants:

- `minimumWindowWidth = 300` (was 800)
- `minimumWindowHeight = 200` (was 600)

These constants were already defined in `SessionPersistence.swift` and used by `AppDelegate` to validate session-restore frames. Wiring them into the SwiftUI frame modifier gives them a second job as the canonical minimum size floor, and means any future tuning only needs to happen in one place.

## Before / After

| | Min width | Min height |
|---|---|---|
| Before | 800 px | 600 px |
| After | 300 px | 200 px |

## Testing

- Verified the only occurrence of the hardcoded `800` constraint in the window layout path is this one modifier.
- No UI tests reference the old 800×600 window minimum.
- Session-restore validation (`AppDelegate`) is unaffected — it already uses `SessionPersistencePolicy.minimumWindowWidth/Height` directly.
- Sidebar clamping logic is unaffected — it caps sidebar width at `1/3` of the available width (floor: 186 px) and collapses gracefully at narrow sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Window minimum dimensions are now derived from application settings rather than fixed values, enabling more flexible sizing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->