### PR TITLE
Fix SwiftPM binary artifact cache collision in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
           if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | grep -q "Could not resolve package dependencies"; then
             echo "SwiftPM package resolution failed, clearing caches and retrying once"
             rm -rf ~/Library/Caches/org.swift.swiftpm
+            mkdir -p ~/Library/Caches/org.swift.swiftpm
             rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
             set +e
             OUTPUT=$(run_unit_tests)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Clear SPM cache
         run: |
           rm -rf ~/Library/Caches/org.swift.swiftpm
+          mkdir -p ~/Library/Caches/org.swift.swiftpm
           rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
 
       - name: Configure SwiftPM cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
           rm -rf ~/Library/Caches/org.swift.swiftpm
+          mkdir -p ~/Library/Caches/org.swift.swiftpm
           rm -rf ~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*
 
       - name: Configure SwiftPM cache


### PR DESCRIPTION
## Summary
- After `rm -rf ~/Library/Caches/org.swift.swiftpm`, immediately `mkdir -p` the directory so SwiftPM gets a clean empty cache instead of colliding with stale binary artifact paths on the self-hosted runner.
- Applied to all three workflows: `nightly.yml`, `release.yml`, and `ci.yml`.
- Fixes: `failed downloading 'Sentry.xcframework.zip': ...already exists in file system` error from [nightly run 22538356196](https://github.com/manaflow-ai/cmux/actions/runs/22538356196).

## Test plan
- [ ] Merge and re-trigger nightly build
- [ ] Verify the "Build app (Release)" step passes without SPM artifact collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline reliability by ensuring proper cache directory handling across continuous integration, nightly, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->