### PR TITLE
Improve Depot test workflow: diagnostics, filter, timeout

### DIFF
--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -17,6 +17,14 @@ on:
         required: false
         default: false
         type: boolean
+      test_filter:
+        description: "Run specific UI test class (e.g. UpdatePillUITests) or empty for all"
+        required: false
+        default: ""
+      test_timeout:
+        description: "Per-test timeout in seconds (default: 120)"
+        required: false
+        default: "120"
 
 jobs:
   tests:
@@ -73,6 +81,18 @@ jobs:
           tar xzf GhosttyKit.xcframework.tar.gz
           rm GhosttyKit.xcframework.tar.gz
           test -d GhosttyKit.xcframework
+
+      - name: Display diagnostics
+        run: |
+          echo "=== Screen resolution ==="
+          system_profiler SPDisplaysDataType 2>/dev/null || echo "No display info available"
+          echo ""
+          echo "=== Window server ==="
+          /usr/sbin/system_profiler SPSoftwareDataType | grep -i "boot mode" || true
+          echo ""
+          echo "=== Accessibility permissions ==="
+          tccutil reset Accessibility 2>/dev/null || true
+          echo "Accessibility reset attempted"
 
       - name: Clean DerivedData
         run: |
@@ -142,11 +162,23 @@ jobs:
 
       - name: Run UI tests
         if: ${{ !inputs.skip_ui_tests }}
+        env:
+          TEST_FILTER: ${{ inputs.test_filter }}
+          TEST_TIMEOUT: ${{ inputs.test_timeout || '120' }}
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+
+          # Build the -only-testing argument
+          if [ -n "$TEST_FILTER" ]; then
+            ONLY_TESTING="-only-testing:cmuxUITests/$TEST_FILTER"
+          else
+            ONLY_TESTING="-only-testing:cmuxUITests"
+          fi
+
           xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
             -disableAutomaticPackageResolution \
             -destination "platform=macOS" \
-            -only-testing:cmuxUITests test
+            -maximum-test-execution-time-allowance "$TEST_TIMEOUT" \
+            $ONLY_TESTING test


### PR DESCRIPTION
## Summary
- Add display diagnostics step (system_profiler, boot mode, accessibility) to debug why XCUITests fail/hang on Depot
- Add `test_filter` input to run a specific test class (e.g. `UpdatePillUITests`) instead of the entire suite
- Add `test_timeout` input (default 120s) with `-maximum-test-execution-time-allowance` to prevent individual tests from hanging forever (SidebarResizeUITests hung for 35+ minutes last run)

## Testing
- Merge to main, then trigger via `gh workflow run test-depot.yml -f skip_unit_tests=true -f test_filter=UpdatePillUITests`

## Related
- Follow-up to PR #718 (full XCUITest suite on Depot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD workflows with flexible test execution options including filtering and skip capabilities
  * Added configurable timeout settings for automated test runs
  * Introduced system diagnostics information gathering in CI pipeline
  * Expanded automated test coverage scope in continuous integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->