### PR TITLE
Add workspace quick-select shortcuts in switcher popup

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -666,6 +666,25 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
     return nil
 }
 
+func commandPaletteWorkspaceShortcutDigit(
+    isCommandPaletteVisible: Bool,
+    flags: NSEvent.ModifierFlags,
+    chars: String
+) -> Int? {
+    guard isCommandPaletteVisible else { return nil }
+
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    guard normalizedFlags == [.command] else { return nil }
+
+    guard let digit = Int(chars), (1...9).contains(digit) else {
+        return nil
+    }
+
+    return digit
+}
+
 func shouldConsumeShortcutWhileCommandPaletteVisible(
     isCommandPaletteVisible: Bool,
     normalizedFlags: NSEvent.ModifierFlags,
@@ -5059,6 +5078,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 name: .commandPaletteMoveSelection,
                 object: paletteWindow,
                 userInfo: ["delta": delta]
+            )
+            return true
+        }
+
+        if let digit = commandPaletteWorkspaceShortcutDigit(
+            isCommandPaletteVisible: commandPaletteVisibleInTargetWindow,
+            flags: event.modifierFlags,
+            chars: chars
+        ),
+           let paletteWindow = commandPaletteTargetWindow {
+            NotificationCenter.default.post(
+                name: .commandPaletteWorkspaceShortcutRequested,
+                object: paletteWindow,
+                userInfo: ["digit": digit]
             )
             return true
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2319,6 +2319,20 @@ struct ContentView: View {
             moveCommandPaletteSelection(by: delta)
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteWorkspaceShortcutRequested)) { notification in
+            guard isCommandPalettePresented else { return }
+            guard case .commands = commandPaletteMode else { return }
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ) else { return }
+            guard let digit = notification.userInfo?["digit"] as? Int else { return }
+            runCommandPaletteWorkspaceShortcut(digit: digit)
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRenameInputInteractionRequested)) { notification in
             guard isCommandPalettePresented else { return }
             guard case .renameInput = commandPaletteMode else { return }
@@ -3099,6 +3113,11 @@ struct ContentView: View {
             let windowId = context.windowId
             let windowTabManager = context.tabManager
             let windowKeywords = commandPaletteWindowKeywords(windowLabel: context.windowLabel)
+            let workspaceIndexById = Dictionary(
+                uniqueKeysWithValues: context.tabManager.tabs.enumerated().map { ($0.element.id, $0.offset) }
+            )
+            let shouldShowWorkspaceShortcuts = context.windowId == self.windowId
+
             for workspace in workspaces {
                 let workspaceName = workspaceDisplayName(workspace)
                 let workspaceCommandId = "switcher.workspace.\(workspace.id.uuidString.lowercased())"
@@ -3114,13 +3133,24 @@ struct ContentView: View {
                     detail: .workspace
                 )
                 let workspaceId = workspace.id
+                let workspaceShortcutHint: String? = {
+                    guard shouldShowWorkspaceShortcuts,
+                          let workspaceIndex = workspaceIndexById[workspaceId],
+                          let digit = WorkspaceShortcutMapper.commandDigitForWorkspace(
+                            at: workspaceIndex,
+                            workspaceCount: context.tabManager.tabs.count
+                          ) else {
+                        return nil
+                    }
+                    return "⌘\(digit)"
+                }()
                 entries.append(
                     CommandPaletteCommand(
                         id: workspaceCommandId,
                         rank: nextRank,
                         title: workspaceName,
                         subtitle: commandPaletteSwitcherSubtitle(base: "Workspace", windowLabel: context.windowLabel),
-                        shortcutHint: nil,
+                        shortcutHint: workspaceShortcutHint,
                         keywords: workspaceKeywords,
                         dismissOnRun: true,
                         action: {
@@ -4447,6 +4477,34 @@ struct ContentView: View {
         let current = commandPaletteSelectedIndex(resultCount: count)
         commandPaletteSelectedResultIndex = min(max(current + delta, 0), count - 1)
         syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func runCommandPaletteWorkspaceShortcut(digit: Int) {
+        guard commandPaletteListScope == .switcher else {
+            NSSound.beep()
+            return
+        }
+
+        let workspaceCount = tabManager.tabs.count
+        guard let targetIndex = WorkspaceShortcutMapper.workspaceIndex(
+            forCommandDigit: digit,
+            workspaceCount: workspaceCount
+        ),
+        targetIndex < tabManager.tabs.count else {
+            NSSound.beep()
+            return
+        }
+
+        let targetWorkspaceId = tabManager.tabs[targetIndex].id
+        let commandId = "switcher.workspace.\(targetWorkspaceId.uuidString.lowercased())"
+
+        if let command = commandPaletteEntries.first(where: { $0.id == commandId }) {
+            runCommandPaletteCommand(command)
+            return
+        }
+
+        tabManager.focusTab(targetWorkspaceId, suppressFlash: true)
+        dismissCommandPalette(restoreFocus: false)
     }
 
     private func handleCommandPaletteControlNavigationKey(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3583,6 +3583,7 @@ extension Notification.Name {
     static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")
     static let commandPaletteRenameWorkspaceRequested = Notification.Name("cmux.commandPaletteRenameWorkspaceRequested")
     static let commandPaletteMoveSelection = Notification.Name("cmux.commandPaletteMoveSelection")
+    static let commandPaletteWorkspaceShortcutRequested = Notification.Name("cmux.commandPaletteWorkspaceShortcutRequested")
     static let commandPaletteRenameInputInteractionRequested = Notification.Name("cmux.commandPaletteRenameInputInteractionRequested")
     static let commandPaletteRenameInputDeleteBackwardRequested = Notification.Name("cmux.commandPaletteRenameInputDeleteBackwardRequested")
     static let ghosttyDidSetTitle = Notification.Name("ghosttyDidSetTitle")

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2371,6 +2371,68 @@ final class CommandPaletteKeyboardNavigationTests: XCTestCase {
     }
 }
 
+final class CommandPaletteWorkspaceShortcutTests: XCTestCase {
+    func testReturnsNilWhenPaletteIsNotVisible() {
+        XCTAssertNil(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: false,
+                flags: [.command],
+                chars: "1"
+            )
+        )
+    }
+
+    func testReturnsCommandDigitForVisiblePalette() {
+        XCTAssertEqual(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [.command],
+                chars: "1"
+            ),
+            1
+        )
+        XCTAssertEqual(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [.command],
+                chars: "9"
+            ),
+            9
+        )
+    }
+
+    func testRejectsUnsupportedModifiersAndDigits() {
+        XCTAssertNil(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [.command, .shift],
+                chars: "1"
+            )
+        )
+        XCTAssertNil(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [],
+                chars: "1"
+            )
+        )
+        XCTAssertNil(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [.command],
+                chars: "0"
+            )
+        )
+        XCTAssertNil(
+            commandPaletteWorkspaceShortcutDigit(
+                isCommandPaletteVisible: true,
+                flags: [.command],
+                chars: "a"
+            )
+        )
+    }
+}
+
 final class CommandPaletteOpenShortcutConsumptionTests: XCTestCase {
     func testDoesNotConsumeWhenPaletteIsNotVisible() {
         XCTAssertFalse(


### PR DESCRIPTION
## Summary\n- allow  while the command-palette switcher popup is open to jump directly to a workspace\n- show the mapped  hint on workspace rows in the current window\n- wire a dedicated notification path from app-level shortcut routing to the switcher overlay\n- add unit tests for command-palette workspace shortcut parsing\n\n## Validation\n- attempted xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
Full build log: /tmp/cmux-xcodebuild-workspace-popup-shortcuts.log *(fails in this environment: Xcode license not accepted)*\n- attempted  *(fails in this environment: Xcode license not accepted)*\n- ran ==> Initializing submodules...
==> Checking for zig...
Error: zig is not installed.
Install via: brew install zig *(initializes submodules; fails later because  is not installed)*\n- ran [1/1] Compiling plugin GenerateManual
[2/2] Compiling plugin GenerateDoccReference
Building for debugging...
[2/6] Write swift-version--1AB21518FC5DEDBE.txt
[4/51] Compiling cmux UpdateViewModel.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[5/51] Compiling cmux WindowAccessor.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[6/51] Compiling cmux WindowDecorationsController.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[7/51] Compiling cmux WindowDragHandleView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[8/55] Compiling cmux SessionPersistence.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[9/55] Compiling cmux SidebarSelectionState.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[10/55] Compiling cmux SocketControlSettings.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[11/55] Compiling cmux TabManager.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[12/55] Compiling cmux TerminalController.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[13/55] Compiling cmux UpdatePopoverView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[14/55] Compiling cmux UpdateTestSupport.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[15/55] Compiling cmux UpdateTestURLProtocol.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[16/55] Compiling cmux UpdateTiming.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[17/55] Compiling cmux UpdateTitlebarAccessory.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[18/55] Compiling cmux UpdateController.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[19/55] Compiling cmux UpdateDelegate.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[20/55] Compiling cmux UpdateDriver.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[21/55] Compiling cmux UpdateLogStore.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[22/55] Compiling cmux UpdatePill.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[23/55] Compiling cmux TerminalNotificationStore.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[24/55] Compiling cmux TerminalView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[25/55] Compiling cmux TerminalWindowPortal.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[26/55] Compiling cmux UITestRecorder.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[27/55] Compiling cmux UpdateBadge.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[28/55] Compiling cmux TerminalPanel.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[29/55] Compiling cmux TerminalPanelView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[30/55] Compiling cmux PortScanner.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[31/55] Compiling cmux PostHogAnalytics.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[32/55] Compiling cmux SentryHelper.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[33/55] Compiling cmux WindowToolbarController.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[34/55] Compiling cmux Workspace.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[35/55] Compiling cmux WorkspaceContentView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[36/55] Compiling cmux cmuxApp.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[37/55] Compiling cmux GhosttyConfig.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[38/55] Compiling cmux GhosttyTerminalView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[39/55] Compiling cmux KeyboardLayout.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[40/55] Compiling cmux KeyboardShortcutSettings.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[41/55] Compiling cmux NotificationsPage.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[42/55] Compiling cmux BrowserPanel.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[43/55] Compiling cmux BrowserPanelView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[44/55] Compiling cmux CmuxWebView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[45/55] Compiling cmux Panel.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[46/55] Compiling cmux PanelContentView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
error: emit-module command failed with exit code 1 (use -v to see invocation)
[47/55] Emitting module cmux
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[48/55] Compiling cmux AppDelegate.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[49/55] Compiling cmux Backport.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[50/55] Compiling cmux BrowserWindowPortal.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[51/55] Compiling cmux ContentView.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications
[52/55] Compiling cmux SurfaceSearchOverlay.swift
/Users/guto/scm/cmux/Sources/AppDelegate.swift:3:8: error: no such module 'Bonsplit'
   1 | import AppKit
   2 | import SwiftUI
   3 | import Bonsplit
     |        `- error: no such module 'Bonsplit'
   4 | import CoreServices
   5 | import UserNotifications *(fails because project depends on Bonsplit/Xcode project wiring not available via SwiftPM build path)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (Cmd+1 through Cmd+9) to quickly switch workspaces when the command palette is open in switcher mode.
  * Command palette now displays workspace shortcut hints to guide users.

* **Tests**
  * Added test coverage for workspace shortcut validation and consumption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->