### PR TITLE
Fix exclusive-access crash in WindowDragHandleView hitTest

### DIFF
--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -359,6 +359,13 @@ struct WindowDragHandleView: NSViewRepresentable {
 
         override func hitTest(_ point: NSPoint) -> NSView? {
             let currentEvent = NSApp.currentEvent
+            // Fast bail-out: only claim hits for left-mouse-down events.
+            // For mouseMoved / mouseEntered / etc., return nil immediately
+            // to avoid re-entering SwiftUI view state during layout passes,
+            // which causes exclusive-access crashes.
+            guard currentEvent?.type == .leftMouseDown else {
+                return nil
+            }
             let shouldCapture = windowDragHandleShouldCaptureHit(
                 point,
                 in: self,


### PR DESCRIPTION
## Summary
- Fix a crash caused by Swift exclusive-access violation in `WindowDragHandleView.DraggableView.hitTest`
- During `mouseMoved` events, SwiftUI's internal layout pass calls `hitTest`, which re-enters SwiftUI view state via `windowDragHandleShouldCaptureHit`, triggering a fatal access conflict
- Added early return for non-`leftMouseDown` events before calling the heavyweight function, avoiding SwiftUI re-entry entirely

Fixes #723

## Root Cause
```
Simultaneous accesses to 0x6000029cc2a0, but modification requires exclusive access.
Fatal access conflict detected.
```
The crash occurs when:
1. A `mouseMoved` event triggers SwiftUI's internal state modification
2. SwiftUI calls `hitTest` on `DraggableView` during that modification
3. `windowDragHandleShouldCaptureHit` accesses SwiftUI-managed view properties before reaching the existing `leftMouseDown` guard, causing re-entry

## Test plan
- [x] Downloaded v0.61.0 release and reproduced the crash by moving the mouse over the titlebar area
- [x] Built debug app with the fix and confirmed the crash no longer reproduces with the same steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag event handling to prevent interface issues that could occur during certain interactions. The application now properly restricts event processing, preventing unwanted behavior and stability issues during layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->