### PR TITLE
Fix menubar icon invisible in light mode

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7750,6 +7750,7 @@ enum MenuBarIconRenderer {
             drawBadge(text: text, in: config.badgeRect, config: config)
         }
 
+        image.isTemplate = true
         return image
     }
 
@@ -7778,7 +7779,7 @@ enum MenuBarIconRenderer {
         path.line(to: map(384.0, 369.0))
         path.close()
 
-        NSColor.white.setFill()
+        NSColor.black.setFill()
         path.fill()
     }
 


### PR DESCRIPTION
## Summary

Set `isTemplate = true` on the menu bar icon so macOS automatically renders it as black in light mode and white in dark mode, matching standard macOS app behavior. Changed glyph fill from hardcoded white to black per Apple's template image convention.

## Testing

- Build succeeds
- In light mode: icon appears black in menu bar
- In dark mode: icon appears white in menu bar

Closes https://github.com/manaflow-ai/cmux/issues/737