### PR TITLE
Respect reduced-motion preference for stars fade animation

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -84,6 +84,12 @@ body {
   animation: fade-in 500ms ease-out;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
+  }
+}
+
 /* Docs prose styles — in @layer base so Tailwind utilities can override */
 @layer base {
   .docs-content h1 {


### PR DESCRIPTION
## Summary
- disable `.animate-fade-in` when users enable `prefers-reduced-motion: reduce`
- keep the existing 500ms fade-in behavior unchanged for users without reduced-motion enabled

## Testing
- `cd web && npm run build` (pass)
- `cd web && npm run lint` (fails due a pre-existing error in `web/app/components/spacing-control.tsx` unrelated to this change)

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Animations are now disabled for users who prefer reduced motion, improving accessibility for motion-sensitive users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->