### PR TITLE
feat: make Ctrl+1-9 surface selection shortcuts customizable

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5771,13 +5771,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
-        if flags == [.control] {
-            if let num = Int(chars), num >= 1 && num <= 9 {
-                if num == 9 {
-                    tabManager?.selectLastSurface()
+        // Numeric shortcuts for surfaces within pane (default: Ctrl+1-9, customizable via Settings)
+        let surfaceShortcutActions: [(KeyboardShortcutSettings.Action, Int?)] = [
+            (.selectSurface1, 0), (.selectSurface2, 1), (.selectSurface3, 2),
+            (.selectSurface4, 3), (.selectSurface5, 4), (.selectSurface6, 5),
+            (.selectSurface7, 6), (.selectSurface8, 7), (.selectSurface9, nil),
+        ]
+        for (action, surfaceIndex) in surfaceShortcutActions {
+            if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
+                if let index = surfaceIndex {
+                    tabManager?.selectSurface(at: index)
                 } else {
-                    tabManager?.selectSurface(at: num - 1)
+                    tabManager?.selectLastSurface()
                 }
                 return true
             }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -35,6 +35,17 @@ enum KeyboardShortcutSettings {
         case splitBrowserRight
         case splitBrowserDown
 
+        // Numbered surface selection (Ctrl+1-9 by default)
+        case selectSurface1
+        case selectSurface2
+        case selectSurface3
+        case selectSurface4
+        case selectSurface5
+        case selectSurface6
+        case selectSurface7
+        case selectSurface8
+        case selectSurface9
+
         // Panels
         case openBrowser
         case toggleBrowserDeveloperTools
@@ -69,6 +80,15 @@ enum KeyboardShortcutSettings {
             case .toggleSplitZoom: return "Toggle Pane Zoom"
             case .splitBrowserRight: return "Split Browser Right"
             case .splitBrowserDown: return "Split Browser Down"
+            case .selectSurface1: return "Select Surface 1"
+            case .selectSurface2: return "Select Surface 2"
+            case .selectSurface3: return "Select Surface 3"
+            case .selectSurface4: return "Select Surface 4"
+            case .selectSurface5: return "Select Surface 5"
+            case .selectSurface6: return "Select Surface 6"
+            case .selectSurface7: return "Select Surface 7"
+            case .selectSurface8: return "Select Surface 8"
+            case .selectSurface9: return "Select Last Surface"
             case .openBrowser: return "Open Browser"
             case .toggleBrowserDeveloperTools: return "Toggle Browser Developer Tools"
             case .showBrowserJavaScriptConsole: return "Show Browser JavaScript Console"
@@ -102,6 +122,15 @@ enum KeyboardShortcutSettings {
             case .nextSurface: return "shortcut.nextSurface"
             case .prevSurface: return "shortcut.prevSurface"
             case .newSurface: return "shortcut.newSurface"
+            case .selectSurface1: return "shortcut.selectSurface1"
+            case .selectSurface2: return "shortcut.selectSurface2"
+            case .selectSurface3: return "shortcut.selectSurface3"
+            case .selectSurface4: return "shortcut.selectSurface4"
+            case .selectSurface5: return "shortcut.selectSurface5"
+            case .selectSurface6: return "shortcut.selectSurface6"
+            case .selectSurface7: return "shortcut.selectSurface7"
+            case .selectSurface8: return "shortcut.selectSurface8"
+            case .selectSurface9: return "shortcut.selectSurface9"
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
@@ -160,6 +189,24 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "[", command: true, shift: true, option: false, control: false)
             case .newSurface:
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
+            case .selectSurface1:
+                return StoredShortcut(key: "1", command: false, shift: false, option: false, control: true)
+            case .selectSurface2:
+                return StoredShortcut(key: "2", command: false, shift: false, option: false, control: true)
+            case .selectSurface3:
+                return StoredShortcut(key: "3", command: false, shift: false, option: false, control: true)
+            case .selectSurface4:
+                return StoredShortcut(key: "4", command: false, shift: false, option: false, control: true)
+            case .selectSurface5:
+                return StoredShortcut(key: "5", command: false, shift: false, option: false, control: true)
+            case .selectSurface6:
+                return StoredShortcut(key: "6", command: false, shift: false, option: false, control: true)
+            case .selectSurface7:
+                return StoredShortcut(key: "7", command: false, shift: false, option: false, control: true)
+            case .selectSurface8:
+                return StoredShortcut(key: "8", command: false, shift: false, option: false, control: true)
+            case .selectSurface9:
+                return StoredShortcut(key: "9", command: false, shift: false, option: false, control: true)
             case .openBrowser:
                 return StoredShortcut(key: "l", command: true, shift: true, option: false, control: false)
             case .toggleBrowserDeveloperTools:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -231,6 +231,26 @@ enum KeyboardShortcutSettings {
         return shortcut
     }
 
+    /// Returns the set of distinct modifier flags used across all surface selection shortcuts.
+    static var surfaceShortcutModifierFlagSets: [(rawValue: UInt, symbol: String)] {
+        let actions: [Action] = [
+            .selectSurface1, .selectSurface2, .selectSurface3,
+            .selectSurface4, .selectSurface5, .selectSurface6,
+            .selectSurface7, .selectSurface8, .selectSurface9,
+        ]
+        var seen: [(rawValue: UInt, symbol: String)] = []
+        for action in actions {
+            let sc = shortcut(for: action)
+            let flags = sc.modifierFlags
+            guard !flags.isEmpty else { continue }
+            let raw = flags.rawValue
+            if !seen.contains(where: { $0.rawValue == raw }) {
+                seen.append((rawValue: raw, symbol: sc.modifierSymbol))
+            }
+        }
+        return seen
+    }
+
     static func setShortcut(_ shortcut: StoredShortcut, for action: Action) {
         if let data = try? JSONEncoder().encode(shortcut) {
             UserDefaults.standard.set(data, forKey: action.defaultsKey)
@@ -314,6 +334,16 @@ struct StoredShortcut: Codable, Equatable {
             keyText = key.uppercased()
         }
         parts.append(keyText)
+        return parts.joined()
+    }
+
+    /// Returns just the modifier symbol portion (e.g. "⌃", "⌥", "⌘⇧").
+    var modifierSymbol: String {
+        var parts: [String] = []
+        if control { parts.append("⌃") }
+        if option { parts.append("⌥") }
+        if shift { parts.append("⇧") }
+        if command { parts.append("⌘") }
         return parts.joined()
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -924,6 +924,9 @@ final class Workspace: Identifiable, ObservableObject {
     /// Callback used by TabManager to capture recently closed browser panels for Cmd+Shift+T restore.
     var onClosedBrowserPanel: ((ClosedBrowserPanelRestoreSnapshot) -> Void)?
 
+    /// Observer token for shortcut hint config refresh.
+    private var shortcutHintObserver: NSObjectProtocol?
+
 
     // Closing tabs mutates split layout immediately; terminal views handle their own AppKit
     // layout/size synchronization.
@@ -1031,7 +1034,38 @@ final class Workspace: Identifiable, ObservableObject {
                     backgroundColor: backgroundColor,
                     backgroundOpacity: backgroundOpacity
                 )
-            )
+            ),
+            shortcutHintConfig: Self.currentShortcutHintConfig()
+        )
+    }
+
+    deinit {
+        if let shortcutHintObserver {
+            NotificationCenter.default.removeObserver(shortcutHintObserver)
+        }
+    }
+
+    private static func currentShortcutHintConfig() -> BonsplitConfiguration.ShortcutHintConfig {
+        let modSets = KeyboardShortcutSettings.surfaceShortcutModifierFlagSets
+        let actions: [KeyboardShortcutSettings.Action] = [
+            .selectSurface1, .selectSurface2, .selectSurface3,
+            .selectSurface4, .selectSurface5, .selectSurface6,
+            .selectSurface7, .selectSurface8, .selectSurface9,
+        ]
+        var digitLabels: [Int: String] = [:]
+        for (i, action) in actions.enumerated() {
+            let sc = KeyboardShortcutSettings.shortcut(for: action)
+            digitLabels[i + 1] = sc.displayString
+        }
+        // Always include Command modifier for pane hints (matches production behavior
+        // where both Cmd and Ctrl trigger pane tab hints).
+        var triggerRawValues = Set(modSets.map { $0.rawValue })
+        let cmdRaw = NSEvent.ModifierFlags.command.intersection(.deviceIndependentFlagsMask).rawValue
+        triggerRawValues.insert(cmdRaw)
+        return .init(
+            triggerModifierRawValues: triggerRawValues,
+            modifierSymbols: Dictionary(modSets.map { ($0.rawValue, $0.symbol) }, uniquingKeysWith: { first, _ in first }),
+            digitLabels: digitLabels
         )
     }
 
@@ -1062,6 +1096,7 @@ final class Workspace: Identifiable, ObservableObject {
             return
         }
         bonsplitController.configuration.appearance.chromeColors.backgroundHex = nextHex
+        bonsplitController.configuration.appearance.shortcutHintConfig = Self.currentShortcutHintConfig()
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme applied workspace=\(id.uuidString) reason=\(reason) resultingBg=\(bonsplitController.configuration.appearance.chromeColors.backgroundHex ?? "nil") resultingBorder=\(bonsplitController.configuration.appearance.chromeColors.borderHex ?? "nil")"
@@ -1116,6 +1151,19 @@ final class Workspace: Identifiable, ObservableObject {
         )
         self.bonsplitController = BonsplitController(configuration: config)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()
+
+        // Refresh pane shortcut hints when the user changes shortcut settings.
+        shortcutHintObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            let updated = Self.currentShortcutHintConfig()
+            if self.bonsplitController.configuration.appearance.shortcutHintConfig != updated {
+                self.bonsplitController.configuration.appearance.shortcutHintConfig = updated
+            }
+        }
 
         // Remove the default "Welcome" tab that bonsplit creates
         let welcomeTabIds = bonsplitController.allTabIds


### PR DESCRIPTION
## Summary

Resolves #577

- Add `selectSurface1`–`selectSurface9` actions to `KeyboardShortcutSettings`
- Replace hardcoded `flags == [.control]` check in `handleCustomShortcut` with `matchShortcut` loop
- Shortcuts appear in Settings > Keyboard Shortcuts and can be remapped to any modifier+key combination
- Default behavior (Ctrl+1-9) is unchanged; existing users are unaffected

## Test plan

- [x] Ctrl+1-9 surface switching works with default shortcuts
- [x] New shortcuts appear in Settings > Keyboard Shortcuts
- [x] Remapping shortcuts (e.g. Opt+1-3) works correctly
- [x] Mixed configuration (some remapped, some default) works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable keyboard shortcuts for surface selection with sensible defaults (Ctrl+1–Ctrl+8 select surfaces 1–8; Ctrl+9 selects the last surface).
  * Shortcut hint display now updates dynamically when shortcut settings change.

* **Refactor**
  * Surface selection logic reworked to be data-driven and extensible, enabling easier customization of shortcut mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->