### PR TITLE
Route Ghostty split action passthrough by tab context

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -992,6 +992,13 @@ class GhosttyApp {
         return Unmanaged<GhosttySurfaceCallbackContext>.fromOpaque(userdata).takeUnretainedValue()
     }
 
+    @MainActor
+    private func tabManagerForSurfaceAction(tabId: UUID?) -> TabManager? {
+        guard let app = AppDelegate.shared else { return nil }
+        guard let tabId else { return app.tabManager }
+        return app.tabManagerFor(tabId: tabId) ?? app.tabManager
+    }
+
     private func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
         if target.tag != GHOSTTY_TARGET_SURFACE {
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG ||
@@ -1120,37 +1127,39 @@ class GhosttyApp {
                 surfaceId: callbackSurfaceId ?? surfaceView.terminalSurface?.id
             )
         }
+        let actionTabId = callbackTabId ?? surfaceView.tabId
+        let actionSurfaceId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
 
         switch action.tag {
         case GHOSTTY_ACTION_NEW_SPLIT:
-            guard let tabId = surfaceView.tabId,
-                  let surfaceId = surfaceView.terminalSurface?.id,
+            guard let tabId = actionTabId,
+                  let surfaceId = actionSurfaceId,
                   let direction = splitDirection(from: action.action.new_split) else {
                 return false
             }
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                guard let tabManager = tabManagerForSurfaceAction(tabId: tabId) else { return false }
                 return tabManager.newSplit(tabId: tabId, surfaceId: surfaceId, direction: direction) != nil
             }
         case GHOSTTY_ACTION_GOTO_SPLIT:
-            guard let tabId = surfaceView.tabId,
-                  let surfaceId = surfaceView.terminalSurface?.id,
+            guard let tabId = actionTabId,
+                  let surfaceId = actionSurfaceId,
                   let direction = focusDirection(from: action.action.goto_split) else {
                 return false
             }
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                guard let tabManager = tabManagerForSurfaceAction(tabId: tabId) else { return false }
                 return tabManager.moveSplitFocus(tabId: tabId, surfaceId: surfaceId, direction: direction)
             }
         case GHOSTTY_ACTION_RESIZE_SPLIT:
-            guard let tabId = surfaceView.tabId,
-                  let surfaceId = surfaceView.terminalSurface?.id,
+            guard let tabId = actionTabId,
+                  let surfaceId = actionSurfaceId,
                   let direction = resizeDirection(from: action.action.resize_split.direction) else {
                 return false
             }
             let amount = action.action.resize_split.amount
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                guard let tabManager = tabManagerForSurfaceAction(tabId: tabId) else { return false }
                 return tabManager.resizeSplit(
                     tabId: tabId,
                     surfaceId: surfaceId,
@@ -1159,20 +1168,20 @@ class GhosttyApp {
                 )
             }
         case GHOSTTY_ACTION_EQUALIZE_SPLITS:
-            guard let tabId = surfaceView.tabId else {
+            guard let tabId = actionTabId else {
                 return false
             }
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                guard let tabManager = tabManagerForSurfaceAction(tabId: tabId) else { return false }
                 return tabManager.equalizeSplits(tabId: tabId)
             }
         case GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM:
-            guard let tabId = surfaceView.tabId,
-                  let surfaceId = surfaceView.terminalSurface?.id else {
+            guard let tabId = actionTabId,
+                  let surfaceId = actionSurfaceId else {
                 return false
             }
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                guard let tabManager = tabManagerForSurfaceAction(tabId: tabId) else { return false }
                 return tabManager.toggleSplitZoom(tabId: tabId, surfaceId: surfaceId)
             }
         case GHOSTTY_ACTION_SCROLLBAR:

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -849,6 +849,45 @@ final class TabManagerNotificationOrderingSourceTests: XCTestCase {
     }
 }
 
+final class GhosttySurfaceSplitActionRoutingSourceTests: XCTestCase {
+    func testSplitActionsResolveTabManagerFromActionTabContext() throws {
+        let projectRoot = findProjectRoot()
+        let sourceURL = projectRoot.appendingPathComponent("Sources/GhosttyTerminalView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        guard let splitStart = source.range(of: "case GHOSTTY_ACTION_NEW_SPLIT:"),
+              let scrollbarStart = source.range(
+                of: "case GHOSTTY_ACTION_SCROLLBAR:",
+                range: splitStart.upperBound..<source.endIndex
+              ) else {
+            XCTFail("Failed to locate Ghostty split action block in Sources/GhosttyTerminalView.swift")
+            return
+        }
+
+        let splitActionBlock = String(source[splitStart.lowerBound..<scrollbarStart.lowerBound])
+        XCTAssertTrue(
+            splitActionBlock.contains("tabManagerForSurfaceAction(tabId: tabId)"),
+            "Expected Ghostty split/equalize passthrough to resolve manager by action tab ID."
+        )
+        XCTAssertFalse(
+            splitActionBlock.contains("AppDelegate.shared?.tabManager"),
+            "Expected Ghostty split/equalize passthrough to avoid active-manager-only routing."
+        )
+    }
+
+    private func findProjectRoot() -> URL {
+        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
+        for _ in 0..<10 {
+            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
+            if FileManager.default.fileExists(atPath: marker.path) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    }
+}
+
 final class SocketControlSettingsTests: XCTestCase {
     func testMigrateModeSupportsExpandedSocketModes() {
         XCTAssertEqual(SocketControlSettings.migrateMode("off"), .off)


### PR DESCRIPTION
## Summary
- Route Ghostty split action passthrough (`new_split`, `goto_split`, `resize_split`, `equalize_splits`, `toggle_split_zoom`) to the owning `TabManager` resolved from the callback tab ID, with active-manager fallback.
- Keep surface/tab resolution anchored to callback context (`callbackTabId`/`callbackSurfaceId`) when present.
- Add a regression source test that guards split action routing against regressions to active-manager-only dispatch.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' build-for-testing` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/GhosttySurfaceSplitActionRoutingSourceTests test` ⚠️ fails to launch tests in this host environment with `IDEPseudoTerminalDomain Code 7 (Device not configured)` after successful build.

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/571
- Related: https://github.com/manaflow-ai/cmux/issues/731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and consistency of split window operations when managing multiple tabs and splits, ensuring actions are routed to the correct context.

* **Tests**
  * Added tests to verify split action routing behavior functions correctly across different tab scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->