### PR TITLE
Make Cmd+1-9 workspace selection shortcuts customizable

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5757,18 +5757,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
-        if flags == [.command],
-           let manager = tabManager,
-           let num = Int(chars),
-           let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
+        // Numeric shortcuts for specific sidebar tabs (default: Cmd+1-9, customizable via Settings)
+        if let manager = tabManager {
+            let workspaceShortcutActions: [(KeyboardShortcutSettings.Action, Int?)] = [
+                (.selectWorkspace1, 0), (.selectWorkspace2, 1), (.selectWorkspace3, 2),
+                (.selectWorkspace4, 3), (.selectWorkspace5, 4), (.selectWorkspace6, 5),
+                (.selectWorkspace7, 6), (.selectWorkspace8, 7), (.selectWorkspace9, nil),
+            ]
+            for (action, workspaceIndex) in workspaceShortcutActions {
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
+                    let targetIndex: Int
+                    if let index = workspaceIndex {
+                        guard index < manager.tabs.count else { continue }
+                        targetIndex = index
+                    } else {
+                        guard manager.tabs.count > 0 else { continue }
+                        targetIndex = manager.tabs.count - 1
+                    }
 #if DEBUG
-            dlog(
-                "shortcut.action name=workspaceDigit digit=\(num) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
-            )
+                    dlog(
+                        "shortcut.action name=workspaceDigit targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
+                    )
 #endif
-            manager.selectTab(at: targetIndex)
-            return true
+                    manager.selectTab(at: targetIndex)
+                    return true
+                }
+            }
         }
 
         // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6572,8 +6572,13 @@ private struct TabItemView: View {
     }
 
     private var workspaceShortcutLabel: String? {
-        guard let action = KeyboardShortcutSettings.workspaceAction(at: index, isLast: false) else { return nil }
-        return KeyboardShortcutSettings.shortcut(for: action).displayString
+        if let action = KeyboardShortcutSettings.workspaceAction(at: index, isLast: false) {
+            return KeyboardShortcutSettings.shortcut(for: action).displayString
+        }
+        if index == tabManager.tabs.count - 1 {
+            return KeyboardShortcutSettings.shortcut(for: .selectWorkspace9).displayString
+        }
+        return nil
     }
 
     private var showsWorkspaceShortcutHint: Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5811,7 +5811,8 @@ enum SidebarCommandHintPolicy {
     static let intentionalHoldDelay: TimeInterval = 0.30
 
     static func shouldShowHints(for modifierFlags: NSEvent.ModifierFlags) -> Bool {
-        modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command]
+        let cleanFlags = modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return KeyboardShortcutSettings.workspaceShortcutModifierFlagSets.contains(cleanFlags)
     }
 
     static func isCurrentWindow(
@@ -6571,8 +6572,8 @@ private struct TabItemView: View {
     }
 
     private var workspaceShortcutLabel: String? {
-        guard let workspaceShortcutDigit else { return nil }
-        return "⌘\(workspaceShortcutDigit)"
+        guard let action = KeyboardShortcutSettings.workspaceAction(at: index, isLast: false) else { return nil }
+        return KeyboardShortcutSettings.shortcut(for: action).displayString
     }
 
     private var showsWorkspaceShortcutHint: Bool {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -35,6 +35,17 @@ enum KeyboardShortcutSettings {
         case splitBrowserRight
         case splitBrowserDown
 
+        // Numbered workspace selection (Cmd+1-9 by default)
+        case selectWorkspace1
+        case selectWorkspace2
+        case selectWorkspace3
+        case selectWorkspace4
+        case selectWorkspace5
+        case selectWorkspace6
+        case selectWorkspace7
+        case selectWorkspace8
+        case selectWorkspace9
+
         // Panels
         case openBrowser
         case toggleBrowserDeveloperTools
@@ -69,6 +80,15 @@ enum KeyboardShortcutSettings {
             case .toggleSplitZoom: return "Toggle Pane Zoom"
             case .splitBrowserRight: return "Split Browser Right"
             case .splitBrowserDown: return "Split Browser Down"
+            case .selectWorkspace1: return "Select Workspace 1"
+            case .selectWorkspace2: return "Select Workspace 2"
+            case .selectWorkspace3: return "Select Workspace 3"
+            case .selectWorkspace4: return "Select Workspace 4"
+            case .selectWorkspace5: return "Select Workspace 5"
+            case .selectWorkspace6: return "Select Workspace 6"
+            case .selectWorkspace7: return "Select Workspace 7"
+            case .selectWorkspace8: return "Select Workspace 8"
+            case .selectWorkspace9: return "Select Last Workspace"
             case .openBrowser: return "Open Browser"
             case .toggleBrowserDeveloperTools: return "Toggle Browser Developer Tools"
             case .showBrowserJavaScriptConsole: return "Show Browser JavaScript Console"
@@ -102,6 +122,15 @@ enum KeyboardShortcutSettings {
             case .nextSurface: return "shortcut.nextSurface"
             case .prevSurface: return "shortcut.prevSurface"
             case .newSurface: return "shortcut.newSurface"
+            case .selectWorkspace1: return "shortcut.selectWorkspace1"
+            case .selectWorkspace2: return "shortcut.selectWorkspace2"
+            case .selectWorkspace3: return "shortcut.selectWorkspace3"
+            case .selectWorkspace4: return "shortcut.selectWorkspace4"
+            case .selectWorkspace5: return "shortcut.selectWorkspace5"
+            case .selectWorkspace6: return "shortcut.selectWorkspace6"
+            case .selectWorkspace7: return "shortcut.selectWorkspace7"
+            case .selectWorkspace8: return "shortcut.selectWorkspace8"
+            case .selectWorkspace9: return "shortcut.selectWorkspace9"
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
@@ -160,6 +189,24 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "[", command: true, shift: true, option: false, control: false)
             case .newSurface:
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace1:
+                return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace2:
+                return StoredShortcut(key: "2", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace3:
+                return StoredShortcut(key: "3", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace4:
+                return StoredShortcut(key: "4", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace5:
+                return StoredShortcut(key: "5", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace6:
+                return StoredShortcut(key: "6", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace7:
+                return StoredShortcut(key: "7", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace8:
+                return StoredShortcut(key: "8", command: true, shift: false, option: false, control: false)
+            case .selectWorkspace9:
+                return StoredShortcut(key: "9", command: true, shift: false, option: false, control: false)
             case .openBrowser:
                 return StoredShortcut(key: "l", command: true, shift: true, option: false, control: false)
             case .toggleBrowserDeveloperTools:
@@ -174,6 +221,40 @@ enum KeyboardShortcutSettings {
         func tooltip(_ base: String) -> String {
             "\(base) (\(KeyboardShortcutSettings.shortcut(for: self).displayString))"
         }
+    }
+
+    /// Returns the workspace selection action for the given zero-based index (0-7),
+    /// or `.selectWorkspace9` (last workspace) when `isLast` is true.
+    static func workspaceAction(at index: Int, isLast: Bool) -> Action? {
+        if isLast { return .selectWorkspace9 }
+        switch index {
+        case 0: return .selectWorkspace1
+        case 1: return .selectWorkspace2
+        case 2: return .selectWorkspace3
+        case 3: return .selectWorkspace4
+        case 4: return .selectWorkspace5
+        case 5: return .selectWorkspace6
+        case 6: return .selectWorkspace7
+        case 7: return .selectWorkspace8
+        default: return nil
+        }
+    }
+
+    /// Returns the set of distinct modifier flags used across all workspace selection shortcuts.
+    static var workspaceShortcutModifierFlagSets: [NSEvent.ModifierFlags] {
+        let actions: [Action] = [
+            .selectWorkspace1, .selectWorkspace2, .selectWorkspace3,
+            .selectWorkspace4, .selectWorkspace5, .selectWorkspace6,
+            .selectWorkspace7, .selectWorkspace8, .selectWorkspace9,
+        ]
+        var seen: [NSEvent.ModifierFlags] = []
+        for action in actions {
+            let flags = shortcut(for: action).modifierFlags
+            if !flags.isEmpty && !seen.contains(flags) {
+                seen.append(flags)
+            }
+        }
+        return seen
     }
 
     static func shortcut(for action: Action) -> StoredShortcut {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -34,6 +34,15 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace1.defaultsKey) private var selectWorkspace1ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace2.defaultsKey) private var selectWorkspace2ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace3.defaultsKey) private var selectWorkspace3ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace4.defaultsKey) private var selectWorkspace4ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace5.defaultsKey) private var selectWorkspace5ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace6.defaultsKey) private var selectWorkspace6ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace7.defaultsKey) private var selectWorkspace7ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace8.defaultsKey) private var selectWorkspace8ShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.selectWorkspace9.defaultsKey) private var selectWorkspace9ShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {
@@ -584,15 +593,40 @@ struct cmuxApp: App {
 
                 Divider()
 
-                // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
-                ForEach(1...9, id: \.self) { number in
-                    Button("Workspace \(number)") {
-                        let manager = activeTabManager
-                        if let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: number, workspaceCount: manager.tabs.count) {
-                            manager.selectTab(at: targetIndex)
-                        }
+                // Workspace selection shortcuts (default: Cmd+1-9, customizable via Settings).
+                // Keyboard shortcuts are handled by the local event monitor in handleCustomShortcut.
+                // We intentionally omit .keyboardShortcut() here because SwiftUI's menu system
+                // does not reliably update key equivalents when settings change at runtime,
+                // which causes stale shortcuts to fire via performKeyEquivalent -> mainMenu fallback.
+                workspaceMenuButton("Workspace 1", shortcut: selectWorkspace1MenuShortcut) {
+                    selectWorkspaceByIndex(0)
+                }
+                workspaceMenuButton("Workspace 2", shortcut: selectWorkspace2MenuShortcut) {
+                    selectWorkspaceByIndex(1)
+                }
+                workspaceMenuButton("Workspace 3", shortcut: selectWorkspace3MenuShortcut) {
+                    selectWorkspaceByIndex(2)
+                }
+                workspaceMenuButton("Workspace 4", shortcut: selectWorkspace4MenuShortcut) {
+                    selectWorkspaceByIndex(3)
+                }
+                workspaceMenuButton("Workspace 5", shortcut: selectWorkspace5MenuShortcut) {
+                    selectWorkspaceByIndex(4)
+                }
+                workspaceMenuButton("Workspace 6", shortcut: selectWorkspace6MenuShortcut) {
+                    selectWorkspaceByIndex(5)
+                }
+                workspaceMenuButton("Workspace 7", shortcut: selectWorkspace7MenuShortcut) {
+                    selectWorkspaceByIndex(6)
+                }
+                workspaceMenuButton("Workspace 8", shortcut: selectWorkspace8MenuShortcut) {
+                    selectWorkspaceByIndex(7)
+                }
+                workspaceMenuButton("Last Workspace", shortcut: selectWorkspace9MenuShortcut) {
+                    let manager = activeTabManager
+                    if manager.tabs.count > 0 {
+                        manager.selectTab(at: manager.tabs.count - 1)
                     }
-                    .keyboardShortcut(KeyEquivalent(Character("\(number)")), modifiers: .command)
                 }
 
                 Divider()
@@ -796,6 +830,50 @@ struct cmuxApp: App {
             return
         }
         _ = tabManager.createBrowserSplit(direction: direction)
+    }
+
+
+    // MARK: - Workspace selection menu shortcuts
+
+    private var selectWorkspace1MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace1ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace1.defaultShortcut)
+    }
+    private var selectWorkspace2MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace2ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace2.defaultShortcut)
+    }
+    private var selectWorkspace3MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace3ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace3.defaultShortcut)
+    }
+    private var selectWorkspace4MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace4ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace4.defaultShortcut)
+    }
+    private var selectWorkspace5MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace5ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace5.defaultShortcut)
+    }
+    private var selectWorkspace6MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace6ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace6.defaultShortcut)
+    }
+    private var selectWorkspace7MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace7ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace7.defaultShortcut)
+    }
+    private var selectWorkspace8MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace8ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace8.defaultShortcut)
+    }
+    private var selectWorkspace9MenuShortcut: StoredShortcut {
+        decodeShortcut(from: selectWorkspace9ShortcutData, fallback: KeyboardShortcutSettings.Action.selectWorkspace9.defaultShortcut)
+    }
+
+    private func selectWorkspaceByIndex(_ index: Int) {
+        let manager = activeTabManager
+        if index < manager.tabs.count {
+            manager.selectTab(at: index)
+        }
+    }
+
+    /// Menu button for workspace selection. Displays the shortcut hint in the title
+    /// but does NOT register a `.keyboardShortcut()` — the local event monitor handles the actual binding.
+    private func workspaceMenuButton(_ title: String, shortcut: StoredShortcut, action: @escaping () -> Void) -> some View {
+        Button("\(title)\t\(shortcut.displayString)", action: action)
     }
 
     @ViewBuilder

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1848,6 +1848,150 @@ final class WorkspaceShortcutMapperTests: XCTestCase {
     }
 }
 
+// MARK: - #645: Customizable Workspace Shortcut Tests
+
+final class WorkspaceActionMappingTests: XCTestCase {
+    func testIndexZeroToSevenMapsToSelectWorkspace1Through8() {
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 0, isLast: false), .selectWorkspace1)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 1, isLast: false), .selectWorkspace2)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 2, isLast: false), .selectWorkspace3)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 3, isLast: false), .selectWorkspace4)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 4, isLast: false), .selectWorkspace5)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 5, isLast: false), .selectWorkspace6)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 6, isLast: false), .selectWorkspace7)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 7, isLast: false), .selectWorkspace8)
+    }
+
+    func testIndexEightOrAboveReturnsNilWhenNotLast() {
+        XCTAssertNil(KeyboardShortcutSettings.workspaceAction(at: 8, isLast: false))
+        XCTAssertNil(KeyboardShortcutSettings.workspaceAction(at: 9, isLast: false))
+        XCTAssertNil(KeyboardShortcutSettings.workspaceAction(at: 100, isLast: false))
+    }
+
+    func testIsLastAlwaysReturnsSelectWorkspace9RegardlessOfIndex() {
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 0, isLast: true), .selectWorkspace9)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 3, isLast: true), .selectWorkspace9)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 7, isLast: true), .selectWorkspace9)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 50, isLast: true), .selectWorkspace9)
+    }
+
+    func testNegativeIndexReturnsNil() {
+        XCTAssertNil(KeyboardShortcutSettings.workspaceAction(at: -1, isLast: false))
+    }
+
+    func testIsLastAtHighIndexReturnsSelectWorkspace9() {
+        // Regression: index 8+ with isLast must return selectWorkspace9 for the hint label.
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 8, isLast: true), .selectWorkspace9)
+        XCTAssertEqual(KeyboardShortcutSettings.workspaceAction(at: 14, isLast: true), .selectWorkspace9)
+    }
+
+    func testIndexEightWithoutIsLastReturnsNil() {
+        // Index 8 is only reachable via isLast (selectWorkspace9). Without isLast, no shortcut.
+        XCTAssertNil(KeyboardShortcutSettings.workspaceAction(at: 8, isLast: false))
+    }
+}
+
+final class WorkspaceShortcutDefaultValuesTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // Ensure no stored overrides interfere with default value tests.
+        for action: KeyboardShortcutSettings.Action in [
+            .selectWorkspace1, .selectWorkspace2, .selectWorkspace3,
+            .selectWorkspace4, .selectWorkspace5, .selectWorkspace6,
+            .selectWorkspace7, .selectWorkspace8, .selectWorkspace9,
+        ] {
+            KeyboardShortcutSettings.resetShortcut(for: action)
+        }
+    }
+
+    func testAllWorkspaceShortcutsDefaultToCommandPlusDigit() {
+        let actions: [(KeyboardShortcutSettings.Action, String)] = [
+            (.selectWorkspace1, "1"), (.selectWorkspace2, "2"), (.selectWorkspace3, "3"),
+            (.selectWorkspace4, "4"), (.selectWorkspace5, "5"), (.selectWorkspace6, "6"),
+            (.selectWorkspace7, "7"), (.selectWorkspace8, "8"), (.selectWorkspace9, "9"),
+        ]
+        for (action, expectedKey) in actions {
+            let sc = KeyboardShortcutSettings.shortcut(for: action)
+            XCTAssertTrue(sc.command, "\(action) should have command modifier")
+            XCTAssertFalse(sc.shift, "\(action) should not have shift modifier")
+            XCTAssertFalse(sc.option, "\(action) should not have option modifier")
+            XCTAssertFalse(sc.control, "\(action) should not have control modifier")
+            XCTAssertEqual(sc.key, expectedKey, "\(action) should use key \(expectedKey)")
+        }
+    }
+
+    func testDefaultDisplayStringsAreCommandSymbolPlusDigit() {
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .selectWorkspace1).displayString, "⌘1")
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .selectWorkspace5).displayString, "⌘5")
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .selectWorkspace9).displayString, "⌘9")
+    }
+
+    func testDefaultModifierFlagSetsContainsOnlyCommand() {
+        let flagSets = KeyboardShortcutSettings.workspaceShortcutModifierFlagSets
+        XCTAssertEqual(flagSets.count, 1)
+        XCTAssertEqual(flagSets.first, NSEvent.ModifierFlags.command)
+    }
+}
+
+final class WorkspaceShortcutCustomizationTests: XCTestCase {
+    private let customizedActions: [KeyboardShortcutSettings.Action] = [
+        .selectWorkspace1, .selectWorkspace2, .selectWorkspace3,
+    ]
+
+    override func tearDown() {
+        // Always clean up any custom shortcuts we stored.
+        for action in customizedActions {
+            KeyboardShortcutSettings.resetShortcut(for: action)
+        }
+        super.tearDown()
+    }
+
+    func testCustomShortcutOverridesDefault() {
+        let custom = StoredShortcut(key: "1", command: false, shift: false, option: true, control: false)
+        KeyboardShortcutSettings.setShortcut(custom, for: .selectWorkspace1)
+        let retrieved = KeyboardShortcutSettings.shortcut(for: .selectWorkspace1)
+        XCTAssertEqual(retrieved, custom)
+        XCTAssertEqual(retrieved.displayString, "⌥1")
+    }
+
+    func testModifierFlagSetsReflectsCustomShortcuts() {
+        // Change workspace 1-3 to Option+N
+        for (i, action) in customizedActions.enumerated() {
+            let custom = StoredShortcut(key: "\(i + 1)", command: false, shift: false, option: true, control: false)
+            KeyboardShortcutSettings.setShortcut(custom, for: action)
+        }
+
+        let flagSets = KeyboardShortcutSettings.workspaceShortcutModifierFlagSets
+        // Should contain both .option (from workspace 1-3) and .command (from workspace 4-9)
+        XCTAssertTrue(flagSets.contains(NSEvent.ModifierFlags.option), "Option modifier should be present")
+        XCTAssertTrue(flagSets.contains(NSEvent.ModifierFlags.command), "Command modifier should still be present")
+        XCTAssertEqual(flagSets.count, 2)
+    }
+
+    func testHintPolicyRespectsCustomModifiers() {
+        // Default: only Command triggers hints
+        XCTAssertTrue(SidebarCommandHintPolicy.shouldShowHints(for: [.command]))
+        XCTAssertFalse(SidebarCommandHintPolicy.shouldShowHints(for: [.option]))
+
+        // Change workspace 1 to Option+1
+        let custom = StoredShortcut(key: "1", command: false, shift: false, option: true, control: false)
+        KeyboardShortcutSettings.setShortcut(custom, for: .selectWorkspace1)
+
+        // Now both Command and Option should trigger hints
+        XCTAssertTrue(SidebarCommandHintPolicy.shouldShowHints(for: [.command]))
+        XCTAssertTrue(SidebarCommandHintPolicy.shouldShowHints(for: [.option]))
+    }
+
+    func testResetShortcutRestoresDefault() {
+        let custom = StoredShortcut(key: "1", command: false, shift: false, option: true, control: false)
+        KeyboardShortcutSettings.setShortcut(custom, for: .selectWorkspace1)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .selectWorkspace1).displayString, "⌥1")
+
+        KeyboardShortcutSettings.resetShortcut(for: .selectWorkspace1)
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .selectWorkspace1).displayString, "⌘1")
+    }
+}
+
 final class BrowserOmnibarCommandNavigationTests: XCTestCase {
     func testArrowNavigationDeltaRequiresFocusedAddressBarAndNoModifierFlags() {
         XCTAssertNil(


### PR DESCRIPTION
## Summary

Adds `selectWorkspace1`–`selectWorkspace9` actions to `KeyboardShortcutSettings`, allowing users to rebind the default Cmd+1-9 workspace selection shortcuts via the Settings UI.

### Changes

- **KeyboardShortcutSettings.swift**: Add 9 new `Action` enum cases with labels, `defaultsKey`s, and default shortcuts (Cmd+1 through Cmd+9). Add `workspaceAction(at:isLast:)` helper for index-to-action mapping and `workspaceShortcutModifierFlagSets` computed property that collects all distinct modifier flags across configured workspace shortcuts.
- **AppDelegate.swift**: Replace the hardcoded `flags == [.command]` check with a `matchShortcut` loop over all workspace actions, so customized bindings are respected at runtime.
- **cmuxApp.swift**: Replace the `ForEach(1...9)` menu block (which used `.keyboardShortcut(.command)`) with individual `workspaceMenuButton` calls that display the configured shortcut in the button title without registering a SwiftUI `.keyboardShortcut()`. This prevents stale key equivalents from firing via `performKeyEquivalent → mainMenu` after the user rebinds shortcuts.
- **ContentView.swift**: Update `SidebarCommandHintPolicy.shouldShowHints` to trigger on any configured workspace modifier (not just `.command`). Update `workspaceShortcutLabel` to display the actual configured shortcut symbol instead of a hardcoded `⌘`.

### Test plan

- [ ] Default behavior: Cmd+1-9 selects workspaces as before
- [ ] Open Settings → Shortcuts, verify "Select Workspace 1"–"Select Last Workspace" appear
- [ ] Rebind workspace 1-3 to Opt+1-3, verify Opt+1-3 switches workspaces and Cmd+1-3 no longer does
- [ ] Verify sidebar hints show the correct modifier symbol when holding the configured modifier key
- [ ] Verify the last workspace hint shows its position number (e.g., ⌘4 for 4 workspaces), not ⌘9

Closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace selection shortcuts (Cmd+1–9) are now customizable via settings; last-slot still selects the last workspace.
  * Shortcut labels now show action descriptions instead of digits and respect customized modifier sets.

* **Refactor**
  * Replaced hard-coded digit handling with a table-driven, configurable shortcut resolution.

* **Tests**
  * Added tests covering mapping, defaults, customization, hint modifier behavior, and reset/restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->