### PR TITLE
Prevent Ghostty visibility-update crash during rapid sidebar shortcuts

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3819,6 +3819,7 @@ final class GhosttySurfaceScrollView: NSView {
 	    private var isLiveScrolling = false
     private var lastSentRow: Int?
     private var isActive = true
+    private var visibilityMutationGeneration: UInt64 = 0
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
@@ -4464,8 +4465,13 @@ final class GhosttySurfaceScrollView: NSView {
 
     func setVisibleInUI(_ visible: Bool) {
         let wasVisible = surfaceView.isVisibleInUI
+        let targetHidden = !visible
+
         surfaceView.setVisibleInUI(visible)
-        isHidden = !visible
+        // Deferring host view hidden-state mutation avoids AppKit constraint recursion when
+        // SwiftUI updates visibility in the middle of an active layout/update-constraints pass.
+        visibilityMutationGeneration &+= 1
+        let generation = visibilityMutationGeneration
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"
@@ -4476,14 +4482,24 @@ final class GhosttySurfaceScrollView: NSView {
             )
         }
 #endif
-        if !visible {
-            // If we were focused, yield first responder.
-            if let window, let fr = window.firstResponder as? NSView,
-               fr === surfaceView || fr.isDescendant(of: surfaceView) {
-                window.makeFirstResponder(nil)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard self.visibilityMutationGeneration == generation else { return }
+
+            let hiddenChanged = self.isHidden != targetHidden
+            if hiddenChanged {
+                self.isHidden = targetHidden
             }
-        } else {
-            applyFirstResponderIfNeeded()
+
+            if !visible {
+                // If we were focused, yield first responder.
+                if let window = self.window, let fr = window.firstResponder as? NSView,
+                   fr === self.surfaceView || fr.isDescendant(of: self.surfaceView) {
+                    window.makeFirstResponder(nil)
+                }
+            } else if wasVisible != visible || hiddenChanged {
+                self.applyFirstResponderIfNeeded()
+            }
         }
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7151,6 +7151,42 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         XCTAssertTrue(state.isHidden)
     }
 
+    func testSetVisibleInUICoalescesRapidVisibilityFlips() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let hostedView = GhosttySurfaceScrollView(
+            surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 120))
+        )
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        hostedView.setVisibleInUI(false)
+        hostedView.setVisibleInUI(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertFalse(
+            hostedView.isHidden,
+            "Rapid visibility flips should converge to the latest requested visible state"
+        )
+    }
+
     func testWindowResignKeyClearsFocusedTerminalFirstResponder() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),


### PR DESCRIPTION
## Summary
Fixes the rapid `Cmd+1`/`Cmd+2` sidebar-switch crash by deferring AppKit visibility mutations to the next main-runloop turn and dropping stale updates via a generation token.

## Root Cause
`setVisibleInUI` could synchronously flip `isHidden` during SwiftUI/AppKit update/layout work, which re-entered constraint/update passes and triggered the AppKit recursion exception (`EXC_BREAKPOINT` / `SIGTRAP`).

## Fix
- Added a visibility generation counter in `GhosttySurfaceScrollView`.
- Applied visibility updates asynchronously on the main queue.
- Dropped stale deferred updates when a newer visibility intent exists.
- Kept focus behavior aligned with the final applied visibility state.

## Tests
- Added/kept rapid flip regression coverage:
  - `GhosttySurfaceOverlayTests/testSetVisibleInUICoalescesRapidVisibilityFlips`
- Verified with:
  - `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testSetVisibleInUICoalescesRapidVisibilityFlips test`

Closes #743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of terminal view visibility state management when rapidly toggling between show and hide states, ensuring the view consistently reflects the intended state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->