### PR TITLE
Enhance split movement + add Join Pane command

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4048,6 +4048,15 @@ struct ContentView: View {
                 when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
             )
         )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.joinPane",
+                title: constant("Join Pane"),
+                subtitle: workspaceSubtitle,
+                keywords: ["join", "merge", "unsplit", "pane"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
 
         return contributions
     }
@@ -4324,6 +4333,9 @@ struct ContentView: View {
                 NSSound.beep()
                 return
             }
+        }
+        registry.register(commandId: "palette.joinPane") {
+            tabManager.selectedWorkspace?.joinFocusedPane()
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2928,6 +2928,46 @@ final class Workspace: Identifiable, ObservableObject {
         return true
     }
 
+    /// Join the focused pane into an adjacent pane, merging all its tabs.
+    /// The source pane auto-collapses when emptied.
+    func joinFocusedPane() {
+        let allPanes = bonsplitController.allPaneIds
+        guard allPanes.count > 1 else { return }
+        guard let sourcePaneId = bonsplitController.focusedPaneId else { return }
+
+        // Find an adjacent pane by trying each direction.
+        var targetPaneId: PaneID?
+        for dir: NavigationDirection in [.left, .right, .up, .down] {
+            bonsplitController.navigateFocus(direction: dir)
+            if let candidate = bonsplitController.focusedPaneId, candidate != sourcePaneId {
+                targetPaneId = candidate
+                break
+            }
+        }
+
+        guard let targetPaneId else {
+            // Restore focus if no neighbor found (shouldn't happen with >1 pane).
+            bonsplitController.focusPane(sourcePaneId)
+            return
+        }
+
+        // Restore focus to the source pane for clean detach.
+        bonsplitController.focusPane(sourcePaneId)
+
+        // Move all tabs from source pane to the target pane.
+        let sourceTabs = bonsplitController.tabs(inPane: sourcePaneId)
+        for tab in sourceTabs {
+            guard let panelId = surfaceIdToPanelId[tab.id] else { continue }
+            moveSurface(panelId: panelId, toPane: targetPaneId, focus: false)
+        }
+
+        // Focus the last-moved tab in the target pane.
+        if let lastTab = bonsplitController.selectedTab(inPane: targetPaneId),
+           let panelId = surfaceIdToPanelId[lastTab.id] {
+            focusPanel(panelId)
+        }
+    }
+
     // MARK: - Context Menu Shortcuts
 
     static func buildContextMenuShortcuts() -> [TabContextAction: KeyboardShortcut] {
@@ -4173,4 +4213,24 @@ extension Workspace: BonsplitDelegate {
     }
 
     // No post-close polling refresh loop: we rely on view invariants and Ghostty's wakeups.
+}
+
+// MARK: - NavigationDirection + Split Helpers
+
+private extension NavigationDirection {
+    /// The split orientation corresponding to this navigation direction.
+    var splitOrientation: SplitOrientation {
+        switch self {
+        case .left, .right: return .horizontal
+        case .up, .down: return .vertical
+        }
+    }
+
+    /// Whether the new pane should be inserted before the source pane.
+    var splitInsertFirst: Bool {
+        switch self {
+        case .left, .up: return true
+        case .right, .down: return false
+        }
+    }
 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2935,6 +2935,9 @@ final class Workspace: Identifiable, ObservableObject {
         guard allPanes.count > 1 else { return }
         guard let sourcePaneId = bonsplitController.focusedPaneId else { return }
 
+        // Remember the user's current tab so we can restore focus after merging.
+        let currentPanelId = focusedPanelId
+
         // Find an adjacent pane by trying each direction.
         var targetPaneId: PaneID?
         for dir: NavigationDirection in [.left, .right, .up, .down] {
@@ -2961,10 +2964,9 @@ final class Workspace: Identifiable, ObservableObject {
             moveSurface(panelId: panelId, toPane: targetPaneId, focus: false)
         }
 
-        // Focus the last-moved tab in the target pane.
-        if let lastTab = bonsplitController.selectedTab(inPane: targetPaneId),
-           let panelId = surfaceIdToPanelId[lastTab.id] {
-            focusPanel(panelId)
+        // Re-focus the tab the user was on before the join.
+        if let currentPanelId {
+            focusPanel(currentPanelId)
         }
     }
 

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -316,6 +316,11 @@ OPEN_CLEAN_ENV=(
   -u XDG_DATA_DIRS
 )
 
+# Copy production preferences so the tagged build inherits the user's configuration.
+if [[ -n "${TAG_SLUG:-}" ]]; then
+  defaults export com.cmuxterm.app - 2>/dev/null | defaults import "$BUNDLE_ID" - 2>/dev/null || true
+fi
+
 if [[ -n "${TAG_SLUG:-}" && -n "${CMUX_SOCKET:-}" ]]; then
   # Ensure tag-specific socket paths win even if the caller has CMUX_* overrides.
   "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" open "$APP_PATH"


### PR DESCRIPTION
add some pane-split-specific nav keyboard shortcuts

https://github.com/user-attachments/assets/c6ef3689-fb5a-4b37-b4d0-613d03235430

## Summary
- **Ctrl+Cmd+HJKL now creates a split** when no adjacent pane exists, instead of silently doing nothing
- If multiple tabs exist in the pane, the **current tab is moved** into the new split; if it's the only tab, a fresh terminal is created
- **"Join Pane" command** added to Cmd+Shift+P palette: merges focused pane's tabs into an adjacent pane, collapsing the split
- Tagged debug builds (`reload.sh --tag`) now **inherit production preferences** (shortcuts, theme, etc.)

## Test plan
- [x] Single pane, press Ctrl+Cmd+L → creates a split right with a new terminal
- [x] Multiple tabs in pane, press Ctrl+Cmd+L → moves current tab into a new split right
- [x] Two panes, press Ctrl+Cmd+H → moves surface to the left pane (existing behavior)
- [x] With splits, Cmd+Shift+P → type "join" → "Join Pane" merges focused pane into adjacent
- [x] `./scripts/reload.sh --tag test` inherits production keyboard shortcuts and theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Join Pane" command to the command palette, letting users merge the focused pane into an adjacent pane and preserve all open tabs and focus.

* **Chores**
  * When a build tag is set, production preferences are exported and applied to the tagged build to propagate settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->