### PR TITLE
fix: prevent crash on sidebar hover

### DIFF
--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -256,7 +256,30 @@ struct WindowDragHandleView: NSViewRepresentable {
     private final class DraggableView: NSView {
         override var mouseDownCanMoveWindow: Bool { false }
 
+        private func shouldParticipateInHitTesting(for eventType: NSEvent.EventType?) -> Bool {
+            switch eventType {
+            case .mouseMoved, .cursorUpdate, .mouseEntered, .mouseExited,
+                 .flagsChanged, .appKitDefined, .systemDefined,
+                 .applicationDefined, .periodic:
+                // Keep hover/cursor routing on underlying titlebar controls.
+                // We only need drag-handle capture for click/drag interactions.
+                return false
+            default:
+                return true
+            }
+        }
+
         override func hitTest(_ point: NSPoint) -> NSView? {
+            let eventType = NSApp.currentEvent?.type
+            guard shouldParticipateInHitTesting(for: eventType) else {
+                #if DEBUG
+                let eventText = eventType.map { "\($0.rawValue)" } ?? "nil"
+                dlog(
+                    "titlebar.dragHandle.hitTestResult capture=false reason=passiveEvent type=\(eventText) point=\(windowDragHandleFormatPoint(point))"
+                )
+                #endif
+                return nil
+            }
             let shouldCapture = windowDragHandleShouldCaptureHit(point, in: self)
             #if DEBUG
             dlog(


### PR DESCRIPTION
Fixes #750

### Summary
Implemented a targeted fix to prevent crashes when hovering the sidebar/titlebar top control cluster.

### Root-cause hypothesis
`WindowDragHandleView` participated in hit-testing during passive hover/cursor events (`mouseMoved`, `cursorUpdate`, etc.). That code path performs complex top-hit/sibling hit-tests intended for drag capture, and it was being exercised on mere pointer motion over titlebar controls.

### Changes
*   In `WindowDragHandleView.DraggableView.hitTest(_:)`, added a gate to return `nil` for passive event types.
*   Kept existing drag-handle capture logic for click/drag events.

Co-authored-by: Codex <noreply@openai.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window titlebar responsiveness by optimizing event handling for mouse interactions, including movement and hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->