### PR TITLE
Add configurable default directory for new workspaces

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
+					F9000000A1B2C3D4E5F60718 /* WorkspaceDirectorySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* WorkspaceDirectorySettingsTests.swift */; };
 			/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -215,6 +216,7 @@
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
+				F9000001A1B2C3D4E5F60718 /* WorkspaceDirectorySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDirectorySettingsTests.swift; sourceTree = "<group>"; };
 			/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -428,6 +430,7 @@
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
+					F9000001A1B2C3D4E5F60718 /* WorkspaceDirectorySettingsTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -638,6 +641,7 @@
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+					F9000000A1B2C3D4E5F60718 /* WorkspaceDirectorySettingsTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -146,6 +146,121 @@ enum WorkspacePlacementSettings {
     }
 }
 
+enum NewWorkspaceDirectoryMode: String, CaseIterable, Identifiable {
+    case inheritCurrent
+    case customPath
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .inheritCurrent:
+            return "Inherit Current"
+        case .customPath:
+            return "Custom Path"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .inheritCurrent:
+            return "Use the focused panel's current directory when creating a workspace."
+        case .customPath:
+            return "Always start new workspaces in a custom directory."
+        }
+    }
+}
+
+enum WorkspaceDirectorySettings {
+    enum CustomDirectoryValidation: Equatable {
+        case empty
+        case valid(path: String)
+        case invalid(path: String, reason: String)
+    }
+
+    static let modeKey = "newWorkspaceDirectoryMode"
+    static let customPathKey = "newWorkspaceDirectoryCustomPath"
+    static let defaultMode: NewWorkspaceDirectoryMode = .inheritCurrent
+    static let defaultCustomPath = ""
+
+    static func current(defaults: UserDefaults = .standard) -> NewWorkspaceDirectoryMode {
+        guard let raw = defaults.string(forKey: modeKey) else {
+            return defaultMode
+        }
+        return NewWorkspaceDirectoryMode(rawValue: raw) ?? defaultMode
+    }
+
+    static func defaultWorkingDirectory(
+        mode: NewWorkspaceDirectoryMode,
+        inheritedDirectory: String?,
+        customDirectory: String?
+    ) -> String? {
+        switch mode {
+        case .inheritCurrent:
+            return inheritedDirectory
+        case .customPath:
+            return customDirectory ?? inheritedDirectory
+        }
+    }
+
+    static func currentCustomDirectory(defaults: UserDefaults = .standard) -> String? {
+        let rawPath = defaults.string(forKey: customPathKey) ?? defaultCustomPath
+        switch validateCustomDirectory(rawPath, homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path) {
+        case .valid(let path):
+            return path
+        case .empty, .invalid:
+            return nil
+        }
+    }
+
+    static func validateCustomDirectory(
+        _ rawPath: String?,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> CustomDirectoryValidation {
+        guard let normalized = normalizedCustomDirectory(rawPath, homeDirectory: homeDirectory) else {
+            return .empty
+        }
+
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: normalized, isDirectory: &isDirectory)
+        guard exists else {
+            return .invalid(path: normalized, reason: "Path does not exist.")
+        }
+        guard isDirectory.boolValue else {
+            return .invalid(path: normalized, reason: "Path is not a directory.")
+        }
+        return .valid(path: normalized)
+    }
+
+    static func normalizedCustomDirectory(_ rawPath: String?, homeDirectory: String) -> String? {
+        guard let rawPath else { return nil }
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let fileURLPath: String?
+        if trimmed.hasPrefix("file://"), let url = URL(string: trimmed), !url.path.isEmpty {
+            fileURLPath = url.path
+        } else {
+            fileURLPath = nil
+        }
+
+        let candidate = fileURLPath ?? trimmed
+        let expanded: String
+        if candidate == "~" {
+            expanded = homeDirectory
+        } else if candidate.hasPrefix("~/") {
+            let relative = String(candidate.dropFirst(2))
+            expanded = (homeDirectory as NSString).appendingPathComponent(relative)
+        } else {
+            expanded = NSString(string: candidate).expandingTildeInPath
+        }
+        let absolute = expanded.hasPrefix("/") ? expanded : (homeDirectory as NSString).appendingPathComponent(expanded)
+        let standardized = NSString(string: absolute).standardizingPath
+        let normalized = standardized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+}
+
 struct WorkspaceTabColorEntry: Equatable, Identifiable {
     let name: String
     let hex: String
@@ -764,7 +879,7 @@ class TabManager: ObservableObject {
         placementOverride: NewWorkspacePlacement? = nil
     ) -> Workspace {
         sentryBreadcrumb("workspace.create", data: ["tabCount": tabs.count + 1])
-        let workingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory) ?? preferredWorkingDirectoryForNewTab()
+        let workingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory) ?? defaultWorkingDirectoryForNewWorkspace()
         let inheritedConfig = inheritedTerminalConfigForNewWorkspace()
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
@@ -867,6 +982,17 @@ class TabManager: ObservableObject {
         let normalized = normalizeDirectory(candidate)
         let trimmed = normalized.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : normalized
+    }
+
+    private func defaultWorkingDirectoryForNewWorkspace() -> String? {
+        let inheritedDirectory = preferredWorkingDirectoryForNewTab()
+        let mode = WorkspaceDirectorySettings.current()
+        let customDirectory = WorkspaceDirectorySettings.currentCustomDirectory()
+        return WorkspaceDirectorySettings.defaultWorkingDirectory(
+            mode: mode,
+            inheritedDirectory: inheritedDirectory,
+            customDirectory: customDirectory
+        )
     }
 
     func moveTabToTop(_ tabId: UUID) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2736,6 +2736,8 @@ struct SettingsView: View {
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
+    @AppStorage(WorkspaceDirectorySettings.modeKey) private var newWorkspaceDirectoryMode = WorkspaceDirectorySettings.defaultMode.rawValue
+    @AppStorage(WorkspaceDirectorySettings.customPathKey) private var newWorkspaceDirectoryCustomPath = WorkspaceDirectorySettings.defaultCustomPath
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
@@ -2766,6 +2768,36 @@ struct SettingsView: View {
 
     private var selectedWorkspacePlacement: NewWorkspacePlacement {
         NewWorkspacePlacement(rawValue: newWorkspacePlacement) ?? WorkspacePlacementSettings.defaultPlacement
+    }
+
+    private var selectedWorkspaceDirectoryMode: NewWorkspaceDirectoryMode {
+        WorkspaceDirectorySettings.current(defaults: .standard)
+    }
+
+    private var workspaceDirectoryModeSelection: Binding<String> {
+        Binding(
+            get: { WorkspaceDirectorySettings.current(defaults: .standard).rawValue },
+            set: { newWorkspaceDirectoryMode = $0 }
+        )
+    }
+
+    private var customWorkspaceDirectoryValidation: WorkspaceDirectorySettings.CustomDirectoryValidation {
+        WorkspaceDirectorySettings.validateCustomDirectory(
+            newWorkspaceDirectoryCustomPath,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path
+        )
+    }
+
+    private var workspaceDirectorySubtitle: String {
+        switch selectedWorkspaceDirectoryMode {
+        case .customPath:
+            if case .valid(let resolved) = customWorkspaceDirectoryValidation {
+                return "Always start new workspaces in \(resolved)."
+            }
+            return "Enter a path such as ~/Developer."
+        default:
+            return selectedWorkspaceDirectoryMode.description
+        }
     }
 
     private var selectedSidebarActiveTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
@@ -2911,6 +2943,51 @@ struct SettingsView: View {
                             }
                             .labelsHidden()
                             .pickerStyle(.menu)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            "New Workspace Directory",
+                            subtitle: workspaceDirectorySubtitle,
+                            controlWidth: pickerColumnWidth
+                        ) {
+                            Picker("", selection: workspaceDirectoryModeSelection) {
+                                ForEach(NewWorkspaceDirectoryMode.allCases) { mode in
+                                    Text(mode.displayName).tag(mode.rawValue)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                        }
+
+                        if selectedWorkspaceDirectoryMode == .customPath {
+                            SettingsCardDivider()
+
+                            SettingsCardRow(
+                                "Custom Workspace Path",
+                                subtitle: "Relative paths resolve from your home directory."
+                            ) {
+                                TextField("e.g. ~/Developer", text: $newWorkspaceDirectoryCustomPath)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: pickerColumnWidth)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                            .stroke(
+                                                {
+                                                    if case .invalid = customWorkspaceDirectoryValidation {
+                                                        return Color.red.opacity(0.65)
+                                                    }
+                                                    return Color.clear
+                                                }(),
+                                                lineWidth: 1
+                                            )
+                                    )
+                            }
+
+                            if case .invalid(let path, let reason) = customWorkspaceDirectoryValidation {
+                                SettingsCardNote("Custom path invalid (\(path)): \(reason)", color: .red)
+                            }
                         }
 
                         SettingsCardDivider()
@@ -3608,6 +3685,8 @@ struct SettingsView: View {
         warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
         newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
+        newWorkspaceDirectoryMode = WorkspaceDirectorySettings.defaultMode.rawValue
+        newWorkspaceDirectoryCustomPath = WorkspaceDirectorySettings.defaultCustomPath
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
@@ -3792,15 +3871,17 @@ private struct SettingsCardDivider: View {
 
 private struct SettingsCardNote: View {
     let text: String
+    let color: Color
 
-    init(_ text: String) {
+    init(_ text: String, color: Color = .secondary) {
         self.text = text
+        self.color = color
     }
 
     var body: some View {
         Text(text)
             .font(.caption)
-            .foregroundColor(.secondary)
+            .foregroundColor(color)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/cmuxTests/WorkspaceDirectorySettingsTests.swift
+++ b/cmuxTests/WorkspaceDirectorySettingsTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class WorkspaceDirectorySettingsTests: XCTestCase {
+    func testCurrentReturnsDefaultWhenUnset() {
+        let defaults = isolatedDefaults()
+        XCTAssertEqual(
+            WorkspaceDirectorySettings.current(defaults: defaults),
+            WorkspaceDirectorySettings.defaultMode
+        )
+    }
+
+    func testCurrentReturnsStoredMode() {
+        let defaults = isolatedDefaults()
+        defaults.set(NewWorkspaceDirectoryMode.customPath.rawValue, forKey: WorkspaceDirectorySettings.modeKey)
+
+        XCTAssertEqual(
+            WorkspaceDirectorySettings.current(defaults: defaults),
+            .customPath
+        )
+    }
+
+    func testCurrentFallsBackToDefaultForInvalidStoredValue() {
+        let defaults = isolatedDefaults()
+        defaults.set("invalid-mode", forKey: WorkspaceDirectorySettings.modeKey)
+
+        XCTAssertEqual(
+            WorkspaceDirectorySettings.current(defaults: defaults),
+            WorkspaceDirectorySettings.defaultMode
+        )
+    }
+
+    func testDefaultWorkingDirectoryInheritUsesInheritedDirectory() {
+        let resolved = WorkspaceDirectorySettings.defaultWorkingDirectory(
+            mode: .inheritCurrent,
+            inheritedDirectory: "/tmp/project",
+            customDirectory: "/Users/tester/Developer"
+        )
+        XCTAssertEqual(resolved, "/tmp/project")
+    }
+
+    func testDefaultWorkingDirectoryInheritCanBeNil() {
+        let resolved = WorkspaceDirectorySettings.defaultWorkingDirectory(
+            mode: .inheritCurrent,
+            inheritedDirectory: nil,
+            customDirectory: "/Users/tester/Developer"
+        )
+        XCTAssertNil(resolved)
+    }
+
+    func testDefaultWorkingDirectoryCustomUsesCustomDirectory() {
+        let resolved = WorkspaceDirectorySettings.defaultWorkingDirectory(
+            mode: .customPath,
+            inheritedDirectory: "/tmp/project",
+            customDirectory: "/Users/tester/Developer"
+        )
+        XCTAssertEqual(resolved, "/Users/tester/Developer")
+    }
+
+    func testDefaultWorkingDirectoryCustomFallsBackToInheritedWhenCustomMissing() {
+        let resolved = WorkspaceDirectorySettings.defaultWorkingDirectory(
+            mode: .customPath,
+            inheritedDirectory: "/tmp/project",
+            customDirectory: nil
+        )
+        XCTAssertEqual(resolved, "/tmp/project")
+    }
+
+    func testCurrentCustomDirectoryReturnsNilWhenUnset() {
+        let defaults = isolatedDefaults()
+        XCTAssertNil(WorkspaceDirectorySettings.currentCustomDirectory(defaults: defaults))
+    }
+
+    func testCurrentCustomDirectoryResolvesRelativePathFromHome() {
+        let defaults = isolatedDefaults()
+        defaults.set(".", forKey: WorkspaceDirectorySettings.customPathKey)
+
+        let resolved = WorkspaceDirectorySettings.currentCustomDirectory(defaults: defaults)
+        XCTAssertEqual(resolved, FileManager.default.homeDirectoryForCurrentUser.path)
+    }
+
+    func testNormalizedCustomDirectoryExpandsTilde() {
+        let resolved = WorkspaceDirectorySettings.normalizedCustomDirectory(
+            "~/Developer",
+            homeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(resolved, "/Users/tester/Developer")
+    }
+
+    func testNormalizedCustomDirectoryAcceptsFileURL() {
+        let resolved = WorkspaceDirectorySettings.normalizedCustomDirectory(
+            "file:///Users/tester/Developer",
+            homeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(resolved, "/Users/tester/Developer")
+    }
+
+    func testValidateCustomDirectoryReturnsInvalidWhenPathMissing() {
+        let missingPath = "/tmp/cmux-missing-\(UUID().uuidString)"
+        let validation = WorkspaceDirectorySettings.validateCustomDirectory(
+            missingPath,
+            homeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(validation, .invalid(path: missingPath, reason: "Path does not exist."))
+    }
+
+    func testValidateCustomDirectoryReturnsInvalidWhenPathIsFile() throws {
+        let tempFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cmux-file-\(UUID().uuidString)")
+        XCTAssertTrue(
+            FileManager.default.createFile(atPath: tempFile.path, contents: Data(), attributes: nil),
+            "Temp file should be created so this test validates the file-vs-directory path."
+        )
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        let validation = WorkspaceDirectorySettings.validateCustomDirectory(
+            tempFile.path,
+            homeDirectory: "/Users/tester"
+        )
+        XCTAssertEqual(validation, .invalid(path: tempFile.path, reason: "Path is not a directory."))
+    }
+
+    func testCurrentCustomDirectoryReturnsNilWhenPathMissing() {
+        let defaults = isolatedDefaults()
+        defaults.set("/tmp/cmux-missing-\(UUID().uuidString)", forKey: WorkspaceDirectorySettings.customPathKey)
+        XCTAssertNil(WorkspaceDirectorySettings.currentCustomDirectory(defaults: defaults))
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "WorkspaceDirectorySettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create UserDefaults suite \(suiteName)")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
i love cmux! i often use different workspaces for different projects, so find myself having to navigate out of the current working directory to get to a new one. i built this feature to make the new workspace directory configurable in settings, so you can keep it as is (inherit current working directory) or customize it (to a specified path).

## Summary
- add a new setting in App settings: **New Workspace Directory**
- options are now:
  - **Inherit Current** (default)
  - **Custom Path**
- apply this setting when creating a new workspace (unless an explicit working directory override is provided)
- normalize custom paths consistently:
  - supports `~/...`
  - supports `file://...`
  - treats relative paths (for example `Developer`) as relative to home
- migrate legacy stored mode value `home` to `customPath` with home prefilled, so existing users keep equivalent behavior
- proactively validate custom paths in Settings:
  - invalid paths get a red field outline
  - inline red error message shows resolved path + reason
  - invalid custom paths are ignored at runtime and safely fall back to inherited directory
- expand unit tests for mode parsing, migration, normalization, validation, and fallback behavior

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/WorkspaceDirectorySettingsTests test`
  - result: `Executed 15 tests, 0 failures`

## Demo Video
https://github.com/user-attachments/assets/048aec23-0209-428b-b674-d282b15ef7c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "New Workspace Directory" preference: mode selector (inherit or custom), custom-path input with live validation, dynamic subtitle showing resolved path, visual dividers, and reset/init defaults. Workspace creation now respects the selected mode.

* **Tests**
  * Added comprehensive tests for mode handling, legacy migration, path resolution (tilde/relative/file URLs), validation rules, and default behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->