### PR TITLE
Fix sporadic unintended main-window creation

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1651,7 +1651,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
-        // In UI tests, `WindowGroup` occasionally fails to materialize a window quickly on the VM.
+        // In UI tests, the primary SwiftUI scene can occasionally fail to materialize a
+        // window quickly on the VM.
         // If there are no windows shortly after launch, force-create one so XCUITest can proceed.
         if isRunningUnderXCTest {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
@@ -2708,9 +2709,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sidebarState: SidebarState,
         sidebarSelectionState: SidebarSelectionState
     ) {
+        let key = ObjectIdentifier(window)
+        if let existing = mainWindowContexts.values.first(where: { $0.windowId == windowId && $0.window !== window }),
+           let existingWindow = existing.window,
+           shouldIgnoreDuplicateWindowRegistration(existingWindow: existingWindow) {
+#if DEBUG
+            dlog(
+                "mainWindow.register.duplicateIgnored windowId=\(String(windowId.uuidString.prefix(8))) " +
+                    "incoming={\(debugWindowToken(window))} existing={\(debugWindowToken(existingWindow))}"
+            )
+#endif
+            window.orderOut(nil)
+            DispatchQueue.main.async { [weak window] in
+                window?.close()
+            }
+            return
+        }
+
         tabManager.window = window
 
-        let key = ObjectIdentifier(window)
         #if DEBUG
         let priorManagerToken = debugManagerToken(self.tabManager)
         #endif
@@ -2753,6 +2770,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if !isTerminatingApp {
             _ = saveSessionSnapshot(includeScrollback: false)
         }
+    }
+
+    private func shouldIgnoreDuplicateWindowRegistration(existingWindow: NSWindow) -> Bool {
+        guard NSApp.windows.contains(existingWindow) else { return false }
+        return existingWindow.isVisible
+            || existingWindow.isMiniaturized
+            || existingWindow.isKeyWindow
+            || existingWindow.isMainWindow
     }
 
     struct MainWindowSummary {
@@ -3919,6 +3944,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             workingDirectory: workingDirectory
         )
         #endif
+        return workspace.id
+    }
+
+    @discardableResult
+    func addWorkspaceWithoutNewWindowFallback(
+        workingDirectory: String? = nil,
+        event: NSEvent? = nil,
+        debugSource: String = "unspecified",
+        fallbackReason: String = "unspecified"
+    ) -> UUID? {
+        let context: MainWindowContext? = {
+            if let activeManager = tabManager,
+               let activeContext = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }) {
+                return activeContext
+            }
+            if let keyContext = contextForMainWindow(NSApp.keyWindow) {
+                return keyContext
+            }
+            if let mainContext = contextForMainWindow(NSApp.mainWindow) {
+                return mainContext
+            }
+            return mainWindowContexts.values.first
+        }()
+
+        guard let context else {
+#if DEBUG
+            logWorkspaceCreationRouting(
+                phase: "fallback_noop",
+                source: debugSource,
+                reason: "\(fallbackReason)_no_context",
+                event: event,
+                chosenContext: nil,
+                workingDirectory: workingDirectory
+            )
+#endif
+            NSSound.beep()
+            return nil
+        }
+
+        if let window = context.window ?? windowForMainWindowId(context.windowId) {
+            setActiveMainWindow(window)
+        }
+
+        let workspace: Workspace
+        if let workingDirectory {
+            workspace = context.tabManager.addWorkspace(workingDirectory: workingDirectory, select: true)
+        } else {
+            workspace = context.tabManager.addTab(select: true)
+        }
+
+#if DEBUG
+        logWorkspaceCreationRouting(
+            phase: "fallback_existing_window",
+            source: debugSource,
+            reason: fallbackReason,
+            event: event,
+            chosenContext: context,
+            workspaceId: workspace.id,
+            workingDirectory: workingDirectory
+        )
+#endif
         return workspace.id
     }
 
@@ -5583,31 +5669,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             dlog("shortcut.action name=newWorkspace \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            // Cmd+N semantics:
-            // - If there are no main windows, create a new window.
-            // - Otherwise, create a new workspace in the active window.
-            if mainWindowContexts.isEmpty {
-                #if DEBUG
-                logWorkspaceCreationRouting(
-                    phase: "fallback_new_window",
-                    source: "shortcut.cmdN",
-                    reason: "no_main_windows",
+            if addWorkspaceInPreferredMainWindow(event: event, debugSource: "shortcut.cmdN") == nil {
+                let reason = mainWindowContexts.isEmpty ? "no_main_windows" : "workspace_creation_returned_nil"
+                _ = addWorkspaceWithoutNewWindowFallback(
                     event: event,
-                    chosenContext: nil
+                    debugSource: "shortcut.cmdN",
+                    fallbackReason: reason
                 )
-                #endif
-                openNewMainWindow(nil)
-            } else if addWorkspaceInPreferredMainWindow(event: event, debugSource: "shortcut.cmdN") == nil {
-                #if DEBUG
-                logWorkspaceCreationRouting(
-                    phase: "fallback_new_window",
-                    source: "shortcut.cmdN",
-                    reason: "workspace_creation_returned_nil",
-                    event: event,
-                    chosenContext: nil
-                )
-                #endif
-                openNewMainWindow(nil)
             }
             return true
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8979,14 +8979,6 @@ class TerminalController {
         DispatchQueue.main.sync {
             NSApp.activate(ignoringOtherApps: true)
             NSApp.unhide(nil)
-            let hasMainTerminalWindow = NSApp.windows.contains { window in
-                guard let raw = window.identifier?.rawValue else { return false }
-                return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
-            }
-
-            if !hasMainTerminalWindow {
-                AppDelegate.shared?.openNewMainWindow(nil)
-            }
 
             if let window = NSApp.mainWindow
                 ?? NSApp.keyWindow

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5,11 +5,11 @@ import Bonsplit
 
 @main
 struct cmuxApp: App {
+    private static let primaryWindowId = UUID()
     @StateObject private var tabManager: TabManager
     @StateObject private var notificationStore = TerminalNotificationStore.shared
     @StateObject private var sidebarState = SidebarState()
     @StateObject private var sidebarSelectionState = SidebarSelectionState()
-    private let primaryWindowId = UUID()
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyle = TitlebarControlsStyle.classic.rawValue
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
@@ -180,8 +180,8 @@ struct cmuxApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
-            ContentView(updateViewModel: appDelegate.updateViewModel, windowId: primaryWindowId)
+        Window("cmux", id: "primary-main-window") {
+            ContentView(updateViewModel: appDelegate.updateViewModel, windowId: Self.primaryWindowId)
                 .environmentObject(tabManager)
                 .environmentObject(notificationStore)
                 .environmentObject(sidebarState)
@@ -374,12 +374,10 @@ struct cmuxApp: App {
                 splitCommandButton(title: "New Workspace", shortcut: newWorkspaceMenuShortcut) {
                     if let appDelegate = AppDelegate.shared {
                         if appDelegate.addWorkspaceInPreferredMainWindow(debugSource: "menu.newWorkspace") == nil {
-#if DEBUG
-                            FocusLogStore.shared.append(
-                                "cmdn.route phase=fallback_new_window src=menu.newWorkspace reason=workspace_creation_returned_nil"
+                            _ = appDelegate.addWorkspaceWithoutNewWindowFallback(
+                                debugSource: "menu.newWorkspace",
+                                fallbackReason: "workspace_creation_returned_nil"
                             )
-#endif
-                            appDelegate.openNewMainWindow(nil)
                         }
                     } else {
                         activeTabManager.addTab()
@@ -399,7 +397,11 @@ struct cmuxApp: App {
                                 workingDirectory: url.path,
                                 debugSource: "menu.openFolder"
                             ) == nil {
-                                appDelegate.openNewMainWindow(nil)
+                                _ = appDelegate.addWorkspaceWithoutNewWindowFallback(
+                                    workingDirectory: url.path,
+                                    debugSource: "menu.openFolder",
+                                    fallbackReason: "workspace_creation_returned_nil"
+                                )
                             }
                         } else {
                             activeTabManager.addWorkspace(workingDirectory: url.path)


### PR DESCRIPTION
## Summary
- switch the primary SwiftUI scene from `WindowGroup` to a single `Window` to prevent system-driven duplicate main windows
- add a defensive duplicate main-window registration guard to ignore/close duplicate scene windows for the same window id
- remove non-explicit new-window fallbacks (`Cmd+N` workspace path, menu workspace/folder fallback, and `activate_app`) so only explicit new-window intents create windows

## Validation
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag fix-issue-616`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`

Closes #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window registration to prevent issues with duplicate window instances.
  * Enhanced workspace creation with more reliable fallback behavior when main windows are unavailable, ensuring operations complete gracefully instead of requiring manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->