### PR TITLE
Fix re-entrant exclusive-access crash in drag handle hit test

### DIFF
--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -218,6 +218,12 @@ func windowDragHandleShouldTreatTopHitAsPassiveHost(_ view: NSView) -> Bool {
     return false
 }
 
+/// Re-entrancy guard for the sibling hit-test walk. When `sibling.hitTest()`
+/// triggers SwiftUI view-body evaluation, AppKit can call back into this
+/// function before the outer invocation finishes, causing a Swift
+/// exclusive-access violation (SIGABRT). Main-thread only, no lock needed.
+private var _windowDragHandleIsResolvingSiblingHits = false
+
 /// Returns whether the titlebar drag handle should capture a hit at `point`.
 /// We only claim the hit when no sibling view already handles it, so interactive
 /// controls layered in the titlebar (e.g. proxy folder icon) keep their gestures.
@@ -294,6 +300,20 @@ func windowDragHandleShouldCaptureHit(
         #endif
         return true
     }
+
+    // Bail out if we're already inside a sibling hit-test walk. This happens
+    // when sibling.hitTest() re-enters SwiftUI layout, which calls hitTest on
+    // this drag handle again. Proceeding would trigger an exclusive-access
+    // violation in the Swift runtime.
+    guard !_windowDragHandleIsResolvingSiblingHits else {
+        #if DEBUG
+        dlog("titlebar.dragHandle.hitTest capture=false reason=reentrant point=\(windowDragHandleFormatPoint(point))")
+        #endif
+        return false
+    }
+
+    _windowDragHandleIsResolvingSiblingHits = true
+    defer { _windowDragHandleIsResolvingSiblingHits = false }
 
     let siblingSnapshot = Array(superview.subviews.reversed())
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6521,6 +6521,24 @@ final class WindowDragHandleHitTests: XCTestCase {
         }
     }
 
+    /// A sibling view whose hitTest re-enters windowDragHandleShouldCaptureHit,
+    /// simulating the crash path where sibling.hitTest triggers a SwiftUI layout
+    /// pass that calls back into the drag handle's hit resolution.
+    private final class ReentrantSiblingView: NSView {
+        weak var dragHandle: NSView?
+        var reenteredResult: Bool?
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            guard bounds.contains(point), let dragHandle else { return nil }
+            // Simulate the re-entry: during sibling hit test, SwiftUI layout
+            // calls windowDragHandleShouldCaptureHit on the drag handle again.
+            reenteredResult = windowDragHandleShouldCaptureHit(
+                point, in: dragHandle, eventType: .leftMouseDown, eventWindow: dragHandle.window
+            )
+            return nil
+        }
+    }
+
     func testDragHandleCapturesHitWhenNoSiblingClaimsPoint() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 36))
         let dragHandle = NSView(frame: container.bounds)
@@ -6748,6 +6766,29 @@ final class WindowDragHandleHitTests: XCTestCase {
         XCTAssertTrue(
             windowDragHandleShouldCaptureHit(NSPoint(x: 180, y: 18), in: dragHandle, eventType: .leftMouseDown),
             "Subview mutations during hit testing should not crash or break drag-handle capture"
+        )
+    }
+
+    func testDragHandleSiblingHitTestReentrancyDoesNotCrash() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 36))
+        let dragHandle = NSView(frame: container.bounds)
+        container.addSubview(dragHandle)
+
+        let reentrantSibling = ReentrantSiblingView(frame: container.bounds)
+        reentrantSibling.dragHandle = dragHandle
+        container.addSubview(reentrantSibling)
+
+        // The outer call enters the sibling walk, which calls
+        // reentrantSibling.hitTest(), which re-enters
+        // windowDragHandleShouldCaptureHit. Without the re-entrancy guard
+        // this would trigger a Swift exclusive-access violation (SIGABRT).
+        let outerResult = windowDragHandleShouldCaptureHit(
+            NSPoint(x: 110, y: 18), in: dragHandle, eventType: .leftMouseDown
+        )
+        XCTAssertTrue(outerResult, "Outer call should still capture when sibling returns nil")
+        XCTAssertEqual(
+            reentrantSibling.reenteredResult, false,
+            "Re-entrant call should bail out (return false) instead of crashing"
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/761.

SIGABRT crash caused by re-entrant calls to `windowDragHandleShouldCaptureHit` during the sibling hit-test walk. When `sibling.hitTest()` triggers a SwiftUI layout pass, AppKit calls back into the drag handle's hit resolution while the outer invocation is still walking siblings. This violates Swift's exclusive-access rules on SwiftUI view state.

The fix adds a module-level re-entrancy guard (`_windowDragHandleIsResolvingSiblingHits`) that bails out on nested calls to the sibling walk. Main-thread only, no lock needed.

Crash stack: `DraggableView.hitTest` -> `windowDragHandleShouldCaptureHit` -> `sibling.hitTest` -> SwiftUI body eval -> `hitTest` (re-entry) -> exclusive-access violation -> SIGABRT.

## Test plan

- Added `testDragHandleSiblingHitTestReentrancyDoesNotCrash` regression test that simulates the re-entrant call path
- Existing drag handle tests continue to pass (same 4 pre-existing failures on main)
- Reproduced on macOS Sequoia 15.1.1 VM, deployed fix, verified crash no longer occurs