### PR TITLE
Add E2E test workflow with video recording

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -230,7 +230,7 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
           ARTIFACT_URL="$RUN_URL#artifacts"
 
-          # Build issue body
+          # Build issue body (no leading whitespace)
           BODY="**Status:** $STATUS_EMOJI
           **Ref:** \`$REF_DISPLAY\`
           **SHA:** [\`${COMMIT_SHA:0:12}\`](https://github.com/${{ github.repository }}/commit/$COMMIT_SHA)
@@ -262,8 +262,11 @@ jobs:
           \`\`\`"
           fi
 
-          gh issue create \
+          ISSUE_URL=$(gh issue create \
             --repo manaflow-ai/cmux-dev-artifacts \
             --title "[$STATUS_EMOJI] $TEST_FILTER @ ${COMMIT_SHA:0:7} ($REF_DISPLAY)" \
             --body "$BODY" \
-            --label "$LABEL"
+            --label "$LABEL")
+
+          echo "Issue posted: $ISSUE_URL"
+          echo "::notice title=Test Result Issue::$ISSUE_URL"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -93,8 +93,8 @@ if [ "$WAIT" = true ]; then
   echo "Result: $STATUS"
   echo "Run: $RUN_URL"
 
-  # Try to find the issue created on cmux-dev-artifacts
-  ISSUE_URL=$(gh issue list --repo manaflow-ai/cmux-dev-artifacts --limit 5 --json url,title --jq ".[].url" 2>/dev/null | head -1)
+  # Find the issue created for this run (search by run ID in body)
+  ISSUE_URL=$(gh search issues "$RUN_ID" --repo manaflow-ai/cmux-dev-artifacts --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)
   if [ -n "$ISSUE_URL" ]; then
     echo "Issue: $ISSUE_URL"
   fi


### PR DESCRIPTION
## Summary

- New `test-e2e.yml` workflow: runs XCUITests on GitHub-hosted `macos-15` runners with video recording of the virtual display
- Posts results (pass/fail, video link, test output) as issues on [`manaflow-ai/cmux-dev-artifacts`](https://github.com/manaflow-ai/cmux-dev-artifacts)
- Convenience script `scripts/run-e2e.sh` to trigger from terminal

## Setup needed

Add a `DEV_ARTIFACTS_TOKEN` secret to `manaflow-ai/cmux` — fine-grained PAT scoped to `manaflow-ai/cmux-dev-artifacts` with `issues: write` + `contents: write`.

## Test plan

- [ ] Add `DEV_ARTIFACTS_TOKEN` secret
- [ ] `./scripts/run-e2e.sh UpdatePillUITests --wait` to verify end-to-end
- [ ] Check workflow artifacts for recording
- [ ] Check `cmux-dev-artifacts` for result issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an on-demand E2E XCUITest workflow on GitHub macOS runners with optional video recording. Uploads the recording, posts a pass/fail summary to cmux-dev-artifacts, and now surfaces the issue URL in both the workflow and script output.

- **New Features**
  - New workflow test-e2e.yml (workflow_dispatch) with inputs: ref, test_filter, test_timeout, record_video.
  - Runs on macos-15, records a virtual display, and uploads a .mov artifact.
  - Posts an issue to manaflow-ai/cmux-dev-artifacts with status, links, and recent logs; prints the issue URL as a GitHub Actions notice.
  - Adds scripts/run-e2e.sh to trigger runs locally and optionally wait; when waiting, prints the result and issue URL (found via run ID).

- **Migration**
  - Add DEV_ARTIFACTS_TOKEN secret to manaflow-ai/cmux (PAT scoped to manaflow-ai/cmux-dev-artifacts with issues:write and contents:write).
  - Verify: ./scripts/run-e2e.sh UpdatePillUITests --wait and check the artifact and issue.

<sup>Written for commit 0969ea3afc1f20de9250084f931113a2c33725fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD infrastructure for automated testing with screen recording and result reporting capabilities on macOS.
  * Added workflow trigger script for streamlined test execution and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->