### PR TITLE
Trigger nightly on push to main, switch to macos-15 runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,8 @@
 name: Nightly macOS build
 
 on:
+  push:
+    branches: [main]
   schedule:
     # Every hour at :30. The 'decide' job skips if main has no new commits.
     - cron: "30 * * * *"
@@ -11,6 +13,10 @@ on:
         required: false
         default: false
         type: boolean
+
+concurrency:
+  group: nightly-build
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -81,7 +87,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: depot-macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Trigger nightly build on every push to main (instant builds on merge instead of waiting up to 60min for cron)
- Add concurrency group with cancel-in-progress so rapid merges only build the latest SHA
- Switch build runner from `depot-macos-latest` to GitHub `macos-15` (similar build times, ~8min vs ~10min, simpler infra)

## Testing
- Merge this PR, then merge any other PR to main and verify nightly fires immediately
- Verify concurrency cancellation by merging two PRs in quick succession

## Related
- Hourly cron kept as safety net for edge cases (force-pushes, manual tag moves)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run nightly macOS builds on every push to main and cancel older runs when new commits land. Switch to GitHub’s macos-15 runner for simpler infra with similar build times.

- **New Features**
  - Trigger builds on push to main; hourly cron remains as fallback.
  - Concurrency group (nightly-build) cancels in-progress runs to keep only the latest.
  - Use GitHub macos-15 runner instead of depot-macos-latest.

<sup>Written for commit 8a2873179106339cde96a0e283c8fdf02041634a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

