### PR TITLE
Install ffmpeg for E2E screen recording

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -97,12 +97,21 @@ jobs:
           echo "=== Display after ==="
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(none)"
 
+      - name: Install ffmpeg
+        if: ${{ inputs.record_video }}
+        run: |
+          brew install --quiet ffmpeg
+          FFMPEG_PATH=$(which ffmpeg)
+          echo "ffmpeg: $FFMPEG_PATH"
+          ffmpeg -version | head -1
+          echo "FFMPEG_PATH=$FFMPEG_PATH" >> "$GITHUB_ENV"
+
       - name: Grant TCC screen recording permission
         continue-on-error: true
         run: |
           TCC_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
           if [ -f "$TCC_DB" ]; then
-            for client in /usr/sbin/screencapture /opt/homebrew/bin/ffmpeg /usr/local/bin/ffmpeg; do
+            for client in /usr/sbin/screencapture "${FFMPEG_PATH:-/opt/homebrew/bin/ffmpeg}" /opt/homebrew/bin/ffmpeg /usr/local/bin/ffmpeg; do
               sqlite3 "$TCC_DB" "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version) VALUES ('kTCCServiceScreenCapture', '$client', 1, 2, 4, 1);" 2>/dev/null || true
             done
           fi


### PR DESCRIPTION
macos-15 runners don't have ffmpeg pre-installed. Adds brew install step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable reliable E2E screen recording on macOS-15 by installing ffmpeg and switching from screencapture to AVFoundation. Produces an MP4 artifact with better diagnostics.

- **Bug Fixes**
  - Use ffmpeg (AVFoundation) instead of screencapture to avoid 0‑second recordings on M‑series runners.
  - Grant TCC screen recording permission to ffmpeg and improve start/stop handling with logs and warnings.
  - Upload test-recording.mp4 and include ffmpeg logs for troubleshooting.

- **Dependencies**
  - Install ffmpeg via Homebrew only when record_video is enabled.

<sup>Written for commit 5f7034159258be3c709ab8c75286d699b6d1b80e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

