### PR TITLE
Add mac-cua submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "vendor/bonsplit"]
 	path = vendor/bonsplit
 	url = https://github.com/manaflow-ai/bonsplit.git
+[submodule "mac-cua"]
+	path = mac-cua
+	url = https://github.com/lawrencecchen/mac-cua.git


### PR DESCRIPTION
## Summary
- Add [mac-cua](https://github.com/lawrencecchen/mac-cua) as a submodule for macOS computer-use CI
- Runs Claude Code with `computer-use-mcp` on macOS GitHub Actions runners, captures screenshots before/after every tool call, records screen with ffmpeg, and creates issues with full trajectories

## Testing
- `git submodule update --init mac-cua` works

## Related
- Task: add mac-cua as submodule

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add mac-cua as a git submodule for macOS computer-use CI. Enables macOS GitHub Actions runners to run Claude Code with computer-use MCP, capture before/after screenshots, record screen with ffmpeg, and create issues with full trajectories.

- **Migration**
  - Initialize locally: git submodule update --init mac-cua
  - Ensure CI checks out submodules (actions/checkout with submodules: true)

<sup>Written for commit df20615440251dd91f5500b1ee82bc4429a52cbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new Git submodule for mac-cua integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->