### PR TITLE
docs: explain Vim visual-mode copy/paste in cmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,32 @@ Browser developer-tool shortcuts follow Safari defaults and are customizable in 
 | Shortcut | Action |
 |----------|--------|
 | ⌘ K | Clear scrollback |
-| ⌘ C | Copy (with selection) |
+| ⌘ C | Copy selection (falls through to app if none) |
 | ⌘ V | Paste |
 | ⌘ + / ⌘ - | Increase / decrease font size |
 | ⌘ 0 | Reset font size |
+
+### Vim and Neovim Clipboard (Visual Mode)
+
+Ghostty supports clipboard read/write (OSC 52), and cmux uses Ghostty's clipboard callbacks.
+In cmux, `⌘ C` is a performable Ghostty binding, so it copies terminal selection when one exists, and falls through to the terminal app when no terminal selection exists.
+
+For Vim/Neovim visual-mode yanks to reach the macOS clipboard:
+
+```vim
+set clipboard+=unnamedplus
+```
+
+For remote SSH sessions, use an OSC 52 clipboard provider in the editor so yanks are sent through the terminal.
+
+Optional Neovim mappings if you want `⌘ C`/`⌘ V` inside the editor:
+
+```vim
+vnoremap <D-c> "+y
+nnoremap <D-v> "+P
+inoremap <D-v> <C-r>+
+cnoremap <D-v> <C-r>+
+```
 
 ### Window
 


### PR DESCRIPTION
## Summary
- clarify Terminal shortcut behavior for `⌘ C` when no terminal selection exists
- add a Vim/Neovim visual-mode clipboard section with OSC 52 guidance and optional `⌘ C`/`⌘ V` mappings

## Testing
- `scripts/codex-review.sh /Users/lawrencechen/fun/cmuxterm-hq/worktrees/task-ghostty-vim-visual-copy-paste` (0 findings)

## Issues
- Related: Task `ghostty support copy paste vim visual mode`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies ⌘ C behavior in cmux (copies selection; falls through to the app when none) and adds Vim/Neovim visual-mode clipboard guidance using OSC 52. Addresses the “ghostty support copy paste vim visual mode” task by documenting setup for macOS and SSH, plus optional ⌘ C/⌘ V mappings.

<sup>Written for commit 30eabe3a7cc5dc149c5caa04b9d5f529931b0851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Cmd+C keyboard shortcut behavior.
  * Added Vim and Neovim clipboard support documentation, including configuration snippets for clipboard integration and optional key mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->