### PR TITLE
Fix Ctrl+H deleting committed text instead of composing text during IME input

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3011,7 +3011,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // AppKit text interpretation and send a single deterministic Ghostty key event.
         // This avoids intermittent drops after rapid split close/reparent transitions.
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) {
+        if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) && !hasMarkedText() {
             ghostty_surface_set_focus(surface, true)
             var keyEvent = ghostty_input_key_s()
             keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS


### PR DESCRIPTION
## Summary
During IME composition (e.g. Japanese input), pressing Ctrl+H deletes already-committed text instead of composing (pre-edit) characters. Backspace key works correctly.

## Root cause
The Ctrl key fast path in `keyDown` (`GhosttyTerminalView.swift:3009`) unconditionally bypasses `interpretKeyEvents()` and sends key events directly to Ghostty. This skips the IME entirely, so Ctrl+H is treated as a terminal backspace even during composition.

Adding a `hasMarkedText()` guard to the fast path condition lets Ctrl+key events fall through to `interpretKeyEvents()` during IME composition, matching Ghostty upstream behavior.

## Test plan
- [x] Launch debug build with `./scripts/reload.sh --tag fix-ime-ctrl-h`
- [x] Open Japanese IME, type hiragana to enter composition state
- [x] Press Ctrl+H — composing text is deleted (not committed text)
- [x] Without IME composition, Ctrl+H/C/D etc. work as normal terminal shortcuts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ctrl+H during IME composition by skipping the Ctrl-key fast path when marked text is present, so composing text is deleted instead of committed text. Ctrl+key events now go through interpretKeyEvents() during composition; normal Ctrl shortcuts remain unchanged outside composition.

<sup>Written for commit 132bc6c3af0d1904c00500ffed0f2da5fb4b6a34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ctrl key handling to properly respect input method composition, allowing uninterrupted text entry for users utilizing IME.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->