### PR TITLE
Handle TLS auth challenges to fix Microsoft device compliance

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3085,6 +3085,24 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         loadErrorPage(in: webView, failedURL: failedURL, error: nsError)
     }
 
+    func webView(
+        _ webView: WKWebView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        // WKWebView rejects all authentication challenges by default when this
+        // delegate method is not implemented (.rejectProtectionSpace). This
+        // breaks TLS client-certificate flows such as Microsoft Entra ID
+        // Conditional Access, which verifies device compliance via a client
+        // certificate stored in the system keychain by MDM enrollment.
+        //
+        // By returning .performDefaultHandling the system's standard URL-loading
+        // behaviour takes over: the keychain is searched for matching client
+        // identities, MDM-installed root CAs are trusted, and any configured SSO
+        // extensions (e.g. Microsoft Enterprise SSO) can intercept the challenge.
+        completionHandler(.performDefaultHandling, nil)
+    }
+
     func webView(_ webView: WKWebView, webContentProcessDidTerminate: WKWebView) {
         NSLog("BrowserPanel web content process terminated, reloading")
         webView.reload()


### PR DESCRIPTION
## Summary

- Implements `webView(_:didReceive:completionHandler:)` on `BrowserNavigationDelegate` with `.performDefaultHandling` disposition

## Problem

When signing into GitHub (or any Microsoft Entra ID-protected resource) via the cmux browser on an MDM-enrolled Mac, Microsoft's Conditional Access shows "this device needs to be under policy" — even though Safari and Chrome on the same machine work fine.

## Root Cause

`WKWebView` silently **rejects all TLS authentication challenges** when the navigation delegate doesn't implement `webView(_:didReceive:completionHandler:)`. Apple's default disposition is `.rejectProtectionSpace`, not `.performDefaultHandling`.

This means:
1. Microsoft's server issues a TLS client-certificate challenge to verify device compliance
2. WKWebView rejects it (no delegate method → reject)
3. The TLS handshake completes without a client certificate
4. Microsoft sees an unmanaged device → blocks access with "device needs to be under policy"

Safari and Chrome handle this automatically because they implement their own authentication challenge handling that searches the system keychain for matching device identity certificates.

## Fix

Add the delegate method and return `.performDefaultHandling`, which tells WebKit to use the system's standard URL-loading behavior:
- Searches the system keychain for matching client identities (device certificates installed by MDM)
- Trusts MDM-installed root CAs during server trust evaluation
- Allows configured SSO extensions (e.g. Microsoft Enterprise SSO plug-in) to intercept and handle challenges

## Test plan

- [x] On an MDM-enrolled Mac, open cmux browser and navigate to `github.com` (or any Microsoft Entra ID-protected SSO)
- [x] Sign in with corporate credentials — should no longer show "this device needs to be under policy"
- [x] Verify regular HTTPS sites still load normally (no regressions in server trust handling)
- [x] Verify non-MDM Macs are unaffected (`.performDefaultHandling` gracefully falls through when no client certificates exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Microsoft Entra ID sign-in showing "device needs to be under policy" in the cmux browser on MDM-enrolled Macs by handling TLS auth challenges in WKWebView. We now let WebKit perform its default handling so device certificates and SSO plugins work.

- **Bug Fixes**
  - Implemented webView(_:didReceive:completionHandler:) in BrowserNavigationDelegate and return .performDefaultHandling.
  - Restores TLS client-certificate flows (uses system keychain and MDM roots) and allows Enterprise SSO plugins to intercept.
  - No change for non-MDM Macs; standard HTTPS sites behave as before.

<sup>Written for commit 577dd7c6e81529d2664a104ffcd7cdf4a6979297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved handling of browser authentication challenges to properly support TLS connections, client certificate authentication, and single sign-on flows through enhanced system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->