### PR TITLE
Support opening .command files, shell scripts, and directories

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -20,6 +20,44 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>command</string>
+				<string>tool</string>
+				<string>sh</string>
+				<string>zsh</string>
+				<string>csh</string>
+				<string>pl</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>Terminal scripts</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folders</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.directory</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Shell</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.unix-executable</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1753,6 +1753,80 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ = saveSessionSnapshot(includeScrollback: false)
     }
 
+    // MARK: - Open File (Finder, dock drop, `open -a`, .command files)
+
+    func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+        var isDirectory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: filename, isDirectory: &isDirectory) else {
+            return false
+        }
+
+        // Suppress session restore when opened via file association.
+        didHandleExplicitOpenIntentAtStartup = true
+        if !didAttemptStartupSessionRestore {
+            startupSessionSnapshot = nil
+            didAttemptStartupSessionRestore = true
+        }
+
+        if isDirectory.boolValue {
+            openWorkspaceFromService(workingDirectory: filename)
+            return true
+        }
+
+        // Script or executable: confirm before executing (sandbox escape mitigation).
+        let alert = NSAlert()
+        alert.messageText = "Allow cmux to execute \"\((filename as NSString).lastPathComponent)\"?"
+        alert.informativeText = filename
+        alert.addButton(withTitle: "Allow")
+        alert.addButton(withTitle: "Cancel")
+        alert.alertStyle = .warning
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return false
+        }
+
+        let parentDir = (filename as NSString).deletingLastPathComponent
+        let workspace: Workspace
+        if let wsId = addWorkspaceInPreferredMainWindow(
+            workingDirectory: parentDir,
+            shouldBringToFront: true,
+            debugSource: "openFile"
+        ), let tm = tabManagerFor(tabId: wsId),
+           let ws = tm.tabs.first(where: { $0.id == wsId }) {
+            workspace = ws
+        } else {
+            // Fallback: create a new window with the script's parent directory.
+            let windowId = createMainWindow(initialWorkingDirectory: parentDir)
+            guard let context = mainWindowContexts.values.first(where: { $0.windowId == windowId }),
+                  let ws = context.tabManager.selectedWorkspace else {
+                return false
+            }
+            workspace = ws
+        }
+
+        // Inject the script execution command once the terminal surface is ready.
+        // Uses the same pattern as Terminal.app and iTerm2: run the script via the
+        // user's shell so profile/rc files load first (important for Homebrew PATH, etc.).
+        let quoted = "'" + filename.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        openFileSendTextWhenReady("\(quoted); exit\n", to: workspace)
+        return true
+    }
+
+    private func openFileSendTextWhenReady(_ text: String, to workspace: Workspace, attempt: Int = 0) {
+        let maxAttempts = 60
+        if let terminalPanel = workspace.focusedTerminalPanel,
+           terminalPanel.surface.surface != nil {
+            terminalPanel.sendText(text)
+            return
+        }
+        guard attempt < maxAttempts else {
+            NSLog("openFile: surface not ready after \(maxAttempts) attempts for workspace \(workspace.id)")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.openFileSendTextWhenReady(text, to: workspace, attempt: attempt + 1)
+        }
+    }
+
     func persistSessionForUpdateRelaunch() {
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)


### PR DESCRIPTION
## Summary

- Register `CFBundleDocumentTypes` in Info.plist for terminal scripts (`.command`, `.tool`, `.sh`, `.zsh`, `.csh`, `.pl`), directories, and unix executables
- Implement `application(_:openFile:)` in AppDelegate to handle files opened via Finder, dock drops, or `open -a cmux`
- Directories open a new workspace with that working directory; scripts show a security confirmation alert then execute via shell stdin injection (same approach as Terminal.app/iTerm2/Ghostty)

This enables [Linear's "Open in coding tools"](https://linear.app/docs/assigning-issues?noRedirect=1#open-issues-in-coding-tools) integration, which generates `.command` files to launch terminal-based tools like Claude Code and Codex.

## Testing

- `open -a "cmux DEV <tag>" ~/some-directory` opens a workspace in that directory
- Create a test `.command` file (`echo "hello from command file"`) and open it with cmux (right-click > Open With or `open -a`). Should see security confirmation, then execution in a new workspace.
- Set cmux as default for `.command` files via `duti -s com.cmuxterm.app.debug .command all` (debug) or Finder > Get Info > Open With
- Linear "Work on issue" with terminal tools should now use cmux when configured

## Related

- Closes https://github.com/manaflow-ai/cmux/issues/807


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for opening .command files, shell scripts, Unix executables, and directories. Directories open a new workspace; scripts run after a confirmation via the user’s shell, enabling Linear’s “Open in coding tools”.

- **New Features**
  - File associations for .command, .tool, .sh, .zsh, .csh, .pl, directories, and Unix executables.
  - Handle opens from Finder, dock drops, and `open -a cmux`.
  - Directories open a workspace at that path.
  - Scripts/executables prompt for approval, then run via the user’s shell (profile/rc respected).

<sup>Written for commit 494121fc2323e3a25d860588806b438dd460b4c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The app now supports opening terminal scripts (.sh, .zsh, .csh, .pl), folders, and shell executables through file associations, drag-and-drop, and the system open command.
  * Scripts can be executed directly within the app with user confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->