### PR TITLE
Modernize deprecated APIs and observation model (fixes #763)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,7 +1,6 @@
 import AppKit
 import SwiftUI
 import Bonsplit
-import CoreServices
 import UserNotifications
 import Sentry
 import WebKit
@@ -4166,10 +4165,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let notificationStore = TerminalNotificationStore.shared
 
         let root = ContentView(updateViewModel: updateViewModel, windowId: windowId)
-            .environmentObject(tabManager)
-            .environmentObject(notificationStore)
-            .environmentObject(sidebarState)
-            .environmentObject(sidebarSelectionState)
+            .environment(tabManager)
+            .environment(notificationStore)
+            .environment(sidebarState)
+            .environment(sidebarSelectionState)
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 460, height: 360),
@@ -4219,7 +4218,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } else {
             window.makeKeyAndOrderFront(nil)
             setActiveMainWindow(window)
-            NSApp.activate(ignoringOtherApps: true)
+            NSApp.activate()
         }
         if let restoredFrame {
             window.setFrame(restoredFrame, display: true)
@@ -4370,7 +4369,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             SettingsWindowController.shared.show()
         },
         activateApplication: @MainActor () -> Void = {
-            NSApp.activate(ignoringOtherApps: true)
+            NSApp.activate()
         }
     ) {
 #if DEBUG
@@ -5323,13 +5322,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         alert.showsSuppressionButton = true
         alert.suppressionButton?.title = "Don't warn again for Cmd+Q"
 
-        let response = alert.runModal()
-        if alert.suppressionButton?.state == .on {
-            QuitWarningSettings.setEnabled(false)
-        }
-
-        if response == .alertFirstButtonReturn {
-            NSApp.terminate(nil)
+        presentNonBlockingAlert(
+            alert,
+            in: NSApp.keyWindow ?? NSApp.mainWindow
+        ) { [weak self] response in
+            if alert.suppressionButton?.state == .on {
+                QuitWarningSettings.setEnabled(false)
+            }
+            if response == .alertFirstButtonReturn {
+                NSApp.terminate(nil)
+            }
+            if let self {
+                #if DEBUG
+                dlog("quit.warning.dismissed response=\(response.rawValue)")
+                #endif
+            }
         }
         return true
     }
@@ -5358,10 +5365,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             input.selectText(nil)
         }
 
-        let response = alert.runModal()
-        guard response == .alertFirstButtonReturn else { return true }
-        tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
+        presentNonBlockingAlert(
+            alert,
+            in: NSApp.keyWindow ?? NSApp.mainWindow
+        ) { [weak tabManager] response in
+            guard response == .alertFirstButtonReturn else { return }
+            guard let tabManager else { return }
+            tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
+        }
         return true
+    }
+
+    private func presentNonBlockingAlert(
+        _ alert: NSAlert,
+        in window: NSWindow?,
+        completion: @escaping (NSApplication.ModalResponse) -> Void
+    ) {
+        if let window {
+            alert.beginSheetModal(for: window, completionHandler: completion)
+            return
+        }
+        completion(alert.runModal())
     }
 
     private func handleCustomShortcut(event: NSEvent) -> Bool {
@@ -6637,8 +6661,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func scheduleLaunchServicesBundleRegistration(
         bundleURL: URL = Bundle.main.bundleURL.standardizedFileURL,
         scheduler: @escaping (@escaping @Sendable () -> Void) -> Void = AppDelegate.enqueueLaunchServicesRegistrationWork,
-        register: @escaping (CFURL) -> OSStatus = { url in
-            LSRegisterURL(url, true)
+        register: @escaping (CFURL) -> OSStatus = { _ in
+            // `LSRegisterURL` is deprecated. Keep this hook for tests/injected behavior only.
+            noErr
         },
         breadcrumb: @escaping (_ message: String, _ data: [String: Any]) -> Void = { message, data in
             sentryBreadcrumb(message, category: "startup", data: data)
@@ -7228,7 +7253,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
             button.toolTip = "cmux"
         }
 
-        notificationsCancellable = notificationStore.$notifications
+        notificationsCancellable = notificationStore.notificationsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshUI()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1483,8 +1483,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         label: "com.cmuxterm.app.launchServicesRegistration",
         qos: .utility
     )
+    private nonisolated static let launchServicesRegisterExecutablePath =
+        "/System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister"
     private nonisolated static func enqueueLaunchServicesRegistrationWork(_ work: @escaping @Sendable () -> Void) {
         launchServicesRegistrationQueue.async(execute: work)
+    }
+    private nonisolated static func registerBundleWithLaunchServices(_ bundleURL: CFURL) -> OSStatus {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchServicesRegisterExecutablePath)
+        process.arguments = ["-f", "-R", "-trusted", (bundleURL as URL).path]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0 ? noErr : OSStatus(process.terminationStatus)
+        } catch {
+            NSLog("LaunchServices registration failed to start: \(error.localizedDescription)")
+            return OSStatus(-1)
+        }
     }
     private var lastSessionAutosaveFingerprint: Int?
     private var lastSessionAutosavePersistedAt: Date = .distantPast
@@ -6661,10 +6676,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func scheduleLaunchServicesBundleRegistration(
         bundleURL: URL = Bundle.main.bundleURL.standardizedFileURL,
         scheduler: @escaping (@escaping @Sendable () -> Void) -> Void = AppDelegate.enqueueLaunchServicesRegistrationWork,
-        register: @escaping (CFURL) -> OSStatus = { _ in
-            // `LSRegisterURL` is deprecated. Keep this hook for tests/injected behavior only.
-            noErr
-        },
+        register: @escaping (CFURL) -> OSStatus = AppDelegate.registerBundleWithLaunchServices,
         breadcrumb: @escaping (_ message: String, _ data: [String: Any]) -> Void = { message, data in
             sentryBreadcrumb(message, category: "startup", data: data)
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import Observation
 import SwiftUI
 import ObjectiveC
 import UniformTypeIdentifiers
@@ -247,9 +248,10 @@ struct TitlebarLayerBackground: NSViewRepresentable {
     }
 }
 
-final class SidebarState: ObservableObject {
-    @Published var isVisible: Bool
-    @Published var persistedWidth: CGFloat
+@Observable
+final class SidebarState {
+    var isVisible: Bool
+    var persistedWidth: CGFloat
 
     init(isVisible: Bool = true, persistedWidth: CGFloat = CGFloat(SessionPersistencePolicy.defaultSidebarWidth)) {
         self.isVisible = isVisible
@@ -1218,12 +1220,12 @@ func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) {
 }
 
 struct ContentView: View {
-    @ObservedObject var updateViewModel: UpdateViewModel
+    var updateViewModel: UpdateViewModel
     let windowId: UUID
-    @EnvironmentObject var tabManager: TabManager
-    @EnvironmentObject var notificationStore: TerminalNotificationStore
-    @EnvironmentObject var sidebarState: SidebarState
-    @EnvironmentObject var sidebarSelectionState: SidebarSelectionState
+    @Environment(TabManager.self) var tabManager: TabManager
+    @Environment(TerminalNotificationStore.self) var notificationStore: TerminalNotificationStore
+    @Environment(SidebarState.self) var sidebarState: SidebarState
+    @Environment(SidebarSelectionState.self) var sidebarSelectionState: SidebarSelectionState
     @State private var sidebarWidth: CGFloat = 200
     @State private var hoveredResizerHandles: Set<SidebarResizerHandle> = []
     @State private var isResizerDragging = false
@@ -1234,7 +1236,7 @@ struct ContentView: View {
     @State private var titlebarText: String = ""
     @State private var isFullScreen: Bool = false
     @State private var observedWindow: NSWindow?
-    @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
+    @State private var fullscreenControlsViewModel = TitlebarControlsViewModel()
     @State private var previousSelectedWorkspaceId: UUID?
     @State private var retiringWorkspaceId: UUID?
     @State private var workspaceHandoffGeneration: UInt64 = 0
@@ -1766,7 +1768,7 @@ struct ContentView: View {
             .onAppear {
                 clampSidebarWidthIfNeeded(availableWidth: totalWidth)
             }
-            .onChange(of: totalWidth) {
+            .onChange(of: totalWidth) { _, _ in
                 clampSidebarWidthIfNeeded(availableWidth: totalWidth)
             }
         }
@@ -1775,11 +1777,18 @@ struct ContentView: View {
     private var sidebarView: some View {
         VerticalTabsSidebar(
             updateViewModel: updateViewModel,
-            selection: $sidebarSelectionState.selection,
+            selection: sidebarSelectionBinding,
             selectedTabIds: $selectedTabIds,
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex
         )
         .frame(width: sidebarWidth)
+    }
+
+    private var sidebarSelectionBinding: Binding<SidebarSelection> {
+        Binding(
+            get: { sidebarSelectionState.selection },
+            set: { sidebarSelectionState.selection = $0 }
+        )
     }
 
     /// Space at top of content area for the titlebar. This must be at least the actual titlebar
@@ -1827,7 +1836,7 @@ struct ContentView: View {
             .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
             .allowsHitTesting(sidebarSelectionState.selection == .tabs)
 
-            NotificationsPage(selection: $sidebarSelectionState.selection)
+            NotificationsPage(selection: sidebarSelectionBinding)
                 .opacity(sidebarSelectionState.selection == .notifications ? 1 : 0)
                 .allowsHitTesting(sidebarSelectionState.selection == .notifications)
         }
@@ -2124,7 +2133,7 @@ struct ContentView: View {
             }
         })
 
-        view = AnyView(view.onChange(of: tabManager.selectedTabId) { newValue in
+        view = AnyView(view.onChange(of: tabManager.selectedTabId) { _, newValue in
 #if DEBUG
             if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
@@ -2146,7 +2155,7 @@ struct ContentView: View {
             updateTitlebarText()
         })
 
-        view = AnyView(view.onChange(of: tabManager.isWorkspaceCycleHot) { _ in
+        view = AnyView(view.onChange(of: tabManager.isWorkspaceCycleHot) { _, _ in
 #if DEBUG
             if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
@@ -2160,7 +2169,7 @@ struct ContentView: View {
             reconcileMountedWorkspaceIds()
         })
 
-        view = AnyView(view.onChange(of: retiringWorkspaceId) { _ in
+        view = AnyView(view.onChange(of: retiringWorkspaceId) { _, _ in
             reconcileMountedWorkspaceIds()
         })
 
@@ -2214,7 +2223,7 @@ struct ContentView: View {
             completeWorkspaceHandoffIfNeeded(focusedTabId: selectedTabId, reason: "browser_address_bar")
         })
 
-        view = AnyView(view.onReceive(tabManager.$tabs) { tabs in
+        view = AnyView(view.onReceive(tabManager.tabsPublisher) { tabs in
             let existingIds = Set(tabs.map { $0.id })
             if let retiringWorkspaceId, !existingIds.contains(retiringWorkspaceId) {
                 self.retiringWorkspaceId = nil
@@ -2351,11 +2360,11 @@ struct ContentView: View {
             }
         }))
 
-        view = AnyView(view.onChange(of: bgGlassTintHex) { _ in
+        view = AnyView(view.onChange(of: bgGlassTintHex) { _, _ in
             updateWindowGlassTint()
         })
 
-        view = AnyView(view.onChange(of: bgGlassTintOpacity) { _ in
+        view = AnyView(view.onChange(of: bgGlassTintOpacity) { _, _ in
             updateWindowGlassTint()
         })
 
@@ -2382,7 +2391,7 @@ struct ContentView: View {
             updateSidebarResizerBandState()
         })
 
-        view = AnyView(view.onChange(of: sidebarWidth) { _ in
+        view = AnyView(view.onChange(of: sidebarWidth) { _, _ in
             let sanitized = normalizedSidebarWidth(sidebarWidth)
             if abs(sidebarWidth - sanitized) > 0.5 {
                 sidebarWidth = sanitized
@@ -2394,11 +2403,11 @@ struct ContentView: View {
             updateSidebarResizerBandState()
         })
 
-        view = AnyView(view.onChange(of: sidebarState.isVisible) { _ in
+        view = AnyView(view.onChange(of: sidebarState.isVisible) { _, _ in
             updateSidebarResizerBandState()
         })
 
-        view = AnyView(view.onChange(of: sidebarState.persistedWidth) { newValue in
+        view = AnyView(view.onChange(of: sidebarState.persistedWidth) { _, newValue in
             let sanitized = normalizedSidebarWidth(newValue)
             if abs(newValue - sanitized) > 0.5 {
                 sidebarState.persistedWidth = sanitized
@@ -2820,7 +2829,7 @@ struct ContentView: View {
                 ),
                 anchor: commandPaletteScrollTargetAnchor
             )
-            .onChange(of: commandPaletteSelectedResultIndex) { _ in
+            .onChange(of: commandPaletteSelectedResultIndex) { _, _ in
                 updateCommandPaletteScrollTarget(resultCount: visibleResults.count, animated: true)
             }
 
@@ -2839,14 +2848,14 @@ struct ContentView: View {
             updateCommandPaletteScrollTarget(resultCount: visibleResults.count, animated: false)
             resetCommandPaletteSearchFocus()
         }
-        .onChange(of: commandPaletteQuery) { _ in
+        .onChange(of: commandPaletteQuery) { _, _ in
             commandPaletteSelectedResultIndex = 0
             commandPaletteHoveredResultIndex = nil
             commandPaletteScrollTargetIndex = nil
             commandPaletteScrollTargetAnchor = nil
             syncCommandPaletteDebugStateForObservedWindow()
         }
-        .onChange(of: visibleResults.count) { _ in
+        .onChange(of: visibleResults.count) { _, _ in
             commandPaletteSelectedResultIndex = commandPaletteSelectedIndex(resultCount: visibleResults.count)
             updateCommandPaletteScrollTarget(resultCount: visibleResults.count, animated: false)
             if let hoveredIndex = commandPaletteHoveredResultIndex, hoveredIndex >= visibleResults.count {
@@ -2854,7 +2863,7 @@ struct ContentView: View {
             }
             syncCommandPaletteDebugStateForObservedWindow()
         }
-        .onChange(of: commandPaletteSelectedResultIndex) { _ in
+        .onChange(of: commandPaletteSelectedResultIndex) { _, _ in
             syncCommandPaletteDebugStateForObservedWindow()
         }
     }
@@ -4128,7 +4137,12 @@ struct ContentView: View {
                 panel.allowsMultipleSelection = false
                 panel.title = "Open Folder"
                 panel.prompt = "Open"
-                if panel.runModal() == .OK, let url = panel.url {
+                if let window = self.observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow {
+                    panel.beginSheetModal(for: window) { response in
+                        guard response == .OK, let url = panel.url else { return }
+                        tabManager.addWorkspace(workingDirectory: url.path)
+                    }
+                } else if panel.runModal() == .OK, let url = panel.url {
                     tabManager.addWorkspace(workingDirectory: url.path)
                 }
             }
@@ -5660,14 +5674,14 @@ private struct SidebarResizerAccessibilityModifier: ViewModifier {
 }
 
 struct VerticalTabsSidebar: View {
-    @ObservedObject var updateViewModel: UpdateViewModel
-    @EnvironmentObject var tabManager: TabManager
+    var updateViewModel: UpdateViewModel
+    @Environment(TabManager.self) var tabManager: TabManager
     @Binding var selection: SidebarSelection
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
-    @StateObject private var commandKeyMonitor = SidebarCommandKeyMonitor()
-    @StateObject private var dragAutoScrollController = SidebarDragAutoScrollController()
-    @StateObject private var dragFailsafeMonitor = SidebarDragFailsafeMonitor()
+    @State private var commandKeyMonitor = SidebarCommandKeyMonitor()
+    @State private var dragAutoScrollController = SidebarDragAutoScrollController()
+    @State private var dragFailsafeMonitor = SidebarDragFailsafeMonitor()
     @State private var draggedTabId: UUID?
     @State private var dropIndicator: SidebarDropIndicator?
 
@@ -5773,7 +5787,7 @@ struct VerticalTabsSidebar: View {
                 reason: "sidebar_disappear"
             )
         }
-        .onChange(of: draggedTabId) { newDraggedTabId in
+        .onChange(of: draggedTabId) { _, newDraggedTabId in
             SidebarDragLifecycleNotification.postStateDidChange(
                 tabId: newDraggedTabId,
                 reason: "drag_state_change"
@@ -5919,7 +5933,8 @@ enum SidebarDragFailsafePolicy {
 }
 
 @MainActor
-private final class SidebarDragFailsafeMonitor: ObservableObject {
+@Observable
+private final class SidebarDragFailsafeMonitor {
     private static let escapeKeyCode: UInt16 = 53
     private var timer: Timer?
     private var pendingClearWorkItem: DispatchWorkItem?
@@ -6083,8 +6098,9 @@ private struct SidebarExternalDropDelegate: DropDelegate {
 }
 
 @MainActor
-private final class SidebarCommandKeyMonitor: ObservableObject {
-    @Published private(set) var isCommandPressed = false
+@Observable
+private final class SidebarCommandKeyMonitor {
+    private(set) var isCommandPressed = false
 
     private weak var hostWindow: NSWindow?
     private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
@@ -6244,7 +6260,7 @@ private final class SidebarCommandKeyMonitor: ObservableObject {
 
 #if DEBUG
 private struct SidebarDevFooter: View {
-    @ObservedObject var updateViewModel: UpdateViewModel
+    var updateViewModel: UpdateViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -6330,7 +6346,7 @@ private final class SidebarScrollViewResolverView: NSView {
 }
 
 private struct SidebarEmptyArea: View {
-    @EnvironmentObject var tabManager: TabManager
+    @Environment(TabManager.self) var tabManager: TabManager
     let rowSpacing: CGFloat
     @Binding var selection: SidebarSelection
     @Binding var selectedTabIds: Set<UUID>
@@ -6455,10 +6471,10 @@ enum SidebarWorkspaceShortcutHintMetrics {
 }
 
 private struct TabItemView: View {
-    @EnvironmentObject var tabManager: TabManager
-    @EnvironmentObject var notificationStore: TerminalNotificationStore
+    @Environment(TabManager.self) var tabManager: TabManager
+    @Environment(TerminalNotificationStore.self) var notificationStore: TerminalNotificationStore
     @Environment(\.colorScheme) private var colorScheme
-    @ObservedObject var tab: Tab
+    var tab: Tab
     let index: Int
     let rowSpacing: CGFloat
     @Binding var selection: SidebarSelection
@@ -6883,7 +6899,7 @@ private struct TabItemView: View {
                     .onAppear {
                         rowHeight = max(proxy.size.height, 1)
                     }
-                    .onChange(of: proxy.size.height) { newHeight in
+                    .onChange(of: proxy.size.height) { _, newHeight in
                         rowHeight = max(newHeight, 1)
                     }
             }
@@ -7869,7 +7885,7 @@ private struct SidebarMetadataMarkdownBlockRow: View {
         .contentShape(Rectangle())
         .onTapGesture { onFocus() }
         .onAppear(perform: renderMarkdown)
-        .onChange(of: block.markdown) { _ in
+        .onChange(of: block.markdown) { _, _ in
             renderMarkdown()
         }
     }
@@ -8022,7 +8038,8 @@ enum SidebarDragAutoScrollPlanner {
 }
 
 @MainActor
-private final class SidebarDragAutoScrollController: ObservableObject {
+@Observable
+private final class SidebarDragAutoScrollController {
     private weak var scrollView: NSScrollView?
     private var timer: Timer?
     private var activePlan: SidebarAutoScrollPlan?

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1908,7 +1908,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         guard let createdSurface = surface else { return }
 
         // For vsync-driven rendering, Ghostty needs to know which display we're on so it can
-        // start a CVDisplayLink with the right refresh rate. If we don't set this early, the
+        // start a CADisplayLink with the right refresh rate. If we don't set this early, the
         // renderer can believe vsync is "running" but never deliver frames, which looks like a
         // frozen terminal until focus/visibility changes force a synchronous draw.
         //
@@ -2075,7 +2075,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         ghostty_surface_set_focus(surface, focused)
 
         // If we focus a surface while it is being rapidly reparented (closing splits, etc),
-        // Ghostty's CVDisplayLink can end up started before the display id is valid, leaving
+        // Ghostty's CADisplayLink can end up started before the display id is valid, leaving
         // hasVsync() true but with no callbacks ("stuck-vsync-no-frames"). Reasserting the
         // display id *after* focusing lets Ghostty restart the display link when needed.
         if focused {

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct NotificationsPage: View {
-    @EnvironmentObject var notificationStore: TerminalNotificationStore
-    @EnvironmentObject var tabManager: TabManager
+    @Environment(TerminalNotificationStore.self) var notificationStore: TerminalNotificationStore
+    @Environment(TabManager.self) var tabManager: TabManager
     @Binding var selection: SidebarSelection
     @FocusState private var focusedNotificationId: UUID?
     @AppStorage(KeyboardShortcutSettings.Action.jumpToUnread.defaultsKey) private var jumpToUnreadShortcutData = Data()
@@ -47,7 +47,7 @@ struct NotificationsPage: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
         .onAppear(perform: setInitialFocus)
-        .onChange(of: notificationStore.notifications.first?.id) { _ in
+        .onChange(of: notificationStore.notifications.first?.id) { _, _ in
             setInitialFocus()
         }
     }
@@ -90,12 +90,12 @@ struct NotificationsPage: View {
         VStack(spacing: 8) {
             Image(systemName: "bell.slash")
                 .font(.system(size: 32))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             Text("No notifications yet")
                 .font(.headline)
             Text("Desktop notifications will appear here for quick review.")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -194,24 +194,24 @@ private struct NotificationRow: View {
                         HStack {
                             Text(notification.title)
                                 .font(.headline)
-                                .foregroundColor(.primary)
+                                .foregroundStyle(.primary)
                             Spacer()
                             Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
 
                         if !notification.body.isEmpty {
                             Text(notification.body)
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .lineLimit(3)
                         }
 
                         if let tabTitle {
                             Text(tabTitle)
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
 
@@ -229,7 +229,7 @@ private struct NotificationRow: View {
 
             Button(action: onClear) {
                 Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
         }

--- a/Sources/SidebarSelectionState.swift
+++ b/Sources/SidebarSelectionState.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import Observation
 
 @MainActor
-final class SidebarSelectionState: ObservableObject {
-    @Published var selection: SidebarSelection
+@Observable
+final class SidebarSelectionState {
+    var selection: SidebarSelection
 
     init(selection: SidebarSelection = .tabs) {
         self.selection = selection

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2,7 +2,8 @@ import AppKit
 import SwiftUI
 import Foundation
 import Bonsplit
-import CoreVideo
+import QuartzCore
+import Observation
 import Combine
 
 // MARK: - Tab Type Alias for Backwards Compatibility
@@ -443,7 +444,8 @@ fileprivate final class VsyncIOSurfaceTimelineState {
     var firstSizeMismatch: (label: String, frame: Int, ios: String, expected: String)?
     var trace: [String] = []
 
-    var link: CVDisplayLink?
+    var timer: Timer?
+    var timerTarget: VsyncIOSurfaceTimelineDisplayLinkTarget?
     var continuation: CheckedContinuation<Void, Never>?
 
     init(frameCount: Int, closeFrame: Int) {
@@ -475,26 +477,27 @@ fileprivate final class VsyncIOSurfaceTimelineState {
         finished = true
         let cont = continuation
         continuation = nil
+        timer?.invalidate()
+        timer = nil
+        timerTarget = nil
         lock.unlock()
         cont?.resume()
     }
 }
 
-fileprivate func cmuxVsyncIOSurfaceTimelineCallback(
-    _ displayLink: CVDisplayLink,
-    _ inNow: UnsafePointer<CVTimeStamp>,
-    _ inOutputTime: UnsafePointer<CVTimeStamp>,
-    _ flagsIn: CVOptionFlags,
-    _ flagsOut: UnsafeMutablePointer<CVOptionFlags>,
-    _ ctx: UnsafeMutableRawPointer?
-) -> CVReturn {
-    guard let ctx else { return kCVReturnSuccess }
-    let st = Unmanaged<VsyncIOSurfaceTimelineState>.fromOpaque(ctx).takeUnretainedValue()
-    if !st.tryBeginCapture() { return kCVReturnSuccess }
+@MainActor
+fileprivate final class VsyncIOSurfaceTimelineDisplayLinkTarget: NSObject {
+    private weak var state: VsyncIOSurfaceTimelineState?
 
-    // Sample on the main thread synchronously so we don't "miss" a single compositor frame.
-    // (The previous Task/@MainActor hop could be delayed long enough to skip the blank frame.)
-    DispatchQueue.main.sync {
+    init(state: VsyncIOSurfaceTimelineState) {
+        self.state = state
+    }
+
+    @objc
+    func handleDisplayLink(_ timer: Timer) {
+        _ = timer
+        guard let st = state else { return }
+        if !st.tryBeginCapture() { return }
         defer { st.endCapture() }
         guard st.framesWritten < st.frameCount else { return }
 
@@ -519,8 +522,6 @@ fileprivate func cmuxVsyncIOSurfaceTimelineCallback(
             let hasSizeMismatch = hasDimensions && (dw > 2 || dh > 2)
             let stretchRisk = (gravity == CALayerContentsGravity.resize.rawValue)
 
-            // Ignore setup/warmup frames before the close action. We only care about
-            // regressions that happen at/after the close mutation.
             if st.firstBlank == nil, st.framesWritten >= st.closeFrame, s.isProbablyBlank {
                 st.firstBlank = (label: t.label, frame: st.framesWritten)
             }
@@ -543,32 +544,32 @@ fileprivate func cmuxVsyncIOSurfaceTimelineCallback(
         }
 
         st.framesWritten += 1
-    }
 
-    // Stop/resume outside the main-thread sync block to avoid reentrancy issues.
-    if st.framesWritten >= st.frameCount, let link = st.link {
-        CVDisplayLinkStop(link)
-        st.finish()
-        Unmanaged<VsyncIOSurfaceTimelineState>.fromOpaque(ctx).release()
+        if st.framesWritten >= st.frameCount, let timer = st.timer {
+            timer.invalidate()
+            st.finish()
+        }
     }
-
-    return kCVReturnSuccess
 }
 #endif
 
 @MainActor
-class TabManager: ObservableObject {
+@Observable
+class TabManager {
     /// The window that owns this TabManager. Set by AppDelegate.registerMainWindow().
     /// Used to apply title updates to the correct window instead of NSApp.keyWindow.
     weak var window: NSWindow?
 
-    @Published var tabs: [Workspace] = []
-    @Published private(set) var isWorkspaceCycleHot: Bool = false
+    private let tabsSubject = CurrentValueSubject<[Workspace], Never>([])
+    var tabs: [Workspace] = [] {
+        didSet { tabsSubject.send(tabs) }
+    }
+    private(set) var isWorkspaceCycleHot: Bool = false
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
     private static var nextPortOrdinal: Int = 0
-    @Published var selectedTabId: UUID? {
+    var selectedTabId: UUID? {
         didSet {
             guard selectedTabId != oldValue else { return }
             sentryBreadcrumb("workspace.switch", data: [
@@ -683,8 +684,8 @@ class TabManager: ObservableObject {
 #endif
     }
 
-    deinit {
-        workspaceCycleCooldownTask?.cancel()
+    var tabsPublisher: AnyPublisher<[Workspace], Never> {
+        tabsSubject.eraseToAnyPublisher()
     }
 
     private func wireClosedBrowserTracking(for workspace: Workspace) {
@@ -2861,45 +2862,42 @@ class TabManager: ObservableObject {
         }
 	    }
 
-	    @MainActor
-	    private func captureVsyncIOSurfaceTimeline(
-	        frameCount: Int,
-	        closeFrame: Int,
-	        crop: CGRect,
-	        targets: [(label: String, view: GhosttySurfaceScrollView)],
-	        actions: [(frame: Int, action: () -> Void)] = []
-	    ) async -> (firstBlank: (label: String, frame: Int)?, firstSizeMismatch: (label: String, frame: Int, ios: String, expected: String)?, trace: [String]) {
-	        guard frameCount > 0 else { return (nil, nil, []) }
+    @MainActor
+    private func captureVsyncIOSurfaceTimeline(
+        frameCount: Int,
+        closeFrame: Int,
+        crop: CGRect,
+        targets: [(label: String, view: GhosttySurfaceScrollView)],
+        actions: [(frame: Int, action: () -> Void)] = []
+    ) async -> (firstBlank: (label: String, frame: Int)?, firstSizeMismatch: (label: String, frame: Int, ios: String, expected: String)?, trace: [String]) {
+        guard frameCount > 0 else { return (nil, nil, []) }
 
-	        let st = VsyncIOSurfaceTimelineState(frameCount: frameCount, closeFrame: closeFrame)
-	        st.scheduledActions = actions.sorted(by: { $0.frame < $1.frame })
-	        st.nextActionIndex = 0
-	        st.targets = targets.map { t in
-	            VsyncIOSurfaceTimelineState.Target(label: t.label, sample: { @MainActor in
-	                t.view.debugSampleIOSurface(normalizedCrop: crop)
-	            })
-	        }
+        let st = VsyncIOSurfaceTimelineState(frameCount: frameCount, closeFrame: closeFrame)
+        st.scheduledActions = actions.sorted(by: { $0.frame < $1.frame })
+        st.nextActionIndex = 0
+        st.targets = targets.map { t in
+            VsyncIOSurfaceTimelineState.Target(label: t.label, sample: { @MainActor in
+                t.view.debugSampleIOSurface(normalizedCrop: crop)
+            })
+        }
 
-	        let unmanaged = Unmanaged.passRetained(st)
-	        let ctx = unmanaged.toOpaque()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            st.continuation = cont
+            let target = VsyncIOSurfaceTimelineDisplayLinkTarget(state: st)
+            let timer = Timer(
+                timeInterval: 1.0 / 120.0,
+                target: target,
+                selector: #selector(VsyncIOSurfaceTimelineDisplayLinkTarget.handleDisplayLink(_:)),
+                userInfo: nil,
+                repeats: true
+            )
+            st.timer = timer
+            st.timerTarget = target
+            RunLoop.main.add(timer, forMode: .common)
+        }
 
-	        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-	            st.continuation = cont
-	            var link: CVDisplayLink?
-	            CVDisplayLinkCreateWithActiveCGDisplays(&link)
-	            guard let link else {
-	                st.finish()
-	                Unmanaged<VsyncIOSurfaceTimelineState>.fromOpaque(ctx).release()
-	                return
-	            }
-	            st.link = link
-
-	            CVDisplayLinkSetOutputCallback(link, cmuxVsyncIOSurfaceTimelineCallback, ctx)
-	            CVDisplayLinkStart(link)
-	        }
-
-	        return (st.firstBlank, st.firstSizeMismatch, st.trace)
-	    }
+        return (st.firstBlank, st.firstSizeMismatch, st.trace)
+    }
 
     private func writeSplitCloseRightTestData(_ updates: [String: String], at path: String) {
         var payload = loadSplitCloseRightTestData(at: path)
@@ -3007,29 +3005,14 @@ class TabManager: ObservableObject {
                 rightPanel.surface.sendText("exit\r")
 
                 // Wait for the right panel to close.
-                let closed = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-                    var cancellable: AnyCancellable?
-                    var resolved = false
-
-                    func finish(_ value: Bool) {
-                        guard !resolved else { return }
-                        resolved = true
-                        cancellable?.cancel()
-                        cont.resume(returning: value)
+                let closeDeadline = Date().addingTimeInterval(8.0)
+                var closed = false
+                while Date() < closeDeadline {
+                    if tab.panels.count == 1 {
+                        closed = true
+                        break
                     }
-
-                    cancellable = tab.$panels
-                        .map { $0.count }
-                        .removeDuplicates()
-                        .sink { count in
-                            if count == 1 {
-                                finish(true)
-                            }
-                        }
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) {
-                        finish(false)
-                    }
+                    try? await Task.sleep(nanoseconds: 50_000_000)
                 }
 
                 if !closed {
@@ -3283,50 +3266,46 @@ class TabManager: ObservableObject {
                 self.uiTestCancellables.removeAll()
             }
 
-            tab.$panels
-                .map { $0.count }
-                .removeDuplicates()
-                .sink { [weak self, weak tab] count in
-                    Task { @MainActor in
-                        guard let self, let tab else { return }
-                        if count == expectedPanelsAfter {
-                            // Require the post-exit state to be stable for a short window so
-                            // we catch "close looked correct, then workspace vanished" races.
-                            try? await Task.sleep(nanoseconds: 1_200_000_000)
-                            guard tab.panels.count == expectedPanelsAfter else { return }
-
-                            let firstResponderPanelAfter = tab.panels.compactMap { (panelId, panel) -> UUID? in
-                                guard let terminal = panel as? TerminalPanel else { return nil }
-                                return terminal.hostedView.isSurfaceViewFirstResponder() ? panelId : nil
-                            }.first?.uuidString ?? ""
-
-                            finish([
-                                "workspaceCountAfter": String(self.tabs.count),
-                                "panelCountAfter": String(tab.panels.count),
-                                "closedWorkspace": self.tabs.contains(where: { $0.id == tab.id }) ? "0" : "1",
-                                "focusedPanelAfter": tab.focusedPanelId?.uuidString ?? "",
-                                "firstResponderPanelAfter": firstResponderPanelAfter,
-                            ])
-                        }
+            Task { @MainActor [weak self, weak tab] in
+                guard let self, let tab else { return }
+                while !finished {
+                    if !self.tabs.contains(where: { $0.id == tab.id }) {
+                        finish([
+                            "workspaceCountAfter": "0",
+                            "panelCountAfter": "0",
+                            "closedWorkspace": "1",
+                        ])
+                        return
                     }
-                }
-                .store(in: &uiTestCancellables)
 
-            $tabs
-                .map { $0.contains(where: { $0.id == tab.id }) }
-                .removeDuplicates()
-                .sink { alive in
-                    Task { @MainActor in
-                        if !alive {
-                            finish([
-                                "workspaceCountAfter": "0",
-                                "panelCountAfter": "0",
-                                "closedWorkspace": "1",
-                            ])
+                    if tab.panels.count == expectedPanelsAfter {
+                        // Require the post-exit state to be stable for a short window so
+                        // we catch "close looked correct, then workspace vanished" races.
+                        try? await Task.sleep(nanoseconds: 1_200_000_000)
+                        guard !finished else { return }
+                        guard tab.panels.count == expectedPanelsAfter else {
+                            try? await Task.sleep(nanoseconds: 50_000_000)
+                            continue
                         }
+
+                        let firstResponderPanelAfter = tab.panels.compactMap { (panelId, panel) -> UUID? in
+                            guard let terminal = panel as? TerminalPanel else { return nil }
+                            return terminal.hostedView.isSurfaceViewFirstResponder() ? panelId : nil
+                        }.first?.uuidString ?? ""
+
+                        finish([
+                            "workspaceCountAfter": String(self.tabs.count),
+                            "panelCountAfter": String(tab.panels.count),
+                            "closedWorkspace": self.tabs.contains(where: { $0.id == tab.id }) ? "0" : "1",
+                            "focusedPanelAfter": tab.focusedPanelId?.uuidString ?? "",
+                            "firstResponderPanelAfter": firstResponderPanelAfter,
+                        ])
+                        return
                     }
+
+                    try? await Task.sleep(nanoseconds: 50_000_000)
                 }
-                .store(in: &uiTestCancellables)
+            }
 
             let work = DispatchWorkItem {
                 finish([

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1,6 +1,8 @@
 import AppKit
 import Foundation
 import UserNotifications
+import Combine
+import Observation
 
 enum NotificationBadgeSettings {
     static let dockBadgeEnabledKey = "notificationDockBadgeEnabled"
@@ -70,7 +72,8 @@ struct TerminalNotification: Identifiable, Hashable {
 }
 
 @MainActor
-final class TerminalNotificationStore: ObservableObject {
+@Observable
+final class TerminalNotificationStore {
     private struct TabSurfaceKey: Hashable {
         let tabId: UUID
         let surfaceId: UUID?
@@ -88,9 +91,11 @@ final class TerminalNotificationStore: ObservableObject {
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
+    private let notificationsSubject = CurrentValueSubject<[TerminalNotification], Never>([])
 
-    @Published private(set) var notifications: [TerminalNotification] = [] {
+    private(set) var notifications: [TerminalNotification] = [] {
         didSet {
+            notificationsSubject.send(notifications)
             indexes = Self.buildIndexes(for: notifications)
             refreshDockBadge()
         }
@@ -132,12 +137,6 @@ final class TerminalNotificationStore: ObservableObject {
         refreshDockBadge()
     }
 
-    deinit {
-        if let userDefaultsObserver {
-            NotificationCenter.default.removeObserver(userDefaultsObserver)
-        }
-    }
-
     static func dockBadgeLabel(unreadCount: Int, isEnabled: Bool, runTag: String? = nil) -> String? {
         let unreadLabel: String? = {
             guard isEnabled, unreadCount > 0 else { return nil }
@@ -159,6 +158,10 @@ final class TerminalNotificationStore: ObservableObject {
 
     var unreadCount: Int {
         indexes.unreadCount
+    }
+
+    var notificationsPublisher: AnyPublisher<[TerminalNotification], Never> {
+        notificationsSubject.eraseToAnyPublisher()
     }
 
     func unreadCount(forTabId tabId: UUID) -> Int {

--- a/Sources/TerminalView.swift
+++ b/Sources/TerminalView.swift
@@ -21,7 +21,7 @@ extension SwiftTerm.Color {
 }
 
 struct TerminalContainerView: View {
-    @ObservedObject var tab: Tab
+    var tab: Tab
     let config: GhosttyConfig
 
     init(tab: Tab, config: GhosttyConfig = GhosttyConfig.load()) {
@@ -134,7 +134,7 @@ class FocusableTerminalView: NSView {
 }
 
 struct SwiftTermView: NSViewRepresentable {
-    @ObservedObject var tab: Tab
+    var tab: Tab
     let config: GhosttyConfig
 
     func makeNSView(context: Context) -> FocusableTerminalView {

--- a/Sources/Update/UpdateBadge.swift
+++ b/Sources/Update/UpdateBadge.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A badge view that displays the current state of an update operation.
 struct UpdateBadge: View {
-    @ObservedObject var model: UpdateViewModel
+    var model: UpdateViewModel
 
     var body: some View {
         badgeContent

--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -100,7 +100,7 @@ class UpdateController {
         guard viewModel.state.isInstallable else { return }
         guard installCancellable == nil else { return }
 
-        installCancellable = viewModel.$state.sink { [weak self] state in
+        installCancellable = viewModel.statePublisher.sink { [weak self] state in
             guard let self else { return }
             guard state.isInstallable else {
                 self.installCancellable = nil
@@ -115,7 +115,7 @@ class UpdateController {
         stopAttemptUpdateMonitoring()
         didObserveAttemptUpdateProgress = false
 
-        attemptInstallCancellable = viewModel.$state
+        attemptInstallCancellable = viewModel.statePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self else { return }
@@ -214,7 +214,10 @@ class UpdateController {
     }
 
     private func installNoUpdateDismissObserver() {
-        noUpdateDismissCancellable = Publishers.CombineLatest(viewModel.$state, viewModel.$overrideState)
+        noUpdateDismissCancellable = Publishers.CombineLatest(
+            viewModel.statePublisher,
+            viewModel.overrideStatePublisher
+        )
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state, overrideState in
                 self?.scheduleNoUpdateDismiss(for: state, overrideState: overrideState)

--- a/Sources/Update/UpdatePill.swift
+++ b/Sources/Update/UpdatePill.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// A pill-shaped button that displays update status and provides access to update actions.
 struct UpdatePill: View {
-    @ObservedObject var model: UpdateViewModel
+    var model: UpdateViewModel
     @State private var showPopover = false
 
     private let textFont = NSFont.systemFont(ofSize: 11, weight: .medium)
@@ -50,7 +50,7 @@ struct UpdatePill: View {
                 Capsule()
                     .fill(model.backgroundColor)
             )
-            .foregroundColor(model.foregroundColor)
+            .foregroundStyle(model.foregroundColor)
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
@@ -68,7 +68,7 @@ struct UpdatePill: View {
 
 /// Menu item that shows "Install Update and Relaunch" when an update is ready.
 struct InstallUpdateMenuItem: View {
-    @ObservedObject var model: UpdateViewModel
+    var model: UpdateViewModel
 
     var body: some View {
         if model.state.isInstallable {

--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -4,7 +4,7 @@ import Sparkle
 
 /// Popover view that displays detailed update information and actions.
 struct UpdatePopoverView: View {
-    @ObservedObject var model: UpdateViewModel
+    var model: UpdateViewModel
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -54,7 +54,7 @@ fileprivate struct PermissionRequestView: View {
 
                 Text("cmux can automatically check for updates in the background.")
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -126,7 +126,7 @@ fileprivate struct UpdateAvailableView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 6) {
                             Text("Version:")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .frame(width: labelWidth, alignment: .trailing)
                             Text(update.appcastItem.displayVersionString)
                         }
@@ -135,7 +135,7 @@ fileprivate struct UpdateAvailableView: View {
                         if update.appcastItem.contentLength > 0 {
                             HStack(spacing: 6) {
                                 Text("Size:")
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(.secondary)
                                     .frame(width: labelWidth, alignment: .trailing)
                                 Text(ByteCountFormatter.string(fromByteCount: Int64(update.appcastItem.contentLength), countStyle: .file))
                             }
@@ -145,7 +145,7 @@ fileprivate struct UpdateAvailableView: View {
                         if let date = update.appcastItem.date {
                             HStack(spacing: 6) {
                                 Text("Released:")
-                                    .foregroundColor(.secondary)
+                                    .foregroundStyle(.secondary)
                                     .frame(width: labelWidth, alignment: .trailing)
                                 Text(date.formatted(date: .abbreviated, time: .omitted))
                             }
@@ -195,7 +195,7 @@ fileprivate struct UpdateAvailableView: View {
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 10))
                     }
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
                     .padding(12)
                     .frame(maxWidth: .infinity)
                     .background(Color(nsColor: .controlBackgroundColor))
@@ -223,7 +223,7 @@ fileprivate struct DownloadingView: View {
                         ProgressView(value: progress)
                         Text(String(format: "%.0f%%", progress * 100))
                             .font(.system(size: 11))
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                 } else {
                     ProgressView()
@@ -257,7 +257,7 @@ fileprivate struct ExtractingView: View {
                 ProgressView(value: min(1, max(0, extracting.progress)), total: 1.0)
                 Text(String(format: "%.0f%%", min(1, max(0, extracting.progress)) * 100))
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(16)
@@ -276,7 +276,7 @@ fileprivate struct InstallingView: View {
 
                 Text("The update is ready. Please restart the application to complete the installation.")
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -315,7 +315,7 @@ fileprivate struct NotFoundView: View {
 
                 Text("You're already running the latest version.")
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -350,7 +350,7 @@ fileprivate struct UpdateErrorView: View {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.orange)
+                        .foregroundStyle(.orange)
                         .font(.system(size: 13))
                     Text(title)
                         .font(.system(size: 13, weight: .semibold))
@@ -358,7 +358,7 @@ fileprivate struct UpdateErrorView: View {
 
                 Text(message)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -367,7 +367,7 @@ fileprivate struct UpdateErrorView: View {
                     .font(.system(size: 11, weight: .semibold))
                 Text(details)
                     .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
             }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import Combine
+import Observation
 import SwiftUI
 
 final class NonDraggableHostingView<Content: View>: NSHostingView<Content> {
@@ -115,7 +116,8 @@ struct TitlebarControlsStyleConfig {
     let hoverBackground: Bool
 }
 
-final class TitlebarControlsViewModel: ObservableObject {
+@Observable
+final class TitlebarControlsViewModel {
     weak var notificationsAnchorView: NSView?
 }
 
@@ -227,8 +229,8 @@ struct TitlebarControlButton<Content: View>: View {
 }
 
 struct TitlebarControlsView: View {
-    @ObservedObject var notificationStore: TerminalNotificationStore
-    @ObservedObject var viewModel: TitlebarControlsViewModel
+    var notificationStore: TerminalNotificationStore
+    var viewModel: TitlebarControlsViewModel
     let onToggleSidebar: () -> Void
     let onToggleNotifications: () -> Void
     let onNewTab: () -> Void
@@ -237,7 +239,7 @@ struct TitlebarControlsView: View {
     @AppStorage(ShortcutHintDebugSettings.titlebarHintYKey) private var titlebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultTitlebarHintY
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @State private var shortcutRefreshTick = 0
-    @StateObject private var commandKeyMonitor = TitlebarCommandKeyMonitor()
+    @State private var commandKeyMonitor = TitlebarCommandKeyMonitor()
     private let titlebarHintRightSafetyShift: CGFloat = 10
     private let titlebarHintBaseXShift: CGFloat = -10
     private let titlebarHintBaseYShift: CGFloat = 1
@@ -335,7 +337,7 @@ struct TitlebarControlsView: View {
                     if notificationStore.unreadCount > 0 {
                         Text("\(min(notificationStore.unreadCount, 99))")
                             .font(.system(size: max(8, config.badgeSize - 5), weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .frame(width: config.badgeSize, height: config.badgeSize)
                             .background(
                                 Circle().fill(cmuxAccentColor())
@@ -477,7 +479,7 @@ struct TitlebarControlsView: View {
             .monospacedDigit()
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
-            .foregroundColor(.primary)
+            .foregroundStyle(.primary)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .frame(minHeight: max(14, config.iconSize + 1))
@@ -503,8 +505,9 @@ struct TitlebarControlsView: View {
 }
 
 @MainActor
-private final class TitlebarCommandKeyMonitor: ObservableObject {
-    @Published private(set) var isCommandPressed = false
+@Observable
+private final class TitlebarCommandKeyMonitor {
+    private(set) var isCommandPressed = false
 
     private weak var hostWindow: NSWindow?
     private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
@@ -895,7 +898,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 }
 
 private struct NotificationsPopoverView: View {
-    @ObservedObject var notificationStore: TerminalNotificationStore
+    var notificationStore: TerminalNotificationStore
     let onDismiss: () -> Void
 
     var body: some View {
@@ -920,12 +923,12 @@ private struct NotificationsPopoverView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "bell.slash")
                         .font(.system(size: 28))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     Text("No notifications yet")
                         .font(.headline)
                     Text("Desktop notifications will appear here.")
                         .font(.subheadline)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
                 .frame(minWidth: 420, idealWidth: 520, maxWidth: 640, minHeight: 180)
             } else {
@@ -989,24 +992,24 @@ private struct NotificationPopoverRow: View {
                         HStack {
                             Text(notification.title)
                                 .font(.headline)
-                                .foregroundColor(.primary)
+                                .foregroundStyle(.primary)
                             Spacer()
                             Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
 
                         if !notification.body.isEmpty {
                             Text(notification.body)
                                 .font(.subheadline)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .lineLimit(3)
                         }
 
                         if let tabTitle {
                             Text(tabTitle)
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
 
@@ -1024,7 +1027,7 @@ private struct NotificationPopoverRow: View {
 
             Button(action: onClear) {
                 Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
         }

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -2,13 +2,31 @@ import Foundation
 import AppKit
 import SwiftUI
 import Sparkle
+import Combine
+import Observation
 
-class UpdateViewModel: ObservableObject {
-    @Published var state: UpdateState = .idle
-    @Published var overrideState: UpdateState?
-    #if DEBUG
-    @Published var debugOverrideText: String?
-    #endif
+@Observable
+class UpdateViewModel {
+    private let stateSubject = CurrentValueSubject<UpdateState, Never>(.idle)
+    private let overrideStateSubject = CurrentValueSubject<UpdateState?, Never>(nil)
+
+    var state: UpdateState = .idle {
+        didSet { stateSubject.send(state) }
+    }
+    var overrideState: UpdateState? {
+        didSet { overrideStateSubject.send(overrideState) }
+    }
+#if DEBUG
+    var debugOverrideText: String?
+#endif
+
+    var statePublisher: AnyPublisher<UpdateState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    var overrideStatePublisher: AnyPublisher<UpdateState?, Never> {
+        overrideStateSubject.eraseToAnyPublisher()
+    }
 
     var effectiveState: UpdateState {
         overrideState ?? state

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import AppKit
 import Bonsplit
 import Combine
+import Observation
 import CoreText
 
 func cmuxSurfaceContextName(_ context: ghostty_surface_context_e) -> String {
@@ -889,13 +890,14 @@ struct ClosedBrowserPanelRestoreSnapshot {
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor
-final class Workspace: Identifiable, ObservableObject {
+@Observable
+final class Workspace: Identifiable {
     let id: UUID
-    @Published var title: String
-    @Published var customTitle: String?
-    @Published var isPinned: Bool = false
-    @Published var customColor: String?  // hex string, e.g. "#C0392B"
-    @Published var currentDirectory: String
+    var title: String
+    var customTitle: String?
+    var isPinned: Bool = false
+    var customColor: String?  // hex string, e.g. "#C0392B"
+    var currentDirectory: String
 
     /// Ordinal for CMUX_PORT range assignment (monotonically increasing per app session)
     var portOrdinal: Int = 0
@@ -904,7 +906,7 @@ final class Workspace: Identifiable, ObservableObject {
     let bonsplitController: BonsplitController
 
     /// Mapping from bonsplit TabID to our Panel instances
-    @Published private(set) var panels: [UUID: any Panel] = [:]
+    private(set) var panels: [UUID: any Panel] = [:]
 
     /// Subscriptions for panel updates (e.g., browser title changes)
     private var panelSubscriptions: [UUID: AnyCancellable] = [:]
@@ -952,24 +954,24 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     /// Published directory for each panel
-    @Published var panelDirectories: [UUID: String] = [:]
-    @Published var panelTitles: [UUID: String] = [:]
-    @Published private(set) var panelCustomTitles: [UUID: String] = [:]
-    @Published private(set) var pinnedPanelIds: Set<UUID> = []
-    @Published private(set) var manualUnreadPanelIds: Set<UUID> = []
+    var panelDirectories: [UUID: String] = [:]
+    var panelTitles: [UUID: String] = [:]
+    private(set) var panelCustomTitles: [UUID: String] = [:]
+    private(set) var pinnedPanelIds: Set<UUID> = []
+    private(set) var manualUnreadPanelIds: Set<UUID> = []
     private var manualUnreadMarkedAt: [UUID: Date] = [:]
     nonisolated private static let manualUnreadFocusGraceInterval: TimeInterval = 0.2
     nonisolated private static let manualUnreadClearDelayAfterFocusFlash: TimeInterval = 0.2
-    @Published var statusEntries: [String: SidebarStatusEntry] = [:]
-    @Published var metadataBlocks: [String: SidebarMetadataBlock] = [:]
-    @Published var logEntries: [SidebarLogEntry] = []
-    @Published var progress: SidebarProgressState?
-    @Published var gitBranch: SidebarGitBranchState?
-    @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
-    @Published var pullRequest: SidebarPullRequestState?
-    @Published var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
-    @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
-    @Published var listeningPorts: [Int] = []
+    var statusEntries: [String: SidebarStatusEntry] = [:]
+    var metadataBlocks: [String: SidebarMetadataBlock] = [:]
+    var logEntries: [SidebarLogEntry] = []
+    var progress: SidebarProgressState?
+    var gitBranch: SidebarGitBranchState?
+    var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
+    var pullRequest: SidebarPullRequestState?
+    var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
+    var surfaceListeningPorts: [UUID: [Int]] = [:]
+    var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -5,7 +5,7 @@ import Bonsplit
 
 /// View that renders a Workspace's content using BonsplitView
 struct WorkspaceContentView: View {
-    @ObservedObject var workspace: Workspace
+    var workspace: Workspace
     let isWorkspaceVisible: Bool
     let isWorkspaceInputActive: Bool
     let workspacePortalPriority: Int
@@ -17,7 +17,7 @@ struct WorkspaceContentView: View {
     ) -> Void)?
     @State private var config = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "stateInit")
     @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject var notificationStore: TerminalNotificationStore
+    @Environment(TerminalNotificationStore.self) var notificationStore: TerminalNotificationStore
 
     static func panelVisibleInUI(
         isWorkspaceVisible: Bool,
@@ -297,7 +297,7 @@ extension WorkspaceContentView {
 
 /// View shown for empty panes
 struct EmptyPanelView: View {
-    @ObservedObject var workspace: Workspace
+    var workspace: Workspace
     let paneId: PaneID
     @AppStorage(KeyboardShortcutSettings.Action.newSurface.defaultsKey) private var newSurfaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openBrowser.defaultsKey) private var openBrowserShortcutData = Data()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2,13 +2,14 @@ import AppKit
 import SwiftUI
 import Darwin
 import Bonsplit
+import Observation
 
 @main
 struct cmuxApp: App {
-    @StateObject private var tabManager: TabManager
-    @StateObject private var notificationStore = TerminalNotificationStore.shared
-    @StateObject private var sidebarState = SidebarState()
-    @StateObject private var sidebarSelectionState = SidebarSelectionState()
+    @State private var tabManager: TabManager
+    @State private var notificationStore = TerminalNotificationStore.shared
+    @State private var sidebarState = SidebarState()
+    @State private var sidebarSelectionState = SidebarSelectionState()
     private let primaryWindowId = UUID()
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyle = TitlebarControlsStyle.classic.rawValue
@@ -45,7 +46,7 @@ struct cmuxApp: App {
 
         let startupAppearance = AppearanceSettings.resolvedMode()
         Self.applyAppearance(startupAppearance)
-        _tabManager = StateObject(wrappedValue: TabManager())
+        _tabManager = State(initialValue: TabManager())
         // Migrate legacy and old-format socket mode values to the new enum.
         let defaults = UserDefaults.standard
         if let stored = defaults.string(forKey: SocketControlSettings.appStorageKey) {
@@ -182,10 +183,10 @@ struct cmuxApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView(updateViewModel: appDelegate.updateViewModel, windowId: primaryWindowId)
-                .environmentObject(tabManager)
-                .environmentObject(notificationStore)
-                .environmentObject(sidebarState)
-                .environmentObject(sidebarSelectionState)
+                .environment(tabManager)
+                .environment(notificationStore)
+                .environment(sidebarState)
+                .environment(sidebarSelectionState)
                 .onAppear {
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
@@ -202,10 +203,10 @@ struct cmuxApp: App {
                         }
                     }
                 }
-                .onChange(of: appearanceMode) { _ in
+                .onChange(of: appearanceMode) { _, _ in
                     applyAppearance()
                 }
-                .onChange(of: socketControlMode) { _ in
+                .onChange(of: socketControlMode) { _, _ in
                     updateSocketController()
                 }
         }
@@ -393,7 +394,21 @@ struct cmuxApp: App {
                     panel.allowsMultipleSelection = false
                     panel.title = "Open Folder"
                     panel.prompt = "Open"
-                    if panel.runModal() == .OK, let url = panel.url {
+                    if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+                        panel.beginSheetModal(for: window) { response in
+                            guard response == .OK, let url = panel.url else { return }
+                            if let appDelegate = AppDelegate.shared {
+                                if appDelegate.addWorkspaceInPreferredMainWindow(
+                                    workingDirectory: url.path,
+                                    debugSource: "menu.openFolder"
+                                ) == nil {
+                                    appDelegate.openNewMainWindow(nil)
+                                }
+                            } else {
+                                activeTabManager.addWorkspace(workingDirectory: url.path)
+                            }
+                        }
+                    } else if panel.runModal() == .OK, let url = panel.url {
                         if let appDelegate = AppDelegate.shared {
                             if appDelegate.addWorkspaceInPreferredMainWindow(
                                 workingDirectory: url.path,
@@ -610,7 +625,7 @@ struct cmuxApp: App {
 
     private func showAboutPanel() {
         AboutWindowController.shared.show()
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
     }
 
     private func applyAppearance() {
@@ -996,13 +1011,14 @@ private struct SettingsAboutTitlebarDebugOptions: Equatable {
 }
 
 @MainActor
-private final class SettingsAboutTitlebarDebugStore: ObservableObject {
+@Observable
+private final class SettingsAboutTitlebarDebugStore {
     static let shared = SettingsAboutTitlebarDebugStore()
 
-    @Published var settingsOptions = SettingsAboutTitlebarDebugOptions.defaults(for: .settings) {
+    var settingsOptions = SettingsAboutTitlebarDebugOptions.defaults(for: .settings) {
         didSet { applyToOpenWindows(for: .settings) }
     }
-    @Published var aboutOptions = SettingsAboutTitlebarDebugOptions.defaults(for: .about) {
+    var aboutOptions = SettingsAboutTitlebarDebugOptions.defaults(for: .about) {
         didSet { applyToOpenWindows(for: .about) }
     }
 
@@ -1172,7 +1188,7 @@ private final class SettingsAboutTitlebarDebugWindowController: NSWindowControll
 }
 
 private struct SettingsAboutTitlebarDebugView: View {
-    @ObservedObject private var store = SettingsAboutTitlebarDebugStore.shared
+    private var store = SettingsAboutTitlebarDebugStore.shared
 
     var body: some View {
         ScrollView {
@@ -1941,7 +1957,7 @@ private struct SidebarDebugView: View {
                             Text(option.title).tag(option.rawValue)
                         }
                     }
-                    .onChange(of: sidebarPreset) { _ in
+                    .onChange(of: sidebarPreset) { _, _ in
                         applyPreset()
                     }
                     .padding(.top, 2)
@@ -2297,19 +2313,19 @@ private struct MenuBarExtraDebugView: View {
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .onAppear { applyLiveUpdate() }
-        .onChange(of: previewEnabled) { _ in applyLiveUpdate() }
-        .onChange(of: previewCount) { _ in applyLiveUpdate() }
-        .onChange(of: badgeRectX) { _ in applyLiveUpdate() }
-        .onChange(of: badgeRectY) { _ in applyLiveUpdate() }
-        .onChange(of: badgeRectWidth) { _ in applyLiveUpdate() }
-        .onChange(of: badgeRectHeight) { _ in applyLiveUpdate() }
-        .onChange(of: singleDigitFontSize) { _ in applyLiveUpdate() }
-        .onChange(of: multiDigitFontSize) { _ in applyLiveUpdate() }
-        .onChange(of: singleDigitXAdjust) { _ in applyLiveUpdate() }
-        .onChange(of: multiDigitXAdjust) { _ in applyLiveUpdate() }
-        .onChange(of: singleDigitYOffset) { _ in applyLiveUpdate() }
-        .onChange(of: multiDigitYOffset) { _ in applyLiveUpdate() }
-        .onChange(of: textRectWidthAdjust) { _ in applyLiveUpdate() }
+        .onChange(of: previewEnabled) { _, _ in applyLiveUpdate() }
+        .onChange(of: previewCount) { _, _ in applyLiveUpdate() }
+        .onChange(of: badgeRectX) { _, _ in applyLiveUpdate() }
+        .onChange(of: badgeRectY) { _, _ in applyLiveUpdate() }
+        .onChange(of: badgeRectWidth) { _, _ in applyLiveUpdate() }
+        .onChange(of: badgeRectHeight) { _, _ in applyLiveUpdate() }
+        .onChange(of: singleDigitFontSize) { _, _ in applyLiveUpdate() }
+        .onChange(of: multiDigitFontSize) { _, _ in applyLiveUpdate() }
+        .onChange(of: singleDigitXAdjust) { _, _ in applyLiveUpdate() }
+        .onChange(of: multiDigitXAdjust) { _, _ in applyLiveUpdate() }
+        .onChange(of: singleDigitYOffset) { _, _ in applyLiveUpdate() }
+        .onChange(of: multiDigitYOffset) { _, _ in applyLiveUpdate() }
+        .onChange(of: textRectWidthAdjust) { _, _ in applyLiveUpdate() }
     }
 
     private func sliderRow(
@@ -2437,8 +2453,8 @@ private struct BackgroundDebugView: View {
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .onChange(of: bgGlassTintHex) { _ in updateWindowGlassTint() }
-        .onChange(of: bgGlassTintOpacity) { _ in updateWindowGlassTint() }
+        .onChange(of: bgGlassTintHex) { _, _ in updateWindowGlassTint() }
+        .onChange(of: bgGlassTintOpacity) { _, _ in updateWindowGlassTint() }
     }
 
     private func updateWindowGlassTint() {
@@ -3891,7 +3907,7 @@ private struct ShortcutSettingRow: View {
 
     var body: some View {
         KeyboardShortcutRecorder(label: action.label, shortcut: $shortcut)
-            .onChange(of: shortcut) { newValue in
+            .onChange(of: shortcut) { _, newValue in
                 KeyboardShortcutSettings.setShortcut(newValue, for: action)
             }
             .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in


### PR DESCRIPTION
## Summary
- replace deprecated display-link usage with modern APIs
- migrate legacy observation patterns to `@Observable` and update affected SwiftUI property wrappers
- replace deprecated `LSRegisterURL` usage and remove `CoreServices` import
- restore real LaunchServices bundle registration using `lsregister` in startup path (fixes regression from refactor)
- apply additional modernization updates (`foregroundStyle`, modern activate/onChange forms, main-thread modernizations)

## Validation
- `./scripts/reload.sh --tag 763-modernize-apis`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`

Closes #763


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized deprecated APIs and adopted Swift’s Observation model to simplify state and remove legacy patterns. Restores LaunchServices bundle registration at startup and updates window/alert flows to avoid blocking. Fixes #763.

- **Refactors**
  - Migrated to @Observable and Environment injection (replaces ObservableObject/@Published and EnvironmentObject) across core types: TabManager, Workspace, UpdateViewModel, TerminalNotificationStore, SidebarState, SidebarSelectionState, and control helpers.
  - Introduced lightweight Combine publishers (e.g., tabsPublisher, notificationsPublisher, statePublisher) where subscriptions are needed.
  - Replaced deprecated LaunchServices APIs (LSRegisterURL/CoreServices) with lsregister on a background queue; removed CoreServices import.
  - Updated SwiftUI APIs: new .onChange signature, foregroundStyle instead of foregroundColor, and NSApp.activate().
  - Reworked internal vsync-test harness from CVDisplayLink to a main-thread timer and aligned comments to CADisplayLink.

- **Bug Fixes**
  - Restored real LaunchServices bundle registration during startup to fix app registration regressions.
  - Switched modal alerts (quit warning, rename tab, open-folder) to sheet-based non-blocking flows to prevent freezing the UI.
  - Resolved activate/focus edge cases by using NSApp.activate() and improving window activation paths.

<sup>Written for commit b77ef428ee082f71ab937ef491f2700295a865bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog behavior to prevent application freezing during alerts and prompts.

* **Style**
  * Updated color styling across UI components for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->