### PR TITLE
Fix Shift+backquote emitting ;2;27~ in terminal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3481,10 +3481,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let chars = event.characters, !chars.isEmpty else { return nil }
 
         if chars.count == 1, let scalar = chars.unicodeScalars.first {
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
             // If we have a single control character, return the character without
             // the control modifier so Ghostty's KeyEncoder can handle it.
             if scalar.value < 0x20 {
-                return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
+                if flags.contains(.control) {
+                    return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
+                }
+
+                // Some AppKit key paths can report Shift+` as a bare ESC control
+                // character even though the physical key should produce "~".
+                if scalar.value == 0x1B,
+                   flags == [.shift],
+                   event.charactersIgnoringModifiers == "`" {
+                    return "~"
+                }
             }
             // Private Use Area characters (function keys) should not be sent
             if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
@@ -3497,7 +3509,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     /// Get the unshifted codepoint for the key event
     private func unshiftedCodepointFromEvent(_ event: NSEvent) -> UInt32 {
-        guard let chars = event.characters(byApplyingModifiers: []),
+        if let layoutChars = KeyboardLayout.character(forKeyCode: event.keyCode),
+           layoutChars.count == 1,
+           let layoutScalar = layoutChars.unicodeScalars.first,
+           layoutScalar.value >= 0x20,
+           !(layoutScalar.value >= 0xF700 && layoutScalar.value <= 0xF8FF) {
+            return layoutScalar.value
+        }
+
+        guard let chars = (event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers ?? event.characters),
               let scalar = chars.unicodeScalars.first else { return 0 }
         return scalar.value
     }

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -882,3 +882,65 @@ final class GhosttySpaceReleaseRegressionTests: XCTestCase {
         XCTAssertNil(releaseEvent.text)
     }
 }
+
+final class GhosttyBackquoteRegressionTests: XCTestCase {
+    func testShiftBackquoteEscFallbackSendsLiteralTilde() {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            window.orderOut(nil)
+        }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        var pressText: String?
+        var pressUnshiftedCodepoint: UInt32?
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 50 else { return }
+            pressUnshiftedCodepoint = keyEvent.unshifted_codepoint
+            if let text = keyEvent.text {
+                pressText = String(cString: text)
+            } else {
+                pressText = nil
+            }
+        }
+
+        let sent = hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
+            characters: "\u{1B}",
+            charactersIgnoringModifiers: "`",
+            keyCode: 50,
+            modifierFlags: [.shift]
+        )
+        XCTAssertTrue(sent, "Expected synthetic Shift+backquote event to be dispatched")
+        XCTAssertEqual(pressText, "~")
+        XCTAssertEqual(pressUnshiftedCodepoint, "`".unicodeScalars.first?.value)
+    }
+}


### PR DESCRIPTION
## Summary
- treat control-character translation as Ctrl-specific, so non-Ctrl key paths no longer leak control payloads
- add a targeted fallback for AppKit's anomalous Shift+backquote event shape (`characters=ESC`, `charactersIgnoringModifiers=\``) to emit a literal `~`
- derive `unshifted_codepoint` from `KeyboardLayout.character(forKeyCode:)` first, so symbol keys are stable even when event text is malformed
- add `GhosttyBackquoteRegressionTests.testShiftBackquoteEscFallbackSendsLiteralTilde` to guard this regression

## Validation
- `./scripts/reload.sh --tag fix-tilde-key-810`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`

## Issue
- Fixes #810


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS key handling bug where Shift+backquote sent an ESC/garbage sequence. Now it reliably emits a literal "~". Fixes #810.

- **Bug Fixes**
  - Apply control-character translation only when Ctrl is pressed, so non-Ctrl keys don’t leak control chars.
  - Add a fallback for AppKit’s anomalous Shift+` event (characters=ESC, ignoringModifiers=`) to send "~".
  - Prefer KeyboardLayout.character(forKeyCode:) for the unshifted codepoint to keep symbol keys stable, and add a regression test for Shift+` output.

<sup>Written for commit 45aad82fc9adc7411f32e5586b2ef2803eb2f17c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control modifier handling for single-character control input.
  * Improved keyboard input handling for special key combinations with certain keyboard layouts.
  * Enhanced support for IME (Input Method Editor) scenarios.

* **Tests**
  * Added regression test for keyboard input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->