### PR TITLE
Remove hourly cron and skipped job from nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,9 +3,6 @@ name: Nightly macOS build
 on:
   push:
     branches: [main]
-  schedule:
-    # Every hour at :30. The 'decide' job skips if main has no new commits.
-    - cron: "30 * * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -367,12 +364,3 @@ jobs:
         run: |
           security delete-keychain build.keychain >/dev/null 2>&1 || true
           rm -f /tmp/cert.p12
-
-  skipped:
-    needs: decide
-    if: needs.decide.outputs.should_build != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: No nightly build needed
-        run: |
-          echo "No changes on main since last nightly tag; skipping build."


### PR DESCRIPTION
## Summary

- Remove the hourly cron schedule (`30 * * * *`) since every merge to main already triggers a nightly build
- Remove the `skipped` job which only echoed a message and caused confusing red X statuses when `cancel-in-progress` cancelled a run

Manual dispatch with `force=true` still works for rebuilding the same commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hourly cron and the cosmetic “skipped” job from the nightly macOS build to avoid redundant runs and confusing red X statuses. Merges to main still trigger nightlies, and you can manually rebuild the same commit via workflow_dispatch with force=true.

- **Refactors**
  - Removed schedule: 30 * * * *.
  - Deleted the skipped job that only echoed when a build was not needed.

<sup>Written for commit 31fd821604736b1cfd2577b6f4bc3a52d3421078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

