### PR TITLE
Fix Cmd+Shift+, Ghostty theme reload in cmux

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3345,6 +3345,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
+    func refreshTerminalSurfacesAfterGhosttyConfigReload(source: String) {
+        var refreshedCount = 0
+        forEachTerminalPanel { terminalPanel in
+            terminalPanel.hostedView.reconcileGeometryNow()
+            terminalPanel.surface.forceRefresh()
+            refreshedCount += 1
+        }
+#if DEBUG
+        dlog("reload.config.surfaceRefresh source=\(source) count=\(refreshedCount)")
+#endif
+    }
+
+    private func forEachTerminalPanel(_ body: (TerminalPanel) -> Void) {
+        var seenManagers: Set<ObjectIdentifier> = []
+
+        func visitManager(_ manager: TabManager?) {
+            guard let manager else { return }
+            let managerId = ObjectIdentifier(manager)
+            guard seenManagers.insert(managerId).inserted else { return }
+            for workspace in manager.tabs {
+                for panel in workspace.panels.values {
+                    guard let terminalPanel = panel as? TerminalPanel else { continue }
+                    body(terminalPanel)
+                }
+            }
+        }
+
+        visitManager(tabManager)
+        for context in mainWindowContexts.values {
+            visitManager(context.tabManager)
+        }
+    }
+
     func focusMainWindow(windowId: UUID) -> Bool {
         guard let window = windowForMainWindowId(windowId) else { return false }
         if TerminalController.shouldSuppressSocketCommandActivation() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -660,6 +660,7 @@ class GhosttyApp {
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
         ghostty_config_load_default_files(config)
         loadLegacyGhosttyConfigIfNeeded(config)
+        ghostty_config_load_recursive_files(config)
         ghostty_config_finalize(config)
     }
 
@@ -767,6 +768,7 @@ class GhosttyApp {
             ghostty_app_update_config(app, config)
             lastAppearanceColorScheme = GhosttyConfig.currentColorSchemePreference()
             NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
+            scheduleSurfaceRefreshAfterConfigurationReload(source: source)
             logThemeAction("reload end source=\(source) soft=\(soft) mode=soft")
             return
         }
@@ -791,7 +793,14 @@ class GhosttyApp {
         config = newConfig
         lastAppearanceColorScheme = GhosttyConfig.currentColorSchemePreference()
         NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
+        scheduleSurfaceRefreshAfterConfigurationReload(source: source)
         logThemeAction("reload end source=\(source) soft=\(soft) mode=full")
+    }
+
+    private func scheduleSurfaceRefreshAfterConfigurationReload(source: String) {
+        DispatchQueue.main.async {
+            AppDelegate.shared?.refreshTerminalSurfacesAfterGhosttyConfigReload(source: source)
+        }
     }
 
     func synchronizeThemeWithAppearance(_ appearance: NSAppearance?, source: String) {


### PR DESCRIPTION
## Summary\n- load recursive Ghostty config includes during reload so included config files are honored\n- refresh all live terminal surfaces after app config reload so theme changes repaint immediately\n- keep existing reload shortcut/menu paths and apply updates without requiring app restart\n\nCloses #812\n\n## Validation\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build\n- ./scripts/reload.sh --tag issue-812-reload-config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ghostty theme reload in cmux so changes apply immediately when using Cmd+Shift+, without restarting the app. Closes #812.

- **Bug Fixes**
  - Load recursive Ghostty config includes during reload so included files are honored.
  - Refresh all open terminal surfaces after config reload for immediate theme repaint.
  - Keep existing reload shortcut/menu paths; no behavior changes for users.

<sup>Written for commit bba759f7ad2b7cd2aca7d14f54b880e75b7917d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal surfaces now automatically refresh when configuration files are reloaded
  * Configuration system now loads recursive configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->