### PR TITLE
Move UNUserNotificationCenter remove calls off main thread

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -8,16 +8,21 @@ import UserNotifications
 // indefinitely. These helpers dispatch the calls off the main thread so they never
 // freeze the UI.
 extension UNUserNotificationCenter {
+    private static let removalQueue = DispatchQueue(
+        label: "com.cmuxterm.notification-removal",
+        qos: .utility
+    )
+
     func removeDeliveredNotificationsOffMain(withIdentifiers ids: [String]) {
         guard !ids.isEmpty else { return }
-        DispatchQueue.global(qos: .utility).async {
+        Self.removalQueue.async {
             self.removeDeliveredNotifications(withIdentifiers: ids)
         }
     }
 
     func removePendingNotificationRequestsOffMain(withIdentifiers ids: [String]) {
         guard !ids.isEmpty else { return }
-        DispatchQueue.global(qos: .utility).async {
+        Self.removalQueue.async {
             self.removePendingNotificationRequests(withIdentifiers: ids)
         }
     }


### PR DESCRIPTION
## Summary

`removeDeliveredNotifications(withIdentifiers:)` and `removePendingNotificationRequests(withIdentifiers:)` perform synchronous XPC to `usernoted` under the hood. When `usernoted` is slow or overwhelmed, this blocks the main thread indefinitely, freezing the entire UI.

Confirmed via `sample` on both cmux (PID 56257) and cmux NIGHTLY (PID 53475): the main thread was stuck in `__NSXPCCONNECTION_IS_WAITING_FOR_A_SYNCHRONOUS_REPLY__` for the full 3-second sample duration. NIGHTLY had accumulated 846MB physical footprint because nothing could be freed while the main thread was blocked.

The fix adds two extension methods on `UNUserNotificationCenter` that dispatch the blocking calls to `DispatchQueue.global(qos: .utility)`. All 13 call sites in `TerminalNotificationStore` are fire-and-forget (void return, no data flows back to the caller), so this is safe. The `@Published` property mutations and dock badge updates remain on `@MainActor`.

Apple provides no async variants of these two methods, so off-main dispatch is the only option.

## Testing

- Build succeeds: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- Verified via `sample` that the blocking XPC calls were the root cause
- Killed `usernoted` to immediately unfreeze both hung processes

## Related

- Root cause: `usernoted` XPC stall blocking main thread in `TerminalNotificationStore.addNotification()` and `TerminalNotificationStore.markRead(forTabId:surfaceId:)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves notification removal off the main thread to prevent UI freezes when usernoted stalls. Updates TerminalNotificationStore to use background-dispatched helpers.

- **Bug Fixes**
  - Added UNUserNotificationCenter extensions that run removeDeliveredNotifications and removePendingNotificationRequests on a dedicated serial background queue to cap concurrency and avoid thread exhaustion.
  - Updated 13 call sites in TerminalNotificationStore to use the new methods; @Published mutations and dock badge updates stay on @MainActor.

<sup>Written for commit 58faf6daad8d21897f330f3e880d5328de965c92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Notification removal now runs off the main thread to avoid blocking the UI. Removal operations are dispatched to a dedicated background queue throughout the notification handling code, improving responsiveness when managing delivered and pending notifications while maintaining existing behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->