### PR TITLE
Fix settings dropdown width for Sidebar Branch Layout

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2985,7 +2985,8 @@ struct SettingsView: View {
                             "Sidebar Branch Layout",
                             subtitle: sidebarBranchVerticalLayout
                                 ? "Vertical: each branch appears on its own line."
-                                : "Inline: all branches share one line."
+                                : "Inline: all branches share one line.",
+                            controlWidth: pickerColumnWidth
                         ) {
                             Picker("", selection: $sidebarBranchVerticalLayout) {
                                 Text("Vertical").tag(true)


### PR DESCRIPTION
## Summary
- The Sidebar Branch Layout picker in Settings was missing `controlWidth: pickerColumnWidth`, causing the dropdown to expand full-width and hide its label/subtitle
- Added the same `controlWidth` parameter that all other picker rows use

## Test plan
- Open Settings, scroll to Sidebar Branch Layout row
- Verify the label and subtitle are visible, and the dropdown is constrained to the right column

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Sidebar Branch Layout picker in Settings so it no longer expands full width; the label and subtitle stay visible by setting controlWidth to pickerColumnWidth.

<sup>Written for commit e0e6589b32f49c174bca870baa468f73b2371f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout of the branch layout picker in Settings, refining the width and alignment of branch layout options for enhanced visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->