### PR TITLE
Revert: Fix Cmd+Tab activation ordering (#766)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1523,7 +1523,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
     private var commandPaletteSelectionByWindowId: [UUID: Int] = [:]
     private var commandPaletteSnapshotByWindowId: [UUID: CommandPaletteDebugSnapshot] = [:]
-    private weak var lastActiveMainWindow: NSWindow?
 
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
@@ -1582,10 +1581,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        if NSApp.activationPolicy() != .regular {
-            NSApp.setActivationPolicy(.regular)
-        }
-
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
         let telemetryEnabled = TelemetrySettings.enabledForCurrentLaunch
@@ -1751,7 +1746,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             tab.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
         }
         notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
-        bringMainWindowToFrontOnActivationIfNeeded()
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -7196,7 +7190,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             queue: .main
         ) { [weak self] note in
             guard let self, let window = note.object as? NSWindow else { return }
-            self.lastActiveMainWindow = window
             self.setActiveMainWindow(window)
         }
     }
@@ -7554,36 +7547,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             notificationStore.markRead(id: notificationId)
         }
-    }
-
-    private func bringMainWindowToFrontOnActivationIfNeeded() {
-        guard let window = frontmostKnownMainWindow() else { return }
-        bringToFront(window)
-    }
-
-    private func frontmostKnownMainWindow() -> NSWindow? {
-        let directCandidates: [NSWindow?] = [lastActiveMainWindow, NSApp.keyWindow, NSApp.mainWindow]
-        for candidate in directCandidates where candidate != nil {
-            if let window = candidate, isMainTerminalWindow(window) {
-                return window
-            }
-        }
-
-        if let activeManager = tabManager,
-           let context = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }),
-           let window = context.window ?? windowForMainWindowId(context.windowId) {
-            return window
-        }
-
-        if let visible = mainWindowContexts.values
-            .compactMap({ $0.window ?? windowForMainWindowId($0.windowId) })
-            .first(where: { $0.isVisible }) {
-            return visible
-        }
-
-        return mainWindowContexts.values
-            .compactMap({ $0.window ?? windowForMainWindowId($0.windowId) })
-            .first
     }
 
 #if DEBUG


### PR DESCRIPTION
## Summary
- Reverts PR #766 which introduced `setActivationPolicy(.regular)` and `bringMainWindowToFrontOnActivationIfNeeded()` in AppDelegate
- This PR caused a regression in the sidebar and topbar appearance by forcing the activation policy to `.regular`

## Context
- PR #766 was merged to fix issue #744 (Cmd+Tab doesn't always work)
- The fix changed `NSApp.setActivationPolicy(.regular)` which altered the window chrome styling
- Issue #744 will need a different approach that doesn't affect the app's visual appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert PR #766 to fix the sidebar/topbar styling regression caused by forcing the app to a regular activation policy. Removes NSApp.setActivationPolicy(.regular) and the main-window bring-to-front logic; Cmd+Tab issue #744 will be addressed separately without changing window chrome.

<sup>Written for commit e5e9a9c524af342a6479df2bbfb7379b015720f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup and optimizations with no impact on user-facing features or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->