### PR TITLE
Fix vi mode: require gg to scroll to top

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -304,10 +304,12 @@ enum TerminalKeyboardCopyModeAction: Equatable {
 struct TerminalKeyboardCopyModeInputState: Equatable {
     var countPrefix: Int?
     var pendingYankLine = false
+    var pendingG = false
 
     mutating func reset() {
         countPrefix = nil
         pendingYankLine = false
+        pendingG = false
     }
 }
 
@@ -439,7 +441,8 @@ func terminalKeyboardCopyModeAction(
         if normalized == [.shift] {
             return hasSelection ? .adjustSelection(.end) : .scrollToBottom
         }
-        return hasSelection ? .adjustSelection(.home) : .scrollToTop
+        // Bare "g" is a prefix key (e.g. gg); handled in resolve.
+        return nil
     case "0", "^":
         return hasSelection ? .adjustSelection(.beginningOfLine) : nil
     case "$", "4":
@@ -486,6 +489,17 @@ func terminalKeyboardCopyModeResolve(
         state.pendingYankLine = false
     }
 
+    if state.pendingG {
+        if chars == "g", normalized.isEmpty {
+            let count = terminalKeyboardCopyModeClampCount(state.countPrefix ?? 1)
+            let action: TerminalKeyboardCopyModeAction = hasSelection ? .adjustSelection(.home) : .scrollToTop
+            state.reset()
+            return .perform(action, count: count)
+        }
+        // Not `gg`, cancel and treat as fresh command.
+        state.pendingG = false
+    }
+
     if normalized.isEmpty,
        let scalar = chars.unicodeScalars.first,
        scalar.isASCII,
@@ -506,6 +520,11 @@ func terminalKeyboardCopyModeResolve(
 
     if !hasSelection, chars == "y", normalized.isEmpty {
         state.pendingYankLine = true
+        return .consume
+    }
+
+    if chars == "g", normalized.isEmpty {
+        state.pendingG = true
         return .consume
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1401,14 +1401,14 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
     }
 
     func testGAndShiftGMapping() {
-        XCTAssertEqual(
+        // Bare "g" is a prefix key (gg), not an immediate action.
+        XCTAssertNil(
             terminalKeyboardCopyModeAction(
                 keyCode: 5,
                 charactersIgnoringModifiers: "g",
                 modifierFlags: [],
                 hasSelection: false
-            ),
-            .scrollToTop
+            )
         )
         XCTAssertEqual(
             terminalKeyboardCopyModeAction(
@@ -1645,6 +1645,43 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(18, chars: "2", hasSelection: false, state: &state), .consume)
         XCTAssertEqual(resolve(7, chars: "x", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testGGScrollsToTop() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .perform(.scrollToTop, count: 1))
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testGGWithSelectionAdjustsToHome() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: true, state: &state), .consume)
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: true, state: &state), .perform(.adjustSelection(.home), count: 1))
+    }
+
+    func testCountedGG() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(22, chars: "5", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .perform(.scrollToTop, count: 5))
+    }
+
+    func testPendingGCancelledByOtherKey() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .consume)
+        // "j" after "g" cancels pending g and processes "j" normally.
+        XCTAssertEqual(resolve(38, chars: "j", hasSelection: false, state: &state), .perform(.scrollLines(1), count: 1))
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testShiftGStillWorksImmediately() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(5, chars: "g", modifiers: [.shift], hasSelection: false, state: &state),
+            .perform(.scrollToBottom, count: 1)
+        )
         XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 }


### PR DESCRIPTION
## Summary
- Single `g` in keyboard copy mode (vi mode) was immediately scrolling to top. Standard vim requires `gg` (two presses).
- Added `pendingG` state to the input state machine, following the existing `pendingYankLine` pattern for `yy`.
- `G` (shift+g) still scrolls to bottom immediately.

## Testing
- Unit tests pass: `gg` scrolls to top, `g` alone consumes and waits, `g` + other key cancels pending and processes normally, counted `5gg` works, `G` unaffected.

## Related
- Fixes https://github.com/manaflow-ai/cmux/issues/841

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make vi copy mode match Vim: only gg scrolls to top; a single g now waits for the next key. Shift+G still scrolls to bottom, counts like 5gg work, and gg adjusts selection to home when a selection is active.

<sup>Written for commit 3dc18e5cd0c536860675b34d0fa8092030f99631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

