### PR TITLE
Skip keychain migration for DEV/staging builds

### DIFF
--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -238,7 +238,6 @@ enum SocketControlPasswordStore {
             kSecAttrAccount: legacyKeychainAccount,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
-            kSecUseAuthenticationUI: kSecUseAuthenticationUIFail,
         ]
 
         var result: CFTypeRef?


### PR DESCRIPTION
## Summary
- Skip `migrateLegacyKeychainPasswordIfNeeded` for debug and staging bundle IDs
- Each tagged DEV build gets a unique bundle ID (`com.cmuxterm.app.debug.<tag>`) with its own UserDefaults domain, so the migration version key is never set and migration runs on every launch
- The `SecItemCopyMatching` call triggers a macOS keychain access prompt because the ad-hoc re-signed binary doesn't match the ACL on the legacy keychain item

## Root cause
1. `reload.sh --tag X` builds with Xcode, copies the `.app`, modifies Info.plist to set a unique bundle ID
2. Re-signs with `codesign --force --sign -` (ad-hoc)
3. On launch, fresh UserDefaults domain means migration guard (`keychainMigrationVersion`) is unset
4. `SecItemCopyMatching` is called for legacy keychain service `com.cmuxterm.app.socket-control`
5. macOS prompts because the ad-hoc signature doesn't match the keychain item's ACL

## Fix
Guard the migration call in `cmuxApp.init()` using the existing `isDebugLikeBundleIdentifier` / `isStagingBundleIdentifier` helpers. DEV/staging builds never have legitimate legacy keychain passwords to migrate.

## Testing
- Build succeeds (`xcodebuild -scheme cmux -configuration Debug`)
- Tagged DEV builds should no longer prompt for keychain access on launch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip legacy keychain password migration for DEV and staging builds to stop macOS keychain prompts on tagged DEV launches. Migration now runs only for production bundle IDs.

- **Bug Fixes**
  - Guarded migrateLegacyKeychainPasswordIfNeeded in cmuxApp.init() using isDebugLikeBundleIdentifier and isStagingBundleIdentifier.

<sup>Written for commit a77dcdd74160ca1b27ee8f7239da68138541a03b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keychain authentication handling to reduce unnecessary system prompts
  * Fixed legacy password migration behavior to prevent authentication dialogs on development builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->