### PR TITLE
Vi mode: half-page scroll, visible cursor, gg fix

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3315,10 +3315,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: ghostty_surface_t) {
-        guard !ghostty_surface_has_selection(surface) else { return }
+        // In visual mode the user owns the selection range; don't disturb it.
+        // Outside visual mode we keep a 1-cell cursor selection for visibility,
+        // so we still need to refresh the viewport row after scrolling.
+        guard !keyboardCopyModeVisualActive else { return }
         guard let anchor = keyboardCopyModeSelectionAnchor(surface: surface) else { return }
         keyboardCopyModeViewportRow = anchor.row
-        _ = ghostty_surface_clear_selection(surface)
+        // Preserve the visible cursor indicator.
+        _ = ghostty_surface_select_cursor_cell(surface)
     }
 
     private func copyCurrentViewportLinesToClipboard(
@@ -3419,9 +3423,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
         case let .scrollHalfPage(delta):
             let fraction = delta > 0 ? 0.5 : -0.5
-            for _ in 0 ..< count {
-                _ = performBindingAction("scroll_page_fractional:\(fraction)")
-            }
+            performBindingAction("scroll_page_fractional:\(fraction)", repeatCount: count)
             refreshKeyboardCopyModeViewportRowFromVisibleAnchor(surface: surface)
         case .scrollToTop:
             keyboardCopyModeViewportRow = 0

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1662,6 +1662,7 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(5, chars: "g", hasSelection: true, state: &state), .consume)
         XCTAssertEqual(resolve(5, chars: "g", hasSelection: true, state: &state), .perform(.adjustSelection(.home), count: 1))
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 
     func testCountedGG() {


### PR DESCRIPTION
## Summary
- **Ctrl+U/D half-page scroll**: Was full-page (same as Ctrl+B/F). Now correctly scrolls half a page using Ghostty's `scroll_page_fractional` binding. Ctrl+B/F remain full-page.
- **Visible cursor on copy mode entry**: `select_cursor_cell` creates a 1-cell selection as a cursor indicator when entering copy mode. Visual mode (`v`) tracked separately so the cursor doesn't make every motion extend a selection.
- **gg two-key sequence**: Single `g` now waits for next key. `gg` scrolls to top. Same `pendingG` state pattern as `pendingYankLine` for `yy`. (Supersedes https://github.com/manaflow-ai/cmux/pull/843)

## Testing
- 9 new unit tests, all passing (662 total passed, 5 pre-existing failures unrelated)
- Tests cover: gg/counted gg/g cancellation/G immediate, Ctrl+U half-page, Ctrl+D half-page, Ctrl+B full-page, Ctrl+F full-page

## Related
- Part of https://github.com/manaflow-ai/cmux/issues/846 (vi mode comprehensive improvement plan)
- Supersedes https://github.com/manaflow-ai/cmux/pull/843 (gg fix only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved vi copy mode with half-page scrolling, a visible cursor indicator, correct gg behavior, and reliable viewport row refresh in non-visual mode.

- **New Features**
  - Ctrl+U/D scroll half-page via Ghostty’s scroll_page_fractional; Ctrl+B/F stay full-page.
  - Visible cursor on entry: create a 1-cell selection; track visual mode (v) separately so motions don’t auto-extend; exiting visual restores the cursor cell.
  - 'g' is now a prefix; 'gg' jumps to top (with selection: adjust to home). Shift+G still jumps to bottom. Counts supported; non-gg cancels.

- **Bug Fixes**
  - Viewport row now refreshes after scrolling when not in visual mode; guard on visual-mode flag and re-create the 1-cell cursor selection to keep it visible.

<sup>Written for commit 2518d7c4832a0f2dadb668066c32070efc9850e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Half-page scrolling in copy-mode for Ctrl‑U/Ctrl‑D and similar commands for smoother navigation
  * Improved "gg" handling: bare "g" acts as a prefix and double "g" jumps to the top reliably
  * Visual-selection improvements so cursor remains visible and scrolling won't unintentionally extend selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->