### PR TITLE
Fix video layout shift on blog post

### DIFF
--- a/web/app/blog/cmd-shift-u/page.tsx
+++ b/web/app/blog/cmd-shift-u/page.tsx
@@ -60,11 +60,13 @@ export default function CmdShiftUPage() {
 
       <video
         src="/blog/cmd-shift-u.mp4"
+        width={1824}
+        height={1080}
         autoPlay
         loop
         muted
         playsInline
-        className="my-6 rounded-lg w-full"
+        className="my-6 rounded-lg w-full h-auto"
       />
 
       <p>


### PR DESCRIPTION
## Summary
- Add explicit `width`/`height` attributes to the video element so the browser reserves the correct aspect ratio (1824x1080) before the video loads

## Testing
- Load `/blog/cmd-shift-u` and confirm no layout shift when the video appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent layout shift on /blog/cmd-shift-u. The video now sets width/height (1824x1080) and uses h-auto so the browser preserves the aspect ratio before it loads.

<sup>Written for commit 5e0477c0cb04c556e8506245e130af9cd24091f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

