### PR TITLE
Reduce typing lag by hiding invisible views from accessibility tree

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1821,15 +1821,18 @@ struct ContentView: View {
                     )
                     .opacity(isVisible ? 1 : 0)
                     .allowsHitTesting(isSelectedWorkspace)
+                    .accessibilityHidden(!isVisible)
                     .zIndex(isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0))
                 }
             }
             .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
             .allowsHitTesting(sidebarSelectionState.selection == .tabs)
+            .accessibilityHidden(sidebarSelectionState.selection != .tabs)
 
             NotificationsPage(selection: $sidebarSelectionState.selection)
                 .opacity(sidebarSelectionState.selection == .notifications ? 1 : 0)
                 .allowsHitTesting(sidebarSelectionState.selection == .notifications)
+                .accessibilityHidden(sidebarSelectionState.selection != .notifications)
         }
         .padding(.top, titlebarPadding)
         .overlay(alignment: .top) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6398,6 +6398,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let container = HostContainerView()
         container.wantsLayer = false
+        // The actual terminal surface lives in the AppKit portal layer above SwiftUI.
+        // This empty placeholder should not be walked by the accessibility subsystem.
+        container.setAccessibilityRole(.none)
+        container.setAccessibilityElement(false)
         return container
     }
 


### PR DESCRIPTION
## Summary

Profiling cmux NIGHTLY with `sample` shows the main thread spending ~24% of CPU time in `AccessibilityViewGraph.needsUpdate` during every SwiftUI layout pass. The accessibility subsystem walks the entire view tree, including invisible views (opacity-0, hit-testing disabled), blocking the run loop from dequeuing key events and causing typing lag.

- Hide inactive workspaces from accessibility (`ContentView.swift`). All mounted workspaces sit in a ZStack; inactive ones are opacity-0 but still walked. Adding `.accessibilityHidden(!isVisible)` eliminates them from the walk.
- Hide the tabs/notifications containers from accessibility when not selected.
- Mark `GhosttyTerminalView`'s `HostContainerView` as non-accessible. This empty NSView placeholder (portal pattern) has no content since the terminal surface lives in the AppKit layer above SwiftUI.

Note: `NotificationsPage` is effectively dead code for users (all notification paths go to the popover). Could be removed entirely in a follow-up.

## Testing

- Built successfully in Debug configuration.
- Profile with `sample <pid> 10` while typing to compare `AccessibilityViewGraph.needsUpdate` sample counts before/after.

## Profiling data (before)

Main thread sample breakdown (10s capture, 5707 samples):
| Samples | % | What |
|---------|---|------|
| 3576 | 63% | `NSHostingView.layout()` → SwiftUI view graph render |
| 1381 | 24% | `AccessibilityViewGraph.needsUpdate` |
| 1287 | 23% | SwiftUI accessibility `UpdateStack::update()` |
| 514 | 9% | `AccessibilityViewModifierAccessor` |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide invisible SwiftUI views from the accessibility tree to reduce layout overhead and improve typing responsiveness. This cuts time spent in AccessibilityViewGraph.needsUpdate during layout.

- **Performance**
  - Add .accessibilityHidden(!isVisible) for inactive workspaces in ContentView.
  - Hide tabs and NotificationsPage from accessibility when not selected.
  - Mark GhosttyTerminalView’s HostContainerView as non-accessible (role .none, element false).

<sup>Written for commit 57427996577c41490ceee01c72d04b6050d99178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen reader and accessibility tool behavior by preventing them from traversing inactive UI sections, including hidden workspaces, non-selected notifications, and terminal placeholders. Users relying on assistive technologies will now experience more streamlined navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->