### PR TITLE
iOS-to-Mac remote terminal: streaming, Convex backend, device registration, SSH foundation

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4,6 +4,9 @@ import Darwin
 import Sentry
 #endif
 
+/// Global flag for attach mode signal handling (must be file-level for C signal handlers).
+private var attachRunning = false
+
 struct CLIError: Error, CustomStringConvertible {
     let message: String
 
@@ -1511,6 +1514,9 @@ struct CMUXCLI {
             let bridged = replaceToken(commandArgs, from: "--panel", to: "--surface")
             try runBrowserCommand(commandArgs: ["is-webview-focused"] + bridged, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        case "attach":
+            try runAttach(commandArgs: commandArgs, client: client, windowId: windowId)
+
         default:
             print(usage())
             throw CLIError(message: "Unknown command: \(command)")
@@ -2269,6 +2275,155 @@ struct CMUXCLI {
             idFormat: idFormat,
             windowOverride: windowOverride
         )
+    }
+
+    // MARK: - Attach
+
+    /// Attach to a terminal surface, bridging stdin/stdout to the surface's I/O.
+    /// Uses polling for screen output and surface.write_pty for raw input forwarding.
+    /// Detach with ~. (tilde-dot after newline/Enter).
+    private func runAttach(commandArgs: [String], client: SocketClient, windowId: String?) throws {
+        let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
+        let (sfArg, _) = parseOption(rem0, name: "--surface")
+        let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+        let surfaceArg = sfArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+
+        // Resolve workspace and surface
+        var params: [String: Any] = [:]
+        let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+        if let wsId { params["workspace_id"] = wsId }
+        let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
+        if let sfId { params["surface_id"] = sfId }
+
+        // Verify the surface exists by reading its content
+        let info = try client.sendV2(method: "surface.read_text", params: params)
+        guard let resolvedWs = info["workspace_id"] as? String,
+              let resolvedSf = info["surface_id"] as? String else {
+            throw CLIError(message: "Could not resolve workspace/surface")
+        }
+
+        // Check that stdin is a terminal
+        guard isatty(STDIN_FILENO) != 0 else {
+            throw CLIError(message: "attach requires an interactive terminal (stdin must be a tty)")
+        }
+
+        // Save original terminal attributes
+        var originalTermios = termios()
+        guard tcgetattr(STDIN_FILENO, &originalTermios) == 0 else {
+            throw CLIError(message: "Failed to get terminal attributes")
+        }
+
+        // Set raw mode
+        var rawTermios = originalTermios
+        cfmakeraw(&rawTermios)
+        tcsetattr(STDIN_FILENO, TCSANOW, &rawTermios)
+
+        // Ensure terminal is restored on exit
+        defer {
+            tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios)
+            // Clear screen and show detach message
+            let msg = "\u{1b}[2J\u{1b}[HDetached from \(resolvedWs)\r\n"
+            msg.withCString { ptr in
+                _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
+            }
+        }
+
+        // Set up signal handling for clean exit
+        attachRunning = true
+        signal(SIGINT) { _ in attachRunning = false }
+        signal(SIGTERM) { _ in attachRunning = false }
+        signal(SIGWINCH, SIG_IGN) // ignore resize for now
+
+        // Make stdin non-blocking
+        let stdinFlags = fcntl(STDIN_FILENO, F_GETFL)
+        fcntl(STDIN_FILENO, F_SETFL, stdinFlags | O_NONBLOCK)
+        defer { fcntl(STDIN_FILENO, F_SETFL, stdinFlags) }
+
+        // Print attach banner to stderr (doesn't interfere with terminal output)
+        FileHandle.standardError.write(Data("Attached to \(resolvedWs) / \(resolvedSf). Detach: ~.\r\n".utf8))
+
+        let readParams: [String: Any] = ["workspace_id": resolvedWs, "surface_id": resolvedSf]
+        let writeParams: [String: Any] = ["workspace_id": resolvedWs, "surface_id": resolvedSf]
+        var lastScreenContent = ""
+        var inputBuffer = [UInt8](repeating: 0, count: 4096)
+        var afterNewline = true // track ~. escape sequence state
+
+        // Initial screen draw
+        if let text = info["text"] as? String {
+            lastScreenContent = text
+            let output = "\u{1b}[2J\u{1b}[H" + text
+            output.withCString { ptr in
+                _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
+            }
+        }
+
+        // Main event loop
+        while attachRunning {
+            // Poll stdin with 50ms timeout
+            var fds = [pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0)]
+            let pollResult = poll(&fds, 1, 50)
+
+            if pollResult > 0 && (fds[0].revents & Int16(POLLIN)) != 0 {
+                let bytesRead = Darwin.read(STDIN_FILENO, &inputBuffer, inputBuffer.count)
+                if bytesRead <= 0 {
+                    break // EOF
+                }
+
+                // Check for ~. detach sequence
+                let inputSlice = inputBuffer[0..<bytesRead]
+                if let detachIdx = detectDetachSequence(inputSlice, afterNewline: &afterNewline) {
+                    // Send bytes before the detach sequence, then exit
+                    if detachIdx > 0 {
+                        let preDetach = Data(inputSlice[0..<detachIdx])
+                        let base64 = preDetach.base64EncodedString()
+                        var wp = writeParams
+                        wp["data"] = base64
+                        _ = try? client.sendV2(method: "surface.write_pty", params: wp)
+                    }
+                    break
+                }
+
+                // Forward all input bytes to the surface via raw pty write
+                let base64 = Data(inputSlice).base64EncodedString()
+                var wp = writeParams
+                wp["data"] = base64
+                _ = try? client.sendV2(method: "surface.write_pty", params: wp)
+            }
+
+            // Poll screen content for changes
+            if let screenRead = try? client.sendV2(method: "surface.read_text", params: readParams),
+               let text = screenRead["text"] as? String,
+               text != lastScreenContent {
+                lastScreenContent = text
+                let output = "\u{1b}[2J\u{1b}[H" + text
+                output.withCString { ptr in
+                    _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
+                }
+            }
+        }
+    }
+
+    /// Detect the ~. (tilde-dot) detach escape sequence in input bytes.
+    /// Returns the index of the tilde that starts the sequence, or nil if not found.
+    /// Updates afterNewline state for tracking across calls.
+    private func detectDetachSequence(_ bytes: ArraySlice<UInt8>, afterNewline: inout Bool) -> Int? {
+        for (i, byte) in bytes.enumerated() {
+            let ch = Character(UnicodeScalar(byte))
+            if afterNewline && ch == "~" {
+                // Check if next byte is "."
+                let nextIdx = bytes.startIndex + i + 1
+                if nextIdx < bytes.endIndex && bytes[nextIdx] == UInt8(ascii: ".") {
+                    return i
+                }
+                // Tilde without dot, not a detach
+                afterNewline = false
+            } else if byte == 0x0D || byte == 0x0A { // CR or LF
+                afterNewline = true
+            } else {
+                afterNewline = false
+            }
+        }
+        return nil
     }
 
     private func runBrowserCommand(
@@ -4223,6 +4378,27 @@ struct CMUXCLI {
             Example:
               cmux read-screen
               cmux read-screen --surface surface:2 --scrollback --lines 200
+            """
+        case "attach":
+            return """
+            Usage: cmux attach [flags]
+
+            Attach to a terminal surface, bridging stdin/stdout to its I/O.
+            Useful for remote access over SSH: ssh mac -- cmux attach --workspace workspace:1
+
+            Input is forwarded as raw bytes to the terminal's pty. Screen content is
+            polled and displayed as plain text (no colors/styles in this version).
+
+            Detach with ~. (tilde then dot, after Enter).
+
+            Flags:
+              --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
+              --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
+
+            Example:
+              cmux attach
+              cmux attach --workspace workspace:3
+              ssh macbook -- cmux attach --workspace workspace:1
             """
         case "send":
             return """
@@ -6415,6 +6591,7 @@ struct CMUXCLI {
           rename-window [--workspace <id|ref>] <title>
           current-workspace
           read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
+          attach [--workspace <id|ref>] [--surface <id|ref>]
           send [--workspace <id|ref>] [--surface <id|ref>] <text>
           send-key [--workspace <id|ref>] [--surface <id|ref>] <key>
           send-panel --panel <id|ref> [--workspace <id|ref>] <text>

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -511,10 +511,79 @@ final class SocketClient {
         }
     }
 
+    /// Raw socket file descriptor. Only valid after connect().
+    var fd: Int32 { socketFD }
+
     func close() {
         if socketFD >= 0 {
             Darwin.close(socketFD)
             socketFD = -1
+        }
+    }
+
+    /// Send a v2 request that upgrades to a raw stream. Returns the JSON header
+    /// and any extra bytes read past the header newline (bootstrap data).
+    func sendV2StreamRequest(method: String, params: [String: Any] = [:]) throws -> (header: [String: Any], extra: Data) {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params
+        ]
+        let requestData = try JSONSerialization.data(withJSONObject: request, options: [])
+        guard let requestLine = String(data: requestData, encoding: .utf8) else {
+            throw CLIError(message: "Failed to encode v2 request")
+        }
+        let payload = requestLine + "\n"
+        try payload.withCString { ptr in
+            let sent = Darwin.write(socketFD, ptr, strlen(ptr))
+            if sent < 0 { throw CLIError(message: "Failed to write to socket") }
+        }
+
+        // Read until we get a complete JSON line (terminated by newline).
+        // Anything after the newline is the start of the raw byte stream.
+        var accumulated = Data()
+        let start = Date()
+        while true {
+            var pollFD = pollfd(fd: socketFD, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&pollFD, 1, 100)
+            if ready < 0 { throw CLIError(message: "Socket read error") }
+            if ready == 0 {
+                if Date().timeIntervalSince(start) > Self.responseTimeoutSeconds {
+                    throw CLIError(message: "Stream request timed out")
+                }
+                continue
+            }
+            var buffer = [UInt8](repeating: 0, count: 8192)
+            let count = Darwin.read(socketFD, &buffer, buffer.count)
+            if count <= 0 { throw CLIError(message: "Socket closed during stream handshake") }
+            accumulated.append(buffer, count: count)
+
+            // Look for the header line terminator
+            if let newlineIdx = accumulated.firstIndex(of: UInt8(0x0A)) {
+                let headerData = accumulated[accumulated.startIndex..<newlineIdx]
+                let extra = accumulated[accumulated.index(after: newlineIdx)...]
+
+                guard let headerStr = String(data: headerData, encoding: .utf8) else {
+                    throw CLIError(message: "Invalid UTF-8 in stream header")
+                }
+                if headerStr.hasPrefix("ERROR:") {
+                    throw CLIError(message: headerStr)
+                }
+                guard let headerJSON = headerStr.data(using: .utf8),
+                      let response = try JSONSerialization.jsonObject(with: headerJSON, options: []) as? [String: Any] else {
+                    throw CLIError(message: "Invalid stream header: \(headerStr)")
+                }
+                if let ok = response["ok"] as? Bool, ok {
+                    let result = (response["result"] as? [String: Any]) ?? [:]
+                    return (result, Data(extra))
+                }
+                if let error = response["error"] as? [String: Any] {
+                    let code = (error["code"] as? String) ?? "error"
+                    let message = (error["message"] as? String) ?? "Unknown error"
+                    throw CLIError(message: "\(code): \(message)")
+                }
+                throw CLIError(message: "Unexpected stream header: \(headerStr)")
+            }
         }
     }
 
@@ -1515,7 +1584,7 @@ struct CMUXCLI {
             try runBrowserCommand(commandArgs: ["is-webview-focused"] + bridged, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
         case "attach":
-            try runAttach(commandArgs: commandArgs, client: client, windowId: windowId)
+            try runAttach(commandArgs: commandArgs, client: client, windowId: windowId, socketPath: socketPath)
 
         default:
             print(usage())
@@ -2282,7 +2351,7 @@ struct CMUXCLI {
     /// Attach to a terminal surface, bridging stdin/stdout to the surface's I/O.
     /// Uses polling for screen output and surface.write_pty for raw input forwarding.
     /// Detach with ~. (tilde-dot after newline/Enter).
-    private func runAttach(commandArgs: [String], client: SocketClient, windowId: String?) throws {
+    private func runAttach(commandArgs: [String], client: SocketClient, windowId: String?, socketPath: String) throws {
         let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
         let (sfArg, _) = parseOption(rem0, name: "--surface")
         let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
@@ -2295,17 +2364,25 @@ struct CMUXCLI {
         let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
         if let sfId { params["surface_id"] = sfId }
 
-        // Verify the surface exists by reading its content
-        let info = try client.sendV2(method: "surface.read_text", params: params)
-        guard let resolvedWs = info["workspace_id"] as? String,
-              let resolvedSf = info["surface_id"] as? String else {
-            throw CLIError(message: "Could not resolve workspace/surface")
-        }
-
         // Check that stdin is a terminal
         guard isatty(STDIN_FILENO) != 0 else {
             throw CLIError(message: "attach requires an interactive terminal (stdin must be a tty)")
         }
+
+        // Open a dedicated connection for the output stream. The original `client`
+        // is used for input forwarding (surface.write_pty) over the RPC protocol.
+        let streamClient = SocketClient(path: socketPath)
+        try streamClient.connect()
+
+        // Request stream upgrade. Server responds with JSON header + bootstrap bytes,
+        // then switches to raw pty output.
+        let (header, extraBytes) = try streamClient.sendV2StreamRequest(
+            method: "surface.attach_stream",
+            params: params
+        )
+        let resolvedWs = (header["workspace_id"] as? String) ?? "unknown"
+        let resolvedSf = (header["surface_id"] as? String) ?? "unknown"
+        let streamFD = streamClient.fd
 
         // Save original terminal attributes
         var originalTermios = termios()
@@ -2321,7 +2398,7 @@ struct CMUXCLI {
         // Ensure terminal is restored on exit
         defer {
             tcsetattr(STDIN_FILENO, TCSANOW, &originalTermios)
-            // Clear screen and show detach message
+            streamClient.close()
             let msg = "\u{1b}[2J\u{1b}[HDetached from \(resolvedWs)\r\n"
             msg.withCString { ptr in
                 _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
@@ -2342,28 +2419,48 @@ struct CMUXCLI {
         // Print attach banner to stderr (doesn't interfere with terminal output)
         FileHandle.standardError.write(Data("Attached to \(resolvedWs) / \(resolvedSf). Detach: ~.\r\n".utf8))
 
-        let readParams: [String: Any] = ["workspace_id": resolvedWs, "surface_id": resolvedSf]
         let writeParams: [String: Any] = ["workspace_id": resolvedWs, "surface_id": resolvedSf]
-        var lastScreenContent = ""
         var inputBuffer = [UInt8](repeating: 0, count: 4096)
+        var streamBuffer = [UInt8](repeating: 0, count: 16384)
         var afterNewline = true // track ~. escape sequence state
 
-        // Initial screen draw
-        if let text = info["text"] as? String {
-            lastScreenContent = text
-            let output = "\u{1b}[2J\u{1b}[H" + text
-            output.withCString { ptr in
-                _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
+        // Write any bootstrap bytes that arrived with the header
+        if !extraBytes.isEmpty {
+            extraBytes.withUnsafeBytes { rawBuf in
+                guard let ptr = rawBuf.baseAddress else { return }
+                _ = Darwin.write(STDOUT_FILENO, ptr, extraBytes.count)
             }
         }
 
-        // Main event loop
+        // Main event loop: multiplex stdin (input) and stream socket (output)
         while attachRunning {
-            // Poll stdin with 50ms timeout
-            var fds = [pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0)]
-            let pollResult = poll(&fds, 1, 50)
+            var fds = [
+                pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0),
+                pollfd(fd: streamFD, events: Int16(POLLIN), revents: 0)
+            ]
+            let pollResult = poll(&fds, 2, 100)
+            if pollResult < 0 {
+                if errno == EINTR { continue }
+                break
+            }
 
-            if pollResult > 0 && (fds[0].revents & Int16(POLLIN)) != 0 {
+            // Handle stream output (pty bytes from cmux app)
+            if fds[1].revents & Int16(POLLIN) != 0 {
+                let bytesRead = Darwin.read(streamFD, &streamBuffer, streamBuffer.count)
+                if bytesRead <= 0 {
+                    // Stream closed (surface destroyed or cmux quit)
+                    break
+                }
+                _ = Darwin.write(STDOUT_FILENO, &streamBuffer, bytesRead)
+            }
+
+            // Check for stream error/hangup
+            if fds[1].revents & (Int16(POLLHUP) | Int16(POLLERR)) != 0 {
+                break
+            }
+
+            // Handle stdin input
+            if fds[0].revents & Int16(POLLIN) != 0 {
                 let bytesRead = Darwin.read(STDIN_FILENO, &inputBuffer, inputBuffer.count)
                 if bytesRead <= 0 {
                     break // EOF
@@ -2388,17 +2485,6 @@ struct CMUXCLI {
                 var wp = writeParams
                 wp["data"] = base64
                 _ = try? client.sendV2(method: "surface.write_pty", params: wp)
-            }
-
-            // Poll screen content for changes
-            if let screenRead = try? client.sendV2(method: "surface.read_text", params: readParams),
-               let text = screenRead["text"] as? String,
-               text != lastScreenContent {
-                lastScreenContent = text
-                let output = "\u{1b}[2J\u{1b}[H" + text
-                output.withCString { ptr in
-                    _ = Darwin.write(STDOUT_FILENO, ptr, strlen(ptr))
-                }
             }
         }
     }
@@ -4383,11 +4469,9 @@ struct CMUXCLI {
             return """
             Usage: cmux attach [flags]
 
-            Attach to a terminal surface, bridging stdin/stdout to its I/O.
-            Useful for remote access over SSH: ssh mac -- cmux attach --workspace workspace:1
-
-            Input is forwarded as raw bytes to the terminal's pty. Screen content is
-            polled and displayed as plain text (no colors/styles in this version).
+            Attach to a terminal surface, streaming raw pty output to stdout and
+            forwarding stdin as input. Supports full colors, cursor movement, and
+            all VT escape sequences. Useful for remote access over SSH.
 
             Detach with ~. (tilde then dot, after Enter).
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -58,6 +58,10 @@
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
+		A5001700 /* ConvexHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701 /* ConvexHTTPClient.swift */; };
+		A5001702 /* TailscaleInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001703 /* TailscaleInfo.swift */; };
+		A5001704 /* DeviceRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001705 /* DeviceRegistrationManager.swift */; };
+		A5001706 /* SurfaceOutputStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001707 /* SurfaceOutputStreamer.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
@@ -190,6 +194,10 @@
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
+		A5001701 /* ConvexHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvexHTTPClient.swift; sourceTree = "<group>"; };
+		A5001703 /* TailscaleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TailscaleInfo.swift; sourceTree = "<group>"; };
+		A5001705 /* DeviceRegistrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegistrationManager.swift; sourceTree = "<group>"; };
+		A5001707 /* SurfaceOutputStreamer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceOutputStreamer.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -367,6 +375,10 @@
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
+				A5001701 /* ConvexHTTPClient.swift */,
+				A5001703 /* TailscaleInfo.swift */,
+				A5001705 /* DeviceRegistrationManager.swift */,
+				A5001707 /* SurfaceOutputStreamer.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -606,6 +618,10 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
+				A5001700 /* ConvexHTTPClient.swift in Sources */,
+				A5001702 /* TailscaleInfo.swift in Sources */,
+				A5001704 /* DeviceRegistrationManager.swift in Sources */,
+				A5001706 /* SurfaceOutputStreamer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1450,6 +1450,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserOmnibarRepeatDelta: Int = 0
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
+    private var deviceRegistrationManager: DeviceRegistrationManager?
     private let updateController = UpdateController()
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(viewModel: updateViewModel)
     private let windowDecorationsController = WindowDecorationsController()
@@ -1670,6 +1671,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             PostHogAnalytics.shared.startIfNeeded()
         }
 
+        if !isRunningUnderXCTest {
+            startDeviceRegistrationIfConfigured()
+        }
+
         // UI tests frequently time out waiting for the main window if we do heavyweight
         // LaunchServices registration / single-instance enforcement synchronously at startup.
         // Skip these during XCTest (the app-under-test) so the window can appear quickly.
@@ -1801,6 +1806,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
         stopSocketListenerHealthMonitor()
+        stopDeviceRegistration()
         TerminalController.shared.stop()
         VSCodeServeWebController.shared.stop()
         BrowserHistoryStore.shared.flushPendingSaves()
@@ -2407,6 +2413,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         lifecycleSnapshotObservers.append(sessionResignObserver)
 
+        let willSleepObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.stopDeviceRegistration()
+            }
+        }
+        lifecycleSnapshotObservers.append(willSleepObserver)
+
         let didWakeObserver = workspaceCenter.addObserver(
             forName: NSWorkspace.didWakeNotification,
             object: nil,
@@ -2414,6 +2431,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.restartSocketListenerIfEnabled(source: "workspace.didWake")
+                self?.startDeviceRegistrationIfConfigured()
             }
         }
         lifecycleSnapshotObservers.append(didWakeObserver)
@@ -2459,6 +2477,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func stopSocketListenerHealthMonitor() {
         socketListenerHealthTimer?.cancel()
         socketListenerHealthTimer = nil
+    }
+
+    // MARK: - Device Registration (Convex)
+
+    private static let convexURLDefaultsKey = "com.cmux.convexURL"
+    private static let convexAPIKeyDefaultsKey = "com.cmux.convexAPIKey"
+
+    private func startDeviceRegistrationIfConfigured() {
+        let defaults = UserDefaults.standard
+        guard let urlString = defaults.string(forKey: Self.convexURLDefaultsKey),
+              let baseURL = URL(string: urlString),
+              let apiKey = defaults.string(forKey: Self.convexAPIKeyDefaultsKey),
+              !apiKey.isEmpty else {
+            return
+        }
+        guard deviceRegistrationManager == nil else { return }
+        let client = ConvexHTTPClient(baseURL: baseURL, apiKey: apiKey)
+        let manager = DeviceRegistrationManager(client: client)
+        deviceRegistrationManager = manager
+        Task {
+            await manager.start()
+        }
+    }
+
+    private func stopDeviceRegistration() {
+        guard let manager = deviceRegistrationManager else { return }
+        deviceRegistrationManager = nil
+        Task {
+            await manager.stop()
+        }
     }
 
     private func restartSocketListenerIfNeededForHealthCheck(source: String) {

--- a/Sources/ConvexHTTPClient.swift
+++ b/Sources/ConvexHTTPClient.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct DeviceRegistration: Codable {
+    let deviceId: String
+    let hostname: String
+    let tailscaleHostname: String?
+    let sshPort: Int
+    let capabilities: [String]
+    let osVersion: String
+    let appVersion: String
+}
+
+struct TerminalEvent: Codable {
+    let deviceId: String
+    let type: String
+    let title: String
+    let body: String?
+    let workspaceId: String?
+}
+
+struct WorkspaceSnapshot: Codable {
+    let id: String
+    let title: String
+    let surfaceCount: Int
+    let hasActivity: Bool
+}
+
+private struct ConvexMutationBody<A: Encodable>: Encodable {
+    let path: String
+    let args: A
+}
+
+/// HTTP client for Convex backend API calls (device registration, events, workspace sync).
+/// Uses URLSession for async HTTP. Auth via Bearer token (API key).
+final class ConvexHTTPClient: @unchecked Sendable {
+    private let baseURL: URL
+    private let apiKey: String
+    private let session: URLSession
+
+    init(baseURL: URL, apiKey: String) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        self.session = URLSession(configuration: config)
+    }
+
+    func registerDevice(_ device: DeviceRegistration) async throws {
+        try await mutation("devices:register", args: device)
+    }
+
+    func heartbeat(deviceId: String) async throws {
+        try await mutation("devices:heartbeat", args: ["deviceId": deviceId])
+    }
+
+    func markOffline(deviceId: String) async throws {
+        try await mutation("devices:markOffline", args: ["deviceId": deviceId])
+    }
+
+    func sendEvent(_ event: TerminalEvent) async throws {
+        try await mutation("events:send", args: event)
+    }
+
+    func syncWorkspaces(deviceId: String, workspaces: [WorkspaceSnapshot]) async throws {
+        struct SyncArgs: Encodable {
+            let deviceId: String
+            let workspaces: [WorkspaceSnapshot]
+        }
+        try await mutation("devices:syncWorkspaces", args: SyncArgs(
+            deviceId: deviceId,
+            workspaces: workspaces
+        ))
+    }
+
+    // MARK: - Transport
+
+    private func mutation<T: Encodable>(_ path: String, args: T) async throws {
+        let url = baseURL.appendingPathComponent("api/mutation")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let body = ConvexMutationBody(path: path, args: args)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ConvexError.invalidResponse
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ConvexError.httpError(statusCode: httpResponse.statusCode, message: message)
+        }
+    }
+
+    private func mutation(_ path: String, args: [String: Any]) async throws {
+        let url = baseURL.appendingPathComponent("api/mutation")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = ["path": path, "args": args]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ConvexError.invalidResponse
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ConvexError.httpError(statusCode: httpResponse.statusCode, message: message)
+        }
+    }
+}
+
+enum ConvexError: Error, LocalizedError {
+    case invalidResponse
+    case httpError(statusCode: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from Convex"
+        case .httpError(let statusCode, let message):
+            return "Convex HTTP \(statusCode): \(message)"
+        }
+    }
+}

--- a/Sources/DeviceRegistrationManager.swift
+++ b/Sources/DeviceRegistrationManager.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Manages device registration with Convex backend.
+/// Registers on launch, sends periodic heartbeats, marks offline on quit.
+final class DeviceRegistrationManager: @unchecked Sendable {
+    private let client: ConvexHTTPClient
+    private let deviceId: String
+    private var heartbeatTimer: Timer?
+    private let heartbeatInterval: TimeInterval = 60
+
+    private static let deviceIdKey = "com.cmux.deviceId"
+
+    init(client: ConvexHTTPClient) {
+        self.client = client
+
+        let defaults = UserDefaults.standard
+        if let existingId = defaults.string(forKey: Self.deviceIdKey) {
+            self.deviceId = existingId
+        } else {
+            let newId = UUID().uuidString
+            defaults.set(newId, forKey: Self.deviceIdKey)
+            self.deviceId = newId
+        }
+    }
+
+    /// Start registration and heartbeat. Call on app launch.
+    func start() async {
+        await register()
+        startHeartbeat()
+    }
+
+    /// Stop heartbeat and mark offline. Call on app quit/sleep.
+    func stop() async {
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
+        do {
+            try await client.markOffline(deviceId: deviceId)
+        } catch {
+            NSLog("DeviceRegistrationManager: failed to mark offline: \(error)")
+        }
+    }
+
+    /// Report a terminal event to Convex.
+    func reportEvent(_ event: TerminalEvent) async {
+        do {
+            try await client.sendEvent(event)
+        } catch {
+            NSLog("DeviceRegistrationManager: failed to send event: \(error)")
+        }
+    }
+
+    /// Sync current workspace list to Convex.
+    func syncWorkspaces(_ workspaces: [WorkspaceSnapshot]) async {
+        do {
+            try await client.syncWorkspaces(deviceId: deviceId, workspaces: workspaces)
+        } catch {
+            NSLog("DeviceRegistrationManager: failed to sync workspaces: \(error)")
+        }
+    }
+
+    // MARK: - Private
+
+    private func register() async {
+        let hostname = ProcessInfo.processInfo.hostName
+        let tailscaleHostname = TailscaleInfo.hostname()
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+
+        let registration = DeviceRegistration(
+            deviceId: deviceId,
+            hostname: hostname,
+            tailscaleHostname: tailscaleHostname,
+            sshPort: 22,
+            capabilities: ["terminal", "notifications", "workspaces"],
+            osVersion: osVersion,
+            appVersion: appVersion
+        )
+
+        do {
+            try await client.registerDevice(registration)
+        } catch {
+            NSLog("DeviceRegistrationManager: failed to register device: \(error)")
+        }
+    }
+
+    private func startHeartbeat() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.heartbeatTimer?.invalidate()
+            self.heartbeatTimer = Timer.scheduledTimer(
+                withTimeInterval: self.heartbeatInterval,
+                repeats: true
+            ) { [weak self] _ in
+                guard let self else { return }
+                Task {
+                    do {
+                        try await self.client.heartbeat(deviceId: self.deviceId)
+                    } catch {
+                        NSLog("DeviceRegistrationManager: heartbeat failed: \(error)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/SurfaceOutputStreamer.swift
+++ b/Sources/SurfaceOutputStreamer.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+/// Streams raw pty output bytes from a ghostty surface to connected clients.
+/// The output handler callback fires from the io-reader thread, so all buffer
+/// operations must be thread-safe and non-blocking.
+///
+/// Architecture:
+/// - ghostty_surface_set_output_handler -> outputHandlerCallback (io thread)
+/// - Callback writes into a lock-free ring buffer
+/// - Connected streaming clients are woken via dispatch sources to drain the buffer
+///
+/// Bootstrap: On attach, the current screen state is serialized as VT escape
+/// sequences and sent before transitioning to the live byte stream.
+final class SurfaceOutputStreamer {
+    /// Ring buffer capacity. 256KB is enough for typical terminal throughput
+    /// while keeping memory usage low.
+    static let bufferCapacity = 256 * 1024
+
+    /// Per-surface streamer keyed by surface UUID.
+    private static let lock = NSLock()
+    private static var streamers: [UUID: SurfaceOutputStreamer] = [:]
+
+    let surfaceId: UUID
+    private let ringBuffer: RingBuffer
+    private let clientsLock = NSLock()
+    private var clients: [StreamClient] = []
+    private var surface: ghostty_surface_t?
+    /// Set when ring buffer overflows; next drain will send a resync.
+    private var needsResync = false
+
+    init(surfaceId: UUID) {
+        self.surfaceId = surfaceId
+        self.ringBuffer = RingBuffer(capacity: Self.bufferCapacity)
+    }
+
+    // MARK: - Registry
+
+    /// Get or create a streamer for the given surface.
+    static func streamer(for surfaceId: UUID) -> SurfaceOutputStreamer {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = streamers[surfaceId] { return existing }
+        let s = SurfaceOutputStreamer(surfaceId: surfaceId)
+        streamers[surfaceId] = s
+        return s
+    }
+
+    /// Remove and detach a streamer.
+    static func remove(for surfaceId: UUID) {
+        lock.lock()
+        let s = streamers.removeValue(forKey: surfaceId)
+        lock.unlock()
+        s?.detach()
+    }
+
+    // MARK: - Ghostty hook
+
+    /// Attach the output handler to a ghostty surface. Must be called from main thread.
+    func attach(to surface: ghostty_surface_t) {
+        self.surface = surface
+        let userdata = Unmanaged.passUnretained(self).toOpaque()
+        ghostty_surface_set_output_handler(surface, Self.outputHandlerCallback, userdata)
+    }
+
+    /// Remove the output handler. Safe to call multiple times.
+    func detach() {
+        if let surface {
+            ghostty_surface_set_output_handler(surface, nil, nil)
+        }
+        surface = nil
+        // Disconnect all clients
+        clientsLock.lock()
+        let snapshot = clients
+        clients.removeAll()
+        clientsLock.unlock()
+        for c in snapshot { c.close() }
+    }
+
+    var hasClients: Bool {
+        clientsLock.lock()
+        defer { clientsLock.unlock() }
+        return !clients.isEmpty
+    }
+
+    // MARK: - Client management
+
+    /// Add a streaming client. The bootstrap payload (screen snapshot) should
+    /// already have been written to the fd before calling this.
+    func addClient(fd: Int32) {
+        let client = StreamClient(fd: fd, streamer: self)
+        clientsLock.lock()
+        clients.append(client)
+        clientsLock.unlock()
+        // Drain any bytes that arrived between bootstrap and hook registration
+        client.drain()
+    }
+
+    /// Remove a disconnected client.
+    func removeClient(_ client: StreamClient) {
+        clientsLock.lock()
+        clients.removeAll { $0 === client }
+        let empty = clients.isEmpty
+        clientsLock.unlock()
+        // If no more clients, we could optionally detach the hook to save
+        // overhead, but keeping it attached is simpler and the cost is negligible.
+        _ = empty
+    }
+
+    // MARK: - Ring buffer drain
+
+    /// Called by clients to read available bytes from the ring buffer.
+    /// Returns the bytes, or nil if empty.
+    func drainBytes() -> Data? {
+        return ringBuffer.drain()
+    }
+
+    // MARK: - Output handler callback
+
+    /// C callback invoked from the io-reader thread with raw pty bytes.
+    /// Must be non-blocking.
+    private static let outputHandlerCallback: @convention(c) (
+        UnsafeMutableRawPointer?, UnsafePointer<UInt8>?, Int
+    ) -> Void = { userdata, data, len in
+        guard let userdata, let data, len > 0 else { return }
+        let streamer = Unmanaged<SurfaceOutputStreamer>.fromOpaque(userdata).takeUnretainedValue()
+
+        let written = streamer.ringBuffer.write(data, count: len)
+        if written < len {
+            // Overflow: oldest bytes were overwritten. Flag for resync.
+            streamer.needsResync = true
+        }
+
+        // Wake all connected clients to drain
+        streamer.clientsLock.lock()
+        let snapshot = streamer.clients
+        streamer.clientsLock.unlock()
+        for client in snapshot {
+            client.signal()
+        }
+    }
+}
+
+// MARK: - Ring Buffer
+
+/// Fixed-size ring buffer. Single producer (io-reader thread), single/multi consumer (drain).
+/// Uses os_unfair_lock for minimal overhead since the critical section is just pointer arithmetic.
+final class RingBuffer {
+    private let capacity: Int
+    private let buffer: UnsafeMutablePointer<UInt8>
+    private var writePos: Int = 0
+    private var readPos: Int = 0
+    private var count: Int = 0
+    private var unfairLock = os_unfair_lock()
+
+    init(capacity: Int) {
+        self.capacity = capacity
+        self.buffer = .allocate(capacity: capacity)
+    }
+
+    deinit {
+        buffer.deallocate()
+    }
+
+    /// Write bytes into the ring buffer. If the buffer is full, overwrites oldest data.
+    /// Returns the number of bytes actually written without overwriting (for overflow detection).
+    func write(_ data: UnsafePointer<UInt8>, count len: Int) -> Int {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+
+        let available = capacity - count
+        var src = data
+        var remaining = len
+
+        // Write in up to two chunks (wrap around)
+        while remaining > 0 {
+            let chunkSize = min(remaining, capacity - writePos)
+            buffer.advanced(by: writePos).update(from: src, count: chunkSize)
+            writePos = (writePos + chunkSize) % capacity
+            src = src.advanced(by: chunkSize)
+            remaining -= chunkSize
+        }
+
+        if len <= available {
+            count += len
+            return len
+        } else {
+            // Overflowed: advance read position past overwritten data
+            count = capacity
+            readPos = writePos
+            return available
+        }
+    }
+
+    /// Drain all available bytes from the buffer.
+    func drain() -> Data? {
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+
+        guard count > 0 else { return nil }
+
+        var result = Data(capacity: count)
+        let toRead = count
+
+        if readPos + toRead <= capacity {
+            result.append(buffer.advanced(by: readPos), count: toRead)
+        } else {
+            let firstChunk = capacity - readPos
+            result.append(buffer.advanced(by: readPos), count: firstChunk)
+            result.append(buffer, count: toRead - firstChunk)
+        }
+
+        readPos = (readPos + toRead) % capacity
+        count = 0
+        return result
+    }
+}
+
+// MARK: - Stream Client
+
+/// Represents a single connected streaming client (Unix socket fd).
+/// Writes are done on a dedicated dispatch queue to avoid blocking the io thread.
+final class StreamClient {
+    let fd: Int32
+    private weak var streamer: SurfaceOutputStreamer?
+    private let queue = DispatchQueue(label: "com.cmux.stream-client", qos: .userInteractive)
+    private var closed = false
+    private let pipe: (readEnd: Int32, writeEnd: Int32)
+
+    init(fd: Int32, streamer: SurfaceOutputStreamer) {
+        self.fd = fd
+        self.streamer = streamer
+        // Make the client socket non-blocking
+        let flags = fcntl(fd, F_GETFL)
+        fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        // Create a self-pipe for signaling
+        var fds: [Int32] = [0, 0]
+        Darwin.pipe(&fds)
+        self.pipe = (fds[0], fds[1])
+        // Start the drain loop
+        startDrainLoop()
+    }
+
+    /// Signal that new data is available.
+    func signal() {
+        let byte: UInt8 = 1
+        withUnsafePointer(to: byte) { ptr in
+            _ = Darwin.write(pipe.writeEnd, ptr, 1)
+        }
+    }
+
+    /// Force an immediate drain attempt.
+    func drain() {
+        signal()
+    }
+
+    func close() {
+        closed = true
+        Darwin.close(pipe.writeEnd)
+        Darwin.close(pipe.readEnd)
+        Darwin.close(fd)
+    }
+
+    private func startDrainLoop() {
+        queue.async { [weak self] in
+            self?.drainLoop()
+        }
+    }
+
+    private func drainLoop() {
+        var pollFds = [
+            pollfd(fd: pipe.readEnd, events: Int16(POLLIN), revents: 0)
+        ]
+        var signalBuf = [UInt8](repeating: 0, count: 64)
+
+        while !closed {
+            // Wait for signal or timeout (1 second for keepalive check)
+            let ret = poll(&pollFds, 1, 1000)
+            if ret < 0 {
+                if errno == EINTR { continue }
+                break
+            }
+
+            // Consume signal bytes
+            if ret > 0 && (pollFds[0].revents & Int16(POLLIN)) != 0 {
+                _ = Darwin.read(pipe.readEnd, &signalBuf, signalBuf.count)
+            }
+
+            // Drain ring buffer and write to client
+            guard let streamer, let data = streamer.drainBytes() else { continue }
+
+            let writeResult = data.withUnsafeBytes { rawBuf -> Int in
+                guard let ptr = rawBuf.baseAddress else { return 0 }
+                var totalWritten = 0
+                while totalWritten < data.count {
+                    let n = Darwin.write(fd, ptr.advanced(by: totalWritten), data.count - totalWritten)
+                    if n <= 0 {
+                        if errno == EAGAIN || errno == EWOULDBLOCK {
+                            // Socket buffer full, try again
+                            usleep(1000) // 1ms backoff
+                            continue
+                        }
+                        return -1 // Client disconnected
+                    }
+                    totalWritten += n
+                }
+                return totalWritten
+            }
+
+            if writeResult < 0 {
+                // Client disconnected
+                break
+            }
+        }
+
+        // Cleanup
+        if !closed { close() }
+        streamer?.removeClient(self)
+    }
+}

--- a/Sources/TailscaleInfo.swift
+++ b/Sources/TailscaleInfo.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Detects Tailscale network information for device registration.
+enum TailscaleInfo {
+    /// Get the Tailscale hostname (e.g., "macbook-pro.tail1234.ts.net").
+    /// Returns nil if Tailscale is not running.
+    static func hostname() -> String? {
+        if let status = runTailscaleStatus() {
+            return status
+        }
+        return nil
+    }
+
+    /// Check if Tailscale is available by looking for a 100.x.x.x address.
+    static var isAvailable: Bool {
+        hostname() != nil
+    }
+
+    // MARK: - Private
+
+    private static func runTailscaleStatus() -> String? {
+        // Try the CLI path first (installed via Mac App Store or standalone).
+        let cliPaths = [
+            "/usr/local/bin/tailscale",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+        ]
+
+        for cliPath in cliPaths {
+            guard FileManager.default.isExecutableFile(atPath: cliPath) else { continue }
+
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: cliPath)
+            process.arguments = ["status", "--json"]
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+
+            do {
+                try process.run()
+            } catch {
+                continue
+            }
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else { continue }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+
+            // The "Self" key contains this machine's info.
+            if let selfNode = json["Self"] as? [String: Any],
+               let dnsName = selfNode["DNSName"] as? String,
+               !dnsName.isEmpty {
+                // DNSName has a trailing dot; strip it.
+                return dnsName.hasSuffix(".") ? String(dnsName.dropLast()) : dnsName
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1263,6 +1263,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceHealth(params: params))
         case "surface.send_text":
             return v2Result(id: id, self.v2SurfaceSendText(params: params))
+        case "surface.write_pty":
+            return v2Result(id: id, self.v2SurfaceWritePty(params: params))
         case "surface.send_key":
             return v2Result(id: id, self.v2SurfaceSendKey(params: params))
         case "surface.clear_history":
@@ -1601,6 +1603,7 @@ class TerminalController {
             "surface.refresh",
             "surface.health",
             "surface.send_text",
+            "surface.write_pty",
             "surface.send_key",
             "surface.read_text",
             "surface.clear_history",
@@ -3749,6 +3752,72 @@ class TerminalController {
                 "surface_id": surfaceId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
                 "queued": queued,
+                "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))
+            ])
+        }
+        return result
+    }
+
+    /// Write raw bytes to a terminal surface's pty via ghostty_surface_text.
+    /// Accepts either "text" (string) or "data" (base64-encoded bytes).
+    /// Unlike surface.send_text, this writes bytes directly to the pty without
+    /// splitting escape sequences into individual key events.
+    private func v2SurfaceWritePty(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        let textParam = params["text"] as? String
+        let dataParam = params["data"] as? String
+        guard textParam != nil || dataParam != nil else {
+            return .err(code: "invalid_params", message: "Missing text or data (base64)", data: nil)
+        }
+
+        let rawData: Data
+        if let dataParam {
+            guard let decoded = Data(base64Encoded: dataParam) else {
+                return .err(code: "invalid_params", message: "Invalid base64 data", data: nil)
+            }
+            rawData = decoded
+        } else if let textParam {
+            rawData = Data(textParam.utf8)
+        } else {
+            return .err(code: "invalid_params", message: "Missing text or data", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to write pty", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let surfaceId else {
+                result = .err(code: "not_found", message: "No focused surface", data: nil)
+                return
+            }
+            guard let terminalPanel = ws.terminalPanel(for: surfaceId) else {
+                result = .err(code: "invalid_params", message: "Surface is not a terminal", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+            guard let surface = terminalPanel.surface.surface else {
+                result = .err(code: "unavailable", message: "Surface not attached", data: nil)
+                return
+            }
+
+            rawData.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+                ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+            }
+            terminalPanel.surface.forceRefresh()
+
+            result = .ok([
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                "bytes": rawData.count,
                 "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))
             ])

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -724,8 +724,15 @@ class TerminalController {
         }
     }
 
+    /// Sentinel prefix returned by processCommand when the socket should be
+    /// upgraded to a raw byte stream (e.g. surface.attach_stream). The handler
+    /// loop stops processing commands and the fd is NOT closed, since the
+    /// SurfaceOutputStreamer now owns it.
+    private static let streamUpgradeSentinel = "__STREAM_UPGRADE__"
+
     private func handleClient(_ socket: Int32, peerPid: pid_t? = nil) {
-        defer { close(socket) }
+        var socketUpgraded = false
+        defer { if !socketUpgraded { close(socket) } }
 
         // In cmuxOnly mode, verify the connecting process is a descendant of cmux.
         // Other modes allow external clients and apply separate auth controls.
@@ -778,19 +785,23 @@ class TerminalController {
                     continue
                 }
 
-                let response = processCommand(trimmed)
+                let response = processCommand(trimmed, clientSocket: socket)
+                if response.hasPrefix(Self.streamUpgradeSentinel) {
+                    socketUpgraded = true
+                    return
+                }
                 writeSocketResponse(response, to: socket)
             }
         }
     }
 
-    private func processCommand(_ command: String) -> String {
+    private func processCommand(_ command: String, clientSocket: Int32 = -1) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "ERROR: Empty command" }
 
         // v2 protocol: newline-delimited JSON.
         if trimmed.hasPrefix("{") {
-            return processV2Command(trimmed)
+            return processV2Command(trimmed, clientSocket: clientSocket)
         }
 
         let parts = trimmed.split(separator: " ", maxSplits: 1).map(String.init)
@@ -1141,7 +1152,7 @@ class TerminalController {
 
     // MARK: - V2 JSON Socket Protocol
 
-    private func processV2Command(_ jsonLine: String) -> String {
+    private func processV2Command(_ jsonLine: String, clientSocket: Int32 = -1) -> String {
         // v1 access-mode gating applies to v2 as well. We can't know which v2 method maps
         // to which v1 command without parsing, so parse first and then apply allow-list.
 
@@ -1271,6 +1282,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceClearHistory(params: params))
         case "surface.trigger_flash":
             return v2Result(id: id, self.v2SurfaceTriggerFlash(params: params))
+        case "surface.attach_stream":
+            return self.v2SurfaceAttachStream(id: id, params: params, clientSocket: clientSocket)
 
         // Panes
         case "pane.list":
@@ -1608,6 +1621,7 @@ class TerminalController {
             "surface.read_text",
             "surface.clear_history",
             "surface.trigger_flash",
+            "surface.attach_stream",
             "pane.list",
             "pane.focus",
             "pane.surfaces",
@@ -3963,6 +3977,98 @@ class TerminalController {
             ])
         }
         return result
+    }
+
+    /// Upgrade a socket connection to a raw pty output stream.
+    /// Protocol:
+    ///   1. Server writes a JSON header line with stream metadata (size, ids)
+    ///   2. Server writes the bootstrap payload (screen snapshot as VT sequences)
+    ///   3. Connection transitions to live raw pty byte stream
+    /// Returns the stream-upgrade sentinel so handleClient stops its read loop.
+    private func v2SurfaceAttachStream(id: Any?, params: [String: Any], clientSocket: Int32) -> String {
+        guard clientSocket >= 0 else {
+            return v2Error(id: id, code: "internal_error", message: "No client socket for stream upgrade")
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return v2Error(id: id, code: "unavailable", message: "TabManager not available")
+        }
+
+        var errorResponse: String?
+        var resolvedWsId: UUID?
+        var resolvedSfId: UUID?
+        var ghosttySurface: ghostty_surface_t?
+        var bootstrapText = ""
+        var cols: UInt16 = 80
+        var rows: UInt16 = 24
+
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                errorResponse = v2Error(id: id, code: "not_found", message: "Workspace not found")
+                return
+            }
+            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let surfaceId else {
+                errorResponse = v2Error(id: id, code: "not_found", message: "No focused surface")
+                return
+            }
+            guard let terminalPanel = ws.terminalPanel(for: surfaceId) else {
+                errorResponse = v2Error(id: id, code: "invalid_params", message: "Surface is not a terminal")
+                return
+            }
+            guard let surface = terminalPanel.surface.surface else {
+                errorResponse = v2Error(id: id, code: "unavailable", message: "Surface not attached")
+                return
+            }
+
+            resolvedWsId = ws.id
+            resolvedSfId = surfaceId
+            ghosttySurface = surface
+
+            // Get terminal size
+            let size = ghostty_surface_size(surface)
+            cols = size.columns
+            rows = size.rows
+
+            // Read current screen content for bootstrap
+            let response = readTerminalTextBase64(terminalPanel: terminalPanel)
+            if response.hasPrefix("OK ") {
+                let base64 = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+                if let data = Data(base64Encoded: base64) {
+                    bootstrapText = String(data: data, encoding: .utf8) ?? ""
+                }
+            }
+
+            // Set up the output handler on this surface
+            let streamer = SurfaceOutputStreamer.streamer(for: surfaceId)
+            streamer.attach(to: surface)
+        }
+
+        if let errorResponse { return errorResponse }
+        guard let wsId = resolvedWsId, let sfId = resolvedSfId else {
+            return v2Error(id: id, code: "internal_error", message: "Failed to resolve surface")
+        }
+
+        // Write the JSON header line to the client (still in text mode)
+        let header = v2Ok(id: id, result: [
+            "stream": true,
+            "workspace_id": wsId.uuidString,
+            "surface_id": sfId.uuidString,
+            "cols": Int(cols),
+            "rows": Int(rows)
+        ])
+        writeSocketResponse(header, to: clientSocket)
+
+        // Write bootstrap payload: clear screen + home cursor + screen content
+        let bootstrap = "\u{1b}[2J\u{1b}[H" + bootstrapText
+        bootstrap.withCString { ptr in
+            _ = Darwin.write(clientSocket, ptr, strlen(ptr))
+        }
+
+        // Hand the socket to the streamer for live byte streaming
+        let streamer = SurfaceOutputStreamer.streamer(for: sfId)
+        streamer.addClient(fd: clientSocket)
+
+        return Self.streamUpgradeSentinel
     }
 
     private func readTerminalTextBase64(terminalPanel: TerminalPanel, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,132 @@
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { api } from "./_generated/api";
+
+const http = httpRouter();
+
+// TODO(auth): Placeholder auth. The Bearer token is treated as the userId directly.
+// Before shipping, replace with real API key validation against an `apiKeys` table
+// or Stack Auth JWT verification. Anyone who knows a userId can impersonate them.
+function extractUserId(request: Request): string | null {
+  const auth = request.headers.get("Authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  const token = auth.slice(7).trim();
+  if (!token) return null;
+  return token;
+}
+
+function unauthorized() {
+  return new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function badRequest(message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function ok(data: unknown = { ok: true }) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+http.route({
+  path: "/api/terminal/register",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const userId = extractUserId(request);
+    if (!userId) return unauthorized();
+
+    let body: any;
+    try { body = await request.json(); } catch { return badRequest("Invalid JSON"); }
+    if (!body.deviceId || typeof body.deviceId !== "string") return badRequest("deviceId required");
+    if (!body.hostname || typeof body.hostname !== "string") return badRequest("hostname required");
+    const id = await ctx.runMutation(api.terminalDevices.register, {
+      userId,
+      deviceId: body.deviceId,
+      hostname: body.hostname,
+      tailscaleHostname: body.tailscaleHostname,
+      sshPort: body.sshPort ?? 22,
+      capabilities: body.capabilities ?? ["cmux"],
+      osVersion: body.osVersion ?? "unknown",
+      appVersion: body.appVersion ?? "unknown",
+    });
+
+    return ok({ id });
+  }),
+});
+
+http.route({
+  path: "/api/terminal/heartbeat",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const userId = extractUserId(request);
+    if (!userId) return unauthorized();
+
+    let body: any;
+    try { body = await request.json(); } catch { return badRequest("Invalid JSON"); }
+    if (!body.deviceId || typeof body.deviceId !== "string") return badRequest("deviceId required");
+
+    await ctx.runMutation(api.terminalDevices.heartbeat, {
+      userId,
+      deviceId: body.deviceId,
+    });
+
+    return ok();
+  }),
+});
+
+http.route({
+  path: "/api/terminal/event",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const userId = extractUserId(request);
+    if (!userId) return unauthorized();
+
+    let body: any;
+    try { body = await request.json(); } catch { return badRequest("Invalid JSON"); }
+    if (!body.deviceId || typeof body.deviceId !== "string") return badRequest("deviceId required");
+    if (!body.type || typeof body.type !== "string") return badRequest("type required");
+    if (!body.title || typeof body.title !== "string") return badRequest("title required");
+    const id = await ctx.runMutation(api.terminalEvents.create, {
+      userId,
+      deviceId: body.deviceId,
+      type: body.type,
+      title: body.title,
+      body: body.body,
+      workspaceId: body.workspaceId,
+      metadata: body.metadata,
+    });
+
+    return ok({ id });
+  }),
+});
+
+http.route({
+  path: "/api/terminal/workspaces",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const userId = extractUserId(request);
+    if (!userId) return unauthorized();
+
+    let body: any;
+    try { body = await request.json(); } catch { return badRequest("Invalid JSON"); }
+    if (!body.deviceId || typeof body.deviceId !== "string") return badRequest("deviceId required");
+    if (!Array.isArray(body.workspaces)) return badRequest("workspaces array required");
+    const id = await ctx.runMutation(api.terminalWorkspaceSnapshots.update, {
+      userId,
+      deviceId: body.deviceId,
+      workspaces: body.workspaces,
+    });
+
+    return ok({ id });
+  }),
+});
+
+export default http;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,53 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  terminalDevices: defineTable({
+    userId: v.string(),
+    deviceId: v.string(),
+    hostname: v.string(),
+    tailscaleHostname: v.optional(v.string()),
+    sshPort: v.number(),
+    capabilities: v.array(v.string()),
+    osVersion: v.string(),
+    appVersion: v.string(),
+    status: v.union(v.literal("online"), v.literal("offline")),
+    lastSeen: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_user_device", ["userId", "deviceId"]),
+
+  terminalWorkspaceSnapshots: defineTable({
+    userId: v.string(),
+    deviceId: v.string(),
+    workspaces: v.array(
+      v.object({
+        id: v.string(),
+        title: v.string(),
+        surfaceCount: v.number(),
+        hasActivity: v.boolean(),
+      })
+    ),
+    updatedAt: v.number(),
+  }).index("by_user_device", ["userId", "deviceId"]),
+
+  terminalEvents: defineTable({
+    userId: v.string(),
+    deviceId: v.string(),
+    type: v.union(
+      v.literal("agent_complete"),
+      v.literal("build_complete"),
+      v.literal("build_failed"),
+      v.literal("notification_bell"),
+      v.literal("command_complete")
+    ),
+    title: v.string(),
+    body: v.optional(v.string()),
+    workspaceId: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+    createdAt: v.number(),
+    read: v.boolean(),
+  })
+    .index("by_user", ["userId", "createdAt"])
+    .index("by_user_unread", ["userId", "read"]),
+});

--- a/convex/terminalDevices.ts
+++ b/convex/terminalDevices.ts
@@ -1,0 +1,104 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const register = mutation({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+    hostname: v.string(),
+    tailscaleHostname: v.optional(v.string()),
+    sshPort: v.number(),
+    capabilities: v.array(v.string()),
+    osVersion: v.string(),
+    appVersion: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("terminalDevices")
+      .withIndex("by_user_device", (q) =>
+        q.eq("userId", args.userId).eq("deviceId", args.deviceId)
+      )
+      .unique();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        hostname: args.hostname,
+        tailscaleHostname: args.tailscaleHostname,
+        sshPort: args.sshPort,
+        capabilities: args.capabilities,
+        osVersion: args.osVersion,
+        appVersion: args.appVersion,
+        status: "online",
+        lastSeen: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("terminalDevices", {
+      ...args,
+      status: "online",
+      lastSeen: now,
+    });
+  },
+});
+
+export const heartbeat = mutation({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const device = await ctx.db
+      .query("terminalDevices")
+      .withIndex("by_user_device", (q) =>
+        q.eq("userId", args.userId).eq("deviceId", args.deviceId)
+      )
+      .unique();
+
+    if (!device) {
+      throw new Error(`Device not found: ${args.deviceId}`);
+    }
+
+    await ctx.db.patch(device._id, {
+      status: "online",
+      lastSeen: Date.now(),
+    });
+  },
+});
+
+export const markOffline = mutation({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const device = await ctx.db
+      .query("terminalDevices")
+      .withIndex("by_user_device", (q) =>
+        q.eq("userId", args.userId).eq("deviceId", args.deviceId)
+      )
+      .unique();
+
+    if (!device) {
+      return;
+    }
+
+    await ctx.db.patch(device._id, {
+      status: "offline",
+    });
+  },
+});
+
+export const listForUser = query({
+  args: {
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("terminalDevices")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .take(100);
+  },
+});

--- a/convex/terminalEvents.ts
+++ b/convex/terminalEvents.ts
@@ -1,0 +1,56 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const create = mutation({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+    type: v.union(
+      v.literal("agent_complete"),
+      v.literal("build_complete"),
+      v.literal("build_failed"),
+      v.literal("notification_bell"),
+      v.literal("command_complete")
+    ),
+    title: v.string(),
+    body: v.optional(v.string()),
+    workspaceId: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("terminalEvents", {
+      ...args,
+      createdAt: Date.now(),
+      read: false,
+    });
+  },
+});
+
+export const listForUser = query({
+  args: {
+    userId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 50;
+    return await ctx.db
+      .query("terminalEvents")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .order("desc")
+      .take(limit);
+  },
+});
+
+export const markRead = mutation({
+  args: {
+    userId: v.string(),
+    eventId: v.id("terminalEvents"),
+  },
+  handler: async (ctx, args) => {
+    const event = await ctx.db.get(args.eventId);
+    if (!event || event.userId !== args.userId) {
+      throw new Error("Event not found");
+    }
+    await ctx.db.patch(args.eventId, { read: true });
+  },
+});

--- a/convex/terminalWorkspaceSnapshots.ts
+++ b/convex/terminalWorkspaceSnapshots.ts
@@ -1,0 +1,55 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const update = mutation({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+    workspaces: v.array(
+      v.object({
+        id: v.string(),
+        title: v.string(),
+        surfaceCount: v.number(),
+        hasActivity: v.boolean(),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("terminalWorkspaceSnapshots")
+      .withIndex("by_user_device", (q) =>
+        q.eq("userId", args.userId).eq("deviceId", args.deviceId)
+      )
+      .unique();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        workspaces: args.workspaces,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("terminalWorkspaceSnapshots", {
+      ...args,
+      updatedAt: now,
+    });
+  },
+});
+
+export const getForDevice = query({
+  args: {
+    userId: v.string(),
+    deviceId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("terminalWorkspaceSnapshots")
+      .withIndex("by_user_device", (q) =>
+        q.eq("userId", args.userId).eq("deviceId", args.deviceId)
+      )
+      .unique();
+  },
+});

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowJs": true,
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["_generated"]
+}

--- a/ghostty.h
+++ b/ghostty.h
@@ -461,6 +461,14 @@ typedef struct {
   uint32_t cell_height_px;
 } ghostty_surface_size_s;
 
+// Callback for observing raw pty output bytes before terminal processing.
+// Fires from the io-reader thread; must be non-blocking and must NOT call
+// back into any ghostty_surface_* function. The data pointer is only valid
+// for the duration of the callback.
+typedef void (*ghostty_output_handler_t)(void* userdata,
+                                         const uint8_t* data,
+                                         size_t len);
+
 // Config types
 
 // config.Color
@@ -1071,6 +1079,9 @@ void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);
 void ghostty_surface_set_color_scheme(ghostty_surface_t,
                                       ghostty_color_scheme_e);
+void ghostty_surface_set_output_handler(ghostty_surface_t,
+                                        ghostty_output_handler_t,
+                                        void*);
 ghostty_input_mods_e ghostty_surface_key_translation_mods(ghostty_surface_t,
                                                           ghostty_input_mods_e);
 bool ghostty_surface_key(ghostty_surface_t, ghostty_input_key_s);

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,50 @@
+# cmux iOS
+
+iOS companion app for cmux. Connects to Mac terminals over SSH using libssh2 for transport and libghostty for terminal rendering.
+
+## Status
+
+Skeleton phase. SSH protocol types and key management are defined. libssh2 integration is pending.
+
+## Building libssh2 for iOS
+
+Build libssh2 as an xcframework targeting iOS arm64:
+
+```bash
+# Clone libssh2
+git clone https://github.com/libssh2/libssh2.git
+cd libssh2 && mkdir build-ios && cd build-ios
+
+# Configure for iOS
+cmake .. \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0 \
+  -DCRYPTO_BACKEND=SecureTransport \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_TESTING=OFF
+
+cmake --build . --config Release
+
+# Create xcframework
+xcodebuild -create-xcframework \
+  -library lib/libssh2.a -headers ../include \
+  -output libssh2.xcframework
+```
+
+Place the resulting `libssh2.xcframework` in `ios/Frameworks/` and add it to the Xcode project.
+
+## Architecture
+
+- `SSHClientProtocol` / `LibSSH2Client`: protocol-based SSH client, swappable for testing
+- `SSHKeyStore`: Ed25519 key generation and iOS Keychain storage
+- `SSHKeyManagementView`: SwiftUI UI for managing keys
+- `SavedConnection`: model for bookmarked SSH hosts
+
+## Key management flow
+
+1. User generates an Ed25519 key pair (stored in Keychain)
+2. User copies the public key in OpenSSH format
+3. User pastes it into `~/.ssh/authorized_keys` on their Mac
+4. Connections authenticate with the private key from Keychain

--- a/ios/Sources/Terminal/SSHClient.swift
+++ b/ios/Sources/Terminal/SSHClient.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+// MARK: - Connection State
+
+/// SSH connection lifecycle states.
+enum SSHConnectionState: Equatable {
+    case disconnected
+    case connecting
+    case authenticating
+    case connected
+    case failed(SSHError)
+}
+
+// MARK: - Errors
+
+enum SSHError: Error, Equatable, LocalizedError {
+    case notConnected
+    case authenticationFailed(String)
+    case connectionFailed(String)
+    case channelError(String)
+    case notImplemented
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected: return "Not connected to SSH server"
+        case .authenticationFailed(let msg): return "Authentication failed: \(msg)"
+        case .connectionFailed(let msg): return "Connection failed: \(msg)"
+        case .channelError(let msg): return "Channel error: \(msg)"
+        case .notImplemented: return "Not implemented"
+        }
+    }
+}
+
+// MARK: - Protocols
+
+/// Protocol for SSH client implementations (libssh2, NIO-SSH, etc.)
+protocol SSHClientProtocol: AnyObject {
+    var state: SSHConnectionState { get }
+    var onStateChange: ((SSHConnectionState) -> Void)? { get set }
+
+    func connect(host: String, port: Int) async throws
+    func authenticate(username: String, privateKey: Data) async throws
+    func execute(command: String) async throws -> CommandResult
+    func startShell(cols: UInt16, rows: UInt16) async throws -> SSHChannel
+    func disconnect()
+}
+
+/// Result of executing a remote command.
+struct CommandResult {
+    let stdout: Data
+    let stderr: Data
+    let exitCode: Int32
+}
+
+/// SSH channel for interactive shell sessions.
+protocol SSHChannel: AnyObject {
+    func write(_ data: Data) async throws
+    func read() async throws -> Data
+    func resize(cols: UInt16, rows: UInt16) async throws
+    func close() async throws
+}
+
+// MARK: - libssh2 Implementation (Stub)
+
+/// Concrete SSH client backed by libssh2.
+/// Placeholder: methods throw `.notImplemented` until the libssh2 xcframework is integrated.
+final class LibSSH2Client: SSHClientProtocol {
+    private(set) var state: SSHConnectionState = .disconnected {
+        didSet { onStateChange?(state) }
+    }
+    var onStateChange: ((SSHConnectionState) -> Void)?
+
+    private var host: String?
+    private var port: Int?
+
+    func connect(host: String, port: Int) async throws {
+        state = .connecting
+        self.host = host
+        self.port = port
+        // TODO: libssh2_session_init, libssh2_session_handshake
+        throw SSHError.notImplemented
+    }
+
+    func authenticate(username: String, privateKey: Data) async throws {
+        guard case .connecting = state else { throw SSHError.notConnected }
+        state = .authenticating
+        // TODO: libssh2_userauth_publickey_frommemory
+        throw SSHError.notImplemented
+    }
+
+    func execute(command: String) async throws -> CommandResult {
+        guard case .connected = state else { throw SSHError.notConnected }
+        // TODO: libssh2_channel_exec
+        throw SSHError.notImplemented
+    }
+
+    func startShell(cols: UInt16, rows: UInt16) async throws -> SSHChannel {
+        guard case .connected = state else { throw SSHError.notConnected }
+        // TODO: libssh2_channel_open_session + request_pty + shell
+        throw SSHError.notImplemented
+    }
+
+    func disconnect() {
+        // TODO: libssh2_session_disconnect, libssh2_session_free
+        host = nil
+        port = nil
+        state = .disconnected
+    }
+}
+
+// MARK: - libssh2 Channel (Stub)
+
+/// Interactive shell channel backed by libssh2.
+final class LibSSH2Channel: SSHChannel {
+    func write(_ data: Data) async throws {
+        throw SSHError.notImplemented
+    }
+
+    func read() async throws -> Data {
+        throw SSHError.notImplemented
+    }
+
+    func resize(cols: UInt16, rows: UInt16) async throws {
+        throw SSHError.notImplemented
+    }
+
+    func close() async throws {
+        throw SSHError.notImplemented
+    }
+}

--- a/ios/Sources/Terminal/SSHKeyManagementView.swift
+++ b/ios/Sources/Terminal/SSHKeyManagementView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+// MARK: - Key Management View
+
+struct SSHKeyManagementView: View {
+    @State private var keys: [SSHKeyPair] = []
+    @State private var newKeyLabel = ""
+    @State private var showingGenerateSheet = false
+    @State private var showingDeleteConfirmation = false
+    @State private var keyToDelete: SSHKeyPair?
+    @State private var errorMessage: String?
+    @State private var copiedKeyLabel: String?
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(keys) { key in
+                    SSHKeyRow(
+                        key: key,
+                        isCopied: copiedKeyLabel == key.label,
+                        onCopyPublicKey: { copyPublicKey(key) },
+                        onDelete: {
+                            keyToDelete = key
+                            showingDeleteConfirmation = true
+                        }
+                    )
+                }
+
+                if keys.isEmpty {
+                    Text("No SSH keys. Generate one to connect to your Mac.")
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("SSH Keys")
+            }
+        }
+        .navigationTitle("SSH Keys")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Generate Key") {
+                    showingGenerateSheet = true
+                }
+            }
+        }
+        .sheet(isPresented: $showingGenerateSheet) {
+            GenerateKeySheet(
+                label: $newKeyLabel,
+                onGenerate: { generateKey() },
+                onCancel: { showingGenerateSheet = false }
+            )
+        }
+        .alert("Delete Key?", isPresented: $showingDeleteConfirmation) {
+            Button("Delete", role: .destructive) { deleteKey() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let key = keyToDelete {
+                Text("This will permanently delete \"\(key.label)\". Remove it from authorized_keys on any servers first.")
+            }
+        }
+        .alert("Error", isPresented: .init(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            if let msg = errorMessage { Text(msg) }
+        }
+        .onAppear { loadKeys() }
+    }
+
+    private func loadKeys() {
+        do {
+            keys = try SSHKeyStore.listKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func generateKey() {
+        let label = newKeyLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !label.isEmpty else { return }
+
+        do {
+            _ = try SSHKeyStore.generateKeyPair(label: label)
+            newKeyLabel = ""
+            showingGenerateSheet = false
+            loadKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func copyPublicKey(_ key: SSHKeyPair) {
+        let pubKey = SSHKeyStore.publicKeyOpenSSH(key)
+        UIPasteboard.general.string = pubKey
+        copiedKeyLabel = key.label
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            if copiedKeyLabel == key.label {
+                copiedKeyLabel = nil
+            }
+        }
+    }
+
+    private func deleteKey() {
+        guard let key = keyToDelete else { return }
+        do {
+            try SSHKeyStore.deleteKey(label: key.label)
+            keyToDelete = nil
+            loadKeys()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Key Row
+
+private struct SSHKeyRow: View {
+    let key: SSHKeyPair
+    let isCopied: Bool
+    let onCopyPublicKey: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(key.label)
+                .font(.headline)
+
+            Text(key.fingerprint)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+
+            Text("Created \(key.createdAt.formatted(date: .abbreviated, time: .omitted))")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) { onDelete() } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .swipeActions(edge: .leading) {
+            Button { onCopyPublicKey() } label: {
+                Label(
+                    isCopied ? "Copied" : "Copy Public Key",
+                    systemImage: isCopied ? "checkmark" : "doc.on.doc"
+                )
+            }
+            .tint(.blue)
+        }
+        .contextMenu {
+            Button { onCopyPublicKey() } label: {
+                Label("Copy Public Key", systemImage: "doc.on.doc")
+            }
+            Button(role: .destructive) { onDelete() } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+}
+
+// MARK: - Generate Key Sheet
+
+private struct GenerateKeySheet: View {
+    @Binding var label: String
+    let onGenerate: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Key Label", text: $label, prompt: Text("e.g. MacBook Pro"))
+                } footer: {
+                    Text("A name to identify this key. An Ed25519 key pair will be generated and stored securely in the Keychain.")
+                }
+            }
+            .navigationTitle("Generate SSH Key")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Generate", action: onGenerate)
+                        .disabled(label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/ios/Sources/Terminal/SSHKeyStore.swift
+++ b/ios/Sources/Terminal/SSHKeyStore.swift
@@ -1,0 +1,226 @@
+import Foundation
+import Security
+import CryptoKit
+
+// MARK: - Key Pair Model
+
+struct SSHKeyPair: Identifiable {
+    let label: String
+    let publicKey: Data
+    let privateKey: Data
+    let createdAt: Date
+    let fingerprint: String
+
+    var id: String { label }
+}
+
+// MARK: - Key Store Errors
+
+enum SSHKeyStoreError: Error, LocalizedError {
+    case keyGenerationFailed
+    case keychainError(OSStatus)
+    case keyNotFound(String)
+    case duplicateKey(String)
+    case invalidKeyData
+
+    var errorDescription: String? {
+        switch self {
+        case .keyGenerationFailed: return "Failed to generate SSH key pair"
+        case .keychainError(let status): return "Keychain error: \(status)"
+        case .keyNotFound(let label): return "Key not found: \(label)"
+        case .duplicateKey(let label): return "Key already exists: \(label)"
+        case .invalidKeyData: return "Invalid key data"
+        }
+    }
+}
+
+// MARK: - Key Store
+
+/// Manages SSH Ed25519 key pairs in the iOS Keychain.
+struct SSHKeyStore {
+    private static let service = "ai.manaflow.cmux.ssh-keys"
+
+    /// Generate a new Ed25519 SSH key pair and store it in the Keychain.
+    static func generateKeyPair(label: String) throws -> SSHKeyPair {
+        if let existing = try? getKey(label: label), existing != nil {
+            throw SSHKeyStoreError.duplicateKey(label)
+        }
+
+        let privateKey = Curve25519.Signing.PrivateKey()
+        let publicKey = privateKey.publicKey
+
+        let privateKeyData = privateKey.rawRepresentation
+        let publicKeyData = publicKey.rawRepresentation
+        let createdAt = Date()
+
+        let fingerprint = Self.sha256Fingerprint(publicKeyData)
+
+        // Store private key in Keychain
+        let metadata = KeyMetadata(label: label, createdAt: createdAt, fingerprint: fingerprint)
+        let metadataJSON = try JSONEncoder().encode(metadata)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: label,
+            kSecValueData as String: privateKeyData,
+            kSecAttrLabel as String: "cmux-ssh-\(label)",
+            kSecAttrComment as String: String(data: metadataJSON, encoding: .utf8) ?? "",
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SSHKeyStoreError.keychainError(status)
+        }
+
+        return SSHKeyPair(
+            label: label,
+            publicKey: publicKeyData,
+            privateKey: privateKeyData,
+            createdAt: createdAt,
+            fingerprint: fingerprint
+        )
+    }
+
+    /// List all stored SSH key pairs.
+    static func listKeys() throws -> [SSHKeyPair] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecItemNotFound { return [] }
+        guard status == errSecSuccess else {
+            throw SSHKeyStoreError.keychainError(status)
+        }
+
+        guard let items = result as? [[String: Any]] else { return [] }
+
+        return items.compactMap { item -> SSHKeyPair? in
+            guard
+                let label = item[kSecAttrAccount as String] as? String,
+                let privateKeyData = item[kSecValueData as String] as? Data,
+                let commentStr = item[kSecAttrComment as String] as? String,
+                let commentData = commentStr.data(using: .utf8),
+                let metadata = try? JSONDecoder().decode(KeyMetadata.self, from: commentData)
+            else { return nil }
+
+            let publicKeyData: Data
+            do {
+                let privKey = try Curve25519.Signing.PrivateKey(rawRepresentation: privateKeyData)
+                publicKeyData = privKey.publicKey.rawRepresentation
+            } catch {
+                return nil
+            }
+
+            return SSHKeyPair(
+                label: label,
+                publicKey: publicKeyData,
+                privateKey: privateKeyData,
+                createdAt: metadata.createdAt,
+                fingerprint: metadata.fingerprint
+            )
+        }
+    }
+
+    /// Get a specific key pair by label.
+    static func getKey(label: String) throws -> SSHKeyPair? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: label,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw SSHKeyStoreError.keychainError(status)
+        }
+
+        guard
+            let item = result as? [String: Any],
+            let privateKeyData = item[kSecValueData as String] as? Data,
+            let commentStr = item[kSecAttrComment as String] as? String,
+            let commentData = commentStr.data(using: .utf8),
+            let metadata = try? JSONDecoder().decode(KeyMetadata.self, from: commentData)
+        else {
+            throw SSHKeyStoreError.invalidKeyData
+        }
+
+        let privKey = try Curve25519.Signing.PrivateKey(rawRepresentation: privateKeyData)
+
+        return SSHKeyPair(
+            label: label,
+            publicKey: privKey.publicKey.rawRepresentation,
+            privateKey: privateKeyData,
+            createdAt: metadata.createdAt,
+            fingerprint: metadata.fingerprint
+        )
+    }
+
+    /// Delete a key pair from the Keychain.
+    static func deleteKey(label: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: label,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SSHKeyStoreError.keychainError(status)
+        }
+    }
+
+    /// Format the public key in OpenSSH authorized_keys format.
+    /// Output: `ssh-ed25519 <base64> <label>`
+    static func publicKeyOpenSSH(_ keyPair: SSHKeyPair) -> String {
+        // OpenSSH wire format for Ed25519:
+        // [4 bytes: length of key type] [key type: "ssh-ed25519"]
+        // [4 bytes: length of public key] [32 bytes: public key]
+        let keyType = "ssh-ed25519"
+        let keyTypeData = keyType.data(using: .utf8)!
+
+        var wireFormat = Data()
+        wireFormat.appendSSHString(keyTypeData)
+        wireFormat.appendSSHString(keyPair.publicKey)
+
+        let base64 = wireFormat.base64EncodedString()
+        return "\(keyType) \(base64) \(keyPair.label)"
+    }
+
+    // MARK: - Private
+
+    private static func sha256Fingerprint(_ publicKey: Data) -> String {
+        let hash = SHA256.hash(data: publicKey)
+        let base64 = Data(hash).base64EncodedString()
+        return "SHA256:\(base64)"
+    }
+}
+
+// MARK: - Helpers
+
+private struct KeyMetadata: Codable {
+    let label: String
+    let createdAt: Date
+    let fingerprint: String
+}
+
+private extension Data {
+    mutating func appendSSHString(_ data: Data) {
+        var length = UInt32(data.count).bigEndian
+        append(Data(bytes: &length, count: 4))
+        append(data)
+    }
+}

--- a/ios/Sources/Terminal/SavedConnection.swift
+++ b/ios/Sources/Terminal/SavedConnection.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// A saved SSH connection to a remote Mac.
+struct SavedConnection: Codable, Identifiable, Hashable {
+    let id: UUID
+    var label: String
+    var host: String
+    var port: Int
+    var username: String
+    /// Reference to an SSHKeyStore key label for authentication.
+    var keyLabel: String?
+    /// When true, this host is running cmux and workspace features are enabled.
+    var isCmux: Bool
+    var lastConnected: Date?
+
+    init(
+        id: UUID = UUID(),
+        label: String,
+        host: String,
+        port: Int = 22,
+        username: String,
+        keyLabel: String? = nil,
+        isCmux: Bool = false,
+        lastConnected: Date? = nil
+    ) {
+        self.id = id
+        self.label = label
+        self.host = host
+        self.port = port
+        self.username = username
+        self.keyLabel = keyLabel
+        self.isCmux = isCmux
+        self.lastConnected = lastConnected
+    }
+}
+
+// MARK: - Persistence
+
+/// Stores saved connections in UserDefaults (will migrate to CloudKit/Keychain later).
+struct SavedConnectionStore {
+    private static let key = "ai.manaflow.cmux.saved-connections"
+
+    static func load() -> [SavedConnection] {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return [] }
+        return (try? JSONDecoder().decode([SavedConnection].self, from: data)) ?? []
+    }
+
+    static func save(_ connections: [SavedConnection]) {
+        let data = try? JSONEncoder().encode(connections)
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    static func add(_ connection: SavedConnection) {
+        var all = load()
+        all.append(connection)
+        save(all)
+    }
+
+    static func update(_ connection: SavedConnection) {
+        var all = load()
+        if let idx = all.firstIndex(where: { $0.id == connection.id }) {
+            all[idx] = connection
+            save(all)
+        }
+    }
+
+    static func delete(id: UUID) {
+        var all = load()
+        all.removeAll { $0.id == id }
+        save(all)
+    }
+}

--- a/tests/test_attach_stream.py
+++ b/tests/test_attach_stream.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""E2E test for cmux attach / surface.attach_stream.
+
+Tests the full streaming pipeline:
+  ghostty pty output → output handler callback → ring buffer → stream client → socket → test harness
+
+Requires: cmux app running with CMUX_SOCKET_MODE=allowAll
+"""
+
+import json
+import os
+import select
+import socket
+import sys
+import time
+import uuid
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug-ios-mac-connect.sock")
+TIMEOUT = 10
+
+
+def send_v2(sock, method, params=None):
+    """Send a v2 JSON-RPC request and return the parsed response."""
+    req = json.dumps({"id": str(uuid.uuid4()), "method": method, "params": params or {}})
+    sock.sendall((req + "\n").encode())
+    data = b""
+    deadline = time.time() + TIMEOUT
+    while time.time() < deadline:
+        ready = select.select([sock], [], [], 1.0)
+        if ready[0]:
+            chunk = sock.recv(8192)
+            if not chunk:
+                break
+            data += chunk
+            if b"\n" in data:
+                break
+    line = data.split(b"\n")[0]
+    return json.loads(line.decode())
+
+
+def connect():
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(SOCKET_PATH)
+    s.settimeout(TIMEOUT)
+    return s
+
+
+def test_workspace_list():
+    """Test 1: workspace.list works and returns at least one workspace."""
+    print("TEST 1: workspace.list ... ", end="", flush=True)
+    sock = connect()
+    try:
+        resp = send_v2(sock, "workspace.list")
+        assert resp.get("ok"), f"Expected ok, got: {resp}"
+        result = resp.get("result", {})
+        workspaces = result.get("workspaces", [])
+        assert len(workspaces) > 0, "Expected at least one workspace"
+        ws = workspaces[0]
+        assert "id" in ws, "Workspace missing 'id'"
+        print(f"PASS ({len(workspaces)} workspace(s), first={ws['id'][:8]}...)")
+        return ws["id"]
+    finally:
+        sock.close()
+
+
+def test_surface_write_pty(workspace_id):
+    """Test 2: surface.write_pty sends bytes to terminal."""
+    print("TEST 2: surface.write_pty ... ", end="", flush=True)
+    sock = connect()
+    try:
+        import base64
+        # Send a simple echo command (base64 encoded)
+        cmd = "echo __CMUX_E2E_MARKER__\n"
+        b64 = base64.b64encode(cmd.encode()).decode()
+        resp = send_v2(sock, "surface.write_pty", {"workspace_id": workspace_id, "data": b64})
+        assert resp.get("ok"), f"Expected ok, got: {resp}"
+        print("PASS")
+    finally:
+        sock.close()
+
+
+def test_surface_read_text(workspace_id):
+    """Test 3: surface.read_text can read screen content."""
+    print("TEST 3: surface.read_text ... ", end="", flush=True)
+    sock = connect()
+    try:
+        resp = send_v2(sock, "surface.read_text", {"workspace_id": workspace_id})
+        assert resp.get("ok"), f"Expected ok, got: {resp}"
+        text = resp.get("result", {}).get("text", "")
+        assert len(text) > 0, "Expected non-empty screen text"
+        print(f"PASS ({len(text)} chars)")
+    finally:
+        sock.close()
+
+
+def test_attach_stream(workspace_id):
+    """Test 4: surface.attach_stream upgrades to raw byte streaming."""
+    print("TEST 4: surface.attach_stream ... ", end="", flush=True)
+    sock = connect()
+    try:
+        # Send the attach_stream request
+        req = json.dumps({
+            "id": str(uuid.uuid4()),
+            "method": "surface.attach_stream",
+            "params": {"workspace_id": workspace_id}
+        })
+        sock.sendall((req + "\n").encode())
+
+        # Read the JSON header line
+        data = b""
+        deadline = time.time() + TIMEOUT
+        while time.time() < deadline:
+            ready = select.select([sock], [], [], 1.0)
+            if ready[0]:
+                chunk = sock.recv(8192)
+                if not chunk:
+                    break
+                data += chunk
+                if b"\n" in data:
+                    break
+
+        # Parse the header
+        parts = data.split(b"\n", 1)
+        header_line = parts[0]
+        extra = parts[1] if len(parts) > 1 else b""
+
+        header = json.loads(header_line.decode())
+        assert header.get("ok"), f"Expected ok header, got: {header}"
+        result = header.get("result", {})
+        assert result.get("stream") == True, f"Expected stream=true, got: {result}"
+        assert "cols" in result, "Missing cols in stream header"
+        assert "rows" in result, "Missing rows in stream header"
+        assert "workspace_id" in result, "Missing workspace_id in stream header"
+        assert "surface_id" in result, "Missing surface_id in stream header"
+
+        cols = result["cols"]
+        rows = result["rows"]
+        ws_id = result["workspace_id"]
+        sf_id = result["surface_id"]
+
+        print(f"header OK (cols={cols}, rows={rows})")
+
+        # Read bootstrap data (screen snapshot)
+        print("  Reading bootstrap ... ", end="", flush=True)
+        bootstrap = extra
+        deadline2 = time.time() + 3
+        while time.time() < deadline2:
+            ready = select.select([sock], [], [], 0.5)
+            if ready[0]:
+                chunk = sock.recv(8192)
+                if not chunk:
+                    break
+                bootstrap += chunk
+            else:
+                break
+
+        print(f"got {len(bootstrap)} bytes")
+
+        # Now test live streaming: send a command via write_pty on a separate connection
+        # and verify we see the output on the stream
+        print("  Testing live stream ... ", end="", flush=True)
+        marker = f"__STREAM_TEST_{uuid.uuid4().hex[:8]}__"
+
+        # Send echo command via separate RPC connection
+        rpc_sock = connect()
+        import base64
+        cmd = f"echo {marker}\n"
+        b64 = base64.b64encode(cmd.encode()).decode()
+        rpc_resp = send_v2(rpc_sock, "surface.write_pty", {
+            "workspace_id": ws_id,
+            "surface_id": sf_id,
+            "data": b64
+        })
+        rpc_sock.close()
+        assert rpc_resp.get("ok"), f"write_pty failed: {rpc_resp}"
+
+        # Read from the stream and look for our marker
+        stream_data = b""
+        deadline3 = time.time() + 5
+        found_marker = False
+        while time.time() < deadline3:
+            ready = select.select([sock], [], [], 0.5)
+            if ready[0]:
+                chunk = sock.recv(8192)
+                if not chunk:
+                    break
+                stream_data += chunk
+                if marker.encode() in stream_data:
+                    found_marker = True
+                    break
+
+        if found_marker:
+            print(f"PASS (received {len(stream_data)} bytes, marker found)")
+        else:
+            print(f"PARTIAL (received {len(stream_data)} bytes, marker not found in stream)")
+            # This might happen if the output handler isn't connected yet
+            # or if the echo output was in the bootstrap data
+            if len(stream_data) > 0:
+                print(f"  Stream data preview: {stream_data[:200]!r}")
+
+    finally:
+        sock.close()
+
+
+def test_attach_stream_roundtrip(workspace_id):
+    """Test 5: Full roundtrip - send input via stream, read output."""
+    print("TEST 5: stream input roundtrip ... ", end="", flush=True)
+
+    # Send a unique marker via write_pty first
+    import base64
+    marker = f"RT_{uuid.uuid4().hex[:8]}"
+
+    rpc = connect()
+    cmd = f"echo {marker}\n"
+    b64 = base64.b64encode(cmd.encode()).decode()
+    resp = send_v2(rpc, "surface.write_pty", {"workspace_id": workspace_id, "data": b64})
+    rpc.close()
+
+    if not resp.get("ok"):
+        print(f"SKIP (write_pty failed: {resp})")
+        return
+
+    # Small delay for terminal to process
+    time.sleep(0.5)
+
+    # Now read_text and verify marker is on screen
+    rpc2 = connect()
+    resp2 = send_v2(rpc2, "surface.read_text", {"workspace_id": workspace_id})
+    rpc2.close()
+
+    if resp2.get("ok"):
+        text = resp2.get("result", {}).get("text", "")
+        if marker in text:
+            print(f"PASS (marker '{marker}' found in screen text)")
+        else:
+            print(f"PARTIAL (marker not in screen text, text len={len(text)})")
+    else:
+        print(f"FAIL (read_text error: {resp2})")
+
+
+def main():
+    print(f"=== cmux attach/stream E2E tests ===")
+    print(f"Socket: {SOCKET_PATH}")
+    print()
+
+    if not os.path.exists(SOCKET_PATH):
+        print(f"ERROR: Socket not found at {SOCKET_PATH}")
+        print("Start cmux with CMUX_SOCKET_MODE=allowAll first.")
+        sys.exit(1)
+
+    # Test 1: List workspaces
+    ws_id = test_workspace_list()
+
+    # Test 2: Write to pty
+    test_surface_write_pty(ws_id)
+
+    time.sleep(0.5)
+
+    # Test 3: Read screen text
+    test_surface_read_text(ws_id)
+
+    # Test 4: Stream attach
+    test_attach_stream(ws_id)
+
+    # Test 5: Roundtrip
+    test_attach_stream_roundtrip(ws_id)
+
+    print()
+    print("=== All tests completed ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Full foundation for iOS-to-Mac remote terminal connectivity (phases 1-3 + 5 of the architecture plan).

### Phase 1: `cmux attach` CLI + streaming
- `cmux attach <workspace>` command for bridging stdin/stdout to terminal I/O
- `surface.write_pty` v2 method for raw byte forwarding (preserves escape sequences)
- `surface.attach_stream` v2 method that upgrades a socket to raw pty byte streaming
- `SurfaceOutputStreamer`: ring buffer + per-client streaming with backpressure
- Stream protocol: JSON header → bootstrap screen snapshot → live raw bytes

### Ghostty fork: output handler API
- `ghostty_surface_set_output_handler` C API for observing raw pty output bytes
- Thread-safe setter using renderer_state mutex (matches inspector pattern)
- Fires from io-reader thread before terminal processing (zero-copy)
- Branch: `feat-output-handler` on manaflow-ai/ghostty

### Phase 3: Convex backend + Mac device registration
- Convex schema: `terminalDevices`, `terminalWorkspaceSnapshots`, `terminalEvents`
- HTTP routes: `/api/terminal/{register,heartbeat,event,workspaces}`
- Input validation on all HTTP endpoints
- Ownership check on `markRead`
- `ConvexHTTPClient`: Swift HTTP client for Convex mutations
- `DeviceRegistrationManager`: register on launch, 60s heartbeat, offline on quit/sleep
- `TailscaleInfo`: detects Tailscale hostname for P2P connectivity

### Phase 5 (partial): iOS SSH foundation
- `SSHClientProtocol` + `LibSSH2Client` stub (ready for libssh2 xcframework)
- `SSHKeyStore`: Ed25519 key generation, iOS Keychain storage, OpenSSH format export
- `SSHKeyManagementView`: SwiftUI key list with generate/copy/delete
- `SavedConnection`: model + UserDefaults persistence

## Testing
- `xcodebuild build` passes (cmux scheme, Debug, macOS)
- Ghostty xcframework rebuilt with output handler changes
- Code reviewed by Claude critic agent (race condition fixed, auth issues documented)

## Related
- Issue: https://github.com/manaflow-ai/cmux/issues/860
- Architecture plan: `~/.claude/plans/proud-zooming-parrot.md`
- Ghostty fork branch: https://github.com/manaflow-ai/ghostty/tree/feat-output-handler

## Known limitations
- Convex auth is placeholder (Bearer token = userId). Marked TODO for API key/JWT validation.
- iOS SSH client methods throw `.notImplemented` until libssh2 xcframework is integrated.
- Push notification trigger not yet wired (Phase 5 completion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `attach` command for streaming interactive terminal sessions over a dedicated socket
  * Device registration with automatic heartbeat, event reporting, and workspace sync
  * iOS companion app with SSH key management and saved-connection UI
  * Workspace snapshots and terminal event tracking with server API and schema
  * Live output streaming infrastructure for surfaces

* **Tests**
  * End-to-end attach/stream integration test covering upgrade, bootstrap, and roundtrip I/O

* **Chores**
  * Project and build configuration updates and new backend modules added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->