### PR TITLE
Fix stuck unread bell count for stale notification clicks

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4457,7 +4457,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self?.showNotificationsPopoverFromMenuBar()
             },
             onOpenNotification: { [weak self] notification in
-                _ = self?.openNotification(
+                _ = self?.openNotificationFromUserAction(
                     tabId: notification.tabId,
                     surfaceId: notification.surfaceId,
                     notificationId: notification.id
@@ -7252,7 +7252,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return nil
             }()
             DispatchQueue.main.async {
-                _ = self.openNotification(tabId: tabId, surfaceId: surfaceId, notificationId: notificationId)
+                _ = self.openNotificationFromUserAction(
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    notificationId: notificationId
+                )
             }
         case UNNotificationDismissActionIdentifier:
             DispatchQueue.main.async {
@@ -7415,6 +7419,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
         window?.performClose(nil)
+    }
+
+    @discardableResult
+    func openNotificationFromUserAction(tabId: UUID, surfaceId: UUID?, notificationId: UUID?) -> Bool {
+        let opened = openNotification(tabId: tabId, surfaceId: surfaceId, notificationId: notificationId)
+        if !opened, let notificationId, let notificationStore {
+            notificationStore.markRead(id: notificationId)
+        }
+        return opened
     }
 
     @discardableResult

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -25,7 +25,7 @@ struct NotificationsPage: View {
                                     // SwiftUI action closures are not guaranteed to run on the main actor.
                                     // Ensure window focus + tab selection happens on the main thread.
                                     DispatchQueue.main.async {
-                                        _ = AppDelegate.shared?.openNotification(
+                                        _ = AppDelegate.shared?.openNotificationFromUserAction(
                                             tabId: notification.tabId,
                                             surfaceId: notification.surfaceId,
                                             notificationId: notification.id

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -956,7 +956,7 @@ private struct NotificationsPopoverView: View {
         // SwiftUI action closures are not guaranteed to run on the main actor.
         // Ensure window focus + tab selection happens on the main thread.
         DispatchQueue.main.async {
-            _ = AppDelegate.shared?.openNotification(
+            _ = AppDelegate.shared?.openNotificationFromUserAction(
                 tabId: notification.tabId,
                 surfaceId: notification.surfaceId,
                 notificationId: notification.id

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -785,7 +785,7 @@ struct cmuxApp: App {
     }
 
     private func openNotificationFromMainMenu(_ notification: TerminalNotification) {
-        _ = appDelegate.openNotification(
+        _ = appDelegate.openNotificationFromUserAction(
             tabId: notification.tabId,
             surfaceId: notification.surfaceId,
             notificationId: notification.id

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -6679,6 +6679,40 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: tab), 0)
         XCTAssertNil(store.latestNotification(forTabId: tab))
     }
+
+    func testOpenNotificationFromUserActionMarksReadWhenTargetCannotOpen() {
+        let tabId = UUID()
+        let notificationId = UUID()
+        let notification = TerminalNotification(
+            id: notificationId,
+            tabId: tabId,
+            surfaceId: nil,
+            title: "Unread",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([notification])
+        XCTAssertEqual(store.unreadCount, 1)
+
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        appDelegate.notificationStore = store
+
+        let opened = appDelegate.openNotificationFromUserAction(
+            tabId: tabId,
+            surfaceId: nil,
+            notificationId: notificationId
+        )
+        XCTAssertFalse(opened)
+        XCTAssertTrue(
+            store.notifications.contains(where: { $0.id == notificationId && $0.isRead }),
+            "User click should acknowledge stale notifications so unread count does not get stuck"
+        )
+        XCTAssertEqual(store.unreadCount, 0)
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Add `AppDelegate.openNotificationFromUserAction(...)` and make it mark notifications read when the target cannot be opened.
- Route all user-click notification open paths through the new helper (menu bar extra, notifications page, titlebar popover, app menu, and system notification click handler).
- Add a regression test to lock behavior when a stale notification is clicked and cannot be opened.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/NotificationDockBadgeTests/testOpenNotificationFromUserActionMarksReadWhenTargetCannotOpen test` (passes)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (passes)
- `scripts/codex-review.sh /Users/lawrencechen/fun/cmuxterm-hq/worktrees/task-notification-bell-stuck-count` (0 findings)

## Issues
- Related task: `task-notification-bell-stuck-count` (HQ user report, 2026-03-04)
- Related comparison: https://github.com/manaflow-ai/cmux/compare/main...task-notification-bell-stuck-count


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stuck unread bell count by marking stale notifications as read when a user clicks one that can’t be opened. Addresses Linear task task-notification-bell-stuck-count.

- **Bug Fixes**
  - Added AppDelegate.openNotificationFromUserAction(...) to mark read when the target cannot open.
  - Routed all notification click paths through the helper (menu bar, notifications page, titlebar popover, main menu, system notification click).
  - Added a regression test to ensure stale clicks clear the unread count.

<sup>Written for commit 4beb94def2d7c6b87e465ae6e5db0aab276786e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

