### PR TITLE
fix(claude-wrapper): resolve symlinks in find_real_claude to prevent infinite exec loop

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -8,12 +8,20 @@
 
 # Find the real claude binary, skipping our own directory.
 find_real_claude() {
+    local self
+    self="$(realpath "$0")"
     local self_dir
-    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    self_dir="$(dirname "$self")"
     local IFS=:
     for d in $PATH; do
         [[ "$d" == "$self_dir" ]] && continue
-        [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
+        local candidate="$d/claude"
+        [[ ! -x "$candidate" ]] && continue
+        local resolved
+        resolved="$(realpath "$candidate" 2>/dev/null)"
+        [[ "$resolved" == "$self" ]] && continue
+        printf '%s' "$candidate"
+        return 0
     done
     return 1
 }


### PR DESCRIPTION
## Problem

The `claude` wrapper script at `Resources/bin/claude` enters an infinite exec loop when another shell script in `$PATH` wraps the `claude` command and is itself a symlink pointing back to the cmux wrapper.

### What was happening

The `find_real_claude` function is supposed to locate the real `claude` binary by walking `$PATH` and skipping its own directory. The self-exclusion logic was:

```bash
self_dir="$(cd "$(dirname "$0")" && pwd)"
...
[[ "$d" == "$self_dir" ]] && continue
```

This compares **directory names only** — it doesn't resolve symlinks. When a user has another `claude` wrapper script in their `$PATH` that symlinks back to the cmux wrapper:

```
~/some/bin/claude  →  (symlink to)  /Applications/cmux.app/Contents/Resources/bin/claude
```

The function skips `/Applications/cmux.app/Contents/Resources/bin` from `$PATH`, but then happily returns `~/some/bin/claude` as the "real" claude — because it's a different directory name, the check passes.

The wrapper then does:

```bash
exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
```

…which re-executes the same script (via the symlink), which calls `find_real_claude` again, which returns the same symlink, which gets exec'd again — **forever**.

### Observed symptoms

With `set -x` tracing enabled, the script produces thousands of lines of output showing the loop:

```
+ for arg in '"$@"'
+ case "$arg" in
+ for arg in '"$@"'
+ case "$arg" in
...
+ exec ~/some/bin/claude --settings '{...}' --settings '{...}' --settings '{...}' ...
```

Each iteration appends another `--settings` flag to the argument list (because the previous invocation's args are passed through), so the command line grows geometrically: ~35 flags, then ~70, then ~140, until the process is killed.

## Fix

Resolve symlinks on both sides of the comparison using `realpath`:

```bash
find_real_claude() {
    local self
    self="$(realpath "$0")"          # resolve our own path through symlinks
    local self_dir
    self_dir="$(dirname "$self")"
    local IFS=:
    for d in $PATH; do
        [[ "$d" == "$self_dir" ]] && continue
        local candidate="$d/claude"
        [[ ! -x "$candidate" ]] && continue
        local resolved
        resolved="$(realpath "$candidate" 2>/dev/null)"
        [[ "$resolved" == "$self" ]] && continue   # skip if it resolves to us
        printf '%s' "$candidate"
        return 0
    done
    return 1
}
```

Now, even if a `claude` entry in `$PATH` is a symlink to the cmux wrapper, `realpath` resolves it to the same absolute path as `self`, and the `continue` correctly skips it — breaking the loop.

The `2>/dev/null` on the candidate `realpath` call gracefully handles broken symlinks or permission errors without failing the function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve symlinks in find_real_claude to prevent an infinite exec loop when a PATH entry is a symlink back to the claude wrapper. This ensures the wrapper never re-execs itself.

- **Bug Fixes**
  - Use realpath to compare resolved paths and skip any candidate that resolves to the wrapper.
  - Suppress realpath errors on candidates (2>/dev/null) to handle broken symlinks safely.

<sup>Written for commit ea98d07165f1254673042fa54609c6a6869fa0a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced binary resolution logic to be more robust and reliable. The script now performs stricter validation when locating executables and prevents potential circular reference issues, ensuring it correctly identifies the intended executable across your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->