### PR TITLE
Fix browser address bar Japanese IME input (#789)

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2294,8 +2294,6 @@ private final class OmnibarNativeTextField: NSTextField {
     }
 
     override func keyDown(with event: NSEvent) {
-        // IME変換中はカスタムキーハンドリングをバイパスし、
-        // NSTextFieldの標準IME処理に委譲する
         if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
             super.keyDown(with: event)
             return
@@ -2624,9 +2622,6 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         )
         let desiredDisplayText = activeInlineCompletion?.displayText ?? text
         if let editor = nsView.currentEditor() as? NSTextView {
-            // IME変換中（marked text あり）はテキスト同期をスキップ。
-            // SwiftUIのバインディング更新がeditor.stringを上書きすると
-            // 変換中のmarked textが破壊される。
             if !editor.hasMarkedText(), editor.string != desiredDisplayText {
                 context.coordinator.isProgrammaticMutation = true
                 editor.string = desiredDisplayText


### PR DESCRIPTION
## Summary
- Japanese IME input (e.g. Japanese, Chinese, Korean) in the browser address bar was completely broken — characters were not entered when typing with an IME
- Guard `keyDown`/`performKeyEquivalent` with `hasMarkedText()` to bypass custom key handling during IME composition
- Guard `updateNSView` text sync and selection range manipulation to prevent SwiftUI binding updates from destroying marked text during composition

## Testing
- Switch to Japanese IME, type in the browser address bar → continuous input works (e.g. "あああああ")
- Confirm with Enter → text commits correctly
- English input still works normally
- IME-off: Return submits, Escape closes, arrows navigate suggestions, Tab accepts inline completion
- Inline completion still works when not composing

## Related
- Fixes #789

## Screenshot

https://github.com/user-attachments/assets/12fe3708-3ddd-4da4-aad8-8f84b4f7a888



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix IME input in the browser address bar so Japanese/Chinese/Korean characters type and commit correctly. Prevents custom key handling and SwiftUI updates from disrupting composition. Fixes #789.

- **Bug Fixes**
  - Guard keyDown and performKeyEquivalent with hasMarkedText() to defer to AppKit during composition.
  - Skip text and selection syncing when editor.hasMarkedText() to preserve marked text.
  - Keep normal shortcuts and inline completion behavior when not composing.

- **Refactors**
  - Removed redundant comments in BrowserPanelView.swift.

<sup>Written for commit 20003956d34f2d79a4805beb52f5dfe5dad7f34d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IME (Input Method Editor) handling: during character composition the app now defers custom omnibar key handling and text synchronization to the native IME, preventing composition disruption and potential text corruption for multi-character languages (e.g., Chinese, Japanese, Korean).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->