### PR TITLE
Fix notification causing terminal screen to go blank

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6570,7 +6570,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let coordinator = context.coordinator
         let previousDesiredIsActive = coordinator.desiredIsActive
         let previousDesiredIsVisibleInUI = coordinator.desiredIsVisibleInUI
-        let previousDesiredShowsUnreadNotificationRing = coordinator.desiredShowsUnreadNotificationRing
         let previousDesiredPortalZPriority = coordinator.desiredPortalZPriority
         let desiredStateChanged =
             previousDesiredIsActive != isActive ||
@@ -6696,7 +6695,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     coordinator.lastBoundHostId != hostId ||
                     hostedView.superview == nil ||
                     previousDesiredIsVisibleInUI != isVisibleInUI ||
-                    previousDesiredShowsUnreadNotificationRing != showsUnreadNotificationRing ||
                     previousDesiredPortalZPriority != portalZPriority
                 if shouldBindNow {
                     TerminalWindowPortalRegistry.bind(


### PR DESCRIPTION
## Summary

- Remove `showsUnreadNotificationRing` from the `shouldBindNow` condition in `GhosttyTerminalView.updateNSView`
- When a notification changed this property, it triggered a full portal re-bind whose geometry could be unsettled during the SwiftUI update cascade, causing `frame=.zero` and a blank screen
- The notification ring visual is already handled independently via `hostedView.setNotificationRing(visible:)` (a CALayer opacity toggle), so no portal re-bind is needed

Fixes #683

## Test plan

- [ ] Trigger a notification in one terminal while viewing another tab
- [ ] Confirm terminal content remains visible (no blank screen)
- [ ] Confirm notification ring indicator still appears correctly on the tab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent blank terminal screens when notifications change by removing showsUnreadNotificationRing from the portal re-bind trigger in GhosttyTerminalView.updateNSView. The notification ring now updates via hostedView.setNotificationRing(visible:), so geometry stays stable and content remains visible. Fixes #683.

<sup>Written for commit de0549ee570a17b56a9bf5d9779f5e4a7db57b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized notification ring state handling to reduce unnecessary interface rebinds, improving performance and visual update stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->