### PR TITLE
fix: prevent crash in parseNotificationPayload when fields are empty

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10837,8 +10837,8 @@ class TerminalController {
     private func parseNotificationPayload(_ args: String) -> (String, String, String) {
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return ("Notification", "", "") }
-        let parts = trimmed.split(separator: "|", maxSplits: 2).map(String.init)
-        let title = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+        let title = parts.count > 0 ? parts[0].trimmingCharacters(in: .whitespacesAndNewlines) : ""
         let subtitle = parts.count > 2 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
         let body = parts.count > 2
             ? parts[2].trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary

Fixes a crash (`EXC_BREAKPOINT` / `SIGTRAP`) in `TerminalController.parseNotificationPayload(_:)` when the notification payload contains empty pipe-delimited fields.

### Root Cause

`String.split(separator:)` omits empty subsequences by default. When the payload has empty fields (e.g. `"||"` or `"||body"`), the resulting array can be empty or misaligned, and the unconditional `parts[0]` access triggers an out-of-bounds Swift runtime trap.

### Changes

1. Pass `omittingEmptySubsequences: false` to `split()` so field positions are preserved across pipe delimiters (e.g. `"title||body"` → `["title", "", "body"]` instead of `["title", "body"]`)
2. Guard `parts[0]` with a bounds check, consistent with how `parts[1]` and `parts[2]` are already accessed

### Reproduction

Triggered via Claude Code's `Notification` hook when `$CLAUDE_NOTIFICATION_TITLE` or `$CLAUDE_NOTIFICATION_BODY` env vars are empty, producing a payload like `"||"`. Also reproducible with `cmux notify --title "" --body ""`.

### Crash Report

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0 cmux   specialized TerminalController.parseNotificationPayload(_:) + 1072
1 cmux   closure #1 in TerminalController.notifyTarget(_:) + 528
```

Exception: `EXC_BREAKPOINT (SIGTRAP)` — cmux v0.61.0, macOS 26.3, Apple Silicon (Mac16,7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a crash in TerminalController.parseNotificationPayload when notification payloads include empty pipe-delimited fields. Parsing now handles inputs like "||" without trapping.

- **Bug Fixes**
  - Preserve field positions by using split(..., omittingEmptySubsequences: false).
  - Guard the first field before trimming to avoid out-of-bounds access.

<sup>Written for commit 5f372628d3b6232d7e1a7b05c7418f89bf241be0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved notification payload handling to gracefully manage incomplete data. The application now correctly extracts notification titles even when certain segments are missing and intelligently falls back to subtitle content for the message body when the body segment is unavailable, enhancing overall notification display reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->