### PR TITLE
Fix notification sound picker style in Settings

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2957,7 +2957,8 @@ struct SettingsView: View {
 
                         SettingsCardRow(
                             "Notification Sound",
-                            subtitle: "Sound played when a notification arrives."
+                            subtitle: "Sound played when a notification arrives.",
+                            controlWidth: pickerColumnWidth
                         ) {
                             HStack(spacing: 6) {
                                 Picker("", selection: $notificationSound) {
@@ -2966,6 +2967,7 @@ struct SettingsView: View {
                                     }
                                 }
                                 .labelsHidden()
+                                .pickerStyle(.menu)
                                 Button {
                                     NotificationSoundSettings.previewSound(value: notificationSound)
                                 } label: {


### PR DESCRIPTION
## Summary
- The notification sound picker was missing `.pickerStyle(.menu)` and `controlWidth: pickerColumnWidth`, causing it to render as an expanded picker with a large empty area instead of a compact dropdown. This is the same pattern that was already applied to the sidebar branch layout picker and all other settings pickers.

## Testing
- Open Settings, scroll to Notification Sound. The picker should render as a compact dropdown menu (same as Sidebar Branch Layout, Theme, etc.) instead of an oversized expanded picker.

## Prevention
Every `Picker` in `SettingsView` must have `.pickerStyle(.menu)` and its parent `SettingsCardRow` should use `controlWidth: pickerColumnWidth`. Consider adding a SwiftLint or build-time check, or extracting a `SettingsPickerRow` helper that enforces this by construction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Notification Sound picker in Settings to display as a compact dropdown menu, matching other settings pickers. Removes the oversized expanded picker and empty space.

- **Bug Fixes**
  - Applied .pickerStyle(.menu) to the Notification Sound picker.
  - Set controlWidth: pickerColumnWidth on its SettingsCardRow.

<sup>Written for commit d8a2b4cc81f92d35a5f42de14f2b13200cae79f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

