### PR TITLE
Guard startup restore against oversized session snapshots

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -18,6 +18,7 @@ enum SessionPersistencePolicy {
     static let maxPanelsPerWorkspace: Int = 512
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
+    static let maxSnapshotBytes: Int = 8_000_000
 
     static func sanitizedSidebarWidth(_ candidate: Double?) -> Double {
         let fallback = defaultSidebarWidth
@@ -357,12 +358,33 @@ struct AppSessionSnapshot: Codable, Sendable {
 enum SessionPersistenceStore {
     static func load(fileURL: URL? = nil) -> AppSessionSnapshot? {
         guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return nil }
-        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        if let fileSize = snapshotFileSize(at: fileURL), fileSize > SessionPersistencePolicy.maxSnapshotBytes {
+            sentryBreadcrumb(
+                "session.restore.skipped.oversize_snapshot",
+                category: "startup",
+                data: [
+                    "path": fileURL.path,
+                    "bytes": fileSize,
+                    "maxBytes": SessionPersistencePolicy.maxSnapshotBytes
+                ]
+            )
+            return nil
+        }
+        guard let data = try? Data(contentsOf: fileURL, options: [.mappedIfSafe]) else { return nil }
+        guard data.count <= SessionPersistencePolicy.maxSnapshotBytes else { return nil }
         let decoder = JSONDecoder()
         guard let snapshot = try? decoder.decode(AppSessionSnapshot.self, from: data) else { return nil }
         guard snapshot.version == SessionSnapshotSchema.currentVersion else { return nil }
         guard !snapshot.windows.isEmpty else { return nil }
         return snapshot
+    }
+
+    private static func snapshotFileSize(at fileURL: URL) -> Int? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let size = attributes[.size] as? NSNumber else {
+            return nil
+        }
+        return size.intValue
     }
 
     @discardableResult

--- a/tests/test_issue_b0_startup_snapshot_size_guard.py
+++ b/tests/test_issue_b0_startup_snapshot_size_guard.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Regression guard for CMUXTERM-MACOS-B0 startup snapshot size protection."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def require(content: str, needle: str, message: str, failures: list[str]) -> None:
+    if needle not in content:
+        failures.append(message)
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    session_persistence_path = repo_root / "Sources" / "SessionPersistence.swift"
+    if not session_persistence_path.exists():
+        print(f"Missing expected file: {session_persistence_path}")
+        return 1
+
+    content = read_text(session_persistence_path)
+    failures: list[str] = []
+
+    require(
+        content,
+        "maxSnapshotBytes",
+        "Session persistence policy is missing a max snapshot size limit",
+        failures,
+    )
+    require(
+        content,
+        "snapshotFileSize(at: fileURL)",
+        "Session restore no longer checks snapshot file size before decode",
+        failures,
+    )
+    require(
+        content,
+        "session.restore.skipped.oversize_snapshot",
+        "Oversized startup snapshots are no longer breadcrumbed for diagnostics",
+        failures,
+    )
+    require(
+        content,
+        "data.count <= SessionPersistencePolicy.maxSnapshotBytes",
+        "Session restore no longer enforces decoded data size limit",
+        failures,
+    )
+
+    if failures:
+        print("FAIL: issue B0 regression(s) detected")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: issue B0 startup snapshot size guards are present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a startup restore size guard (`SessionPersistencePolicy.maxSnapshotBytes`) so oversized session snapshots are skipped before JSON decode
- use file-size precheck plus mapped file loading to avoid expensive main-thread decode work in startup restore
- breadcrumb skipped oversized restores as `session.restore.skipped.oversize_snapshot` for diagnostics
- add regression guard test `tests/test_issue_b0_startup_snapshot_size_guard.py`

## Testing
- `python3 tests/test_issue_b0_startup_snapshot_size_guard.py` (pass)
- `python3 tests/test_issue_494_sleep_wake_git_branch_recovery.py` (pass)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (pass)
- `codex --dangerously-bypass-approvals-and-sandbox --model gpt-5.3-codex -c model_reasoning_effort="xhigh" --search review --uncommitted` (0 findings)

## Issues
- Related: https://manaflow.sentry.io/issues/CMUXTERM-MACOS-B0
- Related: https://manaflow.sentry.io/issues/CMUXTERM-MACOS-AZ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a size guard to startup session restore so oversized snapshots are skipped before JSON decode. Improves launch stability and performance and addresses CMUXTERM-MACOS-B0 reports.

- **Bug Fixes**
  - Enforce maxSnapshotBytes (8 MB) with a file-size precheck and mapped file loading.
  - Skip oversize snapshots and breadcrumb as session.restore.skipped.oversize_snapshot.
  - Add regression test: tests/test_issue_b0_startup_snapshot_size_guard.py.

<sup>Written for commit 2e04e8b7ff24998db3cd78d3f27a7bdbb117d205. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session persistence to safely handle oversized snapshot files during startup by implementing size validation and gracefully skipping snapshots that exceed limits.

* **Tests**
  * Added regression test to verify snapshot size guard implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->