### PR TITLE
Add Markdown code syntax highlighting

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -30,7 +30,9 @@
 		A5001404 /* BrowserPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001414 /* BrowserPanelView.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		A5001423 /* MarkdownCodeSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001422 /* MarkdownCodeSyntaxHighlighter.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
+		A5001293 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = A5001294 /* Highlightr */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
@@ -175,6 +177,7 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		A5001422 /* MarkdownCodeSyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownCodeSyntaxHighlighter.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -242,6 +245,7 @@
 					A5001250 /* Sentry in Frameworks */,
 					A5001270 /* PostHog in Frameworks */,
 					A5001290 /* MarkdownUI in Frameworks */,
+					A5001293 /* Highlightr in Frameworks */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
@@ -371,6 +375,7 @@
 				A5001414 /* BrowserPanelView.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				A5001422 /* MarkdownCodeSyntaxHighlighter.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -482,6 +487,7 @@
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
 					A5001291 /* MarkdownUI */,
+					A5001294 /* Highlightr */,
 				);
 			name = GhosttyTabs;
 			productName = GhosttyTabs;
@@ -568,6 +574,7 @@
 					A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+					A5001295 /* XCRemoteSwiftPackageReference "Highlightr" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
 				);
 			productRefGroup = A5001042 /* Products */;
@@ -620,6 +627,7 @@
 				A5001404 /* BrowserPanelView.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				A5001423 /* MarkdownCodeSyntaxHighlighter.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
@@ -986,6 +994,14 @@
 					minimumVersion = 2.4.1;
 				};
 			};
+			A5001295 /* XCRemoteSwiftPackageReference "Highlightr" */ = {
+				isa = XCRemoteSwiftPackageReference;
+				repositoryURL = "https://github.com/raspu/Highlightr";
+				requirement = {
+					kind = upToNextMajorVersion;
+					minimumVersion = 2.3.0;
+				};
+			};
 			A5001260 /* XCLocalSwiftPackageReference "bonsplit" */ = {
 				isa = XCLocalSwiftPackageReference;
 				relativePath = vendor/bonsplit;
@@ -1017,6 +1033,11 @@
 				isa = XCSwiftPackageProductDependency;
 				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 				productName = MarkdownUI;
+			};
+			A5001294 /* Highlightr */ = {
+				isa = XCSwiftPackageProductDependency;
+				package = A5001295 /* XCRemoteSwiftPackageReference "Highlightr" */;
+				productName = Highlightr;
 			};
 /* End XCSwiftPackageProductDependency section */
 

--- a/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "b66d812c506be67c70b46c63421ab2eb2db013613c74252ad1205f662ada079b",
+  "originHash" : "8a6dd771327960e4b5e2986831a12b3fd9dfcbc732868e67e3aeeb41babf7f37",
   "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
     {
       "identity" : "networkimage",
       "kind" : "remoteSourceControl",

--- a/Sources/Panels/MarkdownCodeSyntaxHighlighter.swift
+++ b/Sources/Panels/MarkdownCodeSyntaxHighlighter.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Highlightr
+import MarkdownUI
+import SwiftUI
+
+/// MarkdownUI syntax highlighter backed by Highlightr/highlight.js.
+/// Supports a broad set of languages via highlight.js and falls back to
+/// automatic language detection when the fenced language is unknown.
+struct CMUXMarkdownCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+    private final class Storage {
+        let highlightr: Highlightr?
+
+        init(themeName: String) {
+            let highlightr = Highlightr()
+            highlightr?.setTheme(to: themeName)
+            highlightr?.theme.setCodeFont(.monospacedSystemFont(ofSize: 13, weight: .regular))
+            self.highlightr = highlightr
+        }
+    }
+
+    private static let darkStorage = Storage(themeName: "atom-one-dark")
+    private static let lightStorage = Storage(themeName: "xcode")
+
+    private let storage: Storage
+
+    init(colorScheme: ColorScheme) {
+        self.storage = colorScheme == .dark ? Self.darkStorage : Self.lightStorage
+    }
+
+    func highlightCode(_ code: String, language: String?) -> Text {
+        guard let highlightr = storage.highlightr else {
+            return Text(code)
+        }
+
+        let normalizedLanguage = Self.normalizedLanguageName(language)
+        let highlighted = highlightr.highlight(code, as: normalizedLanguage) ?? highlightr.highlight(code)
+        guard let highlighted else {
+            return Text(code)
+        }
+
+        guard let attributed = try? AttributedString(highlighted, including: \.appKit) else {
+            return Text(code)
+        }
+        return Text(attributed)
+    }
+
+    private static func normalizedLanguageName(_ language: String?) -> String? {
+        guard let language = language?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !language.isEmpty
+        else {
+            return nil
+        }
+
+        switch language {
+        case "js":
+            return "javascript"
+        case "ts":
+            return "typescript"
+        case "py":
+            return "python"
+        case "rb":
+            return "ruby"
+        case "sh", "shell", "zsh":
+            return "bash"
+        case "c++":
+            return "cpp"
+        case "cs", "c#":
+            return "csharp"
+        case "objc":
+            return "objectivec"
+        case "yml":
+            return "yaml"
+        case "kt":
+            return "kotlin"
+        default:
+            return language
+        }
+    }
+}
+

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -56,6 +56,7 @@ struct MarkdownPanelView: View {
                 // Rendered markdown
                 Markdown(panel.content)
                     .markdownTheme(cmuxMarkdownTheme)
+                    .markdownCodeSyntaxHighlighter(cmuxCodeSyntaxHighlighter)
                     .textSelection(.enabled)
                     .padding(.horizontal, 24)
                     .padding(.vertical, 16)
@@ -103,6 +104,10 @@ struct MarkdownPanelView: View {
         colorScheme == .dark
             ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
             : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
+    }
+
+    private var cmuxCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+        CMUXMarkdownCodeSyntaxHighlighter(colorScheme: colorScheme)
     }
 
     private var cmuxMarkdownTheme: Theme {
@@ -182,7 +187,6 @@ struct MarkdownPanelView: View {
                         .markdownTextStyle {
                             FontFamilyVariant(.monospaced)
                             FontSize(13)
-                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
                         }
                         .padding(12)
                 }

--- a/tests/test_markdown_syntax_highlighting_wiring.py
+++ b/tests/test_markdown_syntax_highlighting_wiring.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import subprocess
+import json
 from pathlib import Path
 
 
@@ -22,6 +23,19 @@ def get_repo_root() -> Path:
 def require(content: str, needle: str, message: str, failures: list[str]) -> None:
     if needle not in content:
         failures.append(message)
+
+def require_package_version(
+    pins_by_identity: dict[str, str | None],
+    identity: str,
+    version: str,
+    failures: list[str],
+) -> None:
+    actual = pins_by_identity.get(identity)
+    if actual is None:
+        failures.append(f"Package.resolved should include {identity}")
+        return
+    if actual != version:
+        failures.append(f"Package.resolved should pin {identity} to {version} (found {actual})")
 
 
 def main() -> int:
@@ -48,6 +62,12 @@ def main() -> int:
     pbxproj = pbxproj_path.read_text(encoding="utf-8")
     resolved = resolved_path.read_text(encoding="utf-8")
     failures: list[str] = []
+    resolved_json = json.loads(resolved)
+    pins_by_identity = {
+        pin.get("identity"): pin.get("state", {}).get("version")
+        for pin in resolved_json.get("pins", [])
+        if pin.get("identity")
+    }
 
     # Markdown view wiring.
     require(
@@ -93,30 +113,8 @@ def main() -> int:
         require(pbxproj, needle, message, failures)
 
     # Dependency versions.
-    require(
-        resolved,
-        '"identity" : "highlightr"',
-        "Package.resolved should pin Highlightr",
-        failures,
-    )
-    require(
-        resolved,
-        '"version" : "2.3.0"',
-        "Package.resolved should pin Highlightr to 2.3.0",
-        failures,
-    )
-    require(
-        resolved,
-        '"identity" : "swift-markdown-ui"',
-        "Package.resolved should include swift-markdown-ui",
-        failures,
-    )
-    require(
-        resolved,
-        '"version" : "2.4.1"',
-        "Package.resolved should keep swift-markdown-ui at 2.4.1",
-        failures,
-    )
+    require_package_version(pins_by_identity, "highlightr", "2.3.0", failures)
+    require_package_version(pins_by_identity, "swift-markdown-ui", "2.4.1", failures)
 
     if failures:
         print("FAIL: markdown syntax-highlighting wiring regression(s) detected")
@@ -130,4 +128,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_markdown_syntax_highlighting_wiring.py
+++ b/tests/test_markdown_syntax_highlighting_wiring.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Regression checks for markdown syntax highlighting wiring."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def require(content: str, needle: str, message: str, failures: list[str]) -> None:
+    if needle not in content:
+        failures.append(message)
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    markdown_view_path = repo_root / "Sources" / "Panels" / "MarkdownPanelView.swift"
+    highlighter_path = repo_root / "Sources" / "Panels" / "MarkdownCodeSyntaxHighlighter.swift"
+    pbxproj_path = repo_root / "GhosttyTabs.xcodeproj" / "project.pbxproj"
+    resolved_path = (
+        repo_root
+        / "GhosttyTabs.xcodeproj"
+        / "project.xcworkspace"
+        / "xcshareddata"
+        / "swiftpm"
+        / "Package.resolved"
+    )
+
+    for path in [markdown_view_path, highlighter_path, pbxproj_path, resolved_path]:
+        if not path.exists():
+            print(f"FAIL: missing expected file: {path}")
+            return 1
+
+    markdown_view = markdown_view_path.read_text(encoding="utf-8")
+    highlighter = highlighter_path.read_text(encoding="utf-8")
+    pbxproj = pbxproj_path.read_text(encoding="utf-8")
+    resolved = resolved_path.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    # Markdown view wiring.
+    require(
+        markdown_view,
+        ".markdownCodeSyntaxHighlighter(cmuxCodeSyntaxHighlighter)",
+        "Markdown panel view must apply markdownCodeSyntaxHighlighter",
+        failures,
+    )
+    require(
+        markdown_view,
+        "private var cmuxCodeSyntaxHighlighter: CodeSyntaxHighlighter",
+        "Markdown panel view must expose a code syntax highlighter property",
+        failures,
+    )
+
+    # Highlighter implementation contract.
+    require(highlighter, "import Highlightr", "Highlighter implementation must import Highlightr", failures)
+    require(
+        highlighter,
+        "struct CMUXMarkdownCodeSyntaxHighlighter: CodeSyntaxHighlighter",
+        "Highlighter implementation must conform to CodeSyntaxHighlighter",
+        failures,
+    )
+    require(
+        highlighter,
+        "highlightr.highlight(code, as: normalizedLanguage) ?? highlightr.highlight(code)",
+        "Highlighter implementation must try fenced language then auto-detect",
+        failures,
+    )
+    require(
+        highlighter,
+        'case "js":',
+        "Highlighter should normalize common language aliases",
+        failures,
+    )
+
+    # Xcode package wiring.
+    for needle, message in [
+        ('XCRemoteSwiftPackageReference "Highlightr"', "Project should include Highlightr package reference"),
+        ('productName = Highlightr;', "Project should include Highlightr package product"),
+        ('Highlightr in Frameworks', "GhosttyTabs target should link Highlightr"),
+    ]:
+        require(pbxproj, needle, message, failures)
+
+    # Dependency versions.
+    require(
+        resolved,
+        '"identity" : "highlightr"',
+        "Package.resolved should pin Highlightr",
+        failures,
+    )
+    require(
+        resolved,
+        '"version" : "2.3.0"',
+        "Package.resolved should pin Highlightr to 2.3.0",
+        failures,
+    )
+    require(
+        resolved,
+        '"identity" : "swift-markdown-ui"',
+        "Package.resolved should include swift-markdown-ui",
+        failures,
+    )
+    require(
+        resolved,
+        '"version" : "2.4.1"',
+        "Package.resolved should keep swift-markdown-ui at 2.4.1",
+        failures,
+    )
+
+    if failures:
+        print("FAIL: markdown syntax-highlighting wiring regression(s) detected")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: markdown syntax-highlighting wiring is present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add a markdown code syntax highlighter using Highlightr (highlight.js) and wire it into MarkdownUI
- preserve markdown readability by removing fixed code-block foreground color override
- add a regression test that verifies highlighter wiring, package dependencies, and versions

## Context
- follow-up to https://github.com/manaflow-ai/cmux/pull/883 so markdown previews render fenced code with language highlighting

## Test Plan
- python3 tests/test_markdown_syntax_highlighting_wiring.py
- python3 tests/test_markdown_open_regressions.py
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag md-syntax-hl

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds syntax highlighting to Markdown code blocks in the Markdown panel, improving readability with theme-aware colors and automatic language detection.

- **New Features**
  - Add CMUXMarkdownCodeSyntaxHighlighter and wire it into MarkdownUI with alias mapping and auto-detect fallback.
  - Apply theme-aware styles (atom-one-dark for dark, xcode for light) and a 13pt monospaced font sop; remove forced code-block foreground color

<sup>Written for commit 27644860e6d0593d3f55711c8cb1fe517726cdca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented syntax highlighting for code blocks in markdown, supporting multiple programming languages with automatic dark and light theme detection.

* **Tests**
  * Added regression tests to verify syntax highlighting integration across the markdown panel and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->