### PR TITLE
Fix browser tab click focus after workspace switch

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9147,6 +9147,12 @@ private extension NSWindow {
         if let eventWindow = event.window, eventWindow !== window {
             return nil
         }
+        if let portalWebView = BrowserWindowPortalRegistry.webViewAtWindowPoint(
+            event.locationInWindow,
+            in: window
+        ) as? CmuxWebView {
+            return portalWebView
+        }
         guard let hitView = cmuxHitViewForCurrentEvent(in: window, event: event) else {
             return nil
         }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1196,6 +1196,12 @@ enum BrowserWindowPortalRegistry {
         portalsByWindowId[windowId]?.detachWebView(withId: webViewId)
     }
 
+    static func webViewAtWindowPoint(_ windowPoint: NSPoint, in window: NSWindow) -> WKWebView? {
+        let windowId = ObjectIdentifier(window)
+        guard let portal = portalsByWindowId[windowId] else { return nil }
+        return portal.webViewAtWindowPoint(windowPoint)
+    }
+
 #if DEBUG
     static func debugPortalCount() -> Int {
         portalsByWindowId.count

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -412,6 +412,67 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
     }
 
     @MainActor
+    func testWindowFirstResponderGuardAllowsPointerInitiatedClickFocusForPortalHostedWebView() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let anchor = NSView(frame: NSRect(x: 80, y: 60, width: 240, height: 150))
+        container.addSubview(anchor)
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let descendant = FirstResponderView(frame: NSRect(x: 0, y: 0, width: 10, height: 10))
+        webView.addSubview(descendant)
+
+        window.makeKeyAndOrderFront(nil)
+        container.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        BrowserWindowPortalRegistry.bind(webView: webView, to: anchor, visibleInUI: true, zPriority: 1)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+
+        defer {
+            BrowserWindowPortalRegistry.detach(webView: webView)
+            AppDelegate.clearWindowFirstResponderGuardTesting()
+            window.orderOut(nil)
+        }
+
+        webView.allowsFirstResponderAcquisition = false
+        _ = window.makeFirstResponder(nil)
+        XCTAssertFalse(window.makeFirstResponder(descendant), "Expected blocked focus without pointer click context")
+
+        let timestamp = ProcessInfo.processInfo.systemUptime
+        let pointerPointInContent = NSPoint(x: anchor.frame.midX, y: anchor.frame.midY)
+        let pointerPointInWindow = container.convert(pointerPointInContent, to: nil)
+        let pointerDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: pointerPointInWindow,
+            modifierFlags: [],
+            timestamp: timestamp,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1.0
+        )
+        XCTAssertNotNil(pointerDownEvent)
+
+        AppDelegate.setWindowFirstResponderGuardTesting(currentEvent: pointerDownEvent, hitView: nil)
+        _ = window.makeFirstResponder(nil)
+        XCTAssertTrue(
+            window.makeFirstResponder(descendant),
+            "Expected portal-hosted pointer click context to bypass blocked policy"
+        )
+    }
+
+    @MainActor
     func testWindowFirstResponderGuardAvoidsTextViewDelegateLookupForWebViewResolution() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/901

- Add `BrowserWindowPortalRegistry.webViewAtWindowPoint(_:in:)` to resolve portal-hosted web views from click coordinates
- Update `AppDelegate`'s window first-responder guard to check portal-hosted web views before the standard hit-test path, so clicks on browser content re-focus correctly after workspace switches
- Add test verifying pointer-initiated click focus works for portal-hosted web views

## Test plan

- [ ] Open a workspace with a browser tab
- [ ] Click on a terminal surface to defocus the browser
- [ ] Switch to a different workspace, then switch back
- [ ] Click on the browser content — it should respond immediately without needing to click the tab header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost click focus in browser tabs after switching workspaces. Clicks on portal-hosted browser content now immediately focus the tab without needing to click the tab header.

- **Bug Fixes**
  - Resolve portal-hosted web views from window coordinates with BrowserWindowPortalRegistry.webViewAtWindowPoint(_:in:).
  - Check portal-hosted web views first in the window first-responder guard to honor pointer click context.
  - Add a test that verifies pointer-initiated click focus for portal-hosted web views.

<sup>Written for commit 9c0f827ae826fab2a13b1691e0eb09089001cbd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved click detection and focus handling for web views in portal-managed windows
  * Enhanced focus acquisition when interacting with portal-hosted web views via pointer events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->