### PR TITLE
Salvage accidental edits from primary checkout

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1542,7 +1542,9 @@ struct CMUXCLI {
                 throw CLIError(message: "set-status requires <key> and <value>")
             }
             let key = r3[0]
-            let value = r3.dropFirst().joined(separator: " ")
+            // Strip leading "--" separator if present (e.g. `set-status mykey -- value`)
+            let valueParts = r3.dropFirst()
+            let value = (valueParts.first == "--" ? Array(valueParts.dropFirst()) : Array(valueParts)).joined(separator: " ")
             guard !value.isEmpty else {
                 throw CLIError(message: "set-status requires a non-empty value")
             }

--- a/test_nsnumber.swift
+++ b/test_nsnumber.swift
@@ -1,0 +1,4 @@
+import Foundation
+let n = NSNumber(value: 3_000_000_000 as UInt64)
+print("intValue:", n.intValue)
+print("int64Value:", n.int64Value)

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -126,16 +126,19 @@ export default function Home() {
           </ul>
         </section>
 
-        {/* Screenshot - break out of max-w-2xl to be wider */}
-        <div data-dev="screenshot" className="mb-12 -mx-6 sm:-mx-24 md:-mx-40 lg:-mx-72 xl:-mx-96">
-          <FadeImage
-            src={landingImage}
-            alt="cmux terminal app screenshot"
-            priority
-            className="w-full rounded-xl"
-          />
-        </div>
+      </main>
 
+      {/* Screenshot - outside main so it can be wider without viewport hacks */}
+      <div data-dev="screenshot" className="mx-auto w-full max-w-5xl px-3 mb-12">
+        <FadeImage
+          src={landingImage}
+          alt="cmux terminal app screenshot"
+          priority
+          className="w-full rounded-xl"
+        />
+      </div>
+
+      <main className="w-full max-w-2xl mx-auto px-6">
         {/* FAQ */}
         <div data-dev="faq-top-spacer" style={{ height: 0 }} />
         <section data-dev="faq" className="mb-10">


### PR DESCRIPTION
This PR moves accidental local edits from the primary checkout into a reviewable branch so the primary checkout can be restored to a clean `main` state.

Included files:
- `CLI/cmux.swift`: `set-status` now accepts an optional leading `--` separator before the value.
- `web/app/page.tsx`: homepage screenshot moved outside the first `main` block into a wider container.
- `test_nsnumber.swift`: local NSNumber int/int64 behavior probe script.

No additional changes were made beyond salvaging the existing local diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves accidental local edits to a reviewable branch and restores the primary checkout to a clean state.

Also: cmux set-status now accepts an optional leading -- separator before the value; the homepage screenshot was moved outside main to allow a wider layout without viewport hacks; and a small NSNumber int/int64 probe script was added.

<sup>Written for commit 32925e275e3299df4af11b093ac1142151b5487a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trailing separators in CLI set-status commands to correctly parse values.

* **Style**
  * Expanded screenshot display area on the webpage for enhanced visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->