### PR TITLE
Add browser camera/video support in cmux browser (#760)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -28,6 +28,8 @@
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>A program running within cmux would like to use your microphone.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>A program running within cmux would like to use your camera.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSServices</key>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -2,6 +2,23 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "NSCameraUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within cmux would like to use your camera."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 内で実行中のプログラムがカメラの使用を求めています。"
+          }
+        }
+      }
+    },
     "NSMicrophoneUsageDescription": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1533,6 +1533,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private static func makeWebView() -> CmuxWebView {
         let config = WKWebViewConfiguration()
         config.processPool = BrowserPanel.sharedProcessPool
+        config.mediaTypesRequiringUserActionForPlayback = []
         // Ensure browser cookies/storage persist across navigations and launches.
         // This reduces repeated consent/bot-challenge flows on sites like Google.
         config.websiteDataStore = .default()
@@ -3650,6 +3651,16 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         panel.begin { result in
             completionHandler(result == .OK ? panel.urls : nil)
         }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.prompt)
     }
 
     func webView(

--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>

--- a/tests/test_microphone_access_metadata.py
+++ b/tests/test_microphone_access_metadata.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression test: cmux advertises and allows microphone access."""
+"""Regression test: cmux advertises media-capture access metadata."""
 
 from __future__ import annotations
 
@@ -36,6 +36,7 @@ def main() -> int:
     entitlements = load_plist(repo_root / "cmux.entitlements", failures)
 
     mic_usage = info.get("NSMicrophoneUsageDescription")
+    camera_usage = info.get("NSCameraUsageDescription")
     if not isinstance(mic_usage, str) or not mic_usage.strip():
         failures.append(
             "Resources/Info.plist must define a non-empty NSMicrophoneUsageDescription"
@@ -50,13 +51,27 @@ def main() -> int:
             "cmux.entitlements must set com.apple.security.device.audio-input to true"
         )
 
+    if not isinstance(camera_usage, str) or not camera_usage.strip():
+        failures.append(
+            "Resources/Info.plist must define a non-empty NSCameraUsageDescription"
+        )
+    elif camera_usage.strip() != "A program running within cmux would like to use your camera.":
+        failures.append(
+            "Resources/Info.plist NSCameraUsageDescription should match the Ghostty-style wording"
+        )
+
+    if entitlements.get("com.apple.security.device.camera") is not True:
+        failures.append(
+            "cmux.entitlements must set com.apple.security.device.camera to true"
+        )
+
     if failures:
-        print("FAIL: microphone access metadata regression(s) detected")
+        print("FAIL: media-capture metadata regression(s) detected")
         for failure in failures:
             print(f"- {failure}")
         return 1
 
-    print("PASS: microphone usage description and entitlement are present")
+    print("PASS: microphone/camera usage descriptions and entitlements are present")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add WKUIDelegate media capture permission handling so WebKit prompts for camera/microphone access
- configure browser web views for media playback without user gesture gating
- add NSCameraUsageDescription to app Info.plist and localized InfoPlist catalog
- add camera entitlement (com.apple.security.device.camera) alongside existing microphone entitlement
- extend metadata regression test to validate both microphone and camera usage/entitlement keys

## Testing
- python3 tests/test_microphone_access_metadata.py
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
- ./scripts/reload.sh --tag feat-issue-760-browser-camera-support

Closes #760

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable camera/video capture in the cmux browser so sites can request camera/microphone access and play media inline. Closes #760.

- **New Features**
  - Prompt users for camera/microphone access via WKUIDelegate; remove user-gesture gating for media playback.
  - Add NSCameraUsageDescription (with en/ja localization) and the com.apple.security.device.camera entitlement.
  - Extend the metadata regression test to verify both mic and camera usage strings and entitlements.

<sup>Written for commit 8cd66534e05bfab07fa11a6d01f183037be8c431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera access permission handling with automatic prompts
  * Media playback now proceeds automatically without requiring user action
  * Camera permission descriptions with English and Japanese localization support
  * Camera security entitlements configured

* **Tests**
  * Enhanced validation for camera access permissions and usage descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->