### PR TITLE
Fix startup SIGSEGV: pre-warm locale before SentrySDK.start

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1656,6 +1656,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
         if telemetryEnabled {
+            // Pre-warm locale before Sentry to avoid a startup data race.
+            // Locale initialization (os.locale.ensureLocale / NSLocale._preferredLanguages)
+            // on the main thread can race with Sentry's background init thread
+            // calling posix.getenv, causing a SIGSEGV ~134ms after launch.
+            // Forcing locale access here before SentrySDK.start eliminates the race.
+            // Related to: #836
+            _ = Locale.current
+            _ = NSLocale.preferredLanguages
+
             SentrySDK.start { options in
                 options.dsn = "https://ecba1ec90ecaee02a102fba931b6d2b3@o4507547940749312.ingest.us.sentry.io/4510796264636416"
                 #if DEBUG


### PR DESCRIPTION
## Motivation

On startup, the following errors appear followed by `cmux` commands being terminated with SIGTERM:

```
[Sentry] [fatal] The SDK is disabled, so addBreadcrumb doesn't work.
Please ensure to start the SDK before adding breadcrumbs.
fish: Job 1, 'cmux ping' terminated by signal SIGTERM (Polite quit request)
```

This is caused by a startup crash in the `sentry-init` background thread (related to #836), which leaves the Sentry SDK in a disabled state.

### Reproduction

1. Launch cmux
2. Run `cmux new-split right` in a pane
3. Run any `cmux` command (e.g. `cmux ping`) in the same pane that executed step 2
4. The `[Sentry] [fatal] The SDK is disabled` errors appear and the command is terminated with SIGTERM

![reproduction](https://github.com/user-attachments/assets/25a09d89-5469-4905-842b-adb94556e5a8)

## Root Cause

The crash is a data race between two threads during `applicationDidFinishLaunching`:

- **sentry-init thread**: spawned by `SentrySDK.start`, calls `posix.getenv`
- **Main thread**: `GhosttyApp.init()` triggers locale initialization via `os.locale.ensureLocale` / `NSLocale._preferredLanguages`

When these run concurrently, a `SIGSEGV` (`KERN_INVALID_ADDRESS`) occurs at `posix.getenv + 324`, crashing the sentry-init thread and disabling the SDK.

```
Exception: EXC_BAD_ACCESS (SIGSEGV)
Crashed Thread: Thread 4 (sentry-init)

Thread 4:
  0  cmux    posix.getenv + 324
  1  cmux    Thread.PosixThreadImpl.spawn

Thread 0 (main):
  9  cmux    os.locale.ensureLocale + 3628
  10 cmux    GhosttyApp.().init()
```

## Fix

Force locale initialization on the main thread **before** `SentrySDK.start` spawns its background thread, eliminating the race window:

```swift
if telemetryEnabled {
    // Pre-warm locale before Sentry to avoid a startup data race.
    // Locale initialization (os.locale.ensureLocale / NSLocale._preferredLanguages)
    // on the main thread can race with Sentry's background init thread
    // calling posix.getenv, causing a SIGSEGV ~134ms after launch.
    // Forcing locale access here before SentrySDK.start eliminates the race.
    // Related to: #836
    _ = Locale.current
    _ = NSLocale.preferredLanguages

    SentrySDK.start { options in
        // ...
    }
}
```

## Testing

**Environment**
- macOS Tahoe 26.3 (25D125)
- Apple M1 Max
- Xcode 26.3 (17C519)

**Steps**
- Built and ran locally via `./scripts/reload.sh`
- Ran `cmux new-split right` and executed `cmux` commands in the same pane multiple times — no errors observed
- `cmux ping` returns successfully without SIGTERM
- `[Sentry] [fatal] The SDK is disabled` errors no longer appear

**Note**: This fix addresses a timing-dependent data race, which is inherently difficult to cover with automated tests. Manual stress testing (repeated split/command execution on startup) was used to verify the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-warms locale on the main thread before SentrySDK.start to eliminate a startup race that crashed the sentry-init thread. This stops the “[Sentry] [fatal] The SDK is disabled” logs and prevents cmux commands from being SIGTERM’d on launch.

- **Bug Fixes**
  - Access Locale.current and NSLocale.preferredLanguages before starting Sentry to avoid a race with posix.getenv in Sentry’s background init.
  - Manually verified: no SIGSEGV, no disabled SDK logs, commands run normally after split.

<sup>Written for commit a72620de17ca8027f99e78486d23c90ee472df15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup reliability by optimizing locale initialization timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->