### PR TITLE
fix: avoid NSTextView tracking loop in omnibar mouseDown

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2276,6 +2276,7 @@ private final class OmnibarNativeTextField: NSTextField {
             // enters an infinite invalidation cycle (e.g. under memory pressure).
             window?.makeFirstResponder(self)
             currentEditor()?.selectAll(nil)
+            shiftClickAnchor = nil
         } else {
             // Already editing — place the cursor at the click position without calling
             // super.mouseDown, which enters NSTextView's mouse-tracking loop. That loop
@@ -2345,6 +2346,7 @@ private final class OmnibarNativeTextField: NSTextField {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        shiftClickAnchor = nil
         if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
             return super.performKeyEquivalent(with: event)
         }


### PR DESCRIPTION
## Summary

Fixes #917. The omnibar's `mouseDown` handler calls `super.mouseDown(with:)` which enters `NSTextView`'s internal mouse-tracking loop. Under certain conditions, `NSTextLayoutManager.enumerateTextLayoutFragments` enters an infinite invalidation cycle inside that loop, causing 100% CPU hang that requires `kill -9` to recover.

The existing mitigation posted a synthetic `mouseUp` event via `NSApp.postEvent` after a 3-second timeout, but this is ineffective because the tracking loop's internal `nextEvent(matching:)` call does not always dequeue events from the application event queue when stuck in the layout fragment enumeration spin.

### Changes

- When the field editor is already active (second click onward), bypass `super.mouseDown` entirely
- Position the cursor at the click location using `NSTextView.characterIndexForInsertion(at:)` and `setSelectedRange`
- Support `Shift+click` to extend selection
- Fall back to `super.mouseDown` only if the field editor is unexpectedly nil

### Trade-offs

- Drag-to-select within the omnibar is no longer supported when already editing. For a single-line URL-bar-style field this is acceptable — users can still double-click to select a word, triple-click to select all, or Shift+click to extend selection.

## Test plan

- [x] Click omnibar to focus — should select all text (unchanged behavior)
- [x] Click again within the text — cursor should be placed at clicked position
- [x] Shift+click — selection should extend from cursor to clicked position
- [x] Double-click a word — should select the word
- [x] Verify no CPU spike or hang after repeated clicking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the omnibar from hanging at 100% CPU by avoiding NSTextView’s mouse-tracking loop on subsequent clicks. When already editing, we set the cursor directly, preserve double/triple-click selection, and support Shift+click, fixing #917.

- **Bug Fixes**
  - Bypass super.mouseDown when editing; set caret via characterIndexForInsertion. Removes synthetic mouseUp workaround.
  - Forward double/triple-clicks to editor.mouseDown to keep word/line selection.
  - Shift+click uses a stored anchor for bidirectional extension; clamp with UTF-16 length.
  - Reset shiftClickAnchor on keyDown, performKeyEquivalent, and when re-focusing to avoid stale anchors after keyboard navigation or shortcuts.
  - Trade-off: drag-to-select is disabled while editing in the single-line omnibar.

<sup>Written for commit 34a284e446e340a4b5a073a6027de06edf86c77b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved omnibar text-field click handling: single clicks now place the caret reliably; Shift+Click extends selection bidirectionally; double/triple-clicks still select words/lines.
  * Clicks fall back to default behavior when no editor is active.
  * Shift-click anchor is cleared on keyboard input to avoid stale selections.
  * Removed prior timing-based workaround that could produce inconsistent cursor placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->