### PR TITLE
Fix split zoom visibility sync to prevent black browser pane

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -612,10 +612,28 @@ final class WindowBrowserPortal: NSObject {
         }
     }
 
-    func detachWebView(withId webViewId: ObjectIdentifier) {
-        guard let entry = entriesByWebViewId.removeValue(forKey: webViewId) else { return }
+    @discardableResult
+    func detachWebView(withId webViewId: ObjectIdentifier, expectedAnchorId: ObjectIdentifier? = nil) -> Bool {
+        guard let entry = entriesByWebViewId[webViewId] else { return false }
+        if let expectedAnchorId {
+            let actualAnchorId = entry.anchorView.map(ObjectIdentifier.init)
+            guard actualAnchorId == expectedAnchorId else {
+#if DEBUG
+                dlog(
+                    "browser.portal.detach.skip web=\(browserPortalDebugToken(entry.webView)) " +
+                    "expectedAnchor=\(String(describing: expectedAnchorId)) " +
+                    "actualAnchor=\(browserPortalDebugToken(entry.anchorView))"
+                )
+#endif
+                return false
+            }
+        }
+        _ = entriesByWebViewId.removeValue(forKey: webViewId)
         if let anchor = entry.anchorView {
-            webViewByAnchorId.removeValue(forKey: ObjectIdentifier(anchor))
+            let anchorId = ObjectIdentifier(anchor)
+            if webViewByAnchorId[anchorId] == webViewId {
+                webViewByAnchorId.removeValue(forKey: anchorId)
+            }
         }
 #if DEBUG
         let hadContainerSuperview = (entry.containerView?.superview === hostView) ? 1 : 0
@@ -629,6 +647,7 @@ final class WindowBrowserPortal: NSObject {
 #endif
         entry.webView?.removeFromSuperview()
         entry.containerView?.removeFromSuperview()
+        return true
     }
 
     /// Update the visibleInUI/zPriority state on an existing entry without rebinding.
@@ -1190,10 +1209,19 @@ enum BrowserWindowPortalRegistry {
         portal.updateEntryVisibility(forWebViewId: webViewId, visibleInUI: visibleInUI, zPriority: zPriority)
     }
 
-    static func detach(webView: WKWebView) {
+    @discardableResult
+    static func detach(webView: WKWebView, expectedAnchorId: ObjectIdentifier? = nil) -> Bool {
         let webViewId = ObjectIdentifier(webView)
-        guard let windowId = webViewToWindowId.removeValue(forKey: webViewId) else { return }
-        portalsByWindowId[windowId]?.detachWebView(withId: webViewId)
+        guard let windowId = webViewToWindowId[webViewId] else { return false }
+        guard let portal = portalsByWindowId[windowId] else {
+            webViewToWindowId.removeValue(forKey: webViewId)
+            return true
+        }
+        let didDetach = portal.detachWebView(withId: webViewId, expectedAnchorId: expectedAnchorId)
+        guard didDetach else { return false }
+        webViewToWindowId.removeValue(forKey: webViewId)
+        pruneWebViewMappings(for: windowId, validWebViewIds: portal.webViewIds())
+        return true
     }
 
     static func webViewAtWindowPoint(_ windowPoint: NSPoint, in window: NSWindow) -> WKWebView? {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1502,7 +1502,9 @@ final class WindowBrowserPortal: NSObject {
         if entry.transientRecoveryRetriesRemaining > 0 {
             scheduleDeferredFullSynchronizeAll()
         }
-        return true
+        // Returning false on the terminal retry tells callers to stop defer-keeping
+        // the old container visible and fall back to a normal hide path.
+        return entry.transientRecoveryRetriesRemaining > 0
     }
 
     private func synchronizeWebView(
@@ -1524,15 +1526,26 @@ final class WindowBrowserPortal: NSObject {
             return
         }
         guard let anchorView = entry.anchorView, let window else {
+            let didScheduleTransientRecovery: Bool
             if entry.visibleInUI {
-                _ = scheduleTransientRecoveryRetryIfNeeded(
+                didScheduleTransientRecovery = scheduleTransientRecoveryRetryIfNeeded(
                     forWebViewId: webViewId,
                     entry: &entry,
                     webView: webView,
                     reason: "missingAnchorOrWindow"
                 )
             } else {
+                didScheduleTransientRecovery = false
                 resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+            }
+            if didScheduleTransientRecovery && !containerView.isHidden {
+#if DEBUG
+                dlog(
+                    "browser.portal.hidden.deferKeep web=\(browserPortalDebugToken(webView)) " +
+                    "reason=missingAnchorOrWindow frame=\(browserPortalDebugFrame(containerView.frame))"
+                )
+#endif
+                return
             }
 #if DEBUG
             if !containerView.isHidden {
@@ -1547,6 +1560,27 @@ final class WindowBrowserPortal: NSObject {
             return
         }
         guard anchorView.window === window else {
+            let didScheduleTransientRecovery: Bool
+            if entry.visibleInUI {
+                didScheduleTransientRecovery = scheduleTransientRecoveryRetryIfNeeded(
+                    forWebViewId: webViewId,
+                    entry: &entry,
+                    webView: webView,
+                    reason: "anchorWindowMismatch"
+                )
+            } else {
+                didScheduleTransientRecovery = false
+                resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+            }
+            if didScheduleTransientRecovery && !containerView.isHidden {
+#if DEBUG
+                dlog(
+                    "browser.portal.hidden.deferKeep web=\(browserPortalDebugToken(webView)) " +
+                    "reason=anchorWindowMismatch frame=\(browserPortalDebugFrame(containerView.frame))"
+                )
+#endif
+                return
+            }
 #if DEBUG
             if !containerView.isHidden {
                 dlog(
@@ -1556,16 +1590,6 @@ final class WindowBrowserPortal: NSObject {
                 )
             }
 #endif
-            if entry.visibleInUI {
-                _ = scheduleTransientRecoveryRetryIfNeeded(
-                    forWebViewId: webViewId,
-                    entry: &entry,
-                    webView: webView,
-                    reason: "anchorWindowMismatch"
-                )
-            } else {
-                resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
-            }
             containerView.setDropZoneOverlay(zone: nil)
             containerView.isHidden = true
             return
@@ -1648,14 +1672,7 @@ final class WindowBrowserPortal: NSObject {
             }
             containerView.setDropZoneOverlay(zone: nil)
             containerView.isHidden = true
-            if entry.visibleInUI {
-                _ = scheduleTransientRecoveryRetryIfNeeded(
-                    forWebViewId: webViewId,
-                    entry: &entry,
-                    webView: webView,
-                    reason: "hostBoundsNotReady"
-                )
-            } else {
+            if !entry.visibleInUI {
                 scheduleDeferredFullSynchronizeAll()
             }
             return

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -660,6 +660,16 @@ final class WindowBrowserPortal: NSObject {
         entriesByWebViewId[webViewId] = entry
     }
 
+    func isWebViewBoundToAnchor(withId webViewId: ObjectIdentifier, anchorView: NSView) -> Bool {
+        guard let entry = entriesByWebViewId[webViewId],
+              let boundAnchor = entry.anchorView else { return false }
+        return boundAnchor === anchorView
+    }
+
+    func hasWebViewEntry(withId webViewId: ObjectIdentifier) -> Bool {
+        entriesByWebViewId[webViewId] != nil
+    }
+
     func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
         guard ensureInstalled() else { return }
 
@@ -1045,17 +1055,26 @@ final class WindowBrowserPortal: NSObject {
         let deadWebViewIds = entriesByWebViewId.compactMap { webViewId, entry -> ObjectIdentifier? in
             guard entry.webView != nil else { return webViewId }
             guard let container = entry.containerView else { return webViewId }
-            guard let anchor = entry.anchorView else { return webViewId }
+            guard let anchor = entry.anchorView else {
+                return entry.visibleInUI ? nil : webViewId
+            }
             if container.superview == nil || !container.isDescendant(of: hostView) {
-                return webViewId
+                // We reparent the container in bind/sync. If it's missing from hostView,
+                // but still visibleInUI, we should recover it during sync instead of pruning it here.
+                return entry.visibleInUI ? nil : webViewId
             }
-            if anchor.window !== currentWindow || anchor.superview == nil {
-                return webViewId
+            
+            let anchorInvalidForCurrentHost =
+                anchor.window !== currentWindow ||
+                anchor.superview == nil ||
+                (installedReferenceView.map { !anchor.isDescendant(of: $0) } ?? false)
+            if anchorInvalidForCurrentHost {
+                // During aggressive tab drag/reorder churn, SwiftUI/AppKit can briefly
+                // detach/rehome anchor hosts while the browser should stay visible.
+                // Avoid pruning those visible entries so sync/bind recovery can reattach.
+                return entry.visibleInUI ? nil : webViewId
             }
-            if let reference = installedReferenceView,
-               !anchor.isDescendant(of: reference) {
-                return webViewId
-            }
+            
             return nil
         }
 
@@ -1207,6 +1226,27 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateEntryVisibility(forWebViewId: webViewId, visibleInUI: visibleInUI, zPriority: zPriority)
+    }
+
+    static func isWebView(_ webView: WKWebView, boundTo anchorView: NSView) -> Bool {
+        let webViewId = ObjectIdentifier(webView)
+        if let windowId = webViewToWindowId[webViewId],
+           let portal = portalsByWindowId[windowId] {
+            return portal.isWebViewBoundToAnchor(withId: webViewId, anchorView: anchorView)
+        }
+        for portal in portalsByWindowId.values {
+            if portal.isWebViewBoundToAnchor(withId: webViewId, anchorView: anchorView) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func hasPortalEntry(for webView: WKWebView) -> Bool {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return false }
+        return portal.hasWebViewEntry(withId: webViewId)
     }
 
     @discardableResult

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2974,6 +2974,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             visibleInUI = visible
         }
 
+    func debugIsVisibleInUI() -> Bool {
+        visibleInUI
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         setup()
@@ -5697,6 +5701,10 @@ final class GhosttySurfaceScrollView: NSView {
         } else {
             applyFirstResponderIfNeeded()
         }
+    }
+
+    func debugIsVisibleInUI() -> Bool {
+        surfaceView.isVisibleInUI
     }
 
     func setActive(_ active: Bool) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1909,6 +1909,9 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
+        // Close is a permanent panel lifecycle transition, so explicitly detach
+        // from the window portal here instead of relying on transient representable teardown.
+        BrowserWindowPortalRegistry.detach(webView: webView)
         webView.stopLoading()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3188,10 +3188,34 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
             coordinator.lastPortalHostId = ObjectIdentifier(host)
         }
-        host.onGeometryChanged = { [weak host, weak coordinator] in
-            guard let host, let coordinator else { return }
+        host.onGeometryChanged = { [weak host, weak webView, weak coordinator] in
+            guard let host, let coordinator, let webView else { return }
             guard coordinator.attachGeneration == generation else { return }
             guard coordinator.lastPortalHostId == ObjectIdentifier(host) else { return }
+            let isBoundToHost = BrowserWindowPortalRegistry.isWebView(webView, boundTo: host)
+            let hasPortalEntry = BrowserWindowPortalRegistry.hasPortalEntry(for: webView)
+            if host.window != nil,
+               !isBoundToHost,
+               !hasPortalEntry {
+#if DEBUG
+                if let panel = coordinator.panel {
+                    Self.logDevToolsState(
+                        panel,
+                        event: "portal.rebindOnGeometry",
+                        generation: coordinator.attachGeneration,
+                        retryCount: 0,
+                        details: Self.attachContext(webView: webView, host: host) + " reason=portalEntryMissing"
+                    )
+                }
+#endif
+                BrowserWindowPortalRegistry.bind(
+                    webView: webView,
+                    to: host,
+                    visibleInUI: coordinator.desiredPortalVisibleInUI,
+                    zPriority: coordinator.desiredPortalZPriority
+                )
+                coordinator.lastPortalHostId = ObjectIdentifier(host)
+            }
             BrowserWindowPortalRegistry.synchronizeForAnchor(host)
         }
 
@@ -3316,6 +3340,9 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         coordinator.attachGeneration += 1
+        coordinator.desiredPortalVisibleInUI = false
+        coordinator.desiredPortalZPriority = 0
+        coordinator.lastPortalHostId = nil
         clearPortalCallbacks(for: nsView)
 
         guard let webView = coordinator.webView else { return }
@@ -3341,10 +3368,17 @@ struct WebViewRepresentable: NSViewRepresentable {
                 window.makeFirstResponder(nil)
             }
         }
-        _ = BrowserWindowPortalRegistry.detach(
-            webView: webView,
-            expectedAnchorId: coordinator.lastPortalHostId
-        )
-        coordinator.lastPortalHostId = nil
+        if BrowserWindowPortalRegistry.isWebView(webView, boundTo: nsView) {
+            BrowserWindowPortalRegistry.updateEntryVisibility(
+                for: webView,
+                visibleInUI: coordinator.desiredPortalVisibleInUI,
+                zPriority: coordinator.desiredPortalZPriority
+            )
+            BrowserWindowPortalRegistry.synchronizeForAnchor(nsView)
+        }
+        // SwiftUI can transiently dismantle/rebuild BrowserPanel representables during
+        // split/tree churn. Do not detach here; that races deferred host rebinding and
+        // can leave a live browser pane blank. Permanent detach happens on panel close,
+        // web view replacement, or explicit registry detach paths.
     }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3466,9 +3466,6 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         coordinator.attachGeneration += 1
-        coordinator.desiredPortalVisibleInUI = false
-        coordinator.desiredPortalZPriority = 0
-        coordinator.lastPortalHostId = nil
         clearPortalCallbacks(for: nsView)
         removeSearchOverlay(from: coordinator)
 
@@ -3495,20 +3492,14 @@ struct WebViewRepresentable: NSViewRepresentable {
                 window.makeFirstResponder(nil)
             }
         }
-        if BrowserWindowPortalRegistry.isWebView(webView, boundTo: nsView) {
-            BrowserWindowPortalRegistry.updateEntryVisibility(
-                for: webView,
-                visibleInUI: coordinator.desiredPortalVisibleInUI,
-                zPriority: coordinator.desiredPortalZPriority
-            )
-            BrowserWindowPortalRegistry.synchronizeForAnchor(nsView)
-        }
         BrowserWindowPortalRegistry.updateDropZoneOverlay(for: webView, zone: nil)
         BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: nil)
         coordinator.lastPortalHostId = nil
-        // SwiftUI can transiently dismantle/rebuild the browser host view during split
-        // rearrangement. Do not detach the portal-hosted WKWebView here; explicit detach
-        // still happens on real web view replacement and panel teardown.
+        // SwiftUI can transiently dismantle/rebuild BrowserPanel representables during
+        // split/tree churn. Do not mutate portal visibility or detach here, both race
+        // deferred host rebinding and can leave a live browser pane blank. Permanent
+        // detach happens on panel close, web view replacement, or explicit registry
+        // detach paths.
     }
 
     private func currentPaneDropContext() -> BrowserPaneDropContext? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3341,7 +3341,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 window.makeFirstResponder(nil)
             }
         }
-        BrowserWindowPortalRegistry.detach(webView: webView)
+        _ = BrowserWindowPortalRegistry.detach(
+            webView: webView,
+            expectedAnchorId: coordinator.lastPortalHostId
+        )
         coordinator.lastPortalHostId = nil
     }
 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3183,7 +3183,11 @@ final class Workspace: Identifiable, ObservableObject {
 
     @discardableResult
     func clearSplitZoom() -> Bool {
-        bonsplitController.clearPaneZoom()
+        let cleared = bonsplitController.clearPaneZoom()
+        if cleared {
+            synchronizeTerminalPortalVisibilityForCurrentLayout()
+        }
+        return cleared
     }
 
     @discardableResult
@@ -3191,7 +3195,63 @@ final class Workspace: Identifiable, ObservableObject {
         guard let paneId = paneId(forPanelId: panelId) else { return false }
         guard bonsplitController.togglePaneZoom(inPane: paneId) else { return false }
         focusPanel(panelId)
+        synchronizeTerminalPortalVisibilityForCurrentLayout()
         return true
+    }
+
+    private func visiblePanelIdsForCurrentLayout() -> Set<UUID> {
+        let renderedPaneIds: [PaneID] = {
+            if let zoomedPaneId = bonsplitController.zoomedPaneId {
+                return [zoomedPaneId]
+            }
+            return bonsplitController.allPaneIds
+        }()
+
+        var visiblePanelIds = Set<UUID>()
+        for paneId in renderedPaneIds {
+            guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
+                  let panelId = panelIdFromSurfaceId(tabId),
+                  panels[panelId] != nil else { continue }
+            visiblePanelIds.insert(panelId)
+        }
+
+        if let focusedPanelId,
+           panels[focusedPanelId] != nil {
+            visiblePanelIds.insert(focusedPanelId)
+        }
+
+        return visiblePanelIds
+    }
+
+    private func synchronizeTerminalPortalVisibilityForCurrentLayout() {
+        let visiblePanelIds = visiblePanelIdsForCurrentLayout()
+        let terminalPanelIds = panels.compactMap { panelId, panel -> UUID? in
+            panel is TerminalPanel ? panelId : nil
+        }
+
+        // During split/tree churn, bonsplit can report a transient empty selection.
+        // Preserve current visibility in that moment instead of hiding every terminal.
+        if !terminalPanelIds.isEmpty && visiblePanelIds.isEmpty {
+            return
+        }
+
+        for panelId in terminalPanelIds {
+            guard let terminalPanel = terminalPanel(for: panelId) else { continue }
+            let shouldBeVisible = visiblePanelIds.contains(panelId)
+            terminalPanel.hostedView.setVisibleInUI(shouldBeVisible)
+            if shouldBeVisible {
+                TerminalWindowPortalRegistry.updateEntryVisibility(
+                    for: terminalPanel.hostedView,
+                    visibleInUI: true
+                )
+            } else {
+                TerminalWindowPortalRegistry.hideHostedView(terminalPanel.hostedView)
+            }
+        }
+    }
+
+    func debugVisiblePanelIdsForCurrentLayout() -> Set<UUID> {
+        visiblePanelIdsForCurrentLayout()
     }
 
     // MARK: - Context Menu Shortcuts

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -4961,6 +4961,46 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testToggleSplitZoomCollapsesVisiblePanelSnapshotToZoomedPaneAndRestoresOnUnzoom() {
+        let workspace = Workspace()
+        guard let firstPanelId = workspace.focusedPanelId,
+              let secondPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal),
+              let firstTerminal = workspace.terminalPanel(for: firstPanelId),
+              let secondTerminal = workspace.terminalPanel(for: secondPanel.id) else {
+            XCTFail("Expected two terminal panels for split-zoom visibility test")
+            return
+        }
+
+        XCTAssertEqual(
+            workspace.debugVisiblePanelIdsForCurrentLayout(),
+            Set([firstPanelId, secondPanel.id]),
+            "Unzoomed layout should report selected panels from both panes as visible"
+        )
+        XCTAssertTrue(firstTerminal.hostedView.debugIsVisibleInUI())
+        XCTAssertTrue(secondTerminal.hostedView.debugIsVisibleInUI())
+
+        XCTAssertTrue(workspace.toggleSplitZoom(panelId: secondPanel.id))
+        XCTAssertEqual(
+            workspace.debugVisiblePanelIdsForCurrentLayout(),
+            Set([secondPanel.id]),
+            "Zoomed layout should report only the zoomed pane panel as visible"
+        )
+        XCTAssertFalse(
+            firstTerminal.hostedView.debugIsVisibleInUI(),
+            "Non-zoomed terminal should be marked not visible to prevent stale portal overlays"
+        )
+        XCTAssertTrue(secondTerminal.hostedView.debugIsVisibleInUI())
+
+        XCTAssertTrue(workspace.toggleSplitZoom(panelId: secondPanel.id))
+        XCTAssertEqual(
+            workspace.debugVisiblePanelIdsForCurrentLayout(),
+            Set([firstPanelId, secondPanel.id]),
+            "Unzoom should restore selected visibility across both panes"
+        )
+        XCTAssertTrue(firstTerminal.hostedView.debugIsVisibleInUI())
+        XCTAssertTrue(secondTerminal.hostedView.debugIsVisibleInUI())
+    }
+
     func testClosingFocusedSplitRestoresBranchForRemainingFocusedPanel() {
         let workspace = Workspace()
         guard let firstPanelId = workspace.focusedPanelId else {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2494,6 +2494,65 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertNil(panel.webView.superview)
         window.orderOut(nil)
     }
+
+    func testWebViewDismantleSkipsDetachWhenCoordinatorHostIsStale() {
+        let (panel, _) = makePanelWithInspector()
+        XCTAssertTrue(panel.showDeveloperTools())
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let staleAnchor = NSView(frame: NSRect(x: 20, y: 20, width: 170, height: 140))
+        let liveAnchor = NSView(frame: NSRect(x: 210, y: 20, width: 170, height: 140))
+        contentView.addSubview(staleAnchor)
+        contentView.addSubview(liveAnchor)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: staleAnchor, visibleInUI: true, zPriority: 1)
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: liveAnchor, visibleInUI: true, zPriority: 1)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(liveAnchor)
+        XCTAssertNotNil(panel.webView.superview)
+
+        let representable = WebViewRepresentable(
+            panel: panel,
+            shouldAttachWebView: true,
+            shouldFocusWebView: false,
+            isPanelFocused: true,
+            portalZPriority: 1
+        )
+        let staleCoordinator = representable.makeCoordinator()
+        staleCoordinator.webView = panel.webView
+        staleCoordinator.lastPortalHostId = ObjectIdentifier(staleAnchor)
+
+        WebViewRepresentable.dismantleNSView(staleAnchor, coordinator: staleCoordinator)
+
+        XCTAssertNotNil(
+            panel.webView.superview,
+            "Stale dismantle should not detach a web view already rebound to another live anchor"
+        )
+        let livePoint = liveAnchor.convert(
+            NSPoint(x: liveAnchor.bounds.midX, y: liveAnchor.bounds.midY),
+            to: nil
+        )
+        XCTAssertTrue(
+            BrowserWindowPortalRegistry.webViewAtWindowPoint(livePoint, in: window) === panel.webView,
+            "Web view should remain portal-hosted at the live anchor after stale dismantle"
+        )
+
+        BrowserWindowPortalRegistry.detach(webView: panel.webView)
+    }
 }
 
 final class WorkspaceShortcutMapperTests: XCTestCase {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2423,7 +2423,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertFalse(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
     }
 
-    func testWebViewDismantleDetachesPortalHostedWebViewWhenDeveloperToolsIntentIsVisible() {
+    func testWebViewDismantlePreservesPortalHostedWebViewWhenDeveloperToolsIntentIsVisible() {
         let (panel, _) = makePanelWithInspector()
         XCTAssertTrue(panel.showDeveloperTools())
 
@@ -2453,13 +2453,18 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         )
         let coordinator = representable.makeCoordinator()
         coordinator.webView = panel.webView
+        coordinator.lastPortalHostId = ObjectIdentifier(anchor)
         WebViewRepresentable.dismantleNSView(anchor, coordinator: coordinator)
 
-        XCTAssertNil(panel.webView.superview)
+        XCTAssertNotNil(panel.webView.superview)
+        XCTAssertTrue(BrowserWindowPortalRegistry.hasPortalEntry(for: panel.webView))
+        let point = anchor.convert(NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY), to: nil)
+        XCTAssertNil(BrowserWindowPortalRegistry.webViewAtWindowPoint(point, in: window))
+        BrowserWindowPortalRegistry.detach(webView: panel.webView)
         window.orderOut(nil)
     }
 
-    func testWebViewDismantleDetachesPortalHostedWebViewWhenDeveloperToolsIntentIsHidden() {
+    func testWebViewDismantlePreservesPortalHostedWebViewWhenDeveloperToolsIntentIsHidden() {
         let (panel, _) = makePanelWithInspector()
         XCTAssertFalse(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
 
@@ -2489,9 +2494,14 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         )
         let coordinator = representable.makeCoordinator()
         coordinator.webView = panel.webView
+        coordinator.lastPortalHostId = ObjectIdentifier(anchor)
         WebViewRepresentable.dismantleNSView(anchor, coordinator: coordinator)
 
-        XCTAssertNil(panel.webView.superview)
+        XCTAssertNotNil(panel.webView.superview)
+        XCTAssertTrue(BrowserWindowPortalRegistry.hasPortalEntry(for: panel.webView))
+        let point = anchor.convert(NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY), to: nil)
+        XCTAssertNil(BrowserWindowPortalRegistry.webViewAtWindowPoint(point, in: window))
+        BrowserWindowPortalRegistry.detach(webView: panel.webView)
         window.orderOut(nil)
     }
 
@@ -9367,6 +9377,49 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         BrowserWindowPortalRegistry.detach(webView: webView)
         XCTAssertNil(webView.superview)
+    }
+
+    func testRegistryReportsWhetherWebViewIsBoundToAnchor() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let firstAnchor = NSView(frame: NSRect(x: 20, y: 20, width: 180, height: 120))
+        let secondAnchor = NSView(frame: NSRect(x: 220, y: 20, width: 180, height: 120))
+        contentView.addSubview(firstAnchor)
+        contentView.addSubview(secondAnchor)
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+        BrowserWindowPortalRegistry.bind(webView: webView, to: firstAnchor, visibleInUI: true, zPriority: 1)
+        XCTAssertTrue(BrowserWindowPortalRegistry.isWebView(webView, boundTo: firstAnchor))
+        XCTAssertFalse(BrowserWindowPortalRegistry.isWebView(webView, boundTo: secondAnchor))
+        XCTAssertTrue(BrowserWindowPortalRegistry.hasPortalEntry(for: webView))
+
+        firstAnchor.removeFromSuperview()
+        XCTAssertNil(firstAnchor.window)
+        XCTAssertTrue(
+            BrowserWindowPortalRegistry.isWebView(webView, boundTo: firstAnchor),
+            "Binding checks should still resolve while anchor is off-window during teardown churn"
+        )
+        contentView.addSubview(firstAnchor)
+
+        BrowserWindowPortalRegistry.bind(webView: webView, to: secondAnchor, visibleInUI: true, zPriority: 1)
+        XCTAssertFalse(BrowserWindowPortalRegistry.isWebView(webView, boundTo: firstAnchor))
+        XCTAssertTrue(BrowserWindowPortalRegistry.isWebView(webView, boundTo: secondAnchor))
+        XCTAssertTrue(BrowserWindowPortalRegistry.hasPortalEntry(for: webView))
+
+        BrowserWindowPortalRegistry.detach(webView: webView)
+        XCTAssertFalse(BrowserWindowPortalRegistry.isWebView(webView, boundTo: secondAnchor))
+        XCTAssertFalse(BrowserWindowPortalRegistry.hasPortalEntry(for: webView))
     }
 }
 

--- a/tests/test_browser_transient_dismantle_lifecycle_regression.py
+++ b/tests/test_browser_transient_dismantle_lifecycle_regression.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Regression guard: browser transient dismantle must not tear down portal state.
+
+This bug class produced intermittent blank browser panes after split/workspace churn.
+The long-term lifecycle contract is:
+1) BrowserPanelView.dismantleNSView treats teardown as transient (no detach/visibility mutation/sync).
+2) BrowserPanel.close() performs permanent detach from BrowserWindowPortalRegistry.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path(__file__).resolve().parents[1]
+
+
+def extract_block(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        raise ValueError(f"Missing signature: {signature}")
+    brace_start = source.find("{", start)
+    if brace_start < 0:
+        raise ValueError(f"Missing opening brace for: {signature}")
+    depth = 0
+    for idx in range(brace_start, len(source)):
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start : idx + 1]
+    raise ValueError(f"Unbalanced braces for: {signature}")
+
+
+def main() -> int:
+    root = repo_root()
+    failures: list[str] = []
+
+    view_path = root / "Sources" / "Panels" / "BrowserPanelView.swift"
+    view_source = view_path.read_text(encoding="utf-8")
+    dismantle_block = extract_block(view_source, "static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator)")
+
+    if "BrowserWindowPortalRegistry.detach(" in dismantle_block:
+        failures.append("BrowserPanelView.dismantleNSView still detaches browser portal entry")
+    if "BrowserWindowPortalRegistry.updateEntryVisibility(" in dismantle_block:
+        failures.append("BrowserPanelView.dismantleNSView still mutates browser portal visibility")
+    if "BrowserWindowPortalRegistry.synchronizeForAnchor(" in dismantle_block:
+        failures.append("BrowserPanelView.dismantleNSView still forces portal synchronize during transient teardown")
+    if "coordinator.desiredPortalVisibleInUI = false" in dismantle_block:
+        failures.append("BrowserPanelView.dismantleNSView still forces desiredPortalVisibleInUI false")
+    if "coordinator.desiredPortalZPriority = 0" in dismantle_block:
+        failures.append("BrowserPanelView.dismantleNSView still forces desiredPortalZPriority to 0")
+
+    panel_path = root / "Sources" / "Panels" / "BrowserPanel.swift"
+    panel_source = panel_path.read_text(encoding="utf-8")
+    close_block = extract_block(panel_source, "func close()")
+    if "BrowserWindowPortalRegistry.detach(webView: webView)" not in close_block:
+        failures.append("BrowserPanel.close() is missing permanent BrowserWindowPortalRegistry.detach call")
+
+    if failures:
+        print("FAIL: browser transient dismantle lifecycle regression guards failed")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("PASS: browser transient dismantle lifecycle regression guards are in place")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
After toggling split zoom (Cmd+Shift+Enter), terminal portal visibility could drift from the active layout during selection churn, leaving the browser pane effectively covered and appearing black.

This change makes zoom and unzoom transitions reconcile terminal visibility from layout state instead of relying on incidental callback ordering.

## What changed
- Added a layout-driven visibility synchronizer in `Workspace`.
- Run synchronizer when toggling split zoom and when clearing split zoom.
- Keep `TerminalWindowPortalRegistry` visibility in lockstep with `setVisibleInUI`.
- Added a transient guard to avoid hiding all terminals during temporary empty tab selection churn.
- Added a regression test that verifies visible panel set and terminal visibility collapse to the zoomed pane, then restore on unzoom.

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testToggleSplitZoomCollapsesVisiblePanelSnapshotToZoomedPaneAndRestoresOnUnzoom test`
- `codex review --base origin/main` (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes split zoom (Cmd+Shift+Enter) so terminal visibility and browser portals stay aligned with the layout, preventing the browser pane from appearing black. Hardens the portal lifecycle to survive SwiftUI host churn, stale dismantle calls, and transient recovery windows.

- **Bug Fixes**
  - Layout-driven synchronizer updates terminal visibility from zoom state and focus; runs on toggle/clear; ignores transient empty selections.
  - Browser portal lifecycle: skip detach/visibility changes during transient dismantle; rebind missing entries on geometry changes; avoid pruning while visible; guarded detach with expectedAnchorId; defer hiding while transiently recovering; explicitly detach on panel close; new helpers to check binding and entry presence.

- **Tests**
  - Added coverage for zoom visibility sync, stale dismantle with stale coordinator hosts, anchor-binding reporting, registry entry checks, and a Python regression guard ensuring dismantle remains transient.

<sup>Written for commit 98d1948784f07199c613a35b398c780e0e2088f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved diagnostic visibility allowing better inspection of panel/web view visibility for debugging.

* **Bug Fixes**
  * Terminal portals reliably sync with layout zooming, preventing visibility mismatches after zoom/unzoom.
  * Web views remain attached and stable across host/window and geometry changes, reducing detaches, visual glitches, and flicker.
  * Panel close now deterministically detaches hosted web views to avoid stale state.

* **Tests**
  * Added regression and unit tests covering split-pane zoom visibility and web view dismantle/detach scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->