### PR TITLE
Prompt bug reporters to verify NIGHTLY reproduction

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,6 +46,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: nightly-repro
+    attributes:
+      label: Can you reproduce this on cmux NIGHTLY?
+      description: "Please test with the latest NIGHTLY build first: https://github.com/manaflow-ai/cmux?tab=readme-ov-file#nightly-builds"
+      options:
+        - Yes, it still reproduces on NIGHTLY
+        - No, it does not reproduce on NIGHTLY
+        - I could not test NIGHTLY
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## Summary
Add a required bug-report field asking whether the issue reproduces on cmux NIGHTLY.

## What changed
- Updated `.github/ISSUE_TEMPLATE/bug_report.yml`
- Added required dropdown: `Can you reproduce this on cmux NIGHTLY?`
- Included direct nightly builds link: https://github.com/manaflow-ai/cmux?tab=readme-ov-file#nightly-builds

## Validation
- YAML parse check passed (`ruby -e 'require "yaml"; YAML.load_file(...)'`)
- Codex review run: 0 findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a required dropdown in the bug report template asking if the issue reproduces on cmux NIGHTLY. This improves triage and nudges reporters to test the latest nightly build via the included link.

<sup>Written for commit 94b39a6c2103494242f68e364510e68cc636a84f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

