### PR TITLE
Fix notification-triggered new window creation

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1831,10 +1831,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         // When visible windows already exist, return false to prevent SwiftUI
         // from creating a new window on dock-click or activation events (#872).
-        if flag {
-            return false
-        }
-        return true
+        return !flag
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -8078,9 +8075,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if window.isMiniaturized {
             window.deminiaturize(nil)
         }
-        window.makeKeyAndOrderFront(nil)
-        // Only activate the app without bringing all windows forward to prevent
-        // SwiftUI from opening new windows on activation events (#872).
+        // Bring the specific window to front across Spaces without activating
+        // all windows, which would cause SwiftUI to spawn new scenes (#872).
+        window.orderFrontRegardless()
         NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8075,8 +8075,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if window.isMiniaturized {
             window.deminiaturize(nil)
         }
-        // Bring the specific window to front across Spaces without activating
-        // all windows, which would cause SwiftUI to spawn new scenes (#872).
+        // Make the window key (for focus/input routing) and bring it forward.
+        // orderFrontRegardless() ensures reliability across Spaces, while
+        // makeKeyAndOrderFront() establishes proper key-window status (#872).
+        window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
         NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1828,6 +1828,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return .terminateNow
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // When visible windows already exist, return false to prevent SwiftUI
+        // from creating a new window on dock-click or activation events (#872).
+        if flag {
+            return false
+        }
+        return true
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
@@ -8070,8 +8079,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             window.deminiaturize(nil)
         }
         window.makeKeyAndOrderFront(nil)
-        // Improve reliability across Spaces / when other helper panels are key.
-        NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        // Only activate the app without bringing all windows forward to prevent
+        // SwiftUI from opening new windows on activation events (#872).
+        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
     }
 
     private func markReadIfFocused(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -221,6 +221,7 @@ struct cmuxApp: App {
                     updateSocketController()
                 }
         }
+        .handlesExternalEvents(matching: [])
         .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .appSettings) {


### PR DESCRIPTION
## Summary

Fixes #872 — Each Claude Code response causes cmux to hide the current window and open a new popup terminal window.

### Root Cause

When a notification fires, `bringToFront()` calls `NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])`. The `.activateAllWindows` option combined with a `WindowGroup` that lacks `handlesExternalEvents(matching:)` causes SwiftUI to create a new window on every activation event.

### Changes

1. **`cmuxApp.swift`** — Added `.handlesExternalEvents(matching: [])` to the `WindowGroup` to prevent SwiftUI from auto-creating windows on activation events
2. **`AppDelegate.swift` `bringToFront()`** — Replaced `.activateAllWindows` with just `.activateIgnoringOtherApps` for more targeted window activation
3. **`AppDelegate.swift`** — Added `applicationShouldHandleReopen(_:hasVisibleWindows:)` returning `false` when visible windows exist, preventing dock-click from spawning new windows

## Test plan

- [ ] Open cmux with a terminal tab running Claude Code
- [ ] Send a prompt and wait for a response — verify no new window is created
- [ ] Minimize the window, trigger a notification, click it — verify the existing window is restored (not a new one)
- [ ] Click the dock icon while a window is visible — verify no new window opens
- [ ] Click the dock icon with no visible windows — verify a window is created
- [ ] Switch between Spaces with cmux open — verify activation doesn't spawn windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cmux from opening a new window on notifications or dock clicks; reuses the existing window and only brings it forward when needed. Fixes #872.

- **Bug Fixes**
  - Add .handlesExternalEvents(matching: []) to WindowGroup to stop auto-creating windows on activation.
  - Update bringToFront(): call makeKeyAndOrderFront() then orderFrontRegardless(), and use .activateIgnoringOtherApps for reliable focus and input across Spaces.
  - applicationShouldHandleReopen(_:hasVisibleWindows:) now returns !flag to avoid new windows when one is visible.

<sup>Written for commit 4bc3f696d8088fc57ad2f95c56cd6f13dc16b0d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented new windows from appearing unexpectedly when reopening or activating the app.
  * Improved focus behavior so only the intended window is brought to the front without activating others.
  * Reduced duplicate window creation during app interactions, improving stability when switching back to the app.

* **New Settings**
  * Improved handling of external events during app startup to avoid unwanted scene creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->