### PR TITLE
Sidebar: show git status counts (uncommitted, ahead/behind)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -72220,6 +72220,38 @@
           }
         }
       }
+    },
+    "settings.app.showGitStatusCounts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Git Status Counts"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gitステータスカウントを表示"
+          }
+        }
+      }
+    },
+    "settings.app.showGitStatusCounts.subtitle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show uncommitted changes (!3), ahead (⇡1), and behind (⇣2) counts next to the branch name."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチ名の横に未コミットの変更(!3)、先行(⇡1)、遅延(⇣2)のカウントを表示します。"
+          }
+        }
+      }
     }
   }
 }

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -199,13 +199,26 @@ _cmux_prompt_command() {
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
         {
-            local branch dirty_opt=""
+            local branch dirty_opt="" count_opts=""
             branch=$(git branch --show-current 2>/dev/null)
             if [[ -n "$branch" ]]; then
-                local first
-                first=$(git status --porcelain -uno 2>/dev/null | head -1)
-                [[ -n "$first" ]] && dirty_opt="--status=dirty"
-                _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                local porcelain changed_count
+                porcelain=$(git status --porcelain 2>/dev/null)
+                if [[ -n "$porcelain" ]]; then
+                    dirty_opt="--status=dirty"
+                    changed_count=$(echo "$porcelain" | wc -l | tr -d ' ')
+                    count_opts="--changed=$changed_count"
+                fi
+                local lr
+                lr=$(git rev-list --left-right --count @{upstream}...HEAD 2>/dev/null)
+                if [[ -n "$lr" ]]; then
+                    local behind_count ahead_count
+                    behind_count="${lr%%	*}"
+                    ahead_count="${lr##*	}"
+                    [[ "$ahead_count" -gt 0 ]] 2>/dev/null && count_opts="$count_opts --ahead=$ahead_count"
+                    [[ "$behind_count" -gt 0 ]] 2>/dev/null && count_opts="$count_opts --behind=$behind_count"
+                fi
+                _cmux_send "report_git_branch $branch $dirty_opt $count_opts --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
             else
                 _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
             fi

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -130,12 +130,26 @@ _cmux_report_git_branch_for_path() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
-    local branch dirty_opt="" first
+    local branch dirty_opt="" count_opts=""
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     if [[ -n "$branch" ]]; then
-        first="$(git -C "$repo_path" status --porcelain -uno 2>/dev/null | head -1)"
-        [[ -n "$first" ]] && dirty_opt="--status=dirty"
-        _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+        local porcelain changed_count
+        porcelain="$(git -C "$repo_path" status --porcelain 2>/dev/null)"
+        if [[ -n "$porcelain" ]]; then
+            dirty_opt="--status=dirty"
+            changed_count=$(echo "$porcelain" | wc -l | tr -d ' ')
+            count_opts="--changed=$changed_count"
+        fi
+        local lr
+        lr="$(git -C "$repo_path" rev-list --left-right --count @{upstream}...HEAD 2>/dev/null)"
+        if [[ -n "$lr" ]]; then
+            local behind_count ahead_count
+            behind_count="${lr%%	*}"
+            ahead_count="${lr##*	}"
+            [[ "$ahead_count" -gt 0 ]] 2>/dev/null && count_opts="$count_opts --ahead=$ahead_count"
+            [[ "$behind_count" -gt 0 ]] 2>/dev/null && count_opts="$count_opts --behind=$behind_count"
+        fi
+        _cmux_send "report_git_branch $branch $dirty_opt $count_opts --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     else
         _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     fi

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6453,6 +6453,7 @@ private struct TabItemView: View {
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
     @AppStorage("sidebarShowGitBranchIcon") private var sidebarShowGitBranchIcon = false
+    @AppStorage("sidebarShowGitStatusCounts") private var sidebarShowGitStatusCounts = true
     @AppStorage("sidebarShowPullRequest") private var sidebarShowPullRequest = true
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
@@ -7356,7 +7357,10 @@ private struct TabItemView: View {
         return lines.joined(separator: " | ")
     }
 
-    private static func gitStatusSuffix(_ state: SidebarGitBranchState) -> String {
+    private static func gitStatusSuffix(_ state: SidebarGitBranchState, showCounts: Bool) -> String {
+        guard showCounts else {
+            return state.isDirty ? "*" : ""
+        }
         var parts: [String] = []
         if let count = state.changedCount, count > 0 {
             parts.append("!\(count)")
@@ -7370,7 +7374,7 @@ private struct TabItemView: View {
 
     private func gitBranchSummaryLines(orderedPanelIds: [UUID]) -> [String] {
         tab.sidebarGitBranchesInDisplayOrder(orderedPanelIds: orderedPanelIds).map { branch in
-            "\(branch.branch)\(Self.gitStatusSuffix(branch))"
+            "\(branch.branch)\(Self.gitStatusSuffix(branch, showCounts: sidebarShowGitStatusCounts))"
         }
     }
 
@@ -7388,7 +7392,7 @@ private struct TabItemView: View {
                 let suffix = Self.gitStatusSuffix(SidebarGitBranchState(
                     branch: branch, isDirty: entry.isDirty,
                     changedCount: entry.changedCount, ahead: entry.ahead, behind: entry.behind
-                ))
+                ), showCounts: sidebarShowGitStatusCounts)
                 return "\(branch)\(suffix)"
             }()
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7356,9 +7356,21 @@ private struct TabItemView: View {
         return lines.joined(separator: " | ")
     }
 
+    private static func gitStatusSuffix(_ state: SidebarGitBranchState) -> String {
+        var parts: [String] = []
+        if let count = state.changedCount, count > 0 {
+            parts.append("!\(count)")
+        } else if state.isDirty {
+            parts.append("*")
+        }
+        if let ahead = state.ahead, ahead > 0 { parts.append("⇡\(ahead)") }
+        if let behind = state.behind, behind > 0 { parts.append("⇣\(behind)") }
+        return parts.isEmpty ? "" : " " + parts.joined(separator: " ")
+    }
+
     private func gitBranchSummaryLines(orderedPanelIds: [UUID]) -> [String] {
         tab.sidebarGitBranchesInDisplayOrder(orderedPanelIds: orderedPanelIds).map { branch in
-            "\(branch.branch)\(branch.isDirty ? "*" : "")"
+            "\(branch.branch)\(Self.gitStatusSuffix(branch))"
         }
     }
 
@@ -7373,7 +7385,11 @@ private struct TabItemView: View {
         return entries.compactMap { entry in
             let branchText: String? = {
                 guard sidebarShowGitBranch, let branch = entry.branch else { return nil }
-                return "\(branch)\(entry.isDirty ? "*" : "")"
+                let suffix = Self.gitStatusSuffix(SidebarGitBranchState(
+                    branch: branch, isDirty: entry.isDirty,
+                    changedCount: entry.changedCount, ahead: entry.ahead, behind: entry.behind
+                ))
+                return "\(branch)\(suffix)"
             }()
 
             let directoryText: String? = {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -219,6 +219,9 @@ struct SessionProgressSnapshot: Codable, Sendable {
 struct SessionGitBranchSnapshot: Codable, Sendable {
     var branch: String
     var isDirty: Bool
+    var changedCount: Int?
+    var ahead: Int?
+    var behind: Int?
 }
 
 struct SessionTerminalPanelSnapshot: Codable, Sendable {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -275,10 +275,15 @@ class TerminalController {
     nonisolated static func shouldReplaceGitBranch(
         current: SidebarGitBranchState?,
         branch: String,
-        isDirty: Bool
+        isDirty: Bool,
+        changedCount: Int?,
+        ahead: Int?,
+        behind: Int?
     ) -> Bool {
         guard let current else { return true }
         return current.branch != branch || current.isDirty != isDirty
+            || current.changedCount != changedCount
+            || current.ahead != ahead || current.behind != behind
     }
 
     nonisolated static func shouldReplacePullRequest(
@@ -9199,7 +9204,7 @@ class TerminalController {
           list_log [--limit=N] [--tab=X] - List log entries
           set_progress <0.0-1.0> [--label=X] [--tab=X] - Set progress bar
           clear_progress [--tab=X] - Clear progress bar
-          report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y] - Report git branch
+          report_git_branch <branch> [--status=dirty] [--changed=N] [--ahead=N] [--behind=N] [--tab=X] [--panel=Y] - Report git branch
           clear_git_branch [--tab=X] [--panel=Y] - Clear git branch
           report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--tab=X] [--panel=Y] - Report pull request / review item
           report_review <number> <url> [--label=MR] [--state=open|merged|closed] [--tab=X] [--panel=Y] - Alias for provider-specific review item
@@ -12630,9 +12635,12 @@ class TerminalController {
     private func reportGitBranch(_ args: String) -> String {
         let parsed = parseOptions(args)
         guard let branch = parsed.positional.first else {
-            return "ERROR: Missing branch name — usage: report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y]"
+            return "ERROR: Missing branch name — usage: report_git_branch <branch> [--status=dirty] [--changed=N] [--ahead=N] [--behind=N] [--tab=X] [--panel=Y]"
         }
         let isDirty = parsed.options["status"]?.lowercased() == "dirty"
+        let changedCount = parsed.options["changed"].flatMap { Int($0) }
+        let ahead = parsed.options["ahead"].flatMap { Int($0) }
+        let behind = parsed.options["behind"].flatMap { Int($0) }
 
         // Shell integration always includes explicit workspace/panel IDs.
         // Keep this telemetry path off-main so wake/main-thread stalls don't
@@ -12646,7 +12654,10 @@ class TerminalController {
                 let validSurfaceIds = Set(tab.panels.keys)
                 tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
                 guard validSurfaceIds.contains(scope.panelId) else { return }
-                tab.updatePanelGitBranch(panelId: scope.panelId, branch: branch, isDirty: isDirty)
+                tab.updatePanelGitBranch(
+                    panelId: scope.panelId, branch: branch, isDirty: isDirty,
+                    changedCount: changedCount, ahead: ahead, behind: behind
+                )
             }
             return "OK"
         }
@@ -12664,7 +12675,7 @@ class TerminalController {
             let surfaceId: UUID
             if let panelArg {
                 if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y]"
+                    result = "ERROR: Missing panel id — usage: report_git_branch <branch> [--status=dirty] [--changed=N] [--ahead=N] [--behind=N] [--tab=X] [--panel=Y]"
                     return
                 }
                 guard let parsedId = UUID(uuidString: panelArg) else {
@@ -12685,7 +12696,10 @@ class TerminalController {
                 return
             }
 
-            tab.updatePanelGitBranch(panelId: surfaceId, branch: branch, isDirty: isDirty)
+            tab.updatePanelGitBranch(
+                panelId: surfaceId, branch: branch, isDirty: isDirty,
+                changedCount: changedCount, ahead: ahead, behind: behind
+            )
         }
         return result
     }
@@ -13161,7 +13175,11 @@ class TerminalController {
             }
 
             if let git = tab.gitBranch {
-                lines.append("git_branch=\(git.branch)\(git.isDirty ? " dirty" : " clean")")
+                var parts = [git.branch, git.isDirty ? "dirty" : "clean"]
+                if let c = git.changedCount { parts.append("changed=\(c)") }
+                if let a = git.ahead { parts.append("ahead=\(a)") }
+                if let b = git.behind { parts.append("behind=\(b)") }
+                lines.append("git_branch=\(parts.joined(separator: " "))")
             } else {
                 lines.append("git_branch=none")
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -147,7 +147,7 @@ extension Workspace {
             SessionProgressSnapshot(value: progress.value, label: progress.label)
         }
         let gitBranchSnapshot = gitBranch.map { branch in
-            SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
+            SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty, changedCount: branch.changedCount, ahead: branch.ahead, behind: branch.behind)
         }
 
         return SessionWorkspaceSnapshot(
@@ -218,7 +218,7 @@ extension Workspace {
             )
         }
         progress = snapshot.progress.map { SidebarProgressState(value: $0.value, label: $0.label) }
-        gitBranch = snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty) }
+        gitBranch = snapshot.gitBranch.map { SidebarGitBranchState(branch: $0.branch, isDirty: $0.isDirty, changedCount: $0.changedCount, ahead: $0.ahead, behind: $0.behind) }
 
         recomputeListeningPorts()
 
@@ -300,7 +300,7 @@ extension Workspace {
         let isPinned = pinnedPanelIds.contains(panelId)
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
         let branchSnapshot = panelGitBranches[panelId].map {
-            SessionGitBranchSnapshot(branch: $0.branch, isDirty: $0.isDirty)
+            SessionGitBranchSnapshot(branch: $0.branch, isDirty: $0.isDirty, changedCount: $0.changedCount, ahead: $0.ahead, behind: $0.behind)
         }
         let listeningPorts = (surfaceListeningPorts[panelId] ?? []).sorted()
         let ttyName = surfaceTTYNames[panelId]
@@ -557,7 +557,7 @@ extension Workspace {
         }
 
         if let branch = snapshot.gitBranch {
-            panelGitBranches[panelId] = SidebarGitBranchState(branch: branch.branch, isDirty: branch.isDirty)
+            panelGitBranches[panelId] = SidebarGitBranchState(branch: branch.branch, isDirty: branch.isDirty, changedCount: branch.changedCount, ahead: branch.ahead, behind: branch.behind)
         } else {
             panelGitBranches.removeValue(forKey: panelId)
         }
@@ -636,6 +636,17 @@ struct SidebarProgressState {
 struct SidebarGitBranchState {
     let branch: String
     let isDirty: Bool
+    let changedCount: Int?
+    let ahead: Int?
+    let behind: Int?
+
+    init(branch: String, isDirty: Bool, changedCount: Int? = nil, ahead: Int? = nil, behind: Int? = nil) {
+        self.branch = branch
+        self.isDirty = isDirty
+        self.changedCount = changedCount
+        self.ahead = ahead
+        self.behind = behind
+    }
 }
 
 enum SidebarPullRequestStatus: String {
@@ -655,12 +666,18 @@ enum SidebarBranchOrdering {
     struct BranchEntry: Equatable {
         let name: String
         let isDirty: Bool
+        let changedCount: Int?
+        let ahead: Int?
+        let behind: Int?
     }
 
     struct BranchDirectoryEntry: Equatable {
         let branch: String?
         let isDirty: Bool
         let directory: String?
+        let changedCount: Int?
+        let ahead: Int?
+        let behind: Int?
     }
 
     static func orderedPaneIds(tree: ExternalTreeNode) -> [String] {
@@ -703,31 +720,55 @@ enum SidebarBranchOrdering {
         panelBranches: [UUID: SidebarGitBranchState],
         fallbackBranch: SidebarGitBranchState?
     ) -> [BranchEntry] {
+        struct BranchMeta {
+            var isDirty: Bool
+            var changedCount: Int?
+            var ahead: Int?
+            var behind: Int?
+        }
+
         var orderedNames: [String] = []
-        var branchDirty: [String: Bool] = [:]
+        var branchMeta: [String: BranchMeta] = [:]
 
         for panelId in orderedPanelIds {
             guard let state = panelBranches[panelId] else { continue }
             let name = state.branch.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !name.isEmpty else { continue }
 
-            if branchDirty[name] == nil {
+            if branchMeta[name] == nil {
                 orderedNames.append(name)
-                branchDirty[name] = state.isDirty
-            } else if state.isDirty {
-                branchDirty[name] = true
+                branchMeta[name] = BranchMeta(
+                    isDirty: state.isDirty,
+                    changedCount: state.changedCount,
+                    ahead: state.ahead,
+                    behind: state.behind
+                )
+            } else {
+                if state.isDirty { branchMeta[name]?.isDirty = true }
+                if let c = state.changedCount { branchMeta[name]?.changedCount = c }
+                if let a = state.ahead { branchMeta[name]?.ahead = a }
+                if let b = state.behind { branchMeta[name]?.behind = b }
             }
         }
 
         if orderedNames.isEmpty, let fallbackBranch {
             let name = fallbackBranch.branch.trimmingCharacters(in: .whitespacesAndNewlines)
             if !name.isEmpty {
-                return [BranchEntry(name: name, isDirty: fallbackBranch.isDirty)]
+                return [BranchEntry(
+                    name: name, isDirty: fallbackBranch.isDirty,
+                    changedCount: fallbackBranch.changedCount,
+                    ahead: fallbackBranch.ahead, behind: fallbackBranch.behind
+                )]
             }
         }
 
         return orderedNames.map { name in
-            BranchEntry(name: name, isDirty: branchDirty[name] ?? false)
+            let meta = branchMeta[name]!
+            return BranchEntry(
+                name: name, isDirty: meta.isDirty,
+                changedCount: meta.changedCount,
+                ahead: meta.ahead, behind: meta.behind
+            )
         }
     }
 
@@ -806,6 +847,9 @@ enum SidebarBranchOrdering {
             var branch: String?
             var isDirty: Bool
             var directory: String?
+            var changedCount: Int?
+            var ahead: Int?
+            var behind: Int?
         }
 
         func normalized(_ text: String?) -> String? {
@@ -838,9 +882,13 @@ enum SidebarBranchOrdering {
             let directory = normalized(panelDirectories[panelId] ?? defaultDirectory)
             guard branch != nil || directory != nil else { continue }
 
+            let panelState = panelBranches[panelId]
             let panelDirty = panelBranch != nil
-                ? (panelBranches[panelId]?.isDirty ?? false)
+                ? (panelState?.isDirty ?? false)
                 : defaultBranchDirty
+            let panelChanged = panelBranch != nil ? panelState?.changedCount : nil
+            let panelAhead = panelBranch != nil ? panelState?.ahead : nil
+            let panelBehind = panelBranch != nil ? panelState?.behind : nil
 
             let key: EntryKey
             if let directoryKey = canonicalDirectoryKey(directory) {
@@ -857,6 +905,9 @@ enum SidebarBranchOrdering {
                     if let branch {
                         existing.branch = branch
                         existing.isDirty = panelDirty
+                        if let c = panelChanged { existing.changedCount = c }
+                        if let a = panelAhead { existing.ahead = a }
+                        if let b = panelBehind { existing.behind = b }
                     } else if existing.branch == nil {
                         existing.isDirty = panelDirty
                     }
@@ -866,11 +917,17 @@ enum SidebarBranchOrdering {
                     entries[key] = existing
                 } else if panelDirty {
                     existing.isDirty = true
+                    if let c = panelChanged { existing.changedCount = c }
+                    if let a = panelAhead { existing.ahead = a }
+                    if let b = panelBehind { existing.behind = b }
                     entries[key] = existing
                 }
             } else {
                 order.append(key)
-                entries[key] = MutableEntry(branch: branch, isDirty: panelDirty, directory: directory)
+                entries[key] = MutableEntry(
+                    branch: branch, isDirty: panelDirty, directory: directory,
+                    changedCount: panelChanged, ahead: panelAhead, behind: panelBehind
+                )
             }
         }
 
@@ -881,7 +938,10 @@ enum SidebarBranchOrdering {
                     BranchDirectoryEntry(
                         branch: normalizedFallbackBranch,
                         isDirty: fallbackBranch?.isDirty ?? false,
-                        directory: fallbackDirectory
+                        directory: fallbackDirectory,
+                        changedCount: fallbackBranch?.changedCount,
+                        ahead: fallbackBranch?.ahead,
+                        behind: fallbackBranch?.behind
                     )
                 ]
             }
@@ -892,7 +952,10 @@ enum SidebarBranchOrdering {
             return BranchDirectoryEntry(
                 branch: entry.branch,
                 isDirty: entry.isDirty,
-                directory: entry.directory
+                directory: entry.directory,
+                changedCount: entry.changedCount,
+                ahead: entry.ahead,
+                behind: entry.behind
             )
         }
     }
@@ -1590,10 +1653,18 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    func updatePanelGitBranch(panelId: UUID, branch: String, isDirty: Bool) {
-        let state = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+    func updatePanelGitBranch(
+        panelId: UUID, branch: String, isDirty: Bool,
+        changedCount: Int? = nil, ahead: Int? = nil, behind: Int? = nil
+    ) {
+        let state = SidebarGitBranchState(
+            branch: branch, isDirty: isDirty,
+            changedCount: changedCount, ahead: ahead, behind: behind
+        )
         let existing = panelGitBranches[panelId]
-        if existing?.branch != branch || existing?.isDirty != isDirty {
+        if existing?.branch != branch || existing?.isDirty != isDirty
+            || existing?.changedCount != changedCount
+            || existing?.ahead != ahead || existing?.behind != behind {
             panelGitBranches[panelId] = state
         }
         if panelId == focusedPanelId {
@@ -1718,7 +1789,10 @@ final class Workspace: Identifiable, ObservableObject {
                 panelBranches: panelGitBranches,
                 fallbackBranch: gitBranch
             )
-            .map { SidebarGitBranchState(branch: $0.name, isDirty: $0.isDirty) }
+            .map { SidebarGitBranchState(
+                branch: $0.name, isDirty: $0.isDirty,
+                changedCount: $0.changedCount, ahead: $0.ahead, behind: $0.behind
+            ) }
     }
 
     func sidebarGitBranchesInDisplayOrder() -> [SidebarGitBranchState] {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2836,6 +2836,7 @@ struct SettingsView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @AppStorage(ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
     private var showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+    @AppStorage("sidebarShowGitStatusCounts") private var sidebarShowGitStatusCounts = true
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
@@ -3414,6 +3415,17 @@ struct SettingsView: View {
                             subtitle: String(localized: "settings.app.showBranchDirectory.subtitle", defaultValue: "Display the built-in git branch and working-directory row.")
                         ) {
                             Toggle("", isOn: $sidebarShowBranchDirectory)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.showGitStatusCounts", defaultValue: "Show Git Status Counts"),
+                            subtitle: String(localized: "settings.app.showGitStatusCounts.subtitle", defaultValue: "Show uncommitted changes (!3), ahead (⇡1), and behind (⇣2) counts next to the branch name.")
+                        ) {
+                            Toggle("", isOn: $sidebarShowGitStatusCounts)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -4115,6 +4127,7 @@ struct SettingsView: View {
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        sidebarShowGitStatusCounts = true
         sidebarShowPorts = true
         sidebarShowLog = true
         sidebarShowProgress = true


### PR DESCRIPTION
## Summary

- Extend sidebar branch display from boolean dirty `*` to rich counts: `!3` (uncommitted changes), `⇡1` (ahead), `⇣2` (behind upstream)
- Add `--changed=N`, `--ahead=N`, `--behind=N` flags to `report_git_branch` socket command
- Update zsh and bash shell integration to collect counts via `git status --porcelain` line count and `git rev-list --left-right --count`
- Thread counts through all ordering, dedup, and persistence layers
- Falls back to `*` when only dirty boolean is available (backward compatible)

## Testing

- Build succeeds: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`
- Shell integration changes are backward compatible (new flags are optional)
- Session persistence uses optional Codable fields, so existing sessions restore cleanly

## Related

- Closes https://github.com/manaflow-ai/cmux/issues/959

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show git status counts in the sidebar — uncommitted changes and ahead/behind vs upstream — rendered as "!N ⇡A ⇣B", with "*" fallback when counts aren't available. Adds a Settings toggle to enable/disable counts (on by default). Closes #959.

- **New Features**
  - Sidebar branch text shows counts in both compact and vertical layouts.
  - report_git_branch adds --changed, --ahead, and --behind flags.
  - Bash/Zsh integrations compute counts via git status --porcelain and git rev-list --left-right --count.
  - Counts are threaded through ordering, dedup, and session persistence (optional fields).
  - Settings: "Show Git Status Counts" toggle to show/hide counts (enabled by default).

- **Migration**
  - Update the shell integration scripts to enable counts; flags are optional and existing setups keep working.

<sup>Written for commit 2a7f61017ed29405c72e30f63e8af76ca3973df2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show uncommitted change counts next to branch names.
  * Show commits ahead/behind the tracked upstream branch.
  * Toggle in Settings to enable/disable showing Git status counts.

* **UI Enhancements**
  * Sidebar, status lines, and terminal outputs display richer branch state (dirty/clean, changed, ahead, behind).

* **Localization**
  * Added translated strings for the new "Show Git Status Counts" setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->