### PR TITLE
Fix browser pane drag routing over portal-hosted web views

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1,9 +1,7 @@
 import AppKit
+import Bonsplit
 import ObjectiveC
 import WebKit
-#if DEBUG
-import Bonsplit
-#endif
 
 private var cmuxWindowBrowserPortalKey: UInt8 = 0
 private var cmuxWindowBrowserPortalCloseObserverKey: UInt8 = 0
@@ -126,6 +124,17 @@ final class WindowBrowserHostView: NSView {
         if shouldPassThroughToSplitDivider(at: point) {
             return nil
         }
+
+        // Mirror terminal portal routing: while tab-reorder drags are active,
+        // pass through to SwiftUI drop targets behind the portal host.
+        // Browser hover routing also arrives as cursor/enter events and may not
+        // report a pressed-button state, so include that path here.
+        if Self.shouldPassThroughToDragTargets(
+            pasteboardTypes: NSPasteboard(name: .drag).types,
+            eventType: NSApp.currentEvent?.type
+        ) {
+            return nil
+        }
         let hitView = super.hitTest(point)
         return hitView === self ? nil : hitView
     }
@@ -227,6 +236,31 @@ final class WindowBrowserHostView: NSView {
         splitDividerCursorKind(at: point) != nil
     }
 
+    static func shouldPassThroughToDragTargets(
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        eventType: NSEvent.EventType?
+    ) -> Bool {
+        if DragOverlayRoutingPolicy.shouldPassThroughPortalHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: eventType
+        ) {
+            return true
+        }
+
+        guard let eventType else { return false }
+        switch eventType {
+        case .cursorUpdate, .mouseEntered, .mouseExited, .mouseMoved:
+            // Browser-side tab drags can surface as hover events with a mixed
+            // pasteboard payload (tabtransfer plus promised-file UTIs). Prefer
+            // the explicit Bonsplit drag types so WKWebView cannot steal the
+            // session as a file upload.
+            return DragOverlayRoutingPolicy.hasBonsplitTabTransfer(pasteboardTypes)
+                || DragOverlayRoutingPolicy.hasSidebarTabReorder(pasteboardTypes)
+        default:
+            return false
+        }
+    }
+
     private static func dividerCursorKind(at windowPoint: NSPoint, in view: NSView) -> DividerCursorKind? {
         guard !view.isHidden else { return nil }
 
@@ -317,8 +351,329 @@ final class WindowBrowserHostView: NSView {
 
 }
 
+private final class BrowserDropZoneOverlayView: NSView {
+    override var acceptsFirstResponder: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+struct BrowserPaneDropContext: Equatable {
+    let workspaceId: UUID
+    let panelId: UUID
+    let paneId: PaneID
+}
+
+struct BrowserPaneDragTransfer: Equatable {
+    let tabId: UUID
+    let sourcePaneId: UUID
+    let sourceProcessId: Int32
+
+    var isFromCurrentProcess: Bool {
+        sourceProcessId == Int32(ProcessInfo.processInfo.processIdentifier)
+    }
+
+    static func decode(from pasteboard: NSPasteboard) -> BrowserPaneDragTransfer? {
+        if let data = pasteboard.data(forType: DragOverlayRoutingPolicy.bonsplitTabTransferType) {
+            return decode(from: data)
+        }
+        if let raw = pasteboard.string(forType: DragOverlayRoutingPolicy.bonsplitTabTransferType) {
+            return decode(from: Data(raw.utf8))
+        }
+        return nil
+    }
+
+    static func decode(from data: Data) -> BrowserPaneDragTransfer? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tab = json["tab"] as? [String: Any],
+              let tabIdRaw = tab["id"] as? String,
+              let tabId = UUID(uuidString: tabIdRaw),
+              let sourcePaneIdRaw = json["sourcePaneId"] as? String,
+              let sourcePaneId = UUID(uuidString: sourcePaneIdRaw) else {
+            return nil
+        }
+
+        let sourceProcessId = (json["sourceProcessId"] as? NSNumber)?.int32Value ?? -1
+        return BrowserPaneDragTransfer(
+            tabId: tabId,
+            sourcePaneId: sourcePaneId,
+            sourceProcessId: sourceProcessId
+        )
+    }
+}
+
+struct BrowserPaneSplitTarget: Equatable {
+    let orientation: SplitOrientation
+    let insertFirst: Bool
+}
+
+enum BrowserPaneDropAction: Equatable {
+    case noOp
+    case move(
+        tabId: UUID,
+        targetWorkspaceId: UUID,
+        targetPane: PaneID,
+        splitTarget: BrowserPaneSplitTarget?
+    )
+}
+
+enum BrowserPaneDropRouting {
+    static func zone(for location: CGPoint, in size: CGSize) -> DropZone {
+        let edgeRatio: CGFloat = 0.25
+        let horizontalEdge = max(80, size.width * edgeRatio)
+        let verticalEdge = max(80, size.height * edgeRatio)
+
+        if location.x < horizontalEdge {
+            return .left
+        } else if location.x > size.width - horizontalEdge {
+            return .right
+        } else if location.y > size.height - verticalEdge {
+            return .top
+        } else if location.y < verticalEdge {
+            return .bottom
+        } else {
+            return .center
+        }
+    }
+
+    static func action(
+        for transfer: BrowserPaneDragTransfer,
+        target: BrowserPaneDropContext,
+        zone: DropZone
+    ) -> BrowserPaneDropAction? {
+        if zone == .center, transfer.sourcePaneId == target.paneId.id {
+            return .noOp
+        }
+
+        let splitTarget: BrowserPaneSplitTarget?
+        switch zone {
+        case .center:
+            splitTarget = nil
+        case .left:
+            splitTarget = BrowserPaneSplitTarget(orientation: .horizontal, insertFirst: true)
+        case .right:
+            splitTarget = BrowserPaneSplitTarget(orientation: .horizontal, insertFirst: false)
+        case .top:
+            splitTarget = BrowserPaneSplitTarget(orientation: .vertical, insertFirst: true)
+        case .bottom:
+            splitTarget = BrowserPaneSplitTarget(orientation: .vertical, insertFirst: false)
+        }
+
+        return .move(
+            tabId: transfer.tabId,
+            targetWorkspaceId: target.workspaceId,
+            targetPane: target.paneId,
+            splitTarget: splitTarget
+        )
+    }
+}
+
+final class BrowserPaneDropTargetView: NSView {
+    weak var slotView: WindowBrowserSlotView?
+    var dropContext: BrowserPaneDropContext?
+    private var activeZone: DropZone?
+#if DEBUG
+    private var lastHitTestSignature: String?
+#endif
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([DragOverlayRoutingPolicy.bonsplitTabTransferType])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    static func shouldCaptureHitTesting(
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        eventType: NSEvent.EventType?
+    ) -> Bool {
+        guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(pasteboardTypes) else { return false }
+        guard let eventType else { return false }
+
+        switch eventType {
+        case .cursorUpdate,
+             .mouseEntered,
+             .mouseExited,
+             .mouseMoved,
+             .leftMouseDragged,
+             .rightMouseDragged,
+             .otherMouseDragged,
+             .appKitDefined,
+             .applicationDefined,
+             .systemDefined,
+             .periodic:
+            return true
+        default:
+            return false
+        }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point), dropContext != nil else { return nil }
+
+        let pasteboardTypes = NSPasteboard(name: .drag).types
+        let eventType = NSApp.currentEvent?.type
+        let capture = Self.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: eventType
+        )
+#if DEBUG
+        logHitTestDecision(capture: capture, pasteboardTypes: pasteboardTypes, eventType: eventType)
+#endif
+        return capture ? self : nil
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        updateDragState(sender, phase: "entered")
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        updateDragState(sender, phase: "updated")
+    }
+
+    override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+        clearDragState(phase: "exited")
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        defer {
+            clearDragState(phase: "perform.clear")
+        }
+
+        guard let dropContext,
+              let transfer = BrowserPaneDragTransfer.decode(from: sender.draggingPasteboard),
+              transfer.isFromCurrentProcess else {
+#if DEBUG
+            dlog("browser.paneDrop.perform allowed=0 reason=missingTransfer")
+#endif
+            return false
+        }
+
+        let location = convert(sender.draggingLocation, from: nil)
+        let zone = BrowserPaneDropRouting.zone(for: location, in: bounds.size)
+        guard let action = BrowserPaneDropRouting.action(
+            for: transfer,
+            target: dropContext,
+            zone: zone
+        ) else {
+#if DEBUG
+            dlog(
+                "browser.paneDrop.perform allowed=0 panel=\(dropContext.panelId.uuidString.prefix(5)) " +
+                "reason=noAction zone=\(zone)"
+            )
+#endif
+            return false
+        }
+
+        switch action {
+        case .noOp:
+#if DEBUG
+            dlog(
+                "browser.paneDrop.perform allowed=1 panel=\(dropContext.panelId.uuidString.prefix(5)) " +
+                "tab=\(transfer.tabId.uuidString.prefix(5)) action=noop"
+            )
+#endif
+            return true
+        case .move(let tabId, let workspaceId, let targetPane, let splitTarget):
+            let moved = AppDelegate.shared?.moveBonsplitTab(
+                tabId: tabId,
+                toWorkspace: workspaceId,
+                targetPane: targetPane,
+                splitTarget: splitTarget.map { ($0.orientation, $0.insertFirst) },
+                focus: true,
+                focusWindow: true
+            ) ?? false
+#if DEBUG
+            let splitLabel = splitTarget.map {
+                "\($0.orientation.rawValue):\($0.insertFirst ? 1 : 0)"
+            } ?? "none"
+            dlog(
+                "browser.paneDrop.perform panel=\(dropContext.panelId.uuidString.prefix(5)) " +
+                "tab=\(tabId.uuidString.prefix(5)) zone=\(zone) pane=\(targetPane.id.uuidString.prefix(5)) " +
+                "split=\(splitLabel) moved=\(moved ? 1 : 0)"
+            )
+#endif
+            return moved
+        }
+    }
+
+    private func updateDragState(_ sender: any NSDraggingInfo, phase: String) -> NSDragOperation {
+        guard let dropContext,
+              let transfer = BrowserPaneDragTransfer.decode(from: sender.draggingPasteboard),
+              transfer.isFromCurrentProcess else {
+            clearDragState(phase: "\(phase).reject")
+            return []
+        }
+
+        let location = convert(sender.draggingLocation, from: nil)
+        let zone = BrowserPaneDropRouting.zone(for: location, in: bounds.size)
+        activeZone = zone
+        slotView?.setPortalDragDropZone(zone)
+#if DEBUG
+        dlog(
+            "browser.paneDrop.\(phase) panel=\(dropContext.panelId.uuidString.prefix(5)) " +
+            "tab=\(transfer.tabId.uuidString.prefix(5)) zone=\(zone)"
+        )
+#endif
+        return .move
+    }
+
+    private func clearDragState(phase: String) {
+        guard activeZone != nil else { return }
+        activeZone = nil
+        slotView?.setPortalDragDropZone(nil)
+#if DEBUG
+        if let dropContext {
+            dlog(
+                "browser.paneDrop.\(phase) panel=\(dropContext.panelId.uuidString.prefix(5)) zone=none"
+            )
+        }
+#endif
+    }
+
+#if DEBUG
+    private func logHitTestDecision(
+        capture: Bool,
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        eventType: NSEvent.EventType?
+    ) {
+        let hasTransferType = DragOverlayRoutingPolicy.hasBonsplitTabTransfer(pasteboardTypes)
+        guard hasTransferType || capture else { return }
+
+        let signature = [
+            capture ? "1" : "0",
+            hasTransferType ? "1" : "0",
+            String(describing: dropContext != nil),
+            eventType.map { String($0.rawValue) } ?? "nil",
+        ].joined(separator: "|")
+        guard lastHitTestSignature != signature else { return }
+        lastHitTestSignature = signature
+
+        let types = pasteboardTypes?.map(\.rawValue).joined(separator: ",") ?? "-"
+        dlog(
+            "browser.paneDrop.hitTest capture=\(capture ? 1 : 0) " +
+            "hasTransfer=\(hasTransferType ? 1 : 0) context=\(dropContext != nil ? 1 : 0) " +
+            "event=\(eventType.map { String($0.rawValue) } ?? "nil") types=\(types)"
+        )
+    }
+#endif
+}
+
 final class WindowBrowserSlotView: NSView {
     override var isOpaque: Bool { false }
+    private let paneDropTargetView = BrowserPaneDropTargetView(frame: .zero)
+    private let dropZoneOverlayView = BrowserDropZoneOverlayView(frame: .zero)
+    private var forwardedDropZone: DropZone?
+    private var portalDragDropZone: DropZone?
+    private var displayedDropZone: DropZone?
+    private var dropZoneOverlayAnimationGeneration: UInt64 = 0
+    private var isRefreshingInteractionLayers = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -326,16 +681,193 @@ final class WindowBrowserSlotView: NSView {
         layer?.masksToBounds = true
         translatesAutoresizingMaskIntoConstraints = true
         autoresizingMask = []
+
+        paneDropTargetView.slotView = self
+
+        dropZoneOverlayView.wantsLayer = true
+        dropZoneOverlayView.layer?.backgroundColor = cmuxAccentNSColor().withAlphaComponent(0.25).cgColor
+        dropZoneOverlayView.layer?.borderColor = cmuxAccentNSColor().cgColor
+        dropZoneOverlayView.layer?.borderWidth = 2
+        dropZoneOverlayView.layer?.cornerRadius = 8
+        dropZoneOverlayView.isHidden = true
+        addSubview(paneDropTargetView, positioned: .above, relativeTo: nil)
+        addSubview(dropZoneOverlayView, positioned: .above, relativeTo: nil)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
     }
+
+    override func layout() {
+        super.layout()
+        paneDropTargetView.frame = bounds
+        applyResolvedDropZoneOverlay()
+    }
+
+    func setDropZoneOverlay(zone: DropZone?) {
+        forwardedDropZone = zone
+        applyResolvedDropZoneOverlay()
+    }
+
+    func setPortalDragDropZone(_ zone: DropZone?) {
+        portalDragDropZone = zone
+        applyResolvedDropZoneOverlay()
+    }
+
+    func setPaneDropContext(_ context: BrowserPaneDropContext?) {
+        paneDropTargetView.dropContext = context
+    }
+
+    override func didAddSubview(_ subview: NSView) {
+        super.didAddSubview(subview)
+        guard subview !== paneDropTargetView, subview !== dropZoneOverlayView else { return }
+        bringInteractionLayersToFrontIfNeeded()
+    }
+
+    private var activeDropZone: DropZone? {
+        portalDragDropZone ?? forwardedDropZone
+    }
+
+    private func applyResolvedDropZoneOverlay() {
+        let resolvedZone = activeDropZone
+        if resolvedZone != nil, (bounds.width <= 2 || bounds.height <= 2) {
+            bringInteractionLayersToFrontIfNeeded()
+            return
+        }
+
+        let previousZone = displayedDropZone
+        displayedDropZone = resolvedZone
+        let previousFrame = dropZoneOverlayView.frame
+
+        guard let zone = resolvedZone else {
+            guard !dropZoneOverlayView.isHidden else {
+                bringInteractionLayersToFrontIfNeeded()
+                return
+            }
+
+            dropZoneOverlayAnimationGeneration &+= 1
+            let animationGeneration = dropZoneOverlayAnimationGeneration
+            dropZoneOverlayView.layer?.removeAllAnimations()
+            bringInteractionLayersToFrontIfNeeded()
+
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.14
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                dropZoneOverlayView.animator().alphaValue = 0
+            } completionHandler: { [weak self] in
+                guard let self else { return }
+                guard self.dropZoneOverlayAnimationGeneration == animationGeneration else { return }
+                guard self.displayedDropZone == nil else { return }
+                self.dropZoneOverlayView.isHidden = true
+                self.dropZoneOverlayView.alphaValue = 1
+            }
+            return
+        }
+
+        let targetFrame = dropZoneOverlayFrame(for: zone, in: bounds.size)
+        let needsFrameUpdate = !Self.rectApproximatelyEqual(previousFrame, targetFrame)
+        let zoneChanged = previousZone != zone
+
+        if !dropZoneOverlayView.isHidden && !needsFrameUpdate && !zoneChanged {
+            bringInteractionLayersToFrontIfNeeded()
+            return
+        }
+
+        dropZoneOverlayAnimationGeneration &+= 1
+        dropZoneOverlayView.layer?.removeAllAnimations()
+
+        if dropZoneOverlayView.isHidden {
+            applyDropZoneOverlayFrame(targetFrame)
+            dropZoneOverlayView.alphaValue = 0
+            dropZoneOverlayView.isHidden = false
+            bringInteractionLayersToFrontIfNeeded()
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.18
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                dropZoneOverlayView.animator().alphaValue = 1
+            }
+            return
+        }
+
+        bringInteractionLayersToFrontIfNeeded()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            if needsFrameUpdate {
+                dropZoneOverlayView.animator().frame = targetFrame
+            }
+            if dropZoneOverlayView.alphaValue < 1 {
+                dropZoneOverlayView.animator().alphaValue = 1
+            }
+        }
+    }
+
+    private func interactionLayerPriority(of view: NSView) -> Int {
+        if view === paneDropTargetView { return 1 }
+        if view === dropZoneOverlayView { return 2 }
+        return 0
+    }
+
+    private func bringInteractionLayersToFrontIfNeeded() {
+        guard !isRefreshingInteractionLayers else { return }
+        isRefreshingInteractionLayers = true
+        defer { isRefreshingInteractionLayers = false }
+
+        if paneDropTargetView.superview !== self {
+            addSubview(paneDropTargetView, positioned: .above, relativeTo: nil)
+        }
+        if dropZoneOverlayView.superview !== self {
+            addSubview(dropZoneOverlayView, positioned: .above, relativeTo: nil)
+        }
+
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        sortSubviews({ lhs, rhs, context in
+            guard let context else { return .orderedSame }
+            let slotView = Unmanaged<WindowBrowserSlotView>.fromOpaque(context).takeUnretainedValue()
+            let lhsPriority = slotView.interactionLayerPriority(of: lhs)
+            let rhsPriority = slotView.interactionLayerPriority(of: rhs)
+            if lhsPriority == rhsPriority { return .orderedSame }
+            return lhsPriority < rhsPriority ? .orderedAscending : .orderedDescending
+        }, context: context)
+    }
+
+    private func applyDropZoneOverlayFrame(_ frame: CGRect) {
+        if Self.rectApproximatelyEqual(dropZoneOverlayView.frame, frame) { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dropZoneOverlayView.frame = frame
+        CATransaction.commit()
+    }
+
+    private func dropZoneOverlayFrame(for zone: DropZone, in size: CGSize) -> CGRect {
+        let padding: CGFloat = 4
+        switch zone {
+        case .center:
+            return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height - padding * 2)
+        case .left:
+            return CGRect(x: padding, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
+        case .right:
+            return CGRect(x: size.width / 2, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
+        case .top:
+            return CGRect(x: padding, y: size.height / 2, width: size.width - padding * 2, height: size.height / 2 - padding)
+        case .bottom:
+            return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height / 2 - padding)
+        }
+    }
+
+    private static func rectApproximatelyEqual(_ lhs: CGRect, _ rhs: CGRect, epsilon: CGFloat = 0.5) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
+            abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
+            abs(lhs.size.width - rhs.size.width) <= epsilon &&
+            abs(lhs.size.height - rhs.size.height) <= epsilon
+    }
 }
 
 @MainActor
 final class WindowBrowserPortal: NSObject {
+    private static let transientRecoveryRetryBudget: Int = 12
+
     private weak var window: NSWindow?
     private let hostView = WindowBrowserHostView(frame: .zero)
     private weak var installedContainerView: NSView?
@@ -350,6 +882,9 @@ final class WindowBrowserPortal: NSObject {
         weak var anchorView: NSView?
         var visibleInUI: Bool
         var zPriority: Int
+        var dropZone: DropZone?
+        var paneDropContext: BrowserPaneDropContext?
+        var transientRecoveryRetriesRemaining: Int
     }
 
     private var entriesByWebViewId: [ObjectIdentifier: Entry] = [:]
@@ -427,22 +962,39 @@ final class WindowBrowserPortal: NSObject {
         hostView.superview?.layoutSubtreeIfNeeded()
         hostView.layoutSubtreeIfNeeded()
         synchronizeAllWebViews(excluding: nil, source: "externalGeometry")
+
+        for entry in entriesByWebViewId.values {
+            guard let webView = entry.webView,
+                  let containerView = entry.containerView,
+                  !containerView.isHidden else { continue }
+            refreshHostedWebViewPresentation(
+                webView,
+                in: containerView,
+                reason: "externalGeometry"
+            )
+        }
     }
 
     @discardableResult
     private func ensureInstalled() -> Bool {
         guard let window else { return false }
         guard let (container, reference) = installationTarget(for: window) else { return false }
+        let placementReference = preferredHostPlacementReference(in: container, fallback: reference)
 
         if hostView.superview !== container ||
             installedContainerView !== container ||
             installedReferenceView !== reference {
             hostView.removeFromSuperview()
-            container.addSubview(hostView, positioned: .above, relativeTo: reference)
+            container.addSubview(hostView, positioned: .above, relativeTo: placementReference)
             installedContainerView = container
             installedReferenceView = reference
-        } else if !Self.isView(hostView, above: reference, in: container) {
-            container.addSubview(hostView, positioned: .above, relativeTo: reference)
+        } else {
+            let aboveReference = Self.isView(hostView, above: reference, in: container)
+            let abovePlacementReference = placementReference === reference
+                || Self.isView(hostView, above: placementReference, in: container)
+            if !aboveReference || !abovePlacementReference {
+                container.addSubview(hostView, positioned: .above, relativeTo: placementReference)
+            }
         }
 
         synchronizeHostFrameToReference()
@@ -526,6 +1078,30 @@ final class WindowBrowserPortal: NSObject {
         )
     }
 
+    /// Convert an anchor view's bounds to window coordinates while honoring ancestor clipping.
+    /// SwiftUI/AppKit hosting layers can briefly report an anchor bounds rect larger than the
+    /// visible split pane during rearrangement; intersecting through ancestor bounds keeps the
+    /// portal locked to the pane the user can actually see.
+    private func effectiveAnchorFrameInWindow(for anchorView: NSView) -> NSRect {
+        var frameInWindow = anchorView.convert(anchorView.bounds, to: nil)
+        var current = anchorView.superview
+        while let ancestor = current {
+            let ancestorBoundsInWindow = ancestor.convert(ancestor.bounds, to: nil)
+            let finiteAncestorBounds =
+                ancestorBoundsInWindow.origin.x.isFinite &&
+                ancestorBoundsInWindow.origin.y.isFinite &&
+                ancestorBoundsInWindow.size.width.isFinite &&
+                ancestorBoundsInWindow.size.height.isFinite
+            if finiteAncestorBounds {
+                frameInWindow = frameInWindow.intersection(ancestorBoundsInWindow)
+                if frameInWindow.isNull { return .zero }
+            }
+            if ancestor === installedReferenceView { break }
+            current = ancestor.superview
+        }
+        return frameInWindow
+    }
+
     private static func frameExtendsOutsideBounds(_ frame: NSRect, bounds: NSRect, epsilon: CGFloat = 0.5) -> Bool {
         frame.minX < bounds.minX - epsilon ||
             frame.minY < bounds.minY - epsilon ||
@@ -557,11 +1133,19 @@ final class WindowBrowserPortal: NSObject {
         return viewIndex > referenceIndex
     }
 
+    private func preferredHostPlacementReference(in container: NSView, fallback reference: NSView) -> NSView {
+        container.subviews.last(where: {
+            $0 !== hostView && ($0 === reference || $0 is WindowTerminalHostView)
+        }) ?? reference
+    }
+
     private func ensureContainerView(for entry: Entry, webView: WKWebView) -> WindowBrowserSlotView {
         if let existing = entry.containerView {
+            existing.setPaneDropContext(entry.paneDropContext)
             return existing
         }
         let created = WindowBrowserSlotView(frame: .zero)
+        created.setPaneDropContext(entry.paneDropContext)
 #if DEBUG
         dlog(
             "browser.portal.container.create web=\(browserPortalDebugToken(webView)) " +
@@ -569,6 +1153,48 @@ final class WindowBrowserPortal: NSObject {
         )
 #endif
         return created
+    }
+
+    private func refreshHostedWebViewPresentation(
+        _ webView: WKWebView,
+        in containerView: WindowBrowserSlotView,
+        reason: String
+    ) {
+        guard !containerView.isHidden else { return }
+
+        containerView.needsLayout = true
+        containerView.needsDisplay = true
+        containerView.setNeedsDisplay(containerView.bounds)
+
+        if let scrollView = webView.enclosingScrollView {
+            scrollView.needsLayout = true
+            scrollView.needsDisplay = true
+            scrollView.setNeedsDisplay(scrollView.bounds)
+        }
+
+        webView.needsLayout = true
+        webView.needsDisplay = true
+        webView.setNeedsDisplay(webView.bounds)
+        DispatchQueue.main.async { [weak self, weak webView, weak containerView] in
+            guard let self, let webView, let containerView, !containerView.isHidden else { return }
+
+            containerView.layoutSubtreeIfNeeded()
+            if let scrollView = webView.enclosingScrollView {
+                scrollView.layoutSubtreeIfNeeded()
+                scrollView.displayIfNeeded()
+            }
+            webView.layoutSubtreeIfNeeded()
+            containerView.displayIfNeeded()
+            webView.displayIfNeeded()
+            (webView.window ?? self.hostView.window)?.displayIfNeeded()
+#if DEBUG
+            dlog(
+                "browser.portal.refresh web=\(browserPortalDebugToken(webView)) " +
+                "container=\(browserPortalDebugToken(containerView)) reason=\(reason) " +
+                "frame=\(browserPortalDebugFrame(containerView.frame))"
+            )
+#endif
+        }
     }
 
     private func moveWebKitRelatedSubviewsIfNeeded(
@@ -641,6 +1267,20 @@ final class WindowBrowserPortal: NSObject {
         entriesByWebViewId[webViewId] = entry
     }
 
+    func updateDropZoneOverlay(forWebViewId webViewId: ObjectIdentifier, zone: DropZone?) {
+        guard var entry = entriesByWebViewId[webViewId] else { return }
+        entry.dropZone = zone
+        entriesByWebViewId[webViewId] = entry
+        entry.containerView?.setDropZoneOverlay(zone: zone)
+    }
+
+    func updatePaneDropContext(forWebViewId webViewId: ObjectIdentifier, context: BrowserPaneDropContext?) {
+        guard var entry = entriesByWebViewId[webViewId] else { return }
+        entry.paneDropContext = context
+        entriesByWebViewId[webViewId] = entry
+        entry.containerView?.setPaneDropContext(context)
+    }
+
     func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
         guard ensureInstalled() else { return }
 
@@ -648,7 +1288,16 @@ final class WindowBrowserPortal: NSObject {
         let anchorId = ObjectIdentifier(anchorView)
         let previousEntry = entriesByWebViewId[webViewId]
         let containerView = ensureContainerView(
-            for: previousEntry ?? Entry(webView: nil, containerView: nil, anchorView: nil, visibleInUI: false, zPriority: 0),
+            for: previousEntry ?? Entry(
+                webView: nil,
+                containerView: nil,
+                anchorView: nil,
+                visibleInUI: false,
+                zPriority: 0,
+                dropZone: nil,
+                paneDropContext: nil,
+                transientRecoveryRetriesRemaining: 0
+            ),
             webView: webView
         )
 
@@ -677,7 +1326,10 @@ final class WindowBrowserPortal: NSObject {
             containerView: containerView,
             anchorView: anchorView,
             visibleInUI: visibleInUI,
-            zPriority: zPriority
+            zPriority: zPriority,
+            dropZone: previousEntry?.dropZone,
+            paneDropContext: previousEntry?.paneDropContext,
+            transientRecoveryRetriesRemaining: previousEntry?.transientRecoveryRetriesRemaining ?? 0
         )
 
         let didChangeAnchor: Bool = {
@@ -747,7 +1399,11 @@ final class WindowBrowserPortal: NSObject {
             hostView.addSubview(containerView, positioned: .above, relativeTo: nil)
         }
 
-        synchronizeWebView(withId: webViewId, source: "bind")
+        synchronizeWebView(
+            withId: webViewId,
+            source: "bind",
+            forcePresentationRefresh: didChangeAnchor
+        )
         pruneDeadEntries()
     }
 
@@ -789,9 +1445,44 @@ final class WindowBrowserPortal: NSObject {
         }
     }
 
-    private func synchronizeWebView(withId webViewId: ObjectIdentifier, source: String) {
+    private func resetTransientRecoveryRetryIfNeeded(forWebViewId webViewId: ObjectIdentifier, entry: inout Entry) {
+        guard entry.transientRecoveryRetriesRemaining != 0 else { return }
+        entry.transientRecoveryRetriesRemaining = 0
+        entriesByWebViewId[webViewId] = entry
+    }
+
+    private func scheduleTransientRecoveryRetryIfNeeded(
+        forWebViewId webViewId: ObjectIdentifier,
+        entry: inout Entry,
+        webView: WKWebView,
+        reason: String
+    ) -> Bool {
+        if entry.transientRecoveryRetriesRemaining == 0 {
+            entry.transientRecoveryRetriesRemaining = Self.transientRecoveryRetryBudget
+        }
+        guard entry.transientRecoveryRetriesRemaining > 0 else { return false }
+
+        entry.transientRecoveryRetriesRemaining -= 1
+        entriesByWebViewId[webViewId] = entry
+#if DEBUG
+        dlog(
+            "browser.portal.sync.deferRecover web=\(browserPortalDebugToken(webView)) " +
+            "reason=\(reason) remaining=\(entry.transientRecoveryRetriesRemaining)"
+        )
+#endif
+        if entry.transientRecoveryRetriesRemaining > 0 {
+            scheduleDeferredFullSynchronizeAll()
+        }
+        return true
+    }
+
+    private func synchronizeWebView(
+        withId webViewId: ObjectIdentifier,
+        source: String,
+        forcePresentationRefresh: Bool = false
+    ) {
         guard ensureInstalled() else { return }
-        guard let entry = entriesByWebViewId[webViewId] else { return }
+        guard var entry = entriesByWebViewId[webViewId] else { return }
         guard let webView = entry.webView else {
             entriesByWebViewId.removeValue(forKey: webViewId)
             return
@@ -804,6 +1495,16 @@ final class WindowBrowserPortal: NSObject {
             return
         }
         guard let anchorView = entry.anchorView, let window else {
+            if entry.visibleInUI {
+                _ = scheduleTransientRecoveryRetryIfNeeded(
+                    forWebViewId: webViewId,
+                    entry: &entry,
+                    webView: webView,
+                    reason: "missingAnchorOrWindow"
+                )
+            } else {
+                resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+            }
 #if DEBUG
             if !containerView.isHidden {
                 dlog(
@@ -812,6 +1513,7 @@ final class WindowBrowserPortal: NSObject {
                 )
             }
 #endif
+            containerView.setDropZoneOverlay(zone: nil)
             containerView.isHidden = true
             return
         }
@@ -825,10 +1527,22 @@ final class WindowBrowserPortal: NSObject {
                 )
             }
 #endif
+            if entry.visibleInUI {
+                _ = scheduleTransientRecoveryRetryIfNeeded(
+                    forWebViewId: webViewId,
+                    entry: &entry,
+                    webView: webView,
+                    reason: "anchorWindowMismatch"
+                )
+            } else {
+                resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+            }
+            containerView.setDropZoneOverlay(zone: nil)
             containerView.isHidden = true
             return
         }
 
+        var refreshReasons: [String] = []
         if containerView.superview !== hostView {
 #if DEBUG
             dlog(
@@ -837,6 +1551,7 @@ final class WindowBrowserPortal: NSObject {
             )
 #endif
             hostView.addSubview(containerView, positioned: .above, relativeTo: nil)
+            refreshReasons.append("syncAttachContainer")
         }
         if webView.superview !== containerView {
 #if DEBUG
@@ -859,12 +1574,11 @@ final class WindowBrowserPortal: NSObject {
             webView.translatesAutoresizingMaskIntoConstraints = true
             webView.autoresizingMask = [.width, .height]
             webView.frame = containerView.bounds
-            webView.needsLayout = true
-            webView.layoutSubtreeIfNeeded()
+            refreshReasons.append("syncAttachWebView")
         }
 
         _ = synchronizeHostFrameToReference()
-        let frameInWindow = anchorView.convert(anchorView.bounds, to: nil)
+        let frameInWindow = effectiveAnchorFrameInWindow(for: anchorView)
         let frameInHostRaw = hostView.convert(frameInWindow, from: nil)
         let frameInHost = Self.pixelSnappedRect(frameInHostRaw, in: hostView)
         let hostBounds = hostView.bounds
@@ -883,8 +1597,38 @@ final class WindowBrowserPortal: NSObject {
                 "anchor=\(browserPortalDebugFrame(frameInHost)) visibleInUI=\(entry.visibleInUI ? 1 : 0)"
             )
 #endif
+            if entry.visibleInUI {
+                let shouldPreserveVisibleOnTransient = !containerView.isHidden &&
+                    scheduleTransientRecoveryRetryIfNeeded(
+                        forWebViewId: webViewId,
+                        entry: &entry,
+                        webView: webView,
+                        reason: "hostBoundsNotReady"
+                    )
+                if shouldPreserveVisibleOnTransient {
+#if DEBUG
+                    dlog(
+                        "browser.portal.hidden.deferKeep web=\(browserPortalDebugToken(webView)) " +
+                        "reason=hostBoundsNotReady frame=\(browserPortalDebugFrame(containerView.frame))"
+                    )
+#endif
+                    return
+                }
+            } else {
+                resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+            }
+            containerView.setDropZoneOverlay(zone: nil)
             containerView.isHidden = true
-            scheduleDeferredFullSynchronizeAll()
+            if entry.visibleInUI {
+                _ = scheduleTransientRecoveryRetryIfNeeded(
+                    forWebViewId: webViewId,
+                    entry: &entry,
+                    webView: webView,
+                    reason: "hostBoundsNotReady"
+                )
+            } else {
+                scheduleDeferredFullSynchronizeAll()
+            }
             return
         }
         let oldFrame = containerView.frame
@@ -908,6 +1652,28 @@ final class WindowBrowserPortal: NSObject {
             tinyFrame ||
             !hasFiniteFrame ||
             outsideHostBounds
+        let transientRecoveryReason: String? = {
+            guard entry.visibleInUI else { return nil }
+            if anchorHidden { return "anchorHidden" }
+            if !hasFiniteFrame { return "nonFiniteFrame" }
+            if outsideHostBounds { return "outsideHostBounds" }
+            if tinyFrame { return "tinyFrame" }
+            return nil
+        }()
+        let didScheduleTransientRecovery: Bool = {
+            guard let transientRecoveryReason else { return false }
+            return scheduleTransientRecoveryRetryIfNeeded(
+                forWebViewId: webViewId,
+                entry: &entry,
+                webView: webView,
+                reason: transientRecoveryReason
+            )
+        }()
+        let shouldPreserveVisibleOnTransientGeometry =
+            didScheduleTransientRecovery &&
+            shouldHide &&
+            entry.visibleInUI &&
+            !containerView.isHidden
 #if DEBUG
         let frameWasClamped = hasFiniteFrame && !Self.rectApproximatelyEqual(frameInHost, targetFrame)
         if frameWasClamped {
@@ -934,13 +1700,20 @@ final class WindowBrowserPortal: NSObject {
             )
         }
 #endif
+        if shouldPreserveVisibleOnTransientGeometry {
+#if DEBUG
+            dlog(
+                "browser.portal.hidden.deferKeep web=\(browserPortalDebugToken(webView)) " +
+                "reason=\(transientRecoveryReason ?? "unknown") frame=\(browserPortalDebugFrame(containerView.frame))"
+            )
+#endif
+        }
         if !Self.rectApproximatelyEqual(oldFrame, targetFrame) {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             containerView.frame = targetFrame
             CATransaction.commit()
-            webView.needsLayout = true
-            webView.layoutSubtreeIfNeeded()
+            refreshReasons.append("frame")
         }
 
         let expectedContainerBounds = NSRect(origin: .zero, size: targetFrame.size)
@@ -957,6 +1730,7 @@ final class WindowBrowserPortal: NSObject {
                 "target=\(browserPortalDebugFrame(expectedContainerBounds))"
             )
 #endif
+            refreshReasons.append("bounds")
         }
 
         let containerBounds = containerView.bounds
@@ -985,20 +1759,51 @@ final class WindowBrowserPortal: NSObject {
                 "source=\(source)"
             )
 #endif
+            refreshReasons.append("webFrame")
         }
 
-        if containerView.isHidden != shouldHide {
+        let revealedForDisplay = !shouldHide && containerView.isHidden
+        if shouldHide, !containerView.isHidden, !shouldPreserveVisibleOnTransientGeometry {
 #if DEBUG
             dlog(
                 "browser.portal.hidden container=\(browserPortalDebugToken(containerView)) " +
                 "web=\(browserPortalDebugToken(webView)) value=\(shouldHide ? 1 : 0) " +
                 "visibleInUI=\(entry.visibleInUI ? 1 : 0) anchorHidden=\(anchorHidden ? 1 : 0) " +
                 "tiny=\(tinyFrame ? 1 : 0) finite=\(hasFiniteFrame ? 1 : 0) " +
+                    "outside=\(outsideHostBounds ? 1 : 0) frame=\(browserPortalDebugFrame(targetFrame)) " +
+                    "host=\(browserPortalDebugFrame(hostBounds))"
+            )
+#endif
+            containerView.isHidden = true
+        } else if !shouldHide, containerView.isHidden {
+#if DEBUG
+            dlog(
+                "browser.portal.hidden container=\(browserPortalDebugToken(containerView)) " +
+                "web=\(browserPortalDebugToken(webView)) value=0 " +
+                "visibleInUI=\(entry.visibleInUI ? 1 : 0) anchorHidden=\(anchorHidden ? 1 : 0) " +
+                "tiny=\(tinyFrame ? 1 : 0) finite=\(hasFiniteFrame ? 1 : 0) " +
                 "outside=\(outsideHostBounds ? 1 : 0) frame=\(browserPortalDebugFrame(targetFrame)) " +
                 "host=\(browserPortalDebugFrame(hostBounds))"
             )
 #endif
-            containerView.isHidden = shouldHide
+            containerView.isHidden = false
+        }
+        containerView.setDropZoneOverlay(zone: containerView.isHidden ? nil : entry.dropZone)
+        if revealedForDisplay {
+            refreshReasons.append("reveal")
+        }
+        if forcePresentationRefresh {
+            refreshReasons.append("anchor")
+        }
+        if transientRecoveryReason == nil {
+            resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)
+        }
+        if !shouldHide, !refreshReasons.isEmpty {
+            refreshHostedWebViewPresentation(
+                webView,
+                in: containerView,
+                reason: "\(source):" + refreshReasons.joined(separator: ",")
+            )
         }
 #if DEBUG
         dlog(
@@ -1026,16 +1831,18 @@ final class WindowBrowserPortal: NSObject {
         let deadWebViewIds = entriesByWebViewId.compactMap { webViewId, entry -> ObjectIdentifier? in
             guard entry.webView != nil else { return webViewId }
             guard let container = entry.containerView else { return webViewId }
-            guard let anchor = entry.anchorView else { return webViewId }
+            guard let anchor = entry.anchorView else {
+                return entry.visibleInUI ? nil : webViewId
+            }
             if container.superview == nil || !container.isDescendant(of: hostView) {
                 return webViewId
             }
-            if anchor.window !== currentWindow || anchor.superview == nil {
-                return webViewId
-            }
-            if let reference = installedReferenceView,
-               !anchor.isDescendant(of: reference) {
-                return webViewId
+            let anchorInvalidForCurrentHost =
+                anchor.window !== currentWindow ||
+                anchor.superview == nil ||
+                (installedReferenceView.map { !anchor.isDescendant(of: $0) } ?? false)
+            if anchorInvalidForCurrentHost {
+                return entry.visibleInUI ? nil : webViewId
             }
             return nil
         }
@@ -1188,6 +1995,20 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateEntryVisibility(forWebViewId: webViewId, visibleInUI: visibleInUI, zPriority: zPriority)
+    }
+
+    static func updateDropZoneOverlay(for webView: WKWebView, zone: DropZone?) {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return }
+        portal.updateDropZoneOverlay(forWebViewId: webViewId, zone: zone)
+    }
+
+    static func updatePaneDropContext(for webView: WKWebView, context: BrowserPaneDropContext?) {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return }
+        portal.updatePaneDropContext(forWebViewId: webViewId, context: context)
     }
 
     static func detach(webView: WKWebView) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -631,7 +631,12 @@ final class FileDropOverlayView: NSView {
     }
 
     /// Hit-tests the window to find a WKWebView (browser panel) under the cursor.
-    private func webViewUnderPoint(_ windowPoint: NSPoint) -> WKWebView? {
+    func webViewUnderPoint(_ windowPoint: NSPoint) -> WKWebView? {
+        if let window,
+           let portalWebView = BrowserWindowPortalRegistry.webViewAtWindowPoint(windowPoint, in: window) {
+            return portalWebView
+        }
+
         guard let window, let contentView = window.contentView else { return nil }
         isHidden = true
         defer { isHidden = false }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -211,6 +211,7 @@ struct BrowserPanelView: View {
     let portalPriority: Int
     let onRequestPanelFocus: () -> Void
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.paneDropZone) private var paneDropZone
     @State private var omnibarState = OmnibarState()
     @State private var addressBarFocused: Bool = false
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var searchEngineRaw = BrowserSearchSettings.defaultSearchEngine.rawValue
@@ -737,7 +738,8 @@ struct BrowserPanelView: View {
                     shouldAttachWebView: isVisibleInUI,
                     shouldFocusWebView: isFocused && !addressBarFocused,
                     isPanelFocused: isFocused,
-                    portalZPriority: portalPriority
+                    portalZPriority: portalPriority,
+                    paneDropZone: paneDropZone
                 )
                 // Keep the host stable for normal pane churn, but force a remount when
                 // BrowserPanel replaces its underlying WKWebView after process termination.
@@ -3005,6 +3007,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     let shouldFocusWebView: Bool
     let isPanelFocused: Bool
     let portalZPriority: Int
+    let paneDropZone: DropZone?
 
     final class Coordinator {
         weak var panel: BrowserPanel?
@@ -3175,6 +3178,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator.desiredPortalZPriority = portalZPriority
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
+        let paneDropContext = shouldAttachWebView ? currentPaneDropContext() : nil
 
         host.onDidMoveToWindow = { [weak host, weak webView, weak coordinator] in
             guard let host, let webView, let coordinator else { return }
@@ -3186,6 +3190,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 visibleInUI: coordinator.desiredPortalVisibleInUI,
                 zPriority: coordinator.desiredPortalZPriority
             )
+            BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: paneDropContext)
             coordinator.lastPortalHostId = ObjectIdentifier(host)
         }
         host.onGeometryChanged = { [weak host, weak coordinator] in
@@ -3228,6 +3233,15 @@ struct WebViewRepresentable: NSViewRepresentable {
                 zPriority: coordinator.desiredPortalZPriority
             )
         }
+
+        BrowserWindowPortalRegistry.updateDropZoneOverlay(
+            for: webView,
+            zone: shouldAttachWebView ? paneDropZone : nil
+        )
+        BrowserWindowPortalRegistry.updatePaneDropContext(
+            for: webView,
+            context: paneDropContext
+        )
 
         panel.restoreDeveloperToolsAfterAttachIfNeeded()
 
@@ -3341,7 +3355,24 @@ struct WebViewRepresentable: NSViewRepresentable {
                 window.makeFirstResponder(nil)
             }
         }
-        BrowserWindowPortalRegistry.detach(webView: webView)
+
+        // SwiftUI can transiently dismantle/rebuild the browser host view during split
+        // rearrangement. Do not detach the portal-hosted WKWebView here; explicit detach
+        // still happens on real web view replacement and panel teardown.
+        BrowserWindowPortalRegistry.updateDropZoneOverlay(for: webView, zone: nil)
+        BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: nil)
         coordinator.lastPortalHostId = nil
+    }
+
+    private func currentPaneDropContext() -> BrowserPaneDropContext? {
+        guard let workspace = AppDelegate.shared?.tabManager?.tabs.first(where: { $0.id == panel.workspaceId }),
+              let paneId = workspace.paneId(forPanelId: panel.id) else {
+            return nil
+        }
+        return BrowserPaneDropContext(
+            workspaceId: panel.workspaceId,
+            panelId: panel.id,
+            paneId: paneId
+        )
     }
 }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -1113,11 +1113,31 @@ final class CmuxWebView: WKWebView {
         NSPasteboard.PasteboardType("com.cmux.sidebar-tab-reorder"),
     ]
 
+    static func shouldRejectInternalPaneDrag(_ pasteboardTypes: [NSPasteboard.PasteboardType]?) -> Bool {
+        DragOverlayRoutingPolicy.hasBonsplitTabTransfer(pasteboardTypes)
+            || DragOverlayRoutingPolicy.hasSidebarTabReorder(pasteboardTypes)
+    }
+
     override func registerForDraggedTypes(_ newTypes: [NSPasteboard.PasteboardType]) {
         let filtered = newTypes.filter { !Self.blockedDragTypes.contains($0) }
         if !filtered.isEmpty {
             super.registerForDraggedTypes(filtered)
         }
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard !Self.shouldRejectInternalPaneDrag(sender.draggingPasteboard.types) else { return [] }
+        return super.draggingEntered(sender)
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard !Self.shouldRejectInternalPaneDrag(sender.draggingPasteboard.types) else { return [] }
+        return super.draggingUpdated(sender)
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard !Self.shouldRejectInternalPaneDrag(sender.draggingPasteboard.types) else { return false }
+        return super.performDragOperation(sender)
     }
 
     override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -726,6 +726,7 @@ final class WindowTerminalPortal: NSObject {
         guard let window else { return false }
         guard let (container, reference) = installedTargetIfStillValid(for: window) ?? installationTarget(for: window)
         else { return false }
+        let browserHost = preferredBrowserHost(in: container)
 
         if hostView.superview !== container ||
             installedContainerView !== container ||
@@ -734,7 +735,11 @@ final class WindowTerminalPortal: NSObject {
             installConstraints.removeAll()
 
             hostView.removeFromSuperview()
-            container.addSubview(hostView, positioned: .above, relativeTo: reference)
+            if let browserHost {
+                container.addSubview(hostView, positioned: .below, relativeTo: browserHost)
+            } else {
+                container.addSubview(hostView, positioned: .above, relativeTo: reference)
+            }
 
             installConstraints = [
                 hostView.leadingAnchor.constraint(equalTo: reference.leadingAnchor),
@@ -745,6 +750,10 @@ final class WindowTerminalPortal: NSObject {
             NSLayoutConstraint.activate(installConstraints)
             installedContainerView = container
             installedReferenceView = reference
+        } else if let browserHost {
+            if !Self.isView(browserHost, above: hostView, in: container) {
+                container.addSubview(hostView, positioned: .below, relativeTo: browserHost)
+            }
         } else if !Self.isView(hostView, above: reference, in: container) {
             container.addSubview(hostView, positioned: .above, relativeTo: reference)
         }
@@ -835,6 +844,10 @@ final class WindowTerminalPortal: NSObject {
             return false
         }
         return viewIndex > referenceIndex
+    }
+
+    private func preferredBrowserHost(in container: NSView) -> WindowBrowserHostView? {
+        container.subviews.last(where: { $0 is WindowBrowserHostView }) as? WindowBrowserHostView
     }
 
 #if DEBUG

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2423,7 +2423,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertFalse(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
     }
 
-    func testWebViewDismantleDetachesPortalHostedWebViewWhenDeveloperToolsIntentIsVisible() {
+    func testWebViewDismantleKeepsPortalHostedWebViewAttachedWhenDeveloperToolsIntentIsVisible() {
         let (panel, _) = makePanelWithInspector()
         XCTAssertTrue(panel.showDeveloperTools())
 
@@ -2449,17 +2449,18 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             shouldAttachWebView: true,
             shouldFocusWebView: false,
             isPanelFocused: true,
-            portalZPriority: 0
+            portalZPriority: 0,
+            paneDropZone: nil
         )
         let coordinator = representable.makeCoordinator()
         coordinator.webView = panel.webView
         WebViewRepresentable.dismantleNSView(anchor, coordinator: coordinator)
 
-        XCTAssertNil(panel.webView.superview)
+        XCTAssertNotNil(panel.webView.superview)
         window.orderOut(nil)
     }
 
-    func testWebViewDismantleDetachesPortalHostedWebViewWhenDeveloperToolsIntentIsHidden() {
+    func testWebViewDismantleKeepsPortalHostedWebViewAttachedWhenDeveloperToolsIntentIsHidden() {
         let (panel, _) = makePanelWithInspector()
         XCTAssertFalse(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
 
@@ -2485,13 +2486,14 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             shouldAttachWebView: true,
             shouldFocusWebView: false,
             isPanelFocused: true,
-            portalZPriority: 0
+            portalZPriority: 0,
+            paneDropZone: nil
         )
         let coordinator = representable.makeCoordinator()
         coordinator.webView = panel.webView
         WebViewRepresentable.dismantleNSView(anchor, coordinator: coordinator)
 
-        XCTAssertNil(panel.webView.superview)
+        XCTAssertNotNil(panel.webView.superview)
         window.orderOut(nil)
     }
 }
@@ -7501,6 +7503,197 @@ final class WindowBrowserHostViewTests: XCTestCase {
         let contentPointInHost = host.convert(contentPointInWindow, from: nil)
         XCTAssertTrue(host.hitTest(contentPointInHost) === child)
     }
+
+    func testDragHoverEventsPassThroughForTabTransferOnBrowserHoverEvents() {
+        XCTAssertTrue(
+            WindowBrowserHostView.shouldPassThroughToDragTargets(
+                pasteboardTypes: [DragOverlayRoutingPolicy.bonsplitTabTransferType],
+                eventType: .cursorUpdate
+            )
+        )
+        XCTAssertTrue(
+            WindowBrowserHostView.shouldPassThroughToDragTargets(
+                pasteboardTypes: [DragOverlayRoutingPolicy.bonsplitTabTransferType],
+                eventType: .mouseEntered
+            )
+        )
+    }
+
+    func testDragHoverEventsPassThroughForSidebarReorderWithoutMouseButtonState() {
+        XCTAssertTrue(
+            WindowBrowserHostView.shouldPassThroughToDragTargets(
+                pasteboardTypes: [DragOverlayRoutingPolicy.sidebarTabReorderType],
+                eventType: .cursorUpdate
+            )
+        )
+    }
+
+    func testDragHoverEventsDoNotPassThroughForUnrelatedPasteboardTypes() {
+        XCTAssertFalse(
+            WindowBrowserHostView.shouldPassThroughToDragTargets(
+                pasteboardTypes: [.fileURL],
+                eventType: .cursorUpdate
+            )
+        )
+    }
+}
+
+@MainActor
+final class CmuxWebViewDragRoutingTests: XCTestCase {
+    func testRejectsInternalPaneDragEvenWhenFilePromiseTypesArePresent() {
+        XCTAssertTrue(
+            CmuxWebView.shouldRejectInternalPaneDrag([
+                DragOverlayRoutingPolicy.bonsplitTabTransferType,
+                NSPasteboard.PasteboardType("com.apple.pasteboard.promised-file-url"),
+            ])
+        )
+    }
+
+    func testAllowsRegularExternalFileDrops() {
+        XCTAssertFalse(CmuxWebView.shouldRejectInternalPaneDrag([.fileURL]))
+    }
+}
+
+@MainActor
+final class BrowserPaneDropRoutingTests: XCTestCase {
+    func testVerticalZonesFollowAppKitCoordinates() {
+        let size = CGSize(width: 240, height: 180)
+
+        XCTAssertEqual(
+            BrowserPaneDropRouting.zone(for: CGPoint(x: size.width * 0.5, y: size.height - 8), in: size),
+            .top
+        )
+        XCTAssertEqual(
+            BrowserPaneDropRouting.zone(for: CGPoint(x: size.width * 0.5, y: 8), in: size),
+            .bottom
+        )
+    }
+
+    func testHitTestingCapturesOnlyForRelevantDragEvents() {
+        XCTAssertTrue(
+            BrowserPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: [DragOverlayRoutingPolicy.bonsplitTabTransferType],
+                eventType: .cursorUpdate
+            )
+        )
+        XCTAssertFalse(
+            BrowserPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: [DragOverlayRoutingPolicy.bonsplitTabTransferType],
+                eventType: .leftMouseDown
+            )
+        )
+        XCTAssertFalse(
+            BrowserPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: [.fileURL],
+                eventType: .cursorUpdate
+            )
+        )
+    }
+
+    func testCenterDropOnSamePaneIsNoOp() {
+        let paneId = PaneID(id: UUID())
+        let target = BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: paneId
+        )
+        let transfer = BrowserPaneDragTransfer(
+            tabId: UUID(),
+            sourcePaneId: paneId.id,
+            sourceProcessId: Int32(ProcessInfo.processInfo.processIdentifier)
+        )
+
+        XCTAssertEqual(
+            BrowserPaneDropRouting.action(for: transfer, target: target, zone: .center),
+            .noOp
+        )
+    }
+
+    func testRightEdgeDropBuildsSplitMoveAction() {
+        let paneId = PaneID(id: UUID())
+        let target = BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: paneId
+        )
+        let tabId = UUID()
+        let transfer = BrowserPaneDragTransfer(
+            tabId: tabId,
+            sourcePaneId: UUID(),
+            sourceProcessId: Int32(ProcessInfo.processInfo.processIdentifier)
+        )
+
+        XCTAssertEqual(
+            BrowserPaneDropRouting.action(for: transfer, target: target, zone: .right),
+            .move(
+                tabId: tabId,
+                targetWorkspaceId: target.workspaceId,
+                targetPane: paneId,
+                splitTarget: BrowserPaneSplitTarget(orientation: .horizontal, insertFirst: false)
+            )
+        )
+    }
+
+    func testDecodeTransferPayloadReadsTabAndSourcePane() {
+        let tabId = UUID()
+        let sourcePaneId = UUID()
+        let payload = try! JSONSerialization.data(
+            withJSONObject: [
+                "tab": ["id": tabId.uuidString],
+                "sourcePaneId": sourcePaneId.uuidString,
+                "sourceProcessId": ProcessInfo.processInfo.processIdentifier,
+            ]
+        )
+
+        let transfer = BrowserPaneDragTransfer.decode(from: payload)
+
+        XCTAssertEqual(transfer?.tabId, tabId)
+        XCTAssertEqual(transfer?.sourcePaneId, sourcePaneId)
+        XCTAssertTrue(transfer?.isFromCurrentProcess == true)
+    }
+}
+
+@MainActor
+final class WindowBrowserSlotViewTests: XCTestCase {
+    private final class CapturingView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
+    private func advanceAnimations() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    }
+
+    func testDropZoneOverlayStaysAboveContentWithoutBlockingHits() {
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let child = CapturingView(frame: slot.bounds)
+        child.autoresizingMask = [.width, .height]
+        slot.addSubview(child)
+
+        slot.setDropZoneOverlay(zone: .right)
+        slot.layoutSubtreeIfNeeded()
+
+        guard let overlay = slot.subviews.first(where: {
+            $0 !== child && String(describing: type(of: $0)).contains("BrowserDropZoneOverlayView")
+        }) else {
+            XCTFail("Expected browser slot drop-zone overlay")
+            return
+        }
+
+        XCTAssertTrue(slot.subviews.last === overlay, "Overlay should stay above the hosted web view")
+        XCTAssertFalse(overlay.isHidden)
+        XCTAssertEqual(overlay.frame.origin.x, 100, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.origin.y, 4, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.size.width, 96, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.size.height, 92, accuracy: 0.5)
+        XCTAssertNil(overlay.hitTest(NSPoint(x: 120, y: 50)), "Overlay should never intercept pointer hits")
+        XCTAssertTrue(slot.hitTest(NSPoint(x: 120, y: 50)) === child)
+
+        slot.setDropZoneOverlay(zone: nil)
+        advanceAnimations()
+        XCTAssertTrue(overlay.isHidden, "Clearing the drop zone should hide the overlay")
+    }
 }
 
 @MainActor
@@ -8504,6 +8697,54 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testTerminalPortalHostStaysBelowBrowserPortalHostWhenBothAreInstalled() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+
+        let browserPortal = WindowBrowserPortal(window: window)
+        let terminalPortal = WindowTerminalPortal(window: window)
+        _ = browserPortal.webViewAtWindowPoint(NSPoint(x: 1, y: 1))
+        _ = terminalPortal.viewAtWindowPoint(NSPoint(x: 1, y: 1))
+
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        func assertHostOrder(_ message: String) {
+            guard let terminalHostIndex = container.subviews.firstIndex(where: { $0 is WindowTerminalHostView }),
+                  let browserHostIndex = container.subviews.firstIndex(where: { $0 is WindowBrowserHostView }) else {
+                XCTFail("Expected both portal hosts in same container")
+                return
+            }
+
+            XCTAssertLessThan(
+                terminalHostIndex,
+                browserHostIndex,
+                message
+            )
+        }
+
+        assertHostOrder("Terminal portal host should start below browser portal host")
+
+        let anchor = NSView(frame: NSRect(x: 24, y: 24, width: 220, height: 150))
+        contentView.addSubview(anchor)
+        let hosted = GhosttySurfaceScrollView(
+            surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+        )
+        terminalPortal.bind(hostedView: hosted, to: anchor, visibleInUI: true)
+        terminalPortal.synchronizeHostedViewForAnchor(anchor)
+
+        assertHostOrder("Terminal portal bind/sync should not rise above the browser portal host")
+    }
+
     func testRegistryPrunesPortalWhenWindowCloses() {
         let baseline = TerminalWindowPortalRegistry.debugPortalCount()
         let window = NSWindow(
@@ -8744,12 +8985,31 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
 
 @MainActor
 final class BrowserWindowPortalLifecycleTests: XCTestCase {
+    private final class TrackingPortalWebView: WKWebView {
+        private(set) var displayIfNeededCount = 0
+
+        override func displayIfNeeded() {
+            displayIfNeededCount += 1
+            super.displayIfNeeded()
+        }
+    }
+
     private func realizeWindowLayout(_ window: NSWindow) {
         window.makeKeyAndOrderFront(nil)
         window.displayIfNeeded()
         window.contentView?.layoutSubtreeIfNeeded()
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         window.contentView?.layoutSubtreeIfNeeded()
+    }
+
+    private func advanceAnimations() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+    }
+
+    private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
+        slot.subviews.first(where: {
+            $0 !== webView && String(describing: type(of: $0)).contains("BrowserDropZoneOverlayView")
+        })
     }
 
     func testPortalHostInstallsAboveContentViewForVisibility() {
@@ -8780,6 +9040,60 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             contentIndex,
             "Browser portal host must remain above content view so portal-hosted web views stay visible"
         )
+    }
+
+    func testBrowserPortalHostStaysAboveTerminalPortalHostDuringPortalChurn() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+
+        let browserPortal = WindowBrowserPortal(window: window)
+        let terminalPortal = WindowTerminalPortal(window: window)
+        _ = browserPortal.webViewAtWindowPoint(NSPoint(x: 1, y: 1))
+        _ = terminalPortal.viewAtWindowPoint(NSPoint(x: 1, y: 1))
+
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        func assertHostOrder(_ message: String) {
+            guard let browserHostIndex = container.subviews.firstIndex(where: { $0 is WindowBrowserHostView }),
+                  let terminalHostIndex = container.subviews.firstIndex(where: { $0 is WindowTerminalHostView }) else {
+                XCTFail("Expected both portal hosts in same container")
+                return
+            }
+
+            XCTAssertGreaterThan(
+                browserHostIndex,
+                terminalHostIndex,
+                message
+            )
+        }
+
+        assertHostOrder("Browser portal host should start above terminal portal host")
+
+        let terminalAnchor = NSView(frame: NSRect(x: 20, y: 20, width: 200, height: 140))
+        contentView.addSubview(terminalAnchor)
+        let terminalHostedView = GhosttySurfaceScrollView(
+            surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+        )
+        terminalPortal.bind(hostedView: terminalHostedView, to: terminalAnchor, visibleInUI: true)
+        terminalPortal.synchronizeHostedViewForAnchor(terminalAnchor)
+        assertHostOrder("Terminal portal sync should not rise above the browser portal host")
+
+        let browserAnchor = NSView(frame: NSRect(x: 240, y: 20, width: 220, height: 140))
+        contentView.addSubview(browserAnchor)
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        browserPortal.bind(webView: webView, to: browserAnchor, visibleInUI: true)
+        browserPortal.synchronizeWebViewForAnchor(browserAnchor)
+        assertHostOrder("Browser portal sync should keep browser panes above portal-hosted terminals")
     }
 
     func testAnchorRebindKeepsWebViewInStablePortalSuperview() {
@@ -8862,6 +9176,46 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.size.height, 150, accuracy: 0.5)
     }
 
+    func testPortalClipsAnchorFrameThroughAncestorBounds() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let clipView = NSView(frame: NSRect(x: 60, y: 40, width: 150, height: 120))
+        contentView.addSubview(clipView)
+
+        // Simulate SwiftUI/AppKit reporting an anchor wider than the actual visible pane.
+        let anchor = NSView(frame: NSRect(x: -30, y: 0, width: 220, height: 120))
+        clipView.addSubview(anchor)
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        contentView.layoutSubtreeIfNeeded()
+        clipView.layoutSubtreeIfNeeded()
+        portal.synchronizeWebViewForAnchor(anchor)
+
+        guard let slot = webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected browser slot")
+            return
+        }
+
+        XCTAssertFalse(slot.isHidden, "Ancestor clipping should keep the browser visible in the real pane")
+        XCTAssertEqual(slot.frame.origin.x, 60, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.origin.y, 40, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.size.width, 150, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.size.height, 120, accuracy: 0.5)
+    }
+
     func testPortalSyncNormalizesOutOfBoundsWebFrame() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 300),
@@ -8932,6 +9286,154 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertGreaterThan(host.bounds.height, 1, "Portal host height should be ready for clipping/sync")
     }
 
+    func testPortalDropZoneOverlayPersistsAcrossVisibilityChanges() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor)
+
+        guard let slot = webView.superview as? WindowBrowserSlotView,
+              let overlay = dropZoneOverlay(in: slot, excluding: webView) else {
+            XCTFail("Expected browser slot overlay")
+            return
+        }
+
+        XCTAssertTrue(overlay.isHidden, "Overlay should start hidden without an active drop zone")
+
+        portal.updateDropZoneOverlay(forWebViewId: ObjectIdentifier(webView), zone: .right)
+        slot.layoutSubtreeIfNeeded()
+        XCTAssertFalse(overlay.isHidden)
+        XCTAssertTrue(slot.subviews.last === overlay, "Overlay should remain above the hosted web view")
+        XCTAssertEqual(overlay.frame.origin.x, 110, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.origin.y, 4, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.size.width, 106, accuracy: 0.5)
+        XCTAssertEqual(overlay.frame.size.height, 152, accuracy: 0.5)
+
+        portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: false, zPriority: 0)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+        XCTAssertTrue(overlay.isHidden, "Invisible browser entries should hide the overlay")
+
+        portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: true, zPriority: 0)
+        portal.synchronizeWebViewForAnchor(anchor)
+        XCTAssertFalse(overlay.isHidden, "Restoring visibility should restore the active drop-zone overlay")
+    }
+
+    func testPortalRevealRefreshesHostedWebViewWithoutFrameDelta() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+        let initialDisplayCount = webView.displayIfNeededCount
+
+        portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: false, zPriority: 0)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+        let hiddenDisplayCount = webView.displayIfNeededCount
+
+        portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: true, zPriority: 0)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        XCTAssertGreaterThanOrEqual(hiddenDisplayCount, initialDisplayCount)
+        XCTAssertGreaterThan(
+            webView.displayIfNeededCount,
+            hiddenDisplayCount,
+            "Revealing an existing portal-hosted browser should refresh WebKit presentation immediately"
+        )
+    }
+
+    func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let anchorFrame = NSRect(x: 40, y: 24, width: 220, height: 160)
+        let anchor1 = NSView(frame: anchorFrame)
+        contentView.addSubview(anchor1)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor1, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor1)
+        advanceAnimations()
+
+        guard let slot = webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected browser slot")
+            return
+        }
+
+        anchor1.removeFromSuperview()
+        portal.synchronizeWebViewForAnchor(anchor1)
+        advanceAnimations()
+
+        XCTAssertTrue(webView.superview === slot, "Visible browser entries should not detach during transient anchor removal")
+        XCTAssertTrue(
+            slot.isHidden,
+            "Transient anchor churn should hide the stale browser slot instead of rendering in the wrong pane"
+        )
+        XCTAssertEqual(portal.debugEntryCount(), 1)
+
+        let displayCountBeforeRebind = webView.displayIfNeededCount
+        let anchor2 = NSView(frame: anchorFrame)
+        contentView.addSubview(anchor2)
+        portal.bind(webView: webView, to: anchor2, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor2)
+        advanceAnimations()
+
+        XCTAssertTrue(webView.superview === slot, "Rebinding after transient anchor removal should reuse the existing portal slot")
+        XCTAssertFalse(slot.isHidden)
+        XCTAssertEqual(portal.debugEntryCount(), 1)
+        XCTAssertGreaterThan(
+            webView.displayIfNeededCount,
+            displayCountBeforeRebind,
+            "Anchor rebinds should refresh hosted browser presentation even when geometry is unchanged"
+        )
+    }
+
     func testRegistryDetachRemovesPortalHostedWebView() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
@@ -8955,6 +9457,57 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         BrowserWindowPortalRegistry.detach(webView: webView)
         XCTAssertNil(webView.superview)
+    }
+}
+
+@MainActor
+final class FileDropOverlayViewTests: XCTestCase {
+    private func realizeWindowLayout(_ window: NSWindow) {
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        window.contentView?.layoutSubtreeIfNeeded()
+    }
+
+    func testOverlayResolvesPortalHostedBrowserWebViewForFileDrops() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        let anchor = NSView(frame: NSRect(x: 40, y: 36, width: 220, height: 150))
+        contentView.addSubview(anchor)
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        BrowserWindowPortalRegistry.bind(webView: webView, to: anchor, visibleInUI: true)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+
+        let overlay = FileDropOverlayView(frame: container.bounds)
+        overlay.autoresizingMask = [.width, .height]
+        container.addSubview(overlay, positioned: .above, relativeTo: nil)
+
+        let point = anchor.convert(
+            NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY),
+            to: nil
+        )
+        XCTAssertTrue(
+            overlay.webViewUnderPoint(point) === webView,
+            "File-drop overlay should resolve portal-hosted browser panes so Finder uploads still reach WKWebView"
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #911.

This updates the browser portal path so pane rearrangement and external file drops both work reliably over portal-hosted `WKWebView` content.

What changed:
- route internal Bonsplit pane drags through the browser portal host instead of letting `WKWebView` steal them as uploads
- add a browser pane drop target/overlay path so drop zones stay visible and aligned during rearrangement
- keep portal-hosted browser web views attached and refreshed during transient SwiftUI/panel churn
- keep browser portal layering above terminal portal hosts during mixed portal churn
- restore external file uploads by teaching `FileDropOverlayView` to resolve portal-hosted browser web views
- add targeted regression coverage for drag routing, overlay hit testing, portal lifecycle, host ordering, and file-drop resolution

Validation:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' test -only-testing:cmuxTests/FileDropOverlayViewTests -only-testing:cmuxTests/BrowserWindowPortalLifecycleTests -only-testing:cmuxTests/CmuxWebViewDragRoutingTests -only-testing:cmuxTests/WindowBrowserHostViewTests -only-testing:cmuxTests/BrowserPaneDropRoutingTests -only-testing:cmuxTests/WindowBrowserSlotViewTests`\n- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build`\n- `./scripts/reload.sh --tag issue-911-browser-drag-targets-hidden`\n\nManual verification on the tagged build covered both browser-pane rearrangement and browser file upload flows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser pane drag-and-drop over portal-hosted web views so pane reordering and external file uploads work reliably; addresses Linear issue 911.

- **Bug Fixes**
  - Route internal Bonsplit pane drags through the browser portal to stop WKWebView from stealing them as file uploads.
  - Add a pane drop-zone overlay with zone-based routing (center/edges) that stays visible and aligned during rearrangement.
  - Keep portal-hosted WKWebView attached and refreshed through transient SwiftUI/panel churn; clip anchor geometry via ancestor bounds.
  - Maintain correct portal stacking: browser portal stays above terminal portal during mixed churn.
  - Restore external file uploads by teaching FileDropOverlayView to resolve portal-hosted browser panes.
  - Block internal pane drag types inside CmuxWebView while allowing normal external file drops.
  - Add targeted tests for drag routing, overlay hit testing, portal lifecycle/ordering, and file-drop resolution.

<sup>Written for commit 84c0ab50e20526961ba7c16a2919106205931315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

