### PR TITLE
Fix browser goto snapshot-after parsing

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2755,12 +2755,17 @@ struct CMUXCLI {
 
         if subcommand == "goto" || subcommand == "navigate" {
             let sid = try requireSurface()
-            let url = subArgs.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+            var urlArgs = subArgs
+            let snapshotAfter = urlArgs.last == "--snapshot-after"
+            if snapshotAfter {
+                urlArgs.removeLast()
+            }
+            let url = urlArgs.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             guard !url.isEmpty else {
                 throw CLIError(message: "browser \(subcommand) requires a URL")
             }
             var params: [String: Any] = ["surface_id": sid, "url": url]
-            if hasFlag(subArgs, name: "--snapshot-after") {
+            if snapshotAfter {
                 params["snapshot_after"] = true
             }
             let payload = try client.sendV2(method: "browser.navigate", params: params)

--- a/tests_v2/test_browser_cli_agent_port.py
+++ b/tests_v2/test_browser_cli_agent_port.py
@@ -173,6 +173,14 @@ def main() -> int:
         _must(routed_url.startswith(page_url), f"Expected routed URL to start with page URL, got: {routed_url_payload}")
         _must("--workspace" not in routed_url and "--window" not in routed_url, f"Routing flags leaked into URL: {routed_url_payload}")
 
+        goto_url = f"{page_url}?goto=1"
+        goto_payload = _run_cli_json(cli, ["browser", surface, "goto", goto_url, "--snapshot-after"])
+        _must(bool(goto_payload.get("post_action_snapshot")), f"Expected goto --snapshot-after to include post_action_snapshot: {goto_payload}")
+        goto_url_payload = _run_cli_json(cli, ["browser", surface, "url"])
+        current_goto_url = str(goto_url_payload.get("url") or "")
+        _must(current_goto_url.startswith(goto_url), f"Expected goto --snapshot-after current URL to match target URL: {goto_url_payload}")
+        _must("--snapshot-after" not in current_goto_url, f"Expected goto URL to exclude trailing flag text: {goto_url_payload}")
+
         find_text = _run_cli_json(cli, ["browser", surface, "find", "text", "row-b"])
         _must(str(find_text.get("element_ref") or "").startswith("@e"), f"Expected element_ref from find text: {find_text}")
 


### PR DESCRIPTION
## Summary
- strip trailing `--snapshot-after` from `cmux browser <surface> goto|navigate <url> ...` before assembling the URL
- add regression coverage that checks the flag no longer ends up in the browser URL and still returns a post-action snapshot

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-cli -configuration Debug -destination '''platform=macOS''' build` (pass)
- manual smoke: `browser surface:47 goto http://127.0.0.1:8766/index.html?goto=1 --snapshot-after` kept the query URL and returned `post_action_snapshot`

## Issues
- Related: Claude browser-skill issue report from nightly build 2273595350501 (`goto <url> --snapshot-after` was being searched as part of the URL)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of --snapshot-after for cmux browser goto/navigate so the flag no longer ends up in the URL while still triggering a post-action snapshot.

- **Bug Fixes**
  - Strip trailing --snapshot-after before building the URL; set snapshot_after=true in params.
  - Add tests to confirm the URL excludes the flag and post_action_snapshot is returned.

<sup>Written for commit 61792c3cafedc1ca99ba2ca1e313a4ba16f94733. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot flag handling in navigation commands. The snapshot-after flag is now properly extracted from URL arguments, removed from the URL string, and processed as a separate parameter.

* **Tests**
  * Added test coverage for snapshot behavior during navigation operations, validating flag extraction, URL construction, and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->