### PR TITLE
Add diagnostics for empty browser snapshots

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2623,6 +2623,29 @@ struct CMUXCLI {
             }
         }
 
+        func displaySnapshotText(_ payload: [String: Any]) -> String {
+            let snapshotText = (payload["snapshot"] as? String) ?? "Empty page"
+            guard snapshotText.contains("\n- (empty)") else {
+                return snapshotText
+            }
+
+            let url = ((payload["url"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            let readyState = ((payload["ready_state"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            var lines = [snapshotText]
+
+            if !url.isEmpty {
+                lines.append("url: \(url)")
+            }
+            if !readyState.isEmpty {
+                lines.append("ready_state: \(readyState)")
+            }
+            if url.isEmpty || url == "about:blank" {
+                lines.append("hint: run 'cmux browser <surface> get url' to verify navigation")
+            }
+
+            return lines.joined(separator: "\n")
+        }
+
         func displayBrowserValue(_ value: Any) -> String {
             if let dict = value as? [String: Any],
                let type = dict["__cmux_t"] as? String,
@@ -2841,10 +2864,8 @@ struct CMUXCLI {
             let payload = try client.sendV2(method: "browser.snapshot", params: params)
             if jsonOutput {
                 print(jsonString(formatIDs(payload, mode: idFormat)))
-            } else if let text = payload["snapshot"] as? String {
-                print(text)
             } else {
-                print("Empty page")
+                print(displaySnapshotText(payload))
             }
             return
         }

--- a/tests_v2/test_browser_cli_agent_port.py
+++ b/tests_v2/test_browser_cli_agent_port.py
@@ -164,6 +164,12 @@ def main() -> int:
         )
         _must(bool(workspace), f"Expected workspace handle from identify: {identify}")
 
+        blank_opened = _run_cli_json(cli, ["browser", "open", "about:blank", "--workspace", workspace])
+        blank_surface = str(blank_opened.get("surface_ref") or blank_opened.get("surface_id") or "")
+        _must(bool(blank_surface), f"Expected about:blank browser open to return a surface: {blank_opened}")
+        blank_snapshot = _run_cli_text(cli, ["browser", blank_surface, "snapshot", "--interactive"])
+        _must("about:blank" in blank_snapshot and "get url" in blank_snapshot, f"Expected empty snapshot diagnostics for about:blank: {blank_snapshot!r}")
+
         opened_routed = _run_cli_json(cli, ["browser", "open", page_url, "--workspace", workspace])
         routed_surface = str(opened_routed.get("surface_ref") or opened_routed.get("surface_id") or "")
         _must(bool(routed_surface), f"browser open --workspace returned no surface handle: {opened_routed}")


### PR DESCRIPTION
## Summary
- add URL, ready-state, and `get url` guidance to text-mode empty browser snapshots instead of printing only `- (empty)`
- add regression coverage for `about:blank` snapshot diagnostics

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-cli -configuration Debug -destination '''platform=macOS''' build` (pass)
- manual smoke: `browser open about:blank --workspace workspace:3` followed by `snapshot --interactive` now prints `url: about:blank`, `ready_state: complete`, and a `get url` hint

## Issues
- Related: Claude browser-skill issue report from nightly build 2273595350501 (empty snapshots did not distinguish blank pages from snapshot failures)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve browser snapshot CLI output to show diagnostics for empty pages, so users can tell about:blank from a failure. Adds a regression test for about:blank.

- **New Features**
  - Text-mode snapshots that include "- (empty)" now append url, ready_state, and a "get url" hint when the url is missing or about:blank.
  - Added regression test to verify about:blank snapshots include these diagnostics.

<sup>Written for commit 21fda61f1690f7da1eda752d72c5b3b2c65bae2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

