### PR TITLE
Prevent agents from building untagged cmux DEV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,16 @@ When reporting a tagged reload result in chat, use the format for your agent typ
 
 Never use `/tmp/cmux-<tag>/...` app links in chat output. If the expected DerivedData path is missing, resolve the real `.app` path and report that `file://` URL.
 
-After making code changes, always run the build:
+After making code changes, always use `reload.sh --tag` to build and launch. **Never run bare `xcodebuild` or `open` an untagged `cmux DEV.app`.** Untagged builds share the default debug socket and bundle ID with other agents, causing conflicts and stealing focus.
 
 ```bash
-xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build
+./scripts/reload.sh --tag <your-branch-slug>
+```
+
+If you only need to verify the build compiles (no launch), use a tagged derivedDataPath:
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-<your-tag> build
 ```
 
 When rebuilding GhosttyKit.xcframework, always use Release optimizations:
@@ -131,21 +137,14 @@ tail -f "$(cat /tmp/cmux-last-debug-log-path 2>/dev/null || echo /tmp/cmux-debug
 - Only explicit focus-intent commands may mutate in-app focus/selection (`window.focus`, `workspace.select/next/previous/last`, `surface.focus`, `pane.focus/last`, browser focus commands, and v1 focus equivalents).
 - All non-focus commands should preserve current user focus context while still applying data/model changes.
 
-## E2E mac UI tests
+## Testing policy
 
-Run UI tests on the UTM macOS VM (never on the host machine). Always run e2e UI tests via `ssh cmux-vm`:
+**Never run tests locally.** All tests (E2E, UI, python socket tests) run via GitHub Actions or on the VM.
 
-```bash
-ssh cmux-vm 'cd /Users/cmux/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" -only-testing:cmuxUITests/UpdatePillUITests test'
-```
-
-## Basic tests
-
-Run basic automated tests on the UTM macOS VM (never on the host machine):
-
-```bash
-ssh cmux-vm 'cd /Users/cmux/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" build && pkill -x "cmux DEV" || true && APP=$(find /Users/cmux/Library/Developer/Xcode/DerivedData -path "*/Build/Products/Debug/cmux DEV.app" -print -quit) && open "$APP" --env CMUX_SOCKET_MODE=allowAll && for i in {1..20}; do [ -S /tmp/cmux-debug.sock ] && break; sleep 0.5; done && python3 tests/test_update_timing.py && python3 tests/test_signals_auto.py && python3 tests/test_ctrl_socket.py && python3 tests/test_notifications.py'
-```
+- **E2E / UI tests:** trigger via `gh workflow run test-e2e.yml` (see cmuxterm-hq CLAUDE.md for details)
+- **Unit tests:** `xcodebuild -scheme cmux-unit` is safe (no app launch), but prefer CI
+- **Python socket tests (tests_v2/):** these connect to a running cmux instance's socket. Never launch an untagged `cmux DEV.app` to run them. If you must test locally, use a tagged build's socket (`/tmp/cmux-debug-<tag>.sock`) with `CMUX_SOCKET=/tmp/cmux-debug-<tag>.sock`
+- **Never `open` an untagged `cmux DEV.app`** from DerivedData. It conflicts with the user's running debug instance.
 
 ## Ghostty submodule workflow
 


### PR DESCRIPTION
## Summary

Agents were following CLAUDE.md instructions to run bare `xcodebuild -scheme cmux build` without `-derivedDataPath`, producing untagged `cmux DEV.app` that shares the default debug socket (`/tmp/cmux-debug.sock`) and steals window focus from the user's session.

- Replace bare xcodebuild build instruction with `./scripts/reload.sh --tag`, add compile-only fallback with explicit `-derivedDataPath`
- Replace "E2E mac UI tests" and "Basic tests" sections with a unified "Testing policy" that forbids local test runs and explains tagged-socket alternatives

## Test plan

- Verify new agents spawned from worktrees follow the updated instructions and use tagged builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CLAUDE.md to require tagged builds via ./scripts/reload.sh and forbid untagged cmux DEV launches. This prevents shared socket conflicts and window focus stealing.

- **Refactors**
  - Require ./scripts/reload.sh --tag; add compile-only fallback using -derivedDataPath.
  - Consolidate tests into a single policy: run E2E/UI via CI; use cmux-unit for unit builds; use tagged sockets for Python tests.

<sup>Written for commit 126f6b04b32d4fcd4c298c60d5a30c9ff9b434a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

