### PR TITLE
Add regression test commit policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,15 @@ tail -f "$(cat /tmp/cmux-last-debug-log-path 2>/dev/null || echo /tmp/cmux-debug
 - Focus events: `focus.panel`, `focus.bonsplit`, `focus.firstResponder`, `focus.moveFocus`
 - Bonsplit events: `tab.select`, `tab.close`, `tab.dragStart`, `tab.drop`, `pane.focus`, `pane.drop`, `divider.dragStart`
 
+## Regression test commit policy
+
+When adding a regression test for a bug fix, use a two-commit structure so CI proves the test catches the bug:
+
+1. **Commit 1:** Add the failing test only (no fix). CI should go red.
+2. **Commit 2:** Add the fix. CI should go green.
+
+This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
+
 ## Pitfalls
 
 - **Custom UTTypes** for drag-and-drop must be declared in `Resources/Info.plist` under `UTExportedTypeDeclarations` (e.g. `com.splittabbar.tabtransfer`, `com.cmux.sidebar-tab-reorder`).


### PR DESCRIPTION
## Summary

- Adds a regression test commit policy: when a PR includes a regression test for a bug fix, use a two-commit structure (test-only first, fix second) so CI goes red then green, proving the test catches the bug in the GitHub PR UI.

## Test plan

- [ ] Meta-only change, no runtime impact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document a regression test commit policy in CLAUDE.md: for bug fixes, use two commits—first add the failing test, then the fix—so CI shows red then green. This makes it clear in the PR UI that the test catches the bug.

<sup>Written for commit d7d39ff55c7cfccdbff8678916784f1d06c8a557. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

