### PR TITLE
Fix browser webview disappearing after redock

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1267,6 +1267,12 @@ final class WindowBrowserPortal: NSObject {
         entriesByWebViewId[webViewId] = entry
     }
 
+    func isWebViewBoundToAnchor(withId webViewId: ObjectIdentifier, anchorView: NSView) -> Bool {
+        guard let entry = entriesByWebViewId[webViewId],
+              let boundAnchor = entry.anchorView else { return false }
+        return boundAnchor === anchorView
+    }
+
     func updateDropZoneOverlay(forWebViewId webViewId: ObjectIdentifier, zone: DropZone?) {
         guard var entry = entriesByWebViewId[webViewId] else { return }
         entry.dropZone = zone
@@ -1995,6 +2001,15 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateEntryVisibility(forWebViewId: webViewId, visibleInUI: visibleInUI, zPriority: zPriority)
+    }
+
+    static func isWebView(_ webView: WKWebView, boundTo anchorView: NSView) -> Bool {
+        let webViewId = ObjectIdentifier(webView)
+        guard let window = anchorView.window else { return false }
+        let windowId = ObjectIdentifier(window)
+        guard webViewToWindowId[webViewId] == windowId,
+              let portal = portalsByWindowId[windowId] else { return false }
+        return portal.isWebViewBoundToAnchor(withId: webViewId, anchorView: anchorView)
     }
 
     static func updateDropZoneOverlay(for webView: WKWebView, zone: DropZone?) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1395,6 +1395,9 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Incremented whenever we replace the underlying WKWebView after a process crash.
     @Published private(set) var webViewInstanceID: UUID = UUID()
 
+    /// Bump this token to force `WebViewRepresentable.updateNSView` after split move churn.
+    @Published var viewReattachToken: UInt64 = 0
+
     /// Prevent the omnibar from auto-focusing for a short window after explicit programmatic focus.
     /// This avoids races where SwiftUI focus state steals first responder back from WebKit.
     private var suppressOmnibarAutofocusUntil: Date?
@@ -1918,6 +1921,10 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewCancellables.removeAll()
         faviconTask?.cancel()
         faviconTask = nil
+    }
+
+    func requestViewReattach() {
+        viewReattachToken &+= 1
     }
 
     private func refreshFavicon(from webView: WKWebView) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3054,6 +3054,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         var desiredPortalVisibleInUI: Bool = true
         var desiredPortalZPriority: Int = 0
         var lastPortalHostId: ObjectIdentifier?
+        var lastReattachToken: UInt64?
         var searchOverlayHostingView: NSHostingView<BrowserSearchOverlay>?
     }
 
@@ -3274,10 +3275,15 @@ struct WebViewRepresentable: NSViewRepresentable {
         let coordinator = context.coordinator
         let previousVisible = coordinator.desiredPortalVisibleInUI
         let previousZPriority = coordinator.desiredPortalZPriority
+        let previousReattachToken = coordinator.lastReattachToken
         coordinator.desiredPortalVisibleInUI = shouldAttachWebView
         coordinator.desiredPortalZPriority = portalZPriority
+        coordinator.lastReattachToken = reattachToken
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
+        let reattachRequested =
+            previousReattachToken != nil &&
+            previousReattachToken != reattachToken
         let paneDropContext = shouldAttachWebView ? currentPaneDropContext() : nil
 
         host.onDidMoveToWindow = { [weak host, weak webView, weak coordinator] in
@@ -3300,10 +3306,21 @@ struct WebViewRepresentable: NSViewRepresentable {
                 )
             }
         }
-        host.onGeometryChanged = { [weak host, weak coordinator] in
-            guard let host, let coordinator else { return }
+        host.onGeometryChanged = { [weak host, weak webView, weak coordinator] in
+            guard let host, let webView, let coordinator else { return }
             guard coordinator.attachGeneration == generation else { return }
             guard coordinator.lastPortalHostId == ObjectIdentifier(host) else { return }
+            if host.window != nil,
+               !BrowserWindowPortalRegistry.isWebView(webView, boundTo: host) {
+                BrowserWindowPortalRegistry.bind(
+                    webView: webView,
+                    to: host,
+                    visibleInUI: coordinator.desiredPortalVisibleInUI,
+                    zPriority: coordinator.desiredPortalZPriority
+                )
+                BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: paneDropContext)
+                coordinator.lastPortalHostId = ObjectIdentifier(host)
+            }
             BrowserWindowPortalRegistry.synchronizeForAnchor(host)
         }
 
@@ -3315,11 +3332,14 @@ struct WebViewRepresentable: NSViewRepresentable {
 
         if host.window != nil {
             let hostId = ObjectIdentifier(host)
+            let portalEntryMissing = !BrowserWindowPortalRegistry.isWebView(webView, boundTo: host)
             let shouldBindNow =
                 coordinator.lastPortalHostId != hostId ||
                 webView.superview == nil ||
                 previousVisible != shouldAttachWebView ||
-                previousZPriority != portalZPriority
+                previousZPriority != portalZPriority ||
+                reattachRequested ||
+                portalEntryMissing
             if shouldBindNow {
                 BrowserWindowPortalRegistry.bind(
                     webView: webView,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3320,6 +3320,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 )
                 BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: paneDropContext)
                 coordinator.lastPortalHostId = ObjectIdentifier(host)
+                if let panel = coordinator.panel {
+                    Self.updateSearchOverlay(
+                        panel: panel,
+                        coordinator: coordinator,
+                        containerView: webView.superview
+                    )
+                }
             }
             BrowserWindowPortalRegistry.synchronizeForAnchor(host)
         }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -742,6 +742,7 @@ struct BrowserPanelView: View {
                     shouldAttachWebView: isVisibleInUI,
                     shouldFocusWebView: isFocused && !addressBarFocused,
                     isPanelFocused: isFocused,
+                    reattachToken: panel.viewReattachToken,
                     portalZPriority: portalPriority,
                     paneDropZone: paneDropZone
                 )
@@ -3042,6 +3043,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     let shouldAttachWebView: Bool
     let shouldFocusWebView: Bool
     let isPanelFocused: Bool
+    let reattachToken: UInt64
     let portalZPriority: Int
     let paneDropZone: DropZone?
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2650,6 +2650,14 @@ class TabManager: ObservableObject {
                     return
                 }
 
+                self.writeBrowserRedockTestData([
+                    "browserAttachedBeforeMove": "1",
+                    "browserLoadedBeforeMove": "1",
+                    "browserSnapshotBeforeMove": "1",
+                    "browserURLBeforeMove": browserReadiness.url,
+                    "browserTitleBeforeMove": browserReadiness.title
+                ], at: path)
+
                 guard let firstSplitTabId = tab.surfaceIdFromPanelId(browserPanel.id),
                       tab.bonsplitController.splitPane(
                         initialPaneId,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -641,6 +641,7 @@ class TabManager: ObservableObject {
 
 #if DEBUG
     private var didSetupSplitCloseRightUITest = false
+    private var didSetupBrowserRedockUITest = false
     private var didSetupUITestFocusShortcuts = false
     private var didSetupChildExitSplitUITest = false
     private var didSetupChildExitKeyboardUITest = false
@@ -678,6 +679,7 @@ class TabManager: ObservableObject {
 #if DEBUG
         setupUITestFocusShortcutsIfNeeded()
         setupSplitCloseRightUITestIfNeeded()
+        setupBrowserRedockUITestIfNeeded()
         setupChildExitSplitUITestIfNeeded()
         setupChildExitKeyboardUITestIfNeeded()
 #endif
@@ -2458,6 +2460,392 @@ class TabManager: ObservableObject {
         }
 
         return (attached, hasSurface, firstResponder)
+    }
+
+    @MainActor
+    private func waitForBrowserPanelReadyForUITest(
+        tab: Workspace,
+        panelId: UUID,
+        expectedHost: String,
+        timeoutSeconds: TimeInterval = 12.0
+    ) async -> (attached: Bool, loaded: Bool, hasSnapshot: Bool, url: String, title: String) {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var attached = false
+        var loaded = false
+        var hasSnapshot = false
+        var urlString = ""
+        var title = ""
+
+        while Date() < deadline {
+            guard let panel = tab.browserPanel(for: panelId) else {
+                return (false, false, false, "", "")
+            }
+
+            attached = panel.webView.window != nil && panel.webView.superview != nil
+            urlString = panel.currentURL?.absoluteString ?? panel.webView.url?.absoluteString ?? ""
+            title = panel.pageTitle
+
+            let hostMatches = urlString.localizedCaseInsensitiveContains(expectedHost)
+            loaded = attached && hostMatches && !panel.webView.isLoading
+
+            if loaded {
+                hasSnapshot = await withCheckedContinuation { continuation in
+                    panel.takeSnapshot { image in
+                        continuation.resume(returning: image != nil)
+                    }
+                }
+                if hasSnapshot {
+                    return (attached, loaded, hasSnapshot, urlString, title)
+                }
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        return (attached, loaded, hasSnapshot, urlString, title)
+    }
+
+    @MainActor
+    private func waitForPaneCountForUITest(
+        tab: Workspace,
+        expectedPaneCount: Int,
+        timeoutSeconds: TimeInterval = 6.0
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if tab.bonsplitController.allPaneIds.count == expectedPaneCount {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return tab.bonsplitController.allPaneIds.count == expectedPaneCount
+    }
+
+    @MainActor
+    private func waitForSelectedPanelKindInPaneForUITest(
+        tab: Workspace,
+        paneId: PaneID,
+        expectedKind: PanelType,
+        timeoutSeconds: TimeInterval = 6.0
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let selected = tab.bonsplitController.selectedTab(inPane: paneId),
+               let panel = tab.panel(for: selected.id),
+               panel.panelType == expectedKind {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        if let selected = tab.bonsplitController.selectedTab(inPane: paneId),
+           let panel = tab.panel(for: selected.id) {
+            return panel.panelType == expectedKind
+        }
+        return false
+    }
+
+    @MainActor
+    private func settleBrowserRedockUITestPresentation(
+        tab: Workspace,
+        browserPanelId: UUID,
+        passes: Int = 8
+    ) async {
+        for _ in 0..<max(1, passes) {
+            NSApp.windows.forEach { window in
+                window.contentView?.layoutSubtreeIfNeeded()
+                window.contentView?.displayIfNeeded()
+            }
+            if let browserPanel = tab.browserPanel(for: browserPanelId) {
+                browserPanel.webView.superview?.layoutSubtreeIfNeeded()
+                browserPanel.webView.layoutSubtreeIfNeeded()
+                browserPanel.webView.window?.displayIfNeeded()
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 40_000_000)
+        }
+    }
+
+    private func setupBrowserRedockUITestIfNeeded() {
+        guard !didSetupBrowserRedockUITest else { return }
+        didSetupBrowserRedockUITest = true
+
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_BROWSER_REDOCK_SETUP"] == "1" else { return }
+        guard let path = env["CMUX_UI_TEST_BROWSER_REDOCK_PATH"], !path.isEmpty else { return }
+        let urlString = (env["CMUX_UI_TEST_BROWSER_REDOCK_URL"] ?? "https://example.com")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let targetURL = URL(string: urlString) else {
+            writeBrowserRedockTestData([
+                "setupError": "Invalid target URL: \(urlString)"
+            ], at: path)
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                guard let tab = self.selectedWorkspace else {
+                    self.writeBrowserRedockTestData(["setupError": "Missing selected workspace"], at: path)
+                    return
+                }
+                guard let initialPaneId = tab.bonsplitController.focusedPaneId ?? tab.bonsplitController.allPaneIds.first else {
+                    self.writeBrowserRedockTestData(["setupError": "Missing initial pane"], at: path)
+                    return
+                }
+                guard let initialPanelId = tab.focusedTerminalPanel?.id ?? tab.focusedPanelId else {
+                    self.writeBrowserRedockTestData(["setupError": "Missing initial terminal panel"], at: path)
+                    return
+                }
+
+                self.writeBrowserRedockTestData([
+                    "targetURL": targetURL.absoluteString,
+                    "initialPaneId": initialPaneId.id.uuidString,
+                    "initialPanelId": initialPanelId.uuidString,
+                    "initialPaneCount": String(tab.bonsplitController.allPaneIds.count),
+                    "visualDone": "0"
+                ], at: path)
+
+                let initialTerminalReadiness = await self.waitForTerminalPanelReadyForUITest(
+                    tab: tab,
+                    panelId: initialPanelId
+                )
+                guard initialTerminalReadiness.attached, initialTerminalReadiness.hasSurface else {
+                    self.writeBrowserRedockTestData([
+                        "initialTerminalAttached": initialTerminalReadiness.attached ? "1" : "0",
+                        "initialTerminalSurfaceReady": initialTerminalReadiness.hasSurface ? "1" : "0",
+                        "setupError": "Initial terminal was not ready"
+                    ], at: path)
+                    return
+                }
+
+                guard let browserPanel = tab.newBrowserSurface(
+                    inPane: initialPaneId,
+                    url: nil,
+                    focus: true,
+                    insertAtEnd: true
+                ) else {
+                    self.writeBrowserRedockTestData(["setupError": "Failed to open browser in current pane"], at: path)
+                    return
+                }
+
+                tab.focusPanel(browserPanel.id)
+                browserPanel.navigate(to: targetURL)
+
+                let browserReadiness = await self.waitForBrowserPanelReadyForUITest(
+                    tab: tab,
+                    panelId: browserPanel.id,
+                    expectedHost: targetURL.host ?? "example.com"
+                )
+                guard browserReadiness.attached, browserReadiness.loaded, browserReadiness.hasSnapshot else {
+                    self.writeBrowserRedockTestData([
+                        "browserAttachedBeforeMove": browserReadiness.attached ? "1" : "0",
+                        "browserLoadedBeforeMove": browserReadiness.loaded ? "1" : "0",
+                        "browserSnapshotBeforeMove": browserReadiness.hasSnapshot ? "1" : "0",
+                        "browserURLBeforeMove": browserReadiness.url,
+                        "browserTitleBeforeMove": browserReadiness.title,
+                        "setupError": "Browser did not finish loading before re-dock"
+                    ], at: path)
+                    return
+                }
+
+                guard let firstSplitTabId = tab.surfaceIdFromPanelId(browserPanel.id),
+                      tab.bonsplitController.splitPane(
+                        initialPaneId,
+                        orientation: .horizontal,
+                        movingTab: firstSplitTabId,
+                        insertFirst: false
+                      ) != nil else {
+                    self.writeBrowserRedockTestData(["setupError": "Failed to split browser to the right"], at: path)
+                    return
+                }
+
+                await self.settleBrowserRedockUITestPresentation(tab: tab, browserPanelId: browserPanel.id)
+                guard await self.waitForPaneCountForUITest(tab: tab, expectedPaneCount: 2),
+                      let middlePaneId = tab.paneId(forPanelId: browserPanel.id) else {
+                    self.writeBrowserRedockTestData(["setupError": "Browser did not land in the first right split"], at: path)
+                    return
+                }
+
+                self.writeBrowserRedockTestData([
+                    "afterFirstSplitPaneCount": String(tab.bonsplitController.allPaneIds.count),
+                    "middlePaneId": middlePaneId.id.uuidString
+                ], at: path)
+
+                guard let secondSplitTabId = tab.surfaceIdFromPanelId(browserPanel.id),
+                      tab.bonsplitController.splitPane(
+                        middlePaneId,
+                        orientation: .horizontal,
+                        movingTab: secondSplitTabId,
+                        insertFirst: false
+                      ) != nil else {
+                    self.writeBrowserRedockTestData(["setupError": "Failed to split browser to the far right"], at: path)
+                    return
+                }
+
+                await self.settleBrowserRedockUITestPresentation(tab: tab, browserPanelId: browserPanel.id)
+                guard await self.waitForPaneCountForUITest(tab: tab, expectedPaneCount: 3) else {
+                    self.writeBrowserRedockTestData([
+                        "setupError": "Expected three panes after dragging browser to far right",
+                        "paneCountAfterSecondSplit": String(tab.bonsplitController.allPaneIds.count)
+                    ], at: path)
+                    return
+                }
+                guard let middleTerminalPaneId = tab.bonsplitController.allPaneIds.first(where: { $0 == middlePaneId }) else {
+                    self.writeBrowserRedockTestData(["setupError": "Middle terminal pane disappeared after second split"], at: path)
+                    return
+                }
+                guard await self.waitForSelectedPanelKindInPaneForUITest(
+                    tab: tab,
+                    paneId: middleTerminalPaneId,
+                    expectedKind: .terminal
+                ) else {
+                    self.writeBrowserRedockTestData(["setupError": "Middle pane did not repair to a terminal"], at: path)
+                    return
+                }
+
+                self.writeBrowserRedockTestData([
+                    "afterSecondSplitPaneCount": String(tab.bonsplitController.allPaneIds.count),
+                    "middleTerminalPaneId": middleTerminalPaneId.id.uuidString
+                ], at: path)
+
+                guard tab.moveSurface(
+                    panelId: browserPanel.id,
+                    toPane: middleTerminalPaneId,
+                    atIndex: nil,
+                    focus: true
+                ) else {
+                    self.writeBrowserRedockTestData(["setupError": "Failed to move far-right browser back into terminal pane"], at: path)
+                    return
+                }
+
+                tab.focusPanel(browserPanel.id)
+                browserPanel.focus()
+                await self.settleBrowserRedockUITestPresentation(tab: tab, browserPanelId: browserPanel.id, passes: 12)
+
+                var finalState: [String: String] = [:]
+                for attempt in 1...18 {
+                    finalState = self.collectBrowserRedockUITestState(
+                        tab: tab,
+                        browserPanelId: browserPanel.id,
+                        expectedPaneId: middleTerminalPaneId
+                    )
+                    finalState["finalAttempt"] = String(attempt)
+                    self.writeBrowserRedockTestData(finalState, at: path)
+
+                    let paneCount = Int(finalState["finalPaneCount"] ?? "") ?? -1
+                    let tabCount = Int(finalState["finalTargetPaneTabCount"] ?? "") ?? -1
+                    let browserSelected = finalState["finalBrowserSelected"] == "1"
+                    let browserAttached = finalState["finalBrowserAttached"] == "1"
+                    let browserVisible = finalState["finalBrowserHidden"] != "1"
+                    if paneCount == 2 && tabCount == 2 && browserSelected && browserAttached && browserVisible {
+                        break
+                    }
+
+                    await self.settleBrowserRedockUITestPresentation(tab: tab, browserPanelId: browserPanel.id, passes: 2)
+                }
+
+                self.writeBrowserRedockTestData(["visualDone": "1"], at: path)
+            }
+        }
+    }
+
+    @MainActor
+    private func collectBrowserRedockUITestState(
+        tab: Workspace,
+        browserPanelId: UUID,
+        expectedPaneId: PaneID
+    ) -> [String: String] {
+        var payload: [String: String] = [
+            "finalPaneCount": String(tab.bonsplitController.allPaneIds.count),
+            "expectedPaneId": expectedPaneId.id.uuidString
+        ]
+
+        let paneKinds = tab.bonsplitController.allPaneIds.map { paneId -> String in
+            let selected = tab.bonsplitController.selectedTab(inPane: paneId)
+            let panelType = selected
+                .flatMap { tab.panel(for: $0.id)?.panelType.rawValue }
+                ?? "none"
+            let tabCount = tab.bonsplitController.tabs(inPane: paneId).count
+            return "\(paneId.id.uuidString.prefix(8)):\(panelType):\(tabCount)"
+        }
+        payload["finalPaneKinds"] = paneKinds.joined(separator: ";")
+
+        guard let browserPanel = tab.browserPanel(for: browserPanelId),
+              let browserPaneId = tab.paneId(forPanelId: browserPanelId) else {
+            payload["finalBrowserAttached"] = "0"
+            payload["finalBrowserHidden"] = "1"
+            payload["finalBrowserMissing"] = "1"
+            return payload
+        }
+
+        payload["finalBrowserPanelId"] = browserPanelId.uuidString
+        payload["finalBrowserPaneId"] = browserPaneId.id.uuidString
+        payload["finalTargetPaneMatchesExpected"] = browserPaneId == expectedPaneId ? "1" : "0"
+        payload["finalTargetPaneTabCount"] = String(tab.bonsplitController.tabs(inPane: browserPaneId).count)
+        payload["finalBrowserSelected"] = (
+            tab.bonsplitController.selectedTab(inPane: browserPaneId)?.id == tab.surfaceIdFromPanelId(browserPanelId)
+        ) ? "1" : "0"
+        payload["finalBrowserAttached"] = (
+            browserPanel.webView.window != nil && browserPanel.webView.superview != nil
+        ) ? "1" : "0"
+        payload["finalBrowserHidden"] = browserPanel.webView.isHiddenOrHasHiddenAncestor ? "1" : "0"
+        payload["finalBrowserURL"] = browserPanel.currentURL?.absoluteString ?? browserPanel.webView.url?.absoluteString ?? ""
+        payload["finalBrowserTitle"] = browserPanel.pageTitle
+        payload["finalBrowserGeometrySummary"] = browserPanel.debugDeveloperToolsGeometrySummary()
+
+        if let screen = browserPanel.webView.window?.screen ?? NSScreen.main {
+            payload["screenFrameX"] = String(format: "%.1f", screen.frame.minX)
+            payload["screenFrameY"] = String(format: "%.1f", screen.frame.minY)
+            payload["screenFrameWidth"] = String(format: "%.1f", screen.frame.width)
+            payload["screenFrameHeight"] = String(format: "%.1f", screen.frame.height)
+        }
+
+        if let window = browserPanel.webView.window {
+            let frame = window.frame
+            payload["windowFrameX"] = String(format: "%.1f", frame.minX)
+            payload["windowFrameY"] = String(format: "%.1f", frame.minY)
+            payload["windowFrameWidth"] = String(format: "%.1f", frame.width)
+            payload["windowFrameHeight"] = String(format: "%.1f", frame.height)
+        }
+
+        let layout = tab.bonsplitController.layoutSnapshot()
+        if let paneGeometry = layout.panes.first(where: { $0.paneId == browserPaneId.id.uuidString }) {
+            payload["paneFrameX"] = String(format: "%.1f", paneGeometry.frame.x)
+            payload["paneFrameY"] = String(format: "%.1f", paneGeometry.frame.y)
+            payload["paneFrameWidth"] = String(format: "%.1f", paneGeometry.frame.width)
+            payload["paneFrameHeight"] = String(format: "%.1f", paneGeometry.frame.height)
+        }
+
+        if let superview = browserPanel.webView.superview,
+           let window = browserPanel.webView.window {
+            let frameInWindow = superview.convert(browserPanel.webView.frame, to: nil)
+            let frameInScreen = window.convertToScreen(frameInWindow)
+            payload["webFrameX"] = String(format: "%.1f", frameInScreen.minX)
+            payload["webFrameY"] = String(format: "%.1f", frameInScreen.minY)
+            payload["webFrameWidth"] = String(format: "%.1f", frameInScreen.width)
+            payload["webFrameHeight"] = String(format: "%.1f", frameInScreen.height)
+        }
+
+        return payload
+    }
+
+    private func writeBrowserRedockTestData(_ updates: [String: String], at path: String) {
+        var payload = loadBrowserRedockTestData(at: path)
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func loadBrowserRedockTestData(at path: String) -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
     }
 
     private func setupUITestFocusShortcutsIfNeeded() {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2485,7 +2485,15 @@ class TabManager: ObservableObject {
             urlString = panel.currentURL?.absoluteString ?? panel.webView.url?.absoluteString ?? ""
             title = panel.pageTitle
 
-            let hostMatches = urlString.localizedCaseInsensitiveContains(expectedHost)
+            let normalizedExpectedHost = expectedHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            var acceptedHosts = Set([normalizedExpectedHost])
+            if normalizedExpectedHost == "example.com" {
+                acceptedHosts.insert("example.org")
+            } else if normalizedExpectedHost == "example.org" {
+                acceptedHosts.insert("example.com")
+            }
+            let normalizedURL = urlString.lowercased()
+            let hostMatches = acceptedHosts.contains { normalizedURL.contains($0) }
             loaded = attached && hostMatches && !panel.webView.isLoading
 
             if loaded {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3476,13 +3476,13 @@ final class Workspace: Identifiable, ObservableObject {
     private func scheduleMovedBrowserRefresh(panelId: UUID) {
         guard browserPanel(for: panelId) != nil else { return }
 
-        // Mirror terminal move repair: force the representable to re-run portal binding after
-        // pane auto-close/reparent churn so the WKWebView reattaches to the surviving host.
-        browserPanel(for: panelId)?.requestViewReattach()
-
         let runRefreshPass: (TimeInterval) -> Void = { [weak self] delay in
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 guard let self, let panel = self.browserPanel(for: panelId) else { return }
+                // Mirror terminal move repair: force the representable to re-run portal binding
+                // after pane auto-close/reparent churn so the WKWebView reattaches to the
+                // surviving host on both the immediate and post-layout passes.
+                panel.requestViewReattach()
                 NSApp.windows.forEach { window in
                     window.contentView?.layoutSubtreeIfNeeded()
                     window.contentView?.displayIfNeeded()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3473,6 +3473,37 @@ final class Workspace: Identifiable, ObservableObject {
         runRefreshPass(0.03)
     }
 
+    private func scheduleMovedBrowserRefresh(panelId: UUID) {
+        guard browserPanel(for: panelId) != nil else { return }
+
+        // Mirror terminal move repair: force the representable to re-run portal binding after
+        // pane auto-close/reparent churn so the WKWebView reattaches to the surviving host.
+        browserPanel(for: panelId)?.requestViewReattach()
+
+        let runRefreshPass: (TimeInterval) -> Void = { [weak self] delay in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                guard let self, let panel = self.browserPanel(for: panelId) else { return }
+                NSApp.windows.forEach { window in
+                    window.contentView?.layoutSubtreeIfNeeded()
+                    window.contentView?.displayIfNeeded()
+                }
+                panel.webView.superview?.layoutSubtreeIfNeeded()
+                panel.webView.needsLayout = true
+                panel.webView.layoutSubtreeIfNeeded()
+                panel.webView.needsDisplay = true
+                panel.webView.setNeedsDisplay(panel.webView.bounds)
+                panel.webView.window?.displayIfNeeded()
+                panel.restoreDeveloperToolsAfterAttachIfNeeded()
+                if self.focusedPanelId == panelId {
+                    panel.focus()
+                }
+            }
+        }
+
+        runRefreshPass(0)
+        runRefreshPass(0.03)
+    }
+
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) {
         for tabId in tabIds {
             if skipPinned,
@@ -4140,6 +4171,7 @@ extension Workspace: BonsplitDelegate {
 #endif
         if let movedPanelId = panelIdFromSurfaceId(tab.id) {
             scheduleMovedTerminalRefresh(panelId: movedPanelId)
+            scheduleMovedBrowserRefresh(panelId: movedPanelId)
         }
 #if DEBUG
         let selectedAfter = controller.selectedTab(inPane: destination)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2450,6 +2450,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             shouldAttachWebView: true,
             shouldFocusWebView: false,
             isPanelFocused: true,
+            reattachToken: 0,
             portalZPriority: 0,
             paneDropZone: nil
         )
@@ -2488,6 +2489,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             shouldAttachWebView: true,
             shouldFocusWebView: false,
             isPanelFocused: true,
+            reattachToken: 0,
             portalZPriority: 0,
             paneDropZone: nil
         )

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -1080,6 +1080,7 @@ final class BrowserRedockUITests: XCTestCase {
     private var socketPath = ""
     private var screenshotDir = ""
     private let launchTag = "ui-tests-browser-redock"
+    private let browserThemeModeKey = "browserThemeMode"
 
     override func setUp() {
         super.setUp()
@@ -1110,6 +1111,7 @@ final class BrowserRedockUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_BROWSER_REDOCK_URL"] = "https://example.com"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = launchTag
+        app.launchArguments += ["-\(browserThemeModeKey)", "light"]
         launchAndEnsureForeground(app)
 
         XCTAssertTrue(
@@ -1178,7 +1180,7 @@ final class BrowserRedockUITests: XCTestCase {
         XCTAssertGreaterThan(
             brightestMean,
             120.0,
-            "Expected example.com to render bright page content after re-dock. stats=\(statsSummary) data=\(data)"
+            "Expected example.com to render bright page content after re-dock with forced light browser theme. stats=\(statsSummary) data=\(data)"
         )
     }
 

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -1140,9 +1140,12 @@ final class BrowserRedockUITests: XCTestCase {
         XCTAssertEqual(data["finalBrowserSelected"], "1", "Expected browser to remain selected after re-dock. data=\(data)")
         XCTAssertEqual(data["finalBrowserAttached"], "1", "Expected browser web view to stay attached after re-dock. data=\(data)")
         XCTAssertNotEqual(data["finalBrowserHidden"], "1", "Expected browser web view to stay visible after re-dock. data=\(data)")
-        XCTAssertTrue(
-            (data["finalBrowserURL"] ?? "").localizedCaseInsensitiveContains("example.com"),
-            "Expected browser to remain on example.com after re-dock. data=\(data)"
+        let browserURLBeforeMove = data["browserURLBeforeMove"] ?? ""
+        XCTAssertFalse(browserURLBeforeMove.isEmpty, "Expected pre-move browser URL to be recorded. data=\(data)")
+        XCTAssertEqual(
+            data["finalBrowserURL"],
+            browserURLBeforeMove,
+            "Expected browser to preserve the loaded URL across re-dock. data=\(data)"
         )
 
         guard let crop = normalizedWebCrop(from: data) else {

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -1074,3 +1074,359 @@ final class SplitCloseRightBlankRegressionUITests: XCTestCase {
         }
     }
 }
+
+final class BrowserRedockUITests: XCTestCase {
+    private var dataPath = ""
+    private var socketPath = ""
+    private var screenshotDir = ""
+    private let launchTag = "ui-tests-browser-redock"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        dataPath = "/tmp/cmux-ui-test-browser-redock-\(UUID().uuidString).json"
+        socketPath = "/tmp/cmux-ui-test-socket-\(UUID().uuidString).sock"
+
+        let leaf = "cmux-ui-test-browser-redock-shots-\(UUID().uuidString)"
+        let preferredURL = URL(fileURLWithPath: "/private/tmp").appendingPathComponent(leaf)
+        let fallbackURL = FileManager.default.temporaryDirectory.appendingPathComponent(leaf)
+        if (try? FileManager.default.createDirectory(at: preferredURL, withIntermediateDirectories: true)) != nil {
+            screenshotDir = preferredURL.path
+        } else {
+            screenshotDir = fallbackURL.path
+        }
+
+        try? FileManager.default.removeItem(atPath: dataPath)
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: screenshotDir)
+        try? FileManager.default.createDirectory(atPath: screenshotDir, withIntermediateDirectories: true)
+    }
+
+    func testRedockingBrowserIntoExistingPaneKeepsVisibleWebContent() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_BROWSER_REDOCK_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BROWSER_REDOCK_PATH"] = dataPath
+        app.launchEnvironment["CMUX_UI_TEST_BROWSER_REDOCK_URL"] = "https://example.com"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(
+            waitForAnyData(timeout: 15.0),
+            "Expected browser redock test data to be written at \(dataPath)"
+        )
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 45.0) { data in
+                data["visualDone"] == "1" || !(data["setupError"] ?? "").isEmpty
+            },
+            "Expected browser redock setup to finish"
+        )
+
+        guard let data = loadData() else {
+            XCTFail("Missing browser redock data at \(dataPath)")
+            return
+        }
+
+        if let setupError = data["setupError"], !setupError.isEmpty {
+            XCTFail("Test setup failed: \(setupError). data=\(data)")
+            return
+        }
+
+        XCTAssertEqual(data["targetURL"], "https://example.com")
+        XCTAssertEqual(data["finalPaneCount"], "2", "Expected the far-right pane to collapse after the re-dock. data=\(data)")
+        XCTAssertEqual(data["finalTargetPaneTabCount"], "2", "Expected browser and terminal to end in the same pane. data=\(data)")
+        XCTAssertEqual(data["finalTargetPaneMatchesExpected"], "1", "Expected browser to re-dock into the repaired middle pane. data=\(data)")
+        XCTAssertEqual(data["finalBrowserSelected"], "1", "Expected browser to remain selected after re-dock. data=\(data)")
+        XCTAssertEqual(data["finalBrowserAttached"], "1", "Expected browser web view to stay attached after re-dock. data=\(data)")
+        XCTAssertNotEqual(data["finalBrowserHidden"], "1", "Expected browser web view to stay visible after re-dock. data=\(data)")
+        XCTAssertTrue(
+            (data["finalBrowserURL"] ?? "").localizedCaseInsensitiveContains("example.com"),
+            "Expected browser to remain on example.com after re-dock. data=\(data)"
+        )
+
+        guard let crop = normalizedWebCrop(from: data) else {
+            XCTFail("Missing final browser crop geometry. data=\(data)")
+            return
+        }
+
+        var samples: [(path: String, stats: CropStats)] = []
+        for index in 1...3 {
+            guard let sample = takeScreenStats(name: String(format: "browser-redock-%02d", index), normalizedCrop: crop) else {
+                XCTFail("Failed to capture browser redock screenshot \(index). shots=\(screenshotDir)")
+                return
+            }
+            samples.append(sample)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.30))
+        }
+
+        let blankSamples = samples.filter { $0.stats.looksBlankDark }
+        if blankSamples.count == samples.count {
+            samples.forEach { addKeptScreenshot(path: $0.path, name: ($0.path as NSString).lastPathComponent) }
+            let statsSummary = samples.map { $0.stats.description }.joined(separator: " | ")
+            XCTFail(
+                "Browser content area stayed dark/blank after re-dock. stats=\(statsSummary) shots=\(screenshotDir) data=\(data)"
+            )
+            return
+        }
+
+        let brightestMean = samples.map { $0.stats.meanLuma }.max() ?? 0
+        let statsSummary = samples.map { $0.stats.description }.joined(separator: " | ")
+        XCTAssertGreaterThan(
+            brightestMean,
+            120.0,
+            "Expected example.com to render bright page content after re-dock. stats=\(statsSummary) data=\(data)"
+        )
+    }
+
+    private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
+        app.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: timeout),
+            "Expected app to launch in foreground. state=\(app.state.rawValue)"
+        )
+    }
+
+    private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) {
+            return true
+        }
+        if app.state == .runningBackground {
+            app.activate()
+            return app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        return false
+    }
+
+    private func waitForAnyData(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if loadData() != nil {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return loadData() != nil
+    }
+
+    private func waitForDataMatch(timeout: TimeInterval, predicate: ([String: String]) -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let data = loadData(), predicate(data) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        if let data = loadData(), predicate(data) {
+            return true
+        }
+        return false
+    }
+
+    private func loadData() -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: dataPath)) else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+
+    private func normalizedWebCrop(from data: [String: String]) -> CGRect? {
+        guard
+            let screenFrame = rectFromData(data, prefix: "screenFrame"),
+            let webFrame = rectFromData(data, prefix: "webFrame"),
+            screenFrame.width > 10,
+            screenFrame.height > 10,
+            webFrame.width > 40,
+            webFrame.height > 40
+        else {
+            return nil
+        }
+
+        let insetX = min(webFrame.width * 0.18, 120)
+        let insetY = min(webFrame.height * 0.18, 120)
+        let insetWebFrame = webFrame.insetBy(dx: insetX, dy: insetY)
+        guard insetWebFrame.width > 20, insetWebFrame.height > 20 else { return nil }
+
+        let normalizedX = (insetWebFrame.minX - screenFrame.minX) / screenFrame.width
+        let normalizedY = (screenFrame.maxY - insetWebFrame.maxY) / screenFrame.height
+        let normalizedWidth = insetWebFrame.width / screenFrame.width
+        let normalizedHeight = insetWebFrame.height / screenFrame.height
+
+        let crop = CGRect(
+            x: CGFloat(normalizedX),
+            y: CGFloat(normalizedY),
+            width: CGFloat(normalizedWidth),
+            height: CGFloat(normalizedHeight)
+        )
+
+        guard
+            crop.origin.x >= 0,
+            crop.origin.y >= 0,
+            crop.maxX <= 1,
+            crop.maxY <= 1
+        else {
+            return nil
+        }
+        return crop
+    }
+
+    private func rectFromData(_ data: [String: String], prefix: String) -> CGRect? {
+        guard
+            let x = data["\(prefix)X"].flatMap(Double.init),
+            let y = data["\(prefix)Y"].flatMap(Double.init),
+            let width = data["\(prefix)Width"].flatMap(Double.init),
+            let height = data["\(prefix)Height"].flatMap(Double.init)
+        else {
+            return nil
+        }
+        return CGRect(x: CGFloat(x), y: CGFloat(y), width: CGFloat(width), height: CGFloat(height))
+    }
+
+    @discardableResult
+    private func writeScreenScreenshot(name: String) -> String? {
+        let shot = XCUIScreen.main.screenshot()
+        let path = "\(screenshotDir)/\(name).png"
+        do {
+            try shot.pngRepresentation.write(to: URL(fileURLWithPath: path))
+            return path
+        } catch {
+            return nil
+        }
+    }
+
+    private func addKeptScreenshot(path: String, name: String) {
+        let attachment = XCTAttachment(contentsOfFile: URL(fileURLWithPath: path))
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func takeScreenStats(name: String, normalizedCrop: CGRect) -> (path: String, stats: CropStats)? {
+        guard let path = writeScreenScreenshot(name: name),
+              let png = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let stats = cropStats(pngData: png, normalizedCrop: normalizedCrop) else {
+            return nil
+        }
+        return (path, stats)
+    }
+
+    private struct CropStats: CustomStringConvertible {
+        let sampleCount: Int
+        let meanLuma: Double
+        let lumaStdDev: Double
+        let uniqueQuantized: Int
+        let modeFraction: Double
+
+        var looksBlankDark: Bool {
+            meanLuma < 90.0 && lumaStdDev < 10.0 && modeFraction > 0.985
+        }
+
+        var description: String {
+            "mean=\(String(format: "%.1f", meanLuma)) std=\(String(format: "%.1f", lumaStdDev)) uniq=\(uniqueQuantized) mode=\(String(format: "%.4f", modeFraction)) samples=\(sampleCount)"
+        }
+    }
+
+    private func cgImage(from pngData: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(pngData as CFData, nil) else {
+            return nil
+        }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private func decodeRGBA(_ image: CGImage) -> [UInt8]? {
+        let width = image.width
+        let height = image.height
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var buffer = [UInt8](repeating: 0, count: height * bytesPerRow)
+
+        let okay = buffer.withUnsafeMutableBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue
+            guard let context = CGContext(
+                data: base,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: bitmapInfo
+            ) else {
+                return false
+            }
+
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+
+        return okay ? buffer : nil
+    }
+
+    private func cropStats(pngData: Data, normalizedCrop: CGRect) -> CropStats? {
+        guard let image = cgImage(from: pngData) else {
+            return nil
+        }
+
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        let cropPx = CGRect(
+            x: max(0, min(CGFloat(width - 1), normalizedCrop.origin.x * CGFloat(width))),
+            y: max(0, min(CGFloat(height - 1), normalizedCrop.origin.y * CGFloat(height))),
+            width: max(1, min(CGFloat(width), normalizedCrop.width * CGFloat(width))),
+            height: max(1, min(CGFloat(height), normalizedCrop.height * CGFloat(height)))
+        ).integral
+
+        let x0 = Int(cropPx.minX)
+        let y0 = Int(cropPx.minY)
+        let x1 = Int(min(CGFloat(width), cropPx.maxX))
+        let y1 = Int(min(CGFloat(height), cropPx.maxY))
+        guard x1 > x0, y1 > y0 else { return nil }
+
+        guard let buffer = decodeRGBA(image) else { return nil }
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        let step = 3
+
+        var lumas: [Double] = []
+        lumas.reserveCapacity(((x1 - x0) / step) * ((y1 - y0) / step))
+
+        var histogram: [UInt16: Int] = [:]
+        histogram.reserveCapacity(256)
+
+        for y in stride(from: y0, to: y1, by: step) {
+            let rowBase = y * bytesPerRow
+            for x in stride(from: x0, to: x1, by: step) {
+                let index = rowBase + x * bytesPerPixel
+                let r = Double(buffer[index])
+                let g = Double(buffer[index + 1])
+                let b = Double(buffer[index + 2])
+                let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                lumas.append(luma)
+
+                let rq = UInt16(UInt8(buffer[index]) >> 4)
+                let gq = UInt16(UInt8(buffer[index + 1]) >> 4)
+                let bq = UInt16(UInt8(buffer[index + 2]) >> 4)
+                let key = (rq << 8) | (gq << 4) | bq
+                histogram[key, default: 0] += 1
+            }
+        }
+
+        guard !lumas.isEmpty else { return nil }
+
+        let mean = lumas.reduce(0.0, +) / Double(lumas.count)
+        let variance = lumas.reduce(0.0) { partial, sample in
+            partial + (sample - mean) * (sample - mean)
+        } / Double(lumas.count)
+        let modeCount = histogram.values.max() ?? 0
+
+        return CropStats(
+            sampleCount: lumas.count,
+            meanLuma: mean,
+            lumaStdDev: sqrt(variance),
+            uniqueQuantized: histogram.count,
+            modeFraction: Double(modeCount) / Double(lumas.count)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a browser redock regression test that reproduces the blank webview state after moving a browser tab back into a pane with a terminal
- refresh moved browser panels after bonsplit tab moves so the portal-hosted WKWebView reattaches visibly
- tighten the regression to preserve the loaded URL across the move

## Testing
- fail-first GitHub E2E: BrowserRedockUITests on commit 64878f02b
- xcrun swiftc -frontend -parse Sources/TabManager.swift
- xcrun swiftc -frontend -parse cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
- xcrun swiftc -frontend -parse Sources/Panels/BrowserPanel.swift
- xcrun swiftc -frontend -parse Sources/Panels/BrowserPanelView.swift
- xcrun swiftc -frontend -parse Sources/Workspace.swift
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where the browser webview went blank after re-docking into a pane with a terminal. The WKWebView now reattaches reliably after tab moves, preserving the loaded URL, visibility, and focus.

- **Bug Fixes**
  - Force WebViewRepresentable.updateNSView via a viewReattachToken and rebind the portal on host/geometry changes or when the portal entry is missing.
  - Added BrowserWindowPortalRegistry.isWebView(... boundTo ...) to detect anchor mismatches and repair bindings.
  - Run a moved-browser refresh after Bonsplit tab moves to relayout/redraw, restore devtools, refocus, and keep the current URL/title.
  - Updated test constructors to pass reattachToken to WebViewRepresentable.

- **New Features**
  - Added BrowserRedockUITests that reproduce the bug and verify visible content via screenshot luma; TabManager includes hooks to orchestrate splits/move and record geometry/state.

<sup>Written for commit 5c8bcd736769c5b3582678965eb9e323de4a2ae7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI-triggerable view-reattach token to force web view reattachment and refresh.

* **Bug Fixes**
  * Ensure browser surfaces are refreshed after tab moves to prevent blank/frozen content and restore focus/devtools.
  * Added a public query to check web view-to-anchor binding state.

* **Tests**
  * Added comprehensive UI tests for browser re-dock flows with state capture and screenshot-based visual validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->