### PR TITLE
Stop reload scripts from stealing window focus

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -318,14 +318,13 @@ OPEN_CLEAN_ENV=(
 
 if [[ -n "${TAG_SLUG:-}" && -n "${CMUX_SOCKET:-}" ]]; then
   # Ensure tag-specific socket paths win even if the caller has CMUX_* overrides.
-  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" open "$APP_PATH"
+  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" open -g "$APP_PATH"
 elif [[ -n "${TAG_SLUG:-}" ]]; then
-  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" open "$APP_PATH"
+  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" open -g "$APP_PATH"
 else
   echo "/tmp/cmux-debug.log" > /tmp/cmux-last-debug-log-path || true
-  "${OPEN_CLEAN_ENV[@]}" open "$APP_PATH"
+  "${OPEN_CLEAN_ENV[@]}" open -g "$APP_PATH"
 fi
-osascript -e "tell application id \"${BUNDLE_ID}\" to activate" || true
 
 # Safety: ensure only one instance is running.
 sleep 0.2

--- a/scripts/reloadp.sh
+++ b/scripts/reloadp.sh
@@ -17,5 +17,4 @@ if [[ -z "${APP_PATH}" ]]; then
 fi
 # Dev shells (including CI/Codex) often force-disable paging by exporting these.
 # Don't leak that into cmux, otherwise `git diff` won't page even with PAGER=less.
-env -u GIT_PAGER -u GH_PAGER open "$APP_PATH"
-osascript -e 'tell application "cmux" to activate' || true
+env -u GIT_PAGER -u GH_PAGER open -g "$APP_PATH"

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -251,8 +251,7 @@ OPEN_CLEAN_ENV=(
 
 # Always inject staging socket paths via env to ensure they take effect
 # (LSEnvironment requires app restart to pick up plist changes).
-"${OPEN_CLEAN_ENV[@]}" CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" open "$APP_PATH"
-osascript -e "tell application id \"${BUNDLE_ID}\" to activate" || true
+"${OPEN_CLEAN_ENV[@]}" CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" open -g "$APP_PATH"
 
 # Safety: ensure only one instance is running.
 sleep 0.2


### PR DESCRIPTION
## Summary

- Add `open -g` (background) flag to all reload scripts so the rebuilt app launches without stealing focus
- Remove `osascript activate` calls that explicitly focused the app after launch

Affected scripts: `reload.sh`, `reloadp.sh`, `reloads.sh` (and `reload2.sh` transitively).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reload scripts from stealing focus by launching the rebuilt app in the background. Your current window stays active during reloads.

- **Bug Fixes**
  - Use open -g in reload.sh, reloadp.sh, and reloads.sh (covers reload2.sh transitively).
  - Remove osascript activate calls that forced app focus.

<sup>Written for commit 1f53f16de9a730351a2e9e06556922de50318ee8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

