### PR TITLE
Fix browser focus after dismissing the command palette by click

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1158,8 +1158,9 @@ private func commandPaletteOwningWebView(for responder: NSResponder?) -> WKWebVi
     }
 
     if let textView = responder as? NSTextView,
-       let delegateView = textView.delegate as? NSView {
-        return commandPaletteOwningWebView(for: delegateView)
+       let delegateView = textView.delegate as? NSView,
+       let webView = commandPaletteOwningWebView(for: delegateView) {
+        return webView
     }
 
     var currentResponder = responder.nextResponder
@@ -4768,8 +4769,8 @@ struct ContentView: View {
             return nil
         }
 
-        let contentPoint = NSPoint(x: contentPoint.x, y: contentPoint.y)
-        let windowPoint = contentView.convert(contentPoint, to: nil)
+        let nsContentPoint = NSPoint(x: contentPoint.x, y: contentPoint.y)
+        let windowPoint = contentView.convert(nsContentPoint, to: nil)
         return commandPaletteBackdropFocusTarget(atWindowPoint: windowPoint, in: window)
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -298,6 +298,10 @@ struct BrowserPanelView: View {
         )
     }
 
+    private var browserContentAccessibilityIdentifier: String {
+        "BrowserPanelContent.\(panel.id.uuidString)"
+    }
+
     private var omnibarPillBackgroundColor: NSColor {
         resolvedBrowserOmnibarPillBackgroundColor(
             for: browserChromeColorScheme,
@@ -749,6 +753,7 @@ struct BrowserPanelView: View {
                 // BrowserPanel replaces its underlying WKWebView after process termination.
                 .id(panel.webViewInstanceID)
                 .contentShape(Rectangle())
+                .accessibilityIdentifier(browserContentAccessibilityIdentifier)
                 .simultaneousGesture(TapGesture().onEnded {
                     // Chrome-like behavior: clicking web content while editing the
                     // omnibar should commit blur and revert transient edits.
@@ -759,6 +764,7 @@ struct BrowserPanelView: View {
             } else {
                 Color(nsColor: browserChromeBackgroundColor)
                     .contentShape(Rectangle())
+                    .accessibilityIdentifier(browserContentAccessibilityIdentifier)
                     .onTapGesture {
                         onRequestPanelFocus()
                         if addressBarFocused {

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -319,9 +319,9 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
             "Expected Cmd+R to open the rename command palette while terminal is focused"
         )
 
-        let window = app.windows.firstMatch
-        XCTAssertTrue(window.waitForExistence(timeout: 2.0), "Expected main window for browser-pane click")
-        window.coordinate(withNormalizedOffset: CGVector(dx: 0.82, dy: 0.78)).click()
+        let browserPane = app.otherElements["BrowserPanelContent.\(expectedBrowserPanelId)"].firstMatch
+        XCTAssertTrue(browserPane.waitForExistence(timeout: 5.0), "Expected browser pane content for click target")
+        browserPane.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         XCTAssertTrue(
             waitForNonExistence(renameField, timeout: 5.0),
             "Expected clicking the browser pane to dismiss the command palette"


### PR DESCRIPTION
## Summary
- detect the underlying responder when the command palette backdrop is clicked
- restore focus to the clicked browser or terminal pane instead of the stale pre-palette target
- add a browser-pane UI regression test for dismissing the Cmd+R rename palette by clicking browser content

## Testing
- built and launched a tagged Debug app via `./scripts/reload.sh --tag issue-983-browser-unfocusable-after-cmdr`
- UI tests not run locally per repo policy; rely on CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes focus after dismissing the command palette by clicking the backdrop. We hit-test the click, map it to the underlying browser or terminal, and restore focus to that exact pane (Linear 983).

- **Bug Fixes**
  - Backdrop click uses a zero-distance DragGesture and overlay hit-test, resolving the owning WKWebView/terminal via the responder chain with fallbacks to window portal registries.
  - Dismiss now accepts a preferred focus target computed from the click and searches across workspaces to map web views to panels, avoiding the stale pre-palette target.
  - Added accessibility IDs for the search/rename fields, backdrop, and browser pane content; new UI test verifies clicking browser content dismisses the palette and keeps browser focus.

<sup>Written for commit 44910d03e81def5de62bed5d27937a74305d46c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced command palette focus behavior when clicking the backdrop to dismiss.

* **Improvements**
  * Improved focus restoration after command palette dismissal.
  * Refined backdrop click handling for better interaction flow.

* **Accessibility**
  * Added accessibility identifiers to command palette fields for better UI testing support.

* **Tests**
  * Added test coverage for command palette dismissal and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->