### PR TITLE
Allow moving terminal tabs to adjacent panes

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -15835,6 +15835,40 @@
         }
       }
     },
+    "command.moveTabToLeftPane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Left Pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左のペインへ移動"
+          }
+        }
+      }
+    },
+    "command.moveTabToRightPane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Right Pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右のペインへ移動"
+          }
+        }
+      }
+    },
     "command.renameWorkspace.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2752,6 +2752,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     @discardableResult
     private func moveSurfaceToAdjacentPane(panelId: UUID, direction: NavigationDirection) -> Bool {
+        let shouldFocus = (focusedPanelId == panelId)
         guard terminalPanel(for: panelId) != nil,
               let sourcePaneId = paneId(forPanelId: panelId),
               let targetPaneId = bonsplitController.adjacentPane(to: sourcePaneId, direction: direction) else {
@@ -2760,7 +2761,7 @@ final class Workspace: Identifiable, ObservableObject {
         if bonsplitController.isSplitZoomed {
             bonsplitController.clearPaneZoom()
         }
-        return moveSurface(panelId: panelId, toPane: targetPaneId, focus: true)
+        return moveSurface(panelId: panelId, toPane: targetPaneId, focus: shouldFocus)
     }
 
     @discardableResult

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2751,6 +2751,16 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
+    private func moveSurfaceToAdjacentPane(panelId: UUID, direction: NavigationDirection) -> Bool {
+        guard terminalPanel(for: panelId) != nil,
+              let sourcePaneId = paneId(forPanelId: panelId),
+              let targetPaneId = bonsplitController.adjacentPane(to: sourcePaneId, direction: direction) else {
+            return false
+        }
+        return moveSurface(panelId: panelId, toPane: targetPaneId, focus: true)
+    }
+
+    @discardableResult
     func reorderSurface(panelId: UUID, toIndex index: Int) -> Bool {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return false }
         guard bonsplitController.reorderTab(tabId, toIndex: index) else { return false }
@@ -4467,6 +4477,12 @@ extension Workspace: BonsplitDelegate {
             closeTabs(tabIdsToCloseOthers(of: tab.id, inPane: pane))
         case .move:
             promptMovePanel(tabId: tab.id)
+        case .moveToLeftPane:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            _ = moveSurfaceToAdjacentPane(panelId: panelId, direction: .left)
+        case .moveToRightPane:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            _ = moveSurfaceToAdjacentPane(panelId: panelId, direction: .right)
         case .newTerminalToRight:
             createTerminalToRight(of: tab.id, inPane: pane)
         case .newBrowserToRight:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2757,6 +2757,9 @@ final class Workspace: Identifiable, ObservableObject {
               let targetPaneId = bonsplitController.adjacentPane(to: sourcePaneId, direction: direction) else {
             return false
         }
+        if bonsplitController.isSplitZoomed {
+            bonsplitController.clearPaneZoom()
+        }
         return moveSurface(panelId: panelId, toPane: targetPaneId, focus: true)
     }
 


### PR DESCRIPTION
Closes #981

## Summary
- add left/right terminal-tab context menu actions that move the selected tab into an adjacent pane
- make terminal-tab drags treat left/right neighboring panes as direct move targets instead of forcing a split-zone hit
- localize the new tab context menu labels and update the Bonsplit submodule pointer

## Notes
- Bonsplit submodule changes are in manaflow-ai/bonsplit#17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow moving terminal tabs to left/right adjacent panes via context menu and drag-and-drop. Implements #981.

- **New Features**
  - Context menu: Move to Left Pane / Move to Right Pane (EN/JA).
  - Dragging a terminal tab now targets adjacent panes directly (no split-zone required).

- **Bug Fixes**
  - Preserves focus when moving a focused tab to an adjacent pane.
  - Clears zoomed splits before adjacent moves to avoid regressions.
  - Updated `bonsplit` submodule for reliable adjacent pane lookup and moves.

<sup>Written for commit af3124bde8a079602cdc0921cb8d6f215392b96d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to move tabs to the left or right pane, making it easier to reorganize workspace layout.

* **Localization**
  * Added localized titles for the new move-tab commands in multiple languages.

* **Chores**
  * Updated a bundled component reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->