### PR TITLE
Fix Release build: move rectApproximatelyEqual out of #if DEBUG

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3131,13 +3131,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             String(format: "%.1f,%.1f %.1fx%.1f", rect.origin.x, rect.origin.y, rect.width, rect.height)
         }
 
-        private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.5) -> Bool {
-            abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
-                abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
-                abs(lhs.width - rhs.width) <= epsilon &&
-                abs(lhs.height - rhs.height) <= epsilon
-        }
-
         private func debugLogHostedInspectorFrames(
             stage: String,
             point: NSPoint? = nil,
@@ -3186,6 +3179,13 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorFrames(stage: "\(reason).layout", hit: hit)
         }
 #endif
+
+        private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.5) -> Bool {
+            abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
+                abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
+                abs(lhs.width - rhs.width) <= epsilon &&
+                abs(lhs.height - rhs.height) <= epsilon
+        }
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()


### PR DESCRIPTION
## Summary

- `HostContainerView.rectApproximatelyEqual` was defined inside `#if DEBUG` but called from non-DEBUG code at lines 3609-3610, breaking Release builds
- Introduced by https://github.com/manaflow-ai/cmux/pull/712 (commit `15c7c0cc3`), first caught by [nightly CI](https://github.com/manaflow-ai/cmux/actions/runs/22750562081/job/65984026312)
- Moved the function out of the `#if DEBUG` block so it's available in all configurations

## Test plan

- [x] Verified no Swift compilation errors in Release configuration locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Release builds by making rectApproximatelyEqual available in all configurations. Moved the helper out of the #if DEBUG block so non-DEBUG call sites compile.

- **Bug Fixes**
  - Relocated rectApproximatelyEqual outside the debug-only block in BrowserPanelView.swift; it was referenced by non-DEBUG code, causing Release compilation errors.

<sup>Written for commit 5c46e3a4d7c0195cda8c41f96da9e799773c9a2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by making a helper utility consistently available across conditional build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->