### PR TITLE
Fix workspace unread dismissal on explicit tab focus

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1601,8 +1601,17 @@ class TabManager: ObservableObject {
         suppressFocusFlash = false
         guard !shouldSuppressFlash else { return }
         guard AppFocusState.isAppActive() else { return }
-        guard let panelId = focusedPanelId(for: tabId) else { return }
-        markPanelReadOnFocusIfActive(tabId: tabId, panelId: panelId)
+        if let panelId = focusedPanelId(for: tabId) {
+            guard let notificationStore = AppDelegate.shared?.notificationStore else { return }
+            if notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: panelId) {
+                markPanelReadOnFocusIfActive(tabId: tabId, panelId: panelId)
+                return
+            }
+        }
+        guard selectedTabId == tabId else { return }
+        guard let notificationStore = AppDelegate.shared?.notificationStore else { return }
+        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: nil) else { return }
+        notificationStore.markRead(forTabId: tabId, surfaceId: nil)
     }
 
     private func markPanelReadOnFocusIfActive(tabId: UUID, panelId: UUID) {
@@ -1738,7 +1747,6 @@ class TabManager: ObservableObject {
             guard let targetPanelId,
                   tab.panels[targetPanelId] != nil else { return }
             guard let notificationStore = AppDelegate.shared?.notificationStore else { return }
-            guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: targetPanelId) else { return }
             tab.triggerNotificationFocusFlash(panelId: targetPanelId, requiresSplit: false, shouldFocus: true)
             notificationStore.markRead(forTabId: tabId, surfaceId: targetPanelId)
         }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7412,6 +7412,53 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(store.latestNotification(forTabId: tabB)?.id, notificationBUnread.id)
     }
 
+    func testSelectingWorkspaceMarksSurfaceLessNotificationRead() {
+        let store = TerminalNotificationStore.shared
+        let previousAppDelegate = AppDelegate.shared
+        let previousFocusOverride = AppFocusState.overrideIsFocused
+        let appDelegate = AppDelegate()
+        let tabManager = TabManager()
+        defer {
+            AppDelegate.shared = previousAppDelegate
+            AppFocusState.overrideIsFocused = previousFocusOverride
+        }
+        appDelegate.tabManager = tabManager
+        appDelegate.notificationStore = store
+        AppDelegate.shared = appDelegate
+        AppFocusState.overrideIsFocused = true
+
+        guard let originalTabId = tabManager.selectedTabId else {
+            XCTFail("Expected selected tab for workspace-level notification selection test")
+            return
+        }
+        guard let originalWorkspace = tabManager.tabs.first(where: { $0.id == originalTabId }) else {
+            XCTFail("Expected original workspace for workspace-level notification selection test")
+            return
+        }
+
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: originalTabId,
+            surfaceId: nil,
+            title: "Unread",
+            subtitle: "",
+            body: "should clear after explicit workspace selection",
+            createdAt: Date(),
+            isRead: false
+        )
+        store.replaceNotificationsForTesting([notification])
+
+        _ = tabManager.addWorkspace(select: true)
+        tabManager.selectWorkspace(originalWorkspace)
+
+        let drained = expectation(description: "workspace-level selection side effects drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertEqual(tabManager.selectedTabId, originalTabId)
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: originalTabId, surfaceId: nil))
+        XCTAssertTrue(store.notifications[0].isRead)
+    }
     func testNotificationIndexesUpdateAfterReadAndClearMutations() {
         let tab = UUID()
         let surfaceUnread = UUID()


### PR DESCRIPTION
## Summary
- add a regression test for selecting a workspace with a workspace-level unread notification (`surfaceId == nil`)
- mark workspace-level unread notifications read when the user explicitly focuses that workspace and there is no focused-panel unread to clear
- restore `AppDelegate.shared` and `AppFocusState.overrideIsFocused` after the regression test so the suite stays order-independent

## Testing
- red: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/lawrencechen/Library/Developer/Xcode/DerivedData/cmux-task-focus-tab-dismiss-regression-red test -only-testing:cmuxTests/NotificationDockBadgeTests/testSelectingWorkspaceMarksSurfaceLessNotificationRead` (fails on commit `12543dbbe^`)
- green: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/lawrencechen/Library/Developer/Xcode/DerivedData/cmux-task-focus-tab-dismiss-regression-green test -only-testing:cmuxTests/NotificationDockBadgeTests/testSelectingWorkspaceMarksSurfaceLessNotificationRead`
- review: `./scripts/codex-review.sh /Users/lawrencechen/fun/cmuxterm-hq/worktrees/task-focus-tab-dismiss-regression2` (0 findings)

## Regression Source
- introduced by https://github.com/manaflow-ai/cmux/commit/5f43a3fc32045cf63cd4bab97befe8f0756c6c16
- author: Austin Wang
- related PR: https://github.com/manaflow-ai/cmux/pull/971
- current `main` already reverted the broader change in https://github.com/manaflow-ai/cmux/commit/a7cef78725cdca4bd6f3959c5c93d2e53bca8052, but that still left the workspace-level unread dismissal case uncovered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where workspace-level unreads (surfaceId = nil) were not dismissed when explicitly focusing a workspace tab. Adds a regression test to lock this behavior and resets global state to keep tests order-independent.

<sup>Written for commit 740762d14948568aa879030aa511609f33ca8272. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification read status logic for focused panels, enhancing how unread states are managed and ensuring notifications clear correctly
  * Fixed notification flash behavior to trigger reliably when navigating workspaces

* **Tests**
  * Added test coverage to verify notifications are properly marked as read when selecting workspaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->