### PR TITLE
Run tmux hooks via detached CLI runner

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -886,6 +886,11 @@ struct CMUXCLI {
             return
         }
 
+        if command == "tmux-hook-runner" {
+            try runTmuxCompatHookRunnerCommand(commandArgs: commandArgs)
+            return
+        }
+
         // If the argument looks like a path (not a known command), open a workspace there.
         if looksLikePath(command) {
             try openPath(command, socketPath: resolvedSocketPath)
@@ -5708,6 +5713,49 @@ struct CMUXCLI {
         var hooks: [String: String] = [:]
     }
 
+    private struct TmuxCompatHookRunnerRequest: Codable {
+        enum Kind: String, Codable {
+            case fire
+            case ping
+            case shutdown
+        }
+
+        var kind: Kind
+        var event: String?
+        var environment: [String: String]
+        var workingDirectory: String?
+    }
+
+    private final class TmuxCompatHookRunnerPipeCapture: @unchecked Sendable {
+        private let fileHandle: FileHandle
+        private let group = DispatchGroup()
+        private let lock = NSLock()
+        private var captured = Data()
+
+        init(pipe: Pipe) {
+            fileHandle = pipe.fileHandleForReading
+        }
+
+        func start() {
+            group.enter()
+            DispatchQueue.global(qos: .utility).async { [self] in
+                defer { group.leave() }
+                let data = fileHandle.readDataToEndOfFile()
+                lock.lock()
+                captured = data
+                lock.unlock()
+                fileHandle.closeFile()
+            }
+        }
+
+        func wait() -> Data {
+            group.wait()
+            lock.lock()
+            defer { lock.unlock() }
+            return captured
+        }
+    }
+
     private func tmuxCompatStoreURL() -> URL {
         let root = NSString(string: "~/.cmuxterm").expandingTildeInPath
         return URL(fileURLWithPath: root).appendingPathComponent("tmux-compat-store.json")
@@ -5728,6 +5776,424 @@ struct CMUXCLI {
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
         let data = try JSONEncoder().encode(store)
         try data.write(to: url, options: .atomic)
+    }
+
+    private func tmuxCompatHookRunnerSocketURL() -> URL {
+        tmuxCompatStoreURL().deletingLastPathComponent().appendingPathComponent("tmux-compat-hook.sock")
+    }
+
+    private func tmuxCompatHookRunnerHasConfiguredHooks(store: TmuxCompatStore? = nil) -> Bool {
+        !(store ?? loadTmuxCompatStore()).hooks.isEmpty
+    }
+
+    private func tmuxCompatHookCommand(
+        for event: String,
+        store: TmuxCompatStore? = nil
+    ) -> String? {
+        let normalized = event.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+        let store = store ?? loadTmuxCompatStore()
+        guard let command = store.hooks[normalized]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !command.isEmpty else {
+            return nil
+        }
+        return command
+    }
+
+    private func tmuxCompatHookRunnerSocketAddress(path: String) -> sockaddr_un? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < maxLength else { return nil }
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &address.sun_path) { pathPtr in
+                let buffer = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, ptr, maxLength - 1)
+            }
+        }
+        return address
+    }
+
+    private func setNoSigPipe(on fd: Int32) {
+        var disableSigPipe: Int32 = 1
+        _ = withUnsafePointer(to: &disableSigPipe) {
+            setsockopt(
+                fd,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                $0,
+                socklen_t(MemoryLayout<Int32>.size)
+            )
+        }
+    }
+
+    private func tmuxCompatHookRunnerCanConnect(to path: String) -> Bool {
+        var st = stat()
+        guard lstat(path, &st) == 0 else { return false }
+        guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else { return false }
+        let socketURL = URL(fileURLWithPath: path)
+        do {
+            let response = try sendTmuxCompatHookRunnerRequest(
+                TmuxCompatHookRunnerRequest(
+                    kind: .ping,
+                    event: nil,
+                    environment: [:],
+                    workingDirectory: nil
+                ),
+                socketURL: socketURL
+            )
+            return response == "OK"
+        } catch {
+            return false
+        }
+    }
+
+    private func tmuxCompatHookRunnerPosixError(_ operation: String) -> CLIError {
+        let code = errno
+        return CLIError(message: "\(operation) failed: \(String(cString: strerror(code))) (\(code))")
+    }
+
+    private func writeAll(_ data: Data, to fd: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return }
+            var offset = 0
+            while offset < rawBuffer.count {
+                let written = Darwin.write(fd, baseAddress.advanced(by: offset), rawBuffer.count - offset)
+                if written < 0 {
+                    throw tmuxCompatHookRunnerPosixError("write")
+                }
+                offset += written
+            }
+        }
+    }
+
+    private func readLine(from fd: Int32) throws -> String {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while true {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count < 0 {
+                throw tmuxCompatHookRunnerPosixError("read")
+            }
+            if count == 0 {
+                break
+            }
+            data.append(buffer, count: count)
+            if data.contains(0x0A) {
+                break
+            }
+        }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private func sendTmuxCompatHookRunnerRequest(
+        _ request: TmuxCompatHookRunnerRequest,
+        socketURL: URL
+    ) throws -> String {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw tmuxCompatHookRunnerPosixError("socket")
+        }
+        defer { Darwin.close(fd) }
+
+        setNoSigPipe(on: fd)
+
+        guard var address = tmuxCompatHookRunnerSocketAddress(path: socketURL.path) else {
+            throw CLIError(message: "Invalid tmux hook runner socket path: \(socketURL.path)")
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            throw tmuxCompatHookRunnerPosixError("connect")
+        }
+
+        var payload = try JSONEncoder().encode(request)
+        payload.append(0x0A)
+        try writeAll(payload, to: fd)
+        return try readLine(from: fd)
+    }
+
+    private func ensureTmuxCompatHookRunnerStarted(
+        socketURL: URL? = nil,
+        requireConfiguredHooks: Bool = true
+    ) throws {
+        let socketURL = socketURL ?? tmuxCompatHookRunnerSocketURL()
+        if requireConfiguredHooks, !tmuxCompatHookRunnerHasConfiguredHooks() {
+            return
+        }
+        if tmuxCompatHookRunnerCanConnect(to: socketURL.path) {
+            return
+        }
+
+        let parent = socketURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        if FileManager.default.fileExists(atPath: socketURL.path) {
+            try? FileManager.default.removeItem(at: socketURL)
+        }
+
+        guard let executablePath = currentExecutablePath(), !executablePath.isEmpty else {
+            throw CLIError(message: "Unable to resolve cmux CLI path for tmux hook runner")
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = ["tmux-hook-runner", "--socket", socketURL.path]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        process.environment = environment
+
+        if let devNull = FileHandle(forUpdatingAtPath: "/dev/null") {
+            process.standardInput = devNull
+            process.standardOutput = devNull
+            process.standardError = devNull
+        }
+
+        try process.run()
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            if tmuxCompatHookRunnerCanConnect(to: socketURL.path) {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        throw CLIError(message: "Timed out waiting for tmux hook runner to start")
+    }
+
+    private func stopTmuxCompatHookRunnerIfRunning(socketURL: URL? = nil) throws {
+        let socketURL = socketURL ?? tmuxCompatHookRunnerSocketURL()
+        if !FileManager.default.fileExists(atPath: socketURL.path) {
+            return
+        }
+        if !tmuxCompatHookRunnerCanConnect(to: socketURL.path) {
+            try? FileManager.default.removeItem(at: socketURL)
+            return
+        }
+
+        let response = try sendTmuxCompatHookRunnerRequest(
+            TmuxCompatHookRunnerRequest(
+                kind: .shutdown,
+                event: nil,
+                environment: [:],
+                workingDirectory: nil
+            ),
+            socketURL: socketURL
+        )
+        if response != "OK" {
+            throw CLIError(message: response.isEmpty ? "tmux hook runner refused shutdown request" : response)
+        }
+    }
+
+    private func runTmuxCompatHookRunnerCommand(commandArgs: [String]) throws {
+        let (socketPath, remainder) = parseOption(commandArgs, name: "--socket")
+        let socketURL = URL(fileURLWithPath: socketPath ?? tmuxCompatHookRunnerSocketURL().path)
+
+        if remainder.contains("--help") || remainder.contains("-h") {
+            print("""
+            Usage: cmux tmux-hook-runner [--ensure|--stop] [--socket <path>]
+
+            Hidden helper for tmux-compatible hook execution outside the GUI process.
+            """)
+            return
+        }
+
+        if remainder.contains("--ensure") {
+            try ensureTmuxCompatHookRunnerStarted(socketURL: socketURL)
+            return
+        }
+
+        if remainder.contains("--stop") {
+            try stopTmuxCompatHookRunnerIfRunning(socketURL: socketURL)
+            return
+        }
+
+        try serveTmuxCompatHookRunner(socketURL: socketURL)
+    }
+
+    private func serveTmuxCompatHookRunner(socketURL: URL) throws {
+        if tmuxCompatHookRunnerCanConnect(to: socketURL.path) {
+            return
+        }
+
+        let parent = socketURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        if FileManager.default.fileExists(atPath: socketURL.path) {
+            try? FileManager.default.removeItem(at: socketURL)
+        }
+
+        let serverFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard serverFD >= 0 else {
+            throw tmuxCompatHookRunnerPosixError("socket")
+        }
+
+        defer {
+            Darwin.close(serverFD)
+            try? FileManager.default.removeItem(at: socketURL)
+        }
+
+        guard var address = tmuxCompatHookRunnerSocketAddress(path: socketURL.path) else {
+            throw CLIError(message: "Invalid tmux hook runner socket path: \(socketURL.path)")
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.bind(serverFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw tmuxCompatHookRunnerPosixError("bind")
+        }
+
+        chmod(socketURL.path, mode_t(0o600))
+
+        guard listen(serverFD, 8) == 0 else {
+            throw tmuxCompatHookRunnerPosixError("listen")
+        }
+
+        while true {
+            let clientFD = accept(serverFD, nil, nil)
+            if clientFD < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw tmuxCompatHookRunnerPosixError("accept")
+            }
+
+            setNoSigPipe(on: clientFD)
+            let shouldContinue = handleTmuxCompatHookRunnerConnection(clientFD)
+            Darwin.close(clientFD)
+            if !shouldContinue {
+                return
+            }
+        }
+    }
+
+    private func handleTmuxCompatHookRunnerConnection(_ fd: Int32) -> Bool {
+        do {
+            let line = try readLine(from: fd)
+            guard !line.isEmpty else {
+                return true
+            }
+
+            guard let data = line.data(using: .utf8),
+                  let request = try? JSONDecoder().decode(TmuxCompatHookRunnerRequest.self, from: data) else {
+                try writeAll(Data("ERROR: Invalid tmux hook runner request\n".utf8), to: fd)
+                return true
+            }
+
+            switch request.kind {
+            case .ping:
+                try writeAll(Data("OK\n".utf8), to: fd)
+                return true
+
+            case .shutdown:
+                try writeAll(Data("OK\n".utf8), to: fd)
+                return false
+
+            case .fire:
+                guard let event = request.event,
+                      let command = tmuxCompatHookCommand(for: event) else {
+                    try writeAll(Data("SKIP\n".utf8), to: fd)
+                    return true
+                }
+                DispatchQueue.global(qos: .utility).async {
+                    self.executeTmuxCompatHookRunnerRequest(request, command: command)
+                }
+                try writeAll(Data("OK\n".utf8), to: fd)
+                return true
+            }
+        } catch {
+            let message = "ERROR: \(error)\n"
+            try? writeAll(Data(message.utf8), to: fd)
+            return true
+        }
+    }
+
+    private func executeTmuxCompatHookRunnerRequest(
+        _ request: TmuxCompatHookRunnerRequest,
+        command: String
+    ) {
+        guard request.kind == .fire,
+              let event = request.event?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !event.isEmpty else {
+            return
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+
+        var environment = ProcessInfo.processInfo.environment
+        for (key, value) in request.environment where !key.isEmpty && !value.isEmpty {
+            environment[key] = value
+        }
+        if environment["PATH"]?.isEmpty ?? true {
+            environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+        }
+        process.environment = environment
+
+        if let workingDirectory = request.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workingDirectory.isEmpty,
+           FileManager.default.fileExists(atPath: workingDirectory) {
+            process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+        }
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        let stdoutCapture = TmuxCompatHookRunnerPipeCapture(pipe: stdout)
+        let stderrCapture = TmuxCompatHookRunnerPipeCapture(pipe: stderr)
+        stdoutCapture.start()
+        stderrCapture.start()
+
+        do {
+            try process.run()
+            stdout.fileHandleForWriting.closeFile()
+            stderr.fileHandleForWriting.closeFile()
+            process.waitUntilExit()
+        } catch {
+            stdout.fileHandleForWriting.closeFile()
+            stderr.fileHandleForWriting.closeFile()
+            _ = stdoutCapture.wait()
+            _ = stderrCapture.wait()
+            NSLog("tmux hook runner failed to launch %@: %@", event, String(describing: error))
+            return
+        }
+
+        let stdoutData = stdoutCapture.wait()
+        let stderrData = stderrCapture.wait()
+        guard process.terminationStatus == 0 else {
+            let stderrText = String(data: stderrData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let stdoutText = String(data: stdoutData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let details = stderrText.isEmpty ? stdoutText : stderrText
+            NSLog(
+                "tmux hook runner command %@ failed (%d): %@",
+                event,
+                process.terminationStatus,
+                details
+            )
+            return
+        }
     }
 
     private func runShellCommand(_ command: String, stdinText: String) throws -> (status: Int32, stdout: String, stderr: String) {
@@ -6034,6 +6500,11 @@ struct CMUXCLI {
                 }
                 store.hooks.removeValue(forKey: event)
                 try saveTmuxCompatStore(store)
+                if store.hooks.isEmpty {
+                    try stopTmuxCompatHookRunnerIfRunning()
+                } else {
+                    try ensureTmuxCompatHookRunnerStarted(requireConfiguredHooks: false)
+                }
                 print("OK")
                 return
             }
@@ -6046,6 +6517,7 @@ struct CMUXCLI {
             }
             store.hooks[event] = commandText
             try saveTmuxCompatStore(store)
+            try ensureTmuxCompatHookRunnerStarted(requireConfiguredHooks: false)
             print("OK")
 
         case "popup":

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -53,6 +53,7 @@ _CMUX_ASYNC_JOB_TIMEOUT="${_CMUX_ASYNC_JOB_TIMEOUT:-20}"
 _CMUX_PORTS_LAST_RUN="${_CMUX_PORTS_LAST_RUN:-0}"
 _CMUX_TTY_NAME="${_CMUX_TTY_NAME:-}"
 _CMUX_TTY_REPORTED="${_CMUX_TTY_REPORTED:-0}"
+_CMUX_TMUX_HOOK_RUNNER_ENSURED="${_CMUX_TMUX_HOOK_RUNNER_ENSURED:-0}"
 
 _cmux_git_resolve_head_path() {
     # Resolve the HEAD file path without invoking git (fast; works for worktrees).
@@ -112,6 +113,15 @@ _cmux_ports_kick() {
     _CMUX_PORTS_LAST_RUN=$SECONDS
     {
         _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    } >/dev/null 2>&1 & disown
+}
+
+_cmux_ensure_tmux_hook_runner_once() {
+    [[ "${_CMUX_TMUX_HOOK_RUNNER_ENSURED:-0}" == "1" ]] && return 0
+    _CMUX_TMUX_HOOK_RUNNER_ENSURED=1
+    command -v cmux >/dev/null 2>&1 || return 0
+    {
+        cmux tmux-hook-runner --ensure >/dev/null 2>&1 || true
     } >/dev/null 2>&1 & disown
 }
 
@@ -314,6 +324,7 @@ _cmux_fix_path() {
     fi
 }
 _cmux_fix_path
+_cmux_ensure_tmux_hook_runner_once
 unset -f _cmux_fix_path
 
 _cmux_install_prompt_command

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -58,6 +58,7 @@ typeset -g _CMUX_PORTS_LAST_RUN=0
 typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
+typeset -g _CMUX_TMUX_HOOK_RUNNER_ENSURED=0
 
 _cmux_git_resolve_head_path() {
     # Resolve the HEAD file path without invoking git (fast; works for worktrees).
@@ -120,6 +121,15 @@ _cmux_ports_kick() {
     _CMUX_PORTS_LAST_RUN=$EPOCHSECONDS
     {
         _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    } >/dev/null 2>&1 &!
+}
+
+_cmux_ensure_tmux_hook_runner_once() {
+    (( _CMUX_TMUX_HOOK_RUNNER_ENSURED )) && return 0
+    _CMUX_TMUX_HOOK_RUNNER_ENSURED=1
+    command -v cmux >/dev/null 2>&1 || return 0
+    {
+        cmux tmux-hook-runner --ensure >/dev/null 2>&1 || true
     } >/dev/null 2>&1 &!
 }
 
@@ -414,6 +424,7 @@ _cmux_fix_path() {
             PATH="${bin_dir}:${(j/:/)parts}"
         fi
     fi
+    _cmux_ensure_tmux_hook_runner_once
     add-zsh-hook -d precmd _cmux_fix_path
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8092,6 +8092,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func closeMainWindowContainingTabId(_ tabId: UUID) {
         guard let context = contextContainingTabId(tabId) else { return }
+        context.tabManager.fireWorkspaceCloseHookIfPresent(tabId: tabId)
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
         window?.performClose(nil)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8017,6 +8017,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // is removed when the last window closes.
         persistWindowGeometry(from: window)
         guard let removed = unregisterMainWindowContext(for: window) else { return }
+        let closingWorkspaceTabIds = removed.tabManager.tabs
+            .map(\.id)
+            .sorted(by: { $0.uuidString < $1.uuidString })
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
         commandPalettePendingOpenByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteRecentRequestAtByWindowId.removeValue(forKey: removed.windowId)
@@ -8024,6 +8027,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         commandPaletteEscapeSuppressionStartedAtByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteSelectionByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteSnapshotByWindowId.removeValue(forKey: removed.windowId)
+
+        for tabId in closingWorkspaceTabIds {
+            removed.tabManager.fireWorkspaceCloseHookIfPresent(tabId: tabId)
+        }
 
         // Avoid stale notifications that can no longer be opened once the owning window is gone.
         if let store = notificationStore {
@@ -8092,10 +8099,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func closeMainWindowContainingTabId(_ tabId: UUID) {
         guard let context = contextContainingTabId(tabId) else { return }
-        context.tabManager.fireWorkspaceCloseHookIfPresent(tabId: tabId)
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
-        let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
-        window?.performClose(nil)
+        guard let window = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier }) else {
+            return
+        }
+        window.performClose(nil)
     }
 
     @discardableResult

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4,16 +4,22 @@ import Foundation
 import Bonsplit
 import CoreVideo
 import Combine
-
-private func cmuxShellQuoted(_ value: String) -> String {
-    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
-}
+import Darwin
 
 enum TmuxCompatHookEvent: String {
     case workspaceCreated = "workspace-created"
     case workspaceClose = "workspace-close"
     case surfaceClose = "surface-close"
     case paneClose = "pane-close"
+}
+
+private func tmuxCompatHookJSONStringArray(_ values: [String]) -> String? {
+    guard !values.isEmpty,
+          let data = try? JSONSerialization.data(withJSONObject: values, options: []),
+          let output = String(data: data, encoding: .utf8) else {
+        return nil
+    }
+    return output
 }
 
 struct TmuxCompatHookContext {
@@ -71,8 +77,8 @@ struct TmuxCompatHookContext {
         if !closedSurfaceIDs.isEmpty {
             env["CMUX_CLOSED_SURFACE_IDS"] = closedSurfaceIDs.map(\.uuidString).joined(separator: ",")
         }
-        if !closedSurfaceDirectories.isEmpty {
-            env["CMUX_CLOSED_SURFACE_DIRECTORIES"] = closedSurfaceDirectories.joined(separator: ":")
+        if let encodedDirectories = tmuxCompatHookJSONStringArray(closedSurfaceDirectories) {
+            env["CMUX_CLOSED_SURFACE_DIRECTORIES"] = encodedDirectories
         }
         if let remainingPanes {
             env["CMUX_REMAINING_PANES"] = String(remainingPanes)
@@ -84,18 +90,19 @@ struct TmuxCompatHookContext {
     }
 }
 
+private struct TmuxCompatHookRunnerRequest: Codable {
+    let kind: String
+    let event: String
+    let environment: [String: String]
+    let workingDirectory: String?
+}
+
 final class TmuxCompatHookDispatcher {
     static let shared = TmuxCompatHookDispatcher()
-
-    private struct TmuxCompatStore: Codable {
-        var buffers: [String: String] = [:]
-        var hooks: [String: String] = [:]
-    }
 
     private let queue = DispatchQueue(label: "com.cmuxterm.tmux-compat-hooks", qos: .utility)
 
     func fire(_ context: TmuxCompatHookContext) {
-        guard let command = command(for: context.event) else { return }
 #if DEBUG
         dlog(
             "hook.fire event=\(context.event.rawValue) workspace=\(context.workspaceId?.uuidString.prefix(5) ?? "nil") " +
@@ -103,66 +110,41 @@ final class TmuxCompatHookDispatcher {
         )
 #endif
         queue.async {
-            self.run(command: command, context: context)
+            self.run(context: context)
         }
     }
 
-    private func command(for event: TmuxCompatHookEvent) -> String? {
-        let url = tmuxCompatStoreURL()
-        guard let data = try? Data(contentsOf: url),
-              let store = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
-            return nil
-        }
-        let command = store.hooks[event.rawValue]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let command, !command.isEmpty else { return nil }
-        return command
-    }
-
-    private func tmuxCompatStoreURL() -> URL {
+    private func hookRunnerSocketURL() -> URL {
         let root = NSString(string: "~/.cmuxterm").expandingTildeInPath
-        return URL(fileURLWithPath: root).appendingPathComponent("tmux-compat-store.json")
+        return URL(fileURLWithPath: root).appendingPathComponent("tmux-compat-hook.sock")
     }
 
-    private func run(command: String, context: TmuxCompatHookContext) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        process.arguments = [
-            "-e", "on run argv",
-            "-e", "do shell script (item 1 of argv)",
-            "-e", "end run",
-            renderedCommand(command: command, context: context)
-        ]
-
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            NSLog("tmux hook %@ failed to launch via osascript: %@", context.event.rawValue, String(describing: error))
-#if DEBUG
-            dlog("hook.exec.fail event=\(context.event.rawValue) reason=launch")
-#endif
+    private func run(context: TmuxCompatHookContext) {
+        let socketURL = hookRunnerSocketURL()
+        var st = stat()
+        guard lstat(socketURL.path, &st) == 0,
+              (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
             return
         }
 
-        guard process.terminationStatus == 0 else {
-            let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let details = stderrText.isEmpty ? stdoutText : stderrText
-            NSLog(
-                "tmux hook %@ failed (%d): %@",
-                context.event.rawValue,
-                process.terminationStatus,
-                details
-            )
+        let request = TmuxCompatHookRunnerRequest(
+            kind: "fire",
+            event: context.event.rawValue,
+            environment: renderedEnvironment(context: context),
+            workingDirectory: normalizedWorkingDirectory(context.workingDirectory)
+        )
+        do {
+            let response = try send(request: request, to: socketURL)
+            if response == "SKIP" {
 #if DEBUG
-            dlog("hook.exec.fail event=\(context.event.rawValue) reason=exit status=\(process.terminationStatus)")
+                dlog("hook.exec.skip event=\(context.event.rawValue)")
+#endif
+                return
+            }
+        } catch {
+            NSLog("tmux hook %@ failed to dispatch: %@", context.event.rawValue, String(describing: error))
+#if DEBUG
+            dlog("hook.exec.fail event=\(context.event.rawValue) reason=dispatch")
 #endif
             return
         }
@@ -171,13 +153,13 @@ final class TmuxCompatHookDispatcher {
 #endif
     }
 
-    private func renderedCommand(command: String, context: TmuxCompatHookContext) -> String {
-        var shellCommand = command
-        if let workingDirectory = context.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !workingDirectory.isEmpty {
-            shellCommand = "cd \(cmuxShellQuoted(workingDirectory)) && \(shellCommand)"
-        }
+    private func normalizedWorkingDirectory(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 
+    private func renderedEnvironment(context: TmuxCompatHookContext) -> [String: String] {
         var env = context.environment(socketPath: SocketControlSettings.socketPath())
         if let currentHome = ProcessInfo.processInfo.environment["HOME"], !currentHome.isEmpty {
             env["HOME"] = currentHome
@@ -195,27 +177,116 @@ final class TmuxCompatHookDispatcher {
             env["SHELL"] = currentShell
         }
 
-        let inheritedPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
-        if let bundledBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin", isDirectory: true).path,
-           !bundledBinPath.isEmpty {
-            if inheritedPath.isEmpty {
-                env["PATH"] = bundledBinPath
-            } else if inheritedPath.split(separator: ":").contains(Substring(bundledBinPath)) {
-                env["PATH"] = inheritedPath
-            } else {
-                env["PATH"] = bundledBinPath + ":" + inheritedPath
+        // Preserve the detached runner's shell-derived PATH so hooks can resolve
+        // user-installed tools (Homebrew, asdf, etc.) outside the app sandbox.
+        return env
+    }
+
+    private func send(request: TmuxCompatHookRunnerRequest, to socketURL: URL) throws -> String {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw posixError("socket")
+        }
+        defer { Darwin.close(fd) }
+
+        var disableSigPipe: Int32 = 1
+        _ = withUnsafePointer(to: &disableSigPipe) {
+            setsockopt(
+                fd,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                $0,
+                socklen_t(MemoryLayout<Int32>.size)
+            )
+        }
+
+        guard var address = socketAddress(path: socketURL.path) else {
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteInvalidFileNameError,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid tmux hook runner socket path"]
+            )
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
-        } else {
-            env["PATH"] = inheritedPath
+        }
+        guard connectResult == 0 else {
+            throw posixError("connect")
         }
 
-        let assignments = env.keys.sorted().compactMap { key -> String? in
-            guard let value = env[key], !value.isEmpty else { return nil }
-            return "\(key)=\(cmuxShellQuoted(value))"
-        }
+        var payload = try JSONEncoder().encode(request)
+        payload.append(0x0A)
+        try writeAll(payload, to: fd)
 
-        let envPrefix = assignments.isEmpty ? "" : assignments.joined(separator: " ") + " "
-        return "/usr/bin/env \(envPrefix)/bin/sh -c \(cmuxShellQuoted(shellCommand))"
+        let response = try readResponse(from: fd)
+        guard response == "OK" || response == "SKIP" else {
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteUnknownError,
+                userInfo: [NSLocalizedDescriptionKey: response.isEmpty ? "tmux hook runner did not acknowledge request" : response]
+            )
+        }
+        return response
+    }
+
+    private func socketAddress(path: String) -> sockaddr_un? {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard path.utf8.count < maxLength else { return nil }
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &address.sun_path) { pathPtr in
+                let buffer = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, ptr, maxLength - 1)
+            }
+        }
+        return address
+    }
+
+    private func writeAll(_ data: Data, to fd: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return }
+            var offset = 0
+            while offset < rawBuffer.count {
+                let written = Darwin.write(fd, baseAddress.advanced(by: offset), rawBuffer.count - offset)
+                guard written >= 0 else {
+                    throw posixError("write")
+                }
+                offset += written
+            }
+        }
+    }
+
+    private func readResponse(from fd: Int32) throws -> String {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 256)
+        while true {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            guard count >= 0 else {
+                throw posixError("read")
+            }
+            if count == 0 {
+                break
+            }
+            data.append(buffer, count: count)
+            if data.contains(0x0A) {
+                break
+            }
+        }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
+    private func posixError(_ operation: String) -> NSError {
+        let code = errno
+        return NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(code))) (\(code))"]
+        )
     }
 }
 
@@ -1480,7 +1551,6 @@ class TabManager: ObservableObject {
         let effectiveSurfaceCount = max(tab.panels.count, bonsplitTabCount)
         let isLastTabInWorkspace = effectiveSurfaceCount <= 1
         if isLastTabInWorkspace {
-            fireSurfaceCloseHook(workspace: tab, panelId: panelId)
             let willCloseWindow = tabs.count <= 1
             let needsConfirm = workspaceNeedsConfirmClose(tab)
             if needsConfirm {
@@ -1508,6 +1578,7 @@ class TabManager: ObservableObject {
                 }
             }
 
+            fireSurfaceCloseHook(workspace: tab, panelId: panelId)
             AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id)
             if willCloseWindow {
                 AppDelegate.shared?.closeMainWindowContainingTabId(tab.id)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5,6 +5,220 @@ import Bonsplit
 import CoreVideo
 import Combine
 
+private func cmuxShellQuoted(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+
+enum TmuxCompatHookEvent: String {
+    case workspaceCreated = "workspace-created"
+    case workspaceClose = "workspace-close"
+    case surfaceClose = "surface-close"
+    case paneClose = "pane-close"
+}
+
+struct TmuxCompatHookContext {
+    let event: TmuxCompatHookEvent
+    let workspaceId: UUID?
+    let workspaceTitle: String?
+    let workspaceDirectory: String?
+    let paneId: UUID?
+    let surfaceId: UUID?
+    let surfaceTitle: String?
+    let surfaceDirectory: String?
+    let surfaceKind: String?
+    let surfaceTTY: String?
+    let workingDirectory: String?
+    let closedSurfaceIDs: [UUID]
+    let closedSurfaceDirectories: [String]
+    let remainingPanes: Int?
+    let remainingSurfaces: Int?
+
+    func environment(socketPath: String) -> [String: String] {
+        var env: [String: String] = [
+            "CMUX_HOOK_EVENT": event.rawValue,
+            "CMUX_SOCKET_PATH": socketPath
+        ]
+        if let workspaceId {
+            env["CMUX_WORKSPACE_ID"] = workspaceId.uuidString
+        }
+        if let workspaceTitle, !workspaceTitle.isEmpty {
+            env["CMUX_WORKSPACE_TITLE"] = workspaceTitle
+        }
+        if let workspaceDirectory, !workspaceDirectory.isEmpty {
+            env["CMUX_WORKSPACE_DIRECTORY"] = workspaceDirectory
+        }
+        if let paneId {
+            env["CMUX_PANE_ID"] = paneId.uuidString
+        }
+        if let surfaceId {
+            env["CMUX_SURFACE_ID"] = surfaceId.uuidString
+        }
+        if let surfaceTitle, !surfaceTitle.isEmpty {
+            env["CMUX_SURFACE_TITLE"] = surfaceTitle
+        }
+        if let surfaceDirectory, !surfaceDirectory.isEmpty {
+            env["CMUX_SURFACE_DIRECTORY"] = surfaceDirectory
+        }
+        if let surfaceKind, !surfaceKind.isEmpty {
+            env["CMUX_SURFACE_KIND"] = surfaceKind
+        }
+        if let surfaceTTY, !surfaceTTY.isEmpty {
+            env["CMUX_SURFACE_TTY"] = surfaceTTY
+        }
+        if let workingDirectory, !workingDirectory.isEmpty {
+            env["CMUX_HOOK_CWD"] = workingDirectory
+        }
+        if !closedSurfaceIDs.isEmpty {
+            env["CMUX_CLOSED_SURFACE_IDS"] = closedSurfaceIDs.map(\.uuidString).joined(separator: ",")
+        }
+        if !closedSurfaceDirectories.isEmpty {
+            env["CMUX_CLOSED_SURFACE_DIRECTORIES"] = closedSurfaceDirectories.joined(separator: ":")
+        }
+        if let remainingPanes {
+            env["CMUX_REMAINING_PANES"] = String(remainingPanes)
+        }
+        if let remainingSurfaces {
+            env["CMUX_REMAINING_SURFACES"] = String(remainingSurfaces)
+        }
+        return env
+    }
+}
+
+final class TmuxCompatHookDispatcher {
+    static let shared = TmuxCompatHookDispatcher()
+
+    private struct TmuxCompatStore: Codable {
+        var buffers: [String: String] = [:]
+        var hooks: [String: String] = [:]
+    }
+
+    private let queue = DispatchQueue(label: "com.cmuxterm.tmux-compat-hooks", qos: .utility)
+
+    func fire(_ context: TmuxCompatHookContext) {
+        guard let command = command(for: context.event) else { return }
+#if DEBUG
+        dlog(
+            "hook.fire event=\(context.event.rawValue) workspace=\(context.workspaceId?.uuidString.prefix(5) ?? "nil") " +
+            "pane=\(context.paneId?.uuidString.prefix(5) ?? "nil") surface=\(context.surfaceId?.uuidString.prefix(5) ?? "nil")"
+        )
+#endif
+        queue.async {
+            self.run(command: command, context: context)
+        }
+    }
+
+    private func command(for event: TmuxCompatHookEvent) -> String? {
+        let url = tmuxCompatStoreURL()
+        guard let data = try? Data(contentsOf: url),
+              let store = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
+            return nil
+        }
+        let command = store.hooks[event.rawValue]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let command, !command.isEmpty else { return nil }
+        return command
+    }
+
+    private func tmuxCompatStoreURL() -> URL {
+        let root = NSString(string: "~/.cmuxterm").expandingTildeInPath
+        return URL(fileURLWithPath: root).appendingPathComponent("tmux-compat-store.json")
+    }
+
+    private func run(command: String, context: TmuxCompatHookContext) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [
+            "-e", "on run argv",
+            "-e", "do shell script (item 1 of argv)",
+            "-e", "end run",
+            renderedCommand(command: command, context: context)
+        ]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            NSLog("tmux hook %@ failed to launch via osascript: %@", context.event.rawValue, String(describing: error))
+#if DEBUG
+            dlog("hook.exec.fail event=\(context.event.rawValue) reason=launch")
+#endif
+            return
+        }
+
+        guard process.terminationStatus == 0 else {
+            let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let details = stderrText.isEmpty ? stdoutText : stderrText
+            NSLog(
+                "tmux hook %@ failed (%d): %@",
+                context.event.rawValue,
+                process.terminationStatus,
+                details
+            )
+#if DEBUG
+            dlog("hook.exec.fail event=\(context.event.rawValue) reason=exit status=\(process.terminationStatus)")
+#endif
+            return
+        }
+#if DEBUG
+        dlog("hook.exec.ok event=\(context.event.rawValue)")
+#endif
+    }
+
+    private func renderedCommand(command: String, context: TmuxCompatHookContext) -> String {
+        var shellCommand = command
+        if let workingDirectory = context.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workingDirectory.isEmpty {
+            shellCommand = "cd \(cmuxShellQuoted(workingDirectory)) && \(shellCommand)"
+        }
+
+        var env = context.environment(socketPath: SocketControlSettings.socketPath())
+        if let currentHome = ProcessInfo.processInfo.environment["HOME"], !currentHome.isEmpty {
+            env["HOME"] = currentHome
+        }
+        if let currentTmpDir = ProcessInfo.processInfo.environment["TMPDIR"], !currentTmpDir.isEmpty {
+            env["TMPDIR"] = currentTmpDir
+        }
+        if let currentUser = ProcessInfo.processInfo.environment["USER"], !currentUser.isEmpty {
+            env["USER"] = currentUser
+        }
+        if let currentLogname = ProcessInfo.processInfo.environment["LOGNAME"], !currentLogname.isEmpty {
+            env["LOGNAME"] = currentLogname
+        }
+        if let currentShell = ProcessInfo.processInfo.environment["SHELL"], !currentShell.isEmpty {
+            env["SHELL"] = currentShell
+        }
+
+        let inheritedPath = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        if let bundledBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin", isDirectory: true).path,
+           !bundledBinPath.isEmpty {
+            if inheritedPath.isEmpty {
+                env["PATH"] = bundledBinPath
+            } else if inheritedPath.split(separator: ":").contains(Substring(bundledBinPath)) {
+                env["PATH"] = inheritedPath
+            } else {
+                env["PATH"] = bundledBinPath + ":" + inheritedPath
+            }
+        } else {
+            env["PATH"] = inheritedPath
+        }
+
+        let assignments = env.keys.sorted().compactMap { key -> String? in
+            guard let value = env[key], !value.isEmpty else { return nil }
+            return "\(key)=\(cmuxShellQuoted(value))"
+        }
+
+        let envPrefix = assignments.isEmpty ? "" : assignments.joined(separator: " ") + " "
+        return "/usr/bin/env \(envPrefix)/bin/sh -c \(cmuxShellQuoted(shellCommand))"
+    }
+}
+
 // MARK: - Tab Type Alias for Backwards Compatibility
 // The old Tab class is replaced by Workspace
 typealias Tab = Workspace
@@ -827,6 +1041,7 @@ class TabManager: ObservableObject {
                 userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
             )
         }
+        fireWorkspaceHook(.workspaceCreated, workspace: newWorkspace)
 #if DEBUG
         UITestRecorder.incrementInt("addTabInvocations")
         UITestRecorder.record([
@@ -1011,10 +1226,25 @@ class TabManager: ObservableObject {
         return trimmed
     }
 
+    func fireWorkspaceHook(_ event: TmuxCompatHookEvent, workspace: Workspace) {
+        TmuxCompatHookDispatcher.shared.fire(workspace.hookContext(for: event))
+    }
+
+    func fireWorkspaceCloseHookIfPresent(tabId: UUID) {
+        guard let workspace = tabs.first(where: { $0.id == tabId }) else { return }
+        fireWorkspaceHook(.workspaceClose, workspace: workspace)
+    }
+
+    func fireSurfaceCloseHook(workspace: Workspace, panelId: UUID) {
+        guard let context = workspace.hookContextForSurfaceClose(panelId: panelId) else { return }
+        TmuxCompatHookDispatcher.shared.fire(context)
+    }
+
     func closeWorkspace(_ workspace: Workspace) {
         guard tabs.count > 1 else { return }
         guard let index = tabs.firstIndex(where: { $0.id == workspace.id }) else { return }
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
+        fireWorkspaceHook(.workspaceClose, workspace: workspace)
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         unwireClosedBrowserTracking(for: workspace)
@@ -1250,6 +1480,7 @@ class TabManager: ObservableObject {
         let effectiveSurfaceCount = max(tab.panels.count, bonsplitTabCount)
         let isLastTabInWorkspace = effectiveSurfaceCount <= 1
         if isLastTabInWorkspace {
+            fireSurfaceCloseHook(workspace: tab, panelId: panelId)
             let willCloseWindow = tabs.count <= 1
             let needsConfirm = workspaceNeedsConfirmClose(tab)
             if needsConfirm {
@@ -1389,6 +1620,7 @@ class TabManager: ObservableObject {
         // Child-exit on the last panel should collapse the workspace, matching explicit close
         // semantics (and close the window when it was the last workspace).
         if tab.panels.count <= 1 {
+            fireSurfaceCloseHook(workspace: tab, panelId: surfaceId)
             if tabs.count <= 1 {
                 if let app = AppDelegate.shared {
                     app.notificationStore?.clearNotifications(forTabId: tabId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1486,6 +1486,98 @@ final class Workspace: Identifiable, ObservableObject {
         return resolvedPanelTitle(panelId: panelId, fallback: fallback)
     }
 
+    private func normalizedHookDirectory(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func representativePanelIdForHook() -> UUID? {
+        if let focusedPanelId, panels[focusedPanelId] != nil {
+            return focusedPanelId
+        }
+        return panels.keys.sorted(by: { $0.uuidString < $1.uuidString }).first
+    }
+
+    func hookContext(for event: TmuxCompatHookEvent) -> TmuxCompatHookContext {
+        let representativePanelId = representativePanelIdForHook()
+        let workspaceDirectory = normalizedHookDirectory(currentDirectory)
+        let surfaceDirectory = representativePanelId.flatMap { normalizedHookDirectory(panelDirectories[$0]) }
+        let orderedPanelIds = panels.keys.sorted(by: { $0.uuidString < $1.uuidString })
+        let closedSurfaceIDs = event == .workspaceClose ? orderedPanelIds : []
+        let closedSurfaceDirectories = event == .workspaceClose
+            ? orderedPanelIds.compactMap { normalizedHookDirectory(panelDirectories[$0]) }
+            : []
+
+        return TmuxCompatHookContext(
+            event: event,
+            workspaceId: id,
+            workspaceTitle: title,
+            workspaceDirectory: workspaceDirectory,
+            paneId: representativePanelId.flatMap { paneId(forPanelId: $0)?.id },
+            surfaceId: representativePanelId,
+            surfaceTitle: representativePanelId.flatMap { panelTitle(panelId: $0) },
+            surfaceDirectory: surfaceDirectory,
+            surfaceKind: representativePanelId.flatMap { panelKind(panelId: $0) },
+            surfaceTTY: representativePanelId.flatMap { surfaceTTYNames[$0] },
+            workingDirectory: surfaceDirectory ?? workspaceDirectory,
+            closedSurfaceIDs: closedSurfaceIDs,
+            closedSurfaceDirectories: closedSurfaceDirectories,
+            remainingPanes: event == .workspaceClose ? 0 : bonsplitController.allPaneIds.count,
+            remainingSurfaces: event == .workspaceClose ? 0 : panels.count
+        )
+    }
+
+    func hookContextForSurfaceClose(panelId: UUID) -> TmuxCompatHookContext? {
+        guard panels[panelId] != nil else { return nil }
+        let workspaceDirectory = normalizedHookDirectory(currentDirectory)
+        let surfaceDirectory = normalizedHookDirectory(panelDirectories[panelId])
+
+        return TmuxCompatHookContext(
+            event: .surfaceClose,
+            workspaceId: id,
+            workspaceTitle: title,
+            workspaceDirectory: workspaceDirectory,
+            paneId: paneId(forPanelId: panelId)?.id,
+            surfaceId: panelId,
+            surfaceTitle: panelTitle(panelId: panelId),
+            surfaceDirectory: surfaceDirectory,
+            surfaceKind: panelKind(panelId: panelId),
+            surfaceTTY: surfaceTTYNames[panelId],
+            workingDirectory: surfaceDirectory ?? workspaceDirectory,
+            closedSurfaceIDs: [panelId],
+            closedSurfaceDirectories: surfaceDirectory.map { [$0] } ?? [],
+            remainingPanes: bonsplitController.allPaneIds.count,
+            remainingSurfaces: max(0, panels.count - 1)
+        )
+    }
+
+    func hookContextForPaneClose(paneId: PaneID, closedPanelIds: [UUID]) -> TmuxCompatHookContext {
+        let orderedClosedPanelIds = closedPanelIds.sorted(by: { $0.uuidString < $1.uuidString })
+        let representativePanelId = orderedClosedPanelIds.first ?? representativePanelIdForHook()
+        let workspaceDirectory = normalizedHookDirectory(currentDirectory)
+        let surfaceDirectory = representativePanelId.flatMap { normalizedHookDirectory(panelDirectories[$0]) }
+
+        return TmuxCompatHookContext(
+            event: .paneClose,
+            workspaceId: id,
+            workspaceTitle: title,
+            workspaceDirectory: workspaceDirectory,
+            paneId: paneId.id,
+            surfaceId: representativePanelId,
+            surfaceTitle: representativePanelId.flatMap { panelTitle(panelId: $0) },
+            surfaceDirectory: surfaceDirectory,
+            surfaceKind: representativePanelId.flatMap { panelKind(panelId: $0) },
+            surfaceTTY: representativePanelId.flatMap { surfaceTTYNames[$0] },
+            workingDirectory: surfaceDirectory ?? workspaceDirectory,
+            closedSurfaceIDs: orderedClosedPanelIds,
+            closedSurfaceDirectories: orderedClosedPanelIds.compactMap { normalizedHookDirectory(panelDirectories[$0]) },
+            remainingPanes: bonsplitController.allPaneIds.count,
+            remainingSurfaces: max(0, panels.count - orderedClosedPanelIds.count)
+        )
+    }
+
     func setPanelPinned(panelId: UUID, pinned: Bool) {
         guard panels[panelId] != nil else { return }
         let wasPinned = pinnedPanelIds.contains(panelId)
@@ -4002,6 +4094,18 @@ extension Workspace: BonsplitDelegate {
         )
 #endif
 
+        let paneClosedViaTabClose = !isDetaching
+            && !controller.allPaneIds.contains(pane)
+            && pendingPaneClosePanelIds[pane.id] == nil
+        if !isDetaching, let hookContext = hookContextForSurfaceClose(panelId: panelId) {
+            TmuxCompatHookDispatcher.shared.fire(hookContext)
+        }
+        if paneClosedViaTabClose {
+            TmuxCompatHookDispatcher.shared.fire(
+                hookContextForPaneClose(paneId: pane, closedPanelIds: [panelId])
+            )
+        }
+
         if isDetaching, let panel {
             let browserPanel = panel as? BrowserPanel
             let cachedTitle = panelTitles[panelId]
@@ -4191,6 +4295,12 @@ extension Workspace: BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {
         let closedPanelIds = pendingPaneClosePanelIds.removeValue(forKey: paneId.id) ?? []
         let shouldScheduleFocusReconcile = !isDetachingCloseTransaction
+        let surfaceHookContexts = !isDetachingCloseTransaction
+            ? closedPanelIds.compactMap { hookContextForSurfaceClose(panelId: $0) }
+            : []
+        let paneHookContext = !isDetachingCloseTransaction && !closedPanelIds.isEmpty
+            ? hookContextForPaneClose(paneId: paneId, closedPanelIds: closedPanelIds)
+            : nil
 #if DEBUG
         dlog(
             "surface.didClosePane.begin pane=\(paneId.id.uuidString.prefix(5)) " +
@@ -4199,6 +4309,12 @@ extension Workspace: BonsplitDelegate {
 #endif
 
         if !closedPanelIds.isEmpty {
+            for hookContext in surfaceHookContexts {
+                TmuxCompatHookDispatcher.shared.fire(hookContext)
+            }
+            if let paneHookContext {
+                TmuxCompatHookDispatcher.shared.fire(paneHookContext)
+            }
             for panelId in closedPanelIds {
 #if DEBUG
                 dlog(

--- a/tests_v2/test_tmux_compat_matrix.py
+++ b/tests_v2/test_tmux_compat_matrix.py
@@ -234,12 +234,25 @@ def main() -> int:
 
         _run_cli(cli, ["clear-history", "--workspace", ws, "--surface", s1])
 
-        _run_cli(cli, ["set-hook", "workspace-created", "echo created"])
+        hook_file = Path(tempfile.gettempdir()) / f"cmux_tmux_hook_{stamp}.log"
+        if hook_file.exists():
+            hook_file.unlink()
+        hook_token = f"TMUX_HOOK_{stamp}"
+        hook_command = f"printf '%s\\n' {hook_token} >> '{hook_file}'"
+
+        _run_cli(cli, ["set-hook", "workspace-close", hook_command])
         hooks = _run_cli(cli, ["set-hook", "--list"])
-        _must("workspace-created" in hooks.stdout, f"set-hook --list missing stored hook: {hooks.stdout!r}")
-        _run_cli(cli, ["set-hook", "--unset", "workspace-created"])
+        _must("workspace-close" in hooks.stdout, f"set-hook --list missing stored hook: {hooks.stdout!r}")
+        _run_cli(cli, ["tmux-hook-runner", "--ensure"])
+        _run_cli(cli, ["tmux-hook-runner", "--ensure"])
+
+        ws_hook = c.new_workspace()
+        _run_cli(cli, ["close-workspace", "--workspace", ws_hook])
+        _wait_for(lambda: hook_file.exists() and hook_token in hook_file.read_text())
+
+        _run_cli(cli, ["set-hook", "--unset", "workspace-close"])
         hooks2 = _run_cli(cli, ["set-hook", "--list"])
-        _must("workspace-created" not in hooks2.stdout, f"set-hook --unset failed: {hooks2.stdout!r}")
+        _must("workspace-close" not in hooks2.stdout, f"set-hook --unset failed: {hooks2.stdout!r}")
 
         for cmd in (["popup"], ["bind-key", "C-b", "split-window"], ["unbind-key", "C-b"], ["copy-mode"]):
             proc = _run_cli(cli, cmd, expect_ok=False)


### PR DESCRIPTION
## Summary
- move tmux-compat hook execution into a detached `cmux tmux-hook-runner` helper so hook commands run outside the app sandbox
- dispatch hook events from the app over a private Unix socket, keep the runner warm from shell integration, and stop it when the last hook is removed
- fire `workspace-close` only after the window actually unregisters, encode closed-surface directories safely, and drain hook stdout/stderr asynchronously to avoid deadlocks
- extend the tmux compatibility matrix test to cover persisted hook execution and idempotent helper startup

## Verification
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag issue-996-set-hook-sandbox`
- no local automated tests were run per repo policy

Fixes #996


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensible hook system for workspace and surface lifecycle events, with a tmux-compatible hook runner and environment-aware command execution.
  * Shell integrations now ensure the hook runner is started automatically.

* **Bug Fixes**
  * Improved stability when closing windows/tabs: safer close handling and guaranteed per-tab close hook invocation.

* **Tests**
  * Added/updated tests covering hook setup, triggering, and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->