### PR TITLE
Polish feedback help menu copy

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -726,13 +726,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Up to 10 images. Large images will be optimized before sending."
+            "value": "Up to 10 images."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "画像は最大10枚まで添付できます。大きな画像は送信前に最適化されます。"
+            "value": "画像は最大10枚まで添付できます。"
           }
         }
       }
@@ -981,13 +981,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A human will read this! You can also reach us at founders@manaflow.com."
+            "value": "You can also reach us at founders@manaflow.com."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "人間がこれを読みます。founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
+            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
           }
         }
       }
@@ -1049,13 +1049,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A human will read this! You can also reach us at founders@manaflow.com."
+            "value": "You can also reach us at founders@manaflow.com."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "人間がこれを読みます。founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
+            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6069,7 +6069,7 @@ enum DevBuildBannerDebugSettings {
 private enum FeedbackComposerSettings {
     static let storedEmailKey = "sidebarHelpFeedbackEmail"
     static let endpointEnvironmentKey = "CMUX_FEEDBACK_API_URL"
-    static let defaultEndpoint = "https://cmux.dev/api/feedback"
+    static let defaultEndpoint = "https://www.cmux.dev/api/feedback"
     static let foundersEmail = "founders@manaflow.com"
     static let maxMessageLength = 4_000
     static let maxAttachmentCount = 10
@@ -7044,7 +7044,7 @@ private struct SidebarFeedbackComposerSheet: View {
             Text(
                 String(
                     localized: "sidebar.help.feedback.successBody",
-                    defaultValue: "A human will read this! You can also reach us at founders@manaflow.com."
+                    defaultValue: "You can also reach us at founders@manaflow.com."
                 )
             )
             .font(.system(size: 12))
@@ -7124,7 +7124,7 @@ private struct SidebarFeedbackComposerSheet: View {
                     Text(
                         String(
                             localized: "sidebar.help.feedback.attachmentsHint",
-                            defaultValue: "Up to 10 images. Large images will be optimized before sending."
+                            defaultValue: "Up to 10 images."
                         )
                     )
                     .font(.system(size: 11))
@@ -7358,7 +7358,7 @@ private struct SidebarFeedbackComposerSheet: View {
                     localized: "sidebar.help.feedback.rateLimited",
                     defaultValue: "Too many feedback attempts. Please try again later."
                 )
-            case 503:
+            case 500...599:
                 return String(
                     localized: "sidebar.help.feedback.endpointError",
                     defaultValue: "Feedback is unavailable right now. Email founders@manaflow.com instead."
@@ -7381,10 +7381,18 @@ private struct SidebarHelpMenuButton: View {
     private let helpTitle = String(localized: "sidebar.help.button", defaultValue: "Help")
     private let buttonSize: CGFloat = 22
     private let iconSize: CGFloat = 11
+    @AppStorage(KeyboardShortcutSettings.Action.sendFeedback.defaultsKey) private var sendFeedbackShortcutData = Data()
 
     let onSendFeedback: () -> Void
 
     @State private var isPopoverPresented = false
+
+    private var sendFeedbackShortcutHint: String {
+        decodeShortcut(
+            from: sendFeedbackShortcutData,
+            fallback: KeyboardShortcutSettings.Action.sendFeedback.defaultShortcut
+        ).displayString
+    }
 
     var body: some View {
         Button {
@@ -7414,6 +7422,7 @@ private struct SidebarHelpMenuButton: View {
                 action: .sendFeedback,
                 accessibilityIdentifier: "SidebarHelpMenuOptionSendFeedback",
                 isExternalLink: false,
+                shortcutHint: sendFeedbackShortcutHint,
                 trailingSystemImage: "bubble.left.and.text.bubble.right"
             )
             helpOptionButton(
@@ -7470,6 +7479,7 @@ private struct SidebarHelpMenuButton: View {
         action: SidebarHelpMenuAction,
         accessibilityIdentifier: String,
         isExternalLink: Bool,
+        shortcutHint: String? = nil,
         trailingSystemImage: String? = nil
     ) -> some View {
         Button {
@@ -7480,6 +7490,9 @@ private struct SidebarHelpMenuButton: View {
                 Text(title)
                     .font(.system(size: 12))
                 Spacer(minLength: 0)
+                if let shortcutHint {
+                    helpOptionShortcutHint(text: shortcutHint)
+                }
                 if let trailingSystemImage {
                     helpOptionTrailingIcon(systemName: trailingSystemImage)
                 }
@@ -7493,6 +7506,15 @@ private struct SidebarHelpMenuButton: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func helpOptionShortcutHint(text: String) -> some View {
+        Text(text)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .font(.system(size: 10, weight: .regular, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(Color(nsColor: .secondaryLabelColor))
     }
 
     private func helpOptionTrailingIcon(systemName: String, size: CGFloat = 13) -> some View {
@@ -7536,6 +7558,14 @@ private struct SidebarHelpMenuButton: View {
             isPopoverPresented = false
             onSendFeedback()
         }
+    }
+
+    private func decodeShortcut(from data: Data, fallback: StoredShortcut) -> StoredShortcut {
+        guard !data.isEmpty,
+              let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) else {
+            return fallback
+        }
+        return shortcut
     }
 }
 

--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -103,7 +103,7 @@ export async function POST(request: Request) {
   const resend = new Resend(feedbackConfig.resendApiKey);
 
   const { error } = await resend.emails.send({
-    from: `cmux feedback <${feedbackConfig.fromEmail}>`,
+    from: `Manaflow <${feedbackConfig.fromEmail}>`,
     to: [feedbackRecipient],
     replyTo: email,
     subject,


### PR DESCRIPTION
## Summary
- point the app feedback form at https://www.cmux.dev/api/feedback
- simplify the feedback sheet copy and show the send-feedback shortcut in the help menu
- use a Manaflow sender display name for feedback emails and treat backend 5xx responses as endpoint failures

## Validation
- ./scripts/reload.sh --tag feedback-merge
- bun x tsc --noEmit
- RESEND_API_KEY=dummy CMUX_FEEDBACK_FROM_EMAIL=noreply@manaflow.ai CMUX_FEEDBACK_RATE_LIMIT_ID=cmux-feedback bun run build

## Notes
- External Codex review could not complete because the review workspace hit a Codex usage-limit error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified feedback copy and added a keyboard shortcut hint in the Help menu. Updated the feedback endpoint and sender name, and improved server error handling.

- **New Features**
  - Show the Send Feedback keyboard shortcut in the Help menu.
  - Default feedback endpoint set to https://www.cmux.dev/api/feedback.
  - Feedback emails now use "Manaflow" as the sender display name.
  - Cleaner copy: concise success message and attachment hint.

- **Bug Fixes**
  - Treat backend 5xx responses as endpoint failures and show a clear fallback message.

<sup>Written for commit e45b83335b631870364230410c9a3acdd5fc1bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

