### PR TITLE
Change feedback recipient to feedback@manaflow.com

### DIFF
--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -8,7 +8,7 @@ import { env } from "@/app/env";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const feedbackRecipient = "founders@manaflow.com";
+const feedbackRecipient = "feedback@manaflow.com";
 const maxAttachmentCount = 10;
 const maxAttachmentBytes = 4 * 1024 * 1024;
 // Keep multipart requests below Vercel Functions' 4.5 MB request-body limit.


### PR DESCRIPTION
Changes feedback email recipient from `founders@manaflow.com` to `feedback@manaflow.com`.

Also update `CMUX_FEEDBACK_FROM_EMAIL` env var in Vercel to `noreply@manaflow.com`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route feedback emails to feedback@manaflow.com so all app feedback goes to the dedicated inbox. Updated Vercel env (CMUX_FEEDBACK_FROM_EMAIL) to noreply@manaflow.com.

<sup>Written for commit 34eec2ccd73f3312ffac6e637b17a44366ad87b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feedback submission routing to direct user feedback to the correct inbox address for processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->