### PR TITLE
Add blog post: The best worktree manager is Claude Code

### DIFF
--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -62,7 +62,7 @@ export default function WorktreeManagerPage() {
         <Link href="https://github.com/coderabbitai/git-worktree-runner">
           git-worktree-runner
         </Link>
-        . We don&apos;t use any of them. We put a few paragraphs of instructions
+        . We ended up not needing one. A few paragraphs of instructions
         in a <code>CLAUDE.md</code> and Claude Code handles the rest: creating
         worktrees, working in them, committing, pushing, opening PRs, cleaning
         up. The worktree manager is just prose.

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -149,19 +149,31 @@ export default function WorktreeManagerPage() {
       <pre>
         <code>{`I want to set up an HQ repo for this project so I can use git worktrees
 to work on multiple things in parallel. Create a new directory called
-<project>-hq one level up from here, git init it, move or clone this
-repo into <project>-hq/repo/, create a worktrees/ directory, and write
-a CLAUDE.md with instructions for the worktree workflow (never edit
-repo/ directly, always create a worktree first, fetch before branching,
-clean up when done, push branches and open PRs).`}</code>
+<project>-hq one level up from here, git init it, clone this repo into
+<project>-hq/repo/, create a worktrees/ directory, and set up the
+following files:
+
+<project>-hq/
+  repo/               # clone of this project (stays on main)
+  worktrees/          # one worktree per task/issue
+  CLAUDE.md           # symlink to AGENTS.md
+  AGENTS.md           # worktree workflow instructions
+
+AGENTS.md should contain instructions for the worktree workflow: never
+edit repo/ directly, always create a worktree first, fetch before
+branching, clean up when done, push branches and open PRs. Symlink
+CLAUDE.md to AGENTS.md so both Claude Code and other agents read the
+same instructions.`}</code>
       </pre>
 
       <p>
-        Claude Code will set up the structure, write the{" "}
-        <code>CLAUDE.md</code>, and from then on it knows how to create
-        worktrees when you ask it to work on something. You can add more
-        instructions over time (naming conventions, build commands, test
-        policies, multi-repo setup) and the workflow grows with you.
+        Claude Code will set up the structure, write the instructions, and from
+        then on it knows how to create worktrees when you ask it to work on
+        something. The <code>AGENTS.md</code> / <code>CLAUDE.md</code> symlink
+        means the same instructions work for any agent that reads either
+        filename. You can add more over time (naming conventions, build
+        commands, test policies, multi-repo setup) and the workflow grows with
+        you.
       </p>
     </>
   );

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -1,0 +1,234 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "The best worktree manager is Claude Code",
+  description:
+    "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
+  keywords: [
+    "cmux",
+    "claude code",
+    "git worktrees",
+    "AI coding agents",
+    "developer tools",
+    "monorepo",
+    "workflow",
+    "terminal",
+    "macOS",
+  ],
+  openGraph: {
+    title: "The best worktree manager is Claude Code",
+    description:
+      "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
+    type: "article",
+    publishedTime: "2026-03-06T00:00:00Z",
+    url: "https://cmux.dev/blog/worktree-manager",
+  },
+  twitter: {
+    card: "summary",
+    title: "The best worktree manager is Claude Code",
+    description:
+      "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
+  },
+  alternates: {
+    canonical: "https://cmux.dev/blog/worktree-manager",
+  },
+};
+
+export default function WorktreeManagerPage() {
+  return (
+    <>
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="text-sm text-muted hover:text-foreground transition-colors"
+        >
+          &larr; Back to blog
+        </Link>
+      </div>
+
+      <h1>The best worktree manager is Claude Code</h1>
+      <time dateTime="2026-03-06" className="text-sm text-muted">
+        March 6, 2026
+      </time>
+
+      <p className="mt-6">
+        We run 10+ agents in parallel on the same codebase. Each agent needs its
+        own working directory so they don&apos;t step on each other&apos;s files.
+        Git worktrees solve this perfectly, and we don&apos;t use a dedicated
+        worktree tool. We just put instructions in a <code>CLAUDE.md</code> and
+        let Claude Code manage them.
+      </p>
+
+      <h2>The HQ pattern</h2>
+
+      <p>
+        The setup is a dedicated repo we call <code>cmuxterm-hq</code>. It sits
+        outside the main project repo and contains two things: a primary
+        checkout and a folder of worktrees.
+      </p>
+
+      <pre>
+        <code>{`cmuxterm-hq/          # its own git repo
+  repo/               # primary checkout of manaflow-ai/cmux (main branch)
+  worktrees/
+    issue-537-notif-crash/
+    issue-541-keychain/
+    feat-sidebar-ports/
+  CLAUDE.md           # instructions for the orchestrator agent
+  scripts/            # shared automation (spawn agents, wait for results, notify)`}</code>
+      </pre>
+
+      <p>
+        The <code>repo/</code> directory stays on <code>main</code> and is never
+        edited directly. It&apos;s the base for creating worktrees. When an
+        agent picks up a task, it runs:
+      </p>
+
+      <pre>
+        <code>{`cd repo
+git worktree add ../worktrees/issue-537-notif-crash -b issue-537-notif-crash origin/main`}</code>
+      </pre>
+
+      <p>
+        Each worktree is a full working copy with its own branch. Agents can
+        build, test, and commit independently. When the work is done, the
+        worktree gets cleaned up.
+      </p>
+
+      <h2>Why a separate repo?</h2>
+
+      <p>
+        The HQ repo is not the project repo. This is intentional. The HQ holds
+        orchestration scripts, shared skills, board state, and a{" "}
+        <code>CLAUDE.md</code> with project-wide conventions. It&apos;s the
+        control plane. The worktrees are the data plane.
+      </p>
+
+      <p>
+        Because the HQ is its own repo, it can version its own automation
+        independently. You can iterate on your agent workflow (scripts,
+        prompts, conventions) without polluting your project&apos;s commit
+        history.
+      </p>
+
+      <h2>Multi-repo conditioning</h2>
+
+      <p>
+        This pattern scales beyond a single project. If you have an iOS app in
+        one repo and a backend in another, the HQ can hold both:
+      </p>
+
+      <pre>
+        <code>{`my-hq/
+  ios-repo/             # primary checkout of the iOS app
+  backend-repo/         # primary checkout of the backend
+  worktrees/
+    ios-issue-42-auth/
+    backend-feat-api-v2/
+  CLAUDE.md             # instructions that span both codebases`}</code>
+      </pre>
+
+      <p>
+        The agent sees one <code>CLAUDE.md</code> that knows about both
+        codebases. It can reason across them: &quot;the iOS app calls{" "}
+        <code>/api/v1/users</code>, the backend is migrating to v2, update
+        both.&quot; This is the monorepo benefit without actually merging repos.
+      </p>
+
+      <h2>Claude Code as the worktree manager</h2>
+
+      <p>
+        We don&apos;t use a separate tool to manage worktrees. The{" "}
+        <code>CLAUDE.md</code> in the HQ repo contains the rules:
+      </p>
+
+      <ul>
+        <li>Never edit code directly in <code>repo/</code></li>
+        <li>
+          Always create a worktree first, named{" "}
+          <code>issue-&lt;N&gt;-&lt;slug&gt;</code>
+        </li>
+        <li>Fetch and sync before branching</li>
+        <li>Clean up worktrees when done</li>
+        <li>Push branches, never push to main</li>
+      </ul>
+
+      <p>
+        Claude Code follows these instructions reliably. It creates worktrees,
+        works in them, commits, pushes, opens PRs, and cleans up. The
+        &quot;worktree manager&quot; is just a paragraph in a markdown file.
+      </p>
+
+      <h2>Shared skills and scripts</h2>
+
+      <p>
+        The HQ repo is also where shared automation lives. We have scripts for
+        spawning agents into{" "}
+        <Link href="https://cmux.dev">cmux</Link> workspaces, waiting for them
+        to finish, running review loops, and sending notifications. These
+        scripts work across any worktree because they live in the HQ, not in the
+        project.
+      </p>
+
+      <p>
+        Claude Code skills defined in the HQ are available to any task,
+        regardless of which worktree the agent is working in. The HQ is the
+        shared context that ties everything together.
+      </p>
+
+      <h2>How to replicate this</h2>
+
+      <p>
+        You don&apos;t need cmux to use this pattern (though it helps for
+        running many agents visually). Here&apos;s the minimal setup:
+      </p>
+
+      <ol>
+        <li>
+          Create a new directory and <code>git init</code> it. This is your HQ.
+        </li>
+        <li>
+          Clone your project into <code>repo/</code> inside it.
+        </li>
+        <li>
+          Add a <code>CLAUDE.md</code> to the HQ root with your worktree
+          conventions and any cross-repo instructions.
+        </li>
+        <li>
+          Start Claude Code from the HQ directory. Ask it to work on an issue.
+          It will create the worktree and do the work there.
+        </li>
+      </ol>
+
+      <pre>
+        <code>{`mkdir my-project-hq && cd my-project-hq
+git init
+git clone https://github.com/you/your-project repo
+mkdir worktrees`}</code>
+      </pre>
+
+      <p>
+        Add a <code>CLAUDE.md</code> like this:
+      </p>
+
+      <pre>
+        <code>{`# my-project-hq
+
+- \`repo/\` is the primary checkout (main branch). Never edit it directly.
+- \`worktrees/\` contains one worktree per task.
+
+When starting work:
+1. cd repo && git fetch origin
+2. git worktree add ../worktrees/<branch> -b <branch> origin/main
+3. Work in the worktree. Push and PR when done.
+4. Clean up: git worktree remove ../worktrees/<branch>`}</code>
+      </pre>
+
+      <p>
+        That&apos;s it. Claude Code reads the instructions, follows them, and
+        you get isolated branches for parallel work with no extra tooling.
+      </p>
+    </>
+  );
+}

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -66,7 +66,7 @@ export default function WorktreeManagerPage() {
       </p>
 
       <p>
-        I personally tried a different approach, which is just putting a few
+        I personally like a different approach, which is just putting a few
         paragraphs of instructions in a <code>CLAUDE.md</code>. Claude Code
         handles the rest: creating worktrees, working in them, committing,
         pushing, opening PRs, cleaning up. The worktree manager is just prose.

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -53,153 +53,71 @@ export default function WorktreeManagerPage() {
       </time>
 
       <p className="mt-6">
-        We run 10+ agents in parallel on the same codebase. Each agent needs its
-        own working directory so they don&apos;t step on each other&apos;s files.
-        Git worktrees solve this perfectly, and we don&apos;t use a dedicated
-        worktree tool. We just put instructions in a <code>CLAUDE.md</code> and
-        let Claude Code manage them.
+        cmux intentionally does not have a builtin git worktree manager. cmux
+        intentionally has no opinion on worktrees. We tried building one and
+        realized we already had something better: a <code>CLAUDE.md</code> file
+        with a few paragraphs of instructions. Claude Code reads them, creates
+        worktrees, works in them, commits, pushes, opens PRs, and cleans up.
+        The worktree manager is just prose.
       </p>
 
-      <h2>The HQ pattern</h2>
+      <h2>What we actually do</h2>
 
       <p>
-        The setup is a dedicated repo we call <code>cmuxterm-hq</code>. It sits
-        outside the main project repo and contains two things: a primary
-        checkout and a folder of worktrees.
+        We have a repo called <code>cmuxterm-hq</code> that sits outside the
+        cmux source repo. It contains a primary checkout, a folder of worktrees,
+        and the <code>CLAUDE.md</code> that tells agents how to use them.
       </p>
 
       <pre>
-        <code>{`cmuxterm-hq/          # its own git repo
-  repo/               # primary checkout of manaflow-ai/cmux (main branch)
+        <code>{`cmuxterm-hq/
+  repo/               # primary checkout (stays on main, never edited directly)
   worktrees/
     issue-537-notif-crash/
     issue-541-keychain/
     feat-sidebar-ports/
-  CLAUDE.md           # instructions for the orchestrator agent
-  scripts/            # shared automation (spawn agents, wait for results, notify)`}</code>
+  CLAUDE.md
+  scripts/`}</code>
       </pre>
 
       <p>
-        The <code>repo/</code> directory stays on <code>main</code> and is never
-        edited directly. It&apos;s the base for creating worktrees. When an
-        agent picks up a task, it runs:
-      </p>
-
-      <pre>
-        <code>{`cd repo
-git worktree add ../worktrees/issue-537-notif-crash -b issue-537-notif-crash origin/main`}</code>
-      </pre>
-
-      <p>
-        Each worktree is a full working copy with its own branch. Agents can
-        build, test, and commit independently. When the work is done, the
-        worktree gets cleaned up.
-      </p>
-
-      <h2>Why a separate repo?</h2>
-
-      <p>
-        The HQ repo is not the project repo. This is intentional. The HQ holds
-        orchestration scripts, shared skills, board state, and a{" "}
-        <code>CLAUDE.md</code> with project-wide conventions. It&apos;s the
-        control plane. The worktrees are the data plane.
+        When an agent picks up a task, it creates a worktree off <code>main</code>,
+        does the work there, and cleans up when done. Each worktree is a full
+        working copy with its own branch, so agents can build and test in
+        parallel without conflicts.
       </p>
 
       <p>
-        Because the HQ is its own repo, it can version its own automation
-        independently. You can iterate on your agent workflow (scripts,
-        prompts, conventions) without polluting your project&apos;s commit
-        history.
+        The HQ being its own repo is nice because you can version your
+        automation, scripts, and agent conventions separately from your
+        project&apos;s commit history. Skills defined in the HQ are available
+        to every agent regardless of which worktree they&apos;re in.
       </p>
 
-      <h2>Multi-repo conditioning</h2>
+      <h2>Multiple codebases</h2>
 
       <p>
-        This pattern scales beyond a single project. If you have an iOS app in
-        one repo and a backend in another, the HQ can hold both:
+        This also works across repos. If you have an iOS app and a backend in
+        separate repos, one HQ can hold both checkouts and a single{" "}
+        <code>CLAUDE.md</code> that spans them.
       </p>
 
       <pre>
         <code>{`my-hq/
-  ios-repo/             # primary checkout of the iOS app
-  backend-repo/         # primary checkout of the backend
+  ios-repo/
+  backend-repo/
   worktrees/
     ios-issue-42-auth/
     backend-feat-api-v2/
-  CLAUDE.md             # instructions that span both codebases`}</code>
+  CLAUDE.md`}</code>
       </pre>
 
       <p>
-        The agent sees one <code>CLAUDE.md</code> that knows about both
-        codebases. It can reason across them: &quot;the iOS app calls{" "}
-        <code>/api/v1/users</code>, the backend is migrating to v2, update
-        both.&quot; This is the monorepo benefit without actually merging repos.
+        The agent can reason across both codebases from one place. Monorepo
+        benefits without merging repos.
       </p>
 
-      <h2>Claude Code as the worktree manager</h2>
-
-      <p>
-        We don&apos;t use a separate tool to manage worktrees. The{" "}
-        <code>CLAUDE.md</code> in the HQ repo contains the rules:
-      </p>
-
-      <ul>
-        <li>Never edit code directly in <code>repo/</code></li>
-        <li>
-          Always create a worktree first, named{" "}
-          <code>issue-&lt;N&gt;-&lt;slug&gt;</code>
-        </li>
-        <li>Fetch and sync before branching</li>
-        <li>Clean up worktrees when done</li>
-        <li>Push branches, never push to main</li>
-      </ul>
-
-      <p>
-        Claude Code follows these instructions reliably. It creates worktrees,
-        works in them, commits, pushes, opens PRs, and cleans up. The
-        &quot;worktree manager&quot; is just a paragraph in a markdown file.
-      </p>
-
-      <h2>Shared skills and scripts</h2>
-
-      <p>
-        The HQ repo is also where shared automation lives. We have scripts for
-        spawning agents into{" "}
-        <Link href="https://cmux.dev">cmux</Link> workspaces, waiting for them
-        to finish, running review loops, and sending notifications. These
-        scripts work across any worktree because they live in the HQ, not in the
-        project.
-      </p>
-
-      <p>
-        Claude Code skills defined in the HQ are available to any task,
-        regardless of which worktree the agent is working in. The HQ is the
-        shared context that ties everything together.
-      </p>
-
-      <h2>How to replicate this</h2>
-
-      <p>
-        You don&apos;t need cmux to use this pattern (though it helps for
-        running many agents visually). Here&apos;s the minimal setup:
-      </p>
-
-      <ol>
-        <li>
-          Create a new directory and <code>git init</code> it. This is your HQ.
-        </li>
-        <li>
-          Clone your project into <code>repo/</code> inside it.
-        </li>
-        <li>
-          Add a <code>CLAUDE.md</code> to the HQ root with your worktree
-          conventions and any cross-repo instructions.
-        </li>
-        <li>
-          Start Claude Code from the HQ directory. Ask it to work on an issue.
-          It will create the worktree and do the work there.
-        </li>
-      </ol>
+      <h2>Try it</h2>
 
       <pre>
         <code>{`mkdir my-project-hq && cd my-project-hq
@@ -209,7 +127,7 @@ mkdir worktrees`}</code>
       </pre>
 
       <p>
-        Add a <code>CLAUDE.md</code> like this:
+        Add a <code>CLAUDE.md</code>:
       </p>
 
       <pre>
@@ -226,8 +144,8 @@ When starting work:
       </pre>
 
       <p>
-        That&apos;s it. Claude Code reads the instructions, follows them, and
-        you get isolated branches for parallel work with no extra tooling.
+        Start Claude Code from the HQ directory and ask it to work on something.
+        It handles the rest.
       </p>
     </>
   );

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -54,11 +54,18 @@ export default function WorktreeManagerPage() {
 
       <p className="mt-6">
         cmux intentionally does not have a builtin git worktree manager. cmux
-        intentionally has no opinion on worktrees. We tried building one and
-        realized we already had something better: a <code>CLAUDE.md</code> file
-        with a few paragraphs of instructions. Claude Code reads them, creates
-        worktrees, works in them, commits, pushes, opens PRs, and cleans up.
-        The worktree manager is just prose.
+        intentionally has no opinion on worktrees. There are plenty of dedicated
+        tools for this now:{" "}
+        <Link href="https://github.com/d-kuro/gwq">gwq</Link>,{" "}
+        <Link href="https://github.com/satococoa/wtp">wtp</Link>,{" "}
+        <Link href="https://github.com/max-sixty/worktrunk">worktrunk</Link>,{" "}
+        <Link href="https://github.com/coderabbitai/git-worktree-runner">
+          git-worktree-runner
+        </Link>
+        . We don&apos;t use any of them. We put a few paragraphs of instructions
+        in a <code>CLAUDE.md</code> and Claude Code handles the rest: creating
+        worktrees, working in them, committing, pushing, opening PRs, cleaning
+        up. The worktree manager is just prose.
       </p>
 
       <h2>What we actually do</h2>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { CodeBlock } from "../../components/code-block";
 
 export const metadata: Metadata = {
-  title: "The best git worktree manager",
+  title: "The best git worktree manager is Claude Code",
   description:
     "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
   keywords: [
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     "macOS",
   ],
   openGraph: {
-    title: "The best git worktree manager",
+    title: "The best git worktree manager is Claude Code",
     description:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
     type: "article",
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary",
-    title: "The best git worktree manager",
+    title: "The best git worktree manager is Claude Code",
     description:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
   },
@@ -48,7 +48,7 @@ export default async function WorktreeManagerPage() {
         </Link>
       </div>
 
-      <h1>The best git worktree manager</h1>
+      <h1>The best git worktree manager is Claude Code</h1>
       <time dateTime="2026-03-06" className="text-sm text-muted">
         March 6, 2026
       </time>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -54,16 +54,16 @@ export default async function WorktreeManagerPage() {
       </time>
 
       <p className="mt-6">
-        cmux intentionally does not have a builtin git worktree manager. cmux
-        intentionally has no opinion on worktrees. There are plenty of dedicated
-        tools for this:{" "}
+
+        cmux intentionally does not have a builtin git worktree manager. There
+        are good ones out there ({" "}
         <Link href="https://github.com/d-kuro/gwq">gwq</Link>,{" "}
         <Link href="https://github.com/satococoa/wtp">wtp</Link>,{" "}
         <Link href="https://github.com/max-sixty/worktrunk">worktrunk</Link>,{" "}
         <Link href="https://github.com/coderabbitai/git-worktree-runner">
           git-worktree-runner
         </Link>
-        .
+        ) but cmux intentionally has no opinion on worktrees.
       </p>
 
       <p>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -152,16 +152,16 @@ AGENTS.md should contain instructions for the worktree workflow:
 - Push branches and open PRs. Never push to main directly.
 - Clean up when done: git worktree remove ../worktrees/<branch>
 
-Symlink CLAUDE.md to AGENTS.md so both Claude Code and other agents read the same instructions.`}</CodeBlock>
+Symlink CLAUDE.md to AGENTS.md so both Claude Code and other agents read the same instructions.
+
+Before writing AGENTS.md, interview me about my project: what language/framework it uses, how to build and test, any branch naming conventions I already follow, whether I use multiple repos, and anything else that would make the instructions more useful. Then write AGENTS.md tailored to my answers.`}</CodeBlock>
 
       <p>
-        Claude Code will set up the structure, write the instructions, and from
-        then on it knows how to create worktrees when you ask it to work on
-        something. The <code>AGENTS.md</code> / <code>CLAUDE.md</code> symlink
-        means the same instructions work for any agent that reads either
-        filename. You can add more over time (naming conventions, build
-        commands, test policies, multi-repo setup) and the workflow grows with
-        you.
+        Claude Code will ask you a few questions, set up the structure, and
+        write an <code>AGENTS.md</code> that actually fits your project. The{" "}
+        <code>CLAUDE.md</code> symlink means the same instructions work for any
+        agent that reads either filename. You can keep adding to it over time
+        and the workflow grows with you.
       </p>
     </>
   );

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { CodeBlock } from "../../components/code-block";
 
 export const metadata: Metadata = {
-  title: "The best worktree manager is Claude Code",
+  title: "The best git worktree manager",
   description:
     "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
   keywords: [
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     "macOS",
   ],
   openGraph: {
-    title: "The best worktree manager is Claude Code",
+    title: "The best git worktree manager",
     description:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
     type: "article",
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary",
-    title: "The best worktree manager is Claude Code",
+    title: "The best git worktree manager",
     description:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
   },
@@ -48,7 +48,7 @@ export default async function WorktreeManagerPage() {
         </Link>
       </div>
 
-      <h1>The best worktree manager is Claude Code</h1>
+      <h1>The best git worktree manager</h1>
       <time dateTime="2026-03-06" className="text-sm text-muted">
         March 6, 2026
       </time>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -129,35 +129,39 @@ export default function WorktreeManagerPage() {
         anything into a monorepo.
       </p>
 
-      <h2>Try it</h2>
-
-      <pre>
-        <code>{`mkdir my-project-hq && cd my-project-hq
-git init
-git clone https://github.com/you/your-project repo
-mkdir worktrees`}</code>
-      </pre>
+      <h2>Skills are just prompts</h2>
 
       <p>
-        Add a <code>CLAUDE.md</code>:
+        We have a Claude Code skill called <code>/issue-workspace-pr</code> that
+        takes a GitHub issue URL (or plain text task), creates a worktree,
+        implements the fix, pushes, and opens a PR. It sounds like a feature but
+        it&apos;s really just a prompt that tells Claude Code the steps. It
+        could live in the <code>CLAUDE.md</code> instead and work the same way.
+        Skills are just prompts you can invoke by name.
+      </p>
+
+      <h2>Try it</h2>
+
+      <p>
+        Open Claude Code in your project directory and paste this:
       </p>
 
       <pre>
-        <code>{`# my-project-hq
-
-- \`repo/\` is the primary checkout (main branch). Never edit it directly.
-- \`worktrees/\` contains one worktree per task.
-
-When starting work:
-1. cd repo && git fetch origin
-2. git worktree add ../worktrees/<branch> -b <branch> origin/main
-3. Work in the worktree. Push and PR when done.
-4. Clean up: git worktree remove ../worktrees/<branch>`}</code>
+        <code>{`I want to set up an HQ repo for this project so I can use git worktrees
+to work on multiple things in parallel. Create a new directory called
+<project>-hq one level up from here, git init it, move or clone this
+repo into <project>-hq/repo/, create a worktrees/ directory, and write
+a CLAUDE.md with instructions for the worktree workflow (never edit
+repo/ directly, always create a worktree first, fetch before branching,
+clean up when done, push branches and open PRs).`}</code>
       </pre>
 
       <p>
-        Start Claude Code from the HQ directory and ask it to work on something.
-        It handles the rest.
+        Claude Code will set up the structure, write the{" "}
+        <code>CLAUDE.md</code>, and from then on it knows how to create
+        worktrees when you ask it to work on something. You can add more
+        instructions over time (naming conventions, build commands, test
+        policies, multi-repo setup) and the workflow grows with you.
       </p>
     </>
   );

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -124,8 +124,9 @@ export default function WorktreeManagerPage() {
       </pre>
 
       <p>
-        The agent can reason across both codebases from one place. Monorepo
-        benefits without merging repos.
+        The agent sees one <code>CLAUDE.md</code> that knows about both
+        projects, so it can reason across them without you having to merge
+        anything into a monorepo.
       </p>
 
       <h2>Try it</h2>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -55,7 +55,7 @@ export default function WorktreeManagerPage() {
       <p className="mt-6">
         cmux intentionally does not have a builtin git worktree manager. cmux
         intentionally has no opinion on worktrees. There are plenty of dedicated
-        tools for this now:{" "}
+        tools for this:{" "}
         <Link href="https://github.com/d-kuro/gwq">gwq</Link>,{" "}
         <Link href="https://github.com/satococoa/wtp">wtp</Link>,{" "}
         <Link href="https://github.com/max-sixty/worktrunk">worktrunk</Link>,{" "}

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -70,7 +70,7 @@ export default async function WorktreeManagerPage() {
         I personally like a different approach, which is just putting a few
         paragraphs of instructions in a <code>CLAUDE.md</code>. Claude Code
         handles the rest: creating worktrees, working in them, committing,
-        pushing, opening PRs, cleaning up. The worktree manager is just prose.
+        pushing, opening PRs, cleaning up.
       </p>
 
       <h2>cmux HQ</h2>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -62,10 +62,14 @@ export default function WorktreeManagerPage() {
         <Link href="https://github.com/coderabbitai/git-worktree-runner">
           git-worktree-runner
         </Link>
-        . We ended up not needing one. A few paragraphs of instructions
-        in a <code>CLAUDE.md</code> and Claude Code handles the rest: creating
-        worktrees, working in them, committing, pushing, opening PRs, cleaning
-        up. The worktree manager is just prose.
+        .
+      </p>
+
+      <p>
+        I personally tried a different approach, which is just putting a few
+        paragraphs of instructions in a <code>CLAUDE.md</code>. Claude Code
+        handles the rest: creating worktrees, working in them, committing,
+        pushing, opening PRs, cleaning up. The worktree manager is just prose.
       </p>
 
       <h2>What we actually do</h2>

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -149,6 +149,7 @@ AGENTS.md should contain instructions for the worktree workflow:
 - Before creating a worktree, always fetch and pull main first: cd repo && git fetch origin && git pull origin main
 - Create worktrees with: git worktree add ../worktrees/<branch> -b <branch> origin/main
 - Name branches issue-<N>-<slug> for issues, feat-<slug> for features.
+- Before writing code in a worktree, read its AGENTS.md and CLAUDE.md if they exist (the project repo may have its own instructions).
 - Push branches and open PRs. Never push to main directly.
 - Clean up when done: git worktree remove ../worktrees/<branch>
 

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { CodeBlock } from "../../components/code-block";
 
 export const metadata: Metadata = {
   title: "The best worktree manager is Claude Code",
@@ -35,7 +36,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function WorktreeManagerPage() {
+export default async function WorktreeManagerPage() {
   return (
     <>
       <div className="mb-8">
@@ -72,7 +73,7 @@ export default function WorktreeManagerPage() {
         pushing, opening PRs, cleaning up. The worktree manager is just prose.
       </p>
 
-      <h2>What we actually do</h2>
+      <h2>cmux HQ</h2>
 
       <p>
         We have a repo called <code>cmuxterm-hq</code> that sits outside the
@@ -129,29 +130,13 @@ export default function WorktreeManagerPage() {
         anything into a monorepo.
       </p>
 
-      <h2>Skills are just prompts</h2>
-
-      <p>
-        We have a Claude Code skill called <code>/issue-workspace-pr</code> that
-        takes a GitHub issue URL (or plain text task), creates a worktree,
-        implements the fix, pushes, and opens a PR. It sounds like a feature but
-        it&apos;s really just a prompt that tells Claude Code the steps. It
-        could live in the <code>CLAUDE.md</code> instead and work the same way.
-        Skills are just prompts you can invoke by name.
-      </p>
-
       <h2>Try it</h2>
 
       <p>
         Open Claude Code in your project directory and paste this:
       </p>
 
-      <pre>
-        <code>{`I want to set up an HQ repo for this project so I can use git worktrees
-to work on multiple things in parallel. Create a new directory called
-<project>-hq one level up from here, git init it, clone this repo into
-<project>-hq/repo/, create a worktrees/ directory, and set up the
-following files:
+      <CodeBlock copyable>{`I want to set up an HQ repo for this project so I can use git worktrees to work on multiple things in parallel. Create a new directory called <project>-hq one level up from here, git init it, clone this repo into <project>-hq/repo/, create a worktrees/ directory, and set up the following files:
 
 <project>-hq/
   repo/               # clone of this project (stays on main)
@@ -159,12 +144,15 @@ following files:
   CLAUDE.md           # symlink to AGENTS.md
   AGENTS.md           # worktree workflow instructions
 
-AGENTS.md should contain instructions for the worktree workflow: never
-edit repo/ directly, always create a worktree first, fetch before
-branching, clean up when done, push branches and open PRs. Symlink
-CLAUDE.md to AGENTS.md so both Claude Code and other agents read the
-same instructions.`}</code>
-      </pre>
+AGENTS.md should contain instructions for the worktree workflow:
+- Never edit code directly in repo/. It stays on main as the base for worktrees.
+- Before creating a worktree, always fetch and pull main first: cd repo && git fetch origin && git pull origin main
+- Create worktrees with: git worktree add ../worktrees/<branch> -b <branch> origin/main
+- Name branches issue-<N>-<slug> for issues, feat-<slug> for features.
+- Push branches and open PRs. Never push to main directly.
+- Clean up when done: git worktree remove ../worktrees/<branch>
+
+Symlink CLAUDE.md to AGENTS.md so both Claude Code and other agents read the same instructions.`}</CodeBlock>
 
       <p>
         Claude Code will set up the structure, write the instructions, and from

--- a/web/app/blog/worktree-manager/page.tsx
+++ b/web/app/blog/worktree-manager/page.tsx
@@ -54,16 +54,16 @@ export default async function WorktreeManagerPage() {
       </time>
 
       <p className="mt-6">
-
-        cmux intentionally does not have a builtin git worktree manager. There
-        are good ones out there ({" "}
+        cmux intentionally does not have a builtin git worktree manager. cmux
+        intentionally has no opinion on worktrees. There are plenty of dedicated
+        tools for this like{" "}
         <Link href="https://github.com/d-kuro/gwq">gwq</Link>,{" "}
         <Link href="https://github.com/satococoa/wtp">wtp</Link>,{" "}
         <Link href="https://github.com/max-sixty/worktrunk">worktrunk</Link>,{" "}
         <Link href="https://github.com/coderabbitai/git-worktree-runner">
           git-worktree-runner
         </Link>
-        ) but cmux intentionally has no opinion on worktrees.
+        .
       </p>
 
       <p>

--- a/web/app/components/blog-posts.ts
+++ b/web/app/components/blog-posts.ts
@@ -1,7 +1,7 @@
 export const blogPosts = [
   {
     slug: "worktree-manager",
-    title: "The best git worktree manager",
+    title: "The best git worktree manager is Claude Code",
     date: "2026-03-06",
     summary:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",

--- a/web/app/components/blog-posts.ts
+++ b/web/app/components/blog-posts.ts
@@ -1,5 +1,12 @@
 export const blogPosts = [
   {
+    slug: "worktree-manager",
+    title: "The best worktree manager is Claude Code",
+    date: "2026-03-06",
+    summary:
+      "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",
+  },
+  {
     slug: "cmd-shift-u",
     title: "Cmd+Shift+U",
     date: "2026-03-04",

--- a/web/app/components/blog-posts.ts
+++ b/web/app/components/blog-posts.ts
@@ -1,7 +1,7 @@
 export const blogPosts = [
   {
     slug: "worktree-manager",
-    title: "The best worktree manager is Claude Code",
+    title: "The best git worktree manager",
     date: "2026-03-06",
     summary:
       "How we use a dedicated HQ repo with git worktrees to run parallel agents across codebases, and how you can replicate it.",

--- a/web/app/components/code-block.tsx
+++ b/web/app/components/code-block.tsx
@@ -1,15 +1,18 @@
 import { codeToHtml } from "shiki";
+import { CopyButton } from "./copy-button";
 
 export async function CodeBlock({
   children,
   title,
   lang,
   variant = "code",
+  copyable = false,
 }: {
   children: string;
   title?: string;
   lang?: string;
   variant?: "code" | "ascii";
+  copyable?: boolean;
 }) {
   const lineHeightClass =
     variant === "ascii" ? "leading-[1.15]" : "leading-[1.45]";
@@ -22,12 +25,13 @@ export async function CodeBlock({
     });
 
     return (
-      <div className="mb-4">
+      <div className="relative mb-4">
         {title && (
           <div className="text-[11px] font-mono text-muted px-4 py-1.5 bg-code-bg border border-border border-b-0 rounded-t-lg">
             {title}
           </div>
         )}
+        {copyable && <CopyButton text={children} />}
         <div
           className={`[&_pre]:bg-code-bg [&_pre]:border [&_pre]:border-border [&_pre]:px-4 [&_pre]:py-3 [&_pre]:overflow-x-auto [&_pre]:text-[13px] [&_pre]:${lineHeightClass} [&_pre]:font-mono ${
             title
@@ -41,12 +45,13 @@ export async function CodeBlock({
   }
 
   return (
-    <div className="mb-4">
+    <div className="relative mb-4">
       {title && (
         <div className="text-[11px] font-mono text-muted px-4 py-1.5 bg-code-bg border border-border border-b-0 rounded-t-lg">
           {title}
         </div>
       )}
+      {copyable && <CopyButton text={children} />}
       <pre
         className={`bg-code-bg border border-border px-4 py-3 overflow-x-auto text-[13px] ${lineHeightClass} ${
           variant === "ascii" ? "" : "font-mono "

--- a/web/app/components/copy-button.tsx
+++ b/web/app/components/copy-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="absolute top-2 right-2 px-2 py-1 text-[11px] font-mono text-muted hover:text-foreground bg-code-bg border border-border rounded transition-colors"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- New blog post at `/blog/worktree-manager` about the HQ pattern for managing git worktrees with Claude Code
- Covers the folder structure (repo/ + worktrees/), multi-repo conditioning, shared skills, and a minimal replication guide
- Added to blog index as the newest post

## Testing

- `npx tsc --noEmit` passes
- Vercel preview will deploy automatically

## Related

- Task: blog post about the cmuxterm-hq worktree workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new blog post at /blog/worktree-manager on using a dedicated HQ repo with git worktrees in Claude Code, plus a copy‑paste “Try it” prompt that interviews you and sets up AGENTS.md with a CLAUDE.md symlink.

- **New Features**
  - New page with a first‑person intro that notes cmux doesn’t ship a worktree manager; links to gwq, wtp, worktrunk, and git‑worktree‑runner; multi‑repo guidance; blog index and full metadata updated.
  - Copyable prompt block (new CopyButton); prompt clones into repo/, creates worktrees/, reads per‑worktree AGENTS.md/CLAUDE.md, and symlinks CLAUDE.md → AGENTS.md.

<sup>Written for commit 21b1cdd1e43b29eb7176a4e7cb0eedd4b5c6e25c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published a new blog post "The best worktree manager is Claude Code" describing a multi-repo worktree HQ pattern, workflows, examples, and sample commands.

* **Documentation**
  * Added full page metadata (title, description, keywords, social previews, canonical) and placed the post at the top of the blog index for discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->