### PR TITLE
Dismiss notifications on click/keystroke in focused terminal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3381,34 +3381,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func dismissNotificationIfPresent() {
-        let logPath = "/tmp/cmux-notif-dismiss-debug.log"
-        let timestamp = Date().timeIntervalSince1970
-
-        func writeLog(_ message: String) {
-            let logMessage = "[\(timestamp)] \(message)\n"
-            if let data = logMessage.data(using: .utf8) {
-                if let fileHandle = FileHandle(forWritingAtPath: logPath) {
-                    fileHandle.seekToEndOfFile()
-                    fileHandle.write(data)
-                    fileHandle.closeFile()
-                } else {
-                    try? data.write(to: URL(fileURLWithPath: logPath), options: .atomic)
-                }
-            }
-        }
-
         #if DEBUG
         dlog("dismissNotificationIfPresent: checking tabId=\(tabId?.uuidString.prefix(8) ?? "nil") surfaceId=\(terminalSurface?.id.uuidString.prefix(8) ?? "nil")")
-        writeLog("dismissNotificationIfPresent: checking tabId=\(tabId?.uuidString.prefix(8) ?? "nil") surfaceId=\(terminalSurface?.id.uuidString.prefix(8) ?? "nil")")
         #endif
 
         guard let tabId,
               let surfaceId = terminalSurface?.id,
-              let notificationStore = AppDelegate.shared?.notificationStore,
-              let tabManager = AppDelegate.shared?.tabManager else {
+              let app = AppDelegate.shared,
+              let notificationStore = app.notificationStore else {
             #if DEBUG
             dlog("dismissNotificationIfPresent: early return - missing required objects")
-            writeLog("dismissNotificationIfPresent: early return - missing required objects tabId=\(tabId == nil ? "nil" : "ok") surfaceId=\(terminalSurface?.id == nil ? "nil" : "ok") store=\(AppDelegate.shared?.notificationStore == nil ? "nil" : "ok") manager=\(AppDelegate.shared?.tabManager == nil ? "nil" : "ok")")
             #endif
             return
         }
@@ -3416,7 +3398,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let hasUnread = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         #if DEBUG
         dlog("dismissNotificationIfPresent: hasUnread=\(hasUnread) for tab=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8))")
-        writeLog("dismissNotificationIfPresent: hasUnread=\(hasUnread) for tab=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8))")
         #endif
 
         guard hasUnread else {
@@ -3425,13 +3406,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         #if DEBUG
         dlog("dismissNotificationIfPresent: dismissing notification and triggering flash")
-        writeLog("dismissNotificationIfPresent: dismissing notification and triggering flash")
         #endif
 
-        guard let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
+        // Find the owning TabManager for this tab (handles secondary windows)
+        guard let tabManager = app.tabManagerFor(tabId: tabId),
+              let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
             #if DEBUG
             dlog("dismissNotificationIfPresent: workspace not found, skipping dismissal")
-            writeLog("dismissNotificationIfPresent: workspace not found for tab=\(tabId.uuidString.prefix(8))")
             #endif
             return
         }
@@ -4479,6 +4460,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        dismissNotificationIfPresent()
         guard let surface = surface else { return }
         if !ghostty_surface_mouse_captured(surface) {
             super.rightMouseDown(with: event)
@@ -4502,6 +4484,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func otherMouseDown(with event: NSEvent) {
+        dismissNotificationIfPresent()
         guard event.buttonNumber == 2 else {
             super.otherMouseDown(with: event)
             return

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3428,9 +3428,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         writeLog("dismissNotificationIfPresent: dismissing notification and triggering flash")
         #endif
 
-        if let workspace = tabManager.tabs.first(where: { $0.id == tabId }) {
-            workspace.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
+        guard let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
+            #if DEBUG
+            dlog("dismissNotificationIfPresent: workspace not found, skipping dismissal")
+            writeLog("dismissNotificationIfPresent: workspace not found for tab=\(tabId.uuidString.prefix(8))")
+            #endif
+            return
         }
+
+        workspace.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
         notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3380,6 +3380,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return surface
     }
 
+    private func dismissNotificationIfPresent() {
+        guard let tabId,
+              let surfaceId = terminalSurface?.id,
+              let notificationStore = AppDelegate.shared?.notificationStore,
+              let tabManager = AppDelegate.shared?.tabManager else {
+            return
+        }
+        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) else {
+            return
+        }
+        if let workspace = tabManager.tabs.first(where: { $0.id == tabId }) {
+            workspace.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
+        }
+        notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
+    }
+
     func performBindingAction(_ action: String) -> Bool {
         guard let surface = surface else { return false }
         return action.withCString { cString in
@@ -3955,6 +3971,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func keyDown(with event: NSEvent) {
+        dismissNotificationIfPresent()
         guard let surface = ensureSurfaceReadyForInput() else {
             super.keyDown(with: event)
             return
@@ -4401,6 +4418,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let debugPoint = convert(event.locationInWindow, from: nil)
         dlog("terminal.mouseDown surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))] clickCount=\(event.clickCount) point=(\(String(format: "%.0f", debugPoint.x)),\(String(format: "%.0f", debugPoint.y)))")
         #endif
+        dismissNotificationIfPresent()
         window?.makeFirstResponder(self)
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3381,8 +3381,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func dismissNotificationIfPresent() {
+        let logPath = "/tmp/cmux-notif-dismiss-debug.log"
+        let timestamp = Date().timeIntervalSince1970
+
+        func writeLog(_ message: String) {
+            let logMessage = "[\(timestamp)] \(message)\n"
+            if let data = logMessage.data(using: .utf8) {
+                if let fileHandle = FileHandle(forWritingAtPath: logPath) {
+                    fileHandle.seekToEndOfFile()
+                    fileHandle.write(data)
+                    fileHandle.closeFile()
+                } else {
+                    try? data.write(to: URL(fileURLWithPath: logPath), options: .atomic)
+                }
+            }
+        }
+
         #if DEBUG
         dlog("dismissNotificationIfPresent: checking tabId=\(tabId?.uuidString.prefix(8) ?? "nil") surfaceId=\(terminalSurface?.id.uuidString.prefix(8) ?? "nil")")
+        writeLog("dismissNotificationIfPresent: checking tabId=\(tabId?.uuidString.prefix(8) ?? "nil") surfaceId=\(terminalSurface?.id.uuidString.prefix(8) ?? "nil")")
         #endif
 
         guard let tabId,
@@ -3391,6 +3408,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
               let tabManager = AppDelegate.shared?.tabManager else {
             #if DEBUG
             dlog("dismissNotificationIfPresent: early return - missing required objects")
+            writeLog("dismissNotificationIfPresent: early return - missing required objects tabId=\(tabId == nil ? "nil" : "ok") surfaceId=\(terminalSurface?.id == nil ? "nil" : "ok") store=\(AppDelegate.shared?.notificationStore == nil ? "nil" : "ok") manager=\(AppDelegate.shared?.tabManager == nil ? "nil" : "ok")")
             #endif
             return
         }
@@ -3398,6 +3416,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let hasUnread = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         #if DEBUG
         dlog("dismissNotificationIfPresent: hasUnread=\(hasUnread) for tab=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8))")
+        writeLog("dismissNotificationIfPresent: hasUnread=\(hasUnread) for tab=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8))")
         #endif
 
         guard hasUnread else {
@@ -3406,6 +3425,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         #if DEBUG
         dlog("dismissNotificationIfPresent: dismissing notification and triggering flash")
+        writeLog("dismissNotificationIfPresent: dismissing notification and triggering flash")
         #endif
 
         if let workspace = tabManager.tabs.first(where: { $0.id == tabId }) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3381,15 +3381,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func dismissNotificationIfPresent() {
+        #if DEBUG
+        dlog("dismissNotificationIfPresent: checking tabId=\(tabId?.uuidString.prefix(8) ?? "nil") surfaceId=\(terminalSurface?.id.uuidString.prefix(8) ?? "nil")")
+        #endif
+
         guard let tabId,
               let surfaceId = terminalSurface?.id,
               let notificationStore = AppDelegate.shared?.notificationStore,
               let tabManager = AppDelegate.shared?.tabManager else {
+            #if DEBUG
+            dlog("dismissNotificationIfPresent: early return - missing required objects")
+            #endif
             return
         }
-        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) else {
+
+        let hasUnread = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
+        #if DEBUG
+        dlog("dismissNotificationIfPresent: hasUnread=\(hasUnread) for tab=\(tabId.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8))")
+        #endif
+
+        guard hasUnread else {
             return
         }
+
+        #if DEBUG
+        dlog("dismissNotificationIfPresent: dismissing notification and triggering flash")
+        #endif
+
         if let workspace = tabManager.tabs.first(where: { $0.id == tabId }) {
             workspace.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
         }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -828,19 +828,8 @@ final class TerminalNotificationStore: ObservableObject {
             return true
         }
 
-        let isActiveTab = AppDelegate.shared?.tabManager?.selectedTabId == tabId
-        let focusedSurfaceId = AppDelegate.shared?.tabManager?.focusedSurfaceId(for: tabId)
-        let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId
-        let isFocusedPanel = isActiveTab && isFocusedSurface
-        let isAppFocused = AppFocusState.isAppFocused()
-        if isAppFocused && isFocusedPanel {
-            if !idsToClear.isEmpty {
-                notifications = updated
-                center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-                center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
-            }
-            return
-        }
+        // Removed auto-dismiss logic - notifications should always show up with blue ring
+        // and be dismissed via user interaction (click/keystroke) instead
 
         if WorkspaceAutoReorderSettings.isEnabled() {
             AppDelegate.shared?.tabManager?.moveTabToTop(tabId)


### PR DESCRIPTION
## Summary
- Added automatic notification dismissal when clicking or typing in a terminal that has an active notification ring
- Triggers flash animation to provide visual feedback when notification is dismissed
- Removed auto-dismiss logic that was preventing notifications from showing on focused terminals

## Implementation
Previously, notifications sent to an already-focused terminal were silently dropped (TerminalNotificationStore.swift:836-843). This prevented the blue ring from appearing in the edge case where a notification arrives for the currently focused terminal.

Now notifications always appear with the blue ring and are dismissed on the next user interaction (click/keystroke), with the flash animation for visual feedback.

Changes:
- Added `dismissNotificationIfPresent()` method to GhosttyTerminalView that checks for unread notifications and triggers dismissal with flash
- Called this method at the start of both `mouseDown()` and `keyDown()` event handlers
- Removed the auto-dismiss early return in `TerminalNotificationStore.addNotification()`

## Testing
- Built and tested with tagged builds
- Verified notifications now appear with blue ring when sent to focused terminal
- Confirmed click/keystroke dismisses notification with flash animation
- Debug logs written to `/tmp/cmux-notif-dismiss-debug.log` during development

## Related
- Task: if notif ring is present/tab has notification, then any clicks/keystrokes should dismiss the notification (and cause the flash). this is for edge case where user is already focused on a terminal. and then notification comes up for exactly that terminal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now remain visible when the app regains focus instead of auto-dismissing.
  * Unread notifications are dismissed immediately when you interact with the terminal (keyboard or mouse).
  * Removed prior auto-dismiss behavior so notifications persist until user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->