### PR TITLE
Add Reddit community link and docs reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The best developers have always built their own tools. Nobody has figured out th
 
 Give a million developers composable primitives and they'll collectively find the most efficient workflows faster than any product team could design top-down.
 
-For more info on how to configure cmux, [head over to our docs](https://cmux.dev/docs/getting-started?utm=readme).
+For more info on how to configure cmux, [head over to our docs](https://cmux.dev/docs/getting-started?utm_source=readme).
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary
- Added Reddit (https://www.reddit.com/r/cmux/) to Community section
- Added docs link after The Zen of cmux section for easier configuration access

## Testing
- Verified markdown formatting
- Confirmed links are valid

## Related
- Task: Add Reddit and docs links to README

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds r/cmux to the Community section and a direct docs link after “The Zen of cmux” for easier configuration and support, with the docs link using the standard utm_source=readme parameter. Fulfills the task to add Reddit and docs links to the README.

<sup>Written for commit b993849e7e6f8a8227c730e6f6463bce9f2dfbd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added documentation link for configuration setup guidance.
* Added new community resource link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->