### PR TITLE
Reorganize README: add Documentation section, move Reddit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The best developers have always built their own tools. Nobody has figured out th
 
 Give a million developers composable primitives and they'll collectively find the most efficient workflows faster than any product team could design top-down.
 
+## Documentation
+
 For more info on how to configure cmux, [head over to our docs](https://cmux.dev/docs/getting-started?utm_source=readme).
 
 ## Keyboard Shortcuts
@@ -244,10 +246,10 @@ Ways to get involved:
 
 - [Discord](https://discord.gg/xsgFEVrWCZ)
 - [GitHub](https://github.com/manaflow-ai/cmux)
-- [Reddit](https://www.reddit.com/r/cmux/)
 - [X / Twitter](https://twitter.com/manaflowai)
 - [YouTube](https://www.youtube.com/channel/UCAa89_j-TWkrXfk9A3CbASw)
 - [LinkedIn](https://www.linkedin.com/company/manaflow-ai/)
+- [Reddit](https://www.reddit.com/r/cmux/)
 
 ## Founder's Edition
 


### PR DESCRIPTION
## Summary
- Created new Documentation section with docs link (previously inline after The Zen of cmux)
- Moved Reddit link below LinkedIn in Community section

## Testing
- Verified markdown formatting
- Confirmed section structure is improved

## Related
- Follow-up to https://github.com/manaflow-ai/cmux/pull/1013

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized the README by adding a dedicated Documentation section and moving the Reddit link below LinkedIn in the Community list. This makes docs easier to find and keeps community links consistent.

<sup>Written for commit 5ca05c943d838680906d6cc3659b5312ed088b85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

