### PR TITLE
Improve Japanese IME preedit editing

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3785,6 +3785,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // For NSTextInputClient - accumulates text during key events
     private var keyTextAccumulator: [String]? = nil
     private var markedText = NSMutableAttributedString()
+    private var markedSelectedRange = NSRange(location: NSNotFound, length: 0)
     private var lastPerformKeyEvent: TimeInterval?
 
 #if DEBUG
@@ -4077,6 +4078,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Track whether we had marked text (IME preedit) before this event,
         // so we can detect when composition ends.
         let markedTextBefore = markedText.length > 0
+        let markedTextBeforeString = markedText.string
+        let markedSelectionBefore = markedSelectedRange
 
         // Capture the keyboard layout ID before interpretation so we can
         // detect if an IME changed it (e.g. toggling input methods).
@@ -4101,6 +4104,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // composition overlay (e.g. for Korean, Japanese, Chinese input).
         syncPreedit(clearIfNeeded: markedTextBefore)
 
+        let accumulatedText = keyTextAccumulator ?? []
+        if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
+            markedTextBefore: markedTextBeforeString,
+            markedSelectionBefore: markedSelectionBefore,
+            markedTextAfter: markedText.string,
+            markedSelectionAfter: markedSelectedRange,
+            accumulatedText: accumulatedText
+        ) {
+            return
+        }
+
         // Build the key event
         var keyEvent = ghostty_input_key_s()
         keyEvent.action = action
@@ -4119,7 +4133,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.composing = markedText.length > 0 || markedTextBefore
 
         // Use accumulated text from insertText (for IME), or compute text for key
-        let accumulatedText = keyTextAccumulator ?? []
         if !accumulatedText.isEmpty {
             // Accumulated text comes from insertText (IME composition result).
             // These never have "composing" set to true because these are the
@@ -6514,7 +6527,10 @@ extension GhosttyNSView: NSTextInputClient {
     }
 
     func selectedRange() -> NSRange {
-        return NSRange(location: NSNotFound, length: 0)
+        guard markedText.length > 0 else {
+            return NSRange(location: NSNotFound, length: 0)
+        }
+        return markedSelectedRange
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
@@ -6524,8 +6540,13 @@ extension GhosttyNSView: NSTextInputClient {
         case let v as String:
             markedText = NSMutableAttributedString(string: v)
         default:
-            break
+            return
         }
+
+        markedSelectedRange = normalizedMarkedSelectionRange(
+            selectedRange,
+            markedLength: markedText.length
+        )
 
         // If we're not in a keyDown event, sync preedit immediately.
         // This can happen due to external events like changing keyboard layouts
@@ -6538,6 +6559,7 @@ extension GhosttyNSView: NSTextInputClient {
     func unmarkText() {
         if markedText.length > 0 {
             markedText.mutableString.setString("")
+            markedSelectedRange = NSRange(location: NSNotFound, length: 0)
             syncPreedit()
         }
     }
@@ -6564,12 +6586,72 @@ extension GhosttyNSView: NSTextInputClient {
         }
     }
 
+    private func normalizedMarkedSelectionRange(_ range: NSRange, markedLength: Int) -> NSRange {
+        guard markedLength > 0 else {
+            return NSRange(location: NSNotFound, length: 0)
+        }
+        guard range.location != NSNotFound else {
+            return NSRange(location: markedLength, length: 0)
+        }
+
+        let clampedLocation = min(range.location, markedLength)
+        let clampedLength = min(range.length, markedLength - clampedLocation)
+        return NSRange(location: clampedLocation, length: clampedLength)
+    }
+
+    private func shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
+        markedTextBefore: String,
+        markedSelectionBefore: NSRange,
+        markedTextAfter: String,
+        markedSelectionAfter: NSRange,
+        accumulatedText: [String]
+    ) -> Bool {
+        guard accumulatedText.isEmpty else { return false }
+
+        let hadMarkedTextBefore = !markedTextBefore.isEmpty
+        let hasMarkedTextAfter = !markedTextAfter.isEmpty
+        guard hadMarkedTextBefore || hasMarkedTextAfter else { return false }
+
+        if markedTextBefore != markedTextAfter {
+            return true
+        }
+
+        return markedSelectionBefore != markedSelectionAfter
+    }
+
+#if DEBUG
+    func shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+        markedTextBefore: String,
+        markedSelectionBefore: NSRange,
+        markedTextAfter: String,
+        markedSelectionAfter: NSRange,
+        accumulatedText: [String]
+    ) -> Bool {
+        shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
+            markedTextBefore: markedTextBefore,
+            markedSelectionBefore: markedSelectionBefore,
+            markedTextAfter: markedTextAfter,
+            markedSelectionAfter: markedSelectionAfter,
+            accumulatedText: accumulatedText
+        )
+    }
+#endif
+
     func validAttributesForMarkedText() -> [NSAttributedString.Key] {
         return []
     }
 
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
-        return nil
+        guard markedText.length > 0, range.location != NSNotFound else {
+            actualRange?.pointee = NSRange(location: NSNotFound, length: 0)
+            return nil
+        }
+
+        let fullRange = NSRange(location: 0, length: markedText.length)
+        let actual = NSIntersectionRange(range, fullRange)
+        actualRange?.pointee = actual
+        guard actual.location != NSNotFound else { return nil }
+        return markedText.attributedSubstring(from: actual)
     }
 
     func characterIndex(for point: NSPoint) -> Int {

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -232,10 +232,51 @@ final class CJKIMEMarkedTextTests: XCTestCase {
 
     // MARK: - selectedRange / validAttributesForMarkedText
 
-    func testSelectedRangeReturnsNotFound() {
+    func testSelectedRangeTracksMarkedTextSelection() {
         let view = GhosttyNSView(frame: .zero)
-        let range = view.selectedRange()
-        XCTAssertEqual(range.location, NSNotFound)
+
+        view.setMarkedText(
+            "にほんご",
+            selectedRange: NSRange(location: 2, length: 1),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        XCTAssertEqual(
+            view.selectedRange(),
+            NSRange(location: 2, length: 1),
+            "selectedRange should mirror the IME caret/selection inside marked text"
+        )
+    }
+
+    func testSelectedRangeReturnsNotFoundAfterCompositionEnds() {
+        let view = GhosttyNSView(frame: .zero)
+
+        view.setMarkedText(
+            "東京",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        view.unmarkText()
+
+        XCTAssertEqual(view.selectedRange().location, NSNotFound)
+    }
+
+    func testAttributedSubstringReturnsMarkedTextSegment() {
+        let view = GhosttyNSView(frame: .zero)
+        view.setMarkedText(
+            "とうきょう",
+            selectedRange: NSRange(location: 3, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        var actualRange = NSRange(location: NSNotFound, length: 0)
+        let substring = view.attributedSubstring(
+            forProposedRange: NSRange(location: 2, length: 2),
+            actualRange: &actualRange
+        )
+
+        XCTAssertEqual(actualRange, NSRange(location: 2, length: 2))
+        XCTAssertEqual(substring?.string, "きょ")
     }
 
     func testValidAttributesForMarkedTextReturnsEmpty() {

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -285,6 +285,64 @@ final class CJKIMEMarkedTextTests: XCTestCase {
     }
 }
 
+final class CJKIMEKeyForwardingSuppressionTests: XCTestCase {
+    func testSuppressesTerminalForwardingWhenJapanesePreeditTextChanges() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertTrue(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "にほん",
+                markedSelectionBefore: NSRange(location: 3, length: 0),
+                markedTextAfter: "にほ",
+                markedSelectionAfter: NSRange(location: 2, length: 0),
+                accumulatedText: []
+            )
+        )
+    }
+
+    func testSuppressesTerminalForwardingWhenJapaneseClauseSelectionMoves() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertTrue(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "東京",
+                markedSelectionBefore: NSRange(location: 0, length: 1),
+                markedTextAfter: "東京",
+                markedSelectionAfter: NSRange(location: 1, length: 1),
+                accumulatedText: []
+            )
+        )
+    }
+
+    func testDoesNotSuppressCommittedIMEInsertText() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertFalse(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "東京",
+                markedSelectionBefore: NSRange(location: 0, length: 1),
+                markedTextAfter: "",
+                markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
+                accumulatedText: ["東京"]
+            )
+        )
+    }
+
+    func testDoesNotSuppressNormalTerminalKeyWhenIMEDidNothing() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertFalse(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "",
+                markedSelectionBefore: NSRange(location: NSNotFound, length: 0),
+                markedTextAfter: "",
+                markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
+                accumulatedText: []
+            )
+        )
+    }
+}
+
 // MARK: - performKeyEquivalent bypasses during IME composition
 
 /// Tests that performKeyEquivalent does not intercept key events when the


### PR DESCRIPTION
## Summary
- preserve IME marked-text selection state and substring reporting in GhosttyNSView
- stop forwarding keys to the terminal when AppKit just used them to edit or move Japanese preedit text
- add regression coverage for marked-text selection, attributed substrings, and IME forwarding suppression

## Testing
- ./scripts/reload.sh --tag ja-ime (build succeeded, tagged app launched)
- Local tests not run, per repo policy

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/787
- Related: https://github.com/manaflow-ai/cmux/issues/294


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Japanese IME preedit editing in GhosttyNSView: track marked-text selection, honor attributedSubstring queries, and suppress terminal key forwarding when the IME edits or moves preedit text. Adds regression tests for selection tracking, substring ranges, and key forwarding suppression.

<sup>Written for commit 9b4924f9e37430e1eafb5d5911a121986e9aac88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

