### PR TITLE
Fix titlebar controls clipped at bottom edge

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -729,6 +729,11 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
         view = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = true
+        // Prevent the titlebar accessory from clipping button backgrounds
+        // at the bottom edge (the system constrains accessory height to the
+        // titlebar, which can be slightly shorter than the button frames).
+        containerView.wantsLayer = true
+        containerView.layer?.masksToBounds = false
         hostingView.translatesAutoresizingMaskIntoConstraints = true
         hostingView.autoresizingMask = [.width, .height]
         containerView.addSubview(hostingView)


### PR DESCRIPTION
## Summary
- Disable `masksToBounds` on the titlebar controls container view so the rounded-rectangle button backgrounds (softButtons style) render fully instead of being cut off at the bottom edge.
- The `NSTitlebarAccessoryViewController` constrains the accessory view height to the titlebar, which can be slightly shorter than the button frames.

## Testing
- Built and launched with `./scripts/reload.sh --tag fix-titlebar-clip`
- Verify the bottom edge of the titlebar control buttons (sidebar toggle, notifications bell, new workspace) is no longer clipped

## Related
- Task: bottom side of titlebar controls is clipped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bottom-edge clipping of titlebar control buttons by turning off layer clipping on the accessory container view. SoftButtons now show full rounded backgrounds even when the titlebar is slightly shorter; addresses the “bottom side of titlebar controls is clipped” task.

<sup>Written for commit e0a7c3f7cb9b698cf446ed789bb7211bbc2e34d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

