### PR TITLE
Rename 'Ghostty Settings' to 'cmux Settings' in app menu (#555)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -30638,115 +30638,115 @@
         }
       }
     },
-    "menu.app.ghosttySettings": {
+    "menu.app.cmuxSettings": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty Settings…"
+            "value": "cmux Settings…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty設定…"
+            "value": "cmux設定…"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty 设置..."
+            "value": "cmux 设置..."
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty 設定..."
+            "value": "cmux 設定..."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty 설정…"
+            "value": "cmux 설정…"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty-Einstellungen …"
+            "value": "cmux-Einstellungen …"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajustes de Ghostty…"
+            "value": "Ajustes de cmux…"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Réglages Ghostty..."
+            "value": "Réglages cmux..."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impostazioni Ghostty…"
+            "value": "Impostazioni cmux…"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty-indstillinger…"
+            "value": "cmux-indstillinger…"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ustawienia Ghostty…"
+            "value": "Ustawienia cmux…"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Настройки Ghostty..."
+            "value": "Настройки cmux..."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty postavke…"
+            "value": "cmux postavke…"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "إعدادات Ghostty…"
+            "value": "إعدادات cmux…"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty-innstillinger …"
+            "value": "cmux-innstillinger …"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajustes do Ghostty…"
+            "value": "Ajustes do cmux…"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การตั้งค่า Ghostty..."
+            "value": "การตั้งค่า cmux..."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ghostty Ayarları…"
+            "value": "cmux Ayarları…"
           }
         }
       }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -236,7 +236,7 @@ struct cmuxApp: App {
                 Button(String(localized: "menu.app.about", defaultValue: "About cmux")) {
                     showAboutPanel()
                 }
-                Button(String(localized: "menu.app.ghosttySettings", defaultValue: "Ghostty Settings…")) {
+                Button(String(localized: "menu.app.cmuxSettings", defaultValue: "cmux Settings…")) {
                     GhosttyApp.shared.openConfigurationInTextEdit()
                 }
                 Button(String(localized: "menu.app.reloadConfiguration", defaultValue: "Reload Configuration")) {


### PR DESCRIPTION
## Summary

Fixes #555 — The app menu still says "Ghostty Settings…" instead of "cmux Settings…".

## Changes

- **`Sources/cmuxApp.swift`**: Changed the localization key from `menu.app.ghosttySettings` to `menu.app.cmuxSettings` with default value "cmux Settings…"
- **`Resources/Localizable.xcstrings`**: Updated the localization key and all 16 language translations (en, ja, zh-Hans, zh-Hant, ko, de, es, fr, it, da, pl, ru, bs, ar, nb, pt-BR, th, tr) replacing "Ghostty" with "cmux"

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/lark1115/cmux/blob/images/pr-screenshots/555/before.png?raw=true) | ![after](https://github.com/lark1115/cmux/blob/images/pr-screenshots/555/after.png?raw=true) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization Updates**
  * Updated settings menu item label across all supported languages from "Ghostty Settings…" to "cmux Settings…"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->