### PR TITLE
Fix color contrast for 'running' status on inactive tabs (#795)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
+					FA000000A1B2C3D4E5F60718 /* SidebarMetadataContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* SidebarMetadataContrastTests.swift */; };
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
@@ -229,6 +230,7 @@
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+				FA000001A1B2C3D4E5F60718 /* SidebarMetadataContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMetadataContrastTests.swift; sourceTree = "<group>"; };
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 				A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 					DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
+					FA000001A1B2C3D4E5F60718 /* SidebarMetadataContrastTests.swift */,
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 				);
@@ -691,6 +694,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+					FA000000A1B2C3D4E5F60718 /* SidebarMetadataContrastTests.swift in Sources */,
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 				);

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9245,12 +9245,22 @@ private struct SidebarMetadataEntryRow: View {
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         srgb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
         if colorScheme == .dark {
-            if b < 0.6 {
-                return Color(nsColor: NSColor(hue: h, saturation: min(s, 0.7), brightness: 0.6, alpha: a))
+            let needsBrightnessFloor = b < 0.6
+            let needsSaturationCap = s > 0.7
+            if needsBrightnessFloor || needsSaturationCap {
+                return Color(nsColor: NSColor(
+                    hue: h,
+                    saturation: min(s, 0.7),
+                    brightness: max(b, 0.6),
+                    alpha: a
+                ))
             }
         } else {
             if b > 0.65 {
                 return Color(nsColor: NSColor(hue: h, saturation: s, brightness: 0.65, alpha: a))
+            }
+            if b < 0.25 {
+                return Color(nsColor: NSColor(hue: h, saturation: s, brightness: 0.25, alpha: a))
             }
         }
         return color

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9229,15 +9229,13 @@ private struct SidebarMetadataEntryRow: View {
     }
 
     private var foregroundColor: Color {
-        if isActive,
-           let raw = entry.color,
-           Color(hex: raw) != nil {
-            return Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 0.95))
+        if isActive {
+            return .white
         }
         if let raw = entry.color, let explicit = Color(hex: raw) {
             return contrastAdjusted(explicit)
         }
-        return isActive ? .white.opacity(0.8) : .secondary
+        return .secondary
     }
 
     private func contrastAdjusted(_ color: Color) -> Color {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9244,26 +9244,13 @@ private struct SidebarMetadataEntryRow: View {
         guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return color }
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         srgb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
-        if colorScheme == .dark {
-            let needsBrightnessFloor = b < 0.6
-            let needsSaturationCap = s > 0.7
-            if needsBrightnessFloor || needsSaturationCap {
-                return Color(nsColor: NSColor(
-                    hue: h,
-                    saturation: min(s, 0.7),
-                    brightness: max(b, 0.6),
-                    alpha: a
-                ))
-            }
-        } else {
-            if b > 0.65 {
-                return Color(nsColor: NSColor(hue: h, saturation: s, brightness: 0.65, alpha: a))
-            }
-            if b < 0.25 {
-                return Color(nsColor: NSColor(hue: h, saturation: s, brightness: 0.25, alpha: a))
-            }
-        }
-        return color
+        let (adjH, adjS, adjB) = Self.contrastAdjustedHSB(h: h, s: s, b: b, isDark: colorScheme == .dark)
+        if adjH == h && adjS == s && adjB == b { return color }
+        return Color(nsColor: NSColor(hue: adjH, saturation: adjS, brightness: adjB, alpha: a))
+    }
+
+    static func contrastAdjustedHSB(h: CGFloat, s: CGFloat, b: CGFloat, isDark: Bool) -> (CGFloat, CGFloat, CGFloat) {
+        MetadataColorContrast.adjustedHSB(h: h, s: s, b: b, isDark: isDark)
     }
 
     private var iconView: AnyView? {
@@ -10652,5 +10639,25 @@ extension NSColor {
             return String(format: "#%02X%02X%02X%02X", redByte, greenByte, blueByte, alphaByte)
         }
         return String(format: "#%02X%02X%02X", redByte, greenByte, blueByte)
+    }
+}
+
+enum MetadataColorContrast {
+    static func adjustedHSB(h: CGFloat, s: CGFloat, b: CGFloat, isDark: Bool) -> (CGFloat, CGFloat, CGFloat) {
+        if isDark {
+            let needsBrightnessFloor = b < 0.6
+            let needsSaturationCap = s > 0.7
+            if needsBrightnessFloor || needsSaturationCap {
+                return (h, min(s, 0.7), max(b, 0.6))
+            }
+        } else {
+            if b > 0.65 {
+                return (h, s, 0.65)
+            }
+            if b < 0.25 {
+                return (h, s, 0.25)
+            }
+        }
+        return (h, s, b)
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9191,6 +9191,7 @@ private struct SidebarMetadataEntryRow: View {
     let entry: SidebarStatusEntry
     let isActive: Bool
     let onFocus: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Group {
@@ -9234,9 +9235,25 @@ private struct SidebarMetadataEntryRow: View {
             return Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 0.95))
         }
         if let raw = entry.color, let explicit = Color(hex: raw) {
-            return explicit
+            return contrastAdjusted(explicit)
         }
         return isActive ? .white.opacity(0.8) : .secondary
+    }
+
+    private func contrastAdjusted(_ color: Color) -> Color {
+        guard let srgb = NSColor(color).usingColorSpace(.sRGB) else { return color }
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        srgb.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        if colorScheme == .dark {
+            if b < 0.6 {
+                return Color(nsColor: NSColor(hue: h, saturation: min(s, 0.7), brightness: 0.6, alpha: a))
+            }
+        } else {
+            if b > 0.65 {
+                return Color(nsColor: NSColor(hue: h, saturation: s, brightness: 0.65, alpha: a))
+            }
+        }
+        return color
     }
 
     private var iconView: AnyView? {

--- a/cmuxTests/SidebarMetadataContrastTests.swift
+++ b/cmuxTests/SidebarMetadataContrastTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SidebarMetadataContrastTests: XCTestCase {
+
+    // MARK: - Dark mode
+
+    func testDarkModeDimColorGetsBrightnessFloor() {
+        let (h, s, b) = MetadataColorContrast.adjustedHSB(h: 0.0, s: 0.5, b: 0.1, isDark: true)
+        XCTAssertEqual(b, 0.6, accuracy: 0.001, "Dark dim color should be raised to brightness 0.6")
+        XCTAssertEqual(s, 0.5, accuracy: 0.001, "Saturation below cap should be unchanged")
+        XCTAssertEqual(h, 0.0, accuracy: 0.001)
+    }
+
+    func testDarkModeHighSaturationGetsCapped() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.5, s: 0.95, b: 0.62, isDark: true)
+        XCTAssertEqual(s, 0.7, accuracy: 0.001, "High saturation should be capped at 0.7")
+        XCTAssertEqual(b, 0.62, accuracy: 0.001, "Brightness above floor should be unchanged")
+    }
+
+    func testDarkModeBothDimAndHighSaturation() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.0, s: 0.95, b: 0.1, isDark: true)
+        XCTAssertEqual(s, 0.7, accuracy: 0.001)
+        XCTAssertEqual(b, 0.6, accuracy: 0.001)
+    }
+
+    func testDarkModeNormalColorUnchanged() {
+        let (h, s, b) = MetadataColorContrast.adjustedHSB(h: 0.3, s: 0.5, b: 0.7, isDark: true)
+        XCTAssertEqual(h, 0.3, accuracy: 0.001)
+        XCTAssertEqual(s, 0.5, accuracy: 0.001)
+        XCTAssertEqual(b, 0.7, accuracy: 0.001, "Color within range should pass through unchanged")
+    }
+
+    // MARK: - Light mode
+
+    func testLightModeBrightColorGetsCeiling() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.16, s: 1.0, b: 1.0, isDark: false)
+        XCTAssertEqual(b, 0.65, accuracy: 0.001, "Bright color should be capped at 0.65")
+        XCTAssertEqual(s, 1.0, accuracy: 0.001, "Saturation should be unchanged in light mode")
+    }
+
+    func testLightModeNearBlackGetsFloor() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.0, s: 0.0, b: 0.04, isDark: false)
+        XCTAssertEqual(b, 0.25, accuracy: 0.001, "Near-black should be raised to 0.25")
+        XCTAssertEqual(s, 0.0, accuracy: 0.001)
+    }
+
+    func testLightModeNormalColorUnchanged() {
+        let (h, s, b) = MetadataColorContrast.adjustedHSB(h: 0.6, s: 0.5, b: 0.5, isDark: false)
+        XCTAssertEqual(h, 0.6, accuracy: 0.001)
+        XCTAssertEqual(s, 0.5, accuracy: 0.001)
+        XCTAssertEqual(b, 0.5, accuracy: 0.001, "Mid-range color should pass through unchanged")
+    }
+
+    // MARK: - Boundary
+
+    func testDarkModeBrightnessExactlyAtFloor() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.0, s: 0.5, b: 0.6, isDark: true)
+        XCTAssertEqual(b, 0.6, accuracy: 0.001, "Exactly at floor should be unchanged")
+        XCTAssertEqual(s, 0.5, accuracy: 0.001)
+    }
+
+    func testDarkModeSaturationExactlyAtCap() {
+        let (_, s, b) = MetadataColorContrast.adjustedHSB(h: 0.0, s: 0.7, b: 0.8, isDark: true)
+        XCTAssertEqual(s, 0.7, accuracy: 0.001, "Exactly at cap should be unchanged")
+        XCTAssertEqual(b, 0.8, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #795 — Metadata text (e.g. "⚡ Running") on sidebar tabs has contrast issues:
1. **Active tab (blue background)**: Text with reduced-opacity white blends into the blue selection background, making it hard to read
2. **Inactive tab (dark/light background)**: Explicit hex colors can be too dark or too saturated for the background

## Changes

- **`Sources/ContentView.swift`**:
  - **Active tab fix**: Simplified `foregroundColor` — active tabs now always use solid `.white` instead of `white.opacity(0.8)` or `white.opacity(0.95)`, maximizing contrast on the blue selection background
  - **Inactive tab fix**: Added `@Environment(\.colorScheme)` and `contrastAdjusted()` helper that dynamically adjusts HSB values:
    - **Dark mode**: brightness floor at 0.6, saturation cap at 0.7
    - **Light mode**: brightness ceiling at 0.65, brightness floor at 0.25
  - Extracted adjustment logic to `MetadataColorContrast` enum for testability

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/before.png?raw=true) | ![after](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/after.png?raw=true) |

## Test plan

- [x] Active tab + color specified: metadata text is solid white, readable on blue background
- [x] Active tab + no color: metadata text is solid white, readable on blue background
- [x] Inactive tab (dark mode) + dark color (`#1a0505`): brightness raised, text readable
- [x] Inactive tab (dark mode) + high saturation color (`#0000ff`): saturation capped, brightness raised
- [x] Light mode + active tab: white text on blue background, readable

### QA Results

| # | Test Case | Screenshot |
|---|-----------|------------|
| T1 | Active tab + `#2ecc71` → white text on blue | ![t1](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/t1-crop.png?raw=true) |
| T2 | Active tab + no color → white text on blue | ![t2](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/t2-crop.png?raw=true) |
| T3 | Inactive tab + `#1a0505` (dark) → brightness raised | ![t3](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/t3-crop.png?raw=true) |
| T4 | Inactive tab + `#0000ff` (high sat) → adjusted | ![t4](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/t4-crop.png?raw=true) |
| T5 | Light mode + active tab → white on blue | ![t5](https://github.com/lark1115/cmux/blob/images/pr-screenshots/795/t5-crop.png?raw=true) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)