### PR TITLE
Add passkey (WebAuthn) support for browser panel

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -96,6 +96,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>cmux uses Bluetooth for cross-device passkey sign-in in embedded browser authentication flows.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -2,6 +2,119 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "NSBluetoothAlwaysUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux uses Bluetooth for cross-device passkey sign-in in embedded browser authentication flows."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux は内蔵ブラウザの認証フローでクロスデバイスパスキーサインインに Bluetooth を使用します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 使用蓝牙在内嵌浏览器认证流程中进行跨设备通行密钥登录。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 使用藍牙在內嵌瀏覽器驗證流程中進行跨裝置通行密鑰登入。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux는 내장 브라우저 인증 흐름에서 크로스 디바이스 패스키 로그인에 Bluetooth를 사용합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux verwendet Bluetooth für die geräteübergreifende Passkey-Anmeldung in eingebetteten Browser-Authentifizierungsabläufen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux usa Bluetooth para el inicio de sesión con clave de acceso entre dispositivos en flujos de autenticación del navegador integrado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux utilise le Bluetooth pour la connexion par clé d'accès inter-appareils dans les flux d'authentification du navigateur intégré."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux utilizza il Bluetooth per l'accesso con passkey tra dispositivi nei flussi di autenticazione del browser integrato."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux bruger Bluetooth til login med adgangsnøgle på tværs af enheder i den integrerede browsers godkendelsesflow."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux używa Bluetooth do logowania kluczem dostępu między urządzeniami w przepływach uwierzytelniania wbudowanej przeglądarki."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux использует Bluetooth для межустройственного входа с помощью ключа доступа во встроенном браузере."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux koristi Bluetooth za prijavu pristupnim ključem između uređaja u tokovima autentifikacije ugrađenog preglednika."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يستخدم cmux البلوتوث لتسجيل الدخول بمفتاح المرور عبر الأجهزة في تدفقات مصادقة المتصفح المضمّن."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux bruker Bluetooth for passordnøkkel-pålogging på tvers av enheter i den innebygde nettleserens autentiseringsflyt."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O cmux usa Bluetooth para login com chave de acesso entre dispositivos nos fluxos de autenticação do navegador integrado."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux ใช้ Bluetooth สำหรับการลงชื่อเข้าใช้ด้วยพาสคีย์ข้ามอุปกรณ์ในขั้นตอนการยืนยันตัวตนของเบราว์เซอร์ในตัว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux, gömülü tarayıcı kimlik doğrulama akışlarında cihazlar arası geçiş anahtarı oturum açma için Bluetooth kullanır."
+          }
+        }
+      }
+    },
     "NSCameraUsageDescription": {
       "extractionState": "manual",
       "localizations": {

--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.developer.web-browser.public-key-credential</key>
+	<true/>
 </dict>
 </plist>

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -103,6 +103,53 @@ final class AppTransportSecurityTests: XCTestCase {
     }
 }
 
+final class PasskeyEntitlementTests: XCTestCase {
+    func testEntitlementsContainPublicKeyCredential() throws {
+        let projectRoot = findProjectRoot()
+        let entitlementsURL = projectRoot.appendingPathComponent("cmux.entitlements")
+        let data = try Data(contentsOf: entitlementsURL)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: &format) as? [String: Any]
+        )
+        XCTAssertEqual(
+            plist["com.apple.developer.web-browser.public-key-credential"] as? Bool,
+            true,
+            "cmux.entitlements must include com.apple.developer.web-browser.public-key-credential for WebAuthn passkey support in WKWebView."
+        )
+    }
+
+    func testInfoPlistContainsBluetoothUsageDescriptionForPasskeys() throws {
+        let projectRoot = findProjectRoot()
+        let infoPlistURL = projectRoot.appendingPathComponent("Resources/Info.plist")
+        let data = try Data(contentsOf: infoPlistURL)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, options: [], format: &format) as? [String: Any]
+        )
+        let usageDescription = try XCTUnwrap(
+            plist["NSBluetoothAlwaysUsageDescription"] as? String,
+            "Resources/Info.plist must include NSBluetoothAlwaysUsageDescription for cross-device passkey Bluetooth flows."
+        )
+        XCTAssertFalse(
+            usageDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "NSBluetoothAlwaysUsageDescription must be non-empty."
+        )
+    }
+
+    private func findProjectRoot() -> URL {
+        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
+        for _ in 0..<10 {
+            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
+            if FileManager.default.fileExists(atPath: marker.path) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    }
+}
+
 final class BrowserInsecureHTTPSettingsTests: XCTestCase {
     func testDefaultAllowlistPatternsArePresent() {
         XCTAssertEqual(

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -8,6 +8,18 @@ import AppKit
 @testable import cmux
 #endif
 
+private func findProjectRoot() -> URL {
+    var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
+    for _ in 0..<10 {
+        let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
+        if FileManager.default.fileExists(atPath: marker.path) {
+            return dir
+        }
+        dir = dir.deletingLastPathComponent()
+    }
+    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+}
+
 /// Regression test: ensures UpdatePill is never gated behind #if DEBUG in production code paths.
 /// This prevents accidentally hiding the update UI in Release builds.
 final class UpdatePillReleaseVisibilityTests: XCTestCase {
@@ -57,19 +69,6 @@ final class UpdatePillReleaseVisibilityTests: XCTestCase {
         }
     }
 
-    private func findProjectRoot() -> URL {
-        // Walk up from the test bundle to find the project root (contains GhosttyTabs.xcodeproj).
-        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
-        for _ in 0..<10 {
-            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
-            if FileManager.default.fileExists(atPath: marker.path) {
-                return dir
-            }
-            dir = dir.deletingLastPathComponent()
-        }
-        // Fallback: assume CWD is project root.
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-    }
 }
 
 /// Regression test: ensure WKWebView can load HTTP development URLs (e.g. *.localtest.me).
@@ -88,18 +87,6 @@ final class AppTransportSecurityTests: XCTestCase {
             true,
             "Resources/Info.plist must allow HTTP loads in WKWebView for local dev hostnames."
         )
-    }
-
-    private func findProjectRoot() -> URL {
-        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
-        for _ in 0..<10 {
-            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
-            if FileManager.default.fileExists(atPath: marker.path) {
-                return dir
-            }
-            dir = dir.deletingLastPathComponent()
-        }
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
     }
 }
 
@@ -135,18 +122,6 @@ final class PasskeyEntitlementTests: XCTestCase {
             usageDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
             "NSBluetoothAlwaysUsageDescription must be non-empty."
         )
-    }
-
-    private func findProjectRoot() -> URL {
-        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
-        for _ in 0..<10 {
-            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
-            if FileManager.default.fileExists(atPath: marker.path) {
-                return dir
-            }
-            dir = dir.deletingLastPathComponent()
-        }
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
     }
 }
 
@@ -347,17 +322,5 @@ final class MainWindowLayoutStyleTests: XCTestCase {
             Without it, initial titlebar/content offsets can be wrong until a manual resize.
             """
         )
-    }
-
-    private func findProjectRoot() -> URL {
-        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
-        for _ in 0..<10 {
-            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
-            if FileManager.default.fileExists(atPath: marker.path) {
-                return dir
-            }
-            dir = dir.deletingLastPathComponent()
-        }
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
     }
 }


### PR DESCRIPTION
## Summary

- Add `com.apple.developer.web-browser.public-key-credential` entitlement to enable WKWebView to process WebAuthn passkey requests for arbitrary relying parties (Google, GitHub, Microsoft, etc.)
- Add `NSBluetoothAlwaysUsageDescription` to Info.plist for cross-device passkey sign-in flows (phone-as-authenticator via Bluetooth)
- Add regression tests to ensure entitlement and Bluetooth privacy key stay present

## Context

Without the `public-key-credential` entitlement, `navigator.credentials.create()` and `navigator.credentials.get()` silently fail in WKWebView — passkey login buttons on sites like Google, GitHub, and Microsoft don't work.

This is the minimal code change needed. No `ASAuthorizationController` code is required — WKWebView handles the WebAuthn protocol internally once the entitlement is present.

**Note:** This is a restricted entitlement pending Apple Developer portal approval. This PR gets the code ready so passkeys work as soon as Apple approves.

## Test plan

- [ ] Verify build succeeds with new entitlement
- [ ] Unit tests pass (`PasskeyEntitlementTests`)
- [ ] Once entitlement is approved: test passkey login on [webauthn.io](https://webauthn.io) or [passkeys.io](https://passkeys.io) in browser panel
- [ ] Once entitlement is approved: test cross-device passkey (scan QR code on phone) triggers Bluetooth permission dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable WebAuthn passkeys in the browser panel by adding the required WKWebView entitlement and Bluetooth usage description. Once Apple approves the entitlement, passkey sign-in (including cross-device) will work for sites like Google, GitHub, and Microsoft.

- **New Features**
  - Add com.apple.developer.web-browser.public-key-credential to cmux.entitlements for WebAuthn in WKWebView.
  - Add NSBluetoothAlwaysUsageDescription to support cross-device passkey flows, and localize it in InfoPlist.xcstrings.
  - Add tests to verify both keys stay present, and deduplicate findProjectRoot() into a single shared helper in tests.

<sup>Written for commit d7f1f27d43eeb3724a769efdda03d79bafef0b05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Passkey authentication with cross-device sign-in support
  * Enabled web-based credential sign-in with Bluetooth-assisted device pairing (localized usage text added)

* **Tests**
  * Added validation tests to verify authentication entitlements and required configuration/settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->