### PR TITLE
Fix browser issues

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2281,6 +2281,28 @@ final class WindowBrowserPortal: NSObject {
             return
         }
         guard anchorView.window === window else {
+            let isOffWindowReparent =
+                entry.visibleInUI &&
+                anchorView.window == nil &&
+                anchorView.superview != nil
+            if isOffWindowReparent {
+                let didScheduleTransientRecovery = scheduleTransientRecoveryRetryIfNeeded(
+                    forWebViewId: webViewId,
+                    entry: &entry,
+                    webView: webView,
+                    reason: "anchorWindowMismatch"
+                )
+#if DEBUG
+                if didScheduleTransientRecovery && !containerView.isHidden {
+                    dlog(
+                        "browser.portal.hidden.deferKeep web=\(browserPortalDebugToken(webView)) " +
+                        "reason=anchorWindowMismatch.offWindow frame=\(browserPortalDebugFrame(containerView.frame))"
+                    )
+                }
+#endif
+                containerView.setDropZoneOverlay(zone: nil)
+                return
+            }
             if scheduleTransientDetachRecovery(reason: "anchorWindowMismatch") {
                 containerView.setPaneTopChromeHeight(0)
                 containerView.setSearchOverlay(nil)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -10745,6 +10745,61 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testVisiblePortalEntryStaysVisibleDuringOffWindowAnchorReparentUntilRebind() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let anchorFrame = NSRect(x: 40, y: 24, width: 220, height: 160)
+        let anchor = NSView(frame: anchorFrame)
+        contentView.addSubview(anchor)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        guard let slot = webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected browser slot")
+            return
+        }
+
+        let offWindowContainer = NSView(frame: anchorFrame)
+        anchor.removeFromSuperview()
+        offWindowContainer.addSubview(anchor)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        XCTAssertTrue(
+            webView.superview === slot,
+            "Off-window anchor reparent should preserve the hosted browser slot during drag churn"
+        )
+        XCTAssertFalse(
+            slot.isHidden,
+            "Off-window anchor reparent should keep the visible browser portal alive until the anchor returns"
+        )
+        XCTAssertEqual(portal.debugEntryCount(), 1)
+
+        contentView.addSubview(anchor)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        XCTAssertTrue(webView.superview === slot, "Rebinding after off-window reparent should reuse the existing portal slot")
+        XCTAssertFalse(slot.isHidden)
+        XCTAssertEqual(portal.debugEntryCount(), 1)
+    }
+
     func testRegistryDetachRemovesPortalHostedWebView() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flicker where the browser portal detaches or hides when a visible webview’s anchor is temporarily reparented off-window during drag. Addresses Linear issue 1024 (terminal drag glitch) by keeping the slot visible until the anchor returns.

- **Bug Fixes**
  - Detects off-window reparent (visible entry + anchor has superview but no window), defers detach via transient recovery, clears drop-zone overlay, and keeps the slot visible.
  - Adds a test to ensure the portal slot stays attached and is reused after the anchor is re-bound.

<sup>Written for commit 72c0f564c87b461751518b63addec0e84c5a251a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of UI elements temporarily repositioned off-window, preventing unintended visibility flashing and enabling more stable recovery.

* **Tests**
  * Added test coverage to verify portal visibility stability during anchor repositioning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->