### PR TITLE
Fix inline VS Code serve-web token exposure via argv

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -420,9 +420,11 @@ final class VSCodeServeWebController {
             }
             self.serveWebProcess = nil
             self.launchingProcess = nil
-            let tokenFileURLs = processes.compactMap {
+            var tokenFileURLs = processes.compactMap {
                 self.connectionTokenFilesByProcessID.removeValue(forKey: ObjectIdentifier($0))
             }
+            tokenFileURLs.append(contentsOf: self.connectionTokenFilesByProcessID.values)
+            self.connectionTokenFilesByProcessID.removeAll()
             self.serveWebURL = nil
             let completions = self.pendingCompletions.map(\.completion)
             self.pendingCompletions.removeAll()


### PR DESCRIPTION
### Motivation
- Prevent leaking the inline VS Code `serve-web` authentication token via process argv on macOS, which allows other local users to harvest the token and access the bound localhost server.
- Preserve the existing serve-web lifecycle and behavior while ensuring the token is not visible in process listings and is not left on disk longer than necessary.

### Description
- Replace passing the plaintext token on argv (`--connection-token <token>`) with a file-based approach (`--connection-token-file <path>`) so only a path is visible to the child process.
- Add `makeConnectionTokenFile()` which generates a random token, writes it to a temporary file created with `O_CREAT|O_EXCL` and mode `0600` (`S_IRUSR|S_IWUSR`), and returns the file `URL`.
- Track the token file via `serveWebConnectionTokenFileURL` and remove the file on `stop()`, on process termination, and on launch failure to avoid lingering secrets on disk.
- Minor imports and plumbing to use POSIX `open`/`write`/`close` safely and to pass only the token file path to the `serve-web` invocation.

### Testing
- Ran `rg -n -- '--connection-token' Sources/AppDelegate.swift` to verify the plaintext `--connection-token` is no longer present and was replaced by `--connection-token-file`, which succeeded.
- Ran `./scripts/setup.sh` to initialize submodules (automated environment); this failed due to network/permissions in the CI-like environment (private submodule clone returned `403`), so submodule-dependent builds could not be exercised locally.
- Ran `./scripts/reload.sh --tag fix-vscode-token` (automated build-and-launch script); this could not complete in the current Linux/container environment because a macOS/Xcode DerivedData app cannot be produced or launched here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8bd2a35083338dea18af58d734d7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the inline VS Code `serve-web` auth token from appearing in argv by switching to a per-process token file. Ensures token files are cleaned up reliably, including orphans, across all lifecycle paths.

- **Bug Fixes**
  - Replace `--connection-token` with `--connection-token-file` when launching `serve-web`.
  - Generate token in a `0600` temp file via `O_CREAT|O_EXCL` and pass only the file path.
  - Track token files per process and remove them on stop, termination, launch failure, and startup read/parse errors.
  - Drain orphaned token files on stop to cover cleanup races.

<sup>Written for commit 165b45a9bdb15c90430fce0111bda9eb5946ba19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for serve-web connection tokens by moving to file-backed tokens, reducing exposure of in-memory tokens.
  * Enhanced cleanup of temporary token files to prevent resource leaks and ensure tokens are removed on process termination, stop, and startup failure paths.
  * Tightened lifecycle handling so no leftover token files persist after shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->