### PR TITLE
Disable titlebar page help tooltips

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2020,6 +2020,13 @@ struct ContentView: View {
         titlebarPageShortcutHintMonitor.isModifierPressed || alwaysShowShortcutHints
     }
 
+    // AppKit tooltip tracking areas have been crashing during titlebar page churn
+    // (hover, drag/drop, close, and selection changes). Keep this strip tooltip-free
+    // until we have a safer non-AppKit tooltip implementation for it.
+    static func titlebarPageControlsShouldInstallHelpTooltips() -> Bool {
+        false
+    }
+
     private func titlebarPageShortcutLabel(index: Int, pageCount: Int) -> String? {
         commandPalettePageShortcutHint(index: index, pageCount: pageCount)
     }
@@ -2196,7 +2203,8 @@ struct ContentView: View {
                 )
 
                 if isTitlebarHovered {
-                    Button(action: {
+                    let newPageLabel = String(localized: "workspace.page.new.tooltip", defaultValue: "New Page")
+                    let newPageButton = Button(action: {
                         _ = workspace.newPage(select: true)
                     }) {
                         Image(systemName: "plus")
@@ -2209,9 +2217,15 @@ struct ContentView: View {
                             )
                     }
                     .buttonStyle(.plain)
-                    .help(String(localized: "workspace.page.new.tooltip", defaultValue: "New Page"))
+                    .accessibilityLabel(newPageLabel)
                     .accessibilityIdentifier("titlebarPageNewButton")
                     .transition(.opacity)
+
+                    if Self.titlebarPageControlsShouldInstallHelpTooltips() {
+                        newPageButton.help(newPageLabel)
+                    } else {
+                        newPageButton
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -2259,7 +2273,7 @@ struct ContentView: View {
         let showTrailingDropIndicator = dragIndicator?.pageId == page.id && dragIndicator?.edge == .trailing
 
         return ZStack(alignment: .trailing) {
-            Button(action: {
+            let pageButton = Button(action: {
                 workspace.selectPage(page.id)
             }) {
                 HStack(spacing: 6) {
@@ -2279,11 +2293,16 @@ struct ContentView: View {
                 .background(
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .fill(fakeTitlebarTextColor.opacity(isActive ? 0.11 : (isHovered ? 0.06 : 0.001)))
-                )
+                    )
             }
             .buttonStyle(.plain)
-            .help(page.title)
             .accessibilityIdentifier(titlebarPageButtonAccessibilityIdentifier(pageId: page.id, isActive: isActive))
+
+            if Self.titlebarPageControlsShouldInstallHelpTooltips() {
+                pageButton.help(page.title)
+            } else {
+                pageButton
+            }
 
             HStack(spacing: 4) {
                 if showsShortcutHint, let shortcutLabel {

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -90,6 +90,15 @@ final class WorkspaceHandoffPolicyTests: XCTestCase {
     }
 }
 
+final class TitlebarPageTooltipPolicyTests: XCTestCase {
+    func testTitlebarPageControlsNeverInstallAppKitHelpTooltips() {
+        XCTAssertFalse(
+            ContentView.titlebarPageControlsShouldInstallHelpTooltips(),
+            "Transient titlebar page controls must not register AppKit help tooltips."
+        )
+    }
+}
+
 @MainActor
 final class WorkspacePageLifecycleTests: XCTestCase {
     func testSwitchingPagesPreservesLivePanelIdentityAcrossDetachAndReattach() throws {


### PR DESCRIPTION
## Summary
- stop installing AppKit `.help()` tooltips on transient titlebar page controls
- keep the new-page button accessible with an explicit accessibility label
- add a small guard test for the titlebar page tooltip policy

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/TitlebarPageTooltipPolicyTests/testTitlebarPageControlsNeverInstallAppKitHelpTooltips test`
- `./scripts/reload.sh --tag issue-1036-tooltip-tracking-uaf`

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/1036

## Context
Sentry issue `CMUXTERM-MACOS-1X1` first appeared on 2026-02-28 in stable `com.cmuxterm.app@0.61.0+73`, so the grouped `NSWindow.cmux_sendEvent` tracking-area crash already existed. The nightly event in https://github.com/manaflow-ai/cmux/issues/1036 first appears in `com.cmuxterm.app.nightly@0.61.0-nightly.20260307+2279003110001`, and the most likely recent trigger is commit `4de975e6a4cc84fd099aa1673348617cafd0e50a` from https://github.com/manaflow-ai/cmux/pull/1030, which added `.help()` tracking to the new titlebar page strip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable AppKit help tooltips on titlebar page controls to prevent tracking-area crashes during hover, drag, close, and selection changes. Keeps the New Page button accessible and adds a guard test.

- **Bug Fixes**
  - Gate help(...) behind ContentView.titlebarPageControlsShouldInstallHelpTooltips() which returns false.
  - Replace the New Page tooltip with an accessibilityLabel to preserve screen reader support.
  - Add TitlebarPageTooltipPolicyTests to enforce the no-tooltip policy.
  - Addresses #1036 and Sentry CMUXTERM-MACOS-1X1.

<sup>Written for commit 54afe8fa9322f19d2c8ac325942919689931d9a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled tooltips for titlebar page controls to improve user experience.

* **Tests**
  * Added test coverage for titlebar page control tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->