### PR TITLE
fix: overlay scrollbar covers terminal text

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5310,15 +5310,15 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
-        let scrollbarInset = overlayScrollbarInsetWidth()
+        let adjustedWidth = max(0, targetSize.width - overlayScrollbarInsetWidth())
         let targetSurfaceFrame = CGRect(
             origin: surfaceView.frame.origin,
-            size: CGSize(width: targetSize.width - scrollbarInset, height: targetSize.height)
+            size: CGSize(width: adjustedWidth, height: targetSize.height)
         )
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
             origin: documentView.frame.origin,
-            size: CGSize(width: scrollView.bounds.width - scrollbarInset, height: documentView.frame.height)
+            size: CGSize(width: adjustedWidth, height: documentView.frame.height)
         )
         _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         _ = setFrameIfNeeded(inactiveOverlayView, to: bounds)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5310,11 +5310,15 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
-        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
+        let scrollbarInset = overlayScrollbarInsetWidth()
+        let targetSurfaceFrame = CGRect(
+            origin: surfaceView.frame.origin,
+            size: CGSize(width: targetSize.width - scrollbarInset, height: targetSize.height)
+        )
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
             origin: documentView.frame.origin,
-            size: CGSize(width: scrollView.bounds.width, height: documentView.frame.height)
+            size: CGSize(width: scrollView.bounds.width - scrollbarInset, height: documentView.frame.height)
         )
         _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         _ = setFrameIfNeeded(inactiveOverlayView, to: bounds)
@@ -6491,7 +6495,7 @@ final class GhosttySurfaceScrollView: NSView {
     /// regions such as scrollbar space) when telling libghostty the terminal size.
     @discardableResult
     private func synchronizeCoreSurface() -> Bool {
-        let width = max(0, scrollView.contentSize.width - overlayScrollbarInsetWidth())
+        let width = surfaceView.frame.width
         let height = surfaceView.frame.height
         guard width > 0, height > 0 else { return false }
         return surfaceView.pushTargetSurfaceSize(CGSize(width: width, height: height))


### PR DESCRIPTION
## Summary

- Narrow `surfaceView` and `documentView` frames by the overlay scrollbar width so the Metal drawable and view bounds match
- Simplify `synchronizeCoreSurface()` to read `surfaceView.frame.width` directly, avoiding double-subtraction

## Problem

The overlay scrollbar in `GhosttySurfaceScrollView` sits on top of terminal text instead of text wrapping to leave space for it. This makes text unreadable behind the scrollbar, especially in long-running sessions.

**Root cause:** `synchronizeGeometryAndContent()` sets `surfaceView.frame` to the full `scrollView.bounds.size`, then `synchronizeCoreSurface()` tells Ghostty to render at a narrower width (minus scrollbar). The Metal layer's `drawableSize` is narrower than the view's bounds, causing the rendered content to stretch — the scrollbar gutter space is lost.

## Solution

1. Subtract `overlayScrollbarInsetWidth()` from `surfaceView.frame.size.width` so the Metal drawable matches the view bounds
2. Subtract the same inset from `documentView.frame.size.width` for consistent scroll view content
3. Simplify `synchronizeCoreSurface()` to use `surfaceView.frame.width` directly

## Test plan

- [ ] Open a terminal pane, run a command with long wrapped lines — scrollbar appears next to text, not on top
- [ ] Text wraps at the correct column (before the scrollbar gutter)
- [ ] Resize the window — no visual glitches during live resize
- [ ] Test with split panes — both panes handle scrollbar correctly
- [ ] Build succeeds locally (`BUILD SUCCEEDED` verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlay scrollbar covering terminal text by sizing the terminal surface to exclude the scrollbar gutter. Text now wraps before the scrollbar, and the Metal drawable matches the view bounds.

- **Bug Fixes**
  - Subtract `overlayScrollbarInsetWidth()` from `surfaceView` and `documentView`, clamped to >= 0 and using the same adjusted width for both.
  - Use `surfaceView.frame.width` in `synchronizeCoreSurface()` to avoid double-subtraction/stretching.

<sup>Written for commit 5969be6eb02b8a439802f44bccaf29462625ffe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout issues caused by the overlay scrollbar gutter so content no longer clips at the right edge.
  * Ensured viewport and content widths are calculated consistently, preventing misalignment when the overlay scrollbar is present.
  * Improved surface synchronization so rendered content stays correctly positioned and sized during scrolling and resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->