### PR TITLE
Fix reentrant layout crash when setting isHidden during SwiftUI render

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4465,7 +4465,15 @@ final class GhosttySurfaceScrollView: NSView {
     func setVisibleInUI(_ visible: Bool) {
         let wasVisible = surfaceView.isVisibleInUI
         surfaceView.setVisibleInUI(visible)
-        isHidden = !visible
+        // Defer isHidden mutation to avoid reentrant layout when called during SwiftUI render.
+        // Setting isHidden triggers constraint/layout invalidation, which causes crashes when
+        // this view hierarchy contains an NSHostingView (search overlay).
+        if isHidden != !visible {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.isHidden = !visible
+            }
+        }
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"


### PR DESCRIPTION
Defer isHidden mutation to avoid constraint/layout invalidation that causes crashes when the view hierarchy contains an NSHostingView (search overlay).

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `isHidden` updates during SwiftUI render to prevent reentrant layout and a crash when an `NSHostingView` (search overlay) is in the hierarchy. Stabilizes visibility toggles for the terminal surface.

- **Bug Fixes**
  - Update `isHidden` asynchronously on the main queue and only when the value changes, avoiding layout invalidation during render.

<sup>Written for commit 93fc249cd93cde55e801b818a1ddc41233da47a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

