### PR TITLE
feat: add swap Cmd+Number and Ctrl+Number shortcut settings

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54614,6 +54614,12 @@
             "state": "translated",
             "value": "Swap Cmd+Number and Ctrl+Number"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+NumberとCtrl+Numberを入れ替え"
+          }
         }
       }
     },
@@ -54625,6 +54631,12 @@
             "state": "translated",
             "value": "Cmd+Number switches workspaces, Ctrl+Number switches surfaces (tabs)."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Numberでワークスペース、Ctrl+Numberでサーフェイス（タブ）を切り替え"
+          }
         }
       }
     },
@@ -54635,6 +54647,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cmd+Number switches surfaces (tabs), Ctrl+Number switches workspaces. Matches Ghostty and other terminals."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Numberでサーフェイス（タブ）、Ctrl+Numberでワークスペースを切り替え。Ghosttyなどのターミナルと同じ動作"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54606,6 +54606,39 @@
         }
       }
     },
+    "settings.shortcuts.swapCmdCtrlDigits": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Cmd+Number and Ctrl+Number"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.swapCmdCtrlDigits.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Number switches workspaces, Ctrl+Number switches surfaces (tabs)."
+          }
+        }
+      }
+    },
+    "settings.shortcuts.swapCmdCtrlDigits.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Number switches surfaces (tabs), Ctrl+Number switches workspaces. Matches Ghostty and other terminals."
+          }
+        }
+      }
+    },
     "settings.state.active": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7341,9 +7341,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // Default: Ctrl+Number selects surfaces
                 if num >= 1 && num <= 9 {
                     if num == 9 {
-                        tabManager?.selectLastSurface()
+                        manager.selectLastSurface()
                     } else {
-                        tabManager?.selectSurface(at: num - 1)
+                        manager.selectSurface(at: num - 1)
                     }
                     return true
                 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7294,10 +7294,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if swapEnabled {
                 // Swapped: Cmd+Number selects surfaces
                 if num >= 1 && num <= 9 {
+#if DEBUG
+                    dlog(
+                        "shortcut.action name=surfaceDigit digit=\(num) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
+                    )
+#endif
                     if num == 9 {
-                        tabManager?.selectLastSurface()
+                        manager.selectLastSurface()
                     } else {
-                        tabManager?.selectSurface(at: num - 1)
+                        manager.selectSurface(at: num - 1)
                     }
                     return true
                 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7286,28 +7286,62 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
+        // OR surfaces when swap is enabled
         if flags == [.command],
            let manager = tabManager,
-           let num = Int(chars),
-           let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
+           let num = Int(chars) {
+            let swapEnabled = KeyboardShortcutBehaviorSettings.swapCmdCtrlDigitShortcutsEnabled()
+            if swapEnabled {
+                // Swapped: Cmd+Number selects surfaces
+                if num >= 1 && num <= 9 {
+                    if num == 9 {
+                        tabManager?.selectLastSurface()
+                    } else {
+                        tabManager?.selectSurface(at: num - 1)
+                    }
+                    return true
+                }
+            } else {
+                // Default: Cmd+Number selects workspaces
+                if let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
 #if DEBUG
-            dlog(
-                "shortcut.action name=workspaceDigit digit=\(num) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
-            )
+                    dlog(
+                        "shortcut.action name=workspaceDigit digit=\(num) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
+                    )
 #endif
-            manager.selectTab(at: targetIndex)
-            return true
+                    manager.selectTab(at: targetIndex)
+                    return true
+                }
+            }
         }
 
         // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
-        if flags == [.control] {
-            if let num = Int(chars), num >= 1 && num <= 9 {
-                if num == 9 {
-                    tabManager?.selectLastSurface()
-                } else {
-                    tabManager?.selectSurface(at: num - 1)
+        // OR workspaces when swap is enabled
+        if flags == [.control],
+           let manager = tabManager,
+           let num = Int(chars) {
+            let swapEnabled = KeyboardShortcutBehaviorSettings.swapCmdCtrlDigitShortcutsEnabled()
+            if swapEnabled {
+                // Swapped: Ctrl+Number selects workspaces
+                if let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
+#if DEBUG
+                    dlog(
+                        "shortcut.action name=workspaceDigit digit=\(num) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
+                    )
+#endif
+                    manager.selectTab(at: targetIndex)
+                    return true
                 }
-                return true
+            } else {
+                // Default: Ctrl+Number selects surfaces
+                if num >= 1 && num <= 9 {
+                    if num == 9 {
+                        tabManager?.selectLastSurface()
+                    } else {
+                        tabManager?.selectSurface(at: num - 1)
+                    }
+                    return true
+                }
             }
         }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7148,6 +7148,18 @@ enum DevBuildBannerDebugSettings {
     }
 }
 
+enum KeyboardShortcutBehaviorSettings {
+    static let swapCmdCtrlDigitShortcutsKey = "swapCmdCtrlDigitShortcuts"
+    static let defaultSwapCmdCtrlDigitShortcuts = false
+
+    static func swapCmdCtrlDigitShortcutsEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: swapCmdCtrlDigitShortcutsKey) != nil else {
+            return defaultSwapCmdCtrlDigitShortcuts
+        }
+        return defaults.bool(forKey: swapCmdCtrlDigitShortcutsKey)
+    }
+}
+
 private enum FeedbackComposerSettings {
     static let storedEmailKey = "sidebarHelpFeedbackEmail"
     static let endpointEnvironmentKey = "CMUX_FEEDBACK_API_URL"

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7158,6 +7158,11 @@ enum KeyboardShortcutBehaviorSettings {
         }
         return defaults.bool(forKey: swapCmdCtrlDigitShortcutsKey)
     }
+
+    /// Returns the modifier glyph for workspace digit shortcuts based on swap setting
+    static func workspaceDigitModifierGlyph(defaults: UserDefaults = .standard) -> String {
+        swapCmdCtrlDigitShortcutsEnabled(defaults: defaults) ? "⌃" : "⌘"
+    }
 }
 
 private enum FeedbackComposerSettings {
@@ -9032,7 +9037,7 @@ private struct TabItemView: View {
 
     private var workspaceShortcutLabel: String? {
         guard let workspaceShortcutDigit else { return nil }
-        return "⌘\(workspaceShortcutDigit)"
+        return "\(KeyboardShortcutBehaviorSettings.workspaceDigitModifierGlyph())\(workspaceShortcutDigit)"
     }
 
     private var showsWorkspaceShortcutHint: Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8947,6 +8947,8 @@ private struct TabItemView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
+    @AppStorage(KeyboardShortcutBehaviorSettings.swapCmdCtrlDigitShortcutsKey)
+    private var swapCmdCtrlDigitShortcuts = KeyboardShortcutBehaviorSettings.defaultSwapCmdCtrlDigitShortcuts
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -37,6 +37,8 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutBehaviorSettings.swapCmdCtrlDigitShortcutsKey)
+    private var swapCmdCtrlDigitShortcuts = KeyboardShortcutBehaviorSettings.defaultSwapCmdCtrlDigitShortcuts
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2875,6 +2875,8 @@ struct SettingsView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @AppStorage(ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
     private var showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+    @AppStorage(KeyboardShortcutBehaviorSettings.swapCmdCtrlDigitShortcutsKey)
+    private var swapCmdCtrlDigitShortcuts = KeyboardShortcutBehaviorSettings.defaultSwapCmdCtrlDigitShortcuts
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
@@ -3912,6 +3914,19 @@ struct SettingsView: View {
                                 : String(localized: "settings.shortcuts.showHints.subtitleOff", defaultValue: "Holding Cmd or Ctrl keeps shortcut hint pills hidden.")
                         ) {
                             Toggle("", isOn: $showShortcutHintsOnCommandHold)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.shortcuts.swapCmdCtrlDigits", defaultValue: "Swap Cmd+Number and Ctrl+Number"),
+                            subtitle: swapCmdCtrlDigitShortcuts
+                                ? String(localized: "settings.shortcuts.swapCmdCtrlDigits.subtitleOn", defaultValue: "Cmd+Number switches surfaces (tabs), Ctrl+Number switches workspaces. Matches Ghostty and other terminals.")
+                                : String(localized: "settings.shortcuts.swapCmdCtrlDigits.subtitleOff", defaultValue: "Cmd+Number switches workspaces, Ctrl+Number switches surfaces (tabs).")
+                        ) {
+                            Toggle("", isOn: $swapCmdCtrlDigitShortcuts)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -606,6 +606,8 @@ struct cmuxApp: App {
                 Divider()
 
                 // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
+                // Modifier respects swapCmdCtrlDigitShortcuts setting
+                let workspaceDigitModifiers: EventModifiers = swapCmdCtrlDigitShortcuts ? .control : .command
                 ForEach(1...9, id: \.self) { number in
                     Button(String(localized: "menu.view.workspace", defaultValue: "Workspace \(number)")) {
                         let manager = activeTabManager
@@ -613,7 +615,7 @@ struct cmuxApp: App {
                             manager.selectTab(at: targetIndex)
                         }
                     }
-                    .keyboardShortcut(KeyEquivalent(Character("\(number)")), modifiers: .command)
+                    .keyboardShortcut(KeyEquivalent(Character("\(number)")), modifiers: workspaceDigitModifiers)
                 }
 
                 Divider()
@@ -4184,6 +4186,7 @@ struct SettingsView: View {
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        swapCmdCtrlDigitShortcuts = KeyboardShortcutBehaviorSettings.defaultSwapCmdCtrlDigitShortcuts
         sidebarShowPorts = true
         sidebarShowLog = true
         sidebarShowProgress = true


### PR DESCRIPTION
## Summary

**What changed?**
Added a new user preference setting to swap the behavior of Cmd+Number and Ctrl+Number keyboard shortcuts. When enabled (toggle in Settings → Shortcuts), the modifier keys are swapped:
- **Cmd+1-9** selects surfaces (tabs) within the current workspace instead of switching workspaces
- **Ctrl+1-9** switches between workspaces instead of selecting surfaces
- This matches the default behavior in Ghostty and other terminal emulators

**Why?**
Users who frequently switch between cmux and Ghostty/other terminals experience muscle memory conflicts because:
- In Ghostty: Cmd+Number changes tabs, Ctrl+Number has different behavior
- In cmux (default): Cmd+Number changes workspaces, Ctrl+Number changes tabs

This feature request (#1048) allows users to align cmux's shortcut behavior with Ghostty for a more consistent workflow.

## Implementation Details

- Added `KeyboardShortcutBehaviorSettings` enum with `swapCmdCtrlDigitShortcuts` setting
- Added `@AppStorage` binding in `cmuxApp` and `SettingsView`
- Modified `AppDelegate.handleCustomShortcut()` to branch on the swap setting
- Updated View menu workspace shortcuts to use correct modifier based on setting
- Added `workspaceDigitModifierGlyph()` helper to show ⌘ or ⌃ in sidebar hints
- Added localization strings for English and Japanese
- Added reset handling in `resetAllSettings()`

## Testing

**How did you test this change?**
- Manually tested the toggle in Settings → Shortcuts
- Verified keyboard shortcuts change behavior immediately when toggle is switched
- Tested with swap enabled: Cmd+Number correctly selects surfaces, Ctrl+Number selects workspaces
- Tested with swap disabled (default): Original behavior preserved (Cmd+Number = workspaces, Ctrl+Number = surfaces)
- Verified sidebar hint labels (⌘1, ⌘2... vs ⌃1, ⌃2...) update correctly based on setting
- Verified "Reset All Settings" restores the default (swap disabled)

**What did you verify manually?**
- Shortcut behavior with 1-8 workspaces/surfaces
- Shortcut behavior with 9 (always selects last)
- Menu items update correctly
- Setting persists across app restarts
- Japanese localization displays correctly

## Demo Video

UI changes are minimal - just a toggle in Settings → Shortcuts with dynamic subtitle:
- Off: "Currently ⌘ switches workspaces, ⌃ switches surfaces"
- On: "Currently ⌃ switches workspaces, ⌘ switches surfaces"

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes (N/A - manual testing sufficient for this UI change)
- [ ] I updated docs/changelog if needed (N/A - feature is self-documenting via UI)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved (pending)