### PR TITLE
Improve Korean README for natural, native phrasing

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,9 +1,9 @@
-> 이 번역은 Claude에 의해 생성되었습니다. 개선 사항이 있으면 PR을 제출해 주세요.
+> 이 문서는 Claude가 번역했어요. 개선할 부분이 있다면 PR을 보내주세요.
 
 <p align="center"><a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a> | 한국어 | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.pt-BR.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a></p>
 
 <h1 align="center">cmux</h1>
-<p align="center">AI 코딩 에이전트를 위한 세로 탭과 알림 기능을 갖춘 Ghostty 기반 macOS 터미널</p>
+<p align="center">세로 탭과 알림을 지원하는 AI 코딩 에이전트용 Ghostty 기반 macOS 터미널</p>
 
 <p align="center">
   <a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">
@@ -17,17 +17,17 @@
 
 ## 기능
 
-- **세로 탭** — 사이드바에 git 브랜치, 작업 디렉토리, 리스닝 포트, 최신 알림 텍스트 표시
-- **알림 링** — AI 에이전트(Claude Code, OpenCode)가 사용자의 주의를 필요로 할 때 패널에 파란색 링이 표시되고 탭이 강조됨
-- **알림 패널** — 모든 대기 중인 알림을 한 곳에서 확인하고, 가장 최근의 읽지 않은 알림으로 바로 이동
-- **분할 패널** — 수평 및 수직 분할 지원
-- **내장 브라우저** — [agent-browser](https://github.com/vercel-labs/agent-browser)에서 포팅된 스크립트 가능한 API를 갖춘 브라우저를 터미널 옆에 분할하여 사용
-- **스크립트 가능** — CLI와 socket API로 워크스페이스 생성, 패널 분할, 키 입력 전송, 브라우저 자동화 가능
-- **네이티브 macOS 앱** — Swift와 AppKit으로 구축, Electron이 아닙니다. 빠른 시작, 낮은 메모리 사용량.
-- **Ghostty 호환** — 기존 `~/.config/ghostty/config`에서 테마, 글꼴, 색상 설정을 읽어옴
-- **GPU 가속** — libghostty로 구동되어 부드러운 렌더링 제공
+- **세로 탭** — 사이드바에서 git 브랜치, 작업 디렉토리, 수신 포트, 최근 알림 텍스트를 한눈에 볼 수 있어요.
+- **알림 링** — AI 에이전트(Claude Code, OpenCode)가 입력을 기다리면 패널에 파란색 링이 뜨고 탭이 강조돼요.
+- **알림 패널** — 대기 중인 알림을 한곳에서 확인하고, 가장 최근 읽지 않은 알림으로 바로 이동할 수 있어요.
+- **분할 패널** — 수평·수직 분할을 지원해요.
+- **내장 브라우저** — [agent-browser](https://github.com/vercel-labs/agent-browser)에서 포팅된 스크립팅 API를 갖춘 브라우저를 터미널 옆에 띄울 수 있어요.
+- **스크립팅** — CLI와 socket API로 워크스페이스 생성, 패널 분할, 키 입력 전송, 브라우저 자동화가 가능해요.
+- **네이티브 macOS 앱** — Electron이 아닌 Swift와 AppKit으로 만들었어요. 빠르게 실행되고 메모리도 적게 써요.
+- **Ghostty 호환** — 기존 `~/.config/ghostty/config`에서 테마, 글꼴, 색상 설정을 그대로 읽어와요.
+- **GPU 가속** — libghostty 기반이라 렌더링이 부드러워요.
 
-## 설치
+## 설치하기
 
 ### DMG (권장)
 
@@ -35,7 +35,7 @@
   <img src="./docs/assets/macos-badge.png" alt="macOS용 cmux 다운로드" width="180" />
 </a>
 
-`.dmg` 파일을 열고 cmux를 응용 프로그램 폴더로 드래그하세요. cmux는 Sparkle을 통해 자동 업데이트되므로, 한 번만 다운로드하면 됩니다.
+`.dmg` 파일을 열고 cmux를 응용 프로그램 폴더로 드래그하면 돼요. Sparkle을 통해 자동 업데이트되니 한 번만 다운로드하면 돼요.
 
 ### Homebrew
 
@@ -44,25 +44,25 @@ brew tap manaflow-ai/cmux
 brew install --cask cmux
 ```
 
-나중에 업데이트하려면:
+나중에 업데이트하려면 아래 명령어를 실행해주세요:
 
 ```bash
 brew upgrade --cask cmux
 ```
 
-처음 실행 시, macOS가 확인된 개발자의 앱을 여는 것을 확인하도록 요청할 수 있습니다. **열기**를 클릭하여 계속 진행하세요.
+처음 실행할 때 macOS에서 개발자 확인 팝업이 뜰 수 있어요. **열기**를 클릭하면 돼요.
 
 ## 왜 cmux를 만들었나요?
 
-저는 Claude Code와 Codex 세션을 대량으로 병렬 실행합니다. 이전에는 Ghostty에서 분할 패널을 여러 개 열어놓고, 에이전트가 저를 필요로 할 때 macOS 기본 알림에 의존했습니다. 하지만 Claude Code의 알림 내용은 항상 "Claude is waiting for your input"이라는 맥락 없는 동일한 메시지뿐이었고, 탭이 많아지면 제목조차 읽을 수 없었습니다.
+저는 Claude Code와 Codex 세션을 여러 개 동시에 돌려요. 예전에는 Ghostty에서 분할 패널을 여러 개 열어놓고, 에이전트가 입력을 기다릴 때 macOS 기본 알림에 의존했어요. 그런데 Claude Code 알림은 항상 "Claude is waiting for your input"이라는 아무 맥락 없이 똑같은 메시지뿐이었고, 탭이 많아지면 제목조차 읽을 수가 없었어요.
 
-몇 가지 코딩 오케스트레이터를 시도해봤지만, 대부분 Electron/Tauri 앱이어서 성능이 마음에 들지 않았습니다. 또한 GUI 오케스트레이터는 특정 워크플로우에 갇히게 되므로 터미널을 더 선호합니다. 그래서 Swift/AppKit으로 네이티브 macOS 앱인 cmux를 만들었습니다. 터미널 렌더링에 libghostty를 사용하고, 기존 Ghostty 설정에서 테마, 글꼴, 색상을 읽어옵니다.
+여러 코딩 오케스트레이터를 써봤는데, 대부분 Electron/Tauri 앱이라 성능이 별로였어요. GUI 오케스트레이터는 특정 워크플로우에 갇히게 돼서 터미널이 더 낫다고 생각했고요. 그래서 Swift/AppKit으로 네이티브 macOS 앱인 cmux를 직접 만들었어요. 터미널 렌더링에는 libghostty를 쓰고, 기존 Ghostty 설정에서 테마, 글꼴, 색상을 그대로 가져와요.
 
-주요 추가 기능은 사이드바와 알림 시스템입니다. 사이드바에는 각 워크스페이스의 git 브랜치, 작업 디렉토리, 리스닝 포트, 최신 알림 텍스트를 보여주는 세로 탭이 있습니다. 알림 시스템은 터미널 시퀀스(OSC 9/99/777)를 감지하고, Claude Code, OpenCode 등의 에이전트 훅에 연결할 수 있는 CLI(`cmux notify`)를 제공합니다. 에이전트가 대기 중일 때 해당 패널에 파란색 링이 표시되고 사이드바에서 탭이 강조되어, 여러 분할 패널과 탭에서 어떤 것이 저를 필요로 하는지 한눈에 알 수 있습니다. ⌘⇧U로 가장 최근의 읽지 않은 알림으로 이동합니다.
+핵심은 사이드바와 알림 시스템이에요. 사이드바에는 각 워크스페이스의 git 브랜치, 작업 디렉토리, 수신 포트, 최근 알림 텍스트를 보여주는 세로 탭이 있어요. 알림 시스템은 터미널 시퀀스(OSC 9/99/777)를 감지하고, Claude Code나 OpenCode 같은 에이전트 훅에 연결할 수 있는 CLI(`cmux notify`)를 제공해요. 에이전트가 대기 중이면 해당 패널에 파란색 링이 뜨고 사이드바 탭이 강조되니까, 여러 패널과 탭 중에서 어디서 입력을 기다리는지 바로 알 수 있어요. ⌘⇧U를 누르면 가장 최근 읽지 않은 알림으로 이동해요.
 
-내장 브라우저는 [agent-browser](https://github.com/vercel-labs/agent-browser)에서 포팅된 스크립트 가능한 API를 갖추고 있습니다. 에이전트가 접근성 트리 스냅샷을 가져오고, 요소 참조를 얻고, 클릭하고, 양식을 작성하고, JS를 실행할 수 있습니다. 터미널 옆에 브라우저 패널을 분할하여 Claude Code가 개발 서버와 직접 상호작용하도록 할 수 있습니다.
+내장 브라우저는 [agent-browser](https://github.com/vercel-labs/agent-browser)에서 포팅한 스크립팅 API를 제공해요. 에이전트가 접근성 트리 스냅샷을 가져오고, 요소를 참조·클릭하고, 양식을 채우고, JS를 실행할 수 있어요. 터미널 옆에 브라우저 패널을 띄워서 Claude Code가 개발 서버와 직접 상호작용하게 할 수 있어요.
 
-모든 것은 CLI와 socket API를 통해 스크립트 가능합니다 — 워크스페이스/탭 생성, 패널 분할, 키 입력 전송, 브라우저에서 URL 열기.
+CLI와 socket API로 모든 걸 자동화할 수 있어요 — 워크스페이스/탭 생성, 패널 분할, 키 입력 전송, 브라우저에서 URL 열기까지요.
 
 ## 키보드 단축키
 
@@ -98,13 +98,13 @@ brew upgrade --cask cmux
 | ⌘ D | 오른쪽으로 분할 |
 | ⌘ ⇧ D | 아래로 분할 |
 | ⌥ ⌘ ← → ↑ ↓ | 방향키로 패널 포커스 이동 |
-| ⌘ ⇧ H | 포커스된 패널 깜빡임 |
+| ⌘ ⇧ H | 현재 패널 깜빡임 |
 
 ### 브라우저
 
 | 단축키 | 동작 |
 |----------|--------|
-| ⌘ ⇧ L | 분할에서 브라우저 열기 |
+| ⌘ ⇧ L | 분할 패널로 브라우저 열기 |
 | ⌘ L | 주소창 포커스 |
 | ⌘ [ | 뒤로 |
 | ⌘ ] | 앞으로 |
@@ -116,7 +116,7 @@ brew upgrade --cask cmux
 | 단축키 | 동작 |
 |----------|--------|
 | ⌘ I | 알림 패널 표시 |
-| ⌘ ⇧ U | 최신 읽지 않은 알림으로 이동 |
+| ⌘ ⇧ U | 최근 읽지 않은 알림으로 이동 |
 
 ### 찾기
 
@@ -125,7 +125,7 @@ brew upgrade --cask cmux
 | ⌘ F | 찾기 |
 | ⌘ G / ⌘ ⇧ G | 다음 찾기 / 이전 찾기 |
 | ⌘ ⇧ F | 찾기 바 숨기기 |
-| ⌘ E | 선택 영역으로 찾기 |
+| ⌘ E | 선택한 텍스트로 찾기 |
 
 ### 터미널
 
@@ -148,6 +148,6 @@ brew upgrade --cask cmux
 
 ## 라이선스
 
-이 프로젝트는 GNU Affero 일반 공중 사용 허가서 v3.0 이상(`AGPL-3.0-or-later`)에 따라 라이선스가 부여됩니다.
+이 프로젝트는 GNU Affero General Public License v3.0 이상(`AGPL-3.0-or-later`)으로 배포돼요.
 
-전체 라이선스 텍스트는 `LICENSE` 파일을 참조하세요.
+자세한 내용은 `LICENSE` 파일을 확인해주세요.


### PR DESCRIPTION
  ## Summary

  - Improve Korean README (README.ko.md) for natural, native-sounding Korean
  - Replace stiff machine-translated expressions with idiomatic Korean (Toss-style 해요체)
  - Fix unnatural word choices: 리스닝 포트→수신 포트, 구축→제작, 양식을 작성→양식을 채우다, etc.

  ## Testing

  - Reviewed all changes line-by-line for natural Korean phrasing
  - No code changes — translation/copy only

  ## Demo Video

  N/A (text-only change)

  ## Review Trigger (Copy/Paste as PR comment)

  @codex review
  @coderabbitai review
  @greptile-apps review
  @cubic-dev-ai review

  ## Checklist

  - [x] I tested the change locally
  - [ ] I added or updated tests for behavior changes
  - [x] I updated docs/changelog if needed
  - [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
  - [ ] All code review bot comments are resolved
  - [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the Korean README (`README.ko.md`) in natural, idiomatic 해요체 to replace stiff machine-translated text and improve clarity. Updated key terms and phrasing (e.g., 리스닝 포트→수신 포트, 구축→제작, 양식을 작성→양식을 채우다); docs-only change.

<sup>Written for commit 13d8d569f2f3638b2a4aab193460cb166dfc0eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Korean README with modernized wording and improved phrasing for better clarity and readability throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->