### PR TITLE
Fix macOS Dictation not working in terminal surfaces

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3730,6 +3730,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override var acceptsFirstResponder: Bool { true }
 
+    // Provide a cached NSTextInputContext so that macOS text-input services
+    // (Dictation, IME activation) can discover this view even though it lives
+    // in the portal layer outside window.contentView.  The default
+    // NSView.inputContext auto-creates a context only for views in the
+    // contentView hierarchy; portal-hosted views need an explicit override.
+    private lazy var _inputContext: NSTextInputContext = {
+        NSTextInputContext(client: self)
+    }()
+
+    override var inputContext: NSTextInputContext? {
+        return _inputContext
+    }
+
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         var shouldApplySurfaceFocus = false
@@ -6654,7 +6667,11 @@ extension GhosttyNSView: NSTextInputClient {
     }
 
     func selectedRange() -> NSRange {
-        return NSRange(location: NSNotFound, length: 0)
+        guard let surface = surface else { return NSRange() }
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_selection(surface, &text) else { return NSRange() }
+        defer { ghostty_surface_free_text(surface, &text) }
+        return NSRange(location: Int(text.offset_start), length: Int(text.offset_len))
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {


### PR DESCRIPTION
## Summary

Fixes macOS Dictation (Globe/Fn key) not working in terminal surfaces. Pressing the dictation key previously produced a system alert "dong" sound with no text inserted, while dictation worked fine in Ghostty standalone and cmux browser tabs.

**Root causes:**

- **Portal-hosted views lack a registered NSTextInputContext.** Terminal views live in the portal layer (NSThemeFrame, sibling of `window.contentView`), so the default `NSView.inputContext` never properly registers with InputMethodKit. A custom cached `NSTextInputContext(client: self)` override lets macOS discover the text-input context regardless of view hierarchy position.

- **`selectedRange()` returned `{NSNotFound, 0}`**, signaling no valid insertion point. Matching Ghostty upstream by querying the surface for the actual selection (falling back to `{0, 0}`) tells macOS the view is ready for text input.

## Changes

- `GhosttyTerminalView.swift`: Override `inputContext` on `GhosttyNSView` to return a cached `NSTextInputContext(client: self)`
- `GhosttyTerminalView.swift`: Fix `selectedRange()` to query the Ghostty surface for actual selection range (matching upstream Ghostty behavior)

## Test plan

- [ ] Open cmux terminal, press Globe/Fn key → dictation microphone indicator should appear
- [ ] Dictate text → recognized text should be inserted into terminal
- [ ] Verify CJK IME (Korean, Japanese, Chinese) input still works correctly
- [ ] Verify regular keyboard input is unaffected
- [ ] Verify terminal rendering on first launch is unaffected

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS Dictation (Globe/Fn) in terminal surfaces by registering a proper text-input context and reporting a valid insertion range. Dictation and IME now activate and insert text as expected.

- **Bug Fixes**
  - Override `GhosttyNSView.inputContext` to return a cached `NSTextInputContext(client: self)` so portal-hosted views are discoverable by macOS input services.
  - Update `selectedRange()` to read the selection from the Ghostty surface (fallback `{0,0}`) to signal a valid insertion point.

<sup>Written for commit 8f095c23b5d1dbaf9ff2b3c4b8053a77704a8d59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled macOS text-input services, including dictation and input method editor (IME) support.

* **Bug Fixes**
  * Improved text selection detection for more accurate selection handling in terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->