### PR TITLE
Fix blank terminal on first launch

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2313,6 +2313,20 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
             dlog("surface.attach.create.done surface=\(id.uuidString.prefix(5)) hasSurface=\(surface != nil ? 1 : 0)")
 #endif
+            // The surface may be created before the window becomes key (e.g.,
+            // when launched by a script that retains focus). Schedule a
+            // deferred refresh so the renderer starts even without a
+            // didBecomeKey trigger.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                guard let self, let surface = self.surface else { return }
+                if let view = self.attachedView,
+                   let displayID = (view.window?.screen ?? NSScreen.main)?.displayID,
+                   displayID != 0 {
+                    ghostty_surface_set_display_id(surface, displayID)
+                }
+                self.attachedView?.forceRefreshSurface()
+                ghostty_surface_refresh(surface)
+            }
         } else if let screen = view.window?.screen ?? NSScreen.main,
                   let displayID = screen.displayID,
                   displayID != 0,
@@ -5414,6 +5428,17 @@ final class GhosttySurfaceScrollView: NSView {
             dlog("find.window.didBecomeKey surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") searchActive=\(searchActive) focusTarget=\(self.searchFocusTarget) firstResponder=\(String(describing: self.window?.firstResponder))")
 #endif
             self.applyFirstResponderIfNeeded()
+
+            // When the window becomes key and the surface view is already the
+            // first responder, applyFirstResponderIfNeeded() returns early.
+            // Force a display-link restart + redraw so the terminal renders.
+            // Without this, the terminal can stay blank after launch because
+            // becomeFirstResponder ran before the window was key.
+            if let window = self.window,
+               let fr = window.firstResponder as? NSView,
+               (fr === self.surfaceView || fr.isDescendant(of: self.surfaceView)) {
+                self.surfaceView.terminalSurface?.forceRefresh(reason: "didBecomeKey")
+            }
         })
         windowObservers.append(NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,
@@ -5437,6 +5462,21 @@ final class GhosttySurfaceScrollView: NSView {
             }
         })
         if window.isKeyWindow { applyFirstResponderIfNeeded() }
+
+        // Also refresh when the app itself becomes active (e.g., user switches
+        // to cmux after it was launched by a script in another terminal).
+        windowObservers.append(NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self,
+                  let window = self.window,
+                  window.isKeyWindow,
+                  let fr = window.firstResponder as? NSView,
+                  (fr === self.surfaceView || fr.isDescendant(of: self.surfaceView)) else { return }
+            self.surfaceView.terminalSurface?.forceRefresh(reason: "appDidBecomeActive")
+        })
     }
 
     func attachSurface(_ terminalSurface: TerminalSurface) {


### PR DESCRIPTION
## Summary

Fixes #399 — the first terminal tab appears blank/white on launch and only renders after opening a second tab or clicking the window.

### Root Cause

When cmux launches, `becomeFirstResponder` sets focus and display ID on the Ghostty surface **before** the window becomes key. When `didBecomeKey` fires later, `applyFirstResponderIfNeeded()` sees the view is already first responder and returns early — so nobody restarts the CVDisplayLink. The terminal stays blank until a tab switch forces a full focus cycle.

**Key evidence:** The shell process IS running during the blank state — typed text appears when the terminal eventually renders. This confirms the issue is purely a display-link/renderer startup problem.

### Fix

Three-part fix covering all timing scenarios:

1. **`forceRefresh` in `didBecomeKey`** — When the window becomes key and the surface view is already first responder, explicitly call `forceRefresh()` to restart the display link instead of relying on `applyFirstResponderIfNeeded()`.

2. **`forceRefresh` on `NSApplication.didBecomeActiveNotification`** — Covers app activation after background launch (e.g., launched by a script that retains focus in another terminal).

3. **Deferred post-create refresh** — 300ms after surface creation, reassert display ID and force refresh as a safety net for cases where `didBecomeKey` and `didBecomeActive` fired before the renderer was ready.

### Why previous fixes didn't fully work

- PR #565 fixed a session-restore race condition but didn't address the display-link timing issue
- `setFocus(true)` in `didBecomeKey` was a no-op because Ghostty already considered the surface focused
- `forceRefresh` in `didBecomeKey` alone only worked when the user clicked the window, not on initial launch from background

### Testing

Tested on macOS 26.2 (Tahoe). Terminal renders immediately on launch across multiple scenarios:
- Normal app launch (click icon)
- Launch from script (`reload.sh`)
- Cold start after force quit

## Test plan

- [ ] Launch cmux — first terminal should render immediately (no blank screen)
- [ ] Open second terminal tab — both tabs should render correctly
- [ ] Launch cmux from a shell script — terminal should render when switching to cmux
- [ ] Verify no regression: terminal rendering after split panes, tab switches, window minimize/restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #399: the first terminal tab no longer appears blank on launch. We force a renderer refresh on key app/window events and add a short deferred refresh so the terminal renders immediately.

- **Bug Fixes**
  - In `didBecomeKey`, restart the display link when the surface view is already first responder.
  - Refresh on `NSApplication.didBecomeActiveNotification` to handle background launches.
  - Add a 300ms deferred post-create refresh to reassert display ID and redraw.

<sup>Written for commit a4cde133b5efc70ac5cdfbe0854739ed436b0ee9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering reliability during window creation and app activation.
  * Enhanced display refresh when the terminal window becomes active or when returning to the application after switching between other apps.
  * Ensures terminal content displays correctly across various window focus and application state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->