### PR TITLE
Fix workspace close not terminating child processes

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1216,16 +1216,19 @@ class TabManager: ObservableObject {
         return trimmed
     }
 
-    func closeWorkspace(_ workspace: Workspace) {
-        guard tabs.count > 1 else { return }
-        guard let index = tabs.firstIndex(where: { $0.id == workspace.id }) else { return }
+    @discardableResult
+    func closeWorkspace(_ workspace: Workspace) -> Bool {
+        guard tabs.count > 1 else { return false }
+        guard teardownWorkspacePanels(workspace) else { return false }
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         clearInitialWorkspaceGitProbe(workspaceId: workspace.id)
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         unwireClosedBrowserTracking(for: workspace)
-        workspace.teardownAllPanels()
 
+        guard let index = tabs.firstIndex(where: { $0.id == workspace.id }) else {
+            return false
+        }
         tabs.remove(at: index)
 
         if selectedTabId == workspace.id {
@@ -1235,6 +1238,7 @@ class TabManager: ObservableObject {
             let newIndex = min(index, max(0, tabs.count - 1))
             selectedTabId = tabs[newIndex].id
         }
+        return true
     }
 
     /// Detach a workspace from this window without closing its panels.
@@ -1415,6 +1419,32 @@ class TabManager: ObservableObject {
         return String(localized: "tab.untitled", defaultValue: "Untitled Tab")
     }
 
+    /// Tears down all panels in the workspace with process cleanup, logging
+    /// telemetry on partial failure. Returns `true` if all panels closed.
+    private func teardownWorkspacePanels(_ workspace: Workspace) -> Bool {
+        let teardown = workspace.closeAllPanelsForWorkspaceClose()
+#if DEBUG
+        if !teardown.allClosed {
+            dlog(
+                "workspace.close.teardown.partial workspace=\(workspace.id.uuidString.prefix(5)) " +
+                "requested=\(teardown.requestedCount) closed=\(teardown.closedCount) failed=\(teardown.failedPanelIds.count)"
+            )
+        }
+#endif
+        guard teardown.allClosed else {
+            sentryBreadcrumb(
+                "workspace.close.teardown.partial",
+                data: [
+                    "requested": teardown.requestedCount,
+                    "closed": teardown.closedCount,
+                    "failed": teardown.failedPanelIds.count
+                ]
+            )
+            return false
+        }
+        return true
+    }
+
     private func closeWorkspaceIfRunningProcess(_ workspace: Workspace) {
         let willCloseWindow = tabs.count <= 1
         if workspaceNeedsConfirmClose(workspace),
@@ -1426,6 +1456,7 @@ class TabManager: ObservableObject {
             return
         }
         if tabs.count <= 1 {
+            guard teardownWorkspacePanels(workspace) else { return }
             // Last workspace in this window: close the window (Cmd+Shift+W behavior).
             AppDelegate.shared?.closeMainWindowContainingTabId(workspace.id)
         } else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2979,26 +2979,26 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
         }
 
-        var found = false
+        var result: V2CallResult = .err(code: "not_found", message: "Workspace not found", data: [
+            "workspace_id": wsId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
+        ])
         v2MainSync {
-            if let ws = tabManager.tabs.first(where: { $0.id == wsId }) {
-                tabManager.closeWorkspace(ws)
-                found = true
+            guard let ws = tabManager.tabs.first(where: { $0.id == wsId }) else { return }
+            guard !ws.isWorkspaceClosingTransaction else {
+                result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+                return
             }
-        }
-
-        let windowId = v2ResolveWindowId(tabManager: tabManager)
-        return found
-            ? .ok([
+            tabManager.closeWorkspace(ws)
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
                 "window_id": v2OrNull(windowId?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: windowId),
                 "workspace_id": wsId.uuidString,
                 "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
             ])
-            : .err(code: "not_found", message: "Workspace not found", data: [
-                "workspace_id": wsId.uuidString,
-                "workspace_ref": v2Ref(kind: .workspace, uuid: wsId)
-            ])
+        }
+        return result
     }
     private func v2WorkspaceMoveToWindow(params: [String: Any]) -> V2CallResult {
         guard let wsId = v2UUID(params, "workspace_id") else {
@@ -3616,6 +3616,25 @@ class TerminalController {
         return tabManager.tabs.first(where: { $0.id == wsId })
     }
 
+    /// Resolves the target workspace and guards against mid-close mutations.
+    /// Sets `result` to the appropriate error and returns `nil` if the workspace
+    /// is not found or is currently being torn down.
+    private func v2ResolveActiveWorkspace(
+        params: [String: Any],
+        tabManager: TabManager,
+        result: inout V2CallResult
+    ) -> Workspace? {
+        guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+            result = .err(code: "not_found", message: "Workspace not found", data: nil)
+            return nil
+        }
+        guard !ws.isWorkspaceClosingTransaction else {
+            result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+            return nil
+        }
+        return ws
+    }
+
     private func v2SurfaceList(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -3750,9 +3769,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create split", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return
             }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
@@ -3803,10 +3820,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create surface", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
@@ -3858,10 +3872,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to close surface", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
 
             let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
             guard let surfaceId else {
@@ -4020,6 +4031,11 @@ class TerminalController {
                 }
                 targetWorkspace = ws
                 targetPane = ws.bonsplitController.focusedPaneId ?? ws.bonsplitController.allPaneIds.first
+            }
+
+            if sourceWorkspace.isWorkspaceClosingTransaction || targetWorkspace.isWorkspaceClosingTransaction {
+                result = .err(code: "invalid_state", message: "Workspace is closing", data: nil)
+                return
             }
 
             guard let destinationPane = targetPane else {
@@ -4777,10 +4793,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create pane", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
             guard let focusedPanelId = ws.focusedPanelId else {
@@ -5860,10 +5873,7 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create markdown panel", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
+            guard let ws = v2ResolveActiveWorkspace(params: params, tabManager: tabManager, result: &result) else { return }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
@@ -11633,8 +11643,9 @@ class TerminalController {
 
         var success = false
         DispatchQueue.main.sync {
-            if let tab = tabManager.tabs.first(where: { $0.id == uuid }) {
-                tabManager.closeTab(tab)
+            if let tab = tabManager.tabs.first(where: { $0.id == uuid }),
+               !tab.isWorkspaceClosingTransaction {
+                tabManager.closeWorkspace(tab)
                 success = true
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4,6 +4,7 @@ import AppKit
 import Bonsplit
 import Combine
 import CoreText
+import Darwin
 
 func cmuxSurfaceContextName(_ context: ghostty_surface_context_e) -> String {
     switch context {
@@ -1269,6 +1270,25 @@ final class Workspace: Identifiable, ObservableObject {
     private var pendingDetachedSurfaces: [TabID: DetachedSurfaceTransfer] = [:]
     private var activeDetachCloseTransactions: Int = 0
     private var isDetachingCloseTransaction: Bool { activeDetachCloseTransactions > 0 }
+    private var activeWorkspaceCloseTransactions: Int = 0
+    var isWorkspaceClosingTransaction: Bool { activeWorkspaceCloseTransactions > 0 }
+
+    /// Result payload for deterministic workspace-close teardown.
+    struct WorkspaceCloseResult {
+        let requestedCount: Int
+        let closedCount: Int
+        let failedPanelIds: [UUID]
+
+        var allClosed: Bool {
+            failedPanelIds.isEmpty && closedCount == requestedCount
+        }
+    }
+
+    /// Process identity snapshot for a terminal session discovered via `ps`.
+    private struct TTYProcessInfo {
+        let pid: Int32
+        let processGroupId: Int32
+    }
 
 #if DEBUG
     private func debugElapsedMs(since start: TimeInterval) -> String {
@@ -2357,6 +2377,210 @@ final class Workspace: Identifiable, ObservableObject {
         terminalInheritanceFontPointsByPanelId.removeAll(keepingCapacity: false)
         lastTerminalConfigInheritancePanelId = nil
         lastTerminalConfigInheritanceFontPoints = nil
+    }
+
+    // MARK: - Workspace Close with Process Cleanup
+
+    /// Closes all panels as part of a workspace-close operation, ensuring child
+    /// processes are terminated even if ARC deallocation is delayed.
+    /// Inspired by IgorTavcar's approach (https://github.com/IgorTavcar/cmux/commit/2b8a9ab).
+    func closeAllPanelsForWorkspaceClose() -> WorkspaceCloseResult {
+        let requestedPanelIds = panels.keys.sorted(by: { $0.uuidString < $1.uuidString })
+        guard !requestedPanelIds.isEmpty else {
+            return WorkspaceCloseResult(requestedCount: 0, closedCount: 0, failedPanelIds: [])
+        }
+
+        activeWorkspaceCloseTransactions += 1
+        defer { activeWorkspaceCloseTransactions -= 1 }
+
+        var closedCount = 0
+        var failedPanelIds: [UUID] = []
+
+        for panelId in requestedPanelIds {
+            if panels[panelId] == nil {
+                closedCount += 1
+                continue
+            }
+
+            guard closePanel(panelId, force: true) else {
+                failedPanelIds.append(panelId)
+                continue
+            }
+
+            if waitForPanelClose(panelId, timeout: 0.6) {
+                closedCount += 1
+                continue
+            }
+
+            // Panel didn't close in time — terminate processes on its TTY
+            // and retry once before declaring failure.
+            let signaled = terminateTTYProcesses(forPanelId: panelId)
+            if signaled {
+                _ = closePanel(panelId, force: true)
+            }
+
+            if waitForPanelClose(panelId, timeout: 0.6) {
+                closedCount += 1
+            } else {
+                failedPanelIds.append(panelId)
+            }
+        }
+
+#if DEBUG
+        dlog(
+            "workspace.close.teardown workspace=\(id.uuidString.prefix(5)) " +
+            "requested=\(requestedPanelIds.count) closed=\(closedCount) failed=\(failedPanelIds.count)"
+        )
+#endif
+
+        return WorkspaceCloseResult(
+            requestedCount: requestedPanelIds.count,
+            closedCount: closedCount,
+            failedPanelIds: failedPanelIds
+        )
+    }
+
+    /// Waits for a panel to be removed from the workspace, draining the
+    /// RunLoop so the UI stays responsive.
+    private func waitForPanelClose(_ panelId: UUID, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while panels[panelId] != nil && Date() < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        return panels[panelId] == nil
+    }
+
+    /// Locates processes on the panel's TTY and sends SIGTERM, escalating
+    /// to SIGKILL if they don't exit within 1 second.
+    private func terminateTTYProcesses(forPanelId panelId: UUID) -> Bool {
+        guard panels[panelId] is TerminalPanel else { return false }
+        guard let ttyName = normalizedTTYName(surfaceTTYNames[panelId]) else {
+#if DEBUG
+            dlog(
+                "workspace.close.kill.skip workspace=\(id.uuidString.prefix(5)) " +
+                "panel=\(panelId.uuidString.prefix(5)) reason=missing_tty"
+            )
+#endif
+            return false
+        }
+
+        let processInfos = ttyProcessInfos(forTTY: ttyName)
+        let appPid = Int32(ProcessInfo.processInfo.processIdentifier)
+        let trackedPids = Set(processInfos.map(\.pid).filter { $0 > 1 && $0 != appPid })
+        var targetGroups = Set(
+            processInfos.map(\.processGroupId).filter { $0 > 1 && $0 != appPid }
+        )
+        guard !trackedPids.isEmpty, !targetGroups.isEmpty else {
+#if DEBUG
+            dlog(
+                "workspace.close.kill.skip workspace=\(id.uuidString.prefix(5)) " +
+                "panel=\(panelId.uuidString.prefix(5)) tty=\(ttyName) reason=no_targets"
+            )
+#endif
+            return false
+        }
+
+        // SIGTERM first — give processes a chance to clean up
+        signalProcessGroups(targetGroups, signal: SIGTERM)
+        var remaining = waitForProcessesToExit(trackedPids, timeout: 1.0)
+
+        // Escalate to SIGKILL for stubborn processes
+        if !remaining.isEmpty {
+            let refreshed = ttyProcessInfos(forTTY: ttyName)
+            targetGroups = Set(
+                refreshed
+                    .filter { remaining.contains($0.pid) }
+                    .map(\.processGroupId)
+                    .filter { $0 > 1 }
+            )
+            if !targetGroups.isEmpty {
+                signalProcessGroups(targetGroups, signal: SIGKILL)
+            }
+            remaining = waitForProcessesToExit(remaining, timeout: 1.0)
+        }
+
+#if DEBUG
+        dlog(
+            "workspace.close.kill workspace=\(id.uuidString.prefix(5)) " +
+            "panel=\(panelId.uuidString.prefix(5)) tty=\(ttyName) " +
+            "tracked=\(trackedPids.count) remaining=\(remaining.count)"
+        )
+#endif
+        return remaining.isEmpty
+    }
+
+    /// Strips `/dev/` prefix for `ps -t` usage.
+    private func normalizedTTYName(_ rawTTY: String?) -> String? {
+        guard let raw = rawTTY?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        if raw.hasPrefix("/dev/") {
+            let short = String(raw.dropFirst("/dev/".count))
+            return short.isEmpty ? nil : short
+        }
+        return raw
+    }
+
+    /// Enumerates PIDs and process groups attached to the given TTY.
+    private func ttyProcessInfos(forTTY ttyName: String) -> [TTYProcessInfo] {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-t", ttyName, "-o", "pid=,pgid="]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+
+        let deadline = Date().addingTimeInterval(5.0)
+        while process.isRunning && Date() < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        guard !process.isRunning, process.terminationStatus == 0 else { return [] }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8), !output.isEmpty else {
+            return []
+        }
+
+        var result: [TTYProcessInfo] = []
+        for line in output.split(whereSeparator: \.isNewline) {
+            let parts = line.split(whereSeparator: \.isWhitespace)
+            guard parts.count >= 2,
+                  let pid = Int32(parts[0]),
+                  let pgid = Int32(parts[1]) else { continue }
+            result.append(TTYProcessInfo(pid: pid, processGroupId: pgid))
+        }
+        return result
+    }
+
+    /// Sends a POSIX signal to each process group (negative PID = group signal).
+    private func signalProcessGroups(_ groups: Set<Int32>, signal: Int32) {
+        for pgid in groups where pgid > 1 {
+            _ = Darwin.kill(-pgid, signal)
+        }
+    }
+
+    /// Waits for processes to exit, returns those still alive after timeout.
+    private func waitForProcessesToExit(_ pids: Set<Int32>, timeout: TimeInterval) -> Set<Int32> {
+        guard !pids.isEmpty else { return [] }
+        let deadline = Date().addingTimeInterval(timeout)
+        var remaining = pids
+        while !remaining.isEmpty && Date() < deadline {
+            remaining = remaining.filter { isProcessAlive($0) }
+            if !remaining.isEmpty {
+                _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+        }
+        return remaining
+    }
+
+    /// Returns true if a process is still alive (or we lack permission to check).
+    private func isProcessAlive(_ pid: Int32) -> Bool {
+        if Darwin.kill(pid, 0) == 0 { return true }
+        return errno == EPERM
     }
 
     /// Close a panel.
@@ -4075,7 +4299,7 @@ extension Workspace: BonsplitDelegate {
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can
         // prune the source workspace/window after the tab is attached elsewhere.
         if panels.isEmpty {
-            if isDetaching {
+            if isDetaching || isWorkspaceClosingTransaction {
 #if DEBUG
                 dlog(
                     "surface.didCloseTab.end tab=\(String(describing: tabId).prefix(5)) " +


### PR DESCRIPTION
## Summary

Fixes #629 — closing a workspace leaves child processes (Claude Code, MCP servers, lazygit, etc.) running as orphans. Over time this causes memory pressure until macOS kills the app.

### Root Cause

`teardownAllPanels()` calls `panel.close()` → `teardownSurface()` → async `ghostty_surface_free()`. The surface free runs on the next runloop turn, but `tabs.remove()` drops the last strong reference to Workspace immediately. If ARC doesn't deallocate in time, SIGHUP never reaches the child processes.

### Fix

**New deterministic teardown flow** (`closeAllPanelsForWorkspaceClose`):

1. For each panel: `closePanel(force: true)` → wait up to 0.6s
2. If process still alive: `SIGTERM` the process group → wait 1s
3. If still alive: escalate to `SIGKILL` → wait 1s
4. All waits use `RunLoop.drain` (10ms ticks) to keep UI responsive
5. Workspace removal gated on successful teardown

**Reentrancy protection:**
- `isWorkspaceClosingTransaction` flag prevents mid-teardown mutations
- All mutating socket handlers (`surface.create/close/split/move`, `workspace.close`, `pane.create`) guarded
- `v2ResolveActiveWorkspace` helper combines workspace resolution with closing guard
- `didCloseTab` skips replacement terminal creation during workspace close

**Process termination** uses `ps -t <tty>` to enumerate PIDs, then `kill(-pgid, signal)` to terminate entire process groups (not just individual PIDs), ensuring child processes of shells are also cleaned up.

### Attribution

Inspired by [@IgorTavcar](https://github.com/IgorTavcar)'s approach in [their fork](https://github.com/IgorTavcar/cmux/commit/2b8a9abf7cbe886046abb9054fa63644e8ba0dd9). We reimplemented from scratch but followed the same SIGTERM → SIGKILL escalation pattern and reentrancy guard design.

## Test plan

- [ ] Open a workspace, start Claude Code (or `sleep 600`), close workspace → verify process is terminated via Activity Monitor
- [ ] Open workspace with multiple split panes running different processes → close workspace → all processes terminated
- [ ] Close last workspace in window → window closes, processes terminated
- [ ] Socket API: `workspace.close` terminates processes
- [ ] Verify no regression: normal tab/workspace switching still works
- [ ] Verify no UI freeze during teardown (RunLoop drain keeps UI responsive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closing a workspace now reliably terminates all child processes and prevents orphaned shells, fixing #629. The teardown is deterministic, gated, and keeps the UI responsive.

- **Bug Fixes**
  - Added `Workspace.closeAllPanelsForWorkspaceClose`: close → wait → SIGTERM process groups → wait → SIGKILL if needed; processes found via `ps -t <tty>`, signaled with `kill(-pgid)`, waits use 10ms RunLoop drains.
  - `TabManager.closeWorkspace` now waits for teardown, gates tab removal on success, and returns `Bool`; applied to last-window close path too.
  - Reentrancy guards: new `isWorkspaceClosingTransaction` flag and `v2ResolveActiveWorkspace` prevent mid-close mutations across `surface.create/close/split/move`, `workspace.close`, and `pane.create`.
  - `didCloseTab` skips creating replacement terminals during workspace close.
  - Socket API: returns `invalid_state` if a workspace is closing and `not_found` when missing.

<sup>Written for commit cced303088e32bc137acb37681c743eda6c84c4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of workspace closure by enhancing panel cleanup and process management during shutdown.
  * Fixed potential issues when performing operations on workspaces that are closing, preventing invalid state errors.
  * Better handling of edge cases during workspace teardown to ensure complete resource cleanup and prevent orphaned processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->