### PR TITLE
feat: add UI zoom scaling for all non-terminal UI elements

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
+		A5D39BD8 /* UIZoomMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5036EBB /* UIZoomMetrics.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
@@ -204,6 +205,7 @@
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
+		A5036EBB /* UIZoomMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIZoomMetrics.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
+				A5036EBB /* UIZoomMetrics.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -662,6 +665,7 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
+				A5D39BD8 /* UIZoomMetrics.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7699,6 +7699,23 @@
         }
       }
     },
+    "browserSearchOverlay.search": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索"
+          }
+        }
+      }
+    },
     "cli.install.adminRequired": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7537,6 +7537,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             case .reset:
                 next = UIZoomMetrics.defaultScale
             }
+            #if DEBUG
+            dlog("uiZoom.\(uiZoomAction) current=\(current) next=\(next)")
+            #endif
             UserDefaults.standard.set(next, forKey: UIZoomMetrics.appStorageKey)
             return true
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1163,6 +1163,46 @@ struct CommandPaletteDebugSnapshot {
     static let empty = CommandPaletteDebugSnapshot(query: "", mode: "commands", results: [])
 }
 
+enum UIZoomShortcutAction: Equatable {
+    case zoomIn
+    case zoomOut
+    case reset
+}
+
+func uiZoomShortcutAction(
+    flags: NSEvent.ModifierFlags,
+    chars: String,
+    keyCode: UInt16,
+    literalChars: String? = nil
+) -> UIZoomShortcutAction? {
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function])
+    // Require exactly Cmd+Shift (no Control, no Option)
+    guard normalizedFlags.contains(.command),
+          normalizedFlags.contains(.shift),
+          normalizedFlags.isDisjoint(with: [.control, .option]) else { return nil }
+    let keys = browserZoomShortcutKeyCandidates(
+        chars: chars,
+        literalChars: literalChars,
+        keyCode: keyCode
+    )
+
+    if keys.contains("=") || keys.contains("+") || keyCode == 24 || keyCode == 69 { // kVK_ANSI_Equal / kVK_ANSI_KeypadPlus
+        return .zoomIn
+    }
+
+    if keys.contains("-") || keys.contains("_") || keyCode == 27 || keyCode == 78 { // kVK_ANSI_Minus / kVK_ANSI_KeypadMinus
+        return .zoomOut
+    }
+
+    if keys.contains("0") || keyCode == 29 || keyCode == 82 { // kVK_ANSI_0 / kVK_ANSI_Keypad0
+        return .reset
+    }
+
+    return nil
+}
+
 func browserZoomShortcutAction(
     flags: NSEvent.ModifierFlags,
     chars: String,
@@ -7478,6 +7518,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if openBrowserAndFocusAddressBar(insertAtEnd: true) != nil {
                 return true
             }
+        }
+
+        // UI zoom: Cmd+Shift+=/Cmd+Shift+-/Cmd+Shift+0
+        if let uiZoomAction = uiZoomShortcutAction(
+            flags: flags,
+            chars: chars,
+            keyCode: event.keyCode,
+            literalChars: event.characters
+        ) {
+            let current = UIZoomMetrics.effectiveScale()
+            let next: Double
+            switch uiZoomAction {
+            case .zoomIn:
+                next = UIZoomMetrics.clamped(current + UIZoomMetrics.step)
+            case .zoomOut:
+                next = UIZoomMetrics.clamped(current - UIZoomMetrics.step)
+            case .reset:
+                next = UIZoomMetrics.defaultScale
+            }
+            UserDefaults.standard.set(next, forKey: UIZoomMetrics.appStorageKey)
+            return true
         }
 
         #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1337,6 +1337,7 @@ struct ContentView: View {
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     @FocusState private var isCommandPaletteSearchFocused: Bool
     @FocusState private var isCommandPaletteRenameFocused: Bool
 
@@ -1599,7 +1600,9 @@ struct ContentView: View {
     private static let commandPaletteCommandsPrefix = ">"
     private static let commandPaletteVisiblePreviewResultLimit = 48
     private static let commandPaletteVisiblePreviewCandidateLimit = 192
-    private static let minimumSidebarWidth: CGFloat = 186
+    private var minimumSidebarWidth: CGFloat {
+        CGFloat(UIZoomMetrics.minimumSidebarWidth(uiZoomScale))
+    }
     private static let maximumSidebarWidthRatio: CGFloat = 1.0 / 3.0
 
     private enum SidebarResizerHandle: Hashable {
@@ -1617,18 +1620,18 @@ struct ContentView: View {
             ?? NSApp.keyWindow?.contentView?.bounds.width
             ?? NSApp.keyWindow?.contentLayoutRect.width
         if let resolvedAvailableWidth, resolvedAvailableWidth > 0 {
-            return max(Self.minimumSidebarWidth, resolvedAvailableWidth * Self.maximumSidebarWidthRatio)
+            return max(minimumSidebarWidth, resolvedAvailableWidth * Self.maximumSidebarWidthRatio)
         }
 
         let fallbackScreenWidth = NSApp.keyWindow?.screen?.frame.width
             ?? NSScreen.main?.frame.width
             ?? 1920
-        return max(Self.minimumSidebarWidth, fallbackScreenWidth * Self.maximumSidebarWidthRatio)
+        return max(minimumSidebarWidth, fallbackScreenWidth * Self.maximumSidebarWidthRatio)
     }
 
     private func clampSidebarWidthIfNeeded(availableWidth: CGFloat? = nil) {
         let nextWidth = max(
-            Self.minimumSidebarWidth,
+            minimumSidebarWidth,
             min(maxSidebarWidth(availableWidth: availableWidth), sidebarWidth)
         )
         guard abs(nextWidth - sidebarWidth) > 0.5 else { return }
@@ -1638,7 +1641,7 @@ struct ContentView: View {
     }
 
     private func normalizedSidebarWidth(_ candidate: CGFloat) -> CGFloat {
-        let minWidth = CGFloat(SessionPersistencePolicy.minimumSidebarWidth)
+        let minWidth = minimumSidebarWidth
         let maxWidth = max(minWidth, maxSidebarWidth())
         if !candidate.isFinite {
             return CGFloat(SessionPersistencePolicy.defaultSidebarWidth)
@@ -1835,7 +1838,7 @@ struct ContentView: View {
                         activateSidebarResizerCursor()
                         let startWidth = sidebarDragStartWidth ?? sidebarWidth
                         let nextWidth = max(
-                            Self.minimumSidebarWidth,
+                            minimumSidebarWidth,
                             min(maxSidebarWidth(availableWidth: availableWidth), startWidth + value.translation.width)
                         )
                         withTransaction(Transaction(animation: nil)) {
@@ -2019,7 +2022,7 @@ struct ContentView: View {
                 }
 
                 Text(titlebarText)
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: UIZoomMetrics.titlebarFontSize(uiZoomScale), weight: .bold))
                     .foregroundColor(fakeTitlebarTextColor)
                     .lineLimit(1)
                     .allowsHitTesting(false)
@@ -2027,10 +2030,10 @@ struct ContentView: View {
                 Spacer()
 
             }
-            .frame(height: 28)
-            .padding(.top, 2)
-            .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? 8 : (sidebarState.isVisible ? 12 : titlebarLeadingInset + CGFloat(debugTitlebarLeadingExtra)))
-            .padding(.trailing, 8)
+            .frame(height: UIZoomMetrics.titlebarHeight(uiZoomScale))
+            .padding(.top, UIZoomMetrics.titlebarTopPadding(uiZoomScale))
+            .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? UIZoomMetrics.titlebarHorizontalPadding(uiZoomScale) : (sidebarState.isVisible ? 12 : titlebarLeadingInset + CGFloat(debugTitlebarLeadingExtra)))
+            .padding(.trailing, UIZoomMetrics.titlebarHorizontalPadding(uiZoomScale))
         }
         .frame(height: titlebarPadding)
         .frame(maxWidth: .infinity)
@@ -2049,7 +2052,7 @@ struct ContentView: View {
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(Color(nsColor: .separatorColor))
-                .frame(height: 1)
+                .frame(height: UIZoomMetrics.titlebarDividerHeight(uiZoomScale))
         }
     }
 
@@ -2950,9 +2953,9 @@ struct ContentView: View {
     private var commandPaletteCommandListView: some View {
         let visibleResults = commandPaletteVisibleResults
         let selectedIndex = commandPaletteSelectedIndex(resultCount: visibleResults.count)
-        let commandPaletteListMaxHeight: CGFloat = 450
-        let commandPaletteRowHeight: CGFloat = 24
-        let commandPaletteEmptyStateHeight: CGFloat = 44
+        let commandPaletteListMaxHeight: CGFloat = UIZoomMetrics.paletteListMaxHeight(uiZoomScale)
+        let commandPaletteRowHeight: CGFloat = UIZoomMetrics.paletteRowHeight(uiZoomScale)
+        let commandPaletteEmptyStateHeight: CGFloat = UIZoomMetrics.paletteEmptyStateHeight(uiZoomScale)
         let commandPaletteListContentHeight = visibleResults.isEmpty
             ? commandPaletteEmptyStateHeight
             : CGFloat(visibleResults.count) * commandPaletteRowHeight
@@ -2961,7 +2964,7 @@ struct ContentView: View {
             HStack(spacing: 8) {
                 TextField(commandPaletteSearchPlaceholder, text: $commandPaletteQuery)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 13, weight: .regular))
+                    .font(.system(size: UIZoomMetrics.paletteFieldFontSize(uiZoomScale), weight: .regular))
                     .tint(Color(nsColor: sidebarActiveForegroundNSColor(opacity: 1.0)))
                     .focused($isCommandPaletteSearchFocused)
                     .accessibilityIdentifier("CommandPaletteSearchField")
@@ -2989,8 +2992,8 @@ struct ContentView: View {
                         handleCommandPaletteControlNavigationKey(modifiers: modifiers, delta: -1)
                     }
             }
-            .padding(.horizontal, 9)
-            .padding(.vertical, 7)
+            .padding(.horizontal, UIZoomMetrics.paletteFieldHPadding(uiZoomScale))
+            .padding(.vertical, UIZoomMetrics.paletteFieldVPadding(uiZoomScale))
 
             Divider()
 
@@ -2999,7 +3002,7 @@ struct ContentView: View {
                     if visibleResults.isEmpty {
                         if commandPaletteHasCurrentResolvedResults {
                             Text(commandPaletteEmptyStateText)
-                                .font(.system(size: 13, weight: .regular))
+                                .font(.system(size: UIZoomMetrics.paletteResultFontSize(uiZoomScale), weight: .regular))
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, 12)
@@ -3025,7 +3028,7 @@ struct ContentView: View {
                                         result.command.title,
                                         matchedIndices: result.titleMatchIndices
                                     )
-                                        .font(.system(size: 13, weight: .regular))
+                                        .font(.system(size: UIZoomMetrics.paletteResultFontSize(uiZoomScale), weight: .regular))
                                         .lineLimit(1)
                                     Spacer()
 
@@ -3033,21 +3036,21 @@ struct ContentView: View {
                                         switch trailingLabel.style {
                                         case .shortcut:
                                             Text(trailingLabel.text)
-                                                .font(.system(size: 11, weight: .medium))
+                                                .font(.system(size: UIZoomMetrics.paletteTrailingFontSize(uiZoomScale), weight: .medium))
                                                 .foregroundStyle(.secondary)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+                                                .padding(.horizontal, UIZoomMetrics.paletteTrailingHPadding(uiZoomScale))
+                                                .padding(.vertical, UIZoomMetrics.paletteTrailingVPadding(uiZoomScale))
+                                                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: UIZoomMetrics.paletteTrailingCornerRadius(uiZoomScale), style: .continuous))
                                         case .kind:
                                             Text(trailingLabel.text)
-                                                .font(.system(size: 11, weight: .regular))
+                                                .font(.system(size: UIZoomMetrics.paletteTrailingFontSize(uiZoomScale), weight: .regular))
                                                 .foregroundStyle(.secondary)
                                                 .lineLimit(1)
                                         }
                                     }
                                 }
-                                .padding(.horizontal, 9)
-                                .padding(.vertical, 2)
+                                .padding(.horizontal, UIZoomMetrics.paletteResultHPadding(uiZoomScale))
+                                .padding(.vertical, UIZoomMetrics.paletteResultVPadding(uiZoomScale))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .background(rowBackground)
                                 .contentShape(Rectangle())
@@ -6923,10 +6926,10 @@ struct VerticalTabsSidebar: View {
     @StateObject private var dragFailsafeMonitor = SidebarDragFailsafeMonitor()
     @State private var draggedTabId: UUID?
     @State private var dropIndicator: SidebarDropIndicator?
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
-    /// Space at top of sidebar for traffic light buttons
-    private let trafficLightPadding: CGFloat = 28
-    private let tabRowSpacing: CGFloat = 2
+    private var trafficLightPadding: CGFloat { UIZoomMetrics.trafficLightPadding(uiZoomScale) }
+    private var tabRowSpacing: CGFloat { UIZoomMetrics.tabRowSpacing(uiZoomScale) }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -6953,7 +6956,7 @@ struct VerticalTabsSidebar: View {
                                 )
                             }
                         }
-                        .padding(.vertical, 8)
+                        .padding(.vertical, UIZoomMetrics.listVerticalPadding(uiZoomScale))
 
                         SidebarEmptyArea(
                             rowSpacing: tabRowSpacing,
@@ -6975,7 +6978,7 @@ struct VerticalTabsSidebar: View {
                     .frame(width: 0, height: 0)
                 )
                 .overlay(alignment: .top) {
-                    SidebarTopScrim(height: trafficLightPadding + 20)
+                    SidebarTopScrim(height: trafficLightPadding + UIZoomMetrics.topScrimExtraHeight(uiZoomScale))
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
@@ -8083,6 +8086,7 @@ private enum SidebarHelpMenuAction {
 
 private struct SidebarFeedbackComposerSheet: View {
     @AppStorage(FeedbackComposerSettings.storedEmailKey) private var email = ""
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     @Environment(\.dismiss) private var dismiss
 
     @State private var message = ""
@@ -8114,8 +8118,8 @@ private struct SidebarFeedbackComposerSheet: View {
                 formView
             }
         }
-        .padding(20)
-        .frame(width: 520)
+        .padding(UIZoomMetrics.feedbackDialogPadding(uiZoomScale))
+        .frame(width: UIZoomMetrics.feedbackDialogWidth(uiZoomScale))
         .accessibilityIdentifier("SidebarFeedbackDialog")
     }
 
@@ -8129,7 +8133,7 @@ private struct SidebarFeedbackComposerSheet: View {
                     defaultValue: "You can also reach us at founders@manaflow.com."
                 )
             )
-            .font(.system(size: 12))
+            .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale)))
             .foregroundStyle(.secondary)
 
             HStack {
@@ -8150,12 +8154,12 @@ private struct SidebarFeedbackComposerSheet: View {
                     defaultValue: "A human will read this! You can also reach us at founders@manaflow.com."
                 )
             )
-            .font(.system(size: 12))
+            .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale)))
             .foregroundStyle(.secondary)
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(String(localized: "sidebar.help.feedback.email", defaultValue: "Your Email"))
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale), weight: .medium))
                 TextField(
                     String(localized: "sidebar.help.feedback.emailPlaceholder", defaultValue: "you@example.com"),
                     text: $email
@@ -8168,10 +8172,10 @@ private struct SidebarFeedbackComposerSheet: View {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .firstTextBaseline) {
                     Text(String(localized: "sidebar.help.feedback.message", defaultValue: "Message"))
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale), weight: .medium))
                     Spacer(minLength: 0)
                     Text("\(message.count)/\(FeedbackComposerSettings.maxMessageLength)")
-                        .font(.system(size: 11))
+                        .font(.system(size: UIZoomMetrics.feedbackSmallFontSize(uiZoomScale)))
                         .foregroundStyle(
                             message.count > FeedbackComposerSettings.maxMessageLength
                                 ? Color.red
@@ -8209,7 +8213,7 @@ private struct SidebarFeedbackComposerSheet: View {
                             defaultValue: "Up to 10 images."
                         )
                     )
-                    .font(.system(size: 11))
+                    .font(.system(size: UIZoomMetrics.feedbackSmallFontSize(uiZoomScale)))
                     .foregroundStyle(.secondary)
                 }
 
@@ -8220,12 +8224,12 @@ private struct SidebarFeedbackComposerSheet: View {
                                 Image(systemName: "photo")
                                     .foregroundStyle(.secondary)
                                 Text(attachment.fileName)
-                                    .font(.system(size: 12))
+                                    .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale)))
                                     .lineLimit(1)
                                     .truncationMode(.middle)
                                 Spacer(minLength: 0)
                                 Text(attachment.displaySize)
-                                    .font(.system(size: 11))
+                                    .font(.system(size: UIZoomMetrics.feedbackSmallFontSize(uiZoomScale)))
                                     .foregroundStyle(.secondary)
                                 Button(
                                     String(localized: "sidebar.help.feedback.removeAttachment", defaultValue: "Remove")
@@ -8246,7 +8250,7 @@ private struct SidebarFeedbackComposerSheet: View {
 
             if let submissionErrorMessage, submissionErrorMessage.isEmpty == false {
                 Text(submissionErrorMessage)
-                    .font(.system(size: 12))
+                    .font(.system(size: UIZoomMetrics.feedbackFontSize(uiZoomScale)))
                     .foregroundStyle(.red)
             }
 
@@ -9072,6 +9076,7 @@ private struct TabItemView: View {
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     @AppStorage("sidebarShowGitBranch") private var sidebarShowGitBranch = true
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
@@ -9229,28 +9234,28 @@ private struct TabItemView: View {
             return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
         }()
 
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: UIZoomMetrics.contentSpacing(uiZoomScale)) {
+            HStack(spacing: UIZoomMetrics.headerSpacing(uiZoomScale)) {
                 let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
                 if unreadCount > 0 {
                     ZStack {
                         Circle()
                             .fill(activeUnreadBadgeFillColor)
                         Text("\(unreadCount)")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale), weight: .semibold))
                             .foregroundColor(.white)
                     }
-                    .frame(width: 16, height: 16)
+                    .frame(width: UIZoomMetrics.badgeSize(uiZoomScale), height: UIZoomMetrics.badgeSize(uiZoomScale))
                 }
 
                 if tab.isPinned {
                     Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale), weight: .semibold))
                         .foregroundColor(activeSecondaryColor(0.8))
                 }
 
                 Text(tab.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(.system(size: UIZoomMetrics.titleFontSize(uiZoomScale), weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -9265,12 +9270,12 @@ private struct TabItemView: View {
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
                         Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .medium))
+                            .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale), weight: .medium))
                             .foregroundColor(activeSecondaryColor(0.7))
                     }
                     .buttonStyle(.plain)
                     .safeHelp(KeyboardShortcutSettings.Action.closeWorkspace.tooltip(closeWorkspaceTooltip))
-                    .frame(width: 16, height: 16, alignment: .center)
+                    .frame(width: UIZoomMetrics.closeButtonSize(uiZoomScale), height: UIZoomMetrics.closeButtonSize(uiZoomScale), alignment: .center)
                     .opacity(showCloseButton && !showsWorkspaceShortcutHint ? 1 : 0)
                     .allowsHitTesting(showCloseButton && !showsWorkspaceShortcutHint)
 
@@ -9278,11 +9283,11 @@ private struct TabItemView: View {
                         Text(workspaceShortcutLabel)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), weight: .semibold, design: .rounded))
                             .monospacedDigit()
                             .foregroundColor(activePrimaryTextColor)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
+                            .padding(.horizontal, UIZoomMetrics.shortcutHintHorizontalPadding(uiZoomScale))
+                            .padding(.vertical, UIZoomMetrics.shortcutHintVerticalPadding(uiZoomScale))
                             .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
                             .offset(
                                 x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
@@ -9292,12 +9297,12 @@ private struct TabItemView: View {
                     }
                 }
                 .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
-                .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
+                .frame(width: workspaceHintSlotWidth, height: UIZoomMetrics.closeButtonSize(uiZoomScale), alignment: .trailing)
             }
 
             if let subtitle = latestNotificationSubtitle {
                 Text(subtitle)
-                    .font(.system(size: 10))
+                    .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale)))
                     .foregroundColor(activeSecondaryColor(0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -9327,12 +9332,12 @@ private struct TabItemView: View {
 
             // Latest log entry
             if sidebarShowLog, let latestLog = tab.logEntries.last {
-                HStack(spacing: 4) {
+                HStack(spacing: UIZoomMetrics.logEntrySpacing(uiZoomScale)) {
                     Image(systemName: logLevelIcon(latestLog.level))
-                        .font(.system(size: 8))
+                        .font(.system(size: UIZoomMetrics.tinyFontSize(uiZoomScale)))
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
-                        .font(.system(size: 10))
+                        .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale)))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -9342,7 +9347,7 @@ private struct TabItemView: View {
 
             // Progress bar
             if sidebarShowProgress, let progress = tab.progress {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: UIZoomMetrics.progressSpacing(uiZoomScale)) {
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
                             Capsule()
@@ -9352,11 +9357,11 @@ private struct TabItemView: View {
                                 .frame(width: max(0, geo.size.width * CGFloat(progress.value)))
                         }
                     }
-                    .frame(height: 3)
+                    .frame(height: UIZoomMetrics.progressBarHeight(uiZoomScale))
 
                     if let label = progress.label {
                         Text(label)
-                            .font(.system(size: 9))
+                            .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale)))
                             .foregroundColor(activeSecondaryColor(0.6))
                             .lineLimit(1)
                     }
@@ -9368,31 +9373,31 @@ private struct TabItemView: View {
             if sidebarShowBranchDirectory {
                 if sidebarBranchVerticalLayout {
                     if !branchDirectoryLines.isEmpty {
-                        HStack(alignment: .top, spacing: 3) {
+                        HStack(alignment: .top, spacing: UIZoomMetrics.branchItemSpacing(uiZoomScale)) {
                             if sidebarShowGitBranchIcon, branchLinesContainBranch {
                                 Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: 9))
+                                    .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale)))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
-                            VStack(alignment: .leading, spacing: 1) {
+                            VStack(alignment: .leading, spacing: UIZoomMetrics.branchLineSpacing(uiZoomScale)) {
                                 ForEach(Array(branchDirectoryLines.enumerated()), id: \.offset) { _, line in
-                                    HStack(spacing: 3) {
+                                    HStack(spacing: UIZoomMetrics.branchItemSpacing(uiZoomScale)) {
                                         if let branch = line.branch {
                                             Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
                                         }
                                         if line.branch != nil, line.directory != nil {
                                             Image(systemName: "circle.fill")
-                                                .font(.system(size: 3))
+                                                .font(.system(size: UIZoomMetrics.separatorDotFontSize(uiZoomScale)))
                                                 .foregroundColor(activeSecondaryColor(0.6))
-                                                .padding(.horizontal, 1)
+                                                .padding(.horizontal, UIZoomMetrics.separatorDotHorizontalPadding(uiZoomScale))
                                         }
                                         if let directory = line.directory {
                                             Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -9403,14 +9408,14 @@ private struct TabItemView: View {
                         }
                     }
                 } else if let dirRow = compactBranchDirectoryRow {
-                    HStack(spacing: 3) {
+                    HStack(spacing: UIZoomMetrics.branchItemSpacing(uiZoomScale)) {
                         if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
                             Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
+                                .font(.system(size: UIZoomMetrics.smallFontSize(uiZoomScale)))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), design: .monospaced))
                             .foregroundColor(activeSecondaryColor(0.75))
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -9420,12 +9425,12 @@ private struct TabItemView: View {
 
             // Pull request rows
             if sidebarShowPullRequest, !pullRequestRows.isEmpty {
-                VStack(alignment: .leading, spacing: 1) {
+                VStack(alignment: .leading, spacing: UIZoomMetrics.pullRequestRowSpacing(uiZoomScale)) {
                     ForEach(pullRequestRows) { pullRequest in
                         Button(action: {
                             openPullRequestLink(pullRequest.url)
                         }) {
-                            HStack(spacing: 4) {
+                            HStack(spacing: UIZoomMetrics.pullRequestItemSpacing(uiZoomScale)) {
                                 PullRequestStatusIcon(
                                     status: pullRequest.status,
                                     color: pullRequestForegroundColor
@@ -9438,7 +9443,7 @@ private struct TabItemView: View {
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), weight: .semibold))
                             .foregroundColor(pullRequestForegroundColor)
                         }
                         .buttonStyle(.plain)
@@ -9450,7 +9455,7 @@ private struct TabItemView: View {
             // Ports row
             if sidebarShowPorts, !tab.listeningPorts.isEmpty {
                 Text(tab.listeningPorts.map { ":\($0)" }.joined(separator: ", "))
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: UIZoomMetrics.subtitleFontSize(uiZoomScale), design: .monospaced))
                     .foregroundColor(activeSecondaryColor(0.75))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -9459,27 +9464,27 @@ private struct TabItemView: View {
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, UIZoomMetrics.horizontalPadding(uiZoomScale))
+        .padding(.vertical, UIZoomMetrics.verticalPadding(uiZoomScale))
         .background(
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: UIZoomMetrics.cornerRadius(uiZoomScale))
                 .fill(backgroundColor)
                 .overlay {
-                    RoundedRectangle(cornerRadius: 6)
+                    RoundedRectangle(cornerRadius: UIZoomMetrics.cornerRadius(uiZoomScale))
                         .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
                 }
                 .overlay(alignment: .leading) {
                     if showsLeadingRail {
                         Capsule(style: .continuous)
                             .fill(railColor)
-                            .frame(width: 3)
-                            .padding(.leading, 4)
-                            .padding(.vertical, 5)
+                            .frame(width: UIZoomMetrics.leadingRailWidth(uiZoomScale))
+                            .padding(.leading, UIZoomMetrics.leadingRailLeadingPadding(uiZoomScale))
+                            .padding(.vertical, UIZoomMetrics.leadingRailVerticalPadding(uiZoomScale))
                             .offset(x: -1)
                     }
                 }
         )
-        .padding(.horizontal, 6)
+        .padding(.horizontal, UIZoomMetrics.outerHorizontalPadding(uiZoomScale))
         .background {
             GeometryReader { proxy in
                 Color.clear
@@ -9505,8 +9510,8 @@ private struct TabItemView: View {
             if showsCenteredTopDropIndicator {
                 Rectangle()
                     .fill(cmuxAccentColor())
-                    .frame(height: 2)
-                    .padding(.horizontal, 8)
+                    .frame(height: UIZoomMetrics.dropIndicatorHeight(uiZoomScale))
+                    .padding(.horizontal, UIZoomMetrics.dropIndicatorHorizontalPadding(uiZoomScale))
                     .offset(y: index == 0 ? 0 : -(rowSpacing / 2))
             }
         }

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -11,8 +11,9 @@ struct BrowserSearchOverlay: View {
     @State private var dragOffset: CGSize = .zero
     @State private var barSize: CGSize = .zero
     @FocusState private var isSearchFieldFocused: Bool
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
-    private let padding: CGFloat = 8
+    private var padding: CGFloat { UIZoomMetrics.searchContainerPadding(uiZoomScale) }
 
     private func requestSearchFieldFocus(maxAttempts: Int = 3) {
         guard maxAttempts > 0 else { return }
@@ -25,31 +26,31 @@ struct BrowserSearchOverlay: View {
 
     var body: some View {
         GeometryReader { geo in
-            HStack(spacing: 4) {
+            HStack(spacing: UIZoomMetrics.searchSpacing(uiZoomScale)) {
                 TextField("Search", text: $searchState.needle)
                     .textFieldStyle(.plain)
                     .accessibilityIdentifier("BrowserFindSearchTextField")
-                    .frame(width: 180)
-                    .padding(.leading, 8)
-                    .padding(.trailing, 50)
-                    .padding(.vertical, 6)
+                    .frame(width: UIZoomMetrics.searchFieldWidth(uiZoomScale))
+                    .padding(.leading, UIZoomMetrics.searchFieldLPadding(uiZoomScale))
+                    .padding(.trailing, UIZoomMetrics.searchFieldRPadding(uiZoomScale))
+                    .padding(.vertical, UIZoomMetrics.searchFieldVPadding(uiZoomScale))
                     .background(Color.primary.opacity(0.1))
-                    .cornerRadius(6)
+                    .cornerRadius(UIZoomMetrics.searchFieldCornerRadius(uiZoomScale))
                     .focused($isSearchFieldFocused)
                     .overlay(alignment: .trailing) {
                     if let selected = searchState.selected {
                         let totalText = searchState.total.map { String($0) } ?? "?"
                         Text("\(selected + 1)/\(totalText)")
-                            .font(.caption)
+                            .font(.system(size: UIZoomMetrics.searchCounterFontSize(uiZoomScale)))
                             .foregroundColor(.secondary)
                             .monospacedDigit()
-                            .padding(.trailing, 8)
+                            .padding(.trailing, UIZoomMetrics.searchCounterTrailingPadding(uiZoomScale))
                     } else if let total = searchState.total {
                         Text(total == 0 ? "0/0" : "-/\(total)")
-                            .font(.caption)
+                            .font(.system(size: UIZoomMetrics.searchCounterFontSize(uiZoomScale)))
                             .foregroundColor(.secondary)
                             .monospacedDigit()
-                            .padding(.trailing, 8)
+                            .padding(.trailing, UIZoomMetrics.searchCounterTrailingPadding(uiZoomScale))
                     }
                 }
                 .onExitCommand {
@@ -97,7 +98,7 @@ struct BrowserSearchOverlay: View {
                 .buttonStyle(SearchButtonStyle())
                 .safeHelp("Close (Esc)")
             }
-            .padding(8)
+            .padding(UIZoomMetrics.searchContainerPadding(uiZoomScale))
             .background(.background)
             .clipShape(clipShape)
             .shadow(radius: 4)
@@ -146,7 +147,7 @@ struct BrowserSearchOverlay: View {
     }
 
     private var clipShape: some Shape {
-        RoundedRectangle(cornerRadius: 8)
+        RoundedRectangle(cornerRadius: UIZoomMetrics.searchContainerCornerRadius(uiZoomScale))
     }
 
     enum Corner {

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -27,7 +27,7 @@ struct BrowserSearchOverlay: View {
     var body: some View {
         GeometryReader { geo in
             HStack(spacing: UIZoomMetrics.searchSpacing(uiZoomScale)) {
-                TextField("Search", text: $searchState.needle)
+                TextField(String(localized: "browserSearchOverlay.search", defaultValue: "Search"), text: $searchState.needle)
                     .textFieldStyle(.plain)
                     .accessibilityIdentifier("BrowserFindSearchTextField")
                     .frame(width: UIZoomMetrics.searchFieldWidth(uiZoomScale))

--- a/Sources/Find/SurfaceSearchOverlay.swift
+++ b/Sources/Find/SurfaceSearchOverlay.swift
@@ -27,12 +27,13 @@ struct SurfaceSearchOverlay: View {
     @State private var dragOffset: CGSize = .zero
     @State private var barSize: CGSize = .zero
     @State private var isSearchFieldFocused: Bool = true
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
-    private let padding: CGFloat = 8
+    private var padding: CGFloat { UIZoomMetrics.searchContainerPadding(uiZoomScale) }
 
     var body: some View {
         GeometryReader { geo in
-            HStack(spacing: 4) {
+            HStack(spacing: UIZoomMetrics.searchSpacing(uiZoomScale)) {
                 SearchTextFieldRepresentable(
                     text: $searchState.needle,
                     isFocused: $isSearchFieldFocused,
@@ -56,26 +57,26 @@ struct SurfaceSearchOverlay: View {
                     }
                 )
                 .accessibilityIdentifier("TerminalFindSearchTextField")
-                .frame(width: 180)
-                .padding(.leading, 8)
-                .padding(.trailing, 50)
-                .padding(.vertical, 6)
+                .frame(width: UIZoomMetrics.searchFieldWidth(uiZoomScale))
+                .padding(.leading, UIZoomMetrics.searchFieldLPadding(uiZoomScale))
+                .padding(.trailing, UIZoomMetrics.searchFieldRPadding(uiZoomScale))
+                .padding(.vertical, UIZoomMetrics.searchFieldVPadding(uiZoomScale))
                 .background(Color.primary.opacity(0.1))
-                .cornerRadius(6)
+                .cornerRadius(UIZoomMetrics.searchFieldCornerRadius(uiZoomScale))
                 .overlay(alignment: .trailing) {
                     if let selected = searchState.selected {
                         let totalText = searchState.total.map { String($0) } ?? "?"
                         Text("\(selected + 1)/\(totalText)")
-                            .font(.caption)
+                            .font(.system(size: UIZoomMetrics.searchCounterFontSize(uiZoomScale)))
                             .foregroundColor(.secondary)
                             .monospacedDigit()
-                            .padding(.trailing, 8)
+                            .padding(.trailing, UIZoomMetrics.searchCounterTrailingPadding(uiZoomScale))
                     } else if let total = searchState.total {
                         Text("-/\(total)")
-                            .font(.caption)
+                            .font(.system(size: UIZoomMetrics.searchCounterFontSize(uiZoomScale)))
                             .foregroundColor(.secondary)
                             .monospacedDigit()
-                            .padding(.trailing, 8)
+                            .padding(.trailing, UIZoomMetrics.searchCounterTrailingPadding(uiZoomScale))
                     }
                 }
 
@@ -112,7 +113,7 @@ struct SurfaceSearchOverlay: View {
                 .buttonStyle(SearchButtonStyle())
                 .safeHelp(String(localized: "search.close.help", defaultValue: "Close (Esc)"))
             }
-            .padding(8)
+            .padding(UIZoomMetrics.searchContainerPadding(uiZoomScale))
             .background(.background)
             .clipShape(clipShape)
             .shadow(radius: 4)
@@ -154,7 +155,7 @@ struct SurfaceSearchOverlay: View {
     }
 
     private var clipShape: some Shape {
-        RoundedRectangle(cornerRadius: 8)
+        RoundedRectangle(cornerRadius: UIZoomMetrics.searchContainerCornerRadius(uiZoomScale))
     }
 
     enum Corner {

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -89,14 +89,14 @@ struct NotificationsPage: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: UIZoomMetrics.notificationEmptySpacing(uiZoomScale)) {
             Image(systemName: "bell.slash")
-                .font(.system(size: 32))
+                .font(.system(size: UIZoomMetrics.notificationEmptyIconSize(uiZoomScale)))
                 .foregroundColor(.secondary)
             Text(String(localized: "notifications.empty.title", defaultValue: "No notifications yet"))
-                .font(.headline)
+                .font(.system(size: UIZoomMetrics.notificationTitleFontSize(uiZoomScale), weight: .semibold))
             Text(String(localized: "notifications.empty.description", defaultValue: "Desktop notifications will appear here for quick review."))
-                .font(.subheadline)
+                .font(.system(size: UIZoomMetrics.notificationBodyFontSize(uiZoomScale)))
                 .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -179,48 +179,49 @@ private struct NotificationRow: View {
     let onOpen: () -> Void
     let onClear: () -> Void
     let focusedNotificationId: FocusState<UUID?>.Binding
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: UIZoomMetrics.notificationRowSpacing(uiZoomScale)) {
             Button(action: onOpen) {
-                HStack(alignment: .top, spacing: 12) {
+                HStack(alignment: .top, spacing: UIZoomMetrics.notificationRowSpacing(uiZoomScale)) {
                     Circle()
                         .fill(notification.isRead ? Color.clear : cmuxAccentColor())
-                        .frame(width: 8, height: 8)
+                        .frame(width: UIZoomMetrics.notificationDotSize(uiZoomScale), height: UIZoomMetrics.notificationDotSize(uiZoomScale))
                         .overlay(
                             Circle()
                                 .stroke(cmuxAccentColor().opacity(notification.isRead ? 0.2 : 1), lineWidth: 1)
                         )
-                        .padding(.top, 6)
+                        .padding(.top, UIZoomMetrics.notificationRowTopPadding(uiZoomScale))
 
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: UIZoomMetrics.notificationRowVStackSpacing(uiZoomScale)) {
                         HStack {
                             Text(notification.title)
-                                .font(.headline)
+                                .font(.system(size: UIZoomMetrics.notificationTitleFontSize(uiZoomScale), weight: .semibold))
                                 .foregroundColor(.primary)
                             Spacer()
                             Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
-                                .font(.caption)
+                                .font(.system(size: UIZoomMetrics.notificationCaptionFontSize(uiZoomScale)))
                                 .foregroundColor(.secondary)
                         }
 
                         if !notification.body.isEmpty {
                             Text(notification.body)
-                                .font(.subheadline)
+                                .font(.system(size: UIZoomMetrics.notificationBodyFontSize(uiZoomScale)))
                                 .foregroundColor(.secondary)
                                 .lineLimit(3)
                         }
 
                         if let tabTitle {
                             Text(tabTitle)
-                                .font(.caption)
+                                .font(.system(size: UIZoomMetrics.notificationCaptionFontSize(uiZoomScale)))
                                 .foregroundColor(.secondary)
                         }
                     }
 
                     Spacer(minLength: 0)
                 }
-                .padding(.trailing, 6)
+                .padding(.trailing, UIZoomMetrics.notificationRowTrailingPadding(uiZoomScale))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
             }
@@ -236,9 +237,9 @@ private struct NotificationRow: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(12)
+        .padding(UIZoomMetrics.notificationRowPadding(uiZoomScale))
         .background(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: UIZoomMetrics.notificationRowCornerRadius(uiZoomScale))
                 .fill(Color(nsColor: .controlBackgroundColor))
         )
     }

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -7,6 +7,7 @@ struct NotificationsPage: View {
     @Binding var selection: SidebarSelection
     @FocusState private var focusedNotificationId: UUID?
     @AppStorage(KeyboardShortcutSettings.Action.jumpToUnread.defaultsKey) private var jumpToUnreadShortcutData = Data()
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,7 +42,7 @@ struct NotificationsPage: View {
                             )
                         }
                     }
-                    .padding(16)
+                    .padding(UIZoomMetrics.notificationContainerPadding(uiZoomScale))
                 }
             }
         }
@@ -83,8 +84,8 @@ struct NotificationsPage: View {
                 .buttonStyle(.bordered)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.horizontal, UIZoomMetrics.notificationItemHPadding(uiZoomScale))
+        .padding(.vertical, UIZoomMetrics.notificationItemVPadding(uiZoomScale))
     }
 
     private var emptyState: some View {
@@ -157,13 +158,14 @@ struct NotificationsPage: View {
 
 private struct ShortcutAnnotation: View {
     let text: String
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     var body: some View {
         Text(text)
-            .font(.system(size: 10, weight: .semibold, design: .rounded))
+            .font(.system(size: UIZoomMetrics.notificationHeaderFontSize(uiZoomScale), weight: .semibold, design: .rounded))
             .foregroundStyle(.primary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
+            .padding(.horizontal, UIZoomMetrics.notificationHeaderHPadding(uiZoomScale))
+            .padding(.vertical, UIZoomMetrics.notificationHeaderVPadding(uiZoomScale))
             .background(
                 RoundedRectangle(cornerRadius: 5)
                     .fill(Color(nsColor: .controlBackgroundColor))

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -570,7 +570,7 @@ struct BrowserPanelView: View {
                 panel.goBack()
             }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIZoomMetrics.addressBarButtonFontSize(uiZoomScale), weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -586,7 +586,7 @@ struct BrowserPanelView: View {
                 panel.goForward()
             }) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIZoomMetrics.addressBarButtonFontSize(uiZoomScale), weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -609,7 +609,7 @@ struct BrowserPanelView: View {
                 }
             }) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: UIZoomMetrics.addressBarButtonFontSize(uiZoomScale), weight: .medium))
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -621,7 +621,7 @@ struct BrowserPanelView: View {
                     ProgressView()
                         .controlSize(.small)
                     Text(String(localized: "browser.downloading", defaultValue: "Downloading..."))
-                        .font(.system(size: 11))
+                        .font(.system(size: UIZoomMetrics.addressBarSmallFontSize(uiZoomScale)))
                         .foregroundStyle(.secondary)
                 }
                 .padding(.leading, 6)
@@ -725,6 +725,7 @@ struct BrowserPanelView: View {
                 isFocused: $addressBarFocused,
                 inlineCompletion: inlineCompletion,
                 placeholder: String(localized: "browser.addressBar.placeholder", defaultValue: "Search or enter URL"),
+                uiZoomScale: uiZoomScale,
                 onTap: {
                     handleOmnibarTap()
                 },
@@ -2678,6 +2679,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     @Binding var isFocused: Bool
     let inlineCompletion: OmnibarInlineCompletion?
     let placeholder: String
+    let uiZoomScale: Double
     let onTap: () -> Void
     let onSubmit: () -> Void
     let onEscape: () -> Void
@@ -3067,7 +3069,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 
     func makeNSView(context: Context) -> OmnibarNativeTextField {
         let field = OmnibarNativeTextField(frame: .zero)
-        field.font = .systemFont(ofSize: 12)
+        field.font = .systemFont(ofSize: UIZoomMetrics.addressBarButtonFontSize(uiZoomScale))
         field.placeholderString = placeholder
         field.delegate = context.coordinator
         field.target = nil
@@ -3090,6 +3092,10 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         context.coordinator.parent = self
         context.coordinator.parentField = nsView
         nsView.placeholderString = placeholder
+        let scaledFont = NSFont.systemFont(ofSize: UIZoomMetrics.addressBarButtonFontSize(uiZoomScale))
+        if nsView.font != scaledFont {
+            nsView.font = scaledFont
+        }
 
         let activeInlineCompletion = omnibarInlineCompletionIfBufferMatchesTypedPrefix(
             bufferText: text,
@@ -3388,26 +3394,26 @@ private struct OmnibarSuggestionsView: View {
                 #endif
                 onCommit(item)
             } label: {
-                HStack(spacing: 6) {
+                HStack(spacing: UIZoomMetrics.popupRowItemSpacing(uiZoomScale)) {
                         Text(item.listText)
-                            .font(.system(size: 11))
+                            .font(.system(size: UIZoomMetrics.popupTextFontSize(uiZoomScale)))
                             .foregroundStyle(listTextColor)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         if let badge = item.trailingBadgeText {
                             Text(badge)
-                                .font(.system(size: 9.5, weight: .medium))
+                                .font(.system(size: UIZoomMetrics.popupBadgeFontSize(uiZoomScale), weight: .medium))
                                 .foregroundStyle(badgeTextColor)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
+                                .padding(.horizontal, UIZoomMetrics.popupBadgeHPadding(uiZoomScale))
+                                .padding(.vertical, UIZoomMetrics.popupBadgeVPadding(uiZoomScale))
                                 .background(
-                                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                    RoundedRectangle(cornerRadius: UIZoomMetrics.popupBadgeCornerRadius(uiZoomScale), style: .continuous)
                                         .fill(badgeBackgroundColor)
                                 )
                         }
                         Spacer(minLength: 0)
                     }
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, UIZoomMetrics.popupRowHPadding(uiZoomScale))
                     .frame(
                         maxWidth: .infinity,
                         minHeight: rowHeight(for: item),

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -236,13 +236,14 @@ struct BrowserPanelView: View {
     @State private var pendingAddressBarFocusRetryGeneration: UInt64 = 0
     @State private var isBrowserThemeMenuPresented = false
     @State private var ghosttyBackgroundGeneration: Int = 0
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     // Keep this below half of the compact omnibar height so it reads as a squircle,
     // not a capsule.
-    private let omnibarPillCornerRadius: CGFloat = 10
-    private let addressBarButtonSize: CGFloat = 22
-    private let addressBarButtonHitSize: CGFloat = 26
-    private let addressBarVerticalPadding: CGFloat = 4
-    private let devToolsButtonIconSize: CGFloat = 11
+    private var omnibarPillCornerRadius: CGFloat { UIZoomMetrics.omnibarCornerRadius(uiZoomScale) }
+    private var addressBarButtonSize: CGFloat { UIZoomMetrics.addressBarButtonSize(uiZoomScale) }
+    private var addressBarButtonHitSize: CGFloat { UIZoomMetrics.addressBarButtonHitSize(uiZoomScale) }
+    private var addressBarVerticalPadding: CGFloat { UIZoomMetrics.addressBarVPadding(uiZoomScale) }
+    private var devToolsButtonIconSize: CGFloat { UIZoomMetrics.devToolsIconSize(uiZoomScale) }
 
     private var searchEngine: BrowserSearchEngine {
         BrowserSearchEngine(rawValue: searchEngineRaw) ?? BrowserSearchSettings.defaultSearchEngine
@@ -3224,17 +3225,18 @@ private struct OmnibarSuggestionsView: View {
     let onCommit: (OmnibarSuggestion) -> Void
     let onHighlight: (Int) -> Void
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     // Keep radii below half of the smallest rendered heights so this keeps a
     // squircle silhouette instead of auto-clamping into a capsule.
-    private let popupCornerRadius: CGFloat = 12
-    private let rowHighlightCornerRadius: CGFloat = 9
-    private let singleLineRowHeight: CGFloat = 24
-    private let rowSpacing: CGFloat = 1
+    private var popupCornerRadius: CGFloat { UIZoomMetrics.popupCornerRadius(uiZoomScale) }
+    private var rowHighlightCornerRadius: CGFloat { UIZoomMetrics.popupRowHighlightRadius(uiZoomScale) }
+    private var singleLineRowHeight: CGFloat { UIZoomMetrics.popupRowHeight(uiZoomScale) }
+    private var rowSpacing: CGFloat { UIZoomMetrics.popupRowSpacing(uiZoomScale) }
     private let topInset: CGFloat = 3
     private let bottomInset: CGFloat = 3
     private var horizontalInset: CGFloat { topInset }
-    private let maxPopupHeight: CGFloat = 560
+    private var maxPopupHeight: CGFloat { UIZoomMetrics.popupMaxHeight(uiZoomScale) }
 
     private var totalRowCount: Int {
         max(1, items.count)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -767,7 +767,7 @@ struct BrowserPanelView: View {
                     panel.shouldSuppressWebViewFocus()
                 }
             )
-                .frame(height: 18)
+                .frame(height: UIZoomMetrics.omnibarTextFieldHeight(uiZoomScale))
                 .accessibilityIdentifier("BrowserOmnibarTextField")
         }
         .padding(.horizontal, 8)

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -83,22 +83,22 @@ struct MarkdownPanelView: View {
     }
 
     private var fileUnavailableView: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: UIZoomMetrics.mdFileUnavailableSpacing(uiZoomScale)) {
             Image(systemName: "doc.questionmark")
-                .font(.system(size: 40))
+                .font(.system(size: UIZoomMetrics.mdFileUnavailableIconSize(uiZoomScale)))
                 .foregroundColor(.secondary)
             Text(String(localized: "markdown.fileUnavailable.title", defaultValue: "File unavailable"))
-                .font(.headline)
+                .font(.system(size: UIZoomMetrics.notificationTitleFontSize(uiZoomScale), weight: .semibold))
                 .foregroundColor(.primary)
             Text(panel.filePath)
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: UIZoomMetrics.mdFileUnavailablePathFontSize(uiZoomScale), design: .monospaced))
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 24)
+                .padding(.horizontal, UIZoomMetrics.mdFileUnavailableHPadding(uiZoomScale))
             Text(String(localized: "markdown.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
-                .font(.caption)
+                .font(.system(size: UIZoomMetrics.notificationCaptionFontSize(uiZoomScale)))
                 .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -114,73 +114,74 @@ struct MarkdownPanelView: View {
 
     private var cmuxMarkdownTheme: Theme {
         let isDark = colorScheme == .dark
+        let scale = uiZoomScale
 
         return Theme()
             // Text
             .text {
                 ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
-                FontSize(14)
+                FontSize(UIZoomMetrics.mdBodyFontSize(scale))
             }
             // Headings
             .heading1 { configuration in
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 8 * scale) {
                     configuration.label
                         .markdownTextStyle {
                             FontWeight(.bold)
-                            FontSize(28)
+                            FontSize(UIZoomMetrics.mdH1FontSize(scale))
                             ForegroundColor(isDark ? .white : .primary)
                         }
                     Divider()
                 }
-                .markdownMargin(top: 24, bottom: 16)
+                .markdownMargin(top: 24 * scale, bottom: 16 * scale)
             }
             .heading2 { configuration in
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 6 * scale) {
                     configuration.label
                         .markdownTextStyle {
                             FontWeight(.bold)
-                            FontSize(22)
+                            FontSize(UIZoomMetrics.mdH2FontSize(scale))
                             ForegroundColor(isDark ? .white : .primary)
                         }
                     Divider()
                 }
-                .markdownMargin(top: 20, bottom: 12)
+                .markdownMargin(top: 20 * scale, bottom: 12 * scale)
             }
             .heading3 { configuration in
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.semibold)
-                        FontSize(18)
+                        FontSize(UIZoomMetrics.mdH3FontSize(scale))
                         ForegroundColor(isDark ? .white : .primary)
                     }
-                    .markdownMargin(top: 16, bottom: 8)
+                    .markdownMargin(top: 16 * scale, bottom: 8 * scale)
             }
             .heading4 { configuration in
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.semibold)
-                        FontSize(16)
+                        FontSize(UIZoomMetrics.mdH4FontSize(scale))
                         ForegroundColor(isDark ? .white : .primary)
                     }
-                    .markdownMargin(top: 12, bottom: 6)
+                    .markdownMargin(top: 12 * scale, bottom: 6 * scale)
             }
             .heading5 { configuration in
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.medium)
-                        FontSize(14)
+                        FontSize(UIZoomMetrics.mdH5FontSize(scale))
                         ForegroundColor(isDark ? .white : .primary)
                     }
-                    .markdownMargin(top: 10, bottom: 4)
+                    .markdownMargin(top: 10 * scale, bottom: 4 * scale)
             }
             .heading6 { configuration in
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.medium)
-                        FontSize(13)
+                        FontSize(UIZoomMetrics.mdH6FontSize(scale))
                         ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
                     }
-                    .markdownMargin(top: 8, bottom: 4)
+                    .markdownMargin(top: 8 * scale, bottom: 4 * scale)
             }
             // Code blocks
             .codeBlock { configuration in
@@ -188,21 +189,21 @@ struct MarkdownPanelView: View {
                     configuration.label
                         .markdownTextStyle {
                             FontFamilyVariant(.monospaced)
-                            FontSize(13)
+                            FontSize(UIZoomMetrics.mdCodeFontSize(scale))
                             ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
                         }
-                        .padding(12)
+                        .padding(UIZoomMetrics.mdCodePadding(scale))
                 }
                 .background(isDark
                     ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
                     : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .markdownMargin(top: 8, bottom: 8)
+                .clipShape(RoundedRectangle(cornerRadius: UIZoomMetrics.mdCodeCornerRadius(scale)))
+                .markdownMargin(top: 8 * scale, bottom: 8 * scale)
             }
             // Inline code
             .code {
                 FontFamilyVariant(.monospaced)
-                FontSize(13)
+                FontSize(UIZoomMetrics.mdCodeFontSize(scale))
                 ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
                 BackgroundColor(isDark
                     ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
@@ -211,17 +212,17 @@ struct MarkdownPanelView: View {
             // Block quotes
             .blockquote { configuration in
                 HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1.5)
+                    RoundedRectangle(cornerRadius: UIZoomMetrics.mdBlockquoteBarRadius(scale))
                         .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
-                        .frame(width: 3)
+                        .frame(width: UIZoomMetrics.mdBlockquoteBarWidth(scale))
                     configuration.label
                         .markdownTextStyle {
                             ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
-                            FontSize(14)
+                            FontSize(UIZoomMetrics.mdBodyFontSize(scale))
                         }
-                        .padding(.leading, 12)
+                        .padding(.leading, UIZoomMetrics.mdBlockquotePadding(scale))
                 }
-                .markdownMargin(top: 8, bottom: 8)
+                .markdownMargin(top: 8 * scale, bottom: 8 * scale)
             }
             // Links
             .link {
@@ -245,22 +246,22 @@ struct MarkdownPanelView: View {
                                 : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
                         )
                     )
-                    .markdownMargin(top: 8, bottom: 8)
+                    .markdownMargin(top: 8 * scale, bottom: 8 * scale)
             }
             // Thematic break (horizontal rule)
             .thematicBreak {
                 Divider()
-                    .markdownMargin(top: 16, bottom: 16)
+                    .markdownMargin(top: 16 * scale, bottom: 16 * scale)
             }
             // List items
             .listItem { configuration in
                 configuration.label
-                    .markdownMargin(top: 4, bottom: 4)
+                    .markdownMargin(top: 4 * scale, bottom: 4 * scale)
             }
             // Paragraphs
             .paragraph { configuration in
                 configuration.label
-                    .markdownMargin(top: 4, bottom: 8)
+                    .markdownMargin(top: 4 * scale, bottom: 8 * scale)
             }
     }
 

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -12,6 +12,7 @@ struct MarkdownPanelView: View {
 
     @State private var focusFlashOpacity: Double = 0.0
     @State private var focusFlashAnimationGeneration: Int = 0
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -50,30 +51,30 @@ struct MarkdownPanelView: View {
             VStack(alignment: .leading, spacing: 0) {
                 // File path breadcrumb
                 filePathHeader
-                    .padding(.horizontal, 24)
-                    .padding(.top, 16)
-                    .padding(.bottom, 8)
+                    .padding(.horizontal, UIZoomMetrics.mdHeaderHPadding(uiZoomScale))
+                    .padding(.top, UIZoomMetrics.mdHeaderVPadding(uiZoomScale))
+                    .padding(.bottom, UIZoomMetrics.mdHeaderSpacing(uiZoomScale) + 2)
 
                 Divider()
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, UIZoomMetrics.mdDividerHPadding(uiZoomScale))
 
                 // Rendered markdown
                 Markdown(panel.content)
                     .markdownTheme(cmuxMarkdownTheme)
                     .textSelection(.enabled)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 16)
+                    .padding(.horizontal, UIZoomMetrics.mdContentHPadding(uiZoomScale))
+                    .padding(.vertical, UIZoomMetrics.mdContentVPadding(uiZoomScale))
             }
         }
     }
 
     private var filePathHeader: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: UIZoomMetrics.mdHeaderSpacing(uiZoomScale)) {
             Image(systemName: "doc.richtext")
                 .foregroundColor(.secondary)
-                .font(.system(size: 12))
+                .font(.system(size: UIZoomMetrics.mdHeaderIconSize(uiZoomScale)))
             Text(panel.filePath)
-                .font(.system(size: 11, design: .monospaced))
+                .font(.system(size: UIZoomMetrics.mdHeaderTextSize(uiZoomScale), design: .monospaced))
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -19,10 +19,14 @@ enum SessionPersistencePolicy {
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
 
+    static func scaledMinimumSidebarWidth() -> Double {
+        UIZoomMetrics.minimumSidebarWidth(UIZoomMetrics.effectiveScale())
+    }
+
     static func sanitizedSidebarWidth(_ candidate: Double?) -> Double {
         let fallback = defaultSidebarWidth
         guard let candidate, candidate.isFinite else { return fallback }
-        return min(max(candidate, minimumSidebarWidth), maximumSidebarWidth)
+        return min(max(candidate, scaledMinimumSidebarWidth()), maximumSidebarWidth)
     }
 
     static func truncatedScrollback(_ text: String?) -> String? {

--- a/Sources/UIZoomMetrics.swift
+++ b/Sources/UIZoomMetrics.swift
@@ -14,7 +14,7 @@ enum UIZoomMetrics {
 
     static func effectiveScale() -> Double {
         let scale = UserDefaults.standard.double(forKey: appStorageKey)
-        return scale == 0 ? defaultScale : scale
+        return clamped(scale == 0 ? defaultScale : scale)
     }
 
     // MARK: - Sidebar Typography
@@ -106,13 +106,20 @@ enum UIZoomMetrics {
     static func addressBarButtonHitSize(_ scale: Double) -> CGFloat { 26 * scale }
     static func addressBarVPadding(_ scale: Double) -> CGFloat { 4 * scale }
     static func addressBarButtonFontSize(_ scale: Double) -> CGFloat { 12 * scale }
-    static func addressBarHPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func addressBarSmallFontSize(_ scale: Double) -> CGFloat { 11 * scale }
     static func devToolsIconSize(_ scale: Double) -> CGFloat { 11 * scale }
     static func popupCornerRadius(_ scale: Double) -> CGFloat { 12 * scale }
     static func popupRowHighlightRadius(_ scale: Double) -> CGFloat { 9 * scale }
     static func popupRowHeight(_ scale: Double) -> CGFloat { 24 * scale }
     static func popupRowSpacing(_ scale: Double) -> CGFloat { 1 * scale }
     static func popupMaxHeight(_ scale: Double) -> CGFloat { 560 * scale }
+    static func popupTextFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func popupBadgeFontSize(_ scale: Double) -> CGFloat { 9.5 * scale }
+    static func popupBadgeHPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func popupBadgeVPadding(_ scale: Double) -> CGFloat { 2 * scale }
+    static func popupBadgeCornerRadius(_ scale: Double) -> CGFloat { 7 * scale }
+    static func popupRowHPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func popupRowItemSpacing(_ scale: Double) -> CGFloat { 6 * scale }
 
     // MARK: - Search Overlay
 
@@ -136,6 +143,18 @@ enum UIZoomMetrics {
     static func notificationHeaderFontSize(_ scale: Double) -> CGFloat { 10 * scale }
     static func notificationHeaderHPadding(_ scale: Double) -> CGFloat { 6 * scale }
     static func notificationHeaderVPadding(_ scale: Double) -> CGFloat { 2 * scale }
+    static func notificationRowSpacing(_ scale: Double) -> CGFloat { 12 * scale }
+    static func notificationDotSize(_ scale: Double) -> CGFloat { 8 * scale }
+    static func notificationRowTopPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func notificationRowVStackSpacing(_ scale: Double) -> CGFloat { 6 * scale }
+    static func notificationRowTrailingPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func notificationRowPadding(_ scale: Double) -> CGFloat { 12 * scale }
+    static func notificationRowCornerRadius(_ scale: Double) -> CGFloat { 10 * scale }
+    static func notificationTitleFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func notificationBodyFontSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func notificationCaptionFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func notificationEmptyIconSize(_ scale: Double) -> CGFloat { 32 * scale }
+    static func notificationEmptySpacing(_ scale: Double) -> CGFloat { 8 * scale }
 
     // MARK: - Markdown Panel
 
@@ -147,6 +166,23 @@ enum UIZoomMetrics {
     static func mdDividerHPadding(_ scale: Double) -> CGFloat { 16 * scale }
     static func mdContentHPadding(_ scale: Double) -> CGFloat { 24 * scale }
     static func mdContentVPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func mdBodyFontSize(_ scale: Double) -> CGFloat { 14 * scale }
+    static func mdH1FontSize(_ scale: Double) -> CGFloat { 28 * scale }
+    static func mdH2FontSize(_ scale: Double) -> CGFloat { 22 * scale }
+    static func mdH3FontSize(_ scale: Double) -> CGFloat { 18 * scale }
+    static func mdH4FontSize(_ scale: Double) -> CGFloat { 16 * scale }
+    static func mdH5FontSize(_ scale: Double) -> CGFloat { 14 * scale }
+    static func mdH6FontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func mdCodeFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func mdCodePadding(_ scale: Double) -> CGFloat { 12 * scale }
+    static func mdCodeCornerRadius(_ scale: Double) -> CGFloat { 6 * scale }
+    static func mdBlockquoteBarWidth(_ scale: Double) -> CGFloat { 3 * scale }
+    static func mdBlockquoteBarRadius(_ scale: Double) -> CGFloat { 1.5 * scale }
+    static func mdBlockquotePadding(_ scale: Double) -> CGFloat { 12 * scale }
+    static func mdFileUnavailableIconSize(_ scale: Double) -> CGFloat { 40 * scale }
+    static func mdFileUnavailablePathFontSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func mdFileUnavailableSpacing(_ scale: Double) -> CGFloat { 12 * scale }
+    static func mdFileUnavailableHPadding(_ scale: Double) -> CGFloat { 24 * scale }
 
     // MARK: - Feedback Dialog
 

--- a/Sources/UIZoomMetrics.swift
+++ b/Sources/UIZoomMetrics.swift
@@ -72,7 +72,7 @@ enum UIZoomMetrics {
     static let baseMinimumSidebarWidth: Double = 186
 
     static func minimumSidebarWidth(_ scale: Double) -> Double {
-        baseMinimumSidebarWidth * clamped(scale)
+        baseMinimumSidebarWidth
     }
 
     // MARK: - Titlebar

--- a/Sources/UIZoomMetrics.swift
+++ b/Sources/UIZoomMetrics.swift
@@ -1,0 +1,176 @@
+import CoreGraphics
+import Foundation
+
+enum UIZoomMetrics {
+    static let appStorageKey = "uiZoomScale"
+    static let defaultScale: Double = 1.0
+    static let minimumScale: Double = 0.5
+    static let maximumScale: Double = 2.0
+    static let step: Double = 0.1
+
+    static func clamped(_ scale: Double) -> Double {
+        min(maximumScale, max(minimumScale, scale))
+    }
+
+    static func effectiveScale() -> Double {
+        let scale = UserDefaults.standard.double(forKey: appStorageKey)
+        return scale == 0 ? defaultScale : scale
+    }
+
+    // MARK: - Sidebar Typography
+
+    static func titleFontSize(_ scale: Double) -> CGFloat { 12.5 * scale }
+    static func subtitleFontSize(_ scale: Double) -> CGFloat { 10 * scale }
+    static func smallFontSize(_ scale: Double) -> CGFloat { 9 * scale }
+    static func tinyFontSize(_ scale: Double) -> CGFloat { 8 * scale }
+    static func separatorDotFontSize(_ scale: Double) -> CGFloat { 3 * scale }
+
+    // MARK: - Sidebar Element sizes
+
+    static func badgeSize(_ scale: Double) -> CGFloat { 16 * scale }
+    static func closeButtonSize(_ scale: Double) -> CGFloat { 16 * scale }
+    static func progressBarHeight(_ scale: Double) -> CGFloat { 3 * scale }
+    static func leadingRailWidth(_ scale: Double) -> CGFloat { 3 * scale }
+    static func dropIndicatorHeight(_ scale: Double) -> CGFloat { 2 * scale }
+
+    // MARK: - Sidebar Spacing
+
+    static func contentSpacing(_ scale: Double) -> CGFloat { 4 * scale }
+    static func headerSpacing(_ scale: Double) -> CGFloat { 8 * scale }
+    static func logEntrySpacing(_ scale: Double) -> CGFloat { 4 * scale }
+    static func progressSpacing(_ scale: Double) -> CGFloat { 2 * scale }
+    static func branchLineSpacing(_ scale: Double) -> CGFloat { 1 * scale }
+    static func branchItemSpacing(_ scale: Double) -> CGFloat { 3 * scale }
+    static func pullRequestRowSpacing(_ scale: Double) -> CGFloat { 1 * scale }
+    static func pullRequestItemSpacing(_ scale: Double) -> CGFloat { 4 * scale }
+    static func tabRowSpacing(_ scale: Double) -> CGFloat { 2 * scale }
+
+    // MARK: - Sidebar Padding
+
+    static func horizontalPadding(_ scale: Double) -> CGFloat { 10 * scale }
+    static func verticalPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func outerHorizontalPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func listVerticalPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func shortcutHintHorizontalPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func shortcutHintVerticalPadding(_ scale: Double) -> CGFloat { 2 * scale }
+    static func separatorDotHorizontalPadding(_ scale: Double) -> CGFloat { 1 * scale }
+    static func dropIndicatorHorizontalPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func leadingRailLeadingPadding(_ scale: Double) -> CGFloat { 4 * scale }
+    static func leadingRailVerticalPadding(_ scale: Double) -> CGFloat { 5 * scale }
+
+    // MARK: - Sidebar Corner radius
+
+    static func cornerRadius(_ scale: Double) -> CGFloat { 6 * scale }
+
+    // MARK: - Sidebar Container
+
+    static func trafficLightPadding(_ scale: Double) -> CGFloat { 28 * scale }
+    static func topScrimExtraHeight(_ scale: Double) -> CGFloat { 20 * scale }
+
+    // MARK: - Minimum sidebar width
+
+    static let baseMinimumSidebarWidth: Double = 186
+
+    static func minimumSidebarWidth(_ scale: Double) -> Double {
+        baseMinimumSidebarWidth * clamped(scale)
+    }
+
+    // MARK: - Titlebar
+
+    static func titlebarFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func titlebarHeight(_ scale: Double) -> CGFloat { 28 * scale }
+    static func titlebarTopPadding(_ scale: Double) -> CGFloat { 2 * scale }
+    static func titlebarHorizontalPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func titlebarDividerHeight(_ scale: Double) -> CGFloat { 1 * scale }
+
+    // MARK: - Command Palette
+
+    static func paletteListMaxHeight(_ scale: Double) -> CGFloat { 450 * scale }
+    static func paletteRowHeight(_ scale: Double) -> CGFloat { 24 * scale }
+    static func paletteEmptyStateHeight(_ scale: Double) -> CGFloat { 44 * scale }
+    static func paletteFieldFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func paletteFieldHPadding(_ scale: Double) -> CGFloat { 9 * scale }
+    static func paletteFieldVPadding(_ scale: Double) -> CGFloat { 7 * scale }
+    static func paletteResultFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func paletteResultHPadding(_ scale: Double) -> CGFloat { 9 * scale }
+    static func paletteResultVPadding(_ scale: Double) -> CGFloat { 2 * scale }
+    static func paletteTrailingFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func paletteTrailingHPadding(_ scale: Double) -> CGFloat { 4 * scale }
+    static func paletteTrailingVPadding(_ scale: Double) -> CGFloat { 1 * scale }
+    static func paletteTrailingCornerRadius(_ scale: Double) -> CGFloat { 4 * scale }
+
+    // MARK: - Browser UI
+
+    static func omnibarCornerRadius(_ scale: Double) -> CGFloat { 10 * scale }
+    static func addressBarButtonSize(_ scale: Double) -> CGFloat { 22 * scale }
+    static func addressBarButtonHitSize(_ scale: Double) -> CGFloat { 26 * scale }
+    static func addressBarVPadding(_ scale: Double) -> CGFloat { 4 * scale }
+    static func addressBarButtonFontSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func addressBarHPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func devToolsIconSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func popupCornerRadius(_ scale: Double) -> CGFloat { 12 * scale }
+    static func popupRowHighlightRadius(_ scale: Double) -> CGFloat { 9 * scale }
+    static func popupRowHeight(_ scale: Double) -> CGFloat { 24 * scale }
+    static func popupRowSpacing(_ scale: Double) -> CGFloat { 1 * scale }
+    static func popupMaxHeight(_ scale: Double) -> CGFloat { 560 * scale }
+
+    // MARK: - Search Overlay
+
+    static func searchFieldWidth(_ scale: Double) -> CGFloat { 180 * scale }
+    static func searchFieldLPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func searchFieldRPadding(_ scale: Double) -> CGFloat { 50 * scale }
+    static func searchFieldVPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func searchFieldCornerRadius(_ scale: Double) -> CGFloat { 6 * scale }
+    static func searchContainerCornerRadius(_ scale: Double) -> CGFloat { 8 * scale }
+    static func searchContainerPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func searchSpacing(_ scale: Double) -> CGFloat { 4 * scale }
+    static func searchCounterFontSize(_ scale: Double) -> CGFloat { 10 * scale }
+    static func searchCounterTrailingPadding(_ scale: Double) -> CGFloat { 8 * scale }
+
+    // MARK: - Notifications
+
+    static func notificationContainerPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func notificationItemSpacing(_ scale: Double) -> CGFloat { 8 * scale }
+    static func notificationItemHPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func notificationItemVPadding(_ scale: Double) -> CGFloat { 12 * scale }
+    static func notificationHeaderFontSize(_ scale: Double) -> CGFloat { 10 * scale }
+    static func notificationHeaderHPadding(_ scale: Double) -> CGFloat { 6 * scale }
+    static func notificationHeaderVPadding(_ scale: Double) -> CGFloat { 2 * scale }
+
+    // MARK: - Markdown Panel
+
+    static func mdHeaderIconSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func mdHeaderTextSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func mdHeaderSpacing(_ scale: Double) -> CGFloat { 6 * scale }
+    static func mdHeaderHPadding(_ scale: Double) -> CGFloat { 24 * scale }
+    static func mdHeaderVPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func mdDividerHPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func mdContentHPadding(_ scale: Double) -> CGFloat { 24 * scale }
+    static func mdContentVPadding(_ scale: Double) -> CGFloat { 16 * scale }
+
+    // MARK: - Feedback Dialog
+
+    static func feedbackDialogWidth(_ scale: Double) -> CGFloat { 520 * scale }
+    static func feedbackDialogPadding(_ scale: Double) -> CGFloat { 20 * scale }
+    static func feedbackFontSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func feedbackSmallFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+
+    // MARK: - Workspace
+
+    static func workspaceTitleFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func workspaceTitleHPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func workspaceTitleVPadding(_ scale: Double) -> CGFloat { 3 * scale }
+    static func emptyStateIconSize(_ scale: Double) -> CGFloat { 48 * scale }
+    static func emptyStateSpacing(_ scale: Double) -> CGFloat { 16 * scale }
+
+    // MARK: - Update UI
+
+    static func updatePopoverWidth(_ scale: Double) -> CGFloat { 300 * scale }
+    static func updatePopoverPadding(_ scale: Double) -> CGFloat { 16 * scale }
+    static func updateTitleFontSize(_ scale: Double) -> CGFloat { 13 * scale }
+    static func updateBodyFontSize(_ scale: Double) -> CGFloat { 11 * scale }
+    static func updatePillSpacing(_ scale: Double) -> CGFloat { 6 * scale }
+    static func updatePillIconSize(_ scale: Double) -> CGFloat { 14 * scale }
+    static func updatePillHPadding(_ scale: Double) -> CGFloat { 8 * scale }
+    static func updatePillVPadding(_ scale: Double) -> CGFloat { 4 * scale }
+}

--- a/Sources/UIZoomMetrics.swift
+++ b/Sources/UIZoomMetrics.swift
@@ -106,6 +106,7 @@ enum UIZoomMetrics {
     static func addressBarButtonHitSize(_ scale: Double) -> CGFloat { 26 * scale }
     static func addressBarVPadding(_ scale: Double) -> CGFloat { 4 * scale }
     static func addressBarButtonFontSize(_ scale: Double) -> CGFloat { 12 * scale }
+    static func omnibarTextFieldHeight(_ scale: Double) -> CGFloat { 18 * scale }
     static func addressBarSmallFontSize(_ scale: Double) -> CGFloat { 11 * scale }
     static func devToolsIconSize(_ scale: Double) -> CGFloat { 11 * scale }
     static func popupCornerRadius(_ scale: Double) -> CGFloat { 12 * scale }

--- a/Sources/Update/UpdatePill.swift
+++ b/Sources/Update/UpdatePill.swift
@@ -7,8 +7,9 @@ import SwiftUI
 struct UpdatePill: View {
     @ObservedObject var model: UpdateViewModel
     @State private var showPopover = false
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
-    private let textFont = NSFont.systemFont(ofSize: 11, weight: .medium)
+    private var textFont: NSFont { NSFont.systemFont(ofSize: UIZoomMetrics.updateBodyFontSize(uiZoomScale), weight: .medium) }
 
     var body: some View {
         let state = model.effectiveState
@@ -35,9 +36,9 @@ struct UpdatePill: View {
                 showPopover.toggle()
             }
         }) {
-            HStack(spacing: 6) {
+            HStack(spacing: UIZoomMetrics.updatePillSpacing(uiZoomScale)) {
                 UpdateBadge(model: model)
-                    .frame(width: 14, height: 14)
+                    .frame(width: UIZoomMetrics.updatePillIconSize(uiZoomScale), height: UIZoomMetrics.updatePillIconSize(uiZoomScale))
 
                 Text(model.text)
                     .font(Font(textFont))
@@ -45,8 +46,8 @@ struct UpdatePill: View {
                     .truncationMode(.tail)
                     .frame(maxWidth: textWidth, alignment: .leading)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, UIZoomMetrics.updatePillHPadding(uiZoomScale))
+            .padding(.vertical, UIZoomMetrics.updatePillVPadding(uiZoomScale))
             .background(
                 Capsule()
                     .fill(model.backgroundColor)

--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -5,6 +5,7 @@ import Sparkle
 /// Popover view that displays detailed update information and actions.
 struct UpdatePopoverView: View {
     @ObservedObject var model: UpdateViewModel
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -38,7 +39,7 @@ struct UpdatePopoverView: View {
                 UpdateErrorView(error: error, dismiss: dismiss)
             }
         }
-        .frame(width: 300)
+        .frame(width: UIZoomMetrics.updatePopoverWidth(uiZoomScale))
     }
 }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -18,6 +18,7 @@ struct WorkspaceContentView: View {
     @State private var config = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "stateInit")
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject var notificationStore: TerminalNotificationStore
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     static func panelVisibleInUI(
         isWorkspaceVisible: Bool,
@@ -105,6 +106,7 @@ struct WorkspaceContentView: View {
                     workspace.bonsplitController.focusPane(paneId)
                 }
         }
+        .environment(\.bonsplitZoomScale, CGFloat(uiZoomScale))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             syncBonsplitNotificationBadges()

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -301,16 +301,18 @@ struct EmptyPanelView: View {
     let paneId: PaneID
     @AppStorage(KeyboardShortcutSettings.Action.newSurface.defaultsKey) private var newSurfaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openBrowser.defaultsKey) private var openBrowserShortcutData = Data()
+    @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
     private struct ShortcutHint: View {
         let text: String
+        @AppStorage(UIZoomMetrics.appStorageKey) private var uiZoomScale = UIZoomMetrics.defaultScale
 
         var body: some View {
             Text(text)
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .font(.system(size: UIZoomMetrics.workspaceTitleFontSize(uiZoomScale), weight: .semibold, design: .rounded))
                 .foregroundStyle(.white.opacity(0.9))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
+                .padding(.horizontal, UIZoomMetrics.workspaceTitleHPadding(uiZoomScale))
+                .padding(.vertical, UIZoomMetrics.workspaceTitleVPadding(uiZoomScale))
                 .background(.white.opacity(0.18), in: Capsule())
         }
     }
@@ -379,9 +381,9 @@ struct EmptyPanelView: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: UIZoomMetrics.emptyStateSpacing(uiZoomScale)) {
             Image(systemName: "terminal.fill")
-                .font(.system(size: 48))
+                .font(.system(size: UIZoomMetrics.emptyStateIconSize(uiZoomScale)))
                 .foregroundStyle(.tertiary)
 
             Text("Empty Panel")


### PR DESCRIPTION
## Summary
- Add VSCode-style UI zoom (`Cmd+Shift+=/-/0`) for all non-terminal UI elements
- New `UIZoomMetrics` enum with scale-aware static functions for font sizes, paddings, heights, icon sizes across all UI areas
- Scale range 0.5x–2.0x, persisted via `@AppStorage("uiZoomScale")`
- Fix sidebar drag resize breaking at max zoom (minimum > maximum width)
- Update Bonsplit submodule to include tab bar zoom scale support (bonsplit PR: https://github.com/manaflow-ai/bonsplit/pull/21)

## Testing
- `./scripts/reload.sh --tag ui-zoom`
- Verified zoom in/out/reset shortcuts work
- Verified terminal (Ghostty) font size is unaffected
- Verified scale persists across app restart
- Verified layout at extreme scales (0.5x, 2.0x)
- GitHub Actions CI

## Checklist
- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add UI zoom controls (Cmd+Shift+=, Cmd+Shift+-, Cmd+Shift+0) across all non-terminal UI with a 0.5x–2.0x scale persisted in `@AppStorage("uiZoomScale")`. Extends scaling to notifications, address bar text, suggestions popup, markdown, and empty/file-unavailable views, localizes the search placeholder, and keeps the terminal font size unchanged.

- **New Features**
  - Introduced `UIZoomMetrics` and applied scaling to titlebar, command palette, browser address bar and suggestions (incl. popup text/badges), search overlays (incl. counter), notifications, markdown panel (headings/code/blockquote sizes and margins), feedback dialog, workspace, and update UI.
  - Localized the Browser Search overlay placeholder (“Search”).
  - Updated `vendor/bonsplit` and passed `bonsplitZoomScale` to support tab bar zoom.

- **Bug Fixes**
  - Prevented sidebar drag resize from locking at max zoom by keeping the minimum sidebar width unscaled and clamping during drag.
  - Scaled the omnibar text field height with UI zoom to prevent clipping at higher scales.
  - Clamped the effective zoom scale loaded from storage and added DEBUG tracing for the zoom shortcut path.

<sup>Written for commit a7649b785e6fe6393c6d3266a5c397e8054f223f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI zoom scaling with keyboard shortcuts (zoom in / zoom out / reset).
  * App UI now scales consistently (titlebar, sidebars, panels, search, notifications, markdown, etc.).
  * Zoom preference persists across launches.

* **Localization**
  * Added/updated search localization entry.

* **Chores**
  * Updated vendored subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->