### PR TITLE
fix: route OAuth/SSO URLs to system browser instead of embedded WebView

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -287,6 +287,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     if let parsed = URL(string: trimmed),
        let scheme = parsed.scheme?.lowercased() {
         if scheme == "http" || scheme == "https" {
+            if browserIsOAuthFlowURL(parsed) {
+                #if DEBUG
+                dlog("link.resolve result=external(oauth) url=\(parsed)")
+                #endif
+                return .external(parsed)
+            }
             guard BrowserInsecureHTTPSettings.normalizeHost(parsed.host ?? "") != nil else {
                 #if DEBUG
                 dlog("link.resolve result=external(invalidHost) url=\(parsed)")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -311,6 +311,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     }
 
     if let webURL = resolveBrowserNavigableURL(trimmed) {
+        if browserIsOAuthFlowURL(webURL) {
+            #if DEBUG
+            dlog("link.resolve result=external(bareHost-oauth) url=\(webURL)")
+            #endif
+            return .external(webURL)
+        }
         guard BrowserInsecureHTTPSettings.normalizeHost(webURL.host ?? "") != nil else {
             #if DEBUG
             dlog("link.resolve result=external(bareHost-invalidHost) url=\(webURL)")

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -531,31 +531,39 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
 /// (Google, Microsoft, GitHub, Apple) block or degrade OAuth in embedded WebViews.
 /// Google explicitly disallows it: https://developers.google.com/identity/protocols/oauth2/policies#browsers
 func browserIsOAuthFlowURL(_ url: URL) -> Bool {
-    let path = url.path.lowercased()
+    // Only intercept web URLs — file:// and other schemes should not be affected.
+    guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+        return false
+    }
+
     let host = url.host?.lowercased() ?? ""
+    let pathSegments = Set(url.path.lowercased().split(separator: "/").map(String.init))
 
-    // Standard OAuth authorize/callback endpoints
-    if path.contains("/oauth") || path.contains("/oauth2") || path.contains("/o/oauth2") {
+    // Standard OAuth authorize/callback endpoints — match as a path segment,
+    // not a substring, so "/docs/oauth" or "/oauth-settings" won't trigger.
+    if pathSegments.contains("oauth") || pathSegments.contains("oauth2") {
         return true
     }
 
-    // Google sign-in
-    if host == "accounts.google.com" && (path.hasPrefix("/signin") || path.hasPrefix("/o/oauth2")) {
+    // Google sign-in (the redirect target after /oauth/authorize)
+    if host == "accounts.google.com" && (url.path.hasPrefix("/signin") || url.path.hasPrefix("/o/oauth2")) {
         return true
     }
 
-    // Microsoft identity platform
-    if host.hasSuffix("login.microsoftonline.com") || host == "login.live.com" {
+    // Microsoft identity platform — boundary-aware match to avoid
+    // "evillogin.microsoftonline.com" false positives.
+    if host == "login.microsoftonline.com" || host.hasSuffix(".login.microsoftonline.com")
+        || host == "login.live.com" {
         return true
     }
 
     // GitHub OAuth
-    if host == "github.com" && path.hasPrefix("/login/oauth") {
+    if host == "github.com" && url.path.lowercased().hasPrefix("/login/oauth") {
         return true
     }
 
     // Apple ID
-    if host == "appleid.apple.com" && path.hasPrefix("/auth") {
+    if host == "appleid.apple.com" && url.path.lowercased().hasPrefix("/auth") {
         return true
     }
 
@@ -3998,6 +4006,9 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
            navigationAction.targetFrame?.isMainFrame != false,
            browserIsOAuthFlowURL(url) {
             let opened = NSWorkspace.shared.open(url)
+            if !opened {
+                NSLog("BrowserPanel OAuth external navigation failed to open URL: %@", url.absoluteString)
+            }
             #if DEBUG
             dlog("browser.navigation.oauth source=navDelegate opened=\(opened ? 1 : 0) url=\(url.absoluteString)")
             #endif

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -527,6 +527,41 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
+/// OAuth and SSO flows must open in the system browser because identity providers
+/// (Google, Microsoft, GitHub, Apple) block or degrade OAuth in embedded WebViews.
+/// Google explicitly disallows it: https://developers.google.com/identity/protocols/oauth2/policies#browsers
+func browserIsOAuthFlowURL(_ url: URL) -> Bool {
+    let path = url.path.lowercased()
+    let host = url.host?.lowercased() ?? ""
+
+    // Standard OAuth authorize/callback endpoints
+    if path.contains("/oauth") || path.contains("/oauth2") || path.contains("/o/oauth2") {
+        return true
+    }
+
+    // Google sign-in
+    if host == "accounts.google.com" && (path.hasPrefix("/signin") || path.hasPrefix("/o/oauth2")) {
+        return true
+    }
+
+    // Microsoft identity platform
+    if host.hasSuffix("login.microsoftonline.com") || host == "login.live.com" {
+        return true
+    }
+
+    // GitHub OAuth
+    if host == "github.com" && path.hasPrefix("/login/oauth") {
+        return true
+    }
+
+    // Apple ID
+    if host == "appleid.apple.com" && path.hasPrefix("/auth") {
+        return true
+    }
+
+    return false
+}
+
 enum BrowserUserAgentSettings {
     // Force a Safari UA. Some WebKit builds return a minimal UA without Version/Safari tokens,
     // and some installs may have legacy Chrome UA overrides. Both can cause Google to serve
@@ -3953,6 +3988,19 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
             )
 #endif
             handleBlockedInsecureHTTPNavigation?(navigationAction.request, intent)
+            decisionHandler(.cancel)
+            return
+        }
+
+        // OAuth/SSO flows must open in the system browser. Identity providers like
+        // Google block OAuth in embedded WebViews, causing the flow to hang.
+        if let url = navigationAction.request.url,
+           navigationAction.targetFrame?.isMainFrame != false,
+           browserIsOAuthFlowURL(url) {
+            let opened = NSWorkspace.shared.open(url)
+            #if DEBUG
+            dlog("browser.navigation.oauth source=navDelegate opened=\(opened ? 1 : 0) url=\(url.absoluteString)")
+            #endif
             decisionHandler(.cancel)
             return
         }


### PR DESCRIPTION
## Summary

- OAuth/SSO URLs (e.g., `claude /login`, GitHub OAuth, Google sign-in) now open in the **system browser** instead of cmux's embedded WebView
- Identity providers like Google [explicitly block OAuth in embedded WebViews](https://developers.google.com/identity/protocols/oauth2/policies#browsers), causing the login flow to hang at "Einen Moment bitte..." / "One moment please..."
- Two-level interception: terminal URL resolution + WKWebView navigation delegate catches redirects

## Problem

When a terminal process (e.g., Claude Code `/login`) calls `open https://claude.ai/oauth/authorize?...`, cmux routes it to the embedded browser. The OAuth flow redirects to `accounts.google.com`, which detects the embedded WebView and blocks the consent flow — the user sees a perpetual loading spinner and can never complete login.

## Fix

**`resolveTerminalOpenURLTarget`** — Detect OAuth URLs before routing to `.embeddedBrowser`:
- `/oauth`, `/oauth2`, `/o/oauth2` path patterns
- `accounts.google.com/signin/*`
- `login.microsoftonline.com`, `login.live.com`
- `github.com/login/oauth`
- `appleid.apple.com/auth`

**`decidePolicyFor navigationAction`** — Catch OAuth redirects from within the embedded browser (e.g., a website's "Sign in with Google" button triggers a redirect to Google's consent screen).

## Test plan

- [ ] Run `claude /login` in cmux terminal — should open system browser, not embedded
- [ ] Click a "Sign in with Google" link on a website in the embedded browser — should bounce to system browser
- [ ] Non-OAuth URLs still open in the embedded browser as before
- [ ] OAuth callback URLs (containing `/oauth`) correctly route to system browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all OAuth/SSO URLs to the system browser instead of the embedded WebView to prevent blocked consent screens and fix hanging logins (Google, Microsoft, GitHub, Apple). Applies to terminal-initiated flows like `claude /login` and in-app redirects.

- **Bug Fixes**
  - Detect and open OAuth/SSO URLs externally during terminal URL resolution and from `WKWebView` main-frame navigations; non-OAuth links stay in the embedded browser.
  - Safer detection: path-segment match for `/oauth` and `/oauth2`, http/https scheme guard, boundary-aware Microsoft hosts, handle bare-host OAuth URLs, and log failures when opening externally. Patterns covered include `accounts.google.com/signin`, `login.microsoftonline.com`, `login.live.com`, `github.com/login/oauth`, `appleid.apple.com/auth`.

<sup>Written for commit 91b6999294d375ecc9d96142cbc553b879eb3f58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects OAuth/SSO authentication URLs and ensures they open in the system browser instead of embedded windows.
  * Cancels embedded navigation for these flows and logs the action for diagnostics.
  * Improves compatibility with common identity providers (Google, Microsoft, GitHub, Apple) while leaving non-auth links unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->