### PR TITLE
Add searchable session tags to cmd-p workspace switcher

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -400,6 +400,86 @@ private final class ClaudeHookSessionStore {
     }
 }
 
+private enum ClaudeHookTagExtractor {
+    private static let sessionIdPattern = try! NSRegularExpression(pattern: "^[a-zA-Z0-9_-]{1,128}$")
+
+    static func isValidSessionId(_ sessionId: String) -> Bool {
+        let range = NSRange(sessionId.startIndex..., in: sessionId)
+        return sessionIdPattern.firstMatch(in: sessionId, range: range) != nil
+    }
+
+    static func isSessionTagsEnabled() -> Bool {
+        for bundleId in ["com.cmuxterm.app", "com.cmuxterm.app.debug"] {
+            if let defaults = UserDefaults(suiteName: bundleId),
+               defaults.object(forKey: "cmdPSessionTags") != nil {
+                return defaults.bool(forKey: "cmdPSessionTags")
+            }
+        }
+        return false
+    }
+
+    private static let stopwords: Set<String> = [
+        "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+        "should", "may", "might", "must", "can", "could", "to", "of", "in",
+        "for", "on", "with", "at", "by", "from", "as", "into", "through",
+        "during", "before", "after", "above", "below", "between", "out",
+        "off", "over", "under", "again", "further", "then", "once", "here",
+        "there", "when", "where", "why", "how", "all", "each", "every",
+        "both", "few", "more", "most", "other", "some", "such", "no", "nor",
+        "not", "only", "own", "same", "so", "than", "too", "very", "just",
+        "about", "up", "down", "and", "but", "or", "if", "while", "that",
+        "this", "it", "its", "i", "me", "my", "we", "our", "you", "your",
+        "he", "she", "they", "them", "his", "her", "their", "what", "which",
+        "who", "whom", "done", "task", "complete", "completed", "finished"
+    ]
+
+    private static let sensitivePatterns: [NSRegularExpression] = {
+        let patterns = [
+            "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+            "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+            "^(sk-|pk-|ghp_|gho_|Bearer |token )",
+            "^(/|~/).+/",
+            "^[A-Z_]{2,}=",
+            "^[0-9]{10,}$"
+        ]
+        return patterns.compactMap { try? NSRegularExpression(pattern: $0, options: .caseInsensitive) }
+    }()
+
+    private static let delimiters = CharacterSet(charactersIn: "/\\.:_- ,;()[]{}\"'`")
+
+    static func extractTags(subtitle: String, body: String) -> [String] {
+        let combined = "\(body) \(subtitle)"
+        let tokens = combined.components(separatedBy: delimiters)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { token in
+                guard token.count >= 3 else { return false }
+                guard !stopwords.contains(token.lowercased()) else { return false }
+                guard !isSensitive(token) else { return false }
+                return true
+            }
+        var seen: Set<String> = []
+        var result: [String] = []
+        for token in tokens {
+            let key = token.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            result.append(token)
+            if result.count >= 20 { break }
+        }
+        return result
+    }
+
+    private static func isSensitive(_ token: String) -> Bool {
+        let range = NSRange(token.startIndex..., in: token)
+        for pattern in sensitivePatterns {
+            if pattern.firstMatch(in: token, range: range) != nil {
+                return true
+            }
+        }
+        return false
+    }
+}
+
 enum CLIIDFormat: String {
     case refs
     case uuids
@@ -1361,6 +1441,49 @@ struct CMUXCLI {
             let wsId = try resolveWorkspaceId(workspaceArg, client: client)
             let params: [String: Any] = ["title": title, "workspace_id": wsId]
             let payload = try client.sendV2(method: "workspace.rename", params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
+
+        case "set-workspace-tags":
+            let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
+            let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let (srcArg, rem1) = parseOption(rem0, name: "--source")
+            let isClear = rem1.contains("--clear")
+            let rem2 = rem1.filter { $0 != "--clear" }
+            if let unknownFlag = rem2.first(where: { $0.hasPrefix("--") && $0 != "--" }) {
+                throw CLIError(message: "set-workspace-tags: unknown flag '\(unknownFlag)'")
+            }
+            let wsId = try resolveWorkspaceId(workspaceArg, client: client)
+            let source = srcArg ?? "manual"
+            if isClear {
+                let payload = try client.sendV2(method: "workspace.clear_tags", params: [
+                    "workspace_id": wsId,
+                    "source": source
+                ])
+                printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
+            } else {
+                let tagArgs = rem2.dropFirst(rem2.first == "--" ? 1 : 0)
+                let tags = Array(tagArgs).filter { !$0.isEmpty }
+                guard !tags.isEmpty else {
+                    throw CLIError(message: "set-workspace-tags requires at least one tag or --clear")
+                }
+                let payload = try client.sendV2(method: "workspace.set_tags", params: [
+                    "workspace_id": wsId,
+                    "source": source,
+                    "tags": tags
+                ])
+                printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
+            }
+
+        case "clear-workspace-tags":
+            let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
+            let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let (srcArg, _) = parseOption(rem0, name: "--source")
+            let wsId = try resolveWorkspaceId(workspaceArg, client: client)
+            var params: [String: Any] = ["workspace_id": wsId]
+            if let source = srcArg {
+                params["source"] = source
+            }
+            let payload = try client.sendV2(method: "workspace.clear_tags", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
 
         case "current-workspace":
@@ -4531,6 +4654,36 @@ struct CMUXCLI {
               cmux rename-workspace "backend logs"
               cmux rename-window --workspace workspace:2 "agent run"
             """
+        case "set-workspace-tags":
+            return """
+            Usage: cmux set-workspace-tags [--workspace <id|ref|index>] [--source <key>] (--clear | <tag> [<tag>...])
+
+            Set or clear search tags for a workspace. Tags appear in cmd-p search results.
+
+            Flags:
+              --workspace <id|ref|index>   Workspace to tag (default: current/$CMUX_WORKSPACE_ID)
+              --source <key>               Tag source namespace (default: "manual")
+              --clear                      Remove tags for the given source
+
+            Example:
+              cmux set-workspace-tags "open claw" "refactor"
+              cmux set-workspace-tags --workspace workspace:2 "auth" "payments"
+              cmux set-workspace-tags --clear
+            """
+        case "clear-workspace-tags":
+            return """
+            Usage: cmux clear-workspace-tags [--workspace <id|ref|index>] [--source <key>]
+
+            Clear all tags (or tags for a specific source) from a workspace.
+
+            Flags:
+              --workspace <id|ref|index>   Workspace to clear (default: current/$CMUX_WORKSPACE_ID)
+              --source <key>               Only clear tags from this source (default: clear all)
+
+            Example:
+              cmux clear-workspace-tags
+              cmux clear-workspace-tags --source claude:abc-123
+            """
         case "current-workspace":
             return """
             Usage: cmux current-workspace
@@ -6228,6 +6381,14 @@ struct CMUXCLI {
             let workspaceId = consumedSession?.workspaceId ?? fallbackWorkspaceId
             try clearClaudeStatus(client: client, workspaceId: workspaceId)
 
+            if let sessionId = parsedInput.sessionId ?? consumedSession?.sessionId,
+               ClaudeHookTagExtractor.isValidSessionId(sessionId) {
+                _ = try? client.sendV2(method: "workspace.clear_tags", params: [
+                    "workspace_id": workspaceId,
+                    "source": "claude:\(sessionId)"
+                ])
+            }
+
             if let completion = summarizeClaudeHookStop(
                 parsedInput: parsedInput,
                 sessionRecord: consumedSession
@@ -6298,6 +6459,18 @@ struct CMUXCLI {
                     lastSubtitle: summary.subtitle,
                     lastBody: summary.body
                 )
+
+                if ClaudeHookTagExtractor.isValidSessionId(sessionId),
+                   ClaudeHookTagExtractor.isSessionTagsEnabled() {
+                    let tags = ClaudeHookTagExtractor.extractTags(subtitle: summary.subtitle, body: summary.body)
+                    if !tags.isEmpty {
+                        _ = try? client.sendV2(method: "workspace.set_tags", params: [
+                            "workspace_id": workspaceId,
+                            "source": "claude:\(sessionId)",
+                            "tags": tags
+                        ])
+                    }
+                }
             }
 
             let response = try sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
@@ -6950,6 +7123,8 @@ struct CMUXCLI {
           select-workspace --workspace <id|ref>
           rename-workspace [--workspace <id|ref>] <title>
           rename-window [--workspace <id|ref>] <title>
+          set-workspace-tags [--workspace <id|ref|index>] [--source <key>] (--clear | <tag>...)
+          clear-workspace-tags [--workspace <id|ref|index>] [--source <key>]
           current-workspace
           read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
           send [--workspace <id|ref>] [--surface <id|ref>] <text>

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -446,11 +446,31 @@ private enum ClaudeHookTagExtractor {
         return patterns.compactMap { try? NSRegularExpression(pattern: $0, options: .caseInsensitive) }
     }()
 
+    /// Unanchored patterns for pre-redacting sensitive spans in full text before tokenization.
+    private static let sensitiveSpanPatterns: [NSRegularExpression] = {
+        let patterns = [
+            "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
+            "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+            "(sk-|pk-|ghp_|gho_|Bearer |token )[a-zA-Z0-9_-]+",
+            "(/|~/)[^ ,;()\\[\\]{}\"'`]+",
+            "[A-Z_]{2,}=[^ ,;()\\[\\]{}\"'`]*",
+            "[0-9]{10,}"
+        ]
+        return patterns.compactMap { try? NSRegularExpression(pattern: $0, options: .caseInsensitive) }
+    }()
+
     private static let delimiters = CharacterSet(charactersIn: "/\\.:_- ,;()[]{}\"'`")
 
     static func extractTags(subtitle: String, body: String) -> [String] {
         let combined = "\(body) \(subtitle)"
-        let tokens = combined.components(separatedBy: delimiters)
+        // Pre-redact sensitive spans on the full string before tokenization
+        // so that UUIDs, emails, paths, etc. split across delimiters are caught.
+        var sanitized = combined
+        for pattern in sensitiveSpanPatterns {
+            let range = NSRange(sanitized.startIndex..., in: sanitized)
+            sanitized = pattern.stringByReplacingMatches(in: sanitized, range: range, withTemplate: "")
+        }
+        let tokens = sanitized.components(separatedBy: delimiters)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { token in
                 guard token.count >= 3 else { return false }
@@ -1454,6 +1474,10 @@ struct CMUXCLI {
             }
             let wsId = try resolveWorkspaceId(workspaceArg, client: client)
             let source = srcArg ?? "manual"
+            let positionalTags = rem2.filter { !$0.hasPrefix("--") && !$0.isEmpty }
+            if isClear && !positionalTags.isEmpty {
+                throw CLIError(message: "set-workspace-tags: --clear cannot be combined with positional tag arguments")
+            }
             if isClear {
                 let payload = try client.sendV2(method: "workspace.clear_tags", params: [
                     "workspace_id": wsId,
@@ -1477,7 +1501,14 @@ struct CMUXCLI {
         case "clear-workspace-tags":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-            let (srcArg, _) = parseOption(rem0, name: "--source")
+            let (srcArg, rem1) = parseOption(rem0, name: "--source")
+            let strayArgs = rem1.filter { !$0.hasPrefix("--") && !$0.isEmpty }
+            if !strayArgs.isEmpty {
+                throw CLIError(message: "clear-workspace-tags: unexpected arguments: \(strayArgs.joined(separator: ", "))")
+            }
+            if let unknownFlag = rem1.first(where: { $0.hasPrefix("--") && $0 != "--" }) {
+                throw CLIError(message: "clear-workspace-tags: unknown flag '\(unknownFlag)'")
+            }
             let wsId = try resolveWorkspaceId(workspaceArg, client: client)
             var params: [String: Any] = ["workspace_id": wsId]
             if let source = srcArg {
@@ -6382,7 +6413,8 @@ struct CMUXCLI {
             try clearClaudeStatus(client: client, workspaceId: workspaceId)
 
             if let sessionId = parsedInput.sessionId ?? consumedSession?.sessionId,
-               ClaudeHookTagExtractor.isValidSessionId(sessionId) {
+               ClaudeHookTagExtractor.isValidSessionId(sessionId),
+               ClaudeHookTagExtractor.isSessionTagsEnabled() {
                 _ = try? client.sendV2(method: "workspace.clear_tags", params: [
                     "workspace_id": workspaceId,
                     "source": "claude:\(sessionId)"
@@ -6468,6 +6500,12 @@ struct CMUXCLI {
                             "workspace_id": workspaceId,
                             "source": "claude:\(sessionId)",
                             "tags": tags
+                        ])
+                    } else {
+                        // Clear stale tags when extraction yields nothing
+                        _ = try? client.sendV2(method: "workspace.clear_tags", params: [
+                            "workspace_id": workspaceId,
+                            "source": "claude:\(sessionId)"
                         ])
                     }
                 }
@@ -6684,128 +6722,31 @@ struct CMUXCLI {
     }
 
     private func summarizeClaudeHookNotification(rawInput: String) -> (subtitle: String, body: String) {
-        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return ("Waiting", "Claude is waiting for your input")
-        }
-
-        guard let data = trimmed.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data, options: []),
-              let object = json as? [String: Any] else {
-            let fallback = truncate(normalizedSingleLine(trimmed), maxLength: 180)
-            return classifyClaudeNotification(signal: fallback, message: fallback)
-        }
-
-        let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
-        let signalParts = [
-            firstString(in: object, keys: ["event", "event_name", "hook_event_name", "type", "kind"]),
-            firstString(in: object, keys: ["notification_type", "matcher", "reason"]),
-            firstString(in: nested, keys: ["type", "kind", "reason"])
-        ]
-        let messageCandidates = [
-            firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
-            firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
-        ]
-        let session = firstString(in: object, keys: ["session_id", "sessionId"])
-        let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
-        let dedupedMessage = dedupeBranchContextLines(message)
-        let normalizedMessage = normalizedSingleLine(dedupedMessage)
-        let signal = signalParts.compactMap { $0 }.joined(separator: " ")
-        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
-
-        if let session, !session.isEmpty {
-            let shortSession = String(session.prefix(8))
-            if !classified.body.contains(shortSession) {
-                classified.body = "\(classified.body) [\(shortSession)]"
-            }
-        }
-
-        classified.body = truncate(classified.body, maxLength: 180)
-        return classified
+        ClaudeHookHelpers.summarizeNotification(rawInput: rawInput)
     }
 
     private func classifyClaudeNotification(signal: String, message: String) -> (subtitle: String, body: String) {
-        let lower = "\(signal) \(message)".lowercased()
-        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") {
-            let body = message.isEmpty ? "Approval needed" : message
-            return ("Permission", body)
-        }
-        if lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
-            let body = message.isEmpty ? "Claude reported an error" : message
-            return ("Error", body)
-        }
-        if lower.contains("idle") || lower.contains("wait") || lower.contains("input") || lower.contains("prompt") {
-            let body = message.isEmpty ? "Claude is waiting for your input" : message
-            return ("Waiting", body)
-        }
-        let body = message.isEmpty ? "Claude needs your input" : message
-        return ("Attention", body)
+        ClaudeHookHelpers.classifyNotification(signal: signal, message: message)
     }
 
     private func dedupeBranchContextLines(_ value: String) -> String {
-        let lines = value.components(separatedBy: .newlines)
-        guard lines.count > 1 else { return value }
-
-        var lastIndexByPath: [String: Int] = [:]
-        for (index, line) in lines.enumerated() {
-            guard let path = branchContextPath(from: line) else { continue }
-            lastIndexByPath[path] = index
-        }
-        guard !lastIndexByPath.isEmpty else { return value }
-
-        let deduped = lines.enumerated().compactMap { index, line -> String? in
-            guard let path = branchContextPath(from: line) else { return line }
-            return lastIndexByPath[path] == index ? line : nil
-        }
-        return deduped.joined(separator: "\n")
-    }
-
-    private func branchContextPath(from line: String) -> String? {
-        let parts = line.split(separator: "•", maxSplits: 1, omittingEmptySubsequences: false)
-        guard parts.count == 2 else { return nil }
-
-        let branch = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-        let path = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !branch.isEmpty, !path.isEmpty else { return nil }
-
-        let looksLikePath = path.hasPrefix("/") || path.hasPrefix("~") || path.hasPrefix(".") || path.contains("/")
-        guard looksLikePath else { return nil }
-
-        let trimmedQuotes = path.trimmingCharacters(in: CharacterSet(charactersIn: "`'\""))
-        let expanded = NSString(string: trimmedQuotes).expandingTildeInPath
-        let standardized = NSString(string: expanded).standardizingPath
-        let normalized = standardized.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalized.isEmpty ? nil : normalized
+        ClaudeHookHelpers.dedupeBranchContextLines(value)
     }
 
     private func firstString(in object: [String: Any], keys: [String]) -> String? {
-        for key in keys {
-            guard let value = object[key] else { continue }
-            if let string = value as? String {
-                let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    return trimmed
-                }
-            }
-        }
-        return nil
+        ClaudeHookHelpers.firstString(in: object, keys: keys)
     }
 
     private func normalizedSingleLine(_ value: String) -> String {
-        let collapsed = value.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-        return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
+        ClaudeHookHelpers.normalizedSingleLine(value)
     }
 
     private func truncate(_ value: String, maxLength: Int) -> String {
-        guard value.count > maxLength else { return value }
-        let index = value.index(value.startIndex, offsetBy: max(0, maxLength - 1))
-        return String(value[..<index]) + "…"
+        ClaudeHookHelpers.truncate(value, maxLength: maxLength)
     }
 
     private func sanitizeNotificationField(_ value: String) -> String {
-        let normalized = normalizedSingleLine(value)
-            .replacingOccurrences(of: "|", with: "¦")
-        return truncate(normalized, maxLength: 180)
+        ClaudeHookHelpers.sanitizeNotificationField(value)
     }
 
     private func versionSummary() -> String {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1446,8 +1446,31 @@ struct ContentView: View {
         let subtitle: String
         let shortcutHint: String?
         let keywords: [String]
+        let tags: [String]
         let dismissOnRun: Bool
         let action: () -> Void
+
+        init(
+            id: String,
+            rank: Int,
+            title: String,
+            subtitle: String,
+            shortcutHint: String?,
+            keywords: [String],
+            tags: [String] = [],
+            dismissOnRun: Bool,
+            action: @escaping () -> Void
+        ) {
+            self.id = id
+            self.rank = rank
+            self.title = title
+            self.subtitle = subtitle
+            self.shortcutHint = shortcutHint
+            self.keywords = keywords
+            self.tags = tags
+            self.dismissOnRun = dismissOnRun
+            self.action = action
+        }
 
         var searchableTexts: [String] {
             [title, subtitle] + keywords
@@ -2952,10 +2975,13 @@ struct ContentView: View {
         let selectedIndex = commandPaletteSelectedIndex(resultCount: visibleResults.count)
         let commandPaletteListMaxHeight: CGFloat = 450
         let commandPaletteRowHeight: CGFloat = 24
+        let commandPaletteTagRowHeight: CGFloat = 40
         let commandPaletteEmptyStateHeight: CGFloat = 44
-        let commandPaletteListContentHeight = visibleResults.isEmpty
+        let commandPaletteListContentHeight: CGFloat = visibleResults.isEmpty
             ? commandPaletteEmptyStateHeight
-            : CGFloat(visibleResults.count) * commandPaletteRowHeight
+            : visibleResults.reduce(CGFloat(0)) { total, result in
+                total + (result.command.tags.isEmpty ? commandPaletteRowHeight : commandPaletteTagRowHeight)
+            }
         let commandPaletteListHeight = min(commandPaletteListMaxHeight, commandPaletteListContentHeight)
         return VStack(spacing: 0) {
             HStack(spacing: 8) {
@@ -3020,30 +3046,40 @@ struct ContentView: View {
                             Button {
                                 runCommandPaletteResult(commandID: result.id)
                             } label: {
-                                HStack(spacing: 8) {
-                                    commandPaletteHighlightedTitleText(
-                                        result.command.title,
-                                        matchedIndices: result.titleMatchIndices
-                                    )
-                                        .font(.system(size: 13, weight: .regular))
-                                        .lineLimit(1)
-                                    Spacer()
+                                VStack(alignment: .leading, spacing: 0) {
+                                    HStack(spacing: 8) {
+                                        commandPaletteHighlightedTitleText(
+                                            result.command.title,
+                                            matchedIndices: result.titleMatchIndices
+                                        )
+                                            .font(.system(size: 13, weight: .regular))
+                                            .lineLimit(1)
+                                        Spacer()
 
-                                    if let trailingLabel = commandPaletteTrailingLabel(for: result.command) {
-                                        switch trailingLabel.style {
-                                        case .shortcut:
-                                            Text(trailingLabel.text)
-                                                .font(.system(size: 11, weight: .medium))
-                                                .foregroundStyle(.secondary)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
-                                        case .kind:
-                                            Text(trailingLabel.text)
-                                                .font(.system(size: 11, weight: .regular))
-                                                .foregroundStyle(.secondary)
-                                                .lineLimit(1)
+                                        if let trailingLabel = commandPaletteTrailingLabel(for: result.command) {
+                                            switch trailingLabel.style {
+                                            case .shortcut:
+                                                Text(trailingLabel.text)
+                                                    .font(.system(size: 11, weight: .medium))
+                                                    .foregroundStyle(.secondary)
+                                                    .padding(.horizontal, 4)
+                                                    .padding(.vertical, 1)
+                                                    .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+                                            case .kind:
+                                                Text(trailingLabel.text)
+                                                    .font(.system(size: 11, weight: .regular))
+                                                    .foregroundStyle(.secondary)
+                                                    .lineLimit(1)
+                                            }
                                         }
+                                    }
+
+                                    if !result.command.tags.isEmpty {
+                                        Text(result.command.tags.joined(separator: " · "))
+                                            .font(.system(size: 10, weight: .regular))
+                                            .foregroundStyle(.tertiary)
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
                                     }
                                 }
                                 .padding(.horizontal, 9)
@@ -3718,6 +3754,7 @@ struct ContentView: View {
                         subtitle: commandPaletteSwitcherSubtitle(base: String(localized: "commandPalette.switcher.workspaceLabel", defaultValue: "Workspace"), windowLabel: context.windowLabel),
                         shortcutHint: nil,
                         keywords: workspaceKeywords,
+                        tags: workspace.searchTags,
                         dismissOnRun: true,
                         action: {
                             focusCommandPaletteSwitcherTarget(
@@ -3829,10 +3866,12 @@ struct ContentView: View {
         let directories = [workspace.currentDirectory]
         let branches = [workspace.gitBranch?.branch].compactMap { $0 }
         let ports = workspace.listeningPorts
+        let tags = workspace.searchTags
         return CommandPaletteSwitcherSearchMetadata(
             directories: directories,
             branches: branches,
-            ports: ports
+            ports: ports,
+            tags: tags
         )
     }
 
@@ -5069,6 +5108,10 @@ struct ContentView: View {
         for port in metadata.ports {
             hasher.combine(port)
         }
+        hasher.combine(metadata.tags.count)
+        for tag in metadata.tags {
+            hasher.combine(tag)
+        }
     }
 
     static func commandPaletteScrollPositionAnchor(
@@ -5958,15 +6001,18 @@ struct CommandPaletteSwitcherSearchMetadata: Equatable, Sendable {
     let directories: [String]
     let branches: [String]
     let ports: [Int]
+    let tags: [String]
 
     init(
         directories: [String] = [],
         branches: [String] = [],
-        ports: [Int] = []
+        ports: [Int] = [],
+        tags: [String] = []
     ) {
         self.directories = directories
         self.branches = branches
         self.ports = ports
+        self.tags = tags
     }
 }
 
@@ -5994,6 +6040,7 @@ enum CommandPaletteSwitcherSearchIndexer {
         let directoryTokens = metadata.directories.flatMap { directoryTokensForSearch($0, detail: detail) }
         let branchTokens = metadata.branches.flatMap { branchTokensForSearch($0, detail: detail) }
         let portTokens = metadata.ports.flatMap(portTokensForSearch)
+        let tagTokens = metadata.tags.flatMap(tagTokensForSearch)
 
         var contextKeywords: [String] = []
         if !directoryTokens.isEmpty {
@@ -6005,8 +6052,11 @@ enum CommandPaletteSwitcherSearchIndexer {
         if !portTokens.isEmpty {
             contextKeywords.append(contentsOf: ["port", "ports"])
         }
+        if !tagTokens.isEmpty {
+            contextKeywords.append(contentsOf: ["tag", "topic", "claude"])
+        }
 
-        return contextKeywords + directoryTokens + branchTokens + portTokens
+        return contextKeywords + directoryTokens + branchTokens + portTokens + tagTokens
     }
 
     private static func directoryTokensForSearch(
@@ -6050,6 +6100,13 @@ enum CommandPaletteSwitcherSearchIndexer {
         guard (1...65535).contains(port) else { return [] }
         let portText = String(port)
         return [portText, ":\(portText)"]
+    }
+
+    private static func tagTokensForSearch(_ rawTag: String) -> [String] {
+        let trimmed = rawTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let components = trimmed.components(separatedBy: metadataDelimiters).filter { !$0.isEmpty }
+        return uniqueNormalizedPreservingOrder([trimmed] + components)
     }
 
     private static func uniqueNormalizedPreservingOrder(_ values: [String]) -> [String] {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1473,7 +1473,7 @@ struct ContentView: View {
         }
 
         var searchableTexts: [String] {
-            [title, subtitle] + keywords
+            [title, subtitle] + keywords + tags
         }
     }
 
@@ -6053,7 +6053,7 @@ enum CommandPaletteSwitcherSearchIndexer {
             contextKeywords.append(contentsOf: ["port", "ports"])
         }
         if !tagTokens.isEmpty {
-            contextKeywords.append(contentsOf: ["tag", "topic", "claude"])
+            contextKeywords.append(contentsOf: ["tag", "topic"])
         }
 
         return contextKeywords + directoryTokens + branchTokens + portTokens + tagTokens

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -330,6 +330,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var processTitle: String
     var customTitle: String?
     var customColor: String?
+    var tagsBySource: [String: [String]]?
     var isPinned: Bool
     var currentDirectory: String
     var focusedPanelId: UUID?

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1728,6 +1728,10 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceReorder(params: params))
         case "workspace.rename":
             return v2Result(id: id, self.v2WorkspaceRename(params: params))
+        case "workspace.set_tags":
+            return v2Result(id: id, self.v2WorkspaceSetTags(params: params))
+        case "workspace.clear_tags":
+            return v2Result(id: id, self.v2WorkspaceClearTags(params: params))
         case "workspace.action":
             return v2Result(id: id, self.v2WorkspaceAction(params: params))
         case "workspace.next":
@@ -2092,6 +2096,8 @@ class TerminalController {
             "workspace.move_to_window",
             "workspace.reorder",
             "workspace.rename",
+            "workspace.set_tags",
+            "workspace.clear_tags",
             "workspace.action",
             "workspace.next",
             "workspace.previous",
@@ -3119,6 +3125,83 @@ class TerminalController {
             "title": title
         ])
     }
+    private func v2WorkspaceSetTags(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let workspaceId = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        guard let source = v2String(params, "source"), !source.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing or empty source", data: nil)
+        }
+        guard let tagsRaw = params["tags"] as? [Any] else {
+            return .err(code: "invalid_params", message: "Missing or invalid tags array", data: nil)
+        }
+        let tags = tagsRaw.compactMap { $0 as? String }
+
+        var applied = false
+        v2MainSync {
+            guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+            workspace.setTags(tags, source: source)
+            applied = true
+        }
+
+        guard applied else {
+            return .err(code: "not_found", message: "Workspace not found", data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId)
+            ])
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "workspace_id": workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "source": source,
+            "tags": tags
+        ])
+    }
+
+    private func v2WorkspaceClearTags(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let workspaceId = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        let source = v2String(params, "source")
+
+        var applied = false
+        v2MainSync {
+            guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+            if let source {
+                workspace.clearTags(source: source)
+            } else {
+                workspace.clearAllTags()
+            }
+            applied = true
+        }
+
+        guard applied else {
+            return .err(code: "not_found", message: "Workspace not found", data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId)
+            ])
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "workspace_id": workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "source": v2OrNull(source)
+        ])
+    }
+
     private func v2WorkspaceNext(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3138,12 +3138,16 @@ class TerminalController {
         guard let tagsRaw = params["tags"] as? [Any] else {
             return .err(code: "invalid_params", message: "Missing or invalid tags array", data: nil)
         }
-        let tags = tagsRaw.compactMap { $0 as? String }
+        guard let tags = tagsRaw as? [String] else {
+            return .err(code: "invalid_params", message: "All elements in tags array must be strings", data: nil)
+        }
 
         var applied = false
+        var storedTags: [String] = []
         v2MainSync {
             guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
             workspace.setTags(tags, source: source)
+            storedTags = workspace.tagsBySource[source] ?? []
             applied = true
         }
 
@@ -3161,7 +3165,7 @@ class TerminalController {
             "window_id": v2OrNull(windowId?.uuidString),
             "window_ref": v2Ref(kind: .window, uuid: windowId),
             "source": source,
-            "tags": tags
+            "tags": storedTags
         ])
     }
 
@@ -3172,7 +3176,12 @@ class TerminalController {
         guard let workspaceId = v2UUID(params, "workspace_id") else {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
         }
+        let hasSourceKey = params.keys.contains("source")
         let source = v2String(params, "source")
+
+        if hasSourceKey && source == nil {
+            return .err(code: "invalid_params", message: "source must be a non-empty string when provided", data: nil)
+        }
 
         var applied = false
         v2MainSync {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -154,6 +154,7 @@ extension Workspace {
             processTitle: processTitle,
             customTitle: customTitle,
             customColor: customColor,
+            tagsBySource: tagsBySource.isEmpty ? nil : tagsBySource,
             isPinned: isPinned,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -193,6 +194,9 @@ extension Workspace {
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
+        if let restoredTags = snapshot.tagsBySource {
+            tagsBySource = restoredTags
+        }
         isPinned = snapshot.isPinned
 
         statusEntries = Dictionary(
@@ -917,6 +921,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customTitle: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    @Published var tagsBySource: [String: [String]] = [:]
     @Published var currentDirectory: String
 
     /// Ordinal for CMUX_PORT range assignment (monotonically increasing per app session)
@@ -1575,6 +1580,42 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customColor = nil
         }
+    }
+
+    // MARK: - Search Tags
+
+    private static let maxTagSources = 10
+    private static let maxTagsPerSource = 20
+    private static let maxTagLength = 100
+
+    var searchTags: [String] {
+        tagsBySource.values.flatMap { $0 }
+    }
+
+    func setTags(_ tags: [String], source: String) {
+        let sanitized = tags
+            .map { String($0.trimmingCharacters(in: .whitespacesAndNewlines).prefix(Self.maxTagLength)) }
+            .filter { !$0.isEmpty }
+            .prefix(Self.maxTagsPerSource)
+        var updated = tagsBySource
+        updated[source] = Array(sanitized)
+        if updated.count > Self.maxTagSources {
+            let sortedKeys = updated.keys.sorted()
+            for key in sortedKeys {
+                if key != source, updated.count > Self.maxTagSources {
+                    updated.removeValue(forKey: key)
+                }
+            }
+        }
+        tagsBySource = updated
+    }
+
+    func clearTags(source: String) {
+        tagsBySource.removeValue(forKey: source)
+    }
+
+    func clearAllTags() {
+        tagsBySource.removeAll()
     }
 
     func setCustomTitle(_ title: String?) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -195,7 +195,10 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
         if let restoredTags = snapshot.tagsBySource {
-            tagsBySource = restoredTags
+            tagsBySource = [:]
+            for (source, tags) in restoredTags {
+                setTags(tags, source: source)
+            }
         }
         isPinned = snapshot.isPinned
 
@@ -1587,22 +1590,44 @@ final class Workspace: Identifiable, ObservableObject {
     private static let maxTagSources = 10
     private static let maxTagsPerSource = 20
     private static let maxTagLength = 100
+    private static let maxSourceLength = 200
 
     var searchTags: [String] {
-        tagsBySource.values.flatMap { $0 }
+        var seen = Set<String>()
+        var result = [String]()
+        for key in tagsBySource.keys.sorted() {
+            for tag in tagsBySource[key] ?? [] {
+                if seen.insert(tag).inserted {
+                    result.append(tag)
+                }
+            }
+        }
+        return result
     }
 
     func setTags(_ tags: [String], source: String) {
-        let sanitized = tags
-            .map { String($0.trimmingCharacters(in: .whitespacesAndNewlines).prefix(Self.maxTagLength)) }
-            .filter { !$0.isEmpty }
-            .prefix(Self.maxTagsPerSource)
+        let truncatedSource = String(source.prefix(Self.maxSourceLength))
+        var seen = Set<String>()
+        var deduped = [String]()
+        for tag in tags {
+            let trimmed = String(tag.trimmingCharacters(in: .whitespacesAndNewlines).prefix(Self.maxTagLength))
+            guard !trimmed.isEmpty else { continue }
+            if seen.insert(trimmed).inserted {
+                deduped.append(trimmed)
+            }
+        }
+        let sanitized = Array(deduped.prefix(Self.maxTagsPerSource))
+
         var updated = tagsBySource
-        updated[source] = Array(sanitized)
+        if sanitized.isEmpty {
+            updated.removeValue(forKey: truncatedSource)
+        } else {
+            updated[truncatedSource] = sanitized
+        }
         if updated.count > Self.maxTagSources {
             let sortedKeys = updated.keys.sorted()
             for key in sortedKeys {
-                if key != source, updated.count > Self.maxTagSources {
+                if key != truncatedSource, updated.count > Self.maxTagSources {
                     updated.removeValue(forKey: key)
                 }
             }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2813,6 +2813,20 @@ enum ClaudeCodeIntegrationSettings {
         }
         return defaults.bool(forKey: hooksEnabledKey)
     }
+
+    static let sessionTagsEnabledKey = "cmdPSessionTags"
+    static let defaultSessionTagsEnabled = false
+
+    static func sessionTagsEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: sessionTagsEnabledKey) == nil {
+            return defaultSessionTagsEnabled
+        }
+        return defaults.bool(forKey: sessionTagsEnabledKey)
+    }
+
+    static func setSessionTagsEnabled(_ isEnabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(isEnabled, forKey: sessionTagsEnabledKey)
+    }
 }
 
 enum TelemetrySettings {


### PR DESCRIPTION
## Summary
- Adds per-source tag storage on workspaces (tagsBySource) with session persistence
- Extends cmd-p search indexer to tokenize and match workspace tags
- Shows tag footnotes below workspace title in cmd-p rows when tags exist
- Adds workspace.set_tags / workspace.clear_tags V2 socket commands
- Adds set-workspace-tags / clear-workspace-tags CLI commands
- Claude Code hooks auto-extract tags from notification content (disabled by default via cmdPSessionTags setting)
- PII sanitization filters out UUIDs, emails, tokens, paths, and env vars from extracted tags

## Test plan
- [ ] Enable setting: defaults write com.cmuxterm.app.debug cmdPSessionTags -bool true
- [ ] Start a Claude Code session discussing a topic (e.g. 'open claw')
- [ ] Open cmd-p and search for that topic — verify the workspace surfaces
- [ ] Verify tag footnotes appear below workspace titles in cmd-p results
- [ ] Test manual tags via CLI: cmux set-workspace-tags 'auth' 'payments'
- [ ] Test tag clearing: cmux clear-workspace-tags
- [ ] Verify session restore preserves tags across app restart
- [ ] Verify no workspace-color-api code is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds searchable session tags to the cmd‑p workspace switcher so you can find workspaces by topic. Tags persist per workspace, can be set via CLI, and can be auto‑extracted from Claude Code (opt‑in).

- **New Features**
  - Per-source workspace tag storage (`tagsBySource`) with session restore and limits (10 sources, 20 tags/source, 100 chars/tag).
  - Cmd‑p indexer tokenizes tags, adds “tag”/“topic” keywords, and shows tag footnotes under workspace titles.
  - V2 socket: `workspace.set_tags` and `workspace.clear_tags`.
  - CLI: `cmux set-workspace-tags` and `cmux clear-workspace-tags` with `--source`/`--clear`.
  - Claude Code (opt‑in via `cmdPSessionTags`, off by default): auto-extracts tags from notifications, clears on session end, and filters PII.

- **Bug Fixes**
  - Pre‑redacts PII across full text before tokenization (UUIDs, emails, tokens, paths, env vars, long IDs).
  - Deduplicates tags and enforces deterministic tag ordering across sources.
  - Stricter input validation and clearer errors in CLI and V2 (unknown flags, `--clear` with tags, empty/invalid source).

<sup>Written for commit e81bcce079e2c40f6a68e5afbb5cecb85f144394. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace tagging: add, clear, and persist tags (per-source) with optional scoping.
  * Tags searchable and visible in the command palette; influence search/ranking and fingerprints.
  * Automatic tag extraction from Claude sessions when session tagging is enabled.
  * CLI and v2 command support to set/clear workspace tags.
  * Feature flag to enable/disable Claude session tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->