### PR TITLE
Shared tabs across windows

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A5001207 /* UpdatePopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001217 /* UpdatePopoverView.swift */; };
 		A5001208 /* UpdateTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001218 /* UpdateTitlebarAccessory.swift */; };
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
+		A5009750 /* WindowTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5009751 /* WindowTabState.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
@@ -199,6 +200,7 @@
 		A5001217 /* UpdatePopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdatePopoverView.swift; sourceTree = "<group>"; };
 		A5001218 /* UpdateTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateTitlebarAccessory.swift; sourceTree = "<group>"; };
 		A5001219 /* WindowToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowToolbarController.swift; sourceTree = "<group>"; };
+		A5009751 /* WindowTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTabState.swift; sourceTree = "<group>"; };
 		A5001222 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				A5001217 /* UpdatePopoverView.swift */,
 				A5001218 /* UpdateTitlebarAccessory.swift */,
 				A5001219 /* WindowToolbarController.swift */,
+				A5009751 /* WindowTabState.swift */,
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
@@ -656,6 +659,7 @@
 				A5001207 /* UpdatePopoverView.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				A5001209 /* WindowToolbarController.swift in Sources */,
+				A5009750 /* WindowTabState.swift in Sources */,
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -6,14 +6,18 @@
 # so that Claude Code hooks fire back into cmux for notifications/status.
 # Outside cmux, it passes through to the real claude binary unchanged.
 
-# Find the real claude binary, skipping our own directory.
+# Find the real claude binary, skipping all cmux wrapper directories.
 find_real_claude() {
     local self_dir
     self_dir="$(cd "$(dirname "$0")" && pwd)"
     local IFS=:
     for d in $PATH; do
         [[ "$d" == "$self_dir" ]] && continue
-        [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
+        [[ -x "$d/claude" ]] || continue
+        # Skip other cmux wrapper copies (e.g. /Applications/cmux.app/.../bin/claude).
+        # A cmux wrapper always lives next to a cmux binary.
+        [[ -x "$d/cmux" ]] && continue
+        printf '%s' "$d/claude" && return 0
     done
     return 1
 }
@@ -30,19 +34,36 @@ cmux_socket_available() {
     [[ -n "$cmux_bin" ]] || return 1
 
     # Keep stale/hung socket checks bounded so claude startup does not block
-    # behind the CLI default timeout (15s).
+    # behind the CLI default timeout (15s). Use a hard process-level timeout
+    # as a backstop — the CLI env var timeout is not always respected (e.g.
+    # the CLI can hang on access-denied errors without exiting).
+    local pid
     CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
-        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1 &
+    pid=$!
+    local i=0
+    while (( i < 15 )); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            wait "$pid" 2>/dev/null
+            return $?
+        fi
+        sleep 0.1
+        (( i++ ))
+    done
+    # Still running after 1.5s — kill and report failure.
+    kill "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    return 1
 }
 
 # Pass through if not in a cmux terminal, hooks are disabled, or the cmux
 # socket is unavailable (stale env / app not running).
 IN_CMUX=0
-if [[ -n "$CMUX_SURFACE_ID" ]]; then
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
     IN_CMUX=1
 fi
 
-if [[ "$IN_CMUX" == "0" || "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]] || ! cmux_socket_available; then
+if [[ "$IN_CMUX" == "0" || "${CMUX_CLAUDE_HOOKS_DISABLED:-}" == "1" ]] || ! cmux_socket_available; then
     # In cmux-launched shells, preserve old behavior and always clear nested
     # Claude session markers, even when we must pass through due to stale socket.
     if [[ "$IN_CMUX" == "1" ]]; then

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1989,10 +1989,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if let startupSnapshot {
-            let additionalWindows = Array(startupSnapshot
-                .windows
-                .dropFirst()
-                .prefix(max(0, SessionPersistencePolicy.maxWindowsPerSnapshot - 1)))
+            // In shared mode, don't restore additional windows — tabs are shared
+            // across windows, so only the primary window needs to exist on launch.
+            // Users can open more windows with Cmd+N.
+            let additionalWindows: [SessionWindowSnapshot] = SharedTabsSettings.isEnabled()
+                ? []
+                : Array(startupSnapshot
+                    .windows
+                    .dropFirst()
+                    .prefix(max(0, SessionPersistencePolicy.maxWindowsPerSnapshot - 1)))
 #if DEBUG
             for (index, windowSnapshot) in additionalWindows.enumerated() {
                 dlog(
@@ -2842,6 +2847,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sidebarSelectionState: SidebarSelectionState
     ) {
         tabManager.window = window
+        if tabManager.windowId == nil {
+            tabManager.windowId = windowId
+            // Claim the currently selected tab in shared mode.
+            if let selectedId = tabManager.selectedTabId {
+                tabManager.claimTab(selectedId)
+            }
+        }
 
         let key = ObjectIdentifier(window)
         #if DEBUG
@@ -4626,7 +4638,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sessionWindowSnapshot: SessionWindowSnapshot? = nil
     ) -> UUID {
         let windowId = UUID()
-        let tabManager = TabManager(initialWorkingDirectory: initialWorkingDirectory)
+        let tabManager = TabManager(
+            initialWorkingDirectory: initialWorkingDirectory,
+            sharedStore: SharedWorkspaceStore.shared
+        )
+        tabManager.windowId = windowId
+        // Claim the initially selected tab now that windowId is set.
+        // (selectedTabId was set during init but claimTab couldn't run without a windowId.)
+        if let selectedId = tabManager.selectedTabId {
+            tabManager.claimTab(selectedId)
+        }
         if let tabManagerSnapshot = sessionWindowSnapshot?.tabManager {
             tabManager.restoreSessionSnapshot(tabManagerSnapshot)
         }
@@ -8215,8 +8236,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         commandPaletteSelectionByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteSnapshotByWindowId.removeValue(forKey: removed.windowId)
 
+        // Release shared tab ownership when a window closes.
+        if let windowId = removed.tabManager.windowId {
+            SharedWorkspaceStore.shared?.releaseAllTabs(fromWindow: windowId)
+        }
+
         // Avoid stale notifications that can no longer be opened once the owning window is gone.
-        if let store = notificationStore {
+        // In shared mode, don't clear notifications for shared tabs (other windows may use them).
+        if let store = notificationStore, removed.tabManager.sharedStore == nil {
             for tab in removed.tabManager.tabs {
                 store.clearNotifications(forTabId: tab.id)
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8237,9 +8237,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         commandPaletteSnapshotByWindowId.removeValue(forKey: removed.windowId)
 
         // Release shared tab ownership when a window closes.
-        if let windowId = removed.tabManager.windowId {
-            SharedWorkspaceStore.shared?.releaseAllTabs(fromWindow: windowId)
-        }
+        SharedWorkspaceStore.shared?.releaseAllTabs(fromWindow: removed.windowId)
 
         // Avoid stale notifications that can no longer be opened once the owning window is gone.
         // In shared mode, don't clear notifications for shared tabs (other windows may use them).

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1857,13 +1857,17 @@ struct ContentView: View {
                     let isSelectedWorkspace = selectedWorkspaceId == tab.id
                     let isRetiringWorkspace = retiringWorkspaceId == tab.id
                     let shouldPrimeInBackground = tabManager.pendingBackgroundWorkspaceLoadIds.contains(tab.id)
+                    // In shared mode, don't show a retiring workspace that's now owned by another
+                    // window — its hosted view needs to move to the other window, and keeping it
+                    // visible here with visibleInUI=true would steal it back via the portal bind.
+                    let isRetiringVisible = isRetiringWorkspace && !tabManager.isOwnedByOtherWindow(tab.id)
                     // Keep the retiring workspace visible during handoff, but never input-active.
                     // Allowing both selected+retiring workspaces to be input-active lets the
                     // old workspace steal first responder (notably with WKWebView), which can
                     // delay handoff completion and make browser returns feel laggy.
                     let isInputActive = isSelectedWorkspace
-                    let isVisible = isSelectedWorkspace || isRetiringWorkspace
-                    let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
+                    let isVisible = isSelectedWorkspace || isRetiringVisible
+                    let portalPriority = isSelectedWorkspace ? 2 : (isRetiringVisible ? 1 : 0)
                     WorkspaceContentView(
                         workspace: tab,
                         isWorkspaceVisible: isVisible,
@@ -2611,8 +2615,8 @@ struct ContentView: View {
 
     private func reconcileMountedWorkspaceIds(tabs: [Workspace]? = nil, selectedId: UUID? = nil) {
         let currentTabs = tabs ?? tabManager.tabs
-        let orderedTabIds = currentTabs.map { $0.id }
         let effectiveSelectedId = selectedId ?? tabManager.selectedTabId
+        let orderedTabIds = currentTabs.map(\.id)
         let handoffPinnedIds = retiringWorkspaceId.map { Set([ $0 ]) } ?? []
         let pinnedIds = handoffPinnedIds.union(tabManager.pendingBackgroundWorkspaceLoadIds)
         let isCycleHot = tabManager.isWorkspaceCycleHot
@@ -2821,8 +2825,13 @@ struct ContentView: View {
         // during transient rebuilds. Hiding here prevents stale terminal/browser
         // portals from covering the newly selected workspace.
         if let retiring, let workspace = tabManager.tabs.first(where: { $0.id == retiring }) {
-            workspace.hideAllTerminalPortalViews()
-            workspace.hideAllBrowserPortalViews()
+            // In shared mode, don't hide portal views for a workspace that's now owned
+            // by another window. The stealing window renders this workspace's surfaces;
+            // hiding them here would blank out the stealing window's terminal.
+            if !tabManager.isOwnedByOtherWindow(retiring) {
+                workspace.hideAllTerminalPortalViews()
+                workspace.hideAllBrowserPortalViews()
+            }
         }
 
         retiringWorkspaceId = nil
@@ -7947,6 +7956,10 @@ private struct TabItemView: View {
         selectedTabIds.contains(tab.id)
     }
 
+    var isOwnedByOtherWindow: Bool {
+        tabManager.isOwnedByOtherWindow(tab.id)
+    }
+
     private var isBeingDragged: Bool {
         draggedTabId == tab.id
     }
@@ -8104,9 +8117,15 @@ private struct TabItemView: View {
 
                 Text(tab.title)
                     .font(.system(size: 12.5, weight: titleFontWeight))
-                    .foregroundColor(activePrimaryTextColor)
+                    .foregroundColor(isOwnedByOtherWindow ? activePrimaryTextColor.opacity(0.4) : activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
+
+                if isOwnedByOtherWindow {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(.secondary.opacity(0.5))
+                }
 
                 Spacer()
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5967,7 +5967,11 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
-        if !window.isKeyWindow {
+        // In shared mode, don't promote a non-key window to key — this prevents
+        // the vacated window from stealing macOS focus. But still set first responder
+        // so the surface renders correctly.
+        let isSharedNonKeyWindow = tabManager.sharedStore != nil && !window.isKeyWindow
+        if !window.isKeyWindow && !isSharedNonKeyWindow {
             window.makeKeyAndOrderFront(nil)
         }
         _ = window.makeFirstResponder(surfaceView)
@@ -6824,6 +6828,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     expectedSurfaceId: portalExpectedSurfaceId,
                     expectedGeneration: portalExpectedGeneration
                 )
+                // Only apply state if the bind succeeded (see onGeometryChanged comment).
+                guard TerminalWindowPortalRegistry.isHostedView(hostedView, boundTo: host) else { return }
                 coordinator.lastBoundHostId = ObjectIdentifier(host)
                 hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
                 hostedView.setActive(coordinator.desiredIsActive)
@@ -6850,10 +6856,15 @@ struct GhosttyTerminalView: NSViewRepresentable {
                         expectedSurfaceId: portalExpectedSurfaceId,
                         expectedGeneration: portalExpectedGeneration
                     )
-                    coordinator.lastBoundHostId = ObjectIdentifier(host)
-                    hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
-                    hostedView.setActive(coordinator.desiredIsActive)
-                    hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                    // Only apply state if the bind succeeded. In shared-tabs mode, the
+                    // cross-window guard may skip the bind, and applying stale desired
+                    // state here would override the owning window's visible/active flags.
+                    if TerminalWindowPortalRegistry.isHostedView(hostedView, boundTo: host) {
+                        coordinator.lastBoundHostId = ObjectIdentifier(host)
+                        hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
+                        hostedView.setActive(coordinator.desiredIsActive)
+                        hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                    }
                 }
                 TerminalWindowPortalRegistry.synchronizeForAnchor(host)
             }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -596,6 +596,9 @@ class TabManager: ObservableObject {
 
     /// Reference to the shared workspace store (non-nil in shared tabs mode).
     let sharedStore: SharedWorkspaceStore?
+    /// True when this TabManager joined an already-populated shared store (i.e. second+ window).
+    /// Used to skip session restore for subsequent windows while allowing the first window to restore.
+    private let startedFromExistingSharedTabs: Bool
     /// The window ID this TabManager belongs to (set by AppDelegate after init).
     var windowId: UUID?
     /// Guard against re-entrant sync from SharedWorkspaceStore.
@@ -610,9 +613,11 @@ class TabManager: ObservableObject {
 
         tabs = newTabs
 
-        // If selected tab was removed, pick the nearest valid tab.
+        // If selected tab was removed, prefer a self-owned tab, then unclaimed, then any.
         if let selectedId = selectedTabId, !tabs.contains(where: { $0.id == selectedId }) {
-            selectedTabId = tabs.first?.id
+            selectedTabId = tabs.first(where: { sharedStore?.owner(of: $0.id) == windowId })?.id
+                ?? sharedStore?.firstUnclaimedTab()?.id
+                ?? tabs.first?.id
         }
     }
 
@@ -740,6 +745,7 @@ class TabManager: ObservableObject {
 
     init(initialWorkingDirectory: String? = nil, sharedStore: SharedWorkspaceStore? = nil) {
         self.sharedStore = sharedStore
+        self.startedFromExistingSharedTabs = sharedStore.map { !$0.tabs.isEmpty } ?? false
 
         if let sharedStore, !sharedStore.tabs.isEmpty {
             // Shared mode with existing tabs: sync from store.
@@ -806,9 +812,8 @@ class TabManager: ObservableObject {
 
     deinit {
         workspaceCycleCooldownTask?.cancel()
-        MainActor.assumeIsolated {
-            sharedStore?.unregister(self)
-        }
+        // No explicit sharedStore?.unregister(self) needed — registeredManagers
+        // is NSHashTable.weakObjects(), so entries are zeroed on deallocation.
     }
 
     private func wireClosedBrowserTracking(for workspace: Workspace) {
@@ -2093,7 +2098,10 @@ class TabManager: ObservableObject {
             ?? nearestTab(from: stolenIndex, matching: { sharedStore.owner(of: $0) != windowId })
         {
             selectedTabId = tabId
+            return
         }
+        // All tabs are owned by other windows — create a new workspace so we have somewhere to land.
+        _ = addWorkspace()
     }
 
     /// Searches outward from `index` for the nearest tab matching a predicate.
@@ -3927,7 +3935,7 @@ extension TabManager {
         // In shared mode, subsequent windows already have tabs from the shared
         // store and a valid selection from init. Skip session restore entirely
         // to avoid stealing tabs that belong to other windows.
-        if let sharedStore, !sharedStore.tabs.isEmpty {
+        if startedFromExistingSharedTabs {
             return
         }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -39,6 +39,18 @@ enum NewWorkspacePlacement: String, CaseIterable, Identifiable {
     }
 }
 
+enum SharedTabsSettings {
+    static let key = "sharedTabsAcrossWindows"
+    static let defaultValue = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: key) == nil {
+            return defaultValue
+        }
+        return defaults.bool(forKey: key)
+    }
+}
+
 enum WorkspaceAutoReorderSettings {
     static let key = "workspaceAutoReorderOnNotification"
     static let defaultValue = true
@@ -567,9 +579,63 @@ class TabManager: ObservableObject {
     /// Used to apply title updates to the correct window instead of NSApp.keyWindow.
     weak var window: NSWindow?
 
-    @Published var tabs: [Workspace] = []
+    @Published var tabs: [Workspace] = [] {
+        didSet {
+            guard let sharedStore, !isSyncingFromSharedStore else { return }
+            let idsChanged = tabs.count != oldValue.count ||
+                !tabs.lazy.map(\.id).elementsEqual(oldValue.lazy.map(\.id))
+            if idsChanged {
+                sharedStore.broadcastTabsUpdate(from: self)
+            }
+        }
+    }
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
+
+    // MARK: - Shared Tabs
+
+    /// Reference to the shared workspace store (non-nil in shared tabs mode).
+    let sharedStore: SharedWorkspaceStore?
+    /// The window ID this TabManager belongs to (set by AppDelegate after init).
+    var windowId: UUID?
+    /// Guard against re-entrant sync from SharedWorkspaceStore.
+    private(set) var isSyncingFromSharedStore = false
+    /// True while vacating due to a tab steal — suppresses focus side effects.
+    private(set) var isVacatingFromSteal = false
+
+    /// Called by SharedWorkspaceStore to sync tabs from another TabManager.
+    func receiveSyncedTabs(_ newTabs: [Workspace]) {
+        isSyncingFromSharedStore = true
+        defer { isSyncingFromSharedStore = false }
+
+        tabs = newTabs
+
+        // If selected tab was removed, pick the nearest valid tab.
+        if let selectedId = selectedTabId, !tabs.contains(where: { $0.id == selectedId }) {
+            selectedTabId = tabs.first?.id
+        }
+    }
+
+    /// Whether this tab is owned by a different window in shared mode.
+    func isOwnedByOtherWindow(_ workspaceId: UUID) -> Bool {
+        guard let sharedStore, let windowId else { return false }
+        guard let owner = sharedStore.owner(of: workspaceId) else { return false }
+        return owner != windowId
+    }
+
+    /// Claims a tab for this window during init (before selectedTabId didSet is active).
+    func claimTab(_ workspaceId: UUID) {
+        guard let sharedStore, let windowId else { return }
+        sharedStore.claim(workspaceId: workspaceId, forWindow: windowId)
+    }
+
+    /// Called by SharedWorkspaceStore when another window steals our tab.
+    func handleTabStolen(_ stolenTabId: UUID) {
+        guard selectedTabId == stolenTabId else { return }
+        isVacatingFromSteal = true
+        defer { isVacatingFromSteal = false }
+        vacateToNearestUnclaimed(from: stolenTabId)
+    }
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -589,6 +655,14 @@ class TabManager: ObservableObject {
             if !isNavigatingHistory, let selectedTabId {
                 recordTabInHistory(selectedTabId)
             }
+            // In shared mode, atomically release the previous tab and claim the new one.
+            if let sharedStore, let windowId, let selectedTabId {
+                sharedStore.switchOwnership(
+                    from: previousTabId,
+                    to: selectedTabId,
+                    forWindow: windowId
+                )
+            }
 #if DEBUG
             let switchId = debugWorkspaceSwitchId
             let switchDtMs = debugWorkspaceSwitchStartTime > 0
@@ -601,9 +675,12 @@ class TabManager: ObservableObject {
 #endif
             selectionSideEffectsGeneration &+= 1
             let generation = selectionSideEffectsGeneration
+            let suppressFocusSideEffects = isVacatingFromSteal
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.selectionSideEffectsGeneration == generation else { return }
-                self.focusSelectedTabPanel(previousTabId: previousTabId)
+                if !suppressFocusSideEffects {
+                    self.focusSelectedTabPanel(previousTabId: previousTabId)
+                }
                 self.updateWindowTitleForSelectedTab()
                 if let selectedTabId = self.selectedTabId {
                     self.markFocusedPanelReadIfActive(tabId: selectedTabId)
@@ -621,6 +698,7 @@ class TabManager: ObservableObject {
         }
     }
     private var observers: [NSObjectProtocol] = []
+    private var ownershipCancellable: AnyCancellable?
     private var suppressFocusFlash = false
     private var lastFocusedPanelByTab: [UUID: UUID] = [:]
     private struct PanelTitleUpdateKey: Hashable {
@@ -660,8 +738,38 @@ class TabManager: ObservableObject {
     private var uiTestCancellables = Set<AnyCancellable>()
 #endif
 
-    init(initialWorkingDirectory: String? = nil) {
-        addWorkspace(workingDirectory: initialWorkingDirectory)
+    init(initialWorkingDirectory: String? = nil, sharedStore: SharedWorkspaceStore? = nil) {
+        self.sharedStore = sharedStore
+
+        if let sharedStore, !sharedStore.tabs.isEmpty {
+            // Shared mode with existing tabs: sync from store.
+            self.tabs = sharedStore.tabs
+            // Select first unclaimed tab, or create a new one if all are claimed.
+            if let unclaimed = sharedStore.firstUnclaimedTab() {
+                self.selectedTabId = unclaimed.id
+            } else {
+                // All tabs claimed — create a new workspace for this window.
+                addWorkspace(workingDirectory: initialWorkingDirectory)
+                // Broadcast the updated tab list so other windows see the new tab.
+                sharedStore.broadcastTabsUpdate(from: self)
+            }
+        } else {
+            addWorkspace(workingDirectory: initialWorkingDirectory)
+            if let sharedStore {
+                // First TabManager in shared mode: seed the store.
+                sharedStore.broadcastTabsUpdate(from: self)
+            }
+        }
+
+        sharedStore?.register(self)
+
+        // Forward ownership changes to trigger SwiftUI re-renders (lock icon, dimming).
+        ownershipCancellable = sharedStore?.$ownershipByTab
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+
         observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidSetTitle,
             object: nil,
@@ -698,6 +806,9 @@ class TabManager: ObservableObject {
 
     deinit {
         workspaceCycleCooldownTask?.cancel()
+        MainActor.assumeIsolated {
+            sharedStore?.unregister(self)
+        }
     }
 
     private func wireClosedBrowserTracking(for workspace: Workspace) {
@@ -1222,6 +1333,11 @@ class TabManager: ObservableObject {
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         clearInitialWorkspaceGitProbe(workspaceId: workspace.id)
 
+        // Release ownership in shared mode before removing.
+        if let windowId {
+            sharedStore?.release(workspaceId: workspace.id, fromWindow: windowId)
+        }
+
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         unwireClosedBrowserTracking(for: workspace)
         workspace.teardownAllPanels()
@@ -1683,7 +1799,9 @@ class TabManager: ObservableObject {
 
     private func focusSelectedTabPanel(previousTabId: UUID?) {
         guard let selectedTabId,
-              let tab = tabs.first(where: { $0.id == selectedTabId }) else { return }
+              let tab = tabs.first(where: { $0.id == selectedTabId }) else {
+            return
+        }
 
         // Try to restore previous focus
         if let restoredPanelId = lastFocusedPanelByTab[selectedTabId],
@@ -1694,7 +1812,9 @@ class TabManager: ObservableObject {
 
         // Focus the panel
         guard let panelId = tab.focusedPanelId,
-              let panel = tab.panels[panelId] else { return }
+              let panel = tab.panels[panelId] else {
+            return
+        }
 
         // Defer unfocusing the previous workspace's panel until ContentView confirms handoff
         // completion (new workspace has focus or timeout fallback), to avoid a visible freeze gap.
@@ -1729,6 +1849,12 @@ class TabManager: ObservableObject {
                 "ws.unfocus.drop tab=\(Self.debugShortWorkspaceId(pending.tabId)) panel=\(String(pending.panelId.uuidString.prefix(5))) reason=selected_again"
             )
 #endif
+            return
+        }
+        // Don't unfocus a workspace now owned by another window — it would undo
+        // focus that the new owner already applied (race during manual switch + claim).
+        guard !isOwnedByOtherWindow(pending.tabId) else {
+            pendingWorkspaceUnfocusTarget = nil
             return
         }
         pendingWorkspaceUnfocusTarget = nil
@@ -1954,6 +2080,33 @@ class TabManager: ObservableObject {
     func focusSurface(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         tab.focusPanel(surfaceId)
+    }
+
+    /// In shared mode, when our selected tab is stolen, pick the nearest unclaimed tab.
+    /// Falls back to stealing the nearest tab from another window if all are claimed.
+    private func vacateToNearestUnclaimed(from stolenTabId: UUID) {
+        guard let sharedStore else { return }
+        guard let stolenIndex = tabs.firstIndex(where: { $0.id == stolenTabId }) else { return }
+
+        // First try unclaimed, then fall back to any tab not owned by us.
+        if let tabId = nearestTab(from: stolenIndex, matching: { sharedStore.owner(of: $0) == nil })
+            ?? nearestTab(from: stolenIndex, matching: { sharedStore.owner(of: $0) != windowId })
+        {
+            selectedTabId = tabId
+        }
+    }
+
+    /// Searches outward from `index` for the nearest tab matching a predicate.
+    private func nearestTab(from index: Int, matching predicate: (UUID) -> Bool) -> UUID? {
+        var lo = index - 1
+        var hi = index + 1
+        while lo >= 0 || hi < tabs.count {
+            if hi < tabs.count, predicate(tabs[hi].id) { return tabs[hi].id }
+            if lo >= 0, predicate(tabs[lo].id) { return tabs[lo].id }
+            lo -= 1
+            hi += 1
+        }
+        return nil
     }
 
     func selectNextTab() {
@@ -3771,6 +3924,13 @@ extension TabManager {
     }
 
     func restoreSessionSnapshot(_ snapshot: SessionTabManagerSnapshot) {
+        // In shared mode, subsequent windows already have tabs from the shared
+        // store and a valid selection from init. Skip session restore entirely
+        // to avoid stealing tabs that belong to other windows.
+        if let sharedStore, !sharedStore.tabs.isEmpty {
+            return
+        }
+
         for tab in tabs {
             unwireClosedBrowserTracking(for: tab)
         }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1013,7 +1013,7 @@ final class WindowTerminalPortal: NSObject {
             anchorView: anchorView,
             visibleInUI: visibleInUI,
             zPriority: zPriority,
-            transientRecoveryRetriesRemaining: 0
+            transientRecoveryRetriesRemaining: visibleInUI ? Self.transientRecoveryRetryBudget : 0
         )
 
         let didChangeAnchor: Bool = {
@@ -1304,12 +1304,18 @@ final class WindowTerminalPortal: NSObject {
             targetFrame.width >= Self.minimumRevealWidth &&
             targetFrame.height >= Self.minimumRevealHeight
         let outsideHostBounds = !hasVisibleIntersection
+        // When visibleInUI is true, don't let anchorHidden force a hide.
+        // During cross-window steals, SwiftUI transiently hides the anchor
+        // (HostContainerView) for a few layout cycles. The other geometric
+        // checks (tinyFrame, outsideHostBounds, !hasFiniteFrame) are
+        // sufficient to catch degenerate cases. We schedule a deferred sync
+        // below so the portal converges once the anchor settles.
         let shouldHide =
             !entry.visibleInUI ||
-            anchorHidden ||
             tinyFrame ||
             !hasFiniteFrame ||
             outsideHostBounds
+        let anchorHiddenButVisible = anchorHidden && entry.visibleInUI && !shouldHide
         let shouldDeferReveal = !shouldHide && hostedView.isHidden && !revealReadyForDisplay
         let transientRecoveryReason: String? = {
             guard Self.transientRecoveryEnabled else { return nil }
@@ -1436,6 +1442,22 @@ final class WindowTerminalPortal: NSObject {
 
         if transientRecoveryReason == nil {
             resetTransientRecoveryRetryIfNeeded(forHostedId: hostedId, entry: &entry)
+        }
+
+        // When the anchor is transiently hidden but the entry should be visible,
+        // schedule a deferred sync so we converge once the anchor settles.
+        // Use the transientRecoveryRetriesRemaining budget to avoid spinning forever
+        // if the anchor stays permanently hidden (e.g., unmounted SwiftUI view).
+        if anchorHiddenButVisible, entry.transientRecoveryRetriesRemaining > 0 {
+            entry.transientRecoveryRetriesRemaining -= 1
+            entriesByHostedId[hostedId] = entry
+            scheduleDeferredFullSynchronizeAll()
+        } else if !anchorHidden, entry.visibleInUI {
+            // Anchor became visible — reset the budget for future transitions.
+            if entry.transientRecoveryRetriesRemaining != Self.transientRecoveryRetryBudget {
+                entry.transientRecoveryRetriesRemaining = Self.transientRecoveryRetryBudget
+                entriesByHostedId[hostedId] = entry
+            }
         }
 
 #if DEBUG
@@ -1726,6 +1748,15 @@ enum TerminalWindowPortalRegistry {
                 "actualState=\(guardState.state)"
             )
 #endif
+            return
+        }
+
+        // In shared-tabs mode, multiple windows mount the same workspaces.
+        // Don't steal a hosted view from another window just to hide it —
+        // that would detach the Metal surface from the owning window.
+        if !visibleInUI,
+           let existingWindowId = hostedToWindowId[hostedId],
+           existingWindowId != windowId {
             return
         }
 

--- a/Sources/WindowTabState.swift
+++ b/Sources/WindowTabState.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Combine
+import Bonsplit
+
+// MARK: - SharedWorkspaceStore
+
+/// Singleton that coordinates shared tabs across multiple windows.
+/// Each window has its own TabManager, but in shared mode they all keep their
+/// `tabs` arrays synchronized through this store. selectedTabId stays per-window
+/// on each TabManager (zero view reference changes needed).
+@MainActor
+class SharedWorkspaceStore {
+    static var shared: SharedWorkspaceStore? = {
+        guard SharedTabsSettings.isEnabled() else { return nil }
+        return SharedWorkspaceStore()
+    }()
+
+    /// Canonical tab list. Updated by the source TabManager on mutation.
+    private(set) var tabs: [Workspace] = []
+
+    /// Maps workspace ID to the owning window's UUID.
+    @Published private(set) var ownershipByTab: [UUID: UUID] = [:]
+
+    /// Registered TabManagers. WeakRef so closed windows are cleaned up.
+    private var registeredManagers: NSHashTable<TabManager> = .weakObjects()
+
+    /// Guard against re-entrant broadcast during sync.
+    private var isBroadcasting = false
+
+    func register(_ manager: TabManager) {
+        registeredManagers.add(manager)
+    }
+
+    func unregister(_ manager: TabManager) {
+        registeredManagers.remove(manager)
+    }
+
+    /// Called by a TabManager after modifying its `tabs` array.
+    /// Broadcasts the change to all other registered TabManagers.
+    func broadcastTabsUpdate(from source: TabManager) {
+        guard !isBroadcasting else { return }
+        isBroadcasting = true
+        defer { isBroadcasting = false }
+
+        tabs = source.tabs
+
+        for manager in registeredManagers.allObjects {
+            guard manager !== source else { continue }
+            manager.receiveSyncedTabs(source.tabs)
+        }
+    }
+
+    // MARK: - Ownership
+
+    /// Atomically releases the old tab and claims the new one, notifying the
+    /// previous owner to vacate. Batches both mutations into a single
+    /// `@Published` update so subscribers only fire once.
+    func switchOwnership(
+        from oldWorkspaceId: UUID?,
+        to newWorkspaceId: UUID,
+        forWindow windowId: UUID
+    ) {
+        // Release old tab if owned by this window.
+        if let oldId = oldWorkspaceId, ownershipByTab[oldId] == windowId {
+            ownershipByTab.removeValue(forKey: oldId)
+        }
+
+        // Claim new tab.
+        let previousOwner = ownershipByTab[newWorkspaceId]
+        ownershipByTab[newWorkspaceId] = windowId
+
+        // If we stole from another window, tell it to vacate directly.
+        if let previousOwner, previousOwner != windowId {
+            for manager in registeredManagers.allObjects {
+                guard manager.windowId == previousOwner else { continue }
+                manager.handleTabStolen(newWorkspaceId)
+                break
+            }
+        }
+    }
+
+    /// Claims a single tab without releasing another (used during init).
+    @discardableResult
+    func claim(workspaceId: UUID, forWindow windowId: UUID) -> UUID? {
+        let previous = ownershipByTab[workspaceId]
+        ownershipByTab[workspaceId] = windowId
+        return previous
+    }
+
+    /// Releases ownership if the given window owns it.
+    func release(workspaceId: UUID, fromWindow windowId: UUID) {
+        if ownershipByTab[workspaceId] == windowId {
+            ownershipByTab.removeValue(forKey: workspaceId)
+        }
+    }
+
+    /// Returns the owning window ID, or nil if unclaimed.
+    func owner(of workspaceId: UUID) -> UUID? {
+        ownershipByTab[workspaceId]
+    }
+
+    /// Releases all tabs owned by a window (called on window close).
+    func releaseAllTabs(fromWindow windowId: UUID) {
+        ownershipByTab = ownershipByTab.filter { $0.value != windowId }
+    }
+
+    /// Returns the first unclaimed tab, or nil.
+    func firstUnclaimedTab() -> Workspace? {
+        tabs.first { owner(of: $0.id) == nil }
+    }
+}

--- a/Sources/WindowTabState.swift
+++ b/Sources/WindowTabState.swift
@@ -9,11 +9,13 @@ import Bonsplit
 /// `tabs` arrays synchronized through this store. selectedTabId stays per-window
 /// on each TabManager (zero view reference changes needed).
 @MainActor
-class SharedWorkspaceStore {
-    static var shared: SharedWorkspaceStore? = {
+final class SharedWorkspaceStore {
+    static let shared: SharedWorkspaceStore? = {
         guard SharedTabsSettings.isEnabled() else { return nil }
         return SharedWorkspaceStore()
     }()
+
+    private init() {}
 
     /// Canonical tab list. Updated by the source TabManager on mutation.
     private(set) var tabs: [Workspace] = []
@@ -29,10 +31,6 @@ class SharedWorkspaceStore {
 
     func register(_ manager: TabManager) {
         registeredManagers.add(manager)
-    }
-
-    func unregister(_ manager: TabManager) {
-        registeredManagers.remove(manager)
     }
 
     /// Called by a TabManager after modifying its `tabs` array.
@@ -82,6 +80,8 @@ class SharedWorkspaceStore {
     /// Claims a single tab without releasing another (used during init).
     @discardableResult
     func claim(workspaceId: UUID, forWindow windowId: UUID) -> UUID? {
+        assert(ownershipByTab[workspaceId] == nil,
+               "claim() called on already-owned tab — use switchOwnership instead")
         let previous = ownershipByTab[workspaceId]
         ownershipByTab[workspaceId] = windowId
         return previous

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -37,7 +37,14 @@ struct WorkspaceContentView: View {
 
         // Inactive workspaces are kept alive in a ZStack (for state preservation) but their
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
-        let _ = { workspace.bonsplitController.isInteractive = isWorkspaceInputActive }()
+        // Only manage interactivity when this view is actually visible. In shared mode, a
+        // non-visible workspace might be actively displayed in another window; overriding
+        // isInteractive here would hide the Bonsplit tab strip in that window.
+        let _ = {
+            if isWorkspaceVisible {
+                workspace.bonsplitController.isInteractive = isWorkspaceInputActive
+            }
+        }()
 
         // Wire up file drop handling so bonsplit's PaneDragContainerView can forward
         // Finder file drops to the correct terminal panel.

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -51,7 +51,7 @@ struct cmuxApp: App {
 
         let startupAppearance = AppearanceSettings.resolvedMode()
         Self.applyAppearance(startupAppearance)
-        _tabManager = StateObject(wrappedValue: TabManager())
+        _tabManager = StateObject(wrappedValue: TabManager(sharedStore: SharedWorkspaceStore.shared))
         // Migrate legacy and old-format socket mode values to the new enum.
         let defaults = UserDefaults.standard
         if let stored = defaults.string(forKey: SocketControlSettings.appStorageKey) {
@@ -2866,6 +2866,7 @@ struct SettingsView: View {
     private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+    @AppStorage(SharedTabsSettings.key) private var sharedTabsEnabled = SharedTabsSettings.defaultValue
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
@@ -3278,6 +3279,17 @@ struct SettingsView: View {
                             subtitle: String(localized: "settings.app.reorderOnNotification.subtitle", defaultValue: "Move workspaces to the top when they receive a notification. Disable for stable shortcut positions.")
                         ) {
                             Toggle("", isOn: $workspaceAutoReorder)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.sharedTabs", defaultValue: "Shared Tabs Across Windows"),
+                            subtitle: String(localized: "settings.app.sharedTabs.subtitle", defaultValue: "All windows share the same tab list. Selecting a tab claims it for that window. Requires restart.")
+                        ) {
+                            Toggle("", isOn: $sharedTabsEnabled)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -4163,6 +4175,7 @@ struct SettingsView: View {
         alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
         newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+        sharedTabsEnabled = SharedTabsSettings.defaultValue
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
         sidebarShowBranchDirectory = true


### PR DESCRIPTION
## What this does

Adds a "Shared Tabs Across Windows" mode where every window sees the same tab bar. Switching to a tab in one window **claims** it — the terminal surfaces move to that window and the previous owner vacates to the nearest unclaimed tab. This lets you spread a single set of workspaces across multiple monitors/windows without duplicating state.

**User-facing behavior:**
- All windows show the same tab list (add/remove/reorder syncs instantly)
- Clicking a tab claims it — terminal surfaces transfer, previous owner vacates to nearest unclaimed tab
- Tabs owned by another window show a dimmed title + lock icon
- Toggle in Settings → App → "Shared Tabs Across Windows" (requires restart)
- On launch, only the primary window restores; open more with Cmd+N

## Architecture & key decisions

**SharedWorkspaceStore** — `@MainActor` singleton holding the canonical `tabs` array and an ownership map (`[workspaceID → windowID]`). Each window's `TabManager` registers on init (via `NSHashTable.weakObjects()` for automatic cleanup). When any `TabManager` mutates its tabs, a `didSet` observer broadcasts to all others via the store. Re-entrancy guards on both sides prevent infinite loops.

**Ownership is lazy/on-select** — windows only claim tabs when the user selects them, keeping unclaimed tabs available as landing spots for new windows or vacate targets. `switchOwnership(from:to:forWindow:)` does an atomic release-old + claim-new; if the new tab was owned elsewhere, the store calls `handleTabStolen` on the victim, which searches outward for the nearest unclaimed tab. `isVacatingFromSteal` suppresses focus side-effects so the stealing window keeps macOS focus.

**Each window keeps its own TabManager** rather than sharing one, because `selectedTabId`, focus tracking, sidebar state, and session persistence are per-window concerns. Only tab-list mutations and ownership need coordination.

**Portal layer** — two changes prevent cross-window surface theft: (1) non-visible workspaces skip binding hosted views already bound in another window, and (2) the portal tolerates transient `anchorHidden` during cross-window steals using the existing retry budget.

**Session restore** — in shared mode, only the primary window restores from snapshot; additional windows skip `restoreSessionSnapshot` to avoid claiming tabs that belong to the primary window.

====

# Test Plan
_(Note: prior section generated via Claude Code, testing entirely manual):_
* Terminal and UI rendering works properly when another window takes ownership of a given tab.
* Claude Code starts properly and can move between windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to share tabs across multiple application windows for improved workflow organization.
  * Tabs owned by other windows are now visually indicated with lock icons and dimmed styling to prevent accidental interactions.

* **New Settings**
  * Added "Shared Tabs Across Windows" toggle in settings to control multi-window tab synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->