### PR TITLE
Add draft PR status to sidebar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -60595,6 +60595,119 @@
         }
       }
     },
+    "sidebar.pullRequest.statusDraft": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "draft"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラフト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "草稿"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "草稿"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초안"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entwurf"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "borrador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "brouillon"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "bozza"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kladde"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "szkic"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "черновик"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nacrt"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسودة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "utkast"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rascunho"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฉบับร่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "taslak"
+          }
+        }
+      }
+    },
     "sidebar.pullRequest.statusClosed": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -230,25 +230,29 @@ _cmux_prompt_command() {
             _CMUX_PR_LAST_PWD="$pwd"
             _CMUX_PR_LAST_RUN=$now
             {
-                local branch pr_tsv number state url status_opt=""
+                local branch pr_tsv number state url is_draft status_opt=""
                 branch=$(git branch --show-current 2>/dev/null)
                 if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
                     _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                 else
-                    pr_tsv="$(gh pr view --json number,state,url --jq '[.number, .state, .url] | @tsv' 2>/dev/null || true)"
+                    pr_tsv="$(gh pr view --json number,state,url,isDraft --jq '[.number, .state, .url, .isDraft] | @tsv' 2>/dev/null || true)"
                     if [[ -z "$pr_tsv" ]]; then
                         _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                     else
-                        IFS=$'\t' read -r number state url <<< "$pr_tsv"
+                        IFS=$'\t' read -r number state url is_draft <<< "$pr_tsv"
                         if [[ -z "$number" || -z "$url" ]]; then
                             _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                         else
-                            case "$state" in
-                                MERGED) status_opt="--state=merged" ;;
-                                OPEN) status_opt="--state=open" ;;
-                                CLOSED) status_opt="--state=closed" ;;
-                                *) status_opt="" ;;
-                            esac
+                            if [[ "$is_draft" == "true" ]]; then
+                                status_opt="--state=draft"
+                            else
+                                case "$state" in
+                                    MERGED) status_opt="--state=merged" ;;
+                                    OPEN) status_opt="--state=open" ;;
+                                    CLOSED) status_opt="--state=closed" ;;
+                                    *) status_opt="" ;;
+                                esac
+                            fi
                             _cmux_send "report_pr $number $url $status_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                         fi
                     fi

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -355,26 +355,30 @@ _cmux_precmd() {
             _CMUX_PR_LAST_PWD="$pwd"
             _CMUX_PR_LAST_RUN=$now
             {
-                local branch pr_tsv number state url status_opt=""
+                local branch pr_tsv number state url is_draft status_opt=""
                 branch=$(git branch --show-current 2>/dev/null)
                 if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
                     _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                 else
-                    pr_tsv="$(gh pr view --json number,state,url --jq '[.number, .state, .url] | @tsv' 2>/dev/null || true)"
+                    pr_tsv="$(gh pr view --json number,state,url,isDraft --jq '[.number, .state, .url, .isDraft] | @tsv' 2>/dev/null || true)"
                     if [[ -z "$pr_tsv" ]]; then
                         _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                     else
                         local IFS=$'\t'
-                        read -r number state url <<< "$pr_tsv"
+                        read -r number state url is_draft <<< "$pr_tsv"
                         if [[ -z "$number" ]] || [[ -z "$url" ]]; then
                             _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                         else
-                            case "$state" in
-                                MERGED) status_opt="--state=merged" ;;
-                                OPEN) status_opt="--state=open" ;;
-                                CLOSED) status_opt="--state=closed" ;;
-                                *) status_opt="" ;;
-                            esac
+                            if [[ "$is_draft" == "true" ]]; then
+                                status_opt="--state=draft"
+                            else
+                                case "$state" in
+                                    MERGED) status_opt="--state=merged" ;;
+                                    OPEN) status_opt="--state=open" ;;
+                                    CLOSED) status_opt="--state=closed" ;;
+                                    *) status_opt="" ;;
+                                esac
+                            fi
                             _cmux_send "report_pr $number $url $status_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                         fi
                     fi

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10079,6 +10079,7 @@ private struct TabItemView: View {
         case .open: return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
         case .merged: return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
         case .closed: return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+        case .draft: return String(localized: "sidebar.pullRequest.statusDraft", defaultValue: "draft")
         }
     }
 
@@ -10132,6 +10133,8 @@ private struct TabItemView: View {
                     .font(.system(size: 7, weight: .regular))
                     .foregroundColor(color)
                     .frame(width: Self.frameSize, height: Self.frameSize)
+            case .draft:
+                PullRequestDraftIcon(color: color)
             }
         }
     }
@@ -10167,6 +10170,44 @@ private struct TabItemView: View {
 
                 Circle()
                     .stroke(color, lineWidth: Self.stroke.lineWidth)
+                    .frame(width: Self.nodeDiameter, height: Self.nodeDiameter)
+                    .position(x: 11.0, y: 11.0)
+            }
+            .frame(width: Self.frameSize, height: Self.frameSize)
+        }
+    }
+
+    private struct PullRequestDraftIcon: View {
+        let color: Color
+        private static let stroke = StrokeStyle(lineWidth: 1.2, lineCap: .round, lineJoin: .round, dash: [2, 2])
+        private static let nodeDiameter: CGFloat = 3.0
+        private static let frameSize: CGFloat = 13
+
+        var body: some View {
+            ZStack {
+                Path { path in
+                    path.move(to: CGPoint(x: 3.0, y: 4.8))
+                    path.addLine(to: CGPoint(x: 3.0, y: 9.2))
+
+                    path.move(to: CGPoint(x: 4.8, y: 3.0))
+                    path.addLine(to: CGPoint(x: 9.4, y: 3.0))
+                    path.addLine(to: CGPoint(x: 11.0, y: 4.6))
+                    path.addLine(to: CGPoint(x: 11.0, y: 9.2))
+                }
+                .stroke(color, style: Self.stroke)
+
+                Circle()
+                    .stroke(color, lineWidth: 1.2)
+                    .frame(width: Self.nodeDiameter, height: Self.nodeDiameter)
+                    .position(x: 3.0, y: 3.0)
+
+                Circle()
+                    .stroke(color, lineWidth: 1.2)
+                    .frame(width: Self.nodeDiameter, height: Self.nodeDiameter)
+                    .position(x: 3.0, y: 11.0)
+
+                Circle()
+                    .stroke(color, lineWidth: 1.2)
                     .frame(width: Self.nodeDiameter, height: Self.nodeDiameter)
                     .position(x: 11.0, y: 11.0)
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13229,7 +13229,7 @@ class TerminalController {
     private func reportPullRequest(_ args: String) -> String {
         let parsed = parseOptions(args)
         guard parsed.positional.count >= 2 else {
-            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--tab=X] [--panel=Y]"
+            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed|draft] [--tab=X] [--panel=Y]"
         }
 
         let rawNumber = parsed.positional[0].trimmingCharacters(in: .whitespacesAndNewlines)
@@ -13247,12 +13247,12 @@ class TerminalController {
 
         let statusRaw = (parsed.options["state"] ?? "open").lowercased()
         guard let status = SidebarPullRequestStatus(rawValue: statusRaw) else {
-            return "ERROR: Invalid pull request state '\(statusRaw)' — use: open, merged, closed"
+            return "ERROR: Invalid pull request state '\(statusRaw)' — use: open, merged, closed, draft"
         }
 
         let labelRaw = normalizedOptionValue(parsed.options["label"]) ?? "PR"
         guard !labelRaw.isEmpty else {
-            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--tab=X] [--panel=Y]"
+            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed|draft] [--tab=X] [--panel=Y]"
         }
         let label = String(labelRaw.prefix(16))
 
@@ -13269,7 +13269,7 @@ class TerminalController {
             let surfaceId: UUID
             if let panelArg {
                 if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--tab=X] [--panel=Y]"
+                    result = "ERROR: Missing panel id — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed|draft] [--tab=X] [--panel=Y]"
                     return
                 }
                 guard let parsedId = UUID(uuidString: panelArg) else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -642,6 +642,7 @@ enum SidebarPullRequestStatus: String {
     case open
     case merged
     case closed
+    case draft
 }
 
 struct SidebarPullRequestState: Equatable {
@@ -738,8 +739,9 @@ enum SidebarBranchOrdering {
     ) -> [SidebarPullRequestState] {
         func statusPriority(_ status: SidebarPullRequestStatus) -> Int {
             switch status {
-            case .merged: return 3
-            case .open: return 2
+            case .merged: return 4
+            case .open: return 3
+            case .draft: return 2
             case .closed: return 1
             }
         }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -5526,6 +5526,81 @@ final class SidebarBranchOrderingTests: XCTestCase {
         )
     }
 
+    func testDraftLosesToOpenInDedupPriority() {
+        let first = UUID()
+        let second = UUID()
+
+        let pullRequests = SidebarBranchOrdering.orderedUniquePullRequests(
+            orderedPanelIds: [first, second],
+            panelPullRequests: [
+                first: pullRequestState(
+                    number: 50,
+                    label: "PR",
+                    url: "https://github.com/manaflow-ai/cmux/pull/50",
+                    status: .draft
+                ),
+                second: pullRequestState(
+                    number: 50,
+                    label: "PR",
+                    url: "https://github.com/manaflow-ai/cmux/pull/50",
+                    status: .open
+                )
+            ],
+            fallbackPullRequest: nil
+        )
+
+        XCTAssertEqual(pullRequests.count, 1)
+        XCTAssertEqual(pullRequests[0].status, .open)
+    }
+
+    func testDraftWinsOverClosedInDedupPriority() {
+        let first = UUID()
+        let second = UUID()
+
+        let pullRequests = SidebarBranchOrdering.orderedUniquePullRequests(
+            orderedPanelIds: [first, second],
+            panelPullRequests: [
+                first: pullRequestState(
+                    number: 60,
+                    label: "PR",
+                    url: "https://github.com/manaflow-ai/cmux/pull/60",
+                    status: .closed
+                ),
+                second: pullRequestState(
+                    number: 60,
+                    label: "PR",
+                    url: "https://github.com/manaflow-ai/cmux/pull/60",
+                    status: .draft
+                )
+            ],
+            fallbackPullRequest: nil
+        )
+
+        XCTAssertEqual(pullRequests.count, 1)
+        XCTAssertEqual(pullRequests[0].status, .draft)
+    }
+
+    func testDraftAppearsInOrderedOutput() {
+        let first = UUID()
+
+        let pullRequests = SidebarBranchOrdering.orderedUniquePullRequests(
+            orderedPanelIds: [first],
+            panelPullRequests: [
+                first: pullRequestState(
+                    number: 70,
+                    label: "PR",
+                    url: "https://github.com/manaflow-ai/cmux/pull/70",
+                    status: .draft
+                )
+            ],
+            fallbackPullRequest: nil
+        )
+
+        XCTAssertEqual(pullRequests.count, 1)
+        XCTAssertEqual(pullRequests[0].status, .draft)
+        XCTAssertEqual(pullRequests[0].number, 70)
+    }
+
     func testOrderedUniquePullRequestsUsesFallbackWhenNoPanelPullRequestsExist() {
         let fallback = pullRequestState(
             number: 11,


### PR DESCRIPTION
## Summary

- Add a dedicated `draft` status to `SidebarPullRequestStatus` so GitHub Draft PRs are distinguishable from open PRs in the sidebar
- Draft PRs display with a dashed-stroke icon and localized "draft" label (18 locales)
- Shell integration (zsh/bash) now queries `isDraft` from `gh pr view` and reports `--state=draft`
- Priority ordering: merged (4) > open (3) > draft (2) > closed (1)

## Testing

- Build with `./scripts/reload.sh --tag draft-pr` and verify draft PR branch shows "draft" label with dashed icon
- Socket command test: `report_pr 123 https://github.com/test/repo/pull/123 --state=draft`
- Backwards compatibility: `--state=open` still shows "open" as before
- 3 unit tests added for draft dedup priority and output

## Demo Video

- N/A (will add after local build verification)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated draft status for pull requests so GitHub Draft PRs are clearly distinguishable from open PRs in the sidebar. Shell integrations and CLI now detect and pass draft state end-to-end.

- **New Features**
  - Added `draft` to `SidebarPullRequestStatus` with a dashed-stroke icon and localized "draft" label (18 locales).
  - Bash/zsh integrations read `isDraft` from `gh pr view` and report `--state=draft`.
  - Updated sidebar ordering: merged > open > draft > closed.
  - `report_pr` usage now accepts `--state=draft`; added unit tests for dedup priority and output.

<sup>Written for commit fb5728155b41ffa84561ea2248e942be19ce1903. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added draft status support for pull requests with multilingual localization (16 languages).
  - Pull request draft status now displays in the UI with a dedicated icon.
  - Shell integration updated to recognize and handle draft pull request status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->