### PR TITLE
Add color field to sidebar_state output

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13626,6 +13626,7 @@ class TerminalController {
 
             var lines: [String] = []
             lines.append("tab=\(tab.id.uuidString)")
+            lines.append("color=\(tab.customColor ?? "none")")
             lines.append("cwd=\(tab.currentDirectory)")
 
             if let focused = tab.focusedPanelId,


### PR DESCRIPTION
## Summary

- What changed?

Expose workspace customColor in sidebar_state so external tools can read it without a new API endpoint.

- Why?

I'm integrating cmux with Elgato Stream Deck https://github.com/gonzaloserrano/streamdeck-cmux and I'd like to reflect workspace colors in the deck button's background color.

## Testing

- How did you test this change?

I did not.

- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose each tab’s workspace custom color in `sidebar_state` as `color=<value>` so external tools can read it without a new API. When unset, the value is `none`.

<sup>Written for commit 3a3a2da6dbe609b3f6761859c73730aa109f17be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

