### PR TITLE
Add tmux shim for native agent teams support

### DIFF
--- a/Resources/bin/tmux
+++ b/Resources/bin/tmux
@@ -181,18 +181,31 @@ list-panes)
     panes=$(cmux_cmd --json list-panes 2>/dev/null || echo "")
 
     if [[ -n "$format" ]]; then
-        # Pass format via env var to avoid code injection through triple-quotes
-        TMUX_SHIM_FORMAT="$format" echo "$panes" | python3 -c "
+        # Pass format and pane map via env vars to avoid code injection
+        TMUX_SHIM_FORMAT="$format" TMUX_SHIM_PANE_MAP="$PANE_MAP" echo "$panes" | python3 -c "
 import sys, json, os
 fmt = os.environ.get('TMUX_SHIM_FORMAT', '')
+pane_map_path = os.environ.get('TMUX_SHIM_PANE_MAP', '')
 try:
     data = json.load(sys.stdin)
 except (json.JSONDecodeError, ValueError):
     sys.exit(0)
+# Build reverse map: cmux surface ref -> tmux pane ID
+rev = {}
+if pane_map_path:
+    try:
+        for line in open(pane_map_path):
+            line = line.strip()
+            if '=' in line:
+                tid, sref = line.split('=', 1)
+                rev[sref] = tid
+    except FileNotFoundError:
+        pass
 panes = data if isinstance(data, list) else []
 for i, p in enumerate(panes):
     line = fmt
-    pane_id = '%' + str(i)
+    sref = p.get('surface_ref', p.get('id', ''))
+    pane_id = rev.get(sref, '%' + str(i))
     line = line.replace('#{pane_id}', pane_id)
     line = line.replace('#{pane_index}', str(i))
     line = line.replace('#{pane_width}', str(p.get('width', 80)))

--- a/Resources/bin/tmux
+++ b/Resources/bin/tmux
@@ -15,6 +15,12 @@
 
 set -euo pipefail
 
+# python3 is required for JSON parsing (split-window, list-panes, new-window).
+if ! command -v python3 &>/dev/null; then
+    echo "cmux tmux shim: python3 is required but not found on PATH" >&2
+    exit 1
+fi
+
 # ── Helpers ──────────────────────────────────────────────────────────
 
 CMUX_CLI="${CMUX_CLI:-cmux}"
@@ -71,7 +77,6 @@ split-window)
     direction="right"
     cwd=""
     shell_cmd=""
-    pane_format=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -79,7 +84,7 @@ split-window)
             -v) direction="down"; shift ;;
             -c) cwd="$2"; shift 2 ;;
             -P) shift ;;  # print pane info (we always do)
-            -F) pane_format="$2"; shift 2 ;;  # format string
+            -F) shift 2 ;;  # format string (ignored, always print pane ID)
             -d) shift ;;  # don't switch focus (we handle via cmux)
             -l) shift 2 ;;  # size (ignore for now)
             -p) shift 2 ;;  # percentage (ignore for now)
@@ -181,8 +186,9 @@ list-panes)
     panes=$(cmux_cmd --json list-panes 2>/dev/null || echo "")
 
     if [[ -n "$format" ]]; then
-        # Pass format and pane map via env vars to avoid code injection
-        TMUX_SHIM_FORMAT="$format" TMUX_SHIM_PANE_MAP="$PANE_MAP" echo "$panes" | python3 -c "
+        # Pass format and pane map via env vars to avoid code injection.
+        # Env vars must prefix the python3 command (not echo) so python sees them.
+        echo "$panes" | TMUX_SHIM_FORMAT="$format" TMUX_SHIM_PANE_MAP="$PANE_MAP" python3 -c "
 import sys, json, os
 fmt = os.environ.get('TMUX_SHIM_FORMAT', '')
 pane_map_path = os.environ.get('TMUX_SHIM_PANE_MAP', '')
@@ -266,13 +272,13 @@ display-message)
     done
 
     if [[ "$print_mode" == true ]]; then
-        case "$message" in
-            *pane_id*)      echo "%${CMUX_SURFACE_ID:-0}" ;;
-            *session_name*) echo "cmux" ;;
-            *window_index*) echo "0" ;;
-            *pane_index*)   echo "0" ;;
-            *)              echo "$message" ;;
-        esac
+        # Substitute tmux format tokens so combined formats work
+        result="$message"
+        result="${result//\#\{pane_id\}/%${CMUX_SURFACE_ID:-0}}"
+        result="${result//\#\{session_name\}/cmux}"
+        result="${result//\#\{window_index\}/0}"
+        result="${result//\#\{pane_index\}/0}"
+        echo "$result"
     else
         cmux_cmd display-message "$message" 2>/dev/null || echo "$message"
     fi
@@ -280,12 +286,12 @@ display-message)
 
 # ── resize-pane ──────────────────────────────────────────────────────
 resize-pane)
-    target="" direction="-R" amount="5"
+    target="" direction="-R" amount="5" absolute=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -t) target="$2"; shift 2 ;;
-            -x) shift 2 ;;  # absolute width (not directly supported)
-            -y) shift 2 ;;  # absolute height (not directly supported)
+            -x) absolute=true; shift 2 ;;  # absolute width (not supported)
+            -y) absolute=true; shift 2 ;;  # absolute height (not supported)
             -L) direction="-L"; shift ;;
             -R) direction="-R"; shift ;;
             -U) direction="-U"; shift ;;
@@ -295,7 +301,9 @@ resize-pane)
         esac
     done
 
-    if [[ -n "$target" ]]; then
+    if [[ "$absolute" == true ]]; then
+        echo "cmux tmux shim: resize-pane -x/-y (absolute sizing) not supported" >&2
+    elif [[ -n "$target" ]]; then
         surface=$(resolve_pane "$target")
         cmux_cmd resize-pane --pane "$surface" "$direction" --amount "$amount" 2>/dev/null
     fi
@@ -303,7 +311,7 @@ resize-pane)
 
 # ── capture-pane ─────────────────────────────────────────────────────
 capture-pane)
-    target="" print_mode=false scrollback=false
+    target="" print_mode=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -t) target="$2"; shift 2 ;;
@@ -326,12 +334,12 @@ capture-pane)
 
 # ── new-window ───────────────────────────────────────────────────────
 new-window)
-    cwd="" shell_cmd="" pane_format=""
+    cwd="" shell_cmd=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -c) cwd="$2"; shift 2 ;;
             -P) shift ;;
-            -F) pane_format="$2"; shift 2 ;;
+            -F) shift 2 ;;  # format string (ignored)
             -n) shift 2 ;;  # window name
             -t) shift 2 ;;  # target
             -d) shift ;;    # don't switch

--- a/Resources/bin/tmux
+++ b/Resources/bin/tmux
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# cmux tmux shim — translates tmux commands to cmux equivalents.
+#
+# Claude Code agent teams detect tmux via the TMUX env var, then call:
+#   tmux split-window -h [-c <dir>] [<command>]
+#   tmux send-keys -t <pane> "text" [Enter]
+#   tmux list-panes [-F <format>]
+#   tmux kill-pane -t <pane>
+#   tmux select-pane -t <pane>
+#   tmux display-message -p <format>
+#   tmux resize-pane -t <pane> -x <w> -y <h>
+#
+# This shim maps those to cmux CLI commands so that agent teams
+# natively spawn in cmux splits without knowing they're not in tmux.
+
+set -euo pipefail
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+CMUX_CLI="${CMUX_CLI:-cmux}"
+SOCKET="${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+
+# Pane target mapping file — maps tmux %N pane IDs to cmux surface refs.
+PANE_MAP_DIR="${TMPDIR:-/tmp}/cmux-tmux-shim-$$"
+PANE_MAP="${CMUX_TMUX_PANE_MAP:-${TMPDIR:-/tmp}/cmux-tmux-pane-map}"
+
+cmux_cmd() {
+    "$CMUX_CLI" --socket "$SOCKET" "$@"
+}
+
+# Map a tmux pane target (%N or numeric) to a cmux surface ref.
+# Falls back to the target as-is if no mapping exists.
+resolve_pane() {
+    local target="$1"
+    if [[ -f "$PANE_MAP" ]] && grep -q "^${target}=" "$PANE_MAP" 2>/dev/null; then
+        grep "^${target}=" "$PANE_MAP" | tail -1 | cut -d= -f2
+    else
+        echo "$target"
+    fi
+}
+
+# Store a mapping from tmux pane ID to cmux surface ref.
+store_pane() {
+    local tmux_id="$1" cmux_ref="$2"
+    # Atomic append
+    echo "${tmux_id}=${cmux_ref}" >> "$PANE_MAP"
+}
+
+# Allocate a tmux-style %N pane ID.
+next_pane_id() {
+    local counter_file="${PANE_MAP}.counter"
+    local n=0
+    if [[ -f "$counter_file" ]]; then
+        n=$(cat "$counter_file" 2>/dev/null || echo 0)
+    fi
+    n=$((n + 1))
+    echo "$n" > "$counter_file"
+    echo "%${n}"
+}
+
+# ── Command dispatch ─────────────────────────────────────────────────
+
+command="${1:-}"
+shift 2>/dev/null || true
+
+case "$command" in
+
+# ── split-window ─────────────────────────────────────────────────────
+split-window)
+    direction="right"
+    cwd=""
+    shell_cmd=""
+    pane_format=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h) direction="right"; shift ;;
+            -v) direction="down"; shift ;;
+            -c) cwd="$2"; shift 2 ;;
+            -P) shift ;;  # print pane info (we always do)
+            -F) pane_format="$2"; shift 2 ;;  # format string
+            -d) shift ;;  # don't switch focus (we handle via cmux)
+            -l) shift 2 ;;  # size (ignore for now)
+            -p) shift 2 ;;  # percentage (ignore for now)
+            -t) shift 2 ;;  # target pane (ignore, split from current)
+            -*) shift ;;
+            *)  shell_cmd="$1"; shift ;;
+        esac
+    done
+
+    # Create split (suppress cmux's own OK line by using --json)
+    result=$(cmux_cmd --json new-split "$direction" 2>&1)
+    surface_ref=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin).get('surface_ref',''))" 2>/dev/null || echo "")
+
+    if [[ -z "$surface_ref" ]]; then
+        echo "Error: failed to create split" >&2
+        exit 1
+    fi
+
+    # Allocate a tmux-style pane ID and store mapping
+    tmux_id=$(next_pane_id)
+    store_pane "$tmux_id" "$surface_ref"
+
+    # If a directory was specified, cd into it
+    if [[ -n "$cwd" ]]; then
+        sleep 0.3
+        cmux_cmd send --surface "$surface_ref" "cd $(printf '%q' "$cwd")\n" >/dev/null 2>&1
+        sleep 0.2
+    fi
+
+    # If a command was specified, send it
+    if [[ -n "$shell_cmd" ]]; then
+        sleep 0.3
+        cmux_cmd send --surface "$surface_ref" "${shell_cmd}\n" >/dev/null 2>&1
+    fi
+
+    # Print pane identifier (Claude Code expects this)
+    echo "$tmux_id"
+    ;;
+
+# ── send-keys ────────────────────────────────────────────────────────
+send-keys)
+    target=""
+    literal=false
+    keys=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -t) target="$2"; shift 2 ;;
+            -l) literal=true; shift ;;
+            *) keys+=("$1"); shift ;;
+        esac
+    done
+
+    if [[ -z "$target" ]]; then
+        echo "Error: send-keys requires -t target" >&2
+        exit 1
+    fi
+
+    surface=$(resolve_pane "$target")
+
+    # Build the text to send
+    text=""
+    for key in "${keys[@]}"; do
+        case "$key" in
+            Enter|enter)    text+=$'\n' ;;
+            Space|space)    text+=" " ;;
+            Tab|tab)        text+=$'\t' ;;
+            Escape|escape)  text+=$'\x1b' ;;
+            BSpace|bspace)  text+=$'\x7f' ;;
+            C-c)            cmux_cmd send-key --surface "$surface" ctrl-c >/dev/null 2>&1; continue ;;
+            C-d)            cmux_cmd send-key --surface "$surface" ctrl-d >/dev/null 2>&1; continue ;;
+            C-z)            cmux_cmd send-key --surface "$surface" ctrl-z >/dev/null 2>&1; continue ;;
+            C-l)            cmux_cmd send-key --surface "$surface" ctrl-l >/dev/null 2>&1; continue ;;
+            *)              text+="$key" ;;
+        esac
+    done
+
+    if [[ -n "$text" ]]; then
+        cmux_cmd send --surface "$surface" "$text" >/dev/null 2>&1
+    fi
+    ;;
+
+# ── list-panes ───────────────────────────────────────────────────────
+list-panes)
+    format=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -F) format="$2"; shift 2 ;;
+            -t) shift 2 ;;  # target window (ignore)
+            *) shift ;;
+        esac
+    done
+
+    # Get cmux panes and format as tmux-style output
+    panes=$(cmux_cmd --json list-panes 2>/dev/null || echo "")
+
+    if [[ -n "$format" ]]; then
+        # Parse format string and fill with cmux data
+        # Common format: #{pane_id}:#{pane_width}x#{pane_height}
+        echo "$panes" | python3 -c "
+import sys, json
+fmt = '''$format'''
+try:
+    data = json.load(sys.stdin)
+except:
+    sys.exit(0)
+# Output basic pane info
+panes = data if isinstance(data, list) else []
+for i, p in enumerate(panes):
+    line = fmt
+    pane_id = '%' + str(i)
+    line = line.replace('#{pane_id}', pane_id)
+    line = line.replace('#{pane_index}', str(i))
+    line = line.replace('#{pane_width}', str(p.get('width', 80)))
+    line = line.replace('#{pane_height}', str(p.get('height', 24)))
+    line = line.replace('#{pane_active}', '1' if p.get('focused', False) else '0')
+    line = line.replace('#{pane_current_command}', p.get('command', 'bash'))
+    line = line.replace('#{pane_pid}', str(p.get('pid', 0)))
+    print(line)
+" 2>/dev/null
+    else
+        cmux_cmd list-panes 2>/dev/null
+    fi
+    ;;
+
+# ── kill-pane ────────────────────────────────────────────────────────
+kill-pane)
+    target=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -t) target="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+
+    if [[ -n "$target" ]]; then
+        surface=$(resolve_pane "$target")
+        cmux_cmd close-surface --surface "$surface" >/dev/null 2>&1
+    fi
+    ;;
+
+# ── select-pane ──────────────────────────────────────────────────────
+select-pane)
+    target=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -t) target="$2"; shift 2 ;;
+            -U|-D|-L|-R) shift ;;  # direction (ignore for now)
+            *) shift ;;
+        esac
+    done
+
+    if [[ -n "$target" ]]; then
+        surface=$(resolve_pane "$target")
+        cmux_cmd focus-panel --panel "$surface" >/dev/null 2>&1
+    fi
+    ;;
+
+# ── display-message ──────────────────────────────────────────────────
+display-message)
+    print_mode=false
+    message=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -p) print_mode=true; shift ;;
+            -t) shift 2 ;;
+            *)  message="$1"; shift ;;
+        esac
+    done
+
+    if [[ "$print_mode" == true ]]; then
+        # Claude Code uses display-message -p to query session info
+        case "$message" in
+            *pane_id*)  echo "%0" ;;
+            *session_name*) echo "cmux" ;;
+            *window_index*) echo "0" ;;
+            *pane_index*)   echo "0" ;;
+            *)              echo "$message" ;;
+        esac
+    else
+        cmux_cmd display-message "$message" 2>/dev/null || echo "$message"
+    fi
+    ;;
+
+# ── resize-pane ──────────────────────────────────────────────────────
+resize-pane)
+    target="" direction="-R" amount="5"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -t) target="$2"; shift 2 ;;
+            -x) shift 2 ;;  # absolute width (not directly supported)
+            -y) shift 2 ;;  # absolute height (not directly supported)
+            -L) direction="-L"; shift ;;
+            -R) direction="-R"; shift ;;
+            -U) direction="-U"; shift ;;
+            -D) direction="-D"; shift ;;
+            [0-9]*) amount="$1"; shift ;;
+            *) shift ;;
+        esac
+    done
+
+    if [[ -n "$target" ]]; then
+        surface=$(resolve_pane "$target")
+        cmux_cmd resize-pane --pane "$surface" "$direction" --amount "$amount" 2>/dev/null
+    fi
+    ;;
+
+# ── capture-pane ─────────────────────────────────────────────────────
+capture-pane)
+    target="" print_mode=false scrollback=false
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -t) target="$2"; shift 2 ;;
+            -p) print_mode=true; shift ;;
+            -S) shift 2 ;;  # start line
+            -E) shift 2 ;;  # end line
+            -J) shift ;;    # join lines
+            *) shift ;;
+        esac
+    done
+
+    args=()
+    if [[ -n "$target" ]]; then
+        surface=$(resolve_pane "$target")
+        args+=(--surface "$surface")
+    fi
+
+    cmux_cmd capture-pane "${args[@]}" 2>/dev/null
+    ;;
+
+# ── new-window ───────────────────────────────────────────────────────
+new-window)
+    cwd="" shell_cmd="" pane_format=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -c) cwd="$2"; shift 2 ;;
+            -P) shift ;;
+            -F) pane_format="$2"; shift 2 ;;
+            -n) shift 2 ;;  # window name
+            -t) shift 2 ;;  # target
+            -d) shift ;;    # don't switch
+            -*) shift ;;
+            *)  shell_cmd="$1"; shift ;;
+        esac
+    done
+
+    result=$(cmux_cmd --json new-workspace 2>/dev/null)
+    # After creating workspace, get the new surface
+    sleep 0.3
+
+    if [[ -n "$cwd" ]]; then
+        cmux_cmd send "cd $(printf '%q' "$cwd")"$'\n' 2>/dev/null
+        sleep 0.2
+    fi
+    if [[ -n "$shell_cmd" ]]; then
+        cmux_cmd send "${shell_cmd}"$'\n' 2>/dev/null
+    fi
+
+    tmux_id=$(next_pane_id)
+    echo "$tmux_id"
+    ;;
+
+# ── kill-session / kill-server ───────────────────────────────────────
+kill-session|kill-server)
+    # No-op for safety — don't kill the cmux app
+    ;;
+
+# ── has-session ──────────────────────────────────────────────────────
+has-session)
+    # Always succeed — cmux is running if we got here
+    exit 0
+    ;;
+
+# ── list-sessions ────────────────────────────────────────────────────
+list-sessions|ls)
+    echo "cmux: 1 windows (created $(date))"
+    ;;
+
+# ── set-option / set ─────────────────────────────────────────────────
+set-option|set)
+    # Silently accept — tmux options don't apply
+    ;;
+
+# ── Passthrough to cmux tmux-compat layer ────────────────────────────
+wait-for|swap-pane|break-pane|join-pane|pipe-pane|respawn-pane|\
+set-buffer|paste-buffer|list-buffers|set-hook|rename-window|\
+last-pane|last-window|next-window|previous-window|find-window|clear-history)
+    cmux_cmd "$command" "$@" 2>/dev/null
+    ;;
+
+# ── Unsupported ──────────────────────────────────────────────────────
+*)
+    echo "cmux tmux shim: unsupported command '$command'" >&2
+    exit 0  # Don't fail — some callers probe for features
+    ;;
+
+esac

--- a/Resources/bin/tmux
+++ b/Resources/bin/tmux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cmux tmux shim — translates tmux commands to cmux equivalents.
 #
-# Claude Code agent teams detect tmux via the TMUX env var, then call:
+# AI coding agent teams detect tmux via the TMUX env var, then call:
 #   tmux split-window -h [-c <dir>] [<command>]
 #   tmux send-keys -t <pane> "text" [Enter]
 #   tmux list-panes [-F <format>]
@@ -21,7 +21,6 @@ CMUX_CLI="${CMUX_CLI:-cmux}"
 SOCKET="${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
 
 # Pane target mapping file — maps tmux %N pane IDs to cmux surface refs.
-PANE_MAP_DIR="${TMPDIR:-/tmp}/cmux-tmux-shim-$$"
 PANE_MAP="${CMUX_TMUX_PANE_MAP:-${TMPDIR:-/tmp}/cmux-tmux-pane-map}"
 
 cmux_cmd() {
@@ -32,8 +31,8 @@ cmux_cmd() {
 # Falls back to the target as-is if no mapping exists.
 resolve_pane() {
     local target="$1"
-    if [[ -f "$PANE_MAP" ]] && grep -q "^${target}=" "$PANE_MAP" 2>/dev/null; then
-        grep "^${target}=" "$PANE_MAP" | tail -1 | cut -d= -f2
+    if [[ -f "$PANE_MAP" ]] && grep -Fq "${target}=" "$PANE_MAP" 2>/dev/null; then
+        grep -F "${target}=" "$PANE_MAP" | tail -1 | cut -d= -f2
     else
         echo "$target"
     fi
@@ -42,19 +41,21 @@ resolve_pane() {
 # Store a mapping from tmux pane ID to cmux surface ref.
 store_pane() {
     local tmux_id="$1" cmux_ref="$2"
-    # Atomic append
     echo "${tmux_id}=${cmux_ref}" >> "$PANE_MAP"
 }
 
-# Allocate a tmux-style %N pane ID.
+# Allocate a tmux-style %N pane ID (atomic via flock).
 next_pane_id() {
     local counter_file="${PANE_MAP}.counter"
-    local n=0
-    if [[ -f "$counter_file" ]]; then
+    local lock_file="${PANE_MAP}.lock"
+    local n
+    n=$(
+        flock -x 200
         n=$(cat "$counter_file" 2>/dev/null || echo 0)
-    fi
-    n=$((n + 1))
-    echo "$n" > "$counter_file"
+        n=$((n + 1))
+        echo "$n" > "$counter_file"
+        echo "$n"
+    ) 200>"$lock_file"
     echo "%${n}"
 }
 
@@ -114,7 +115,7 @@ split-window)
         cmux_cmd send --surface "$surface_ref" "${shell_cmd}\n" >/dev/null 2>&1
     fi
 
-    # Print pane identifier (Claude Code expects this)
+    # Print pane identifier (agents expect this)
     echo "$tmux_id"
     ;;
 
@@ -142,6 +143,10 @@ send-keys)
     # Build the text to send
     text=""
     for key in "${keys[@]}"; do
+        if [[ "$literal" == true ]]; then
+            text+="$key"
+            continue
+        fi
         case "$key" in
             Enter|enter)    text+=$'\n' ;;
             Space|space)    text+=" " ;;
@@ -176,16 +181,14 @@ list-panes)
     panes=$(cmux_cmd --json list-panes 2>/dev/null || echo "")
 
     if [[ -n "$format" ]]; then
-        # Parse format string and fill with cmux data
-        # Common format: #{pane_id}:#{pane_width}x#{pane_height}
-        echo "$panes" | python3 -c "
-import sys, json
-fmt = '''$format'''
+        # Pass format via env var to avoid code injection through triple-quotes
+        TMUX_SHIM_FORMAT="$format" echo "$panes" | python3 -c "
+import sys, json, os
+fmt = os.environ.get('TMUX_SHIM_FORMAT', '')
 try:
     data = json.load(sys.stdin)
-except:
+except (json.JSONDecodeError, ValueError):
     sys.exit(0)
-# Output basic pane info
 panes = data if isinstance(data, list) else []
 for i, p in enumerate(panes):
     line = fmt
@@ -250,9 +253,8 @@ display-message)
     done
 
     if [[ "$print_mode" == true ]]; then
-        # Claude Code uses display-message -p to query session info
         case "$message" in
-            *pane_id*)  echo "%0" ;;
+            *pane_id*)      echo "%${CMUX_SURFACE_ID:-0}" ;;
             *session_name*) echo "cmux" ;;
             *window_index*) echo "0" ;;
             *pane_index*)   echo "0" ;;
@@ -325,19 +327,22 @@ new-window)
         esac
     done
 
-    result=$(cmux_cmd --json new-workspace 2>/dev/null)
-    # After creating workspace, get the new surface
+    result=$(cmux_cmd --json new-workspace 2>&1)
+    surface_ref=$(echo "$result" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r.get('surface_ref','') or r.get('workspace_id',''))" 2>/dev/null || echo "")
     sleep 0.3
 
-    if [[ -n "$cwd" ]]; then
-        cmux_cmd send "cd $(printf '%q' "$cwd")"$'\n' 2>/dev/null
+    if [[ -n "$cwd" && -n "$surface_ref" ]]; then
+        cmux_cmd send --surface "$surface_ref" "cd $(printf '%q' "$cwd")\n" >/dev/null 2>&1
         sleep 0.2
     fi
-    if [[ -n "$shell_cmd" ]]; then
-        cmux_cmd send "${shell_cmd}"$'\n' 2>/dev/null
+    if [[ -n "$shell_cmd" && -n "$surface_ref" ]]; then
+        cmux_cmd send --surface "$surface_ref" "${shell_cmd}\n" >/dev/null 2>&1
     fi
 
     tmux_id=$(next_pane_id)
+    if [[ -n "$surface_ref" ]]; then
+        store_pane "$tmux_id" "$surface_ref"
+    fi
     echo "$tmux_id"
     ;;
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2390,7 +2390,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Backward-compatible shell integration keys used by existing scripts/tests.
         env["CMUX_PANEL_ID"] = id.uuidString
         env["CMUX_TAB_ID"] = tabId.uuidString
-        env["CMUX_SOCKET_PATH"] = SocketControlSettings.socketPath()
+        let socketPath = SocketControlSettings.socketPath()
+        env["CMUX_SOCKET_PATH"] = socketPath
+
+        // Expose TMUX env var so tools that detect tmux (e.g. Claude Code agent
+        // teams split-pane mode) route through the cmux tmux shim at Resources/bin/tmux.
+        // Format mirrors real tmux: <socket-path>,<pid>,<window-index>
+        env["TMUX"] = "\(socketPath),\(ProcessInfo.processInfo.processIdentifier),0"
         if let bundleId = Bundle.main.bundleIdentifier, !bundleId.isEmpty {
             env["CMUX_BUNDLE_ID"] = bundleId
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2393,10 +2393,6 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let socketPath = SocketControlSettings.socketPath()
         env["CMUX_SOCKET_PATH"] = socketPath
 
-        // Expose TMUX env var so tools that detect tmux (e.g. Claude Code agent
-        // teams split-pane mode) route through the cmux tmux shim at Resources/bin/tmux.
-        // Format mirrors real tmux: <socket-path>,<pid>,<window-index>
-        env["TMUX"] = "\(socketPath),\(ProcessInfo.processInfo.processIdentifier),0"
         if let bundleId = Bundle.main.bundleIdentifier, !bundleId.isEmpty {
             env["CMUX_BUNDLE_ID"] = bundleId
         }
@@ -2412,17 +2408,6 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let claudeHooksEnabled = ClaudeCodeIntegrationSettings.hooksEnabled()
         if !claudeHooksEnabled {
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
-        }
-
-        if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
-            let currentPath = env["PATH"]
-                ?? getenv("PATH").map { String(cString: $0) }
-                ?? ProcessInfo.processInfo.environment["PATH"]
-                ?? ""
-            if !currentPath.split(separator: ":").contains(Substring(cliBinPath)) {
-                let separator = currentPath.isEmpty ? "" : ":"
-                env["PATH"] = "\(cliBinPath)\(separator)\(currentPath)"
-            }
         }
 
         // Shell integration: inject ZDOTDIR wrapper for zsh shells.
@@ -2464,6 +2449,28 @@ final class TerminalSurface: Identifiable, ObservableObject {
         if !additionalEnvironment.isEmpty {
             for (key, value) in additionalEnvironment where !key.isEmpty && !value.isEmpty {
                 env[key] = value
+            }
+        }
+
+        // Set TMUX and PATH after additionalEnvironment merge so they cannot
+        // be accidentally overridden by caller-supplied environment variables.
+
+        // Expose TMUX env var so tools that detect tmux (e.g. AI coding agent
+        // teams split-pane mode) route through the cmux tmux shim at Resources/bin/tmux.
+        // Format mirrors real tmux: <socket-path>,<pid>,<session>
+        // Use surface UUID suffix to give each surface a unique TMUX value.
+        let surfaceIdShort = String(id.uuidString.prefix(8))
+        env["TMUX"] = "\(socketPath),\(ProcessInfo.processInfo.processIdentifier),\(surfaceIdShort)"
+
+        // Prepend Resources/bin to PATH so the tmux shim is found first.
+        if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+            let currentPath = env["PATH"]
+                ?? getenv("PATH").map { String(cString: $0) }
+                ?? ProcessInfo.processInfo.environment["PATH"]
+                ?? ""
+            if !currentPath.split(separator: ":").contains(Substring(cliBinPath)) {
+                let separator = currentPath.isEmpty ? "" : ":"
+                env["PATH"] = "\(cliBinPath)\(separator)\(currentPath)"
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds a `tmux` shim at `Resources/bin/tmux` that translates tmux commands to cmux equivalents, enabling AI coding agent teams to natively spawn teammates in cmux splits
- Exports `TMUX` env var in every cmux shell (`GhosttyTerminalView.swift`) so tools that detect tmux route through the shim

## How it works

AI coding agents with team/multi-agent features detect tmux via the `TMUX` env var, then call:
1. `tmux split-window -h` → shim runs `cmux new-split right`
2. `tmux send-keys -t %N "command" Enter` → shim runs `cmux send --surface surface:N "..."`
3. `tmux capture-pane -t %N -p` → shim runs `cmux capture-pane --surface surface:N`
4. `tmux kill-pane -t %N` → shim runs `cmux close-surface --surface surface:N`

The shim maintains a `%N` → `surface:N` pane ID mapping file so all commands target the correct cmux surfaces.

Since `Resources/bin/` is prepended to `PATH` in every cmux shell, the shim intercepts `tmux` calls before the real tmux binary (if installed).

### Supported tmux commands

| tmux command | cmux equivalent |
|---|---|
| `split-window -h/-v` | `new-split right/down` |
| `send-keys -t %N` | `send --surface surface:N` |
| `capture-pane -t %N -p` | `capture-pane --surface surface:N` |
| `kill-pane -t %N` | `close-surface --surface surface:N` |
| `select-pane -t %N` | `focus-panel --panel surface:N` |
| `resize-pane` | `resize-pane` (passthrough) |
| `has-session` | always succeeds |
| `display-message -p` | returns cmux session info |
| `list-panes -F` | `list-panes` with format translation |
| `new-window` | `new-workspace` |
| + 12 more | passthrough to cmux tmux-compat layer |

## Test plan

- [x] `split-window` → creates visible cmux split, returns clean `%N` pane ID
- [x] `send-keys` → sends text and Enter to correct surface, no stdout noise
- [x] `capture-pane` → reads terminal content from target surface
- [x] `kill-pane` → closes the correct surface cleanly
- [x] `has-session` / `list-sessions` / `display-message` → return expected values
- [x] Full agent teams spawn pattern: split → cd → send command → capture output → cleanup
- [ ] Needs end-to-end testing with actual agent team spawning after rebuild

Resolves #1080

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tmux` shim and sets a per-surface `TMUX` env var so tmux-aware tools can split, send keys, and capture panes natively in `cmux`. Resolves #1080.

- **New Features**
  - `Resources/bin/tmux`: translates core `tmux` commands to `cmux` (`split-window`, `send-keys`, `capture-pane`, `kill-pane`, `select-pane`, `list-panes`, `display-message`, `resize-pane`, `new-window`; others passthrough/no-op).
  - Per-surface `TMUX=<socket>,<pid>,<surface>` and `PATH` prepended with `Resources/bin/` in `GhosttyTerminalView.swift` (set after env merge to ensure the shim is used and not overridden).

- **Bug Fixes**
  - `list-panes -F`: returns real `%N` via reverse map; prevents format injection by passing the format via env; fixes env scoping by prefixing env vars to `python3`.
  - Reliability/correctness: atomic `%N` allocation with `flock`; honors `send-keys -l`; `new-window` stores pane map; `display-message -p` uses `CMUX_SURFACE_ID` with token replacement so combined formats work.
  - Safety: `grep -F` for literal matching; warns and skips unsupported `resize-pane -x/-y` absolute sizing.
  - Startup: checks for `python3` and exits with a clear message if missing.

<sup>Written for commit fae9d600f6f999fe81393e7baadcaab06e2c2b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a tmux compatibility shim so standard tmux commands and tools work with the multiplexing backend.
  * Provides pane/window/session management, prints created pane/window IDs, and maintains mappings to underlying surfaces.
  * Gracefully handles unsupported commands to preserve workflows.

* **Environment**
  * Sets TMUX metadata and ensures the shim is prepended to PATH after merging caller-provided environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->