### PR TITLE
Fix focused OSC 777 notifications

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1468,7 +1468,8 @@ class GhosttyApp {
                         surfaceId: surfaceId,
                         title: command,
                         subtitle: "",
-                        body: body
+                        body: body,
+                        source: .terminalEscapeSequence
                     )
                     return true
                 }
@@ -1712,8 +1713,8 @@ class GhosttyApp {
             }
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            guard let tabId = surfaceView.tabId else { return true }
-            let surfaceId = surfaceView.terminalSurface?.id
+            guard let tabId = callbackTabId ?? surfaceView.tabId else { return true }
+            let surfaceId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
             let actionTitle = action.action.desktop_notification.title
                 .flatMap { String(cString: $0) } ?? ""
             let actionBody = action.action.desktop_notification.body
@@ -1727,7 +1728,8 @@ class GhosttyApp {
                     surfaceId: surfaceId,
                     title: command,
                     subtitle: "",
-                    body: body
+                    body: body,
+                    source: .terminalEscapeSequence
                 )
             }
             return true

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -615,6 +615,11 @@ struct TerminalNotification: Identifiable, Hashable {
     var isRead: Bool
 }
 
+enum TerminalNotificationSource {
+    case app
+    case terminalEscapeSequence
+}
+
 @MainActor
 final class TerminalNotificationStore: ObservableObject {
     private struct TabSurfaceKey: Hashable {
@@ -819,7 +824,14 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.latestUnreadByTabId[tabId] ?? indexes.latestByTabId[tabId]
     }
 
-    func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
+    func addNotification(
+        tabId: UUID,
+        surfaceId: UUID?,
+        title: String,
+        subtitle: String,
+        body: String,
+        source: TerminalNotificationSource = .app
+    ) {
         var updated = notifications
         var idsToClear: [String] = []
         updated.removeAll { existing in
@@ -833,7 +845,11 @@ final class TerminalNotificationStore: ObservableObject {
         let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId
         let isFocusedPanel = isActiveTab && isFocusedSurface
         let isAppFocused = AppFocusState.isAppFocused()
-        if isAppFocused && isFocusedPanel {
+        let isFocusedDeliveryTarget = isAppFocused && isFocusedPanel
+        // Keep explicit terminal escape notifications visible even when the
+        // user is typing in the originating pane. We store them as read so
+        // they don't create unread churn, but still allow native delivery.
+        if isFocusedDeliveryTarget && source == .app {
             if !idsToClear.isEmpty {
                 notifications = updated
                 center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -854,7 +870,7 @@ final class TerminalNotificationStore: ObservableObject {
             subtitle: subtitle,
             body: body,
             createdAt: Date(),
-            isRead: false
+            isRead: isFocusedDeliveryTarget
         )
         updated.insert(notification, at: 0)
         notifications = updated

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -215,6 +215,33 @@ def test_rxvt_notification_osc777(client: cmux) -> TestResult:
     return result
 
 
+def test_rxvt_notification_osc777_when_focused(client: cmux) -> TestResult:
+    result = TestResult("RXVT OSC 777 Focused Terminal")
+    try:
+        client.clear_notifications()
+        client.set_app_focus(True)
+        # Avoid Ghostty's 1s desktop notification rate limit.
+        time.sleep(1.1)
+        surface = focused_surface_index(client)
+        command = "printf '\\x1b]777;notify;Focused Title;Focused Body\\x07'"
+        client.send_surface(surface, command + "\\n")
+        items = wait_for_notifications(client, 1)
+        if len(items) != 1:
+            result.failure(f"Expected 1 notification, got {len(items)}")
+        elif items[0]["title"] != "Focused Title" or items[0]["body"] != "Focused Body":
+            result.failure(
+                f"Expected title/body 'Focused Title'/'Focused Body', got "
+                f"'{items[0]['title']}'/'{items[0]['body']}'"
+            )
+        elif not items[0]["is_read"]:
+            result.failure("Expected focused OSC 777 notification to be stored as read")
+        else:
+            result.success("Focused OSC 777 notification preserved")
+    except Exception as e:
+        result.failure(f"Exception: {e}")
+    return result
+
+
 def test_mark_read_on_focus_change(client: cmux) -> TestResult:
     result = TestResult("Mark Read On Panel Focus")
     try:
@@ -455,6 +482,7 @@ def run_tests() -> int:
         results.append(test_kitty_notification_simple(client))
         results.append(test_kitty_notification_chunked(client))
         results.append(test_rxvt_notification_osc777(client))
+        results.append(test_rxvt_notification_osc777_when_focused(client))
         results.append(test_mark_read_on_focus_change(client))
         results.append(test_mark_read_on_app_active(client))
         results.append(test_mark_read_on_tab_switch(client))

--- a/tests_v2/test_notifications.py
+++ b/tests_v2/test_notifications.py
@@ -215,6 +215,33 @@ def test_rxvt_notification_osc777(client: cmux) -> TestResult:
     return result
 
 
+def test_rxvt_notification_osc777_when_focused(client: cmux) -> TestResult:
+    result = TestResult("RXVT OSC 777 Focused Terminal")
+    try:
+        client.clear_notifications()
+        client.set_app_focus(True)
+        # Avoid Ghostty's 1s desktop notification rate limit.
+        time.sleep(1.1)
+        surface = focused_surface_index(client)
+        command = "printf '\\x1b]777;notify;Focused Title;Focused Body\\x07'"
+        client.send_surface(surface, command + "\\n")
+        items = wait_for_notifications(client, 1)
+        if len(items) != 1:
+            result.failure(f"Expected 1 notification, got {len(items)}")
+        elif items[0]["title"] != "Focused Title" or items[0]["body"] != "Focused Body":
+            result.failure(
+                f"Expected title/body 'Focused Title'/'Focused Body', got "
+                f"'{items[0]['title']}'/'{items[0]['body']}'"
+            )
+        elif not items[0]["is_read"]:
+            result.failure("Expected focused OSC 777 notification to be stored as read")
+        else:
+            result.success("Focused OSC 777 notification preserved")
+    except Exception as e:
+        result.failure(f"Exception: {e}")
+    return result
+
+
 def test_mark_read_on_focus_change(client: cmux) -> TestResult:
     result = TestResult("Mark Read On Panel Focus")
     try:
@@ -455,6 +482,7 @@ def run_tests() -> int:
         results.append(test_kitty_notification_simple(client))
         results.append(test_kitty_notification_chunked(client))
         results.append(test_rxvt_notification_osc777(client))
+        results.append(test_rxvt_notification_osc777_when_focused(client))
         results.append(test_mark_read_on_focus_change(client))
         results.append(test_mark_read_on_app_active(client))
         results.append(test_mark_read_on_tab_switch(client))


### PR DESCRIPTION
## Summary\n- add a regression test for OSC 777 notifications emitted from the focused terminal\n- preserve Ghostty terminal escape notifications even when the originating pane is focused\n- keep generic app-generated focused notifications suppressed while using callback-context IDs for the surface path\n\n## Verification\n- ./scripts/reload.sh --tag issue-1103-osc-777-notifications\n- manual socket check: inactive OSC 777 stored unread, focused OSC 777 stored read, focused app-generated notification remains suppressed\n\nCloses #1103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSC 777 notifications from the focused terminal pane so they still deliver and are stored as read. App-generated focused notifications remain suppressed. Closes #1103.

- **Bug Fixes**
  - Added `TerminalNotificationSource` and only suppress focused `.app` notifications; allow `.terminalEscapeSequence` while marking them read.
  - Used `callbackTabId`/`callbackSurfaceId` to correctly attribute notifications, and set source to `.terminalEscapeSequence`.
  - Added focused OSC 777 regression tests in both test suites.

<sup>Written for commit 76db700c5a3699b86c0cad13472a8e184c827e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification source categorization to distinguish between app-generated and terminal-originated notifications.
  * Improved notification delivery when the application window is focused—notifications are now automatically marked as read to reduce clutter.

* **Tests**
  * Added test coverage for notification behavior when the application is focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->