### PR TITLE
Fix omnibar UI test history seeding

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1043,6 +1043,9 @@ final class BrowserHistoryStore: ObservableObject {
     }
 
     nonisolated private static func defaultHistoryFileURL() -> URL? {
+        if let overrideURL = uiTestHistoryFileURLOverride() {
+            return overrideURL
+        }
         let fm = FileManager.default
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
@@ -1054,6 +1057,7 @@ final class BrowserHistoryStore: ObservableObject {
     }
 
     nonisolated private static func legacyTaggedHistoryFileURL() -> URL? {
+        guard uiTestHistoryFileURLOverride() == nil else { return nil }
         guard let bundleId = Bundle.main.bundleIdentifier else { return nil }
         let namespace = normalizedBrowserHistoryNamespace(bundleIdentifier: bundleId)
         guard namespace != bundleId else { return nil }
@@ -1063,6 +1067,18 @@ final class BrowserHistoryStore: ObservableObject {
         }
         let dir = appSupport.appendingPathComponent(bundleId, isDirectory: true)
         return dir.appendingPathComponent("browser_history.json", isDirectory: false)
+    }
+
+    nonisolated private static func uiTestHistoryFileURLOverride() -> URL? {
+        let env = ProcessInfo.processInfo.environment
+        // UI tests pass an explicit temp-file path so the runner and app don't
+        // depend on sharing the same Application Support directory.
+        guard let rawPath = env["CMUX_UI_TEST_BROWSER_HISTORY_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawPath.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: rawPath)
     }
 
     nonisolated private static func persistSnapshot(_ snapshot: [Entry], to fileURL: URL) throws {

--- a/cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
+++ b/cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
@@ -3,15 +3,18 @@ import Foundation
 
 final class BrowserOmnibarSuggestionsUITests: XCTestCase {
     private var dataPath = ""
+    private var historyPath = ""
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         dataPath = "/tmp/cmux-ui-test-omnibar-suggestions-\(UUID().uuidString).json"
         try? FileManager.default.removeItem(atPath: dataPath)
+        historyPath = "/tmp/cmux-ui-test-omnibar-history-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: historyPath)
 
         // Terminate any lingering app from a prior test so its debounced
-        // history-save doesn't overwrite the seeded browser_history.json.
+        // history-save doesn't leak state into the next isolated history file.
         let cleanup = XCUIApplication()
         cleanup.terminate()
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))
@@ -25,11 +28,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         ])
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        // Keep suggestions deterministic for the keyboard-nav assertions.
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         // Focus omnibar.
@@ -111,11 +110,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        // Keep suggestions deterministic.
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
@@ -198,10 +193,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         app.launchEnvironment["CMUX_UI_TEST_REMOTE_SUGGESTIONS_JSON"] = #"["go tutorial","go json","go fmt"]"#
         launchAndEnsureForeground(app)
 
@@ -243,10 +235,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         app.launchEnvironment["CMUX_UI_TEST_REMOTE_SUGGESTIONS_JSON"] = #"["go tutorial","go json","go fmt"]"#
         launchAndEnsureForeground(app)
 
@@ -271,10 +260,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         app.typeKey("l", modifierFlags: [.command])
@@ -332,10 +318,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
@@ -389,10 +372,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         )
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         app.typeKey("l", modifierFlags: [.command])
@@ -462,10 +442,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
 
     func testOmnibarSingleRowPopupUsesMinimumHeight() {
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         app.typeKey("l", modifierFlags: [.command])
@@ -507,10 +484,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         app.typeKey("l", modifierFlags: [.command])
@@ -544,10 +518,7 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         seedBrowserHistoryForTest()
 
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
-        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        configureLaunchEnvironment(for: app)
         launchAndEnsureForeground(app)
 
         app.typeKey("l", modifierFlags: [.command])
@@ -590,6 +561,14 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         )
     }
 
+    private func configureLaunchEnvironment(for app: XCUIApplication) {
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        app.launchEnvironment["CMUX_UI_TEST_DISABLE_REMOTE_SUGGESTIONS"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BROWSER_HISTORY_PATH"] = historyPath
+    }
+
     private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
         if app.wait(for: .runningForeground, timeout: timeout) {
             return true
@@ -609,21 +588,17 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
     }
 
     private func seedBrowserHistoryForTest(entries: [(String, String)]? = nil, seedEntries: [SeedEntry]? = nil) {
-        // Keep the test hermetic: write a deterministic history file in the app's support dir
-        // so the omnibar always has at least one local suggestion row.
+        // Keep the test hermetic: write a deterministic history file to a per-test path
+        // and launch the app against that explicit store.
         let fileManager = FileManager.default
-        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            XCTFail("Missing Application Support directory")
-            return
-        }
-
-        let bundleId = "com.cmuxterm.app.debug"
-        let dir = appSupport.appendingPathComponent(bundleId, isDirectory: true)
-        let url = dir.appendingPathComponent("browser_history.json", isDirectory: false)
+        let url = URL(fileURLWithPath: historyPath)
         do {
-            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
         } catch {
-            XCTFail("Failed to create app support dir: \(error)")
+            XCTFail("Failed to create browser history seed dir: \(error)")
             return
         }
 

--- a/cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
+++ b/cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
@@ -8,9 +8,15 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        dataPath = "/tmp/cmux-ui-test-omnibar-suggestions-\(UUID().uuidString).json"
+        // GitHub Actions' UI test runner can deny writes to hardcoded /tmp paths.
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        dataPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-omnibar-suggestions-\(UUID().uuidString).json")
+            .path
         try? FileManager.default.removeItem(atPath: dataPath)
-        historyPath = "/tmp/cmux-ui-test-omnibar-history-\(UUID().uuidString).json"
+        historyPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-omnibar-history-\(UUID().uuidString).json")
+            .path
         try? FileManager.default.removeItem(atPath: historyPath)
 
         // Terminate any lingering app from a prior test so its debounced
@@ -18,6 +24,12 @@ final class BrowserOmnibarSuggestionsUITests: XCTestCase {
         let cleanup = XCUIApplication()
         cleanup.terminate()
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: dataPath)
+        try? FileManager.default.removeItem(atPath: historyPath)
+        super.tearDown()
     }
 
     func testOmnibarSuggestionsAlignToPillAndCmdNP() {


### PR DESCRIPTION
## Summary
- route BrowserHistoryStore through a UI-test-specific history file when CMUX_UI_TEST_BROWSER_HISTORY_PATH is set
- make BrowserOmnibarSuggestionsUITests launch against a per-test temp history file instead of assuming Application Support is shared with the app under test
- keep the Gmail autocomplete test on explicit seeded history so it no longer falls back to only the search row

## Verification
- built and launched with `./scripts/reload.sh --tag issue-1108-e2e-omnibar-autocomplete`
- did not run UI tests locally per repo policy

Closes #1108

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route browser history to a per-test file during UI tests and update omnibar tests to seed and use that file. This removes cross-test state leaks and makes autocomplete behavior deterministic for #1108.

- **Bug Fixes**
  - Respect `CMUX_UI_TEST_BROWSER_HISTORY_PATH` in `BrowserHistoryStore`; skip the legacy path when set.
  - UI tests write a unique history file under `FileManager.temporaryDirectory`, seed it, and pass it via launch env (no Application Support).
  - Terminate lingering app instances in `setUp`; add `tearDown` to clean up temp files.
  - Keep the Gmail autocomplete test on explicit seeded history to avoid falling back to only the search row.

- **Refactors**
  - Consolidated app launch environment setup into `configureLaunchEnvironment` to reduce duplication across tests.

<sup>Written for commit 7095468cabf7ec06f1e1b9a3d374233a15fecf5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved browser history UI tests with per-test temporary history files, automated setup/teardown and centralized test environment configuration for more reliable, hermetic, and isolated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->