### PR TITLE
Fix OSC 777 notification delivery auth flow

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1454,24 +1454,24 @@ class GhosttyApp {
                     .flatMap { String(cString: $0) } ?? ""
                 let actionBody = action.action.desktop_notification.body
                     .flatMap { String(cString: $0) } ?? ""
-                return performOnMain {
+                DispatchQueue.main.async {
                     guard let tabManager = AppDelegate.shared?.tabManager,
                           let tabId = tabManager.selectedTabId else {
-                        return false
+                        return
                     }
                     let tabTitle = tabManager.titleForTab(tabId) ?? "Terminal"
                     let command = actionTitle.isEmpty ? tabTitle : actionTitle
                     let body = actionBody
                     let surfaceId = tabManager.focusedSurfaceId(for: tabId)
-                    TerminalNotificationStore.shared.addNotification(
+                    TerminalNotificationStore.shared.addTerminalEscapeNotification(
                         tabId: tabId,
                         surfaceId: surfaceId,
                         title: command,
                         subtitle: "",
                         body: body
                     )
-                    return true
                 }
+                return true
             }
 
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG {
@@ -1712,17 +1712,17 @@ class GhosttyApp {
             }
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            guard let tabId = surfaceView.tabId else { return true }
-            let surfaceId = surfaceView.terminalSurface?.id
+            guard let tabId = callbackTabId ?? surfaceView.tabId else { return true }
+            let surfaceId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
             let actionTitle = action.action.desktop_notification.title
                 .flatMap { String(cString: $0) } ?? ""
             let actionBody = action.action.desktop_notification.body
                 .flatMap { String(cString: $0) } ?? ""
-            performOnMain {
+            DispatchQueue.main.async {
                 let tabTitle = AppDelegate.shared?.tabManager?.titleForTab(tabId) ?? "Terminal"
                 let command = actionTitle.isEmpty ? tabTitle : actionTitle
                 let body = actionBody
-                TerminalNotificationStore.shared.addNotification(
+                TerminalNotificationStore.shared.addTerminalEscapeNotification(
                     tabId: tabId,
                     surfaceId: surfaceId,
                     title: command,

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -634,10 +634,17 @@ final class TerminalNotificationStore: ObservableObject {
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
-    private enum AuthorizationRequestOrigin: String {
+    enum AuthorizationRequestOrigin: String {
         case notificationDelivery = "notification_delivery"
         case settingsButton = "settings_button"
         case settingsTest = "settings_test"
+    }
+    enum AuthorizationDecision: Equatable {
+        case allowDelivery
+        case promptSettingsAndDeny
+        case deferRequestAndDeny
+        case requestAuthorization
+        case denySilently
     }
 
     @Published private(set) var notifications: [TerminalNotification] = [] {
@@ -1045,30 +1052,52 @@ final class TerminalNotificationStore: ObservableObject {
                 self.logAuthorization(
                     "ensure status origin=\(origin.rawValue) status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(self.authorizationState.statusLabel) appActive=\(AppFocusState.isAppActive())"
                 )
-                switch settings.authorizationStatus {
-                case .authorized, .provisional, .ephemeral:
+                switch Self.authorizationDecision(
+                    origin: origin,
+                    status: settings.authorizationStatus,
+                    isAppActive: AppFocusState.isAppActive()
+                ) {
+                case .allowDelivery:
                     completion(true)
-                case .denied:
+                case .promptSettingsAndDeny:
                     self.logAuthorization("ensure denied origin=\(origin.rawValue) prompting_settings")
                     self.promptToEnableNotifications()
                     completion(false)
-                case .notDetermined:
-                    if Self.shouldDeferAutomaticAuthorizationRequest(
-                        origin: origin,
-                        status: settings.authorizationStatus,
-                        isAppActive: AppFocusState.isAppActive()
-                    ) {
-                        self.logAuthorization("ensure deferred origin=\(origin.rawValue)")
-                        self.hasDeferredAuthorizationRequest = true
-                        completion(false)
-                    } else {
-                        self.requestAuthorizationIfNeeded(origin: origin, completion)
-                    }
-                @unknown default:
+                case .deferRequestAndDeny:
+                    self.logAuthorization("ensure deferred origin=\(origin.rawValue)")
+                    self.hasDeferredAuthorizationRequest = true
+                    completion(false)
+                case .requestAuthorization:
+                    self.requestAuthorizationIfNeeded(origin: origin, completion)
+                case .denySilently:
                     self.logAuthorization("ensure unknown status origin=\(origin.rawValue)")
                     completion(false)
                 }
             }
+        }
+    }
+
+    static func authorizationDecision(
+        origin: AuthorizationRequestOrigin,
+        status: UNAuthorizationStatus,
+        isAppActive: Bool
+    ) -> AuthorizationDecision {
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            return .allowDelivery
+        case .denied:
+            return .promptSettingsAndDeny
+        case .notDetermined:
+            if shouldDeferAutomaticAuthorizationRequest(
+                origin: origin,
+                status: status,
+                isAppActive: isAppActive
+            ) {
+                return .deferRequestAndDeny
+            }
+            return .requestAuthorization
+        @unknown default:
+            return .denySilently
         }
     }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -827,6 +827,41 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
+        addNotification(
+            tabId: tabId,
+            surfaceId: surfaceId,
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            allowFocusedDelivery: false
+        )
+    }
+
+    func addTerminalEscapeNotification(
+        tabId: UUID,
+        surfaceId: UUID?,
+        title: String,
+        subtitle: String,
+        body: String
+    ) {
+        addNotification(
+            tabId: tabId,
+            surfaceId: surfaceId,
+            title: title,
+            subtitle: subtitle,
+            body: body,
+            allowFocusedDelivery: true
+        )
+    }
+
+    private func addNotification(
+        tabId: UUID,
+        surfaceId: UUID?,
+        title: String,
+        subtitle: String,
+        body: String,
+        allowFocusedDelivery: Bool
+    ) {
         var updated = notifications
         var idsToClear: [String] = []
         updated.removeAll { existing in
@@ -840,7 +875,8 @@ final class TerminalNotificationStore: ObservableObject {
         let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId
         let isFocusedPanel = isActiveTab && isFocusedSurface
         let isAppFocused = AppFocusState.isAppFocused()
-        if isAppFocused && isFocusedPanel {
+        let isFocusedDeliveryTarget = isAppFocused && isFocusedPanel
+        if isFocusedDeliveryTarget && !allowFocusedDelivery {
             if !idsToClear.isEmpty {
                 notifications = updated
                 center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -861,7 +897,7 @@ final class TerminalNotificationStore: ObservableObject {
             subtitle: subtitle,
             body: body,
             createdAt: Date(),
-            isRead: false
+            isRead: isFocusedDeliveryTarget
         )
         updated.insert(notification, at: 0)
         notifications = updated
@@ -1070,7 +1106,16 @@ final class TerminalNotificationStore: ObservableObject {
                 case .requestAuthorization:
                     self.requestAuthorizationIfNeeded(origin: origin, completion)
                 case .denySilently:
-                    self.logAuthorization("ensure unknown status origin=\(origin.rawValue)")
+                    switch settings.authorizationStatus {
+                    case .denied:
+                        self.logAuthorization("ensure denied origin=\(origin.rawValue) skipping_prompt")
+                    case .notDetermined:
+                        self.logAuthorization("ensure notDetermined origin=\(origin.rawValue) skipping_request")
+                    case .authorized, .provisional, .ephemeral:
+                        self.logAuthorization("ensure status origin=\(origin.rawValue) skipping_delivery")
+                    @unknown default:
+                        self.logAuthorization("ensure unknown status origin=\(origin.rawValue)")
+                    }
                     completion(false)
                 }
             }
@@ -1086,8 +1131,14 @@ final class TerminalNotificationStore: ObservableObject {
         case .authorized, .provisional, .ephemeral:
             return .allowDelivery
         case .denied:
+            if origin == .notificationDelivery {
+                return .denySilently
+            }
             return .promptSettingsAndDeny
         case .notDetermined:
+            if origin == .notificationDelivery {
+                return .denySilently
+            }
             if shouldDeferAutomaticAuthorizationRequest(
                 origin: origin,
                 status: status,

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7234,6 +7234,50 @@ final class NotificationDockBadgeTests: XCTestCase {
         )
     }
 
+    func testNotificationDeliverySkipsAuthorizationRequestWhenStatusIsNotDetermined() {
+        XCTAssertEqual(
+            TerminalNotificationStore.authorizationDecision(
+                origin: .notificationDelivery,
+                status: .notDetermined,
+                isAppActive: true
+            ),
+            .denySilently
+        )
+    }
+
+    func testNotificationDeliverySkipsSettingsPromptWhenStatusIsDenied() {
+        XCTAssertEqual(
+            TerminalNotificationStore.authorizationDecision(
+                origin: .notificationDelivery,
+                status: .denied,
+                isAppActive: true
+            ),
+            .denySilently
+        )
+    }
+
+    func testNotificationSettingsButtonStillRequestsAuthorizationWhenNotDetermined() {
+        XCTAssertEqual(
+            TerminalNotificationStore.authorizationDecision(
+                origin: .settingsButton,
+                status: .notDetermined,
+                isAppActive: true
+            ),
+            .requestAuthorization
+        )
+    }
+
+    func testNotificationSettingsButtonStillPromptsWhenDenied() {
+        XCTAssertEqual(
+            TerminalNotificationStore.authorizationDecision(
+                origin: .settingsButton,
+                status: .denied,
+                isAppActive: true
+            ),
+            .promptSettingsAndDeny
+        )
+    }
+
     func testNotificationSettingsPromptUsesSheetAndNeverRunsModal() {
         let store = TerminalNotificationStore.shared
         let alertSpy = NotificationSettingsAlertSpy()


### PR DESCRIPTION
## Summary
- add a regression test first for terminal-origin notification authorization handling so CI can show the failure before the fix
- skip permission request / settings prompt flows during OSC 777 delivery and only use existing notification authorization
- dispatch OSC 777 notification handling asynchronously on the main queue so terminal delivery does not block waiting on the permission path

## Verification
- `./scripts/reload.sh --tag issue-1103-osc-777-retry`
- manually triggered `printf $'\\e]777;notify;Title;Body\\a'` in the tagged app and confirmed the debug log shows `ensure notDetermined origin=notification_delivery skipping_request`
- did not run tests locally per repo policy

Closes #1103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSC 777 notification delivery so terminal-origin notifications never trigger permission prompts and never block the terminal. Matches #1103 by skipping requests when not determined or denied, and delivering on the main queue.

- **Bug Fixes**
  - Skip permission requests and settings prompts for OSC 777 delivery; allow when authorized, deny silently when notDetermined/denied.
  - Dispatch OSC 777 notification handling asynchronously on the main queue to avoid blocking terminal callbacks.
  - Keep settings button/test flows unchanged (request or prompt as appropriate).
  - Add addTerminalEscapeNotification to deliver even when focused (marked as read); preserve existing behavior for regular notifications.
  - Add regression tests for authorization decision logic.

<sup>Written for commit 4a299b134605111d1f2e27d2c4d35095e980cb93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for notifications that deliver when the app is focused, improving notification delivery for terminal-generated notifications.
  
* **Improvements**
  * Refined desktop notification authorization flow with smarter decision-making for when to request permissions or prompt settings.

* **Tests**
  * Added tests for notification authorization behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->