### PR TITLE
Fix browser DevTools reopening after manual close

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2899,19 +2899,24 @@ extension BrowserPanel {
         }
     }
 
-    /// Test seam for portal-triggered DevTools restores. The initial regression-test
-    /// commit keeps the pre-fix behavior so CI proves the tests fail without the fix.
+    /// Stable portal updates should respect a manual close; only portal mutations that
+    /// were preceded by a visible inspector should try to restore it afterward.
     func reconcileDeveloperToolsAfterPortalUpdate(
         inspectorWasVisibleBeforeUpdate: Bool,
         didReattach: Bool,
         didChangeVisibility: Bool,
-        didChangeZPriority: Bool
+        didChangeZPriority _: Bool
     ) {
-        _ = inspectorWasVisibleBeforeUpdate
-        _ = didReattach
-        _ = didChangeVisibility
-        _ = didChangeZPriority
-        restoreDeveloperToolsAfterAttachIfNeeded()
+        let shouldRestore =
+            hasPendingDeveloperToolsRefreshAfterAttach() ||
+            (didChangeVisibility && preferredDeveloperToolsVisible) ||
+            (didReattach && inspectorWasVisibleBeforeUpdate)
+
+        if shouldRestore {
+            restoreDeveloperToolsAfterAttachIfNeeded()
+        } else {
+            syncDeveloperToolsPreferenceFromInspector()
+        }
     }
 
     @discardableResult

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2845,6 +2845,7 @@ extension BrowserPanel {
             return
         }
         preferredDeveloperToolsVisible = false
+        forceDeveloperToolsRefreshOnNextAttach = false
         cancelDeveloperToolsRestoreRetry()
     }
 
@@ -2907,10 +2908,14 @@ extension BrowserPanel {
         didChangeVisibility: Bool,
         didChangeZPriority _: Bool
     ) {
+        let didPortalMutation = didReattach || didChangeVisibility
         let shouldRestore =
-            hasPendingDeveloperToolsRefreshAfterAttach() ||
-            (didChangeVisibility && preferredDeveloperToolsVisible) ||
-            (didReattach && inspectorWasVisibleBeforeUpdate)
+            didPortalMutation &&
+            (
+                hasPendingDeveloperToolsRefreshAfterAttach() ||
+                (didChangeVisibility && preferredDeveloperToolsVisible) ||
+                (didReattach && inspectorWasVisibleBeforeUpdate)
+            )
 
         if shouldRestore {
             restoreDeveloperToolsAfterAttachIfNeeded()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2899,6 +2899,21 @@ extension BrowserPanel {
         }
     }
 
+    /// Test seam for portal-triggered DevTools restores. The initial regression-test
+    /// commit keeps the pre-fix behavior so CI proves the tests fail without the fix.
+    func reconcileDeveloperToolsAfterPortalUpdate(
+        inspectorWasVisibleBeforeUpdate: Bool,
+        didReattach: Bool,
+        didChangeVisibility: Bool,
+        didChangeZPriority: Bool
+    ) {
+        _ = inspectorWasVisibleBeforeUpdate
+        _ = didReattach
+        _ = didChangeVisibility
+        _ = didChangeZPriority
+        restoreDeveloperToolsAfterAttachIfNeeded()
+    }
+
     @discardableResult
     func isDeveloperToolsVisible() -> Bool {
         guard let inspector = webView.cmuxInspectorObject() else { return false }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4421,13 +4421,21 @@ struct WebViewRepresentable: NSViewRepresentable {
             panel.syncDeveloperToolsPreferenceFromInspector()
         }
 
+        let inspectorWasVisibleBeforePortalUpdate =
+            host.window != nil &&
+            portalHostAccepted &&
+            panel.isDeveloperToolsVisible()
+
+        var didReattachPortalHost = false
         if host.window != nil, portalHostAccepted {
             let geometryRevision = host.geometryRevision
             let portalEntryMissing = !BrowserWindowPortalRegistry.isWebView(webView, boundTo: portalAnchorView)
-            let shouldBindNow =
+            didReattachPortalHost =
                 coordinator.lastPortalHostId != hostId ||
                 webView.superview == nil ||
-                portalEntryMissing ||
+                portalEntryMissing
+            let shouldBindNow =
+                didReattachPortalHost ||
                 previousVisible != shouldAttachWebView ||
                 previousZPriority != portalZPriority
             if shouldBindNow {
@@ -4478,7 +4486,14 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
         }
 
-        panel.restoreDeveloperToolsAfterAttachIfNeeded()
+        if host.window != nil, portalHostAccepted {
+            panel.reconcileDeveloperToolsAfterPortalUpdate(
+                inspectorWasVisibleBeforeUpdate: inspectorWasVisibleBeforePortalUpdate,
+                didReattach: didReattachPortalHost,
+                didChangeVisibility: previousVisible != coordinator.desiredPortalVisibleInUI,
+                didChangeZPriority: previousZPriority != coordinator.desiredPortalZPriority
+            )
+        }
 
         #if DEBUG
         Self.logDevToolsState(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2560,6 +2560,69 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertEqual(inspector.showCount, 2)
     }
 
+    func testPortalUpdateWithoutMutationKeepsPendingRefreshQueued() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test")
+        XCTAssertTrue(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: true,
+            didReattach: false,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+        XCTAssertTrue(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+    }
+
+    func testPortalUpdateWithoutMutationCancelsPendingRefreshAfterManualClose() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test")
+        XCTAssertTrue(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: false,
+            didReattach: false,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+        XCTAssertFalse(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+    }
+
+    func testPortalUpdatePendingRefreshRestoresInspectorOnReattach() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test")
+        XCTAssertTrue(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: false,
+            didReattach: true,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 2)
+        XCTAssertFalse(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+    }
+
     func testForcedRefreshAfterAttachKeepsVisibleInspectorState() {
         let (panel, inspector) = makePanelWithInspector()
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2467,6 +2467,99 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertEqual(inspector.showCount, 2)
     }
 
+    func testPortalUpdateSyncsManualCloseWithoutUnexpectedReopen() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+
+        // Simulate the user closing inspector chrome while the portal host stays attached.
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: false,
+            didReattach: false,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+
+        // Later auto-restore passes should keep honoring the user's close intent.
+        panel.restoreDeveloperToolsAfterAttachIfNeeded()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+    }
+
+    func testPortalUpdateReattachHonorsManualCloseThatPredatedTheUpdate() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+
+        // Simulate the user already having closed inspector chrome before a later reattach.
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: false,
+            didReattach: true,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+    }
+
+    func testPortalUpdateVisibilityChangeRestoresInspectorWhenIntentRemainsVisible() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+
+        // Simulate the portal hiding the inspector during a pane visibility transition.
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: false,
+            didReattach: false,
+            didChangeVisibility: true,
+            didChangeZPriority: false
+        )
+
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 2)
+    }
+
+    func testPortalUpdateRestoresInspectorAfterReattach() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 1)
+
+        // Simulate WebKit closing inspector during a host reattach.
+        inspector.close()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.reconcileDeveloperToolsAfterPortalUpdate(
+            inspectorWasVisibleBeforeUpdate: true,
+            didReattach: true,
+            didChangeVisibility: false,
+            didChangeZPriority: false
+        )
+
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.showCount, 2)
+    }
+
     func testForcedRefreshAfterAttachKeepsVisibleInspectorState() {
         let (panel, inspector) = makePanelWithInspector()
 


### PR DESCRIPTION
## Summary
- only auto-restore browser DevTools after portal updates when the inspector was visible immediately before the portal mutation or the stored visible intent should survive a visibility transition
- stop treating every portal rebind as a DevTools reattach, so stale preferred-visible state cannot resurrect a manual close during ordinary layout churn
- keep `refresh after next attach` requests queued until a real attach-style portal mutation happens, and clear that pending refresh when a synced manual close overrides the old visible intent
- add regression coverage for stable updates, true reattachs, visibility transitions, and pending-refresh edge cases using the required red-then-green test/fix structure for the initial bug fix

## Testing
- ./scripts/reload.sh --tag issue-1113-devtools-reopens

Fixes #1113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Developer Tools state preservation during portal updates to respect manual close actions
  * Fixed inspector visibility restoration when portal host reattaches or visibility changes
  * Enhanced stability of Developer Tools across portal update scenarios

* **Tests**
  * Added test coverage for Developer Tools behavior during portal-hosted inspector synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->