### PR TITLE
Fix raw OSC 777 text after malformed UTF-8

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -31,6 +31,17 @@ When we change the fork, update this document and the parent submodule SHA.
   - Restarts the CVDisplayLink when `setMacOSDisplayID` updates the current CGDisplay.
   - Prevents a rare state where vsync is "running" but no callbacks arrive, which can look like a frozen surface until focus/occlusion changes.
 
+### 3) OSC 777 survives malformed UTF-8 boundaries
+
+- Commits:
+  - `1f8f10f06` (test(terminal): cover OSC 777 chunked stream parsing)
+  - `8c1f9112f` (fix(terminal): preserve OSC parsing after malformed UTF-8)
+- Files:
+  - `src/terminal/stream.zig`
+- Summary:
+  - Adds regression coverage for OSC 777 desktop notifications across chunk splits and malformed UTF-8 boundaries.
+  - Fixes the SIMD-to-scalar fallback so an `ESC` byte surfaced during UTF-8 error recovery switches back to control-sequence parsing instead of printing the rest of the OSC payload as raw text.
+
 ## Merge conflict notes
 
 These files change frequently upstream; be careful when rebasing the fork:
@@ -41,5 +52,8 @@ These files change frequently upstream; be careful when rebasing the fork:
 
 - `src/terminal/osc.zig`
   - OSC dispatch logic moves often. Re-check the integration points for the OSC 99 parser.
+
+- `src/terminal/stream.zig`
+  - The SIMD/scalar handoff is performance-sensitive. Re-check chunk-boundary handling when rebasing stream parser changes.
 
 If you resolve a conflict, update this doc with what changed.

--- a/scripts/ghosttykit-checksums.txt
+++ b/scripts/ghosttykit-checksums.txt
@@ -2,3 +2,4 @@
 # Update this file in a reviewed PR whenever the ghostty submodule SHA changes.
 # Format: <ghostty_sha> <sha256>
 7dd589824d4c9bda8265355718800cccaf7189a0 3915af4256850a0a7bee671c3ba0a47cbfee5dbfc6d71caf952acefdf2ee4207
+8c1f9112ffdb2d70e69827a2c8ca2e0228043139 ab2738b6bdbaecac3f28d5b382a3ba5837ba8d0cb061414d65e6c5b8783906a8


### PR DESCRIPTION
## Summary
- add Ghostty regression coverage for OSC 777 across chunk splits and malformed UTF-8 boundaries
- fix the SIMD-to-scalar fallback so an ESC surfaced during UTF-8 error recovery switches back into control-sequence parsing
- update the fork notes with the new Ghostty commits

## Verification
- rebuilt `ghostty/macos/GhosttyKit.xcframework` with `zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast`
- ran `./scripts/reload.sh --tag issue-1107-osc-777`

Closes #1107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSC 777 notifications printing as raw text after malformed UTF-8 by restoring control-sequence parsing during UTF-8 error recovery. Adds regression coverage for chunked streams and updates the `ghostty` submodule, `GhosttyKit` checksum, and fork notes.

- **Bug Fixes**
  - Preserve OSC parsing when an ESC byte appears during UTF-8 error recovery (SIMD to scalar handoff).
  - Prevent raw text output after malformed UTF-8 in OSC 777.

- **Dependencies**
  - Update `ghostty` submodule and pin `GhosttyKit` checksum for the OSC 777 fix.
  - Update `docs/ghostty-fork.md` with the new commits and rebasing notes.

<sup>Written for commit bf368d02aeca081c42abe846e63f11a461ef6b34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

