### PR TITLE
Fix terminal keyboard focus after workspace switch (#1122)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5039,7 +5039,9 @@ final class GhosttySurfaceScrollView: NSView {
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
-    // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
+    // Bounded focus reassert only while the selected workspace is reattaching/activating.
+    private var focusRequestGeneration: UInt64 = 0
+    private static let focusEnsureRetryDelay: TimeInterval = 0.03
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
     /// when the window becomes key while the find bar is open.
@@ -6147,13 +6149,41 @@ final class GhosttySurfaceScrollView: NSView {
     }
     #endif
 
-    func ensureFocus(for tabId: UUID, surfaceId: UUID, attemptsRemaining: Int = 3) {
+    func ensureFocus(
+        for tabId: UUID,
+        surfaceId: UUID,
+        attemptsRemaining: Int = 6,
+        requestGeneration: UInt64? = nil
+    ) {
+        let generation: UInt64
+        if let requestGeneration {
+            generation = requestGeneration
+        } else {
+            focusRequestGeneration &+= 1
+            generation = focusRequestGeneration
+        }
+
         func retry() {
             guard attemptsRemaining > 0 else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
-                self?.ensureFocus(for: tabId, surfaceId: surfaceId, attemptsRemaining: attemptsRemaining - 1)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.focusEnsureRetryDelay) { [weak self] in
+                guard let self, self.focusRequestGeneration == generation else { return }
+                self.ensureFocus(
+                    for: tabId,
+                    surfaceId: surfaceId,
+                    attemptsRemaining: attemptsRemaining - 1,
+                    requestGeneration: generation
+                )
             }
         }
+
+        guard focusRequestGeneration == generation else { return }
+
+        guard let delegate = AppDelegate.shared,
+              let tabManager = delegate.tabManagerFor(tabId: tabId) ?? delegate.tabManager else {
+            retry()
+            return
+        }
+        guard tabManager.selectedTabId == tabId else { return }
 
         let hasUsablePortalGeometry: Bool = {
             let size = bounds.size
@@ -6161,8 +6191,14 @@ final class GhosttySurfaceScrollView: NSView {
         }()
         let isHiddenForFocus = isHiddenOrHasHiddenAncestor || surfaceView.isHiddenOrHasHiddenAncestor
 
-        guard isActive else { return }
-        guard let window else { return }
+        guard isActive else {
+            retry()
+            return
+        }
+        guard let window else {
+            retry()
+            return
+        }
         guard surfaceView.isVisibleInUI else {
             retry()
             return
@@ -6175,13 +6211,6 @@ final class GhosttySurfaceScrollView: NSView {
                 "frame=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) attempts=\(attemptsRemaining)"
             )
 #endif
-            retry()
-            return
-        }
-
-        guard let delegate = AppDelegate.shared,
-              let tabManager = delegate.tabManagerFor(tabId: tabId) ?? delegate.tabManager,
-              tabManager.selectedTabId == tabId else {
             retry()
             return
         }
@@ -6596,7 +6625,7 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
 
     func cancelFocusRequest() {
-        // Intentionally no-op (no retry loops).
+        focusRequestGeneration &+= 1
     }
 
     private func synchronizeSurfaceView() {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1743,6 +1743,9 @@ class TabManager: ObservableObject {
         }
         pendingWorkspaceUnfocusTarget = nil
         unfocusWorkspacePanel(tabId: pending.tabId, panelId: pending.panelId)
+        // The retiring workspace can synchronously clear first responder to nil while it yields
+        // focus. Reassert the selected terminal afterward so keyboard input does not get stranded.
+        ensureFocusedTerminalFirstResponder()
 #if DEBUG
         if let snapshot = debugCurrentWorkspaceSwitchSnapshot() {
             let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000

--- a/tests/test_issue_1122_workspace_switch_keyboard.py
+++ b/tests/test_issue_1122_workspace_switch_keyboard.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Regression test for #1122: terminal keyboard focus must survive workspace switch-back.
+
+Why: workspace activation and first-responder restoration can race. If the retiring
+workspace clears first responder before the selected terminal reclaims it, typing stops
+until the user clicks the terminal again.
+
+This test verifies:
+  1) Repeated switch-away / switch-back cycles restore the selected terminal as first responder.
+  2) Simulated typing reaches that terminal through the real current first-responder path.
+"""
+
+import os
+import sys
+import time
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+FOCUS_FILE = Path(tempfile.gettempdir()) / f"cmux_issue_1122_focus_{os.getpid()}.txt"
+
+
+def _selected_terminal_panel_id(c: cmux) -> str:
+    surfaces = c.list_surfaces()
+    if not surfaces:
+        raise cmuxError("Expected a selected terminal surface")
+    return surfaces[0][1]
+
+
+def _wait_for_terminal_focus(c: cmux, panel_id: str, timeout_s: float = 3.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if c.is_terminal_focused(panel_id):
+            return
+        time.sleep(0.05)
+    raise cmuxError(f"Timed out waiting for terminal focus after workspace switch: {panel_id}")
+
+
+def _wait_for_file_content(path: Path, timeout_s: float = 3.0) -> str:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if path.exists():
+            data = path.read_text().strip()
+            if data:
+                return data
+        time.sleep(0.05)
+    raise cmuxError(f"Timed out waiting for file content: {path}")
+
+
+def _assert_typed_input_routes_to_selected_terminal(c: cmux, expected_surface_id: str) -> None:
+    FOCUS_FILE.unlink(missing_ok=True)
+    c.simulate_type(f"printf %s $CMUX_SURFACE_ID > {FOCUS_FILE}")
+    c.simulate_shortcut("enter")
+    actual = _wait_for_file_content(FOCUS_FILE)
+    if actual != expected_surface_id:
+        raise cmuxError(
+            f"Typed input routed to wrong terminal after workspace switch: "
+            f"expected={expected_surface_id} actual={actual}"
+        )
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        ws_a = c.new_workspace()
+        time.sleep(0.3)
+        c.activate_app()
+        time.sleep(0.2)
+        panel_a = _selected_terminal_panel_id(c)
+
+        ws_b = c.new_workspace()
+        time.sleep(0.3)
+
+        for _ in range(6):
+            c.select_workspace(ws_a)
+            time.sleep(0.12)
+            c.select_workspace(ws_b)
+            time.sleep(0.12)
+
+        c.select_workspace(ws_a)
+        time.sleep(0.2)
+
+        _wait_for_terminal_focus(c, panel_a, timeout_s=3.0)
+        _assert_typed_input_routes_to_selected_terminal(c, panel_a)
+
+    print("PASS: workspace switch-back restores terminal keyboard focus")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a regression test that exercises real first-responder typing after switching away from and back to a workspace
- keep terminal focus restoration retries alive across transient workspace activation/remount states and cancel stale retries when focus intent changes
- reassert the selected terminal after the retiring workspace yields first responder so keyboard input is not left stranded on nil

## Testing
- ./scripts/reload.sh --tag issue-1122-keyboard-unresponsive
- Local tests not run per repo policy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost keyboard input after switching workspaces by reliably restoring terminal focus. Adds a regression test to ensure typing reaches the selected terminal via the real first-responder path.

- **Bug Fixes**
  - Added a bounded, generation-based focus retry that survives activation/remount and cancels stale attempts.
  - Reasserted the selected terminal after the retiring workspace clears first responder to avoid nil focus.
  - Verified with `tests/test_issue_1122_workspace_switch_keyboard.py`, which simulates switch cycles and checks that typing routes to the selected terminal.

<sup>Written for commit 87ef6402dbba45542290e21aad4c6d939cb7a80a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard focus handling when switching workspaces to prevent keyboard input from becoming unresponsive during rapid workspace transitions.
  * Added safety focus reassertion mechanism to ensure keyboard input is properly routed to the active terminal after workspace switches.

* **Tests**
  * Added regression test to verify keyboard input resilience across workspace switch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->