### PR TITLE
Clarify source-shape test policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,11 @@ This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the
 ## Test quality policy
 
 - Do not add tests that only verify source code text, method signatures, AST fragments, or grep-style patterns.
+- Do not add tests that read checked-in metadata or project files such as `Resources/Info.plist`, `project.pbxproj`, `.xcconfig`, or source files only to assert that a key, string, plist entry, or snippet exists.
 - Tests must verify observable runtime behavior through executable paths (unit/integration/e2e/CLI), not implementation shape.
+- For metadata changes, prefer verifying the built app bundle or the runtime behavior that depends on that metadata, not the checked-in source file.
 - If a behavior cannot be exercised end-to-end yet, add a small runtime seam or harness first, then test through that seam.
+- If no meaningful behavioral or artifact-level test is practical, skip the fake regression test and state that explicitly.
 
 ## Socket command threading policy
 


### PR DESCRIPTION
## Summary
- clarify the repo-local test-quality policy to ban source-shape tests against plist, project, and source files
- tell agents to prefer built-artifact or runtime verification for metadata changes

## Testing
- not run (policy/docs-only change)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the test-quality policy to ban source-shape tests and prefer runtime or built-artifact verification, especially for metadata changes. Updates `CLAUDE.md` with examples (`Info.plist`, `project.pbxproj`, `.xcconfig`) and guidance to add a small seam when needed or explicitly skip untestable regressions.

<sup>Written for commit 879fb05969f11d2fed877594bf26ef1f9c1dd3d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal testing guidelines to enhance test quality standards and clarify best practices for validation approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->