### PR TITLE
Fix browser overlay staying above terminal after pane switches

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1838,8 +1838,9 @@ final class BrowserPanel: Panel, ObservableObject {
         return true
     }
 
-    func releasePortalHostIfOwned(hostId: ObjectIdentifier, reason: String) {
-        guard let current = activePortalHostLease, current.hostId == hostId else { return }
+    @discardableResult
+    func releasePortalHostIfOwned(hostId: ObjectIdentifier, reason: String) -> Bool {
+        guard let current = activePortalHostLease, current.hostId == hostId else { return false }
         activePortalHostLease = nil
 #if DEBUG
         dlog(
@@ -1848,6 +1849,7 @@ final class BrowserPanel: Panel, ObservableObject {
             "inWin=\(current.inWindow ? 1 : 0) area=\(String(format: "%.1f", current.area))"
         )
 #endif
+        return true
     }
 
     var displayIcon: String? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4323,11 +4323,23 @@ struct WebViewRepresentable: NSViewRepresentable {
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil
         let activeSearchOverlay = coordinator.desiredPortalVisibleInUI ? searchOverlay : nil
         let portalAnchorView = panel.portalAnchorView
+        let portalHideReason = !isCurrentPaneOwner ? "lostPaneOwnership" : "hidden"
+        let didReleasePortalHost: Bool
         if !shouldAttachWebView || !isCurrentPaneOwner {
-            panel.releasePortalHostIfOwned(
+            didReleasePortalHost = panel.releasePortalHostIfOwned(
                 hostId: hostId,
-                reason: !isCurrentPaneOwner ? "lostPaneOwnership" : "hidden"
+                reason: portalHideReason
             )
+            // Only the host that currently owns the portal is allowed to hide it.
+            // Older keep-alive hosts can still receive updates after a new owner binds.
+            if didReleasePortalHost {
+                BrowserWindowPortalRegistry.hide(
+                    webView: webView,
+                    source: "viewStateChanged.\(portalHideReason)"
+                )
+            }
+        } else {
+            didReleasePortalHost = false
         }
         let portalHostAccepted =
             shouldAttachWebView &&
@@ -4345,7 +4357,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                 "browser.portal.owner.skip panel=\(panel.id.uuidString.prefix(5)) " +
                 "viewPane=\(paneId.id.uuidString.prefix(5)) " +
                 "currentPane=\(paneDropContext?.paneId.id.uuidString.prefix(5) ?? "nil") " +
-                "host=\(Self.objectID(host)) hostInWin=\(host.window != nil ? 1 : 0)"
+                "host=\(Self.objectID(host)) hostInWin=\(host.window != nil ? 1 : 0) " +
+                "released=\(didReleasePortalHost ? 1 : 0)"
             )
         }
 #endif


### PR DESCRIPTION
## Summary
- hide the browser portal entry when the owning host loses visibility or pane ownership
- only let the host that actually owned the portal hide it, so stale keep-alive hosts do not clobber a newer binding
- preserve the existing portal/devtools rebind flow for active browser panes

## Verification
- built and launched with `./scripts/reload.sh --tag issue-1129-browser-overlay`

Fixes #1129

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1129: Hide the browser portal when its host loses pane ownership or visibility, so the overlay no longer sits above the terminal after pane switches. Only the current portal owner can hide it, preserving the devtools/portal rebind flow and preventing stale keep-alive hosts from clobbering newer bindings.

<sup>Written for commit 7aa4b5d33aa40c90d1184d1238a321ef171b3d2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal portal host management logic to better track and handle ownership state during cleanup operations, enhancing the reliability of resource teardown processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->