### PR TITLE
Fix sidebar collapse crash from titlebar button

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4205,6 +4205,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
+    func toggleSidebar(in window: NSWindow?) -> Bool {
+        if let window,
+           let context = contextForMainTerminalWindow(window) {
+            setActiveMainWindow(window)
+            context.sidebarState.toggle()
+            return true
+        }
+        return toggleSidebarInActiveMainWindow()
+    }
+
+    @discardableResult
     func toggleSidebarInActiveMainWindow() -> Bool {
         if let activeManager = tabManager,
            let activeContext = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -315,7 +315,12 @@ struct TitlebarControlsView: View {
                 #if DEBUG
                 dlog("titlebar.toggleSidebar")
                 #endif
-                onToggleSidebar()
+                // Defer the sidebar mutation until the click/cursor-update cycle
+                // finishes. Older macOS versions can crash if SwiftUI tears down
+                // sidebar hover/tracking views during the same event turn.
+                DispatchQueue.main.async {
+                    onToggleSidebar()
+                }
             }) {
                 iconLabel(systemName: "sidebar.left", config: config)
             }
@@ -726,6 +731,16 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         )
 
         super.init(nibName: nil, bundle: nil)
+
+        hostingView.rootView = TitlebarControlsView(
+            notificationStore: notificationStore,
+            viewModel: viewModel,
+            onToggleSidebar: { [weak self] in
+                _ = AppDelegate.shared?.toggleSidebar(in: self?.view.window)
+            },
+            onToggleNotifications: toggleNotifications,
+            onNewTab: newTab
+        )
 
         view = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = true


### PR DESCRIPTION
## Summary
- defer the titlebar sidebar toggle to the next main-loop turn so SwiftUI/AppKit can finish the click and cursor-update cycle before sidebar hover/tracking views are torn down
- route the titlebar sidebar button through the window-specific AppDelegate sidebar toggle path instead of the shared fallback state pointer
- closes #1104

## Testing
- built and launched with warning: Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'GhosttyTabs' from project 'GhosttyTabs')
** BUILD SUCCEEDED **
Full build log: /tmp/cmux-xcodebuild-issue-1104-sidebar-collapse-crash.log

Tag cleanup status:
  current tag: issue-1104-sidebar-collapse-crash (keep this running until you verify)
  stale tags: none
  stale cleanup: not needed
After you verify current tag, cleanup command:
  pkill -f "cmux DEV issue-1104-sidebar-collapse-crash.app/Contents/MacOS/cmux DEV"
  rm -rf "/tmp/cmux-issue-1104-sidebar-collapse-crash" "/tmp/cmux-debug-issue-1104-sidebar-collapse-crash.sock"
  rm -f "/tmp/cmux-debug-issue-1104-sidebar-collapse-crash.log"
  rm -f "/Users/austinwang/Library/Application Support/cmux/cmuxd-dev-issue-1104-sidebar-collapse-crash.sock"
- did not run local tests per repo policy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when collapsing the sidebar from the titlebar button by deferring the toggle to the next run loop and routing the action through the window-specific toggle. Prevents teardown-related crashes on older macOS and ensures the correct window is targeted.

- **Bug Fixes**
  - Defer `onToggleSidebar` via `DispatchQueue.main.async` so the click/cursor cycle completes before hover/tracking views are removed.
  - Add `AppDelegate.toggleSidebar(in:)` and wire the titlebar button to it, using the current window context with fallback to `toggleSidebarInActiveMainWindow()`.

<sup>Written for commit f45c3d6ed66929931490e6709cb1509ad1103fd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

