### PR TITLE
Fix terminal wrap width sizing

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5090,6 +5090,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate func debugRegisteredDropTypes() -> [String] {
         (registeredDraggedTypes ?? []).map(\.rawValue)
     }
+
+    func debugPendingSurfaceSize() -> CGSize? {
+        pendingSurfaceSize
+    }
 #endif
 
     // MARK: NSDraggingDestination
@@ -6269,6 +6273,24 @@ final class GhosttySurfaceScrollView: NSView {
 
     func debugHasKeyboardCopyModeIndicator() -> Bool {
         keyboardCopyModeBadgeView.superview === self && !keyboardCopyModeBadgeView.isHidden
+    }
+
+    func debugSetOverlayScrollerVisibility(hidden: Bool, alpha: CGFloat) {
+        guard let verticalScroller = scrollView.verticalScroller else { return }
+        verticalScroller.isHidden = hidden
+        verticalScroller.alphaValue = alpha
+    }
+
+    func debugForceSurfaceLayoutPass() {
+        surfaceView.layout()
+    }
+
+    func debugSurfaceSizingState() -> (contentSize: CGSize, overlayInsetWidth: CGFloat, pendingSurfaceSize: CGSize?) {
+        (
+            scrollView.contentSize,
+            overlayScrollbarInsetWidth(),
+            surfaceView.debugPendingSurfaceSize()
+        )
     }
 
 #endif

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9725,6 +9725,32 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         return nil
     }
 
+    private func makeHostedTerminalWindow(
+        size: NSSize = NSSize(width: 360, height: 240)
+    ) -> (window: NSWindow, surface: TerminalSurface, hostedView: GhosttySurfaceScrollView) {
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = NSRect(origin: .zero, size: size)
+        hostedView.autoresizingMask = [.width, .height]
+        window.contentView?.addSubview(hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        return (window, surface, hostedView)
+    }
+
     func testTrackpadScrollRoutesToTerminalSurfaceAndPreservesKeyboardFocusPath() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
@@ -9799,6 +9825,84 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         hostedView.setInactiveOverlay(color: .black, opacity: 0.35, visible: false)
         state = hostedView.debugInactiveOverlayState()
         XCTAssertTrue(state.isHidden)
+    }
+
+    func testVisibleOverlayScrollbarWidthSurvivesStandaloneSurfaceLayoutPass() throws {
+#if DEBUG
+        let (window, surface, hostedView) = makeHostedTerminalWindow()
+        defer {
+            window.orderOut(nil)
+            _ = surface
+        }
+
+        hostedView.debugSetOverlayScrollerVisibility(hidden: false, alpha: 1)
+        XCTAssertTrue(hostedView.reconcileGeometryNow(), "Expected hosted terminal geometry reconciliation")
+
+        var sizing = hostedView.debugSurfaceSizingState()
+        let initialPending = try XCTUnwrap(sizing.pendingSurfaceSize)
+        XCTAssertGreaterThan(
+            sizing.overlayInsetWidth,
+            0,
+            "Visible overlay scroller should reserve a wrap gutter"
+        )
+        XCTAssertEqual(
+            initialPending.width,
+            sizing.contentSize.width - sizing.overlayInsetWidth,
+            accuracy: 0.5,
+            "Hosted terminal width should exclude the visible overlay scroller gutter"
+        )
+
+        hostedView.debugForceSurfaceLayoutPass()
+
+        sizing = hostedView.debugSurfaceSizingState()
+        let pendingAfterSurfaceLayout = try XCTUnwrap(sizing.pendingSurfaceSize)
+        XCTAssertEqual(
+            pendingAfterSurfaceLayout.width,
+            sizing.contentSize.width - sizing.overlayInsetWidth,
+            accuracy: 0.5,
+            "Standalone Ghostty surface layout must not overwrite the wrapped width with full bounds"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
+
+    func testHiddenOrTransparentOverlayScrollbarDoesNotReserveWrapGutter() throws {
+#if DEBUG
+        let (window, surface, hostedView) = makeHostedTerminalWindow()
+        defer {
+            window.orderOut(nil)
+            _ = surface
+        }
+
+        hostedView.debugSetOverlayScrollerVisibility(hidden: true, alpha: 1)
+        XCTAssertTrue(hostedView.reconcileGeometryNow(), "Expected hosted terminal geometry reconciliation")
+
+        var sizing = hostedView.debugSurfaceSizingState()
+        let hiddenPending = try XCTUnwrap(sizing.pendingSurfaceSize)
+        XCTAssertEqual(sizing.overlayInsetWidth, 0, accuracy: 0.01)
+        XCTAssertEqual(
+            hiddenPending.width,
+            sizing.contentSize.width,
+            accuracy: 0.5,
+            "Hidden overlay scrollers should not shrink the terminal wrap width"
+        )
+
+        hostedView.debugSetOverlayScrollerVisibility(hidden: false, alpha: 0)
+        XCTAssertTrue(hostedView.reconcileGeometryNow(), "Expected hosted terminal geometry reconciliation")
+
+        sizing = hostedView.debugSurfaceSizingState()
+        let transparentPending = try XCTUnwrap(sizing.pendingSurfaceSize)
+        XCTAssertEqual(sizing.overlayInsetWidth, 0, accuracy: 0.01)
+        XCTAssertEqual(
+            transparentPending.width,
+            sizing.contentSize.width,
+            accuracy: 0.5,
+            "Transparent overlay scrollers should not reserve a wrap gutter"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
     }
 
     func testWindowResignKeyClearsFocusedTerminalFirstResponder() {


### PR DESCRIPTION
Closes #1082

## Summary
- add regression coverage for overlay-scrollbar wrap width sizing
- stop `GhosttyNSView.layout()` from overwriting the hosted surface width
- only reserve overlay scrollbar gutter while the scroller is actually visible

## Commit structure
- commit 1: failing regression tests
- commit 2: production fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal wrap width when overlay scrollbars are present to stop line truncation. Closes #1082.

- **Bug Fixes**
  - Prevent `GhosttyNSView.layout()` from resetting the hosted surface width during standalone layout passes.
  - Reserve the overlay scrollbar gutter only while the vertical scroller is visible and opaque; hidden or transparent scrollers no longer shrink wrap width (with regression tests under DEBUG).

<sup>Written for commit b27b9a95c7e5de68e34469bdcace442cd2097949. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

