### PR TITLE
Fix main CI failures

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -37,11 +37,22 @@ jobs:
             echo "Could not determine version" >&2
             exit 1
           fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "Invalid version: ${VERSION}" >&2
+              exit 1
+            fi
+            echo "Skipping homebrew cask update for non-release ref: ${VERSION}"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "skip=false" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Updating homebrew cask to version $VERSION"
 
       - name: Download DMG and get SHA256
         id: sha
+        if: steps.version.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           URL="https://github.com/manaflow-ai/cmux/releases/download/v${VERSION}/cmux-macos.dmg"
@@ -65,6 +76,7 @@ jobs:
           echo "DMG SHA256: $SHA256"
 
       - name: Checkout homebrew-cmux
+        if: steps.version.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: manaflow-ai/homebrew-cmux
@@ -72,6 +84,7 @@ jobs:
           path: homebrew-cmux
 
       - name: Update cask formula
+        if: steps.version.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
           SHA256: ${{ steps.sha.outputs.sha256 }}
@@ -107,6 +120,7 @@ jobs:
           sed -i 's/^          //' homebrew-cmux/Casks/cmux.rb
 
       - name: Verify cask SHA matches DMG
+        if: steps.version.outputs.skip != 'true'
         run: |
           CASK_SHA=$(grep 'sha256' homebrew-cmux/Casks/cmux.rb | sed 's/.*"\(.*\)".*/\1/')
           ACTUAL_SHA=$(shasum -a 256 cmux.dmg | cut -d' ' -f1)
@@ -117,6 +131,7 @@ jobs:
           echo "SHA verification passed: $CASK_SHA"
 
       - name: Commit and push
+        if: steps.version.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9957,6 +9957,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         )
     }
 
+    @MainActor
     func testKeyboardCopyModeIndicatorMountsAndUnmounts() {
         let surface = TerminalSurface(
             tabId: UUID(),
@@ -9967,10 +9968,10 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         let hostedView = surface.hostedView
         XCTAssertFalse(hostedView.debugHasKeyboardCopyModeIndicator())
 
-        hostedView.setKeyboardCopyModeIndicator(visible: true)
+        hostedView.syncKeyStateIndicator(text: "vim")
         XCTAssertTrue(hostedView.debugHasKeyboardCopyModeIndicator())
 
-        hostedView.setKeyboardCopyModeIndicator(visible: false)
+        hostedView.syncKeyStateIndicator(text: nil)
         XCTAssertFalse(hostedView.debugHasKeyboardCopyModeIndicator())
     }
 


### PR DESCRIPTION
## Summary
- update the stale copy-mode badge unit test to use the current `syncKeyStateIndicator` API
- skip Homebrew cask updates when `Release macOS app` is run from a non-version branch, while still rejecting invalid manual versions

## Testing
- `bash` simulation of update-homebrew version resolution matched tagged, branch, and invalid manual cases
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-main-ci-cd-failing build-for-testing`

## Issues
- Related: https://github.com/manaflow-ai/cmux/actions/runs/22882642941
- Related: https://github.com/manaflow-ai/cmux/actions/runs/22882719168
- Related: https://github.com/manaflow-ai/cmux/actions/runs/22883454751

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes main CI by updating the copy-mode indicator test to the current API and making the Homebrew workflow skip updates on non-release refs while still validating manual versions.

- **Bug Fixes**
  - Updated unit test to use `syncKeyStateIndicator(text:)` and added `@MainActor` to reflect UI behavior.
  - In `.github/workflows/update-homebrew.yml`, skip cask updates when the version isn’t SemVer on non-release refs, but fail for invalid `workflow_dispatch` versions; gated subsequent steps on `steps.version.outputs.skip`.

<sup>Written for commit b3ed48191e1995e8671f75adc8222c2e60f45ec9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow robustness for version handling and release processes.
  * Updated internal test infrastructure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->