### PR TITLE
Add Ghostty theme picker to the command palette

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -72915,6 +72915,12 @@
             "state": "translated",
             "value": "Back"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "戻る"
+          }
         }
       }
     },
@@ -72925,6 +72931,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ghostty Themes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマ"
           }
         }
       }
@@ -72937,6 +72949,12 @@
             "state": "translated",
             "value": "Loading Ghostty themes…"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマを読み込み中…"
+          }
         }
       }
     },
@@ -72948,6 +72966,12 @@
             "state": "translated",
             "value": "Ghostty Theme"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマ"
+          }
         }
       }
     },
@@ -72955,6 +72979,12 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ✓"
+          }
+        },
+        "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ ✓"
@@ -72970,6 +73000,12 @@
             "state": "translated",
             "value": "Ghostty Theme"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマ"
+          }
         }
       }
     },
@@ -72980,6 +73016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Ghostty themes found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマが見つかりません"
           }
         }
       }
@@ -72992,6 +73034,12 @@
             "state": "translated",
             "value": "Ghostty Theme"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマ"
+          }
         }
       }
     },
@@ -73002,6 +73050,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ghostty Theme…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマ…"
           }
         }
       }
@@ -73014,6 +73068,12 @@
             "state": "translated",
             "value": "Appearance"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外観"
+          }
         }
       }
     },
@@ -73025,6 +73085,12 @@
             "state": "translated",
             "value": "Search Ghostty themes"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyテーマを検索"
+          }
         }
       }
     },
@@ -73035,6 +73101,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No Ghostty themes match your search."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索に一致するGhosttyテーマがありません。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -72906,6 +72906,138 @@
           }
         }
       }
+    },
+    "command.ghosttyTheme.back.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.back.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Themes"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.loading.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Ghostty themes…"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.loading.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Theme"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.current.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ✓"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Theme"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Ghostty themes found"
+          }
+        }
+      }
+    },
+    "command.ghosttyTheme.empty.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Theme"
+          }
+        }
+      }
+    },
+    "command.ghosttyThemeMenu.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty Theme…"
+          }
+        }
+      }
+    },
+    "command.ghosttyThemeMenu.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
+          }
+        }
+      }
+    },
+    "commandPalette.search.ghosttyThemesPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search Ghostty themes"
+          }
+        }
+      }
+    },
+    "commandPalette.search.ghosttyThemesEmpty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Ghostty themes match your search."
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3108,11 +3108,7 @@ struct ContentView: View {
         .onChange(of: commandPaletteQuery) { _ in
             if !commandPaletteQuery.hasPrefix(Self.commandPaletteCommandsPrefix) {
                 commandPaletteCommandSubmenu = nil
-                commandPaletteGhosttyThemeLoadTask?.cancel()
-                commandPaletteGhosttyThemeLoadTask = nil
-                commandPaletteGhosttyThemeNames = []
-                commandPaletteGhosttyResolvedCurrentTheme = nil
-                commandPaletteGhosttyThemesAreLoading = false
+                resetCommandPaletteGhosttyThemeState()
             }
             commandPaletteSelectedResultIndex = 0
             commandPaletteSelectionAnchorCommandID = nil
@@ -3980,13 +3976,17 @@ struct ContentView: View {
         syncCommandPaletteDebugStateForObservedWindow()
     }
 
-    private func exitCommandPaletteGhosttyThemeMenu() {
-        commandPaletteCommandSubmenu = nil
+    private func resetCommandPaletteGhosttyThemeState() {
         commandPaletteGhosttyThemeLoadTask?.cancel()
         commandPaletteGhosttyThemeLoadTask = nil
         commandPaletteGhosttyThemeNames = []
         commandPaletteGhosttyResolvedCurrentTheme = nil
         commandPaletteGhosttyThemesAreLoading = false
+    }
+
+    private func exitCommandPaletteGhosttyThemeMenu() {
+        commandPaletteCommandSubmenu = nil
+        resetCommandPaletteGhosttyThemeState()
         commandPaletteQuery = Self.commandPaletteCommandsPrefix
         commandPaletteSelectedResultIndex = 0
         commandPaletteSelectionAnchorCommandID = nil
@@ -4024,6 +4024,8 @@ struct ContentView: View {
         commandPaletteGhosttyThemesAreLoading = true
         let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
         commandPaletteGhosttyThemeLoadTask = Task.detached(priority: .userInitiated) {
+            guard !Task.isCancelled else { return }
+
             let resolvedCurrentTheme = (
                 GhosttyConfig.load(
                     preferredColorScheme: preferredColorScheme,
@@ -4035,16 +4037,19 @@ struct ContentView: View {
                     )
                 }
             )?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !Task.isCancelled else { return }
+
             let themes = GhosttyConfig.discoverThemeNames()
 
             guard !Task.isCancelled else { return }
 
             await MainActor.run {
+                commandPaletteGhosttyThemesAreLoading = false
+                commandPaletteGhosttyThemeLoadTask = nil
                 guard commandPaletteCommandSubmenu == .ghosttyThemes else { return }
                 commandPaletteGhosttyThemeNames = themes
                 commandPaletteGhosttyResolvedCurrentTheme = resolvedCurrentTheme
-                commandPaletteGhosttyThemesAreLoading = false
-                commandPaletteGhosttyThemeLoadTask = nil
                 scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
                 syncCommandPaletteDebugStateForObservedWindow()
             }
@@ -5602,11 +5607,7 @@ struct ContentView: View {
     private func resetCommandPaletteListState(initialQuery: String) {
         commandPaletteMode = .commands
         commandPaletteCommandSubmenu = nil
-        commandPaletteGhosttyThemeLoadTask?.cancel()
-        commandPaletteGhosttyThemeLoadTask = nil
-        commandPaletteGhosttyThemeNames = []
-        commandPaletteGhosttyResolvedCurrentTheme = nil
-        commandPaletteGhosttyThemesAreLoading = false
+        resetCommandPaletteGhosttyThemeState()
         commandPaletteQuery = initialQuery
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0
@@ -5633,11 +5634,7 @@ struct ContentView: View {
         isCommandPalettePresented = false
         commandPaletteMode = .commands
         commandPaletteCommandSubmenu = nil
-        commandPaletteGhosttyThemeLoadTask?.cancel()
-        commandPaletteGhosttyThemeLoadTask = nil
-        commandPaletteGhosttyThemeNames = []
-        commandPaletteGhosttyResolvedCurrentTheme = nil
-        commandPaletteGhosttyThemesAreLoading = false
+        resetCommandPaletteGhosttyThemeState()
         commandPaletteQuery = ""
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1337,6 +1337,7 @@ struct ContentView: View {
     @State private var commandPaletteGhosttyResolvedCurrentTheme: String?
     @State private var commandPaletteGhosttyThemesAreLoading = false
     @State private var commandPaletteGhosttyThemeLoadTask: Task<Void, Never>?
+    @State private var commandPaletteGhosttyThemeLoadRequestID: UInt64 = 0
     @State private var isFeedbackComposerPresented = false
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
@@ -3273,6 +3274,9 @@ struct ContentView: View {
         switch commandPaletteListScope {
         case .commands:
             if commandPaletteCommandSubmenu == .ghosttyThemes {
+                if commandPaletteGhosttyThemesAreLoading {
+                    return ""
+                }
                 return String(localized: "commandPalette.search.ghosttyThemesEmpty", defaultValue: "No Ghostty themes match your search.")
             }
             return String(localized: "commandPalette.search.commandsEmpty", defaultValue: "No commands match your search.")
@@ -4022,6 +4026,8 @@ struct ContentView: View {
 
         commandPaletteGhosttyThemeLoadTask?.cancel()
         commandPaletteGhosttyThemesAreLoading = true
+        commandPaletteGhosttyThemeLoadRequestID &+= 1
+        let requestID = commandPaletteGhosttyThemeLoadRequestID
         let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
         commandPaletteGhosttyThemeLoadTask = Task.detached(priority: .userInitiated) {
             guard !Task.isCancelled else { return }
@@ -4045,6 +4051,7 @@ struct ContentView: View {
             guard !Task.isCancelled else { return }
 
             await MainActor.run {
+                guard commandPaletteGhosttyThemeLoadRequestID == requestID else { return }
                 commandPaletteGhosttyThemesAreLoading = false
                 commandPaletteGhosttyThemeLoadTask = nil
                 guard commandPaletteCommandSubmenu == .ghosttyThemes else { return }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3932,6 +3932,22 @@ struct ContentView: View {
             return commands
         }
 
+        if themes.isEmpty {
+            commands.append(
+                CommandPaletteCommand(
+                    id: "palette.ghosttyTheme.empty",
+                    rank: 1,
+                    title: String(localized: "command.ghosttyTheme.empty.title", defaultValue: "No Ghostty themes found"),
+                    subtitle: String(localized: "command.ghosttyTheme.empty.subtitle", defaultValue: "Ghostty Theme"),
+                    shortcutHint: nil,
+                    keywords: [],
+                    dismissOnRun: false,
+                    action: {}
+                )
+            )
+            return commands
+        }
+
         for (index, themeName) in themes.enumerated() {
             let isCurrentTheme = currentTheme?.localizedCaseInsensitiveCompare(themeName) == .orderedSame
             commands.append(
@@ -4006,10 +4022,13 @@ struct ContentView: View {
 
         commandPaletteGhosttyThemeLoadTask?.cancel()
         commandPaletteGhosttyThemesAreLoading = true
+        let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
         commandPaletteGhosttyThemeLoadTask = Task.detached(priority: .userInitiated) {
-            let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
             let resolvedCurrentTheme = (
-                GhosttyConfig.load(useCache: false).theme.map {
+                GhosttyConfig.load(
+                    preferredColorScheme: preferredColorScheme,
+                    useCache: false
+                ).theme.map {
                     GhosttyConfig.resolveThemeName(
                         from: $0,
                         preferredColorScheme: preferredColorScheme

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1333,6 +1333,10 @@ struct ContentView: View {
     @State private var commandPaletteResultsRevision: UInt64 = 0
     @State private var commandPaletteUsageHistoryByCommandId: [String: CommandPaletteUsageEntry] = [:]
     @State private var commandPaletteCommandSubmenu: CommandPaletteCommandSubmenu?
+    @State private var commandPaletteGhosttyThemeNames: [String] = []
+    @State private var commandPaletteGhosttyResolvedCurrentTheme: String?
+    @State private var commandPaletteGhosttyThemesAreLoading = false
+    @State private var commandPaletteGhosttyThemeLoadTask: Task<Void, Never>?
     @State private var isFeedbackComposerPresented = false
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
@@ -3102,6 +3106,14 @@ struct ContentView: View {
             resetCommandPaletteSearchFocus()
         }
         .onChange(of: commandPaletteQuery) { _ in
+            if !commandPaletteQuery.hasPrefix(Self.commandPaletteCommandsPrefix) {
+                commandPaletteCommandSubmenu = nil
+                commandPaletteGhosttyThemeLoadTask?.cancel()
+                commandPaletteGhosttyThemeLoadTask = nil
+                commandPaletteGhosttyThemeNames = []
+                commandPaletteGhosttyResolvedCurrentTheme = nil
+                commandPaletteGhosttyThemesAreLoading = false
+            }
             commandPaletteSelectedResultIndex = 0
             commandPaletteSelectionAnchorCommandID = nil
             commandPaletteHoveredResultIndex = nil
@@ -3886,10 +3898,10 @@ struct ContentView: View {
     }
 
     private func commandPaletteGhosttyThemeCommands() -> [CommandPaletteCommand] {
-        let currentTheme = GhosttyConfig.load(useCache: false).theme?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let themes = GhosttyConfig.discoverThemeNames()
+        let currentTheme = commandPaletteGhosttyResolvedCurrentTheme
+        let themes = commandPaletteGhosttyThemeNames
         var commands: [CommandPaletteCommand] = []
-        commands.reserveCapacity(themes.count + 1)
+        commands.reserveCapacity(max(2, themes.count + 1))
 
         commands.append(
             CommandPaletteCommand(
@@ -3904,11 +3916,27 @@ struct ContentView: View {
             )
         )
 
+        if commandPaletteGhosttyThemesAreLoading && themes.isEmpty {
+            commands.append(
+                CommandPaletteCommand(
+                    id: "palette.ghosttyTheme.loading",
+                    rank: 1,
+                    title: String(localized: "command.ghosttyTheme.loading.title", defaultValue: "Loading Ghostty themes…"),
+                    subtitle: String(localized: "command.ghosttyTheme.loading.subtitle", defaultValue: "Ghostty Theme"),
+                    shortcutHint: nil,
+                    keywords: ["loading", "theme", "ghostty"],
+                    dismissOnRun: false,
+                    action: {}
+                )
+            )
+            return commands
+        }
+
         for (index, themeName) in themes.enumerated() {
             let isCurrentTheme = currentTheme?.localizedCaseInsensitiveCompare(themeName) == .orderedSame
             commands.append(
                 CommandPaletteCommand(
-                    id: "palette.ghosttyTheme.\(themeName.lowercased())",
+                    id: commandPaletteGhosttyThemeCommandID(for: themeName),
                     rank: index + 1,
                     title: isCurrentTheme
                         ? String(localized: "command.ghosttyTheme.current.title", defaultValue: "\(themeName) ✓")
@@ -3930,6 +3958,7 @@ struct ContentView: View {
         commandPaletteQuery = Self.commandPaletteCommandsPrefix
         commandPaletteSelectedResultIndex = 0
         commandPaletteSelectionAnchorCommandID = nil
+        refreshCommandPaletteGhosttyThemeData(force: true)
         scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
         resetCommandPaletteSearchFocus()
         syncCommandPaletteDebugStateForObservedWindow()
@@ -3937,6 +3966,11 @@ struct ContentView: View {
 
     private func exitCommandPaletteGhosttyThemeMenu() {
         commandPaletteCommandSubmenu = nil
+        commandPaletteGhosttyThemeLoadTask?.cancel()
+        commandPaletteGhosttyThemeLoadTask = nil
+        commandPaletteGhosttyThemeNames = []
+        commandPaletteGhosttyResolvedCurrentTheme = nil
+        commandPaletteGhosttyThemesAreLoading = false
         commandPaletteQuery = Self.commandPaletteCommandsPrefix
         commandPaletteSelectedResultIndex = 0
         commandPaletteSelectionAnchorCommandID = nil
@@ -3947,8 +3981,12 @@ struct ContentView: View {
 
     private func applyGhosttyThemeFromPalette(_ themeName: String) {
         do {
-            try GhosttyConfig.applyTheme(themeName)
+            try GhosttyConfig.applyTheme(
+                themeName,
+                preferredColorScheme: GhosttyConfig.currentColorSchemePreference()
+            )
             GhosttyConfig.invalidateLoadCache()
+            commandPaletteGhosttyResolvedCurrentTheme = themeName
             GhosttyApp.shared.reloadConfiguration(source: "commandPalette.ghosttyTheme")
         } catch {
             NSSound.beep()
@@ -3958,6 +3996,45 @@ struct ContentView: View {
                 error.localizedDescription
             )
         }
+    }
+
+    private func refreshCommandPaletteGhosttyThemeData(force: Bool = false) {
+        if !force,
+           (!commandPaletteGhosttyThemeNames.isEmpty || commandPaletteGhosttyThemesAreLoading) {
+            return
+        }
+
+        commandPaletteGhosttyThemeLoadTask?.cancel()
+        commandPaletteGhosttyThemesAreLoading = true
+        commandPaletteGhosttyThemeLoadTask = Task.detached(priority: .userInitiated) {
+            let preferredColorScheme = GhosttyConfig.currentColorSchemePreference()
+            let resolvedCurrentTheme = (
+                GhosttyConfig.load(useCache: false).theme.map {
+                    GhosttyConfig.resolveThemeName(
+                        from: $0,
+                        preferredColorScheme: preferredColorScheme
+                    )
+                }
+            )?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let themes = GhosttyConfig.discoverThemeNames()
+
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                guard commandPaletteCommandSubmenu == .ghosttyThemes else { return }
+                commandPaletteGhosttyThemeNames = themes
+                commandPaletteGhosttyResolvedCurrentTheme = resolvedCurrentTheme
+                commandPaletteGhosttyThemesAreLoading = false
+                commandPaletteGhosttyThemeLoadTask = nil
+                scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
+                syncCommandPaletteDebugStateForObservedWindow()
+            }
+        }
+    }
+
+    private func commandPaletteGhosttyThemeCommandID(for themeName: String) -> String {
+        let encoded = themeName.utf8.map { String(format: "%02x", $0) }.joined()
+        return "palette.ghosttyTheme.\(encoded)"
     }
 
     private func commandPaletteShortcutHint(
@@ -5506,6 +5583,11 @@ struct ContentView: View {
     private func resetCommandPaletteListState(initialQuery: String) {
         commandPaletteMode = .commands
         commandPaletteCommandSubmenu = nil
+        commandPaletteGhosttyThemeLoadTask?.cancel()
+        commandPaletteGhosttyThemeLoadTask = nil
+        commandPaletteGhosttyThemeNames = []
+        commandPaletteGhosttyResolvedCurrentTheme = nil
+        commandPaletteGhosttyThemesAreLoading = false
         commandPaletteQuery = initialQuery
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0
@@ -5532,6 +5614,11 @@ struct ContentView: View {
         isCommandPalettePresented = false
         commandPaletteMode = .commands
         commandPaletteCommandSubmenu = nil
+        commandPaletteGhosttyThemeLoadTask?.cancel()
+        commandPaletteGhosttyThemeLoadTask = nil
+        commandPaletteGhosttyThemeNames = []
+        commandPaletteGhosttyResolvedCurrentTheme = nil
+        commandPaletteGhosttyThemesAreLoading = false
         commandPaletteQuery = ""
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1332,6 +1332,7 @@ struct ContentView: View {
     @State private var commandPalettePendingActivation: CommandPalettePendingActivation?
     @State private var commandPaletteResultsRevision: UInt64 = 0
     @State private var commandPaletteUsageHistoryByCommandId: [String: CommandPaletteUsageEntry] = [:]
+    @State private var commandPaletteCommandSubmenu: CommandPaletteCommandSubmenu?
     @State private var isFeedbackComposerPresented = false
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
@@ -1339,6 +1340,10 @@ struct ContentView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @FocusState private var isCommandPaletteSearchFocused: Bool
     @FocusState private var isCommandPaletteRenameFocused: Bool
+
+    private enum CommandPaletteCommandSubmenu {
+        case ghosttyThemes
+    }
 
     private enum CommandPaletteMode {
         case commands
@@ -3247,6 +3252,9 @@ struct ContentView: View {
     private var commandPaletteSearchPlaceholder: String {
         switch commandPaletteListScope {
         case .commands:
+            if commandPaletteCommandSubmenu == .ghosttyThemes {
+                return String(localized: "commandPalette.search.ghosttyThemesPlaceholder", defaultValue: "Search Ghostty themes")
+            }
             return String(localized: "commandPalette.search.commandsPlaceholder", defaultValue: "Type a command")
         case .switcher:
             return String(localized: "commandPalette.search.switcherPlaceholder", defaultValue: "Search workspaces")
@@ -3256,6 +3264,9 @@ struct ContentView: View {
     private var commandPaletteEmptyStateText: String {
         switch commandPaletteListScope {
         case .commands:
+            if commandPaletteCommandSubmenu == .ghosttyThemes {
+                return String(localized: "commandPalette.search.ghosttyThemesEmpty", defaultValue: "No Ghostty themes match your search.")
+            }
             return String(localized: "commandPalette.search.commandsEmpty", defaultValue: "No commands match your search.")
         case .switcher:
             return String(localized: "commandPalette.search.switcherEmpty", defaultValue: "No workspaces match your search.")
@@ -3837,6 +3848,10 @@ struct ContentView: View {
     }
 
     private func commandPaletteCommands() -> [CommandPaletteCommand] {
+        if commandPaletteCommandSubmenu == .ghosttyThemes {
+            return commandPaletteGhosttyThemeCommands()
+        }
+
         let context = commandPaletteContextSnapshot()
         let contributions = commandPaletteCommandContributions()
         var handlerRegistry = CommandPaletteHandlerRegistry()
@@ -3868,6 +3883,81 @@ struct ContentView: View {
         }
 
         return commands
+    }
+
+    private func commandPaletteGhosttyThemeCommands() -> [CommandPaletteCommand] {
+        let currentTheme = GhosttyConfig.load(useCache: false).theme?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let themes = GhosttyConfig.discoverThemeNames()
+        var commands: [CommandPaletteCommand] = []
+        commands.reserveCapacity(themes.count + 1)
+
+        commands.append(
+            CommandPaletteCommand(
+                id: "palette.ghosttyTheme.back",
+                rank: 0,
+                title: String(localized: "command.ghosttyTheme.back.title", defaultValue: "Back"),
+                subtitle: String(localized: "command.ghosttyTheme.back.subtitle", defaultValue: "Ghostty Themes"),
+                shortcutHint: nil,
+                keywords: ["back", "theme", "ghostty"],
+                dismissOnRun: false,
+                action: { exitCommandPaletteGhosttyThemeMenu() }
+            )
+        )
+
+        for (index, themeName) in themes.enumerated() {
+            let isCurrentTheme = currentTheme?.localizedCaseInsensitiveCompare(themeName) == .orderedSame
+            commands.append(
+                CommandPaletteCommand(
+                    id: "palette.ghosttyTheme.\(themeName.lowercased())",
+                    rank: index + 1,
+                    title: isCurrentTheme
+                        ? String(localized: "command.ghosttyTheme.current.title", defaultValue: "\(themeName) ✓")
+                        : themeName,
+                    subtitle: String(localized: "command.ghosttyTheme.subtitle", defaultValue: "Ghostty Theme"),
+                    shortcutHint: nil,
+                    keywords: ["theme", "ghostty", "appearance", themeName],
+                    dismissOnRun: true,
+                    action: { applyGhosttyThemeFromPalette(themeName) }
+                )
+            )
+        }
+
+        return commands
+    }
+
+    private func enterCommandPaletteGhosttyThemeMenu() {
+        commandPaletteCommandSubmenu = .ghosttyThemes
+        commandPaletteQuery = Self.commandPaletteCommandsPrefix
+        commandPaletteSelectedResultIndex = 0
+        commandPaletteSelectionAnchorCommandID = nil
+        scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
+        resetCommandPaletteSearchFocus()
+        syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func exitCommandPaletteGhosttyThemeMenu() {
+        commandPaletteCommandSubmenu = nil
+        commandPaletteQuery = Self.commandPaletteCommandsPrefix
+        commandPaletteSelectedResultIndex = 0
+        commandPaletteSelectionAnchorCommandID = nil
+        scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
+        resetCommandPaletteSearchFocus()
+        syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func applyGhosttyThemeFromPalette(_ themeName: String) {
+        do {
+            try GhosttyConfig.applyTheme(themeName)
+            GhosttyConfig.invalidateLoadCache()
+            GhosttyApp.shared.reloadConfiguration(source: "commandPalette.ghosttyTheme")
+        } catch {
+            NSSound.beep()
+            NSLog(
+                "commandPalette.ghosttyTheme.apply failed theme=%@ error=%@",
+                themeName,
+                error.localizedDescription
+            )
+        }
     }
 
     private func commandPaletteShortcutHint(
@@ -4357,6 +4447,15 @@ struct ContentView: View {
 
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.ghosttyThemeMenu",
+                title: constant(String(localized: "command.ghosttyThemeMenu.title", defaultValue: "Ghostty Theme…")),
+                subtitle: constant(String(localized: "command.ghosttyThemeMenu.subtitle", defaultValue: "Appearance")),
+                keywords: ["theme", "ghostty", "appearance", "color", "terminal"],
+                dismissOnRun: false
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.openWorkspacePullRequests",
                 title: constant(String(localized: "command.openWorkspacePRLinks.title", defaultValue: "Open All Workspace PR Links")),
                 subtitle: workspaceSubtitle,
@@ -4647,6 +4746,9 @@ struct ContentView: View {
     }
 
     private func registerCommandPaletteHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
+        registry.register(commandId: "palette.ghosttyThemeMenu") {
+            enterCommandPaletteGhosttyThemeMenu()
+        }
         registry.register(commandId: "palette.newWorkspace") {
             tabManager.addWorkspace()
         }
@@ -5403,6 +5505,7 @@ struct ContentView: View {
 
     private func resetCommandPaletteListState(initialQuery: String) {
         commandPaletteMode = .commands
+        commandPaletteCommandSubmenu = nil
         commandPaletteQuery = initialQuery
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0
@@ -5428,6 +5531,7 @@ struct ContentView: View {
         commandPaletteSearchRequestID &+= 1
         isCommandPalettePresented = false
         commandPaletteMode = .commands
+        commandPaletteCommandSubmenu = nil
         commandPaletteQuery = ""
         commandPaletteRenameDraft = ""
         commandPaletteSelectedResultIndex = 0

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -7,6 +7,13 @@ struct GhosttyConfig {
         case dark
     }
 
+    private struct ThemeSettingComponents {
+        var fallback: String?
+        var light: String?
+        var dark: String?
+        var hasExplicitVariants = false
+    }
+
     private static let loadCacheLock = NSLock()
     private static var cachedConfigsByColorScheme: [ColorSchemePreference: GhosttyConfig] = [:]
 
@@ -243,60 +250,26 @@ struct GhosttyConfig {
         from rawThemeValue: String,
         preferredColorScheme: ColorSchemePreference
     ) -> String {
-        var fallbackTheme: String?
-        var lightTheme: String?
-        var darkTheme: String?
-
-        for token in rawThemeValue.split(separator: ",").map(String.init) {
-            let entry = token.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !entry.isEmpty else { continue }
-
-            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
-            if parts.count != 2 {
-                if fallbackTheme == nil {
-                    fallbackTheme = entry
-                }
-                continue
-            }
-
-            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !value.isEmpty else { continue }
-
-            switch key {
-            case "light":
-                if lightTheme == nil {
-                    lightTheme = value
-                }
-            case "dark":
-                if darkTheme == nil {
-                    darkTheme = value
-                }
-            default:
-                if fallbackTheme == nil {
-                    fallbackTheme = value
-                }
-            }
-        }
+        let components = themeSettingComponents(from: rawThemeValue)
 
         switch preferredColorScheme {
         case .light:
-            if let lightTheme {
+            if let lightTheme = components.light {
                 return lightTheme
             }
         case .dark:
-            if let darkTheme {
+            if let darkTheme = components.dark {
                 return darkTheme
             }
         }
 
-        if let fallbackTheme {
+        if let fallbackTheme = components.fallback {
             return fallbackTheme
         }
-        if let darkTheme {
+        if let darkTheme = components.dark {
             return darkTheme
         }
-        if let lightTheme {
+        if let lightTheme = components.light {
             return lightTheme
         }
         return rawThemeValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -482,7 +455,7 @@ struct GhosttyConfig {
 
             for child in children {
                 let values = try? child.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
-                guard values?.isRegularFile == true || values?.isDirectory == false else { continue }
+                guard values?.isRegularFile == true else { continue }
                 let name = child.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !name.isEmpty else { continue }
                 let normalized = name
@@ -500,10 +473,10 @@ struct GhosttyConfig {
 
     static func configSearchPaths() -> [String] {
         [
-            "~/.config/ghostty/config.ghostty",
             "~/.config/ghostty/config",
-            "~/Library/Application Support/com.mitchellh.ghostty/config.ghostty",
+            "~/.config/ghostty/config.ghostty",
             "~/Library/Application Support/com.mitchellh.ghostty/config",
+            "~/Library/Application Support/com.mitchellh.ghostty/config.ghostty",
         ].map { NSString(string: $0).expandingTildeInPath }
     }
 
@@ -530,12 +503,10 @@ struct GhosttyConfig {
         try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
-        var lines = existing.isEmpty ? [] : existing.components(separatedBy: .newlines)
-        if lines.last == "" {
-            lines.removeLast()
-        }
+        var lines = configLines(from: existing)
 
         var replaced = false
+        var lastMatchIndex: Int?
         for index in lines.indices {
             let line = lines[index]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -546,11 +517,13 @@ struct GhosttyConfig {
                   rawKey == key else {
                 continue
             }
+            lastMatchIndex = index
+        }
 
-            let indentation = String(line.prefix { $0 == " " || $0 == "\t" })
+        if let index = lastMatchIndex {
+            let indentation = String(lines[index].prefix { $0 == " " || $0 == "\t" })
             lines[index] = "\(indentation)\(key) = \(value)"
             replaced = true
-            break
         }
 
         if !replaced {
@@ -568,14 +541,136 @@ struct GhosttyConfig {
     static func applyTheme(
         _ themeName: String,
         fileManager: FileManager = .default,
+        preferredColorScheme: ColorSchemePreference = currentColorSchemePreference(),
         searchPaths: [String]? = nil
     ) throws -> String {
-        try upsertConfigValue(
-            key: "theme",
-            value: themeName,
-            fileManager: fileManager,
-            searchPaths: searchPaths
+        let path = writableConfigPath(fileManager: fileManager, searchPaths: searchPaths)
+        let url = URL(fileURLWithPath: path)
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        var lines = configLines(from: existing)
+        let lastThemeAssignment = lastActiveConfigAssignment(forKey: "theme", in: lines)
+        let nextThemeValue = updatedThemeValueForSelection(
+            existingThemeValue: lastThemeAssignment?.value,
+            selectedTheme: themeName,
+            preferredColorScheme: preferredColorScheme
         )
+
+        if let assignment = lastThemeAssignment {
+            let indentation = String(lines[assignment.index].prefix { $0 == " " || $0 == "\t" })
+            lines[assignment.index] = "\(indentation)theme = \(nextThemeValue)"
+        } else {
+            if !lines.isEmpty, !(lines.last?.isEmpty ?? true) {
+                lines.append("")
+            }
+            lines.append("theme = \(nextThemeValue)")
+        }
+
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    static func updatedThemeValueForSelection(
+        existingThemeValue: String?,
+        selectedTheme: String,
+        preferredColorScheme: ColorSchemePreference
+    ) -> String {
+        guard let existingThemeValue else { return selectedTheme }
+        let components = themeSettingComponents(from: existingThemeValue)
+        guard components.hasExplicitVariants else { return selectedTheme }
+
+        var updated = components
+        switch preferredColorScheme {
+        case .light:
+            updated.light = selectedTheme
+        case .dark:
+            updated.dark = selectedTheme
+        }
+
+        var entries: [String] = []
+        if let fallback = updated.fallback, !fallback.isEmpty {
+            entries.append(fallback)
+        }
+        if let light = updated.light, !light.isEmpty {
+            entries.append("light:\(light)")
+        }
+        if let dark = updated.dark, !dark.isEmpty {
+            entries.append("dark:\(dark)")
+        }
+        return entries.isEmpty ? selectedTheme : entries.joined(separator: ",")
+    }
+
+    private static func themeSettingComponents(from rawThemeValue: String) -> ThemeSettingComponents {
+        var components = ThemeSettingComponents()
+
+        for token in rawThemeValue.split(separator: ",").map(String.init) {
+            let entry = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !entry.isEmpty else { continue }
+
+            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count != 2 {
+                if components.fallback == nil {
+                    components.fallback = entry
+                }
+                continue
+            }
+
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+
+            switch key {
+            case "light":
+                components.hasExplicitVariants = true
+                if components.light == nil {
+                    components.light = value
+                }
+            case "dark":
+                components.hasExplicitVariants = true
+                if components.dark == nil {
+                    components.dark = value
+                }
+            default:
+                if components.fallback == nil {
+                    components.fallback = value
+                }
+            }
+        }
+
+        return components
+    }
+
+    private static func configLines(from contents: String) -> [String] {
+        var lines = contents.isEmpty ? [] : contents.components(separatedBy: .newlines)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func lastActiveConfigAssignment(
+        forKey key: String,
+        in lines: [String]
+    ) -> (index: Int, value: String)? {
+        for index in lines.indices.reversed() {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            guard let rawKey = parts.first?.trimmingCharacters(in: .whitespaces),
+                  rawKey == key else {
+                continue
+            }
+
+            let rawValue = parts.count == 2
+                ? parts[1].trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                : ""
+            return (index, rawValue)
+        }
+        return nil
     }
 
     private static func readConfigFile(at path: String) -> String? {

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -459,7 +459,7 @@ struct GhosttyConfig {
                 let name = child.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !name.isEmpty else { continue }
                 let normalized = name
-                    .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                    .folding(options: [.caseInsensitive], locale: .current)
                     .lowercased()
                 guard seen.insert(normalized).inserted else { continue }
                 discovered.append(name)
@@ -485,10 +485,10 @@ struct GhosttyConfig {
         searchPaths: [String]? = nil
     ) -> String {
         let resolvedSearchPaths = searchPaths ?? configSearchPaths()
-        for path in resolvedSearchPaths where fileManager.fileExists(atPath: path) {
+        for path in resolvedSearchPaths.reversed() where fileManager.fileExists(atPath: path) {
             return path
         }
-        return resolvedSearchPaths.first ?? NSString(string: "~/.config/ghostty/config.ghostty").expandingTildeInPath
+        return resolvedSearchPaths.last ?? NSString(string: "~/.config/ghostty/config.ghostty").expandingTildeInPath
     }
 
     @discardableResult
@@ -502,7 +502,12 @@ struct GhosttyConfig {
         let url = URL(fileURLWithPath: path)
         try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let existing: String
+        if fileManager.fileExists(atPath: path) {
+            existing = try String(contentsOf: url, encoding: .utf8)
+        } else {
+            existing = ""
+        }
         var lines = configLines(from: existing)
 
         var replaced = false
@@ -544,11 +549,20 @@ struct GhosttyConfig {
         preferredColorScheme: ColorSchemePreference = currentColorSchemePreference(),
         searchPaths: [String]? = nil
     ) throws -> String {
+        guard !themeName.contains(where: { $0.isNewline || $0 == "," }) else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+
         let path = writableConfigPath(fileManager: fileManager, searchPaths: searchPaths)
         let url = URL(fileURLWithPath: path)
         try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let existing: String
+        if fileManager.fileExists(atPath: path) {
+            existing = try String(contentsOf: url, encoding: .utf8)
+        } else {
+            existing = ""
+        }
         var lines = configLines(from: existing)
         let lastThemeAssignment = lastActiveConfigAssignment(forKey: "theme", in: lines)
         let nextThemeValue = updatedThemeValueForSelection(

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -75,8 +75,8 @@ struct GhosttyConfig {
 
     static func invalidateLoadCache() {
         loadCacheLock.lock()
+        defer { loadCacheLock.unlock() }
         cachedConfigsByColorScheme.removeAll()
-        loadCacheLock.unlock()
     }
 
     private static func cachedLoad(for colorScheme: ColorSchemePreference) -> GhosttyConfig? {
@@ -510,7 +510,6 @@ struct GhosttyConfig {
         }
         var lines = configLines(from: existing)
 
-        var replaced = false
         var lastMatchIndex: Int?
         for index in lines.indices {
             let line = lines[index]
@@ -528,10 +527,7 @@ struct GhosttyConfig {
         if let index = lastMatchIndex {
             let indentation = String(lines[index].prefix { $0 == " " || $0 == "\t" })
             lines[index] = "\(indentation)\(key) = \(value)"
-            replaced = true
-        }
-
-        if !replaced {
+        } else {
             if !lines.isEmpty, !(lines.last?.isEmpty ?? true) {
                 lines.append("")
             }
@@ -549,7 +545,10 @@ struct GhosttyConfig {
         preferredColorScheme: ColorSchemePreference = currentColorSchemePreference(),
         searchPaths: [String]? = nil
     ) throws -> String {
-        guard !themeName.contains(where: { $0.isNewline || $0 == "," }) else {
+        guard !themeName.isEmpty,
+              !themeName.contains(where: { $0.isNewline || $0 == "," }),
+              !themeName.contains(".."),
+              !themeName.contains("/") else {
             throw CocoaError(.fileWriteInvalidFileName)
         }
 

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -409,6 +409,175 @@ struct GhosttyConfig {
         return paths
     }
 
+    static func themeSearchDirectories(
+        environment: [String: String],
+        bundleResourceURL: URL?
+    ) -> [String] {
+        var paths: [String] = []
+
+        func appendUniquePath(_ path: String?) {
+            guard let path else { return }
+            let expanded = NSString(string: path).expandingTildeInPath
+            guard !expanded.isEmpty else { return }
+            if !paths.contains(expanded) {
+                paths.append(expanded)
+            }
+        }
+
+        func appendThemeDirectory(in resourcesRoot: String?) {
+            guard let resourcesRoot else { return }
+            let expanded = NSString(string: resourcesRoot).expandingTildeInPath
+            guard !expanded.isEmpty else { return }
+            appendUniquePath(
+                URL(fileURLWithPath: expanded)
+                    .appendingPathComponent("themes", isDirectory: true)
+                    .path
+            )
+        }
+
+        appendThemeDirectory(in: environment["GHOSTTY_RESOURCES_DIR"])
+        appendUniquePath(
+            bundleResourceURL?
+                .appendingPathComponent("ghostty/themes", isDirectory: true)
+                .path
+        )
+
+        if let xdgDataDirs = environment["XDG_DATA_DIRS"] {
+            for dataDir in xdgDataDirs.split(separator: ":").map(String.init) {
+                guard !dataDir.isEmpty else { continue }
+                appendUniquePath(
+                    URL(fileURLWithPath: dataDir)
+                        .appendingPathComponent("ghostty/themes", isDirectory: true)
+                        .path
+                )
+            }
+        }
+
+        appendUniquePath("/Applications/Ghostty.app/Contents/Resources/ghostty/themes")
+        appendUniquePath("~/.config/ghostty/themes")
+        appendUniquePath("~/Library/Application Support/com.mitchellh.ghostty/themes")
+
+        return paths
+    }
+
+    static func discoverThemeNames(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleResourceURL: URL? = Bundle.main.resourceURL,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var discovered: [String] = []
+        var seen: Set<String> = []
+
+        for directory in themeSearchDirectories(
+            environment: environment,
+            bundleResourceURL: bundleResourceURL
+        ) {
+            guard let children = try? fileManager.contentsOfDirectory(
+                at: URL(fileURLWithPath: directory, isDirectory: true),
+                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                continue
+            }
+
+            for child in children {
+                let values = try? child.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+                guard values?.isRegularFile == true || values?.isDirectory == false else { continue }
+                let name = child.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !name.isEmpty else { continue }
+                let normalized = name
+                    .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+                    .lowercased()
+                guard seen.insert(normalized).inserted else { continue }
+                discovered.append(name)
+            }
+        }
+
+        return discovered.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+    }
+
+    static func configSearchPaths() -> [String] {
+        [
+            "~/.config/ghostty/config.ghostty",
+            "~/.config/ghostty/config",
+            "~/Library/Application Support/com.mitchellh.ghostty/config.ghostty",
+            "~/Library/Application Support/com.mitchellh.ghostty/config",
+        ].map { NSString(string: $0).expandingTildeInPath }
+    }
+
+    static func writableConfigPath(
+        fileManager: FileManager = .default,
+        searchPaths: [String]? = nil
+    ) -> String {
+        let resolvedSearchPaths = searchPaths ?? configSearchPaths()
+        for path in resolvedSearchPaths where fileManager.fileExists(atPath: path) {
+            return path
+        }
+        return resolvedSearchPaths.first ?? NSString(string: "~/.config/ghostty/config.ghostty").expandingTildeInPath
+    }
+
+    @discardableResult
+    static func upsertConfigValue(
+        key: String,
+        value: String,
+        fileManager: FileManager = .default,
+        searchPaths: [String]? = nil
+    ) throws -> String {
+        let path = writableConfigPath(fileManager: fileManager, searchPaths: searchPaths)
+        let url = URL(fileURLWithPath: path)
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        var lines = existing.isEmpty ? [] : existing.components(separatedBy: .newlines)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+
+        var replaced = false
+        for index in lines.indices {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            guard let rawKey = parts.first?.trimmingCharacters(in: .whitespaces),
+                  rawKey == key else {
+                continue
+            }
+
+            let indentation = String(line.prefix { $0 == " " || $0 == "\t" })
+            lines[index] = "\(indentation)\(key) = \(value)"
+            replaced = true
+            break
+        }
+
+        if !replaced {
+            if !lines.isEmpty, !(lines.last?.isEmpty ?? true) {
+                lines.append("")
+            }
+            lines.append("\(key) = \(value)")
+        }
+
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    @discardableResult
+    static func applyTheme(
+        _ themeName: String,
+        fileManager: FileManager = .default,
+        searchPaths: [String]? = nil
+    ) throws -> String {
+        try upsertConfigValue(
+            key: "theme",
+            value: themeName,
+            fileManager: fileManager,
+            searchPaths: searchPaths
+        )
+    }
+
     private static func readConfigFile(at path: String) -> String? {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: path) else { return nil }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -339,6 +339,18 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertThrowsError(try GhosttyConfig.applyTheme("Bad,Theme"))
     }
 
+    func testApplyThemeRejectsPathTraversal() {
+        XCTAssertThrowsError(try GhosttyConfig.applyTheme("../../../etc/passwd"))
+    }
+
+    func testApplyThemeRejectsThemeNameWithSlash() {
+        XCTAssertThrowsError(try GhosttyConfig.applyTheme("sub/theme"))
+    }
+
+    func testApplyThemeRejectsEmptyName() {
+        XCTAssertThrowsError(try GhosttyConfig.applyTheme(""))
+    }
+
     func testLoadCachesPerColorScheme() {
         GhosttyConfig.invalidateLoadCache()
         defer { GhosttyConfig.invalidateLoadCache() }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -314,6 +314,31 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(contents, "theme = Solarized Dark\n")
     }
 
+    func testWritableConfigPathPicksHighestPrecedenceFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-writable-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let lowPrecedence = root.appendingPathComponent("config")
+        let highPrecedence = root.appendingPathComponent("config.ghostty")
+        try "".write(to: lowPrecedence, atomically: true, encoding: .utf8)
+        try "".write(to: highPrecedence, atomically: true, encoding: .utf8)
+
+        let chosen = GhosttyConfig.writableConfigPath(
+            searchPaths: [lowPrecedence.path, highPrecedence.path]
+        )
+        XCTAssertEqual(chosen, highPrecedence.path)
+    }
+
+    func testApplyThemeRejectsThemeNameWithNewline() {
+        XCTAssertThrowsError(try GhosttyConfig.applyTheme("Bad\nTheme"))
+    }
+
+    func testApplyThemeRejectsThemeNameWithComma() {
+        XCTAssertThrowsError(try GhosttyConfig.applyTheme("Bad,Theme"))
+    }
+
     func testLoadCachesPerColorScheme() {
         GhosttyConfig.invalidateLoadCache()
         defer { GhosttyConfig.invalidateLoadCache() }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -199,6 +199,27 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(themes, ["Nord", "Tokyo Night"])
     }
 
+    func testDiscoverThemeNamesIgnoresNonRegularFiles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-nonregular-\(UUID().uuidString)")
+        let themesDir = root.appendingPathComponent("themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let realTheme = themesDir.appendingPathComponent("Catppuccin")
+        try "background = #111111\n".write(to: realTheme, atomically: true, encoding: .utf8)
+
+        let symlink = themesDir.appendingPathComponent("Catppuccin Link")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: realTheme)
+
+        let themes = GhosttyConfig.discoverThemeNames(
+            environment: ["GHOSTTY_RESOURCES_DIR": root.path],
+            bundleResourceURL: nil
+        )
+
+        XCTAssertEqual(themes, ["Catppuccin"])
+    }
+
     func testApplyThemeUpdatesExistingThemeLine() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ghostty-config-update-\(UUID().uuidString)")
@@ -220,6 +241,60 @@ final class GhosttyConfigTests: XCTestCase {
         let contents = try String(contentsOf: configPath, encoding: .utf8)
         XCTAssertTrue(contents.contains("theme = New Theme"))
         XCTAssertFalse(contents.contains("theme = Old Theme"))
+    }
+
+    func testApplyThemeUpdatesLastActiveThemeEntry() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-config-last-write-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configPath = root.appendingPathComponent("config.ghostty")
+        try """
+        theme = First Theme
+        # theme = Commented Theme
+        theme = Second Theme
+        """.write(to: configPath, atomically: true, encoding: .utf8)
+
+        try GhosttyConfig.applyTheme(
+            "Replacement Theme",
+            searchPaths: [configPath.path]
+        )
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(contents.contains("theme = First Theme"))
+        XCTAssertTrue(contents.contains("theme = Replacement Theme"))
+        XCTAssertFalse(contents.contains("theme = Second Theme"))
+    }
+
+    func testApplyThemePreservesLightDarkThemeVariantsForLightMode() {
+        let updated = GhosttyConfig.updatedThemeValueForSelection(
+            existingThemeValue: "light:Solarized Light,dark:Solarized Dark",
+            selectedTheme: "Nord",
+            preferredColorScheme: .light
+        )
+
+        XCTAssertEqual(updated, "light:Nord,dark:Solarized Dark")
+    }
+
+    func testApplyThemePreservesLightDarkThemeVariantsForDarkMode() {
+        let updated = GhosttyConfig.updatedThemeValueForSelection(
+            existingThemeValue: "light:Solarized Light,dark:Solarized Dark",
+            selectedTheme: "Tokyo Night",
+            preferredColorScheme: .dark
+        )
+
+        XCTAssertEqual(updated, "light:Solarized Light,dark:Tokyo Night")
+    }
+
+    func testApplyThemePreservesFallbackAlongsideVariants() {
+        let updated = GhosttyConfig.updatedThemeValueForSelection(
+            existingThemeValue: "Builtin Gruvbox,light:Solarized Light,dark:Solarized Dark",
+            selectedTheme: "Nord",
+            preferredColorScheme: .dark
+        )
+
+        XCTAssertEqual(updated, "Builtin Gruvbox,light:Solarized Light,dark:Nord")
     }
 
     func testApplyThemeCreatesConfigWhenMissing() throws {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -164,6 +164,81 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(rgb255(config.backgroundColor), RGB(red: 253, green: 246, blue: 227))
     }
 
+    func testDiscoverThemeNamesMergesDirectoriesAndDeduplicatesCaseInsensitively() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-discover-\(UUID().uuidString)")
+        let resourcesDir = root.appendingPathComponent("resources")
+        let bundleDir = root.appendingPathComponent("bundle")
+        let resourcesThemesDir = resourcesDir.appendingPathComponent("themes")
+        let bundleThemesDir = bundleDir.appendingPathComponent("ghostty/themes")
+        try FileManager.default.createDirectory(at: resourcesThemesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: bundleThemesDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "background = #111111\n".write(
+            to: resourcesThemesDir.appendingPathComponent("Nord"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "background = #222222\n".write(
+            to: bundleThemesDir.appendingPathComponent("nord"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "background = #333333\n".write(
+            to: bundleThemesDir.appendingPathComponent("Tokyo Night"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let themes = GhosttyConfig.discoverThemeNames(
+            environment: ["GHOSTTY_RESOURCES_DIR": resourcesDir.path],
+            bundleResourceURL: bundleDir
+        )
+
+        XCTAssertEqual(themes, ["Nord", "Tokyo Night"])
+    }
+
+    func testApplyThemeUpdatesExistingThemeLine() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-config-update-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let configPath = root.appendingPathComponent("config.ghostty")
+        try """
+        font-family = JetBrains Mono
+        theme = Old Theme
+        background = #000000
+        """.write(to: configPath, atomically: true, encoding: .utf8)
+
+        try GhosttyConfig.applyTheme(
+            "New Theme",
+            searchPaths: [configPath.path]
+        )
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertTrue(contents.contains("theme = New Theme"))
+        XCTAssertFalse(contents.contains("theme = Old Theme"))
+    }
+
+    func testApplyThemeCreatesConfigWhenMissing() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-config-create-\(UUID().uuidString)")
+        let fileManager = FileManager.default
+        defer { try? fileManager.removeItem(at: root) }
+
+        let configPath = root.appendingPathComponent("nested/config.ghostty")
+        let writtenPath = try GhosttyConfig.applyTheme(
+            "Solarized Dark",
+            searchPaths: [configPath.path]
+        )
+
+        XCTAssertEqual(writtenPath, configPath.path)
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        XCTAssertEqual(contents, "theme = Solarized Dark\n")
+    }
+
     func testLoadCachesPerColorScheme() {
         GhosttyConfig.invalidateLoadCache()
         defer { GhosttyConfig.invalidateLoadCache() }


### PR DESCRIPTION
## Summary
- add a Ghostty Theme menu entry in the command palette that opens a focused theme submenu
- discover available Ghostty themes from standard Ghostty resource and config search paths and mark the currently configured theme
- apply the selected theme by updating the Ghostty config, invalidating the config cache, and reloading Ghostty configuration
- add unit coverage for theme discovery and config upsert/create behavior

## Testing
- swiftc -parse Sources/GhosttyConfig.swift Sources/ContentView.swift cmuxTests/GhosttyConfigTests.swift
- git diff --check
- xcodebuild tests not run in this environment because the active developer directory points to Command Line Tools rather than a full Xcode install

## Scope notes
- this PR implements the command-palette theme submenu path from #526
- sidebar theme-awareness remains follow-up scope rather than being coupled into this first PR

Closes #526

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Ghostty Theme picker to the command palette with a focused submenu that discovers installed themes, highlights the current one, and applies the selection by updating config and reloading Ghostty. Implements the command‑palette theme submenu from #526 and hardens async loading, validation, and config handling.

- New Features
  - Adds “Ghostty Theme…” command with Back action, search placeholder, and loading/empty entries; hides empty text while themes are loading.
  - Discovers themes from env, app bundle, `XDG_DATA_DIRS`, and user dirs; case‑insensitive de‑dupe without diacritic folding; ignores non‑regular files. Marks the current theme and applies selection by updating the last active theme line, preserving light/dark variants and fallback; creates the config if missing, invalidates cache, and reloads.
  - Localization: adds Japanese translations for all new command‑palette strings.

- Bug Fixes
  - Picks the highest‑precedence writable config file; reads current appearance on the main actor; validates theme names (rejects empty, newline, comma, `..`, `/`); avoids clobbering unreadable configs.
  - Hardens async loading: request‑token guard to prevent stale results, early cancellation on exit/query change, and clears task refs; uses defer in `invalidateLoadCache`; minor upsert cleanup. Adds tests for precedence, validation, discovery, and apply flows.

<sup>Written for commit 3f37356395d5deeff9e498f445fe3f9dc1d3ed68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ghostty theme submenu in the command palette to browse and apply themes; UI updates for submenu placeholders and empty states.
  * Automatic discovery of Ghostty themes across app and system locations with case-insensitive deduplication; applying a theme updates or creates config while preserving light/dark variants and fallbacks.

* **Localization**
  * Added localized UI strings for Ghostty theme commands, statuses, and menu labels in multiple languages.

* **Tests**
  * Extensive tests for discovery, application, variant preservation, config precedence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->