### PR TITLE
Add os_log diagnostics for IME + resize freeze

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1902,7 +1902,7 @@ struct ContentView: View {
                 // Consume hover motion in divider band so overlapped views cannot
                 // continuously reassert their own cursor while we are resizing.
                 if event.type == .appKitDefined || event.type == .systemDefined {
-                    let hasIME = (observedWindow?.firstResponder as? GhosttyNSView)?.hasMarkedText() == true
+                    let hasIME = (observedWindow?.firstResponder as? NSTextInputClient)?.hasMarkedText() == true
                     if hasIME {
                         let evType: String = String(describing: event.type)
                         os_log(.info, log: imeResizeSidebarLog, "sidebar.eventConsumed type=%{public}@ subtype=%d dragging=%d band=%d",
@@ -1982,7 +1982,7 @@ struct ContentView: View {
                             } else {
                                 frType = "nil"
                             }
-                            let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
+                            let hasMarked: Int = (fr as? NSTextInputClient)?.hasMarkedText() == true ? 1 : 0
                             os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragStart fr=%{public}@ hasMarkedText=%d",
                                    frType as NSString, hasMarked)
                             #if DEBUG
@@ -2008,7 +2008,7 @@ struct ContentView: View {
                         } else {
                             frType = "nil"
                         }
-                        let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
+                        let hasMarked: Int = (fr as? NSTextInputClient)?.hasMarkedText() == true ? 1 : 0
                         os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragEnd fr=%{public}@ hasMarkedText=%d",
                                frType as NSString, hasMarked)
                         if isResizerDragging {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
+import os.log
+
+private let imeResizeSidebarLog = OSLog(subsystem: "com.cmuxterm.app", category: "ime-resize-sidebar")
 
 private extension Color {
     init?(hex: String) {
@@ -1898,6 +1901,11 @@ struct ContentView: View {
             if shouldOverrideCursorEvent, (isResizerBandActive || isResizerDragging) {
                 // Consume hover motion in divider band so overlapped views cannot
                 // continuously reassert their own cursor while we are resizing.
+                if event.type == .appKitDefined || event.type == .systemDefined {
+                    let evType: String = String(describing: event.type)
+                    os_log(.info, log: imeResizeSidebarLog, "sidebar.eventConsumed type=%{public}s subtype=%d dragging=%d band=%d",
+                           evType, event.subtype.rawValue, isResizerDragging ? 1 : 0, isResizerBandActive ? 1 : 0)
+                }
                 activateSidebarResizerCursor()
                 Self.fixedSidebarResizeCursor.set()
                 return nil
@@ -1964,6 +1972,14 @@ struct ContentView: View {
                             TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
                             isResizerDragging = true
                             sidebarDragStartWidth = sidebarWidth
+                            let fr = observedWindow?.firstResponder
+                            let frType: String = fr.map { String(describing: type(of: $0)) } ?? "nil"
+                            let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
+                            os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragStart fr=%{public}s hasMarkedText=%d",
+                                   frType, hasMarked)
+                            #if DEBUG
+                            dlog("sidebar.resizeDragStart")
+                            #endif
                         }
 
                         activateSidebarResizerCursor()
@@ -1977,6 +1993,11 @@ struct ContentView: View {
                         }
                     }
                     .onEnded { _ in
+                        let fr = observedWindow?.firstResponder
+                        let frType: String = fr.map { String(describing: type(of: $0)) } ?? "nil"
+                        let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
+                        os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragEnd fr=%{public}s hasMarkedText=%d",
+                               frType, hasMarked)
                         if isResizerDragging {
                             TerminalWindowPortalRegistry.endInteractiveGeometryResize()
                             isResizerDragging = false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1902,9 +1902,12 @@ struct ContentView: View {
                 // Consume hover motion in divider band so overlapped views cannot
                 // continuously reassert their own cursor while we are resizing.
                 if event.type == .appKitDefined || event.type == .systemDefined {
-                    let evType: String = String(describing: event.type)
-                    os_log(.info, log: imeResizeSidebarLog, "sidebar.eventConsumed type=%{public}s subtype=%d dragging=%d band=%d",
-                           evType, event.subtype.rawValue, isResizerDragging ? 1 : 0, isResizerBandActive ? 1 : 0)
+                    let hasIME = (observedWindow?.firstResponder as? GhosttyNSView)?.hasMarkedText() == true
+                    if hasIME {
+                        let evType: String = String(describing: event.type)
+                        os_log(.info, log: imeResizeSidebarLog, "sidebar.eventConsumed type=%{public}@ subtype=%d dragging=%d band=%d",
+                               evType as NSString, event.subtype.rawValue, isResizerDragging ? 1 : 0, isResizerBandActive ? 1 : 0)
+                    }
                 }
                 activateSidebarResizerCursor()
                 Self.fixedSidebarResizeCursor.set()
@@ -1973,10 +1976,15 @@ struct ContentView: View {
                             isResizerDragging = true
                             sidebarDragStartWidth = sidebarWidth
                             let fr = observedWindow?.firstResponder
-                            let frType: String = fr.map { String(describing: type(of: $0)) } ?? "nil"
+                            let frType: String
+                            if let fr {
+                                frType = String(describing: type(of: fr))
+                            } else {
+                                frType = "nil"
+                            }
                             let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
-                            os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragStart fr=%{public}s hasMarkedText=%d",
-                                   frType, hasMarked)
+                            os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragStart fr=%{public}@ hasMarkedText=%d",
+                                   frType as NSString, hasMarked)
                             #if DEBUG
                             dlog("sidebar.resizeDragStart")
                             #endif
@@ -1994,10 +2002,15 @@ struct ContentView: View {
                     }
                     .onEnded { _ in
                         let fr = observedWindow?.firstResponder
-                        let frType: String = fr.map { String(describing: type(of: $0)) } ?? "nil"
+                        let frType: String
+                        if let fr {
+                            frType = String(describing: type(of: fr))
+                        } else {
+                            frType = "nil"
+                        }
                         let hasMarked: Int = (fr as? GhosttyNSView)?.hasMarkedText() == true ? 1 : 0
-                        os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragEnd fr=%{public}s hasMarkedText=%d",
-                               frType, hasMarked)
+                        os_log(.info, log: imeResizeSidebarLog, "sidebar.resizeDragEnd fr=%{public}@ hasMarkedText=%d",
+                               frType as NSString, hasMarked)
                         if isResizerDragging {
                             TerminalWindowPortalRegistry.endInteractiveGeometryResize()
                             isResizerDragging = false

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4045,13 +4045,28 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         invalidateTextInputCoordinates()
     }
 
+    /// Throttle interval for IME layout logging to avoid flooding during live-resize.
+    private static let imeLayoutLogInterval: CFTimeInterval = 0.2
+    private var lastIMELayoutLogTime: CFTimeInterval = 0
+
     override func layout() {
         super.layout()
         if markedText.length > 0 {
-            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
-            let frDesc: String = window?.firstResponder === self ? "self" : String(describing: type(of: window?.firstResponder as Any))
-            os_log(.info, log: imeResizeLog, "ime.layout markedLen=%d surface=%{public}s fr=%{public}s bounds=%.0fx%.0f",
-                   markedText.length, surfaceId, frDesc, bounds.width, bounds.height)
+            let now = CACurrentMediaTime()
+            if now - lastIMELayoutLogTime >= Self.imeLayoutLogInterval {
+                lastIMELayoutLogTime = now
+                let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+                let frDesc: String
+                if window?.firstResponder === self {
+                    frDesc = "self"
+                } else if let fr = window?.firstResponder {
+                    frDesc = String(describing: type(of: fr))
+                } else {
+                    frDesc = "nil"
+                }
+                os_log(.info, log: imeResizeLog, "ime.layout markedLen=%d surface=%{public}@ fr=%{public}@ bounds=%.0fx%.0f",
+                       markedText.length, surfaceId as NSString, frDesc as NSString, bounds.width, bounds.height)
+            }
         }
         updateSurfaceSize()
         invalidateTextInputCoordinates()
@@ -4657,7 +4672,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override func becomeFirstResponder() -> Bool {
         if markedText.length > 0 {
             let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
-            os_log(.info, log: imeResizeLog, "ime.becomeFirstResponder markedLen=%d surface=%{public}s", markedText.length, surfaceId)
+            os_log(.info, log: imeResizeLog, "ime.becomeFirstResponder markedLen=%d surface=%{public}@", markedText.length, surfaceId as NSString)
         }
         let result = super.becomeFirstResponder()
         var shouldApplySurfaceFocus = false
@@ -4733,9 +4748,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override func resignFirstResponder() -> Bool {
         if markedText.length > 0 {
             let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
-            let caller: String = Thread.callStackSymbols.prefix(8).joined(separator: "\n")
-            os_log(.fault, log: imeResizeLog, "ime.resignFirstResponder markedLen=%d surface=%{public}s caller=%{public}s",
-                   markedText.length, surfaceId, caller)
+            os_log(.fault, log: imeResizeLog, "ime.resignFirstResponder markedLen=%d surface=%{public}@",
+                   markedText.length, surfaceId as NSString)
         }
         let result = super.resignFirstResponder()
         if result {
@@ -4818,9 +4832,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let fr = window?.firstResponder as? NSView,
               fr === self || fr.isDescendant(of: self) else {
             if markedText.length > 0 {
-                let frType: String = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-                os_log(.fault, log: imeResizeLog, "ime.performKeyEquiv.REJECTED frMismatch markedLen=%d keyCode=%d frType=%{public}s",
-                       markedText.length, event.keyCode, frType)
+                let frType: String
+                if let fr = window?.firstResponder {
+                    frType = String(describing: type(of: fr))
+                } else {
+                    frType = "nil"
+                }
+                os_log(.fault, log: imeResizeLog, "ime.performKeyEquiv.REJECTED frMismatch markedLen=%d keyCode=%d frType=%{public}@",
+                       markedText.length, event.keyCode, frType as NSString)
             }
             return false
         }
@@ -4976,16 +4995,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
         if markedText.length > 0 {
             let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
-            let frDesc: String = window?.firstResponder === self ? "self" : String(describing: type(of: window?.firstResponder as Any))
-            os_log(.info, log: imeResizeLog, "ime.keyDown markedLen=%d keyCode=%d surface=%{public}s fr=%{public}s",
-                   markedText.length, event.keyCode, surfaceId, frDesc)
+            let frDesc: String
+            if window?.firstResponder === self {
+                frDesc = "self"
+            } else if let fr = window?.firstResponder {
+                frDesc = String(describing: type(of: fr))
+            } else {
+                frDesc = "nil"
+            }
+            os_log(.info, log: imeResizeLog, "ime.keyDown markedLen=%d keyCode=%d surface=%{public}@ fr=%{public}@",
+                   markedText.length, event.keyCode, surfaceId as NSString, frDesc as NSString)
         }
         guard let surface = ensureSurfaceReadyForInput() else {
 #if DEBUG
             ensureSurfaceMs = (ProcessInfo.processInfo.systemUptime - ensureSurfaceStart) * 1000.0
 #endif
             if markedText.length > 0 {
-                os_log(.fault, log: imeResizeLog, "ime.keyDown.REJECTED noSurface markedLen=%d keyCode=%d",
+                os_log(.fault, log: imeResizeLog, "ime.keyDown.REJECTED.noSurface markedLen=%d keyCode=%d",
                        markedText.length, event.keyCode)
             }
             super.keyDown(with: event)
@@ -8596,8 +8622,8 @@ extension GhosttyNSView: NSTextInputClient {
         do {
             let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
             let accum: String = keyTextAccumulator != nil ? "yes" : "nil"
-            os_log(.info, log: imeResizeLog, "ime.setMarkedText prev=%d new=%d accum=%{public}s surface=%{public}s",
-                   previousLength, markedText.length, accum, surfaceId)
+            os_log(.info, log: imeResizeLog, "ime.setMarkedText prev=%d new=%d accum=%{public}@ surface=%{public}@",
+                   previousLength, markedText.length, accum as NSString, surfaceId as NSString)
         }
 
         // If we're not in a keyDown event, sync preedit immediately.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9,6 +9,9 @@ import Sentry
 import Bonsplit
 import IOSurface
 import UniformTypeIdentifiers
+import os.log
+
+private let imeResizeLog = OSLog(subsystem: "com.cmuxterm.app", category: "ime-resize")
 
 #if os(macOS)
 func cmuxShouldUseTransparentBackgroundWindow() -> Bool {
@@ -4044,6 +4047,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func layout() {
         super.layout()
+        if markedText.length > 0 {
+            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+            let frDesc: String = window?.firstResponder === self ? "self" : String(describing: type(of: window?.firstResponder as Any))
+            os_log(.info, log: imeResizeLog, "ime.layout markedLen=%d surface=%{public}s fr=%{public}s bounds=%.0fx%.0f",
+                   markedText.length, surfaceId, frDesc, bounds.width, bounds.height)
+        }
         updateSurfaceSize()
         invalidateTextInputCoordinates()
     }
@@ -4646,6 +4655,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override var acceptsFirstResponder: Bool { true }
 
     override func becomeFirstResponder() -> Bool {
+        if markedText.length > 0 {
+            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+            os_log(.info, log: imeResizeLog, "ime.becomeFirstResponder markedLen=%d surface=%{public}s", markedText.length, surfaceId)
+        }
         let result = super.becomeFirstResponder()
         var shouldApplySurfaceFocus = false
         if result {
@@ -4718,6 +4731,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func resignFirstResponder() -> Bool {
+        if markedText.length > 0 {
+            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+            let caller: String = Thread.callStackSymbols.prefix(8).joined(separator: "\n")
+            os_log(.fault, log: imeResizeLog, "ime.resignFirstResponder markedLen=%d surface=%{public}s caller=%{public}s",
+                   markedText.length, surfaceId, caller)
+        }
         let result = super.resignFirstResponder()
         if result {
             desiredFocus = false
@@ -4797,7 +4816,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
         guard event.type == .keyDown else { return false }
         guard let fr = window?.firstResponder as? NSView,
-              fr === self || fr.isDescendant(of: self) else { return false }
+              fr === self || fr.isDescendant(of: self) else {
+            if markedText.length > 0 {
+                let frType: String = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+                os_log(.fault, log: imeResizeLog, "ime.performKeyEquiv.REJECTED frMismatch markedLen=%d keyCode=%d frType=%{public}s",
+                       markedText.length, event.keyCode, frType)
+            }
+            return false
+        }
         guard let surface = ensureSurfaceReadyForInput() else { return false }
 
         // If the IME is composing (marked text present) and the key has no Cmd
@@ -4948,10 +4974,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         let ensureSurfaceStart = ProcessInfo.processInfo.systemUptime
 #endif
+        if markedText.length > 0 {
+            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+            let frDesc: String = window?.firstResponder === self ? "self" : String(describing: type(of: window?.firstResponder as Any))
+            os_log(.info, log: imeResizeLog, "ime.keyDown markedLen=%d keyCode=%d surface=%{public}s fr=%{public}s",
+                   markedText.length, event.keyCode, surfaceId, frDesc)
+        }
         guard let surface = ensureSurfaceReadyForInput() else {
 #if DEBUG
             ensureSurfaceMs = (ProcessInfo.processInfo.systemUptime - ensureSurfaceStart) * 1000.0
 #endif
+            if markedText.length > 0 {
+                os_log(.fault, log: imeResizeLog, "ime.keyDown.REJECTED noSurface markedLen=%d keyCode=%d",
+                       markedText.length, event.keyCode)
+            }
             super.keyDown(with: event)
             return
         }
@@ -8547,6 +8583,7 @@ extension GhosttyNSView: NSTextInputClient {
             )
         }
 #endif
+        let previousLength = markedText.length
         switch string {
         case let v as NSAttributedString:
             markedText = NSMutableAttributedString(attributedString: v)
@@ -8554,6 +8591,13 @@ extension GhosttyNSView: NSTextInputClient {
             markedText = NSMutableAttributedString(string: v)
         default:
             break
+        }
+
+        do {
+            let surfaceId: String = String(terminalSurface?.id.uuidString.prefix(5) ?? "nil")
+            let accum: String = keyTextAccumulator != nil ? "yes" : "nil"
+            os_log(.info, log: imeResizeLog, "ime.setMarkedText prev=%d new=%d accum=%{public}s surface=%{public}s",
+                   previousLength, markedText.length, accum, surfaceId)
         }
 
         // If we're not in a keyDown event, sync preedit immediately.


### PR DESCRIPTION
## Summary
- Add Release-safe `os_log` instrumentation to capture terminal state when IME composition is active during sidebar/pane resize
- Targets a nightly-only freeze where typing becomes unresponsive after resizing with active marked text (Japanese IME)
- Logs key events: layout during IME, firstResponder changes, keyDown rejection, setMarkedText transitions, sidebar drag with IME state

## Context
The freeze only reproduces in the distributed nightly build, not in local Debug or Release builds. These diagnostics will help capture the exact failure sequence via `log stream --predicate 'subsystem == "com.cmuxterm.app" AND category BEGINSWITH "ime-resize"'` when the issue next occurs.

## Test plan
- [ ] Verify nightly build includes the logging (check with `log stream`)
- [ ] Reproduce the freeze and collect os_log output
- [ ] Remove diagnostic logging once root cause is identified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add release-safe `os_log` diagnostics for IME composition during sidebar/pane resize to investigate the nightly-only typing freeze. Logs are throttled and scoped to capture responder, layout, key, and input paths to pinpoint the failure sequence.

- New Features
  - Instrumented `GhosttyNSView` and `ContentView` with subsystem `com.cmuxterm.app`, categories `ime-resize` / `ime-resize-sidebar`; logs include surface ID, marked text length, first responder, key codes, and bounds.
  - Logged: `layout()` during IME (200ms throttle), `becomeFirstResponder`/`resignFirstResponder`, `performKeyEquivalent` rejections (FR mismatch), `keyDown` with IME (incl. no-surface fault), `setMarkedText` transitions (prev/new length and accumulator), sidebar drag start/end (FR type + `hasMarkedText`) and IME-only consumption of `appKitDefined`/`systemDefined` events.
  - Capture via: log stream --predicate 'subsystem == "com.cmuxterm.app" AND category BEGINSWITH "ime-resize"'.

- Bug Fixes
  - Removed `Thread.callStackSymbols` from `resignFirstResponder`.
  - Fixed responder-type logging by unwrapping `window?.firstResponder` and using `%{public}@` with `NSString` bridging.
  - Added IME guard to `sidebar.eventConsumed` and used `NSTextInputClient` to detect composition for any first responder.

<sup>Written for commit 7a006cb8457db565d89eccb02bbac080d38dc142. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added additional runtime debug logging for IME/text-composition activity, surface focus/first-responder transitions, and sidebar resize/hover interactions (including pointer-monitor events and contextual state). These are diagnostics-only changes with no user-facing behavior or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->