### PR TITLE
Fix blank terminal pane when notification fires on another tab

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3058,6 +3058,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     func applyWindowBackgroundIfActive() {
         guard let window else { return }
+        // Always maintain the surface-level background to prevent blank panes.
+        // This is safe even when window-level background is skipped (idempotent).
+        applySurfaceBackground()
         let appDelegate = AppDelegate.shared
         let owningManager = tabId.flatMap { appDelegate?.tabManagerFor(tabId: $0) }
         let owningSelectedTabId = owningManager?.selectedTabId
@@ -3070,7 +3073,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) else {
             return
         }
-        applySurfaceBackground()
         let color = effectiveBackgroundColor()
         if cmuxShouldUseClearWindowBackground(for: color.alphaComponent) {
             window.backgroundColor = cmuxTransparentWindowBaseColor()

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -843,7 +843,12 @@ final class TerminalNotificationStore: ObservableObject {
         }
 
         if WorkspaceAutoReorderSettings.isEnabled() {
-            AppDelegate.shared?.tabManager?.moveTabToTop(tabId)
+            // Defer tab reordering to the next run loop iteration to avoid
+            // cascading SwiftUI re-renders (tabs + notifications @Published
+            // changes in the same frame) that can blank the active pane (#914).
+            DispatchQueue.main.async {
+                AppDelegate.shared?.tabManager?.moveTabToTop(tabId)
+            }
         }
 
         let notification = TerminalNotification(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -749,6 +749,88 @@ final class WindowBackgroundSelectionGateTests: XCTestCase {
     }
 }
 
+// MARK: - Issue #914 regression tests
+
+/// Validates that `shouldApplyWindowBackground` returning false does NOT
+/// prevent surface background from being maintained. The fix moves
+/// `applySurfaceBackground()` before the guard so it always runs.
+///
+/// These tests verify the decision logic that was previously the sole
+/// gate for surface background application. When the guard rejects,
+/// the surface background must still be applied (tested via the code
+/// change, not a mock — these tests document the rejection scenarios).
+final class WindowBackgroundSurfaceBackgroundGuaranteeTests: XCTestCase {
+    func testShouldApplyRejectsWhenOwningSelectionDiffersButSurfaceMustStayVisible() {
+        let surfaceTabId = UUID()
+        let differentSelectedTab = UUID()
+
+        // This is the scenario that triggers #914: the owning manager's
+        // selectedTabId temporarily differs from the surface's tabId
+        // (e.g., during notification-triggered tab reorder).
+        let rejected = !GhosttyNSView.shouldApplyWindowBackground(
+            surfaceTabId: surfaceTabId,
+            owningManagerExists: true,
+            owningSelectedTabId: differentSelectedTab,
+            activeSelectedTabId: surfaceTabId
+        )
+        XCTAssertTrue(rejected, "Guard should reject when owning selection differs — this is the #914 trigger condition")
+    }
+
+    func testShouldApplyRejectsWhenActiveSelectionDiffersWithNoOwningManager() {
+        let surfaceTabId = UUID()
+        let differentActiveTab = UUID()
+
+        let rejected = !GhosttyNSView.shouldApplyWindowBackground(
+            surfaceTabId: surfaceTabId,
+            owningManagerExists: false,
+            owningSelectedTabId: nil,
+            activeSelectedTabId: differentActiveTab
+        )
+        XCTAssertTrue(rejected, "Guard should reject when active selection differs — surface background must still be maintained")
+    }
+}
+
+/// Validates that notification-driven tab reorder is deferred to avoid
+/// cascading @Published changes in the same run loop frame (#914).
+final class NotificationTabReorderDeferralTests: XCTestCase {
+    func testMoveTabToTopIsNotCalledSynchronouslyDuringAddNotification() {
+        // This test documents the expectation: when addNotification() is
+        // called with auto-reorder enabled, moveTabToTop() must NOT run
+        // in the same synchronous call stack. It should be deferred via
+        // DispatchQueue.main.async to prevent two @Published changes
+        // (tabs reorder + notifications update) from triggering a
+        // compounded SwiftUI re-render that blanks the active pane.
+        //
+        // The fix wraps moveTabToTop() in DispatchQueue.main.async inside
+        // TerminalNotificationStore.addNotification(). This test validates
+        // the architectural invariant rather than mocking internals.
+        let store = TerminalNotificationStore.shared
+        let tabId = UUID()
+
+        // Capture the tab count before adding a notification.
+        // If moveTabToTop were synchronous, it would fire during
+        // addNotification and could trigger observable side effects
+        // in the same run loop. The deferred version delays this.
+        let expectation = XCTestExpectation(description: "Deferred reorder completes")
+        store.addNotification(
+            tabId: tabId,
+            surfaceId: nil,
+            title: "Test",
+            subtitle: "",
+            body: "Test notification"
+        )
+        // The moveTabToTop should be deferred — verify by checking
+        // that the notification was added (synchronous) while the
+        // reorder hasn't happened yet in this same run loop tick.
+        DispatchQueue.main.async {
+            // By the time this fires, the deferred moveTabToTop would
+            // also have been dispatched. This validates the async path.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
 final class NotificationBurstCoalescerTests: XCTestCase {
     func testSignalsInSameBurstFlushOnce() {
         let coalescer = NotificationBurstCoalescer(delay: 0.01)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -749,24 +749,11 @@ final class WindowBackgroundSelectionGateTests: XCTestCase {
     }
 }
 
-// MARK: - Issue #914 regression tests
-
-/// Validates that `shouldApplyWindowBackground` returning false does NOT
-/// prevent surface background from being maintained. The fix moves
-/// `applySurfaceBackground()` before the guard so it always runs.
-///
-/// These tests verify the decision logic that was previously the sole
-/// gate for surface background application. When the guard rejects,
-/// the surface background must still be applied (tested via the code
-/// change, not a mock — these tests document the rejection scenarios).
 final class WindowBackgroundSurfaceBackgroundGuaranteeTests: XCTestCase {
     func testShouldApplyRejectsWhenOwningSelectionDiffersButSurfaceMustStayVisible() {
         let surfaceTabId = UUID()
         let differentSelectedTab = UUID()
 
-        // This is the scenario that triggers #914: the owning manager's
-        // selectedTabId temporarily differs from the surface's tabId
-        // (e.g., during notification-triggered tab reorder).
         let rejected = !GhosttyNSView.shouldApplyWindowBackground(
             surfaceTabId: surfaceTabId,
             owningManagerExists: true,
@@ -790,63 +777,37 @@ final class WindowBackgroundSurfaceBackgroundGuaranteeTests: XCTestCase {
     }
 }
 
-/// Validates that notification-driven tab reorder is deferred to avoid
-/// cascading @Published changes in the same run loop frame (#914).
-///
-/// Uses source-code inspection (same pattern as
-/// `TabManagerNotificationOrderingSourceTests`) to assert that
-/// `moveTabToTop` is wrapped in `DispatchQueue.main.async` inside
-/// `addNotification`. This avoids singleton state pollution from
-/// `TerminalNotificationStore.shared` and provides a meaningful
-/// regression guard — unlike a runtime test, this will fail if the
-/// async wrapper is removed.
 final class NotificationTabReorderDeferralTests: XCTestCase {
     func testMoveTabToTopIsDeferredInsideAddNotification() throws {
         let projectRoot = findProjectRoot()
         let storeURL = projectRoot.appendingPathComponent("Sources/TerminalNotificationStore.swift")
         let source = try String(contentsOf: storeURL, encoding: .utf8)
 
-        // Locate the addNotification method body.
         guard let methodStart = source.range(of: "func addNotification(tabId:") else {
             XCTFail("Failed to locate addNotification(tabId:) in TerminalNotificationStore.swift")
             return
         }
 
-        // Find the next top-level `func` after addNotification to bound the search.
         let searchRange = methodStart.upperBound..<source.endIndex
         let methodEnd = source.range(of: "\n    func ", range: searchRange)?.lowerBound ?? source.endIndex
         let methodBody = String(source[methodStart.lowerBound..<methodEnd])
 
-        // The critical invariant: moveTabToTop must be called inside
-        // DispatchQueue.main.async, NOT directly. A synchronous call
-        // causes two @Published mutations in the same run loop frame
-        // (tabs reorder + notifications update), triggering a cascading
-        // SwiftUI re-render that blanks the active pane (#914).
         XCTAssertTrue(
             methodBody.contains("DispatchQueue.main.async"),
-            """
-            addNotification must defer moveTabToTop via DispatchQueue.main.async \
-            to prevent cascading @Published changes that blank the active pane (#914).
-            """
+            "addNotification must defer moveTabToTop via DispatchQueue.main.async (#914)."
         )
         XCTAssertTrue(
             methodBody.contains("moveTabToTop"),
             "addNotification must call moveTabToTop for auto-reorder behavior."
         )
 
-        // Verify moveTabToTop appears ONLY inside the async block, not outside it.
-        // Split on DispatchQueue.main.async and check that moveTabToTop doesn't
-        // appear in the portion before the async block within the reorder section.
         if let reorderStart = methodBody.range(of: "WorkspaceAutoReorderSettings.isEnabled()") {
             let reorderSection = String(methodBody[reorderStart.lowerBound..<methodBody.endIndex])
             if let asyncStart = reorderSection.range(of: "DispatchQueue.main.async") {
                 let beforeAsync = String(reorderSection[reorderSection.startIndex..<asyncStart.lowerBound])
                 XCTAssertFalse(
                     beforeAsync.contains("moveTabToTop"),
-                    """
-                    moveTabToTop must NOT be called synchronously before the \
-                    DispatchQueue.main.async block — it must be inside it (#914).
-                    """
+                    "moveTabToTop must be inside the DispatchQueue.main.async block, not before it (#914)."
                 )
             }
         }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -792,42 +792,76 @@ final class WindowBackgroundSurfaceBackgroundGuaranteeTests: XCTestCase {
 
 /// Validates that notification-driven tab reorder is deferred to avoid
 /// cascading @Published changes in the same run loop frame (#914).
+///
+/// Uses source-code inspection (same pattern as
+/// `TabManagerNotificationOrderingSourceTests`) to assert that
+/// `moveTabToTop` is wrapped in `DispatchQueue.main.async` inside
+/// `addNotification`. This avoids singleton state pollution from
+/// `TerminalNotificationStore.shared` and provides a meaningful
+/// regression guard — unlike a runtime test, this will fail if the
+/// async wrapper is removed.
 final class NotificationTabReorderDeferralTests: XCTestCase {
-    func testMoveTabToTopIsNotCalledSynchronouslyDuringAddNotification() {
-        // This test documents the expectation: when addNotification() is
-        // called with auto-reorder enabled, moveTabToTop() must NOT run
-        // in the same synchronous call stack. It should be deferred via
-        // DispatchQueue.main.async to prevent two @Published changes
-        // (tabs reorder + notifications update) from triggering a
-        // compounded SwiftUI re-render that blanks the active pane.
-        //
-        // The fix wraps moveTabToTop() in DispatchQueue.main.async inside
-        // TerminalNotificationStore.addNotification(). This test validates
-        // the architectural invariant rather than mocking internals.
-        let store = TerminalNotificationStore.shared
-        let tabId = UUID()
+    func testMoveTabToTopIsDeferredInsideAddNotification() throws {
+        let projectRoot = findProjectRoot()
+        let storeURL = projectRoot.appendingPathComponent("Sources/TerminalNotificationStore.swift")
+        let source = try String(contentsOf: storeURL, encoding: .utf8)
 
-        // Capture the tab count before adding a notification.
-        // If moveTabToTop were synchronous, it would fire during
-        // addNotification and could trigger observable side effects
-        // in the same run loop. The deferred version delays this.
-        let expectation = XCTestExpectation(description: "Deferred reorder completes")
-        store.addNotification(
-            tabId: tabId,
-            surfaceId: nil,
-            title: "Test",
-            subtitle: "",
-            body: "Test notification"
-        )
-        // The moveTabToTop should be deferred — verify by checking
-        // that the notification was added (synchronous) while the
-        // reorder hasn't happened yet in this same run loop tick.
-        DispatchQueue.main.async {
-            // By the time this fires, the deferred moveTabToTop would
-            // also have been dispatched. This validates the async path.
-            expectation.fulfill()
+        // Locate the addNotification method body.
+        guard let methodStart = source.range(of: "func addNotification(tabId:") else {
+            XCTFail("Failed to locate addNotification(tabId:) in TerminalNotificationStore.swift")
+            return
         }
-        wait(for: [expectation], timeout: 1.0)
+
+        // Find the next top-level `func` after addNotification to bound the search.
+        let searchRange = methodStart.upperBound..<source.endIndex
+        let methodEnd = source.range(of: "\n    func ", range: searchRange)?.lowerBound ?? source.endIndex
+        let methodBody = String(source[methodStart.lowerBound..<methodEnd])
+
+        // The critical invariant: moveTabToTop must be called inside
+        // DispatchQueue.main.async, NOT directly. A synchronous call
+        // causes two @Published mutations in the same run loop frame
+        // (tabs reorder + notifications update), triggering a cascading
+        // SwiftUI re-render that blanks the active pane (#914).
+        XCTAssertTrue(
+            methodBody.contains("DispatchQueue.main.async"),
+            """
+            addNotification must defer moveTabToTop via DispatchQueue.main.async \
+            to prevent cascading @Published changes that blank the active pane (#914).
+            """
+        )
+        XCTAssertTrue(
+            methodBody.contains("moveTabToTop"),
+            "addNotification must call moveTabToTop for auto-reorder behavior."
+        )
+
+        // Verify moveTabToTop appears ONLY inside the async block, not outside it.
+        // Split on DispatchQueue.main.async and check that moveTabToTop doesn't
+        // appear in the portion before the async block within the reorder section.
+        if let reorderStart = methodBody.range(of: "WorkspaceAutoReorderSettings.isEnabled()") {
+            let reorderSection = String(methodBody[reorderStart.lowerBound..<methodBody.endIndex])
+            if let asyncStart = reorderSection.range(of: "DispatchQueue.main.async") {
+                let beforeAsync = String(reorderSection[reorderSection.startIndex..<asyncStart.lowerBound])
+                XCTAssertFalse(
+                    beforeAsync.contains("moveTabToTop"),
+                    """
+                    moveTabToTop must NOT be called synchronously before the \
+                    DispatchQueue.main.async block — it must be inside it (#914).
+                    """
+                )
+            }
+        }
+    }
+
+    private func findProjectRoot() -> URL {
+        var dir = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent()
+        for _ in 0..<10 {
+            let marker = dir.appendingPathComponent("GhosttyTabs.xcodeproj")
+            if FileManager.default.fileExists(atPath: marker.path) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the active terminal pane going blank when a notification fires on a different tab (#914).

**Root cause**: Two compounding issues triggered by the same event chain:

1. **Surface background not maintained on guard rejection** — `applyWindowBackgroundIfActive()` called `applySurfaceBackground()` only *after* the `shouldApplyWindowBackground()` guard. When a notification-triggered tab reorder caused the owning manager's `selectedTabId` to temporarily differ from the surface's `tabId`, the guard rejected and the method returned early *without* maintaining the surface background, leaving the pane in a stale transparent state.

2. **Synchronous `moveTabToTop()` during `addNotification()`** — When workspace auto-reorder is enabled, `moveTabToTop()` was called synchronously inside `addNotification()`, producing two `@Published` changes (`tabs` reorder + `notifications` update) in the same run loop frame. This compounded SwiftUI re-renders that triggered portal visibility races (Bonsplit transiently reporting `isSelectedInPane=false`) and background application failures.

## Changes

- **`GhosttyTerminalView.swift`**: Move `applySurfaceBackground()` before the `shouldApplyWindowBackground()` guard so it always runs, even when window-level background application is skipped. The call is idempotent.
- **`TerminalNotificationStore.swift`**: Wrap `moveTabToTop()` in `DispatchQueue.main.async` to defer tab reordering out of the notification hot path, breaking the synchronous cascade.
- **`GhosttyConfigTests.swift`**: Add regression tests documenting the #914 trigger conditions.

## Test plan

- [x] `WindowBackgroundSurfaceBackgroundGuaranteeTests` — verifies the guard rejection scenarios that previously caused blanking
- [x] `NotificationTabReorderDeferralTests` — validates deferred reorder via async expectation
- [ ] Manual: open multiple tabs, trigger notifications on background tabs, verify active pane stays visible
- [ ] Manual: verify workspace auto-reorder still works correctly (tab moves to top after notification, just deferred by one frame)

Closes #914

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a blank active terminal pane when a notification fires on another tab (#914). Ensures the surface background is always applied and defers tab reordering to prevent SwiftUI race conditions.

- **Bug Fixes**
  - In `GhosttyTerminalView.swift`, call `applySurfaceBackground()` before the `shouldApplyWindowBackground()` guard so the pane never goes transparent.
  - In `TerminalNotificationStore.swift`, defer `moveTabToTop()` with `DispatchQueue.main.async` to avoid tabs + notifications updates in the same frame.
  - Tests: add guard-rejection regression tests, rewrite `NotificationTabReorderDeferralTests` to assert deferral via source inspection, and strip comments to match project style.

<sup>Written for commit bf962a49623d4b996e90127993566653a3fbf094. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal surface background now remains consistently visible even when window-level background updates are skipped.
  * Tab reordering triggered by notifications is deferred to prevent unnecessary UI re-renders.

* **Tests**
  * Added regression tests for background-application guarantees and deferred notification-driven tab reordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->