### PR TITLE
Fix cmuxOnly socket auth after long uptime

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10,6 +10,19 @@ struct CLIError: Error, CustomStringConvertible {
     var description: String { message }
 }
 
+private enum SocketControlInternalAuth {
+    static let tokenEnvKey = "CMUX_SOCKET_TOKEN"
+    static let v2Method = "auth.cmux"
+
+    static func configuredToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        guard let raw = environment[tokenEnvKey] else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
 private final class CLISocketSentryTelemetry {
     private let command: String
     private let subcommand: String
@@ -928,6 +941,21 @@ struct CMUXCLI {
             throw error
         }
         defer { client.close() }
+
+        if let internalToken = SocketControlInternalAuth.configuredToken(environment: processEnv) {
+            do {
+                _ = try client.sendV2(
+                    method: SocketControlInternalAuth.v2Method,
+                    params: ["token": internalToken]
+                )
+                cliTelemetry.breadcrumb("socket.auth.cmux.success")
+            } catch {
+                cliTelemetry.breadcrumb(
+                    "socket.auth.cmux.failure",
+                    data: ["error": String(describing: error)]
+                )
+            }
+        }
 
         if let socketPassword = SocketPasswordResolver.resolve(explicit: socketPasswordArg) {
             let authResponse = try client.send(command: "auth \(socketPassword)")

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2480,6 +2480,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Backward-compatible shell integration keys used by existing scripts/tests.
         env["CMUX_PANEL_ID"] = id.uuidString
         env["CMUX_TAB_ID"] = tabId.uuidString
+        env[SocketControlInternalAuth.tokenEnvKey] = SocketControlInternalAuth.sessionToken
         env["CMUX_SOCKET_PATH"] = SocketControlSettings.socketPath()
         if let bundleId = Bundle.main.bundleIdentifier, !bundleId.isEmpty {
             env["CMUX_BUNDLE_ID"] = bundleId

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -285,6 +285,35 @@ enum SocketControlPasswordStore {
     }
 }
 
+enum SocketControlInternalAuth {
+    static let tokenEnvKey = "CMUX_SOCKET_TOKEN"
+    static let v2Method = "auth.cmux"
+    static let sessionToken = generateToken()
+
+    static func generateToken() -> String {
+        [UUID().uuidString, UUID().uuidString]
+            .joined()
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
+    }
+
+    static func configuredToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        normalizedToken(environment[tokenEnvKey])
+    }
+
+    static func verify(token candidate: String, expected: String) -> Bool {
+        normalizedToken(candidate) == normalizedToken(expected)
+    }
+
+    static func normalizedToken(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
 struct SocketControlSettings {
     static let appStorageKey = "socketControlMode"
     static let legacyEnabledKey = "socketControlEnabled"

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -928,6 +928,16 @@ class TerminalController {
         }
     }
 
+    private func accessDeniedResponse(for command: String) -> String {
+        let message = "Access denied — only processes started inside cmux can connect"
+        guard command.hasPrefix("{"),
+              let data = command.data(using: .utf8),
+              let dict = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+            return "ERROR: \(message)"
+        }
+        return v2Error(id: dict["id"], code: "access_denied", message: message)
+    }
+
     private func passwordAuthRequiredResponse(for command: String) -> String {
         let message = "Authentication required. Send auth <password> first."
         guard command.hasPrefix("{"),
@@ -937,6 +947,73 @@ class TerminalController {
         }
         let id = dict["id"]
         return v2Error(id: id, code: "auth_required", message: message)
+    }
+
+    private func internalTokenLoginV2ResponseIfNeeded(
+        for command: String,
+        authenticated: inout Bool,
+        canAttemptTokenAuth: Bool
+    ) -> String? {
+        guard command.hasPrefix("{"),
+              let data = command.data(using: .utf8),
+              let dict = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String: Any] else {
+            return nil
+        }
+        let id = dict["id"]
+        let method = (dict["method"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard method == SocketControlInternalAuth.v2Method else {
+            return nil
+        }
+
+        guard accessMode == .cmuxOnly else {
+            return v2Ok(
+                id: id,
+                result: [
+                    "authenticated": authenticated,
+                    "required": accessMode.requiresPasswordAuth,
+                    "mode": accessMode.rawValue
+                ]
+            )
+        }
+
+        guard authenticated || canAttemptTokenAuth else {
+            return accessDeniedResponse(for: command)
+        }
+
+        if authenticated {
+            return v2Ok(
+                id: id,
+                result: [
+                    "authenticated": true,
+                    "required": false,
+                    "mode": accessMode.rawValue
+                ]
+            )
+        }
+
+        guard let params = dict["params"] as? [String: Any],
+              let provided = params["token"] as? String,
+              SocketControlInternalAuth.normalizedToken(provided) != nil else {
+            return v2Error(
+                id: id,
+                code: "invalid_params",
+                message: "auth.cmux requires params.token"
+            )
+        }
+
+        guard SocketControlInternalAuth.verify(token: provided, expected: SocketControlInternalAuth.sessionToken) else {
+            return v2Error(id: id, code: "auth_failed", message: "Invalid cmux token")
+        }
+
+        authenticated = true
+        return v2Ok(
+            id: id,
+            result: [
+                "authenticated": true,
+                "required": false,
+                "mode": accessMode.rawValue
+            ]
+        )
     }
 
     private func passwordLoginV1ResponseIfNeeded(for command: String, authenticated: inout Bool) -> String? {
@@ -996,19 +1073,36 @@ class TerminalController {
         return v2Ok(id: id, result: ["authenticated": true])
     }
 
-    private func authResponseIfNeeded(for command: String, authenticated: inout Bool) -> String? {
-        guard accessMode.requiresPasswordAuth else {
+    private func authResponseIfNeeded(
+        for command: String,
+        authenticated: inout Bool,
+        canAttemptTokenAuth: Bool
+    ) -> String? {
+        if let internalAuthResponse = internalTokenLoginV2ResponseIfNeeded(
+            for: command,
+            authenticated: &authenticated,
+            canAttemptTokenAuth: canAttemptTokenAuth
+        ) {
+            return internalAuthResponse
+        }
+
+        if accessMode.requiresPasswordAuth {
+            if let v2Response = passwordLoginV2ResponseIfNeeded(for: command, authenticated: &authenticated) {
+                return v2Response
+            }
+            if let v1Response = passwordLoginV1ResponseIfNeeded(for: command, authenticated: &authenticated) {
+                return v1Response
+            }
+            if !authenticated {
+                return passwordAuthRequiredResponse(for: command)
+            }
             return nil
         }
-        if let v2Response = passwordLoginV2ResponseIfNeeded(for: command, authenticated: &authenticated) {
-            return v2Response
+
+        if accessMode == .cmuxOnly, !authenticated {
+            return accessDeniedResponse(for: command)
         }
-        if let v1Response = passwordLoginV1ResponseIfNeeded(for: command, authenticated: &authenticated) {
-            return v1Response
-        }
-        if !authenticated {
-            return passwordAuthRequiredResponse(for: command)
-        }
+
         return nil
     }
 
@@ -1228,38 +1322,28 @@ class TerminalController {
     private func handleClient(_ socket: Int32, peerPid: pid_t? = nil) {
         defer { close(socket) }
 
-        // In cmuxOnly mode, verify the connecting process is a descendant of cmux.
-        // Other modes allow external clients and apply separate auth controls.
+        var authenticated = !accessMode.requiresPasswordAuth && accessMode != .cmuxOnly
+        var canAttemptTokenAuth = false
+
+        // In cmuxOnly mode, keep the current fast ancestry check, but allow a
+        // same-user client to recover with an internal token when the process
+        // tree no longer traces back to cmux after long uptime/reparenting.
         if accessMode == .cmuxOnly {
-            // Use pre-captured peer PID if available (captured in accept loop before
-            // the peer can disconnect), falling back to live lookup.
             let pid = peerPid ?? getPeerPid(socket)
-            if let pid {
-                guard isDescendant(pid) else {
-                    let msg = "ERROR: Access denied — only processes started inside cmux can connect\n"
-                    msg.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
-                    return
-                }
-            }
-            // If pid is nil, LOCAL_PEERPID failed (peer disconnected before we
-            // could read it — common with ncat --send-only). We still verify the
-            // peer runs as the same user via LOCAL_PEERCRED. This is the same
-            // security boundary as the socket file permissions (0600), so it does
-            // not widen the attack surface. We also require that the peer actually
-            // sent data (checked in the read loop below) — a connect-only probe
-            // with no data is harmless.
-            if pid == nil {
+            if let pid, isDescendant(pid) {
+                authenticated = true
+            } else {
                 guard peerHasSameUID(socket) else {
                     let msg = "ERROR: Unable to verify client process\n"
                     msg.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
                     return
                 }
+                canAttemptTokenAuth = true
             }
         }
 
         var buffer = [UInt8](repeating: 0, count: 4096)
         var pending = ""
-        var authenticated = false
 
         while withListenerState({ isRunning }) {
             let bytesRead = read(socket, &buffer, buffer.count - 1)
@@ -1274,7 +1358,11 @@ class TerminalController {
                 let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { continue }
 
-                if let authResponse = authResponseIfNeeded(for: trimmed, authenticated: &authenticated) {
+                if let authResponse = authResponseIfNeeded(
+                    for: trimmed,
+                    authenticated: &authenticated,
+                    canAttemptTokenAuth: canAttemptTokenAuth
+                ) {
                     writeSocketResponse(authResponse, to: socket)
                     continue
                 }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1033,6 +1033,37 @@ final class SocketControlSettingsTests: XCTestCase {
         XCTAssertEqual(path, "/tmp/cmux.sock")
     }
 
+    func testInternalSocketTokenConfiguredTokenTrimsWhitespace() {
+        let token = SocketControlInternalAuth.configuredToken(
+            environment: [SocketControlInternalAuth.tokenEnvKey: "  token-value \n"]
+        )
+
+        XCTAssertEqual(token, "token-value")
+    }
+
+    func testInternalSocketTokenConfiguredTokenRejectsBlankValues() {
+        XCTAssertNil(
+            SocketControlInternalAuth.configuredToken(
+                environment: [SocketControlInternalAuth.tokenEnvKey: " \n\t "]
+            )
+        )
+    }
+
+    func testInternalSocketTokenVerifyRequiresExactNormalizedMatch() {
+        XCTAssertTrue(
+            SocketControlInternalAuth.verify(
+                token: " token-value \n",
+                expected: "token-value"
+            )
+        )
+        XCTAssertFalse(
+            SocketControlInternalAuth.verify(
+                token: "different-token",
+                expected: "token-value"
+            )
+        )
+    }
+
     func testNightlyReleaseUsesDedicatedDefaultAndIgnoresAmbientSocketOverride() {
         let path = SocketControlSettings.socketPath(
             environment: [


### PR DESCRIPTION
## Summary
- add an internal per-launch socket token for cmux-spawned shells and have the CLI auto-send it
- keep the existing `cmuxOnly` PID ancestry fast path, but fall back to token auth for same-user clients when ancestry breaks after long uptime or reparenting
- add unit coverage for the internal token normalization and verification helper

Closes #1159.

## Verification
- `./scripts/reload.sh --tag fix-1159-socket-access-uptime`
- build succeeded and launched the tagged debug app
- did not run tests locally, per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmuxOnly socket auth failures after long uptime or reparenting by adding a per-launch internal token with CLI auto-auth, while keeping the fast PID ancestry path. Closes #1159.

- **Bug Fixes**
  - Added v2 `auth.cmux` with a per-launch token; CLI sends it when present.
  - Injected `CMUX_SOCKET_TOKEN` into cmux-spawned shells and verify it server-side.
  - Kept PID ancestry check; fall back to token auth for same-UID clients when ancestry breaks.
  - Added unit tests for token normalization and verification.

<sup>Written for commit 87926ba921284e5b6d21776d2ff8868320fb3a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced token-based authentication support for socket control operations, configurable through environment variables. This new authentication method complements existing password-based authentication mechanisms.

* **Tests**
  * Added test coverage for token authentication handling, including validation of whitespace normalization and token verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->