### PR TITLE
Constrain notification sound picker width

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2833,6 +2833,7 @@ enum TelemetrySettings {
 struct SettingsView: View {
     private let contentTopInset: CGFloat = 8
     private let pickerColumnWidth: CGFloat = 196
+    private let notificationSoundControlWidth: CGFloat = 280
 
     @AppStorage(LanguageSettings.languageKey) private var appLanguage = LanguageSettings.defaultLanguage.rawValue
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
@@ -3321,7 +3322,8 @@ struct SettingsView: View {
 
                         SettingsCardRow(
                             String(localized: "settings.notifications.sound.title", defaultValue: "Notification Sound"),
-                            subtitle: String(localized: "settings.notifications.sound.subtitle", defaultValue: "Sound played when a notification arrives.")
+                            subtitle: String(localized: "settings.notifications.sound.subtitle", defaultValue: "Sound played when a notification arrives."),
+                            controlWidth: notificationSoundControlWidth
                         ) {
                             VStack(alignment: .trailing, spacing: 6) {
                                 HStack(spacing: 6) {
@@ -3381,6 +3383,7 @@ struct SettingsView: View {
                                     }
                                 }
                             }
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                         }
 
                         SettingsCardDivider()


### PR DESCRIPTION
## Summary
- constrain the Notification Sound controls to a fixed trailing column in Settings
- keep the custom-file controls right-aligned so the `Custom File...` picker no longer stretches across the whole card

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-notification-sound-picker-height` (`BUILD SUCCEEDED`, tagged app launched)

## Issues
- Task reference: plain-text request `fix the fat one` for the oversized Notification Sound custom file row shown in Settings > App


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrained the Notification Sound picker to a fixed 280pt trailing column in Settings and right-aligned its controls so the “Custom File…” button no longer stretches across the card. Fixes the oversized row in Settings > App.

<sup>Written for commit 73a3f1890823f9a9aa9f2569683617956404f0ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment of notification sound controls in settings for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->