### PR TITLE
Address followup focus review comments

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1440,8 +1440,7 @@ final class WindowBrowserSlotView: NSView {
         let firstResponderSummary: String = {
             guard let firstResponder = window?.firstResponder else { return "nil" }
             if let editor = firstResponder as? NSTextView, editor.isFieldEditor {
-                let delegateSummary = editor.delegate.map { String(describing: type(of: $0)) } ?? "nil"
-                return "fieldEditor(delegate=\(delegateSummary))"
+                return "fieldEditor"
             }
             return String(describing: type(of: firstResponder))
         }()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5334,7 +5334,9 @@ struct ContentView: View {
         focusedBrowserAddressBarPanelId: UUID?,
         focusedPanelId: UUID?
     ) -> Bool {
-        focusedPanelIsBrowser && focusedBrowserAddressBarPanelId == focusedPanelId
+        focusedPanelIsBrowser &&
+            focusedBrowserAddressBarPanelId != nil &&
+            focusedBrowserAddressBarPanelId == focusedPanelId
     }
 
     private func syncCommandPaletteDebugStateForObservedWindow() {
@@ -5484,7 +5486,7 @@ struct ContentView: View {
     ) -> CommandPaletteRestoreFocusTarget? {
         let overlayController = commandPaletteWindowOverlayController(for: window)
         if let responder = overlayController.underlyingResponder(atWindowPoint: windowPoint),
-           let target = commandPaletteBackdropFocusTarget(for: responder) {
+           let target = commandPaletteBackdropFocusTarget(for: responder, in: window) {
             return target
         }
 
@@ -5508,7 +5510,10 @@ struct ContentView: View {
         return nil
     }
 
-    private func commandPaletteBackdropFocusTarget(for responder: NSResponder) -> CommandPaletteRestoreFocusTarget? {
+    private func commandPaletteBackdropFocusTarget(
+        for responder: NSResponder,
+        in window: NSWindow?
+    ) -> CommandPaletteRestoreFocusTarget? {
         if let terminalView = cmuxOwningGhosttyView(for: responder),
            let workspaceId = terminalView.tabId,
            let panelId = terminalView.terminalSurface?.id,
@@ -5516,28 +5521,37 @@ struct ContentView: View {
             return commandPaletteRestoreFocusTarget(
                 workspaceId: workspaceId,
                 panelId: panelId,
+                explicitIntent: commandPaletteTerminalFocusIntent(for: responder),
                 fallbackIntent: .terminal(.surface),
-                in: observedWindow
+                in: window
             )
         }
 
+        if let target = commandPaletteBrowserAddressBarFocusTarget(for: responder, in: window) {
+            return target
+        }
+
         if let webView = commandPaletteOwningWebView(for: responder),
-           let target = commandPaletteBrowserFocusTarget(for: webView) {
+           let target = commandPaletteBrowserFocusTarget(for: webView, responder: responder, in: window) {
             return target
         }
 
         return nil
     }
 
-    private func commandPaletteBrowserFocusTarget(for webView: WKWebView) -> CommandPaletteRestoreFocusTarget? {
+    private func commandPaletteBrowserFocusTarget(
+        for webView: WKWebView,
+        responder: NSResponder? = nil,
+        in window: NSWindow? = nil
+    ) -> CommandPaletteRestoreFocusTarget? {
         if let selectedWorkspace = tabManager.selectedWorkspace,
-           let target = commandPaletteBrowserFocusTarget(in: selectedWorkspace, for: webView) {
+           let target = commandPaletteBrowserFocusTarget(in: selectedWorkspace, for: webView, responder: responder, in: window) {
             return target
         }
 
         let selectedWorkspaceId = tabManager.selectedTabId
         for workspace in tabManager.tabs where workspace.id != selectedWorkspaceId {
-            if let target = commandPaletteBrowserFocusTarget(in: workspace, for: webView) {
+            if let target = commandPaletteBrowserFocusTarget(in: workspace, for: webView, responder: responder, in: window) {
                 return target
             }
         }
@@ -5547,7 +5561,9 @@ struct ContentView: View {
 
     private func commandPaletteBrowserFocusTarget(
         in workspace: Workspace,
-        for webView: WKWebView
+        for webView: WKWebView,
+        responder: NSResponder? = nil,
+        in window: NSWindow? = nil
     ) -> CommandPaletteRestoreFocusTarget? {
         for (panelId, panel) in workspace.panels {
             guard let browserPanel = panel as? BrowserPanel,
@@ -5558,8 +5574,13 @@ struct ContentView: View {
             return commandPaletteRestoreFocusTarget(
                 workspaceId: workspace.id,
                 panelId: panelId,
+                explicitIntent: commandPaletteBrowserFocusIntent(
+                    for: responder,
+                    panelId: panelId,
+                    in: window
+                ),
                 fallbackIntent: .browser(.webView),
-                in: observedWindow
+                in: window
             )
         }
 
@@ -5569,10 +5590,11 @@ struct ContentView: View {
     private func commandPaletteRestoreFocusTarget(
         workspaceId: UUID,
         panelId: UUID,
+        explicitIntent: PanelFocusIntent? = nil,
         fallbackIntent: PanelFocusIntent,
         in window: NSWindow?
     ) -> CommandPaletteRestoreFocusTarget {
-        let intent = tabManager.tabs
+        let intent = explicitIntent ?? tabManager.tabs
             .first(where: { $0.id == workspaceId })?
             .panels[panelId]?
             .captureFocusIntent(in: window) ?? fallbackIntent
@@ -5582,6 +5604,73 @@ struct ContentView: View {
             panelId: panelId,
             intent: intent
         )
+    }
+
+    private func commandPaletteTerminalFocusIntent(for responder: NSResponder) -> PanelFocusIntent {
+        if commandPaletteResponderIsTerminalSearchOverlay(responder) {
+            return .terminal(.findField)
+        }
+        return .terminal(.surface)
+    }
+
+    private func commandPaletteBrowserFocusIntent(
+        for responder: NSResponder?,
+        panelId: UUID,
+        in window: NSWindow?
+    ) -> PanelFocusIntent? {
+        if let responder,
+           let window,
+           BrowserWindowPortalRegistry.searchOverlayPanelId(for: responder, in: window) == panelId {
+            return .browser(.findField)
+        }
+
+        if browserOmnibarPanelId(for: responder) == panelId {
+            return .browser(.addressBar)
+        }
+
+        return nil
+    }
+
+    private func commandPaletteBrowserAddressBarFocusTarget(
+        for responder: NSResponder,
+        in window: NSWindow?
+    ) -> CommandPaletteRestoreFocusTarget? {
+        guard let panelId = browserOmnibarPanelId(for: responder) else {
+            return nil
+        }
+
+        for workspace in tabManager.tabs where workspace.panels[panelId] is BrowserPanel {
+            return commandPaletteRestoreFocusTarget(
+                workspaceId: workspace.id,
+                panelId: panelId,
+                explicitIntent: .browser(.addressBar),
+                fallbackIntent: .browser(.addressBar),
+                in: window
+            )
+        }
+
+        return nil
+    }
+
+    private func commandPaletteResponderOwningView(for responder: NSResponder?) -> NSView? {
+        guard let responder else { return nil }
+        if let editor = responder as? NSTextView,
+           editor.isFieldEditor,
+           let editedView = editor.delegate as? NSView {
+            return editedView
+        }
+        return responder as? NSView
+    }
+
+    private func commandPaletteResponderIsTerminalSearchOverlay(_ responder: NSResponder) -> Bool {
+        var current = commandPaletteResponderOwningView(for: responder)
+        while let view = current {
+            if view is NSHostingView<SurfaceSearchOverlay> {
+                return true
+            }
+            current = view.superview
+        }
+        return false
     }
 
     private func restoreCommandPaletteFocus(

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -14,7 +14,8 @@ struct BrowserSearchOverlay: View {
     @State private var corner: Corner = .topRight
     @State private var dragOffset: CGSize = .zero
     @State private var barSize: CGSize = .zero
-    @FocusState private var isSearchFieldFocused: Bool
+    @State private var isSearchFieldFocused = false
+    @State private var focusRequestNonce: UInt64 = 0
 
     private let padding: CGFloat = 8
 
@@ -23,8 +24,7 @@ struct BrowserSearchOverlay: View {
         guard let window = NSApp.keyWindow else { return "nil" }
         guard let firstResponder = window.firstResponder else { return "nil" }
         if let editor = firstResponder as? NSTextView, editor.isFieldEditor {
-            let delegateSummary = editor.delegate.map { String(describing: type(of: $0)) } ?? "nil"
-            return "fieldEditor(delegate=\(delegateSummary))"
+            return "fieldEditor"
         }
         return String(describing: type(of: firstResponder))
     }
@@ -50,8 +50,10 @@ struct BrowserSearchOverlay: View {
 #endif
             return
         }
+
         logFocusState("request.begin origin=\(origin) remaining=\(maxAttempts)")
         isSearchFieldFocused = true
+        focusRequestNonce &+= 1
 #if DEBUG
         DispatchQueue.main.async {
             guard canApplyFocusRequest(focusRequestGeneration) else {
@@ -76,17 +78,35 @@ struct BrowserSearchOverlay: View {
     var body: some View {
         GeometryReader { geo in
             HStack(spacing: 4) {
-                TextField("Search", text: $searchState.needle)
-                    .textFieldStyle(.plain)
-                    .accessibilityIdentifier("BrowserFindSearchTextField")
-                    .frame(width: 180)
-                    .padding(.leading, 8)
-                    .padding(.trailing, 50)
-                    .padding(.vertical, 6)
-                    .background(Color.primary.opacity(0.1))
-                    .cornerRadius(6)
-                    .focused($isSearchFieldFocused)
-                    .overlay(alignment: .trailing) {
+                BrowserSearchTextFieldRepresentable(
+                    text: $searchState.needle,
+                    isFocused: $isSearchFieldFocused,
+                    focusRequestNonce: focusRequestNonce,
+                    focusRequestGeneration: focusRequestGeneration,
+                    canApplyFocusRequest: canApplyFocusRequest,
+                    onFieldDidFocus: {
+                        logFocusState("nativeField.didFocus")
+                        onFieldDidFocus()
+                    },
+                    onSubmit: { isShift in
+                        if isShift {
+                            onPrevious()
+                        } else {
+                            onNext()
+                        }
+                    },
+                    onEscape: {
+                        onClose()
+                    }
+                )
+                .accessibilityIdentifier("BrowserFindSearchTextField")
+                .frame(width: 180)
+                .padding(.leading, 8)
+                .padding(.trailing, 50)
+                .padding(.vertical, 6)
+                .background(Color.primary.opacity(0.1))
+                .cornerRadius(6)
+                .overlay(alignment: .trailing) {
                     if let selected = searchState.selected {
                         let totalText = searchState.total.map { String($0) } ?? "?"
                         Text("\(selected + 1)/\(totalText)")
@@ -100,17 +120,6 @@ struct BrowserSearchOverlay: View {
                             .foregroundColor(.secondary)
                             .monospacedDigit()
                             .padding(.trailing, 8)
-                    }
-                }
-                .onExitCommand {
-                    onClose()
-                }
-                .onSubmit {
-                    // onSubmit fires only after IME composition is committed.
-                    if NSEvent.modifierFlags.contains(.shift) {
-                        onPrevious()
-                    } else {
-                        onNext()
                     }
                 }
 
@@ -160,17 +169,15 @@ struct BrowserSearchOverlay: View {
             }
             .onChange(of: isSearchFieldFocused) { _, focused in
                 logFocusState("focusState.change next=\(focused ? 1 : 0)")
-                if focused {
-                    onFieldDidFocus()
-                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .browserSearchFocus)) { notification in
                 guard let notifiedPanelId = notification.object as? UUID,
                       notifiedPanelId == panelId else { return }
                 logFocusState("notification.received")
-                DispatchQueue.main.async {
-                    requestSearchFieldFocus(origin: "notification")
-                }
+                requestSearchFieldFocus(origin: "notification")
+            }
+            .onExitCommand {
+                onClose()
             }
             .background(
                 GeometryReader { barGeo in
@@ -247,5 +254,143 @@ struct BrowserSearchOverlay: View {
             return point.y < midY ? .topLeft : .bottomLeft
         }
         return point.y < midY ? .topRight : .bottomRight
+    }
+}
+
+private final class BrowserSearchNativeTextField: NSTextField {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        isBordered = false
+        isBezeled = false
+        drawsBackground = false
+        focusRingType = .none
+        usesSingleLineMode = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+    let focusRequestNonce: UInt64
+    let focusRequestGeneration: UInt64
+    let canApplyFocusRequest: (UInt64) -> Bool
+    let onFieldDidFocus: () -> Void
+    let onSubmit: (_ isShift: Bool) -> Void
+    let onEscape: () -> Void
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: BrowserSearchTextFieldRepresentable
+        var isProgrammaticMutation = false
+        var lastAppliedFocusRequestNonce: UInt64 = 0
+        var pendingFocusRequest = false
+        weak var parentField: BrowserSearchNativeTextField?
+
+        init(parent: BrowserSearchTextFieldRepresentable) {
+            self.parent = parent
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard !isProgrammaticMutation else { return }
+            guard let field = obj.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            parent.onFieldDidFocus()
+            if !parent.isFocused {
+                DispatchQueue.main.async {
+                    self.parent.isFocused = true
+                }
+            }
+        }
+
+        func controlTextDidEndEditing(_ obj: Notification) {
+            if parent.isFocused {
+                DispatchQueue.main.async {
+                    self.parent.isFocused = false
+                }
+            }
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            switch commandSelector {
+            case #selector(NSResponder.cancelOperation(_:)):
+                if textView.hasMarkedText() {
+                    return false
+                }
+                parent.onEscape()
+                return true
+            case #selector(NSResponder.insertNewline(_:)):
+                if textView.hasMarkedText() {
+                    return false
+                }
+                let isShift = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+                parent.onSubmit(isShift)
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> BrowserSearchNativeTextField {
+        let field = BrowserSearchNativeTextField(frame: .zero)
+        field.font = .systemFont(ofSize: NSFont.systemFontSize)
+        field.placeholderString = String(localized: "search.placeholder", defaultValue: "Search")
+        field.setAccessibilityIdentifier("BrowserFindSearchTextField")
+        field.delegate = context.coordinator
+        field.stringValue = text
+        context.coordinator.parentField = field
+        return field
+    }
+
+    func updateNSView(_ nsView: BrowserSearchNativeTextField, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.parentField = nsView
+
+        if let editor = nsView.currentEditor() as? NSTextView {
+            if editor.string != text, !editor.hasMarkedText() {
+                context.coordinator.isProgrammaticMutation = true
+                editor.string = text
+                nsView.stringValue = text
+                context.coordinator.isProgrammaticMutation = false
+            }
+        } else if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+
+        guard isFocused,
+              focusRequestNonce != 0,
+              focusRequestNonce != context.coordinator.lastAppliedFocusRequestNonce,
+              canApplyFocusRequest(focusRequestGeneration),
+              !context.coordinator.pendingFocusRequest else {
+            return
+        }
+
+        context.coordinator.lastAppliedFocusRequestNonce = focusRequestNonce
+        context.coordinator.pendingFocusRequest = true
+        DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
+            guard let nsView, let coordinator else { return }
+            coordinator.pendingFocusRequest = false
+            guard coordinator.parent.isFocused else { return }
+            guard coordinator.parent.canApplyFocusRequest(coordinator.parent.focusRequestGeneration) else { return }
+            guard let window = nsView.window else { return }
+
+            let firstResponder = window.firstResponder
+            let alreadyFocused =
+                firstResponder === nsView ||
+                nsView.currentEditor() != nil ||
+                ((firstResponder as? NSTextView)?.delegate as? NSTextField) === nsView
+            guard !alreadyFocused else { return }
+            window.makeFirstResponder(nsView)
+        }
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6865,16 +6865,16 @@ final class GhosttySurfaceScrollView: NSView {
 
     func capturePanelFocusIntent(in window: NSWindow?) -> TerminalPanelFocusIntent {
         if surfaceView.terminalSurface?.searchState != nil {
-            if let firstResponder = window?.firstResponder as? NSView,
-               (firstResponder === surfaceView || firstResponder.isDescendant(of: surfaceView)) {
-                return .surface
+            if searchFocusTarget == .searchField {
+                return .findField
             }
             if let firstResponder = window?.firstResponder,
                isCurrentSurfaceSearchResponder(firstResponder) {
                 return .findField
             }
-            if searchFocusTarget == .searchField {
-                return .findField
+            if let firstResponder = window?.firstResponder as? NSView,
+               (firstResponder === surfaceView || firstResponder.isDescendant(of: surfaceView)) {
+                return .surface
             }
         }
         return .surface
@@ -7016,17 +7016,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func isCurrentSurfaceSearchResponder(_ responder: NSResponder) -> Bool {
-        let resolvedResponder: NSResponder
-        if let editor = responder as? NSTextView,
-           editor.isFieldEditor,
-           let editedView = editor.delegate as? NSView {
-            resolvedResponder = editedView
-        } else {
-            resolvedResponder = responder
-        }
-
-        guard let view = resolvedResponder as? NSView else { return false }
-        return view.isDescendant(of: self)
+        isSearchOverlayOrDescendant(responder)
     }
 
 #if DEBUG

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3231,7 +3231,7 @@ extension BrowserPanel {
         if suppressWebViewFocusForAddressBar {
             return true
         }
-        if searchState != nil {
+        if searchState != nil && preferredFocusIntent == .findField {
             return true
         }
         if let until = suppressWebViewFocusUntil {
@@ -3289,7 +3289,7 @@ extension BrowserPanel {
     }
 
     func noteWebViewFocused() {
-        guard searchState == nil else { return }
+        guard !(searchState != nil && preferredFocusIntent == .findField) else { return }
         guard preferredFocusIntent != .webView else { return }
         preferredFocusIntent = .webView
         invalidateSearchFocusRequests(reason: "webViewFocused")

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2,6 +2,30 @@ import Bonsplit
 import SwiftUI
 import WebKit
 import AppKit
+import ObjectiveC
+
+private var browserOmnibarPanelAssociationKey: UInt8 = 0
+
+func browserOmnibarPanelId(for responder: NSResponder?) -> UUID? {
+    var current = browserOmnibarOwningView(for: responder)
+    while let view = current {
+        if let panelId = objc_getAssociatedObject(view, &browserOmnibarPanelAssociationKey) as? UUID {
+            return panelId
+        }
+        current = view.superview
+    }
+    return nil
+}
+
+private func browserOmnibarOwningView(for responder: NSResponder?) -> NSView? {
+    guard let responder else { return nil }
+    if let editor = responder as? NSTextView,
+       editor.isFieldEditor,
+       let editedView = editor.delegate as? NSView {
+        return editedView
+    }
+    return responder as? NSView
+}
 
 enum BrowserDevToolsIconOption: String, CaseIterable, Identifiable {
     case wrenchAndScrewdriver = "wrench.and.screwdriver"
@@ -738,6 +762,7 @@ struct BrowserPanelView: View {
                     }
                 ),
                 isFocused: $addressBarFocused,
+                panelId: panel.id,
                 inlineCompletion: inlineCompletion,
                 placeholder: String(localized: "browser.addressBar.placeholder", defaultValue: "Search or enter URL"),
                 onTap: {
@@ -2710,6 +2735,7 @@ private final class OmnibarNativeTextField: NSTextField {
 private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
+    let panelId: UUID
     let inlineCompletion: OmnibarInlineCompletion?
     let placeholder: String
     let onTap: () -> Void
@@ -3103,6 +3129,8 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         let field = OmnibarNativeTextField(frame: .zero)
         field.font = .systemFont(ofSize: 12)
         field.placeholderString = placeholder
+        field.setAccessibilityIdentifier("BrowserOmnibarTextField")
+        objc_setAssociatedObject(field, &browserOmnibarPanelAssociationKey, panelId, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         field.delegate = context.coordinator
         field.target = nil
         field.action = nil
@@ -3124,6 +3152,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         context.coordinator.parent = self
         context.coordinator.parentField = nsView
         nsView.placeholderString = placeholder
+        objc_setAssociatedObject(nsView, &browserOmnibarPanelAssociationKey, panelId, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
         let activeInlineCompletion = omnibarInlineCompletionIfBufferMatchesTypedPrefix(
             bufferText: text,

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -3445,6 +3445,16 @@ final class CommandPaletteRestoreFocusStateMachineTests: XCTestCase {
             )
         )
     }
+
+    func testDoesNotRestoreBrowserAddressBarWhenNoPanelHadAddressBarFocus() {
+        XCTAssertFalse(
+            ContentView.shouldRestoreBrowserAddressBarAfterCommandPaletteDismiss(
+                focusedPanelIsBrowser: true,
+                focusedBrowserAddressBarPanelId: nil,
+                focusedPanelId: nil
+            )
+        )
+    }
 }
 
 final class CommandPaletteRenameSelectionSettingsTests: XCTestCase {


### PR DESCRIPTION
Addresses the unresolved followup comments from https://github.com/manaflow-ai/cmux/pull/1162

Includes a regression test for the command palette browser address bar restore nil-case, tighter terminal search focus ownership, safer browser overlay debug logging, native browser find focus callbacks, and explicit backdrop intent preservation for address bar/find targets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes focus restoration and search focus ownership in browser and terminal. Improves browser find field reliability with native focus callbacks and adds a regression test.

- **Bug Fixes**
  - Correctly restores focus after the command palette to the browser address bar or find fields, and skips restore when no panel had address bar focus (regression test added).
  - Prevents the browser web view from stealing focus while find is active and tightens terminal search focus detection.

- **Refactors**
  - Rebuilt the browser find field using a native `NSTextField` for reliable focus/IME callbacks and Escape/Enter handling.
  - Associated the omnibar field with its panel ID to map focus intent, and simplified focus debug logging.

<sup>Written for commit e62859a8c111e32ac0e0f96c816c9c18ed5d927f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved focus handling when dismissing the command palette to ensure proper restoration across browser and search features
* Enhanced multi-window support for more reliable focus targeting in different application windows
* Refined search overlay focus behavior with improved text field management

**Tests**
* Added test coverage for command palette focus restoration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->