### PR TITLE
Fix browser inspector responder crash on hide

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1489,6 +1489,12 @@ final class BrowserPaneDropTargetView: NSView {
 
 final class WindowBrowserSlotView: NSView {
     override var isOpaque: Bool { false }
+    override var isHidden: Bool {
+        didSet {
+            guard isHidden, !oldValue, let window else { return }
+            yieldOwnedFirstResponderIfNeeded(in: window, reason: "slotHidden")
+        }
+    }
     private let paneDropTargetView = BrowserPaneDropTargetView(frame: .zero)
     private let dropZoneOverlayView = BrowserDropZoneOverlayView(frame: .zero)
     private var searchOverlayHostingView: NSHostingView<BrowserSearchOverlay>?
@@ -1525,6 +1531,13 @@ final class WindowBrowserSlotView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         nil
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow == nil, let currentWindow = window {
+            yieldOwnedFirstResponderIfNeeded(in: currentWindow, reason: "slotWillLeaveWindow")
+        }
+        super.viewWillMove(toWindow: newWindow)
     }
 
     override func layout() {
@@ -1666,6 +1679,23 @@ final class WindowBrowserSlotView: NSView {
               searchOverlayPanelId(for: firstResponder) == panelId else {
             return false
         }
+        return window.makeFirstResponder(nil)
+    }
+
+    @discardableResult
+    private func yieldOwnedFirstResponderIfNeeded(in window: NSWindow, reason: String) -> Bool {
+        guard let firstResponder = window.firstResponder,
+              let owningView = firstResponder.browserPortalOwningView,
+              owningView === self || owningView.isDescendant(of: self) else {
+            return false
+        }
+#if DEBUG
+        dlog(
+            "browser.slot.firstResponder.yield reason=\(reason) " +
+            "slot=\(browserPortalDebugToken(self)) " +
+            "responder=\(String(describing: type(of: firstResponder)))"
+        )
+#endif
         return window.makeFirstResponder(nil)
     }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1488,6 +1488,10 @@ final class BrowserPaneDropTargetView: NSView {
 }
 
 final class WindowBrowserSlotView: NSView {
+    struct HostedContentLayoutSnapshot {
+        let normalizedFrames: [ObjectIdentifier: CGRect]
+    }
+
     override var isOpaque: Bool { false }
     override var isHidden: Bool {
         didSet {
@@ -1506,6 +1510,7 @@ final class WindowBrowserSlotView: NSView {
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var isRefreshingInteractionLayers = false
     private var paneTopChromeHeight: CGFloat = 0
+    private var pendingHostedContentLayoutSnapshot: HostedContentLayoutSnapshot?
     var preferredHostedInspectorWidth: CGFloat?
     var onHostedInspectorLayout: ((WindowBrowserSlotView) -> Void)?
     fileprivate var isApplyingHostedInspectorLayout = false
@@ -1521,6 +1526,65 @@ final class WindowBrowserSlotView: NSView {
             }
             return true
         }
+    }
+
+    func prepareHostedContentLayoutSnapshot(from sourceSlot: WindowBrowserSlotView, hostedSubviews: [NSView]) {
+        let sourceBounds = sourceSlot.bounds
+        guard sourceBounds.width > 1, sourceBounds.height > 1 else {
+            pendingHostedContentLayoutSnapshot = nil
+            return
+        }
+
+        let normalizedFrames = hostedSubviews.reduce(into: [ObjectIdentifier: CGRect]()) { result, view in
+            guard view.superview === sourceSlot else { return }
+            let frame = view.frame
+            guard frame.width > 1, frame.height > 1 else { return }
+            result[ObjectIdentifier(view)] = CGRect(
+                x: frame.minX / sourceBounds.width,
+                y: frame.minY / sourceBounds.height,
+                width: frame.width / sourceBounds.width,
+                height: frame.height / sourceBounds.height
+            )
+        }
+
+        pendingHostedContentLayoutSnapshot = normalizedFrames.isEmpty
+            ? nil
+            : HostedContentLayoutSnapshot(normalizedFrames: normalizedFrames)
+    }
+
+    func applyHostedContentLayoutSnapshotIfNeeded(to hostedSubviews: [NSView]) {
+        guard let snapshot = pendingHostedContentLayoutSnapshot else { return }
+        let targetBounds = bounds
+        guard targetBounds.width > 1, targetBounds.height > 1 else { return }
+
+        var appliedAny = false
+        for view in hostedSubviews {
+            guard view.superview === self,
+                  let normalizedFrame = snapshot.normalizedFrames[ObjectIdentifier(view)] else {
+                continue
+            }
+
+            let nextFrame = CGRect(
+                x: normalizedFrame.minX * targetBounds.width,
+                y: normalizedFrame.minY * targetBounds.height,
+                width: normalizedFrame.width * targetBounds.width,
+                height: normalizedFrame.height * targetBounds.height
+            )
+            guard nextFrame.width > 1, nextFrame.height > 1 else { continue }
+            guard !Self.rectApproximatelyEqual(view.frame, nextFrame, epsilon: 0.5) else {
+                continue
+            }
+            view.frame = nextFrame
+            view.needsLayout = true
+            view.needsDisplay = true
+            appliedAny = true
+        }
+
+        if appliedAny {
+            needsLayout = true
+            needsDisplay = true
+        }
+        pendingHostedContentLayoutSnapshot = nil
     }
 
     override init(frame frameRect: NSRect) {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1510,6 +1510,19 @@ final class WindowBrowserSlotView: NSView {
     var onHostedInspectorLayout: ((WindowBrowserSlotView) -> Void)?
     fileprivate var isApplyingHostedInspectorLayout = false
 
+    func localInlineHostedContentSubviews(primaryWebView: WKWebView) -> [NSView] {
+        let excludedHostingViews = [searchOverlayHostingView].compactMap { $0 }
+        return subviews.filter { view in
+            if view === paneDropTargetView || view === dropZoneOverlayView {
+                return false
+            }
+            if excludedHostingViews.contains(where: { $0 === view }) {
+                return false
+            }
+            return true
+        }
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1749,6 +1749,8 @@ final class BrowserPanel: Panel, ObservableObject {
     private var activeLocalInlineHostLease: LocalInlineHostLease?
     private var pendingDistinctPortalHostReplacementPaneId: UUID?
     private var lockedPortalHost: PortalHostLock?
+    private var pendingDistinctLocalInlineHostReplacementPaneId: UUID?
+    private var lockedLocalInlineHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
     private var navigationDelegate: BrowserNavigationDelegate?
     private var uiDelegate: BrowserUIDelegate?
@@ -1816,6 +1818,22 @@ final class BrowserPanel: Panel, ObservableObject {
 #if DEBUG
         dlog(
             "browser.portal.host.rearm panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) pane=\(paneId.id.uuidString.prefix(5))"
+        )
+#endif
+    }
+
+    func prepareLocalInlineHostReplacementForNextDistinctClaim(
+        inPane paneId: PaneID,
+        reason: String
+    ) {
+        pendingDistinctLocalInlineHostReplacementPaneId = paneId.id
+        if lockedLocalInlineHost?.paneId == paneId.id {
+            lockedLocalInlineHost = nil
+        }
+#if DEBUG
+        dlog(
+            "browser.localHost.rearm panel=\(id.uuidString.prefix(5)) " +
             "reason=\(reason) pane=\(paneId.id.uuidString.prefix(5))"
         )
 #endif
@@ -1959,6 +1977,11 @@ final class BrowserPanel: Panel, ObservableObject {
         )
 
         if let current = activeLocalInlineHostLease {
+            if let lock = lockedLocalInlineHost,
+               (lock.hostId != current.hostId || lock.paneId != current.paneId) {
+                lockedLocalInlineHost = nil
+            }
+
             if current.hostId == hostId {
                 activeLocalInlineHostLease = next
                 return true
@@ -1966,15 +1989,47 @@ final class BrowserPanel: Panel, ObservableObject {
 
             let currentUsable = Self.localInlineHostIsUsable(current)
             let nextUsable = Self.localInlineHostIsUsable(next)
+            let isSamePaneReplacement = current.paneId == paneId.id
+            let shouldForceDistinctReplacement =
+                !isSamePaneReplacement &&
+                pendingDistinctLocalInlineHostReplacementPaneId == paneId.id &&
+                inWindow
+            if shouldForceDistinctReplacement {
+#if DEBUG
+                dlog(
+                    "browser.localHost.claim panel=\(id.uuidString.prefix(5)) " +
+                    "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                    "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                    "replacingHost=\(current.hostId) replacingPane=\(current.paneId.uuidString.prefix(5)) " +
+                    "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area)) " +
+                    "forced=1"
+                )
+#endif
+                activeLocalInlineHostLease = next
+                pendingDistinctLocalInlineHostReplacementPaneId = nil
+                lockedLocalInlineHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
+                return true
+            }
+
+            let lockBlocksSamePaneReplacement =
+                isSamePaneReplacement &&
+                currentUsable &&
+                lockedLocalInlineHost?.hostId == current.hostId &&
+                lockedLocalInlineHost?.paneId == current.paneId
             let shouldReplace =
-                current.paneId != paneId.id ||
                 !currentUsable ||
                 (
+                    isSamePaneReplacement &&
+                    !lockBlocksSamePaneReplacement &&
                     nextUsable &&
                     next.area > (current.area * Self.portalHostReplacementAreaGainRatio)
                 )
 
             if shouldReplace {
+                if lockedLocalInlineHost?.hostId == current.hostId &&
+                    lockedLocalInlineHost?.paneId == current.paneId {
+                    lockedLocalInlineHost = nil
+                }
 #if DEBUG
                 dlog(
                     "browser.localHost.claim panel=\(id.uuidString.prefix(5)) " +
@@ -1994,7 +2049,8 @@ final class BrowserPanel: Panel, ObservableObject {
                 "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
                 "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
                 "ownerHost=\(current.hostId) ownerPane=\(current.paneId.uuidString.prefix(5)) " +
-                "ownerInWin=\(current.inWindow ? 1 : 0) ownerArea=\(String(format: "%.1f", current.area))"
+                "ownerInWin=\(current.inWindow ? 1 : 0) ownerArea=\(String(format: "%.1f", current.area)) " +
+                "locked=\(lockBlocksSamePaneReplacement ? 1 : 0)"
             )
 #endif
             return false
@@ -2016,6 +2072,9 @@ final class BrowserPanel: Panel, ObservableObject {
     func releaseLocalInlineHostIfOwned(hostId: ObjectIdentifier, reason: String) -> Bool {
         guard let current = activeLocalInlineHostLease, current.hostId == hostId else { return false }
         activeLocalInlineHostLease = nil
+        if lockedLocalInlineHost?.hostId == hostId {
+            lockedLocalInlineHost = nil
+        }
 #if DEBUG
         dlog(
             "browser.localHost.release panel=\(id.uuidString.prefix(5)) " +

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1735,11 +1735,18 @@ final class BrowserPanel: Panel, ObservableObject {
         let inWindow: Bool
         let area: CGFloat
     }
+    private struct LocalInlineHostLease {
+        let hostId: ObjectIdentifier
+        let paneId: UUID
+        let inWindow: Bool
+        let area: CGFloat
+    }
     private struct PortalHostLock {
         let hostId: ObjectIdentifier
         let paneId: UUID
     }
     private var activePortalHostLease: PortalHostLease?
+    private var activeLocalInlineHostLease: LocalInlineHostLease?
     private var pendingDistinctPortalHostReplacementPaneId: UUID?
     private var lockedPortalHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
@@ -1791,6 +1798,10 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private static func portalHostIsUsable(_ lease: PortalHostLease) -> Bool {
+        lease.inWindow && lease.area > portalHostAreaThreshold
+    }
+
+    private static func localInlineHostIsUsable(_ lease: LocalInlineHostLease) -> Bool {
         lease.inWindow && lease.area > portalHostAreaThreshold
     }
 
@@ -1926,6 +1937,88 @@ final class BrowserPanel: Panel, ObservableObject {
 #if DEBUG
         dlog(
             "browser.portal.host.release panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) host=\(hostId) pane=\(current.paneId.uuidString.prefix(5)) " +
+            "inWin=\(current.inWindow ? 1 : 0) area=\(String(format: "%.1f", current.area))"
+        )
+#endif
+        return true
+    }
+
+    func claimLocalInlineHost(
+        hostId: ObjectIdentifier,
+        paneId: PaneID,
+        inWindow: Bool,
+        bounds: CGRect,
+        reason: String
+    ) -> Bool {
+        let next = LocalInlineHostLease(
+            hostId: hostId,
+            paneId: paneId.id,
+            inWindow: inWindow,
+            area: Self.portalHostArea(for: bounds)
+        )
+
+        if let current = activeLocalInlineHostLease {
+            if current.hostId == hostId {
+                activeLocalInlineHostLease = next
+                return true
+            }
+
+            let currentUsable = Self.localInlineHostIsUsable(current)
+            let nextUsable = Self.localInlineHostIsUsable(next)
+            let shouldReplace =
+                current.paneId != paneId.id ||
+                !currentUsable ||
+                (
+                    nextUsable &&
+                    next.area > (current.area * Self.portalHostReplacementAreaGainRatio)
+                )
+
+            if shouldReplace {
+#if DEBUG
+                dlog(
+                    "browser.localHost.claim panel=\(id.uuidString.prefix(5)) " +
+                    "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                    "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                    "replacingHost=\(current.hostId) replacingPane=\(current.paneId.uuidString.prefix(5)) " +
+                    "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area))"
+                )
+#endif
+                activeLocalInlineHostLease = next
+                return true
+            }
+
+#if DEBUG
+            dlog(
+                "browser.localHost.skip panel=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                "ownerHost=\(current.hostId) ownerPane=\(current.paneId.uuidString.prefix(5)) " +
+                "ownerInWin=\(current.inWindow ? 1 : 0) ownerArea=\(String(format: "%.1f", current.area))"
+            )
+#endif
+            return false
+        }
+
+        activeLocalInlineHostLease = next
+#if DEBUG
+        dlog(
+            "browser.localHost.claim panel=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+            "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+            "replacingHost=nil"
+        )
+#endif
+        return true
+    }
+
+    @discardableResult
+    func releaseLocalInlineHostIfOwned(hostId: ObjectIdentifier, reason: String) -> Bool {
+        guard let current = activeLocalInlineHostLease, current.hostId == hostId else { return false }
+        activeLocalInlineHostLease = nil
+#if DEBUG
+        dlog(
+            "browser.localHost.release panel=\(id.uuidString.prefix(5)) " +
             "reason=\(reason) host=\(hostId) pane=\(current.paneId.uuidString.prefix(5)) " +
             "inWin=\(current.inWindow ? 1 : 0) area=\(String(format: "%.1f", current.area))"
         )

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2272,6 +2272,11 @@ final class BrowserPanel: Panel, ObservableObject {
         viewReattachToken &+= 1
     }
 
+    func ownsUsableLocalInlineHost(for paneId: PaneID) -> Bool {
+        guard let lease = activeLocalInlineHostLease else { return false }
+        return lease.paneId == paneId.id && Self.localInlineHostIsUsable(lease)
+    }
+
     func sessionNavigationHistorySnapshot() -> (
         backHistoryURLStrings: [String],
         forwardHistoryURLStrings: [String]

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1680,6 +1680,10 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Increment to request a UI-only flash highlight (e.g. from a keyboard shortcut).
     @Published private(set) var focusFlashToken: Int = 0
 
+    /// Bump this token to force SwiftUI to call `updateNSView` on `WebViewRepresentable`
+    /// after bonsplit move/reparent sequences leave the current host detached.
+    @Published var viewReattachToken: UInt64 = 0
+
     /// Sticky omnibar-focus intent. This survives view mount timing races and is
     /// cleared only after BrowserPanelView acknowledges handling it.
     @Published private(set) var pendingAddressBarFocusRequestId: UUID?
@@ -2110,6 +2114,10 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func triggerFlash() {
         focusFlashToken &+= 1
+    }
+
+    func requestViewReattach() {
+        viewReattachToken &+= 1
     }
 
     func sessionNavigationHistorySnapshot() -> (

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3619,11 +3619,15 @@ struct WebViewRepresentable: NSViewRepresentable {
     final class Coordinator {
         weak var panel: BrowserPanel?
         weak var webView: WKWebView?
+        weak var localInlineSlotView: WindowBrowserSlotView?
         var attachGeneration: Int = 0
         var desiredPortalVisibleInUI: Bool = true
         var desiredPortalZPriority: Int = 0
         var lastPortalHostId: ObjectIdentifier?
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
+        var lastLocalInlinePanelFocused: Bool?
+        var lastLocalInlineWebResponder: Bool?
+        var localInlineDidReparent: Bool = false
     }
 
     final class HostContainerView: NSView {
@@ -4552,6 +4556,52 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
     }
 
+    private static func resetLocalInlineFocusRefreshState(_ coordinator: Coordinator) {
+        coordinator.localInlineSlotView = nil
+        coordinator.lastLocalInlinePanelFocused = nil
+        coordinator.lastLocalInlineWebResponder = nil
+        coordinator.localInlineDidReparent = false
+    }
+
+    static func refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
+        _ webView: WKWebView,
+        in container: WindowBrowserSlotView,
+        coordinator: Coordinator,
+        isPanelFocused: Bool,
+        isWebViewFirstResponder: Bool,
+        reason: String
+    ) {
+        defer {
+            coordinator.lastLocalInlinePanelFocused = isPanelFocused
+            coordinator.lastLocalInlineWebResponder = isWebViewFirstResponder
+            coordinator.localInlineDidReparent = false
+        }
+
+        guard !container.isHidden, container.window != nil else { return }
+        guard !coordinator.localInlineDidReparent else { return }
+        guard let lastPanelFocused = coordinator.lastLocalInlinePanelFocused,
+              let lastWebResponder = coordinator.lastLocalInlineWebResponder else {
+            return
+        }
+        guard lastPanelFocused != isPanelFocused || lastWebResponder != isWebViewFirstResponder else {
+            return
+        }
+
+#if DEBUG
+        dlog(
+            "browser.localHost.focusRefresh web=\(ObjectIdentifier(webView)) " +
+            "container=\(Self.objectID(container)) reason=\(reason) " +
+            "oldPanelFocused=\(lastPanelFocused ? 1 : 0) newPanelFocused=\(isPanelFocused ? 1 : 0) " +
+            "oldWebResponder=\(lastWebResponder ? 1 : 0) newWebResponder=\(isWebViewFirstResponder ? 1 : 0)"
+        )
+#endif
+        refreshLocalInlineHostedWebViewPresentation(
+            webView,
+            in: container,
+            reason: reason
+        )
+    }
+
     private static func installPortalAnchorView(_ anchorView: NSView, in host: NSView) {
         // SwiftUI can keep transient replacement hosts alive off-window during split
         // reparenting. Never let those hosts steal the shared portal anchor, or the
@@ -4585,6 +4635,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         let slotView = host.ensureLocalInlineSlotView()
 
         let coordinator = context.coordinator
+        coordinator.localInlineSlotView = slotView
         coordinator.desiredPortalVisibleInUI = false
         coordinator.desiredPortalZPriority = 0
         coordinator.attachGeneration += 1
@@ -4628,6 +4679,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         let didReparentIntoLocalHost = webView.superview !== slotView
+        coordinator.localInlineDidReparent = didReparentIntoLocalHost
         if webView.superview !== slotView {
             if let sourceSuperview = webView.superview {
                 Self.moveWebKitRelatedSubviewsIntoHostIfNeeded(
@@ -4678,6 +4730,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         host.releaseHostedWebViewConstraints()
 
         let coordinator = context.coordinator
+        Self.resetLocalInlineFocusRefreshState(coordinator)
         let paneDropContext = currentPaneDropContext()
         let isCurrentPaneOwner = paneDropContext?.paneId.id == paneId.id
         let hostId = ObjectIdentifier(host)
@@ -4882,27 +4935,46 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.detach(webView: previousWebView)
             coordinator.lastPortalHostId = nil
             coordinator.lastSynchronizedHostGeometryRevision = 0
+            Self.resetLocalInlineFocusRefreshState(coordinator)
         }
         coordinator.panel = panel
         coordinator.webView = webView
 
         Self.clearPortalCallbacks(for: nsView)
+        let resolvedPanelFocused = isPanelFocused && isCurrentPaneOwner
+        let resolvedShouldFocusWebView = shouldFocusWebView && isCurrentPaneOwner
         let hostOwnsPortal = useLocalInlineHosting
             ? updateUsingLocalInlineHosting(nsView, context: context, webView: webView)
             : updateUsingWindowPortal(nsView, context: context, webView: webView)
         Self.applyWebViewFirstResponderPolicy(
             panel: panel,
             webView: webView,
-            isPanelFocused: isPanelFocused && isCurrentPaneOwner && hostOwnsPortal
+            isPanelFocused: resolvedPanelFocused && hostOwnsPortal
         )
 
         Self.applyFocus(
             panel: panel,
             webView: webView,
             nsView: nsView,
-            shouldFocusWebView: shouldFocusWebView && isCurrentPaneOwner && hostOwnsPortal,
-            isPanelFocused: isPanelFocused && isCurrentPaneOwner && hostOwnsPortal
+            shouldFocusWebView: resolvedShouldFocusWebView && hostOwnsPortal,
+            isPanelFocused: resolvedPanelFocused && hostOwnsPortal
         )
+
+        if useLocalInlineHosting,
+           hostOwnsPortal,
+           let slotView = coordinator.localInlineSlotView,
+           let window = nsView.window ?? webView.window {
+            Self.refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
+                webView,
+                in: slotView,
+                coordinator: coordinator,
+                isPanelFocused: resolvedPanelFocused,
+                isWebViewFirstResponder: Self.responderChainContains(window.firstResponder, target: webView),
+                reason: "localHost.focusChange"
+            )
+        } else {
+            Self.resetLocalInlineFocusRefreshState(coordinator)
+        }
     }
 
     private static func applyFocus(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -602,6 +602,13 @@ struct BrowserPanelView: View {
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
             ghosttyBackgroundGeneration &+= 1
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)
+                .compactMap { $0.object as? NSWindow }
+        ) { window in
+            guard window === panel.webView.window else { return }
+            requestVisibleLocalInlineRefreshIfNeeded(reason: "window.didBecomeKey")
+        }
     }
 
     private var addressBar: some View {
@@ -1233,6 +1240,18 @@ struct BrowserPanelView: View {
             browserThemeModeRaw = mode.rawValue
         }
         panel.setBrowserThemeMode(mode)
+    }
+
+    private func requestVisibleLocalInlineRefreshIfNeeded(reason: String) {
+        guard isFocused else { return }
+        guard panel.shouldUseLocalInlineDeveloperToolsHosting() else { return }
+#if DEBUG
+        dlog(
+            "browser.localHost.keyRefresh.request panel=\(panel.id.uuidString.prefix(5)) " +
+            "reason=\(reason) focused=\(isFocused ? 1 : 0)"
+        )
+#endif
+        panel.requestViewReattach()
     }
 
     private func handleOmnibarTap() {
@@ -3629,6 +3648,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
         var lastLocalInlinePanelFocused: Bool?
         var lastLocalInlineWebResponder: Bool?
+        var lastLocalInlineRefreshToken: UInt64?
         var localInlineDidReparent: Bool = false
     }
 
@@ -4625,7 +4645,35 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator.localInlineSlotView = nil
         coordinator.lastLocalInlinePanelFocused = nil
         coordinator.lastLocalInlineWebResponder = nil
+        coordinator.lastLocalInlineRefreshToken = nil
         coordinator.localInlineDidReparent = false
+    }
+
+    static func refreshLocalInlineHostedWebViewPresentationIfRequested(
+        _ webView: WKWebView,
+        in container: WindowBrowserSlotView,
+        coordinator: Coordinator,
+        refreshToken: UInt64,
+        reason: String
+    ) {
+        defer { coordinator.lastLocalInlineRefreshToken = refreshToken }
+
+        guard !container.isHidden, container.window != nil else { return }
+        guard let lastRefreshToken = coordinator.lastLocalInlineRefreshToken else { return }
+        guard lastRefreshToken != refreshToken else { return }
+
+#if DEBUG
+        dlog(
+            "browser.localHost.tokenRefresh web=\(ObjectIdentifier(webView)) " +
+            "container=\(Self.objectID(container)) reason=\(reason) " +
+            "oldToken=\(lastRefreshToken) newToken=\(refreshToken)"
+        )
+#endif
+        refreshLocalInlineHostedWebViewPresentation(
+            webView,
+            in: container,
+            reason: reason
+        )
     }
 
     static func refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
@@ -4710,10 +4758,6 @@ struct WebViewRepresentable: NSViewRepresentable {
         let retryDeferredAttachIfNeeded: (String) -> Void = { [weak host, weak webView, weak coordinator, weak slotView, weak browserPanel = panel] reason in
             guard let host, let webView, let coordinator, let slotView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
-            if let currentPaneId = currentPaneDropContext()?.paneId.id,
-               currentPaneId != paneId.id {
-                return
-            }
             guard browserPanel.claimLocalInlineHost(
                 hostId: ObjectIdentifier(host),
                 paneId: paneId,
@@ -4725,6 +4769,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 host.releaseHostedWebViewConstraints()
                 return
             }
+            // During move churn the visible replacement host can join a window before
+            // workspace pane mapping converges to the destination pane. Once this host
+            // successfully owns the local inline lease, trust that lease instead of
+            // re-checking the potentially stale pane mapping here.
             guard host.window != nil else { return }
             guard webView.superview !== slotView else { return }
 
@@ -5126,6 +5174,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 isPanelFocused: resolvedPanelFocused,
                 isWebViewFirstResponder: Self.responderChainContains(window.firstResponder, target: webView),
                 reason: "localHost.focusChange"
+            )
+            Self.refreshLocalInlineHostedWebViewPresentationIfRequested(
+                webView,
+                in: slotView,
+                coordinator: coordinator,
+                refreshToken: reattachToken,
+                reason: "localHost.reattachToken"
             )
         } else {
             Self.resetLocalInlineFocusRefreshState(coordinator)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4491,6 +4491,49 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
     }
 
+    private static func attachLocalInlineHostedWebView(
+        _ webView: WKWebView,
+        to slotView: WindowBrowserSlotView,
+        in host: HostContainerView,
+        coordinator: Coordinator,
+        panel: BrowserPanel,
+        reason: String
+    ) {
+        let didReparentIntoLocalHost = webView.superview !== slotView
+        coordinator.localInlineDidReparent = didReparentIntoLocalHost
+        if didReparentIntoLocalHost {
+            if let sourceSuperview = webView.superview {
+                Self.moveWebKitRelatedSubviewsIntoHostIfNeeded(
+                    from: sourceSuperview,
+                    to: slotView,
+                    primaryWebView: webView,
+                    reason: reason
+                )
+            } else {
+                slotView.addSubview(webView, positioned: .above, relativeTo: nil)
+            }
+        }
+
+        slotView.isHidden = false
+        host.pinHostedWebView(webView, in: slotView)
+        coordinator.lastPortalHostId = nil
+        coordinator.lastSynchronizedHostGeometryRevision = 0
+        panel.restoreDeveloperToolsAfterAttachIfNeeded()
+        webView.needsLayout = true
+        webView.layoutSubtreeIfNeeded()
+        slotView.layoutSubtreeIfNeeded()
+        host.displayIfNeeded()
+        slotView.displayIfNeeded()
+        webView.displayIfNeeded()
+        if didReparentIntoLocalHost {
+            Self.refreshLocalInlineHostedWebViewPresentation(
+                webView,
+                in: slotView,
+                reason: reason
+            )
+        }
+    }
+
     private static func runLocalInlineHostedWebViewRefreshPass(
         _ webView: WKWebView,
         in container: WindowBrowserSlotView,
@@ -4639,6 +4682,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator.desiredPortalVisibleInUI = false
         coordinator.desiredPortalZPriority = 0
         coordinator.attachGeneration += 1
+        let generation = coordinator.attachGeneration
 
         if panel.releasePortalHostIfOwned(
             hostId: ObjectIdentifier(host),
@@ -4678,39 +4722,61 @@ struct WebViewRepresentable: NSViewRepresentable {
             return false
         }
 
-        let didReparentIntoLocalHost = webView.superview !== slotView
-        coordinator.localInlineDidReparent = didReparentIntoLocalHost
-        if webView.superview !== slotView {
-            if let sourceSuperview = webView.superview {
-                Self.moveWebKitRelatedSubviewsIntoHostIfNeeded(
-                    from: sourceSuperview,
-                    to: slotView,
-                    primaryWebView: webView,
-                    reason: "attachLocalHost"
-                )
-            } else {
-                slotView.addSubview(webView, positioned: .above, relativeTo: nil)
+        let retryDeferredAttachIfNeeded: (String) -> Void = { [weak host, weak webView, weak coordinator, weak slotView, weak browserPanel = panel] reason in
+            guard let host, let webView, let coordinator, let slotView, let browserPanel else { return }
+            guard coordinator.attachGeneration == generation else { return }
+            if let currentPaneId = currentPaneDropContext()?.paneId.id,
+               currentPaneId != paneId.id {
+                return
+            }
+            guard host.window != nil else { return }
+            guard webView.superview !== slotView else { return }
+
+            host.layoutSubtreeIfNeeded()
+            slotView.layoutSubtreeIfNeeded()
+            guard slotView.bounds.width > 1, slotView.bounds.height > 1 else { return }
+
+#if DEBUG
+            dlog(
+                "browser.localHost.deferredAttach web=\(Self.objectID(webView)) " +
+                "reason=\(reason) host=\(Self.objectID(host)) slot=\(Self.objectID(slotView))"
+            )
+#endif
+            Self.attachLocalInlineHostedWebView(
+                webView,
+                to: slotView,
+                in: host,
+                coordinator: coordinator,
+                panel: browserPanel,
+                reason: reason
+            )
+#if DEBUG
+            Self.logDevToolsState(
+                browserPanel,
+                event: "localHost.update",
+                generation: generation,
+                retryCount: 0,
+                details: Self.attachContext(webView: webView, host: host) + " deferred=1 reason=\(reason)"
+            )
+#endif
+        }
+        host.onDidMoveToWindow = {
+            DispatchQueue.main.async {
+                retryDeferredAttachIfNeeded("localHost.didMoveToWindow")
             }
         }
-
-        slotView.isHidden = false
-        host.pinHostedWebView(webView, in: slotView)
-        coordinator.lastPortalHostId = nil
-        coordinator.lastSynchronizedHostGeometryRevision = 0
-        panel.restoreDeveloperToolsAfterAttachIfNeeded()
-        webView.needsLayout = true
-        webView.layoutSubtreeIfNeeded()
-        slotView.layoutSubtreeIfNeeded()
-        host.displayIfNeeded()
-        slotView.displayIfNeeded()
-        webView.displayIfNeeded()
-        if didReparentIntoLocalHost {
-            Self.refreshLocalInlineHostedWebViewPresentation(
-                webView,
-                in: slotView,
-                reason: "localHost.attach"
-            )
+        host.onGeometryChanged = {
+            retryDeferredAttachIfNeeded("localHost.geometryChanged")
         }
+
+        Self.attachLocalInlineHostedWebView(
+            webView,
+            to: slotView,
+            in: host,
+            coordinator: coordinator,
+            panel: panel,
+            reason: "localHost.attach"
+        )
 
 #if DEBUG
         Self.logDevToolsState(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4466,9 +4466,14 @@ struct WebViewRepresentable: NSViewRepresentable {
         reason: String
     ) {
         guard sourceSuperview !== container else { return }
-        let relatedSubviews = sourceSuperview.subviews.filter { view in
-            if view === primaryWebView { return true }
-            return String(describing: type(of: view)).contains("WK")
+        let relatedSubviews: [NSView]
+        if let sourceSlot = sourceSuperview as? WindowBrowserSlotView {
+            relatedSubviews = sourceSlot.localInlineHostedContentSubviews(primaryWebView: primaryWebView)
+        } else {
+            relatedSubviews = sourceSuperview.subviews.filter { view in
+                if view === primaryWebView { return true }
+                return String(describing: type(of: view)).contains("WK")
+            }
         }
         guard !relatedSubviews.isEmpty else { return }
 #if DEBUG

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4500,7 +4500,21 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator: Coordinator,
         panel: BrowserPanel,
         reason: String
-    ) {
+    ) -> Bool {
+        guard host.window != nil else {
+            host.setLocalInlineSlotHidden(true)
+            host.releaseHostedWebViewConstraints()
+            coordinator.localInlineDidReparent = false
+#if DEBUG
+            dlog(
+                "browser.localHost.attach.skip web=\(Self.objectID(webView)) " +
+                "reason=\(reason) host=\(Self.objectID(host)) slot=\(Self.objectID(slotView)) " +
+                "skip=hostWithoutWindow"
+            )
+#endif
+            return false
+        }
+
         let didReparentIntoLocalHost = webView.superview !== slotView
         coordinator.localInlineDidReparent = didReparentIntoLocalHost
         if didReparentIntoLocalHost {
@@ -4534,6 +4548,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 reason: reason
             )
         }
+        return true
     }
 
     private static func runLocalInlineHostedWebViewRefreshPass(
@@ -4678,6 +4693,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     private func updateUsingLocalInlineHosting(_ nsView: NSView, context: Context, webView: WKWebView) -> Bool {
         guard let host = nsView as? HostContainerView else { return false }
         let slotView = host.ensureLocalInlineSlotView()
+        let hostId = ObjectIdentifier(host)
 
         let coordinator = context.coordinator
         coordinator.localInlineSlotView = slotView
@@ -4686,14 +4702,112 @@ struct WebViewRepresentable: NSViewRepresentable {
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
 
+        let retryDeferredAttachIfNeeded: (String) -> Void = { [weak host, weak webView, weak coordinator, weak slotView, weak browserPanel = panel] reason in
+            guard let host, let webView, let coordinator, let slotView, let browserPanel else { return }
+            guard coordinator.attachGeneration == generation else { return }
+            if let currentPaneId = currentPaneDropContext()?.paneId.id,
+               currentPaneId != paneId.id {
+                return
+            }
+            guard browserPanel.claimLocalInlineHost(
+                hostId: ObjectIdentifier(host),
+                paneId: paneId,
+                inWindow: host.window != nil,
+                bounds: host.bounds,
+                reason: reason
+            ) else {
+                host.setLocalInlineSlotHidden(true)
+                host.releaseHostedWebViewConstraints()
+                return
+            }
+            guard host.window != nil else { return }
+            guard webView.superview !== slotView else { return }
+
+            host.layoutSubtreeIfNeeded()
+            slotView.layoutSubtreeIfNeeded()
+            guard slotView.bounds.width > 1, slotView.bounds.height > 1 else { return }
+
+#if DEBUG
+            dlog(
+                "browser.localHost.deferredAttach web=\(Self.objectID(webView)) " +
+                "reason=\(reason) host=\(Self.objectID(host)) slot=\(Self.objectID(slotView))"
+            )
+#endif
+            guard Self.attachLocalInlineHostedWebView(
+                webView,
+                to: slotView,
+                in: host,
+                coordinator: coordinator,
+                panel: browserPanel,
+                reason: reason
+            ) else {
+                return
+            }
+#if DEBUG
+            Self.logDevToolsState(
+                browserPanel,
+                event: "localHost.update",
+                generation: generation,
+                retryCount: 0,
+                details: Self.attachContext(webView: webView, host: host) + " deferred=1 reason=\(reason)"
+            )
+#endif
+        }
+        host.onDidMoveToWindow = { [weak host, weak browserPanel = panel] in
+            DispatchQueue.main.async {
+                guard let host, let browserPanel else { return }
+                _ = browserPanel.claimLocalInlineHost(
+                    hostId: ObjectIdentifier(host),
+                    paneId: paneId,
+                    inWindow: host.window != nil,
+                    bounds: host.bounds,
+                    reason: "didMoveToWindow"
+                )
+                retryDeferredAttachIfNeeded("localHost.didMoveToWindow")
+            }
+        }
+        host.onGeometryChanged = {
+            _ = panel.claimLocalInlineHost(
+                hostId: hostId,
+                paneId: paneId,
+                inWindow: host.window != nil,
+                bounds: host.bounds,
+                reason: "geometryChanged"
+            )
+            retryDeferredAttachIfNeeded("localHost.geometryChanged")
+        }
+
         if panel.releasePortalHostIfOwned(
-            hostId: ObjectIdentifier(host),
+            hostId: hostId,
             reason: "localInlineHosting"
         ) {
             BrowserWindowPortalRegistry.hide(
                 webView: webView,
                 source: "viewStateChanged.localInlineHosting"
             )
+        }
+
+        guard panel.claimLocalInlineHost(
+            hostId: hostId,
+            paneId: paneId,
+            inWindow: host.window != nil,
+            bounds: host.bounds,
+            reason: "update"
+        ) else {
+            host.setLocalInlineSlotHidden(true)
+            host.releaseHostedWebViewConstraints()
+            coordinator.lastPortalHostId = nil
+            coordinator.lastSynchronizedHostGeometryRevision = 0
+#if DEBUG
+            Self.logDevToolsState(
+                panel,
+                event: "localHost.skip",
+                generation: coordinator.attachGeneration,
+                retryCount: 0,
+                details: Self.attachContext(webView: webView, host: host) + " reason=hostOwnershipRejected"
+            )
+#endif
+            return false
         }
 
         let shouldPreserveExistingExternalLocalHost =
@@ -4724,61 +4838,25 @@ struct WebViewRepresentable: NSViewRepresentable {
             return false
         }
 
-        let retryDeferredAttachIfNeeded: (String) -> Void = { [weak host, weak webView, weak coordinator, weak slotView, weak browserPanel = panel] reason in
-            guard let host, let webView, let coordinator, let slotView, let browserPanel else { return }
-            guard coordinator.attachGeneration == generation else { return }
-            if let currentPaneId = currentPaneDropContext()?.paneId.id,
-               currentPaneId != paneId.id {
-                return
-            }
-            guard host.window != nil else { return }
-            guard webView.superview !== slotView else { return }
-
-            host.layoutSubtreeIfNeeded()
-            slotView.layoutSubtreeIfNeeded()
-            guard slotView.bounds.width > 1, slotView.bounds.height > 1 else { return }
-
-#if DEBUG
-            dlog(
-                "browser.localHost.deferredAttach web=\(Self.objectID(webView)) " +
-                "reason=\(reason) host=\(Self.objectID(host)) slot=\(Self.objectID(slotView))"
-            )
-#endif
-            Self.attachLocalInlineHostedWebView(
-                webView,
-                to: slotView,
-                in: host,
-                coordinator: coordinator,
-                panel: browserPanel,
-                reason: reason
-            )
-#if DEBUG
-            Self.logDevToolsState(
-                browserPanel,
-                event: "localHost.update",
-                generation: generation,
-                retryCount: 0,
-                details: Self.attachContext(webView: webView, host: host) + " deferred=1 reason=\(reason)"
-            )
-#endif
-        }
-        host.onDidMoveToWindow = {
-            DispatchQueue.main.async {
-                retryDeferredAttachIfNeeded("localHost.didMoveToWindow")
-            }
-        }
-        host.onGeometryChanged = {
-            retryDeferredAttachIfNeeded("localHost.geometryChanged")
-        }
-
-        Self.attachLocalInlineHostedWebView(
+        guard Self.attachLocalInlineHostedWebView(
             webView,
             to: slotView,
             in: host,
             coordinator: coordinator,
             panel: panel,
             reason: "localHost.attach"
-        )
+        ) else {
+#if DEBUG
+            Self.logDevToolsState(
+                panel,
+                event: "localHost.skip",
+                generation: coordinator.attachGeneration,
+                retryCount: 0,
+                details: Self.attachContext(webView: webView, host: host) + " reason=hostWithoutWindow"
+            )
+#endif
+            return false
+        }
 
 #if DEBUG
         Self.logDevToolsState(
@@ -4796,6 +4874,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         guard let host = nsView as? HostContainerView else { return false }
         host.setLocalInlineSlotHidden(true)
         host.releaseHostedWebViewConstraints()
+        _ = panel.releaseLocalInlineHostIfOwned(
+            hostId: ObjectIdentifier(host),
+            reason: "windowPortal"
+        )
 
         let coordinator = context.coordinator
         Self.resetLocalInlineFocusRefreshState(coordinator)
@@ -5134,6 +5216,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         clearPortalCallbacks(for: nsView)
         if let panel = coordinator.panel, let host = nsView as? HostContainerView {
             panel.releasePortalHostIfOwned(
+                hostId: ObjectIdentifier(host),
+                reason: "dismantle"
+            )
+            panel.releaseLocalInlineHostIfOwned(
                 hostId: ObjectIdentifier(host),
                 reason: "dismantle"
             )

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4676,8 +4676,11 @@ struct WebViewRepresentable: NSViewRepresentable {
         reason: String
     ) {
         guard !container.isHidden, container.window != nil else { return }
-        if let lastRefreshToken = coordinator.lastLocalInlineRefreshToken,
-           lastRefreshToken == refreshToken {
+        guard let lastRefreshToken = coordinator.lastLocalInlineRefreshToken else {
+            coordinator.lastLocalInlineRefreshToken = refreshToken
+            return
+        }
+        if lastRefreshToken == refreshToken {
             return
         }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4489,6 +4489,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         let relatedSubviews: [NSView]
         if let sourceSlot = sourceSuperview as? WindowBrowserSlotView {
             relatedSubviews = sourceSlot.localInlineHostedContentSubviews(primaryWebView: primaryWebView)
+            container.prepareHostedContentLayoutSnapshot(
+                from: sourceSlot,
+                hostedSubviews: relatedSubviews
+            )
         } else {
             relatedSubviews = sourceSuperview.subviews.filter { view in
                 if view === primaryWebView { return true }
@@ -4563,6 +4567,9 @@ struct WebViewRepresentable: NSViewRepresentable {
         webView.needsLayout = true
         webView.layoutSubtreeIfNeeded()
         slotView.layoutSubtreeIfNeeded()
+        slotView.applyHostedContentLayoutSnapshotIfNeeded(
+            to: slotView.localInlineHostedContentSubviews(primaryWebView: webView)
+        )
         host.displayIfNeeded()
         slotView.displayIfNeeded()
         webView.displayIfNeeded()
@@ -4583,6 +4590,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         phase: String
     ) {
         guard !container.isHidden else { return }
+
+        container.applyHostedContentLayoutSnapshotIfNeeded(
+            to: container.localInlineHostedContentSubviews(primaryWebView: webView)
+        )
 
         webView.needsLayout = true
         webView.needsDisplay = true

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 import WebKit
 import AppKit
 
+protocol LocalHostRenderingStateProbe: AnyObject {
+    func cmuxDidInvokeLocalHostSelector(_ rawSelector: String)
+}
+
 private extension NSObject {
     @discardableResult
     func cmuxLocalHostCallVoidIfAvailable(_ rawSelector: String) -> Bool {
@@ -11,6 +15,7 @@ private extension NSObject {
         typealias Fn = @convention(c) (AnyObject, Selector) -> Void
         let fn = unsafeBitCast(method(for: selector), to: Fn.self)
         fn(self, selector)
+        (self as? LocalHostRenderingStateProbe)?.cmuxDidInvokeLocalHostSelector(rawSelector)
         return true
     }
 }
@@ -19,6 +24,9 @@ private extension WKWebView {
     func cmuxReattachLocalHostRenderingState(reason: String) {
         guard window != nil else { return }
 
+        // These optional private WebKit selectors repair visibility and in-window
+        // state after a locally hosted browser view is reattached. The debug log
+        // records which ones still exist so future WebKit changes are diagnosable.
         let firedSelectors = [
             "viewDidUnhide",
             "_enterInWindow",
@@ -4667,17 +4675,17 @@ struct WebViewRepresentable: NSViewRepresentable {
         refreshToken: UInt64,
         reason: String
     ) {
-        defer { coordinator.lastLocalInlineRefreshToken = refreshToken }
-
         guard !container.isHidden, container.window != nil else { return }
-        guard let lastRefreshToken = coordinator.lastLocalInlineRefreshToken else { return }
-        guard lastRefreshToken != refreshToken else { return }
+        if let lastRefreshToken = coordinator.lastLocalInlineRefreshToken,
+           lastRefreshToken == refreshToken {
+            return
+        }
 
 #if DEBUG
         dlog(
             "browser.localHost.tokenRefresh web=\(ObjectIdentifier(webView)) " +
             "container=\(Self.objectID(container)) reason=\(reason) " +
-            "oldToken=\(lastRefreshToken) newToken=\(refreshToken)"
+            "oldToken=\(String(describing: coordinator.lastLocalInlineRefreshToken)) newToken=\(refreshToken)"
         )
 #endif
         refreshLocalInlineHostedWebViewPresentation(
@@ -4685,6 +4693,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             in: container,
             reason: reason
         )
+        coordinator.lastLocalInlineRefreshToken = refreshToken
     }
 
     static func refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
@@ -4784,11 +4793,9 @@ struct WebViewRepresentable: NSViewRepresentable {
             // workspace pane mapping converges to the destination pane. Once this host
             // successfully owns the local inline lease, trust that lease instead of
             // re-checking the potentially stale pane mapping here.
-            guard host.window != nil else { return }
-            guard webView.superview !== slotView else { return }
-
             host.layoutSubtreeIfNeeded()
             slotView.layoutSubtreeIfNeeded()
+            guard host.window != nil else { return }
             guard slotView.bounds.width > 1, slotView.bounds.height > 1 else { return }
 
 #if DEBUG
@@ -4817,9 +4824,10 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
 #endif
         }
-        host.onDidMoveToWindow = { [weak host, weak browserPanel = panel] in
+        host.onDidMoveToWindow = { [weak host, weak coordinator, weak browserPanel = panel] in
             DispatchQueue.main.async {
-                guard let host, let browserPanel else { return }
+                guard let host, let coordinator, let browserPanel else { return }
+                guard coordinator.attachGeneration == generation else { return }
                 _ = browserPanel.claimLocalInlineHost(
                     hostId: ObjectIdentifier(host),
                     paneId: paneId,
@@ -4899,6 +4907,14 @@ struct WebViewRepresentable: NSViewRepresentable {
                 details: Self.attachContext(webView: webView, host: host)
             )
 #endif
+            return false
+        }
+
+        host.layoutSubtreeIfNeeded()
+        slotView.layoutSubtreeIfNeeded()
+        guard slotView.bounds.width > 1, slotView.bounds.height > 1 else {
+            host.setLocalInlineSlotHidden(true)
+            host.releaseHostedWebViewConstraints()
             return false
         }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3,6 +3,54 @@ import SwiftUI
 import WebKit
 import AppKit
 
+private extension NSObject {
+    @discardableResult
+    func cmuxLocalHostCallVoidIfAvailable(_ rawSelector: String) -> Bool {
+        let selector = NSSelectorFromString(rawSelector)
+        guard responds(to: selector) else { return false }
+        typealias Fn = @convention(c) (AnyObject, Selector) -> Void
+        let fn = unsafeBitCast(method(for: selector), to: Fn.self)
+        fn(self, selector)
+        return true
+    }
+}
+
+private extension WKWebView {
+    func cmuxReattachLocalHostRenderingState(reason: String) {
+        guard window != nil else { return }
+
+        let firedSelectors = [
+            "viewDidUnhide",
+            "_enterInWindow",
+            "_endDeferringViewInWindowChangesSync",
+        ].filter {
+            cmuxLocalHostCallVoidIfAvailable($0)
+        }
+
+        if let scrollView = enclosingScrollView {
+            scrollView.needsLayout = true
+            scrollView.needsDisplay = true
+            scrollView.setNeedsDisplay(scrollView.bounds)
+            scrollView.contentView.needsLayout = true
+            scrollView.contentView.needsDisplay = true
+        }
+
+        needsLayout = true
+        needsDisplay = true
+        setNeedsDisplay(bounds)
+
+#if DEBUG
+        if !firedSelectors.isEmpty {
+            dlog(
+                "browser.localHost.webview.reattach web=\(ObjectIdentifier(self)) " +
+                "reason=\(reason) selectors=\(firedSelectors.joined(separator: ",")) " +
+                "frame=\(NSStringFromRect(frame))"
+            )
+        }
+#endif
+    }
+}
+
 enum BrowserDevToolsIconOption: String, CaseIterable, Identifiable {
     case wrenchAndScrewdriver = "wrench.and.screwdriver"
     case wrenchAndScrewdriverFill = "wrench.and.screwdriver.fill"
@@ -4439,6 +4487,71 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
     }
 
+    private static func runLocalInlineHostedWebViewRefreshPass(
+        _ webView: WKWebView,
+        in container: WindowBrowserSlotView,
+        reason: String,
+        phase: String
+    ) {
+        guard !container.isHidden else { return }
+
+        webView.needsLayout = true
+        webView.needsDisplay = true
+        webView.setNeedsDisplay(webView.bounds)
+
+        container.layoutSubtreeIfNeeded()
+        if let scrollView = webView.enclosingScrollView {
+            scrollView.layoutSubtreeIfNeeded()
+            scrollView.contentView.layoutSubtreeIfNeeded()
+            scrollView.displayIfNeeded()
+        }
+        webView.layoutSubtreeIfNeeded()
+        webView.cmuxReattachLocalHostRenderingState(reason: "\(reason):\(phase)")
+        container.displayIfNeeded()
+        webView.displayIfNeeded()
+        (webView.window ?? container.window)?.displayIfNeeded()
+#if DEBUG
+        dlog(
+            "browser.localHost.refresh web=\(ObjectIdentifier(webView)) " +
+            "container=\(Self.objectID(container)) reason=\(reason) phase=\(phase) " +
+            "frame=\(Self.rectDescription(container.frame))"
+        )
+#endif
+    }
+
+    static func refreshLocalInlineHostedWebViewPresentation(
+        _ webView: WKWebView,
+        in container: WindowBrowserSlotView,
+        reason: String
+    ) {
+        guard !container.isHidden else { return }
+
+        Self.runLocalInlineHostedWebViewRefreshPass(
+            webView,
+            in: container,
+            reason: reason,
+            phase: "immediate"
+        )
+        DispatchQueue.main.async { [weak webView, weak container] in
+            guard let webView, let container else { return }
+            Self.runLocalInlineHostedWebViewRefreshPass(
+                webView,
+                in: container,
+                reason: reason,
+                phase: "async"
+            )
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak webView, weak container] in
+            guard let webView, let container else { return }
+            Self.runLocalInlineHostedWebViewRefreshPass(
+                webView,
+                in: container,
+                reason: reason,
+                phase: "delayed"
+            )
+        }
+    }
+
     private static func installPortalAnchorView(_ anchorView: NSView, in host: NSView) {
         // SwiftUI can keep transient replacement hosts alive off-window during split
         // reparenting. Never let those hosts steal the shared portal anchor, or the
@@ -4514,6 +4627,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             return false
         }
 
+        let didReparentIntoLocalHost = webView.superview !== slotView
         if webView.superview !== slotView {
             if let sourceSuperview = webView.superview {
                 Self.moveWebKitRelatedSubviewsIntoHostIfNeeded(
@@ -4538,6 +4652,13 @@ struct WebViewRepresentable: NSViewRepresentable {
         host.displayIfNeeded()
         slotView.displayIfNeeded()
         webView.displayIfNeeded()
+        if didReparentIntoLocalHost {
+            Self.refreshLocalInlineHostedWebViewPresentation(
+                webView,
+                in: slotView,
+                reason: "localHost.attach"
+            )
+        }
 
 #if DEBUG
         Self.logDevToolsState(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -875,6 +875,7 @@ struct BrowserPanelView: View {
                 WebViewRepresentable(
                     panel: panel,
                     paneId: paneId,
+                    reattachToken: panel.viewReattachToken,
                     shouldAttachWebView: isVisibleInUI && isCurrentPaneOwner && !useLocalInlineDeveloperToolsHosting,
                     useLocalInlineHosting: useLocalInlineDeveloperToolsHosting,
                     shouldFocusWebView: isFocused && !addressBarFocused,
@@ -3607,6 +3608,7 @@ private struct OmnibarSuggestionsView: View {
 struct WebViewRepresentable: NSViewRepresentable {
     let panel: BrowserPanel
     let paneId: PaneID
+    let reattachToken: UInt64
     let shouldAttachWebView: Bool
     let useLocalInlineHosting: Bool
     let shouldFocusWebView: Bool

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4671,6 +4671,10 @@ extension Workspace: BonsplitDelegate {
         let movedPanelIdAfter = panelIdFromSurfaceId(tab.id)
 #endif
         if let movedPanelId = panelIdFromSurfaceId(tab.id) {
+            browserPanel(for: movedPanelId)?.prepareLocalInlineHostReplacementForNextDistinctClaim(
+                inPane: destination,
+                reason: "workspace.didMoveTab"
+            )
             scheduleMovedTerminalRefresh(panelId: movedPanelId)
             scheduleMovedBrowserRefresh(panelId: movedPanelId)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3811,6 +3811,9 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func scheduleMovedBrowserRefresh(panelId: UUID, remainingPasses: Int = 8) {
         guard let browser = browserPanel(for: panelId) else { return }
+        let paneOwnsUsableLocalHost = paneId(forPanelId: panelId).map {
+            browser.ownsUsableLocalInlineHost(for: $0)
+        } ?? false
 
         // Tab drag/move can leave the replacement browser host off-window for a few turns.
         // Keep nudging SwiftUI until the WKWebView is reattached to a live host again.
@@ -3818,6 +3821,7 @@ final class Workspace: Identifiable, ObservableObject {
         browser.requestDeveloperToolsRefreshAfterNextAttach(reason: "workspace.movedBrowserRefresh")
 
         let webViewAttached =
+            paneOwnsUsableLocalHost &&
             browser.webView.superview != nil &&
             browser.webView.window != nil &&
             browser.webView.bounds.width > 1 &&

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3809,6 +3809,26 @@ final class Workspace: Identifiable, ObservableObject {
         runRefreshPass(0.03)
     }
 
+    private func scheduleMovedBrowserRefresh(panelId: UUID, remainingPasses: Int = 8) {
+        guard let browser = browserPanel(for: panelId) else { return }
+
+        // Tab drag/move can leave the replacement browser host off-window for a few turns.
+        // Keep nudging SwiftUI until the WKWebView is reattached to a live host again.
+        browser.requestViewReattach()
+        browser.requestDeveloperToolsRefreshAfterNextAttach(reason: "workspace.movedBrowserRefresh")
+
+        let webViewAttached =
+            browser.webView.superview != nil &&
+            browser.webView.window != nil &&
+            browser.webView.bounds.width > 1 &&
+            browser.webView.bounds.height > 1
+        guard !webViewAttached, remainingPasses > 1 else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            self?.scheduleMovedBrowserRefresh(panelId: panelId, remainingPasses: remainingPasses - 1)
+        }
+    }
+
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) {
         for tabId in tabIds {
             if skipPinned,
@@ -4652,6 +4672,7 @@ extension Workspace: BonsplitDelegate {
 #endif
         if let movedPanelId = panelIdFromSurfaceId(tab.id) {
             scheduleMovedTerminalRefresh(panelId: movedPanelId)
+            scheduleMovedBrowserRefresh(panelId: movedPanelId)
         }
 #if DEBUG
         let selectedAfter = controller.selectedTab(inPane: destination)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9535,6 +9535,78 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         XCTAssertEqual(webView.firedSelectors.count, 9)
     }
 
+    func testLocalInlineHostedRefreshReattachesAfterFocusTransitionWithoutReparent() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 40, y: 24, width: 240, height: 180))
+        contentView.addSubview(slot)
+
+        let webView = ReattachProbeWebView(
+            frame: slot.bounds,
+            configuration: WKWebViewConfiguration()
+        )
+        slot.addSubview(webView)
+        slot.pinHostedWebView(webView)
+        contentView.layoutSubtreeIfNeeded()
+        slot.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        let coordinator = WebViewRepresentable.Coordinator()
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            isPanelFocused: true,
+            isWebViewFirstResponder: true,
+            reason: "test"
+        )
+
+        XCTAssertTrue(webView.firedSelectors.isEmpty)
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            isPanelFocused: false,
+            isWebViewFirstResponder: false,
+            reason: "test"
+        )
+
+        XCTAssertEqual(
+            webView.firedSelectors,
+            ["viewDidUnhide", "_enterInWindow", "_endDeferringViewInWindowChangesSync"]
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.06))
+
+        XCTAssertEqual(webView.firedSelectors.count, 9)
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationAfterFocusChangeIfNeeded(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            isPanelFocused: false,
+            isWebViewFirstResponder: false,
+            reason: "test"
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.06))
+
+        XCTAssertEqual(webView.firedSelectors.count, 9)
+    }
+
     func testWindowBrowserSlotReattachesPlainWebViewAtFullBoundsAfterHiddenHostResize() {
         let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 400, height: 180))
         let webView = WKWebView(frame: .zero)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2069,6 +2069,81 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
         XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.005)
         XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.005)
     }
+
+    func testLocalInlineHostKeepsUsableOwnerUntilDistinctHandoffIsPrepared() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let ownerPaneId = PaneID(id: UUID())
+        let contenderPaneId = PaneID(id: UUID())
+        let ownerHost = NSView()
+        let contenderHost = NSView()
+        let ownerHostId = ObjectIdentifier(ownerHost)
+        let contenderHostId = ObjectIdentifier(contenderHost)
+        let ownerBounds = CGRect(x: 0, y: 0, width: 600, height: 400)
+        let contenderBounds = CGRect(x: 0, y: 0, width: 900, height: 400)
+
+        XCTAssertTrue(
+            panel.claimLocalInlineHost(
+                hostId: ownerHostId,
+                paneId: ownerPaneId,
+                inWindow: true,
+                bounds: ownerBounds,
+                reason: "test"
+            )
+        )
+
+        XCTAssertFalse(
+            panel.claimLocalInlineHost(
+                hostId: contenderHostId,
+                paneId: contenderPaneId,
+                inWindow: true,
+                bounds: contenderBounds,
+                reason: "test"
+            )
+        )
+
+        XCTAssertFalse(panel.releaseLocalInlineHostIfOwned(hostId: contenderHostId, reason: "test"))
+        XCTAssertTrue(panel.releaseLocalInlineHostIfOwned(hostId: ownerHostId, reason: "test"))
+    }
+
+    func testPreparedDistinctLocalInlineHandoffAllowsDestinationPaneToClaim() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let sourcePaneId = PaneID(id: UUID())
+        let destinationPaneId = PaneID(id: UUID())
+        let sourceHost = NSView()
+        let destinationHost = NSView()
+        let sourceHostId = ObjectIdentifier(sourceHost)
+        let destinationHostId = ObjectIdentifier(destinationHost)
+        let sourceBounds = CGRect(x: 0, y: 0, width: 600, height: 400)
+        let destinationBounds = CGRect(x: 0, y: 0, width: 400, height: 400)
+
+        XCTAssertTrue(
+            panel.claimLocalInlineHost(
+                hostId: sourceHostId,
+                paneId: sourcePaneId,
+                inWindow: true,
+                bounds: sourceBounds,
+                reason: "test"
+            )
+        )
+
+        panel.prepareLocalInlineHostReplacementForNextDistinctClaim(
+            inPane: destinationPaneId,
+            reason: "test"
+        )
+
+        XCTAssertTrue(
+            panel.claimLocalInlineHost(
+                hostId: destinationHostId,
+                paneId: destinationPaneId,
+                inWindow: true,
+                bounds: destinationBounds,
+                reason: "test"
+            )
+        )
+
+        XCTAssertFalse(panel.releaseLocalInlineHostIfOwned(hostId: sourceHostId, reason: "test"))
+        XCTAssertTrue(panel.releaseLocalInlineHostIfOwned(hostId: destinationHostId, reason: "test"))
+    }
 }
 
 final class GhosttyBackgroundThemeTests: XCTestCase {
@@ -9875,6 +9950,76 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.06))
 
         XCTAssertEqual(webView.firedSelectors.count, 9)
+    }
+
+    func testLocalInlineHostedRefreshReattachesAfterRefreshTokenChangeWithoutFocusTransition() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 40, y: 24, width: 240, height: 180))
+        contentView.addSubview(slot)
+
+        let webView = ReattachProbeWebView(
+            frame: slot.bounds,
+            configuration: WKWebViewConfiguration()
+        )
+        slot.addSubview(webView)
+        slot.pinHostedWebView(webView)
+        contentView.layoutSubtreeIfNeeded()
+        slot.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        let coordinator = WebViewRepresentable.Coordinator()
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationIfRequested(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            refreshToken: 0,
+            reason: "test"
+        )
+
+        XCTAssertTrue(webView.firedSelectors.isEmpty)
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationIfRequested(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            refreshToken: 1,
+            reason: "test"
+        )
+
+        XCTAssertEqual(
+            webView.firedSelectors,
+            ["viewDidUnhide", "_enterInWindow", "_endDeferringViewInWindowChangesSync"]
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.06))
+
+        let refreshedSelectorCount = webView.firedSelectors.count
+        XCTAssertGreaterThanOrEqual(refreshedSelectorCount, 6)
+        XCTAssertEqual(coordinator.lastLocalInlineRefreshToken, 1)
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentationIfRequested(
+            webView,
+            in: slot,
+            coordinator: coordinator,
+            refreshToken: 1,
+            reason: "test"
+        )
+
+        XCTAssertEqual(webView.firedSelectors.count, refreshedSelectorCount)
+        XCTAssertEqual(coordinator.lastLocalInlineRefreshToken, 1)
     }
 
     func testWindowBrowserSlotReattachesPlainWebViewAtFullBoundsAfterHiddenHostResize() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -10022,6 +10022,40 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         XCTAssertEqual(coordinator.lastLocalInlineRefreshToken, 1)
     }
 
+    func testWindowBrowserSlotRestoresHostedContentFramesAfterReparentSnapshot() {
+        let sourceSlot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 1200, height: 1314))
+        let targetSlot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 589, height: 1314))
+
+        let webView = WKWebView(frame: NSRect(x: 0, y: 500, width: 1200, height: 814))
+        let inspectorView = NSView(frame: NSRect(x: 0, y: 0, width: 1200, height: 500))
+        sourceSlot.addSubview(webView)
+        sourceSlot.addSubview(inspectorView)
+
+        let hostedSubviews = sourceSlot.localInlineHostedContentSubviews(primaryWebView: webView)
+        targetSlot.prepareHostedContentLayoutSnapshot(from: sourceSlot, hostedSubviews: hostedSubviews)
+
+        webView.removeFromSuperview()
+        inspectorView.removeFromSuperview()
+        targetSlot.addSubview(webView)
+        targetSlot.addSubview(inspectorView)
+        webView.frame = targetSlot.bounds
+        inspectorView.frame = targetSlot.bounds
+
+        targetSlot.applyHostedContentLayoutSnapshotIfNeeded(
+            to: targetSlot.localInlineHostedContentSubviews(primaryWebView: webView)
+        )
+
+        XCTAssertEqual(webView.frame.minX, 0, accuracy: 0.5)
+        XCTAssertEqual(webView.frame.minY, 500, accuracy: 0.5)
+        XCTAssertEqual(webView.frame.width, 589, accuracy: 0.5)
+        XCTAssertEqual(webView.frame.height, 814, accuracy: 0.5)
+
+        XCTAssertEqual(inspectorView.frame.minX, 0, accuracy: 0.5)
+        XCTAssertEqual(inspectorView.frame.minY, 0, accuracy: 0.5)
+        XCTAssertEqual(inspectorView.frame.width, 589, accuracy: 0.5)
+        XCTAssertEqual(inspectorView.frame.height, 500, accuracy: 0.5)
+    }
+
     func testWindowBrowserSlotReattachesPlainWebViewAtFullBoundsAfterHiddenHostResize() {
         let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 400, height: 180))
         let webView = WKWebView(frame: .zero)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2865,6 +2865,21 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         }
 
         visibleHosting.removeFromSuperview()
+        contentView.layoutSubtreeIfNeeded()
+        replacementHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let replacementSlotWhileOffWindow = findWindowBrowserSlotView(in: replacementHosting) else {
+            XCTFail("Expected off-window replacement slot")
+            return
+        }
+
+        XCTAssertNil(replacementHosting.window)
+        XCTAssertTrue(
+            panel.webView.superview !== replacementSlotWhileOffWindow,
+            "A replacement local host must not steal the DevTools-hosted web view until that host actually joins a window"
+        )
+
         replacementHosting.removeFromSuperview()
         replacementHosting.frame = contentView.bounds
         replacementHosting.autoresizingMask = [.width, .height]
@@ -9315,7 +9330,7 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
     private final class ReattachProbeWebView: WKWebView {
         private(set) var firedSelectors: [String] = []
 
-        @objc func viewDidUnhide() {
+        override func viewDidUnhide() {
             firedSelectors.append("viewDidUnhide")
         }
 
@@ -9797,6 +9812,16 @@ final class CmuxWebViewDragRoutingTests: XCTestCase {
 #if compiler(>=6.2)
 @MainActor
 final class InternalTabDragConfigurationTests: XCTestCase {
+    private func dragOperationValue<T>(_ operations: T, labels: [String]) -> Bool? {
+        let mirror = Mirror(reflecting: operations)
+        for label in labels {
+            if let value = mirror.children.first(where: { $0.label == label })?.value as? Bool {
+                return value
+            }
+        }
+        return nil
+    }
+
     func testDisablesExternalOperationsForInternalTabDrags() throws {
         guard #available(macOS 26.0, *) else {
             throw XCTSkip("Requires macOS 26 drag configuration APIs")
@@ -9804,15 +9829,15 @@ final class InternalTabDragConfigurationTests: XCTestCase {
 
         let configuration = InternalTabDragConfigurationProvider.value
 
-        XCTAssertFalse(configuration.operationsWithinApp.allowCopy)
-        XCTAssertTrue(configuration.operationsWithinApp.allowMove)
-        XCTAssertFalse(configuration.operationsWithinApp.allowDelete)
-        XCTAssertFalse(configuration.operationsWithinApp.allowAlias)
+        XCTAssertEqual(dragOperationValue(configuration.operationsWithinApp, labels: ["allowCopy"]), false)
+        XCTAssertEqual(dragOperationValue(configuration.operationsWithinApp, labels: ["allowMove"]), true)
+        XCTAssertEqual(dragOperationValue(configuration.operationsWithinApp, labels: ["allowDelete", "_allowDelete"]), false)
+        XCTAssertEqual(dragOperationValue(configuration.operationsWithinApp, labels: ["allowAlias", "_allowAlias"]), false)
 
-        XCTAssertFalse(configuration.operationsOutsideApp.allowCopy)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowMove)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowDelete)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowAlias)
+        XCTAssertEqual(dragOperationValue(configuration.operationsOutsideApp, labels: ["allowCopy"]), false)
+        XCTAssertEqual(dragOperationValue(configuration.operationsOutsideApp, labels: ["allowMove"]), false)
+        XCTAssertEqual(dragOperationValue(configuration.operationsOutsideApp, labels: ["allowDelete", "_allowDelete"]), false)
+        XCTAssertEqual(dragOperationValue(configuration.operationsOutsideApp, labels: ["allowAlias", "_allowAlias"]), false)
     }
 }
 #endif

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9486,6 +9486,21 @@ final class WindowBrowserHostViewTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelHostContainerViewTests: XCTestCase {
+    private func waitForCondition(
+        timeout: TimeInterval = 1.0,
+        step: TimeInterval = 0.01,
+        _ condition: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(step))
+        }
+        return condition()
+    }
+
     private final class PrimaryPageProbeView: NSView {
         override func hitTest(_ point: NSPoint) -> NSView? {
             bounds.contains(point) ? self : nil
@@ -9514,19 +9529,11 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         }
     }
 
-    private final class ReattachProbeWebView: WKWebView {
+    private final class ReattachProbeWebView: WKWebView, LocalHostRenderingStateProbe {
         private(set) var firedSelectors: [String] = []
 
-        override func viewDidUnhide() {
-            firedSelectors.append("viewDidUnhide")
-        }
-
-        @objc func _enterInWindow() {
-            firedSelectors.append("_enterInWindow")
-        }
-
-        @objc func _endDeferringViewInWindowChangesSync() {
-            firedSelectors.append("_endDeferringViewInWindowChangesSync")
+        func cmuxDidInvokeLocalHostSelector(_ rawSelector: String) {
+            firedSelectors.append(rawSelector)
         }
     }
 
@@ -9870,14 +9877,23 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
             reason: "test"
         )
 
-        XCTAssertEqual(
-            webView.firedSelectors,
-            ["viewDidUnhide", "_enterInWindow", "_endDeferringViewInWindowChangesSync"]
+        let expectedSelectors: Set<String> = [
+            "viewDidUnhide",
+            "_enterInWindow",
+            "_endDeferringViewInWindowChangesSync",
+        ]
+        XCTAssertTrue(
+            Set(webView.firedSelectors).isSuperset(of: expectedSelectors),
+            "Expected the initial refresh to invoke the local-host rendering selectors. fired=\(webView.firedSelectors)"
         )
 
-        RunLoop.current.run(until: Date().addingTimeInterval(0.06))
-
-        XCTAssertEqual(webView.firedSelectors.count, 9)
+        let initialCount = webView.firedSelectors.count
+        XCTAssertTrue(
+            waitForCondition {
+                webView.firedSelectors.count > initialCount
+            },
+            "Expected an async follow-up refresh pass. fired=\(webView.firedSelectors)"
+        )
     }
 
     func testLocalInlineHostedRefreshReattachesAfterFocusTransitionWithoutReparent() {
@@ -11768,7 +11784,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
     }
 
-    private final class WKInspectorProbeView: NSView {}
+    private final class WKInspectorProbeView: NSView {
+        override var acceptsFirstResponder: Bool { true }
+    }
 
     private func realizeWindowLayout(_ window: NSWindow) {
         window.makeKeyAndOrderFront(nil)
@@ -12138,8 +12156,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         slot.isHidden = true
 
-        XCTAssertNil(
-            window.firstResponder,
+        XCTAssertFalse(
+            window.firstResponder === inspectorView,
             "Hiding a browser slot should yield any owned inspector responder before it goes off-screen"
         )
     }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2434,7 +2434,9 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
 
 @MainActor
 final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
-    private final class WKInspectorProbeView: NSView {}
+    private final class WKInspectorProbeView: NSView {
+        override var acceptsFirstResponder: Bool { true }
+    }
 
     private final class FakeInspector: NSObject {
         private(set) var attachCount = 0
@@ -11465,6 +11467,46 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             webView.frame.width,
             slot.bounds.width,
             "Side-docked inspector should still own part of the slot after pane resize"
+        )
+    }
+
+    func testHidingBrowserSlotYieldsOwnedInspectorFirstResponder() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 40, y: 24, width: 260, height: 180))
+        contentView.addSubview(slot)
+
+        let inspectorContainer = NSView(frame: slot.bounds)
+        inspectorContainer.autoresizingMask = [.width, .height]
+        let inspectorView = WKInspectorProbeView(frame: inspectorContainer.bounds)
+        inspectorView.autoresizingMask = [.width, .height]
+        inspectorContainer.addSubview(inspectorView)
+        slot.addSubview(inspectorContainer)
+        contentView.layoutSubtreeIfNeeded()
+
+        XCTAssertTrue(
+            window.makeFirstResponder(inspectorView),
+            "Precondition failed: inspector probe should become first responder"
+        )
+        XCTAssertTrue(window.firstResponder === inspectorView)
+
+        slot.isHidden = true
+
+        XCTAssertNil(
+            window.firstResponder,
+            "Hiding a browser slot should yield any owned inspector responder before it goes off-screen"
         )
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2901,6 +2901,118 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         )
         XCTAssertTrue(replacementSlot.window === window)
     }
+
+    func testReplacementLocalHostMovesNonWebKitDevToolsCompanionViews() {
+        let (panel, _) = makePanelWithInspector()
+        XCTAssertTrue(panel.showDeveloperTools())
+
+        let initialPaneId = PaneID(id: UUID())
+        let replacementPaneId = PaneID(id: UUID())
+        func makeRepresentable(for paneId: PaneID) -> WebViewRepresentable {
+            WebViewRepresentable(
+                panel: panel,
+                paneId: paneId,
+                reattachToken: 0,
+                shouldAttachWebView: false,
+                useLocalInlineHosting: true,
+                shouldFocusWebView: false,
+                isPanelFocused: true,
+                portalZPriority: 0,
+                paneDropZone: nil,
+                searchOverlay: nil,
+                paneTopChromeHeight: 0
+            )
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let visibleHosting = NSHostingView(rootView: makeRepresentable(for: initialPaneId))
+        visibleHosting.frame = NSRect(x: 0, y: 0, width: 210, height: contentView.bounds.height)
+        visibleHosting.autoresizingMask = [.height]
+        contentView.addSubview(visibleHosting)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        visibleHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let visibleSlot = panel.webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected visible local inline slot")
+            return
+        }
+
+        let inspectorView = WKInspectorProbeView(
+            frame: NSRect(x: 0, y: 0, width: visibleSlot.bounds.width, height: 72)
+        )
+        inspectorView.autoresizingMask = [.width]
+        visibleSlot.addSubview(inspectorView)
+
+        let companionToolbar = NSView(
+            frame: NSRect(x: 0, y: inspectorView.frame.maxY, width: visibleSlot.bounds.width, height: 24)
+        )
+        companionToolbar.identifier = NSUserInterfaceItemIdentifier("DevToolsCompanionToolbar")
+        companionToolbar.autoresizingMask = [.width]
+        visibleSlot.addSubview(companionToolbar)
+
+        panel.webView.frame = NSRect(
+            x: 0,
+            y: companionToolbar.frame.maxY,
+            width: visibleSlot.bounds.width,
+            height: visibleSlot.bounds.height - companionToolbar.frame.maxY
+        )
+        visibleSlot.layoutSubtreeIfNeeded()
+
+        let detachedRoot = NSView(frame: visibleHosting.frame)
+        let replacementHosting = NSHostingView(rootView: makeRepresentable(for: replacementPaneId))
+        replacementHosting.frame = detachedRoot.bounds
+        replacementHosting.autoresizingMask = [.width, .height]
+        detachedRoot.addSubview(replacementHosting)
+        detachedRoot.layoutSubtreeIfNeeded()
+        replacementHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        replacementHosting.removeFromSuperview()
+        replacementHosting.frame = NSRect(x: 210, y: 0, width: 210, height: contentView.bounds.height)
+        replacementHosting.autoresizingMask = [.minXMargin, .height]
+        contentView.addSubview(replacementHosting)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        replacementHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let replacementSlot = findWindowBrowserSlotView(in: replacementHosting) else {
+            XCTFail("Expected replacement local inline slot")
+            return
+        }
+
+        XCTAssertTrue(
+            panel.webView.superview === replacementSlot,
+            "A replacement local host should move the shared browser web view into the new pane"
+        )
+        XCTAssertTrue(
+            inspectorView.superview === replacementSlot,
+            "A replacement local host should move WKInspector companion views into the new pane"
+        )
+        XCTAssertTrue(
+            companionToolbar.superview === replacementSlot,
+            "A replacement local host should move non-WebKit DevTools companion views into the new pane so old panes do not leave stray inspector chrome behind"
+        )
+        XCTAssertFalse(
+            visibleSlot.subviews.contains(where: { $0 === companionToolbar }),
+            "The retiring pane should not keep stale DevTools companion views after local host reparent"
+        )
+    }
 }
 
 final class WorkspaceShortcutMapperTests: XCTestCase {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2623,6 +2623,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let representable = WebViewRepresentable(
             panel: panel,
             paneId: paneId,
+            reattachToken: 0,
             shouldAttachWebView: true,
             useLocalInlineHosting: false,
             shouldFocusWebView: false,
@@ -2665,6 +2666,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let representable = WebViewRepresentable(
             panel: panel,
             paneId: paneId,
+            reattachToken: 0,
             shouldAttachWebView: true,
             useLocalInlineHosting: false,
             shouldFocusWebView: false,
@@ -2726,6 +2728,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let representable = WebViewRepresentable(
             panel: panel,
             paneId: paneId,
+            reattachToken: 0,
             shouldAttachWebView: false,
             useLocalInlineHosting: true,
             shouldFocusWebView: false,
@@ -2809,6 +2812,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let representable = WebViewRepresentable(
             panel: panel,
             paneId: paneId,
+            reattachToken: 0,
             shouldAttachWebView: false,
             useLocalInlineHosting: true,
             shouldFocusWebView: false,
@@ -5383,6 +5387,51 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             workspace.focusedPanelId,
             originalFocusedPanelId,
             "Expected non-focus browser split to preserve pre-split focus"
+        )
+    }
+
+    func testMovedBrowserTabRequestsViewReattachRefresh() {
+        let workspace = Workspace()
+        guard let originalFocusedPanelId = workspace.focusedPanelId,
+              let originalPaneId = workspace.paneId(forPanelId: originalFocusedPanelId) else {
+            XCTFail("Expected initial focused panel and pane")
+            return
+        }
+
+        guard let browserSplitPanel = workspace.newBrowserSplit(
+            from: originalFocusedPanelId,
+            orientation: .horizontal,
+            focus: true
+        ) else {
+            XCTFail("Expected browser split panel to be created")
+            return
+        }
+
+        guard let browserTabId = workspace.surfaceIdFromPanelId(browserSplitPanel.id),
+              let browserPaneId = workspace.paneId(forPanelId: browserSplitPanel.id) else {
+            XCTFail("Expected browser split tab and pane mapping")
+            return
+        }
+
+        XCTAssertNotEqual(browserPaneId, originalPaneId, "Expected browser split to land in a different pane")
+
+        let initialReattachToken = browserSplitPanel.viewReattachToken
+        XCTAssertTrue(
+            workspace.bonsplitController.moveTab(browserTabId, toPane: originalPaneId),
+            "Expected browser tab move to succeed"
+        )
+
+        drainMainQueue()
+
+        XCTAssertGreaterThan(
+            browserSplitPanel.viewReattachToken,
+            initialReattachToken,
+            "Moving a browser tab should force a follow-up representable update so detached web views can reattach"
+        )
+        XCTAssertEqual(
+            workspace.paneId(forPanelId: browserSplitPanel.id),
+            originalPaneId,
+            "Expected moved browser panel to resolve to the destination pane"
         )
     }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -2495,6 +2495,18 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         return nil
     }
 
+    private func findWindowBrowserSlotView(in root: NSView) -> WindowBrowserSlotView? {
+        if let slot = root as? WindowBrowserSlotView {
+            return slot
+        }
+        for subview in root.subviews {
+            if let slot = findWindowBrowserSlotView(in: subview) {
+                return slot
+            }
+        }
+        return nil
+    }
+
     func testRestoreReopensInspectorAfterAttachWhenPreferredVisible() {
         let (panel, inspector) = makePanelWithInspector()
 
@@ -2787,6 +2799,88 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             inspectorView.superview === visibleSlot,
             "An off-window replacement host should leave DevTools companion views in the visible local host"
         )
+    }
+
+    func testOffWindowReplacementLocalHostReattachesWhenItJoinsAWindow() {
+        let (panel, _) = makePanelWithInspector()
+        XCTAssertTrue(panel.showDeveloperTools())
+
+        let paneId = PaneID(id: UUID())
+        let representable = WebViewRepresentable(
+            panel: panel,
+            paneId: paneId,
+            shouldAttachWebView: false,
+            useLocalInlineHosting: true,
+            shouldFocusWebView: false,
+            isPanelFocused: true,
+            portalZPriority: 0,
+            paneDropZone: nil,
+            searchOverlay: nil,
+            paneTopChromeHeight: 0
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let visibleHosting = NSHostingView(rootView: representable)
+        visibleHosting.frame = contentView.bounds
+        visibleHosting.autoresizingMask = [.width, .height]
+        contentView.addSubview(visibleHosting)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        visibleHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let visibleSlot = panel.webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected visible local inline slot")
+            return
+        }
+
+        let detachedRoot = NSView(frame: visibleHosting.frame)
+        let replacementHosting = NSHostingView(rootView: representable)
+        replacementHosting.frame = detachedRoot.bounds
+        replacementHosting.autoresizingMask = [.width, .height]
+        detachedRoot.addSubview(replacementHosting)
+        detachedRoot.layoutSubtreeIfNeeded()
+        replacementHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard findHostContainerView(in: replacementHosting) != nil else {
+            XCTFail("Expected off-window replacement host")
+            return
+        }
+
+        visibleHosting.removeFromSuperview()
+        replacementHosting.removeFromSuperview()
+        replacementHosting.frame = contentView.bounds
+        replacementHosting.autoresizingMask = [.width, .height]
+        contentView.addSubview(replacementHosting)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        replacementHosting.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let replacementSlot = findWindowBrowserSlotView(in: replacementHosting) else {
+            XCTFail("Expected replacement local inline slot")
+            return
+        }
+
+        XCTAssertNil(visibleSlot.window)
+        XCTAssertTrue(
+            panel.webView.superview === replacementSlot,
+            "A replacement local host should reattach the DevTools-hosted web view once it joins a window"
+        )
+        XCTAssertTrue(replacementSlot.window === window)
     }
 }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9169,6 +9169,22 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         }
     }
 
+    private final class ReattachProbeWebView: WKWebView {
+        private(set) var firedSelectors: [String] = []
+
+        @objc func viewDidUnhide() {
+            firedSelectors.append("viewDidUnhide")
+        }
+
+        @objc func _enterInWindow() {
+            firedSelectors.append("_enterInWindow")
+        }
+
+        @objc func _endDeferringViewInWindowChangesSync() {
+            firedSelectors.append("_endDeferringViewInWindowChangesSync")
+        }
+    }
+
     private func makeMouseEvent(type: NSEvent.EventType, location: NSPoint, window: NSWindow) -> NSEvent {
         guard let event = NSEvent.mouseEvent(
             with: type,
@@ -9184,6 +9200,14 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
             fatalError("Failed to create \(type) mouse event")
         }
         return event
+    }
+
+    private func realizeWindowLayout(_ window: NSWindow) {
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        window.contentView?.layoutSubtreeIfNeeded()
     }
 
     func testBrowserPanelHostPrefersNativeHostedInspectorSiblingDividerHit() {
@@ -9466,6 +9490,49 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
         XCTAssertTrue(webView.translatesAutoresizingMaskIntoConstraints)
         XCTAssertEqual(webView.autoresizingMask, [.width, .height])
         XCTAssertEqual(webView.frame, slot.bounds)
+    }
+
+    func testLocalInlineHostedRefreshReattachesRenderingStateAcrossAsyncPasses() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 40, y: 24, width: 240, height: 180))
+        contentView.addSubview(slot)
+
+        let webView = ReattachProbeWebView(
+            frame: slot.bounds,
+            configuration: WKWebViewConfiguration()
+        )
+        slot.addSubview(webView)
+        slot.pinHostedWebView(webView)
+        contentView.layoutSubtreeIfNeeded()
+        slot.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        WebViewRepresentable.refreshLocalInlineHostedWebViewPresentation(
+            webView,
+            in: slot,
+            reason: "test"
+        )
+
+        XCTAssertEqual(
+            webView.firedSelectors,
+            ["viewDidUnhide", "_enterInWindow", "_endDeferringViewInWindowChangesSync"]
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.06))
+
+        XCTAssertEqual(webView.firedSelectors.count, 9)
     }
 
     func testWindowBrowserSlotReattachesPlainWebViewAtFullBoundsAfterHiddenHostResize() {


### PR DESCRIPTION
## Summary
- add a regression test for hiding a browser slot while an inspector-owned responder is active
- yield first responder when a browser slot hides or leaves its window so WebKit does not reactivate a stale inspector responder
- keep the two-commit regression-test-then-fix structure for CI

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-webkit-inspector-activation-crash`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when hiding a browser slot while the WebKit Inspector is first responder. Hardens local inline DevTools hosting with lease-based ownership, explicit pane handoff, focus- and token-gated reattach, and layout-preserving reparent to avoid jank.

- **Bug Fixes**
  - `WindowBrowserSlotView` yields its owned first responder on hide and when leaving its window.
  - Local inline hosting: defers attach until the host is in-window and sized; adds a per-pane lease with in-window/area checks, lock, and distinct handoff via `prepareLocalInlineHostReplacementForNextDistinctClaim`; prevents off-window hosts from stealing DevTools and retries attach when a host joins a window; honors token-gated refreshes with `viewReattachToken`, reattaches after tab moves and when the window becomes key, and refreshes after focus transitions without reparent; repairs visibility/in-window state with immediate/async/delayed passes; moves non-WebKit DevTools companion views with the web view during reparent; preserves hosted subview frames across reparent via a normalized layout snapshot.

<sup>Written for commit 70bebebfe98ae94795427e7f1a20d19a70c3d809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved local inline web-view hosting with reattachment, refresh and focus-recovery; added a reattach token to the embedding API.

* **Bug Fixes**
  * Views now yield/release first-responder ownership when hidden or moved, preventing stale responder ownership and improving lifecycle behavior.

* **Tests**
  * Expanded tests covering reattachment, visibility, focus, inspector responder handoff, and cross-window/rehosting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->