### PR TITLE
Fix drag configuration test compatibility on macOS 15

### DIFF
--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -9511,6 +9511,41 @@ final class CmuxWebViewDragRoutingTests: XCTestCase {
 }
 
 #if compiler(>=6.2)
+@available(macOS 26.0, *)
+private struct DragConfigurationOperationsSnapshot: Equatable {
+    let allowCopy: Bool
+    let allowMove: Bool
+    let allowDelete: Bool
+    let allowAlias: Bool
+}
+
+@available(macOS 26.0, *)
+private enum DragConfigurationSnapshotError: Error {
+    case missingBoolField(primary: String, fallback: String?)
+}
+
+@available(macOS 26.0, *)
+private func dragConfigurationOperationsSnapshot<T>(from operations: T) throws -> DragConfigurationOperationsSnapshot {
+    let mirror = Mirror(reflecting: operations)
+
+    func readBool(_ primary: String, fallback: String? = nil) throws -> Bool {
+        if let value = mirror.descendant(primary) as? Bool {
+            return value
+        }
+        if let fallback, let value = mirror.descendant(fallback) as? Bool {
+            return value
+        }
+        throw DragConfigurationSnapshotError.missingBoolField(primary: primary, fallback: fallback)
+    }
+
+    return try DragConfigurationOperationsSnapshot(
+        allowCopy: readBool("allowCopy", fallback: "_allowCopy"),
+        allowMove: readBool("allowMove", fallback: "_allowMove"),
+        allowDelete: readBool("allowDelete", fallback: "_allowDelete"),
+        allowAlias: readBool("allowAlias", fallback: "_allowAlias")
+    )
+}
+
 @MainActor
 final class InternalTabDragConfigurationTests: XCTestCase {
     func testDisablesExternalOperationsForInternalTabDrags() throws {
@@ -9519,16 +9554,28 @@ final class InternalTabDragConfigurationTests: XCTestCase {
         }
 
         let configuration = InternalTabDragConfigurationProvider.value
+        let withinApp = try dragConfigurationOperationsSnapshot(from: configuration.operationsWithinApp)
+        let outsideApp = try dragConfigurationOperationsSnapshot(from: configuration.operationsOutsideApp)
 
-        XCTAssertFalse(configuration.operationsWithinApp.allowCopy)
-        XCTAssertTrue(configuration.operationsWithinApp.allowMove)
-        XCTAssertFalse(configuration.operationsWithinApp.allowDelete)
-        XCTAssertFalse(configuration.operationsWithinApp.allowAlias)
+        XCTAssertEqual(
+            withinApp,
+            DragConfigurationOperationsSnapshot(
+                allowCopy: false,
+                allowMove: true,
+                allowDelete: false,
+                allowAlias: false
+            )
+        )
 
-        XCTAssertFalse(configuration.operationsOutsideApp.allowCopy)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowMove)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowDelete)
-        XCTAssertFalse(configuration.operationsOutsideApp.allowAlias)
+        XCTAssertEqual(
+            outsideApp,
+            DragConfigurationOperationsSnapshot(
+                allowCopy: false,
+                allowMove: false,
+                allowDelete: false,
+                allowAlias: false
+            )
+        )
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- replace direct `DragConfiguration` flag property reads in `InternalTabDragConfigurationTests` with a compatibility snapshot helper
- keep the macOS 26 runtime guard while making the test compile against current SwiftUI drag configuration APIs on older macOS runners

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-task-fix-drag-config-tests-unit build-for-testing CODE_SIGNING_ALLOWED=NO`

## Issues
- Related: https://github.com/manaflow-ai/cmux/actions/runs/22937723809/job/66572642675


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab drag configuration tests on macOS 15 by swapping direct flag reads for a reflection-based snapshot. Tests still only run on macOS 26, but now compile on older runners to unblock CI.

- **Bug Fixes**
  - Added a snapshot helper to read `allowCopy/move/delete/alias` via reflection (with underscored fallbacks) and updated tests to compare snapshots for within/outside app operations.
  - Kept the macOS 26 availability/runtime guard so older macOS runners compile the tests without running them.

<sup>Written for commit dfc0c4462441eb5e35b660db44b729f5ed955336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

