### PR TITLE
Fix Claude auth command passthrough in cmux wrapper

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -55,16 +55,16 @@ fi
 # Find real claude.
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
+# Unset CLAUDECODE to avoid "nested session" detection, even for auth and
+# management passthrough commands launched inside cmux shells.
+unset CLAUDECODE
+
 # Pass through management subcommands that don't start Claude sessions.
 case "${1:-}" in
     agents|auth|config|doctor|install|mcp|plugin|plugins|setup-token|update|upgrade|api-key)
         exec "$REAL_CLAUDE" "$@"
         ;;
 esac
-
-# Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
-# independent sessions even when the parent shell was launched from Claude Code.
-unset CLAUDECODE
 
 # Check if the user already specified a session/resume flag.
 # If so, don't inject our own --session-id (it would conflict).

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -55,9 +55,11 @@ fi
 # Find real claude.
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
-# Pass through subcommands that don't support session/hook flags.
+# Pass through management subcommands that don't start Claude sessions.
 case "${1:-}" in
-    mcp|config|api-key) exec "$REAL_CLAUDE" "$@" ;;
+    agents|auth|config|doctor|install|mcp|plugin|plugins|setup-token|update|upgrade|api-key)
+        exec "$REAL_CLAUDE" "$@"
+        ;;
 esac
 
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -166,11 +166,21 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
 
 
+def test_auth_subcommands_skip_hook_injection(failures: list[str]) -> None:
+    for argv in (["auth"], ["setup-token"]):
+        code, real_argv, cmux_log, stderr, claudecode = run_wrapper(socket_state="live", argv=argv)
+        expect(code == 0, f"{argv[0]}: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == argv, f"{argv[0]}: expected passthrough args, got {real_argv}", failures)
+        expect(any(" ping" in line for line in cmux_log), f"{argv[0]}: expected cmux ping probe, got {cmux_log}", failures)
+        expect(claudecode == "__UNSET__", f"{argv[0]}: expected CLAUDECODE unset, got {claudecode!r}", failures)
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_auth_subcommands_skip_hook_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_zshrc_api_key_passthrough.py
+++ b/tests/test_claude_zshrc_api_key_passthrough.py
@@ -35,6 +35,9 @@ def main() -> int:
     if not (SHELL_WRAPPER_DIR / ".zshenv").exists():
         print(f"SKIP: missing zsh wrapper at {SHELL_WRAPPER_DIR}")
         return 0
+    if shutil.which("zsh") is None:
+        print("SKIP: zsh is not available on PATH")
+        return 0
     if not SOURCE_CLAUDE_WRAPPER.exists():
         print(f"SKIP: missing Claude wrapper at {SOURCE_CLAUDE_WRAPPER}")
         return 0

--- a/tests/test_claude_zshrc_api_key_passthrough.py
+++ b/tests/test_claude_zshrc_api_key_passthrough.py
@@ -32,10 +32,11 @@ def read_text(path: Path) -> str:
 
 
 def main() -> int:
+    zsh_bin = shutil.which("zsh")
     if not (SHELL_WRAPPER_DIR / ".zshenv").exists():
         print(f"SKIP: missing zsh wrapper at {SHELL_WRAPPER_DIR}")
         return 0
-    if shutil.which("zsh") is None:
+    if zsh_bin is None:
         print("SKIP: zsh is not available on PATH")
         return 0
     if not SOURCE_CLAUDE_WRAPPER.exists():
@@ -112,7 +113,7 @@ exit 0
 
         try:
             result = subprocess.run(
-                ["zsh", "-d", "-i", "-c", "claude hello"],
+                [zsh_bin, "-d", "-i", "-c", "claude hello"],
                 env=env,
                 capture_output=True,
                 text=True,

--- a/tests/test_claude_zshrc_api_key_passthrough.py
+++ b/tests/test_claude_zshrc_api_key_passthrough.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Regression: a Claude auth env var exported from the user's .zshrc should still
+reach the real Claude binary when cmux's zsh wrapper and Claude wrapper are both
+active.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SHELL_WRAPPER_DIR = ROOT / "Resources" / "shell-integration"
+SOURCE_CLAUDE_WRAPPER = ROOT / "Resources" / "bin" / "claude"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    if not (SHELL_WRAPPER_DIR / ".zshenv").exists():
+        print(f"SKIP: missing zsh wrapper at {SHELL_WRAPPER_DIR}")
+        return 0
+    if not SOURCE_CLAUDE_WRAPPER.exists():
+        print(f"SKIP: missing Claude wrapper at {SOURCE_CLAUDE_WRAPPER}")
+        return 0
+
+    base = Path(tempfile.gettempdir()) / f"cmux_claude_zshrc_auth_{os.getpid()}"
+    try:
+        shutil.rmtree(base, ignore_errors=True)
+        base.mkdir(parents=True, exist_ok=True)
+
+        home = base / "home"
+        orig_zdotdir = base / "zdotdir"
+        wrapper_bin = base / "wrapper-bin"
+        real_bin = base / "real-bin"
+        for path in (home, orig_zdotdir, wrapper_bin, real_bin):
+            path.mkdir(parents=True, exist_ok=True)
+
+        seen_key_path = base / "seen-api-key.txt"
+        seen_args_path = base / "seen-args.txt"
+        cmux_log_path = base / "cmux.log"
+        socket_path = base / "cmux.sock"
+
+        (orig_zdotdir / ".zshrc").write_text(
+            'export ANTHROPIC_API_KEY="from-zshrc"\n',
+            encoding="utf-8",
+        )
+
+        shutil.copy2(SOURCE_CLAUDE_WRAPPER, wrapper_bin / "claude")
+        (wrapper_bin / "claude").chmod(0o755)
+
+        make_executable(
+            real_bin / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "${ANTHROPIC_API_KEY-__UNSET__}" > "$FAKE_SEEN_KEY_PATH"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_SEEN_ARGS_PATH"
+done
+""",
+        )
+
+        make_executable(
+            wrapper_bin / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CMUX_LOG"
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket.bind(str(socket_path))
+
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env["USER"] = env.get("USER", "cmux-test")
+        env["SHELL"] = "/bin/zsh"
+        env["ZDOTDIR"] = str(SHELL_WRAPPER_DIR)
+        env["CMUX_ZSH_ZDOTDIR"] = str(orig_zdotdir)
+        env["CMUX_SHELL_INTEGRATION"] = "0"
+        env["PATH"] = f"{wrapper_bin}:{real_bin}:/usr/bin:/bin"
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_SOCKET_PATH"] = str(socket_path)
+        env["FAKE_SEEN_KEY_PATH"] = str(seen_key_path)
+        env["FAKE_SEEN_ARGS_PATH"] = str(seen_args_path)
+        env["FAKE_CMUX_LOG"] = str(cmux_log_path)
+
+        try:
+            result = subprocess.run(
+                ["zsh", "-d", "-i", "-c", "claude hello"],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=8,
+                check=False,
+            )
+        finally:
+            test_socket.close()
+
+        if result.returncode != 0:
+            print(f"FAIL: zsh exited non-zero rc={result.returncode}")
+            if result.stderr.strip():
+                print(result.stderr.strip())
+            return 1
+
+        seen_key = read_text(seen_key_path)
+        if seen_key != "from-zshrc":
+            print(f"FAIL: expected ANTHROPIC_API_KEY from .zshrc, got {seen_key!r}")
+            return 1
+
+        seen_args = [line for line in read_text(seen_args_path).splitlines() if line]
+        if "--settings" not in seen_args or "--session-id" not in seen_args or "hello" not in seen_args:
+            print(f"FAIL: expected wrapped Claude args, got {seen_args!r}")
+            return 1
+
+        cmux_log = read_text(cmux_log_path)
+        if "ping" not in cmux_log:
+            print(f"FAIL: expected wrapper to probe cmux socket, got {cmux_log!r}")
+            return 1
+
+        print("PASS: .zshrc-exported Claude auth env reaches wrapped claude")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- skip Claude management and auth commands in the cmux wrapper so login and token setup flows run unmodified
- add regression coverage for auth-command passthrough and for `.zshrc`-exported Claude auth env reaching the wrapped real binary

## Testing
- `bash -n Resources/bin/claude`
- `python3 -m py_compile tests/test_claude_wrapper_hooks.py tests/test_claude_zshrc_api_key_passthrough.py`
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-claude-code-shell-auth` (`BUILD SUCCEEDED`)

## Task
- Claude Code auth edge cases in cmux wrapper. Verify whether an API key exported from `.zshrc` still works, and fix the case where Claude can be authenticated in Ghostty but not in cmux.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip auth and management commands in the `cmux` `claude` wrapper so login/token and admin flows run unmodified, and always unset `CLAUDECODE` to prevent nested-session errors in `cmux` shells.

- **Bug Fixes**
  - Pass through non-session subcommands without hook injection: `agents`, `auth`, `config`, `doctor`, `install`, `mcp`, `plugin`, `plugins`, `setup-token`, `update`, `upgrade`, `api-key`; keep `CLAUDECODE` unset even for passthrough.
  - Add regression tests: verify passthrough for `auth`/`setup-token` with cmux ping and unset `CLAUDECODE`, confirm `.zshrc`-exported `ANTHROPIC_API_KEY` reaches the real `claude`, and resolve `zsh` path in the test for reliability.

<sup>Written for commit 80d37e399f2d778347ea0cbd14df1026f8d19a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent nested session detection by unsetting internal session flag earlier, ensuring management subcommands (agents, auth, config, doctor, install, mcp, plugin(s), setup-token, update, upgrade, api-key) run as passthrough without starting interactive sessions.
  * Improved API key propagation from shell startup files into wrapped command execution.

* **Tests**
  * Added regression tests covering auth subcommand passthrough and shell (.zshrc) API-key propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->