### PR TITLE
Adds Chrome-style certificate bypass for local development against HTTPS servers with self-signed or unknown-root certificates

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2653,7 +2653,7 @@ struct CMUXCLI {
         var surfaceRaw = surfaceOpt
         var args = argsWithoutSurfaceFlag
 
-        let verbsWithoutSurface: Set<String> = ["open", "open-split", "new", "identify"]
+        let verbsWithoutSurface: Set<String> = ["open", "open-split", "new", "identify", "cert-bypass"]
         if surfaceRaw == nil, let first = args.first {
             if !first.hasPrefix("-") && !verbsWithoutSurface.contains(first.lowercased()) {
                 surfaceRaw = first
@@ -5051,7 +5051,8 @@ struct CMUXCLI {
               viewport <width> <height>
               geolocation|geo <latitude> <longitude>
               offline <true|false>
-              cert-bypass <get|set> [true|false]
+              cert-bypass get
+              cert-bypass set <true|false>
               trace <start|stop> [path]
               network <route|unroute|requests> ...
                 route <pattern> [--abort] [--body <text>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3903,6 +3903,21 @@ struct CMUXCLI {
             return
         }
 
+        if subcommand == "cert-bypass" {
+            let action = subArgs.first ?? "get"
+            var params: [String: Any] = ["action": action]
+            if let value = subArgs.dropFirst().first {
+                params["value"] = value
+            }
+            let payload = try client.sendV2(method: "browser.cert_bypass", params: params)
+            if let enabled = payload["enabled"] as? Bool {
+                output(payload, fallback: enabled ? "true" : "false")
+            } else {
+                output(payload, fallback: "OK")
+            }
+            return
+        }
+
         throw CLIError(message: "Unsupported browser subcommand: \(subcommand)")
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5051,6 +5051,7 @@ struct CMUXCLI {
               viewport <width> <height>
               geolocation|geo <latitude> <longitude>
               offline <true|false>
+              cert-bypass <get|set> [true|false]
               trace <start|stop> [path]
               network <route|unroute|requests> ...
                 route <pattern> [--abort] [--body <text>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5051,8 +5051,7 @@ struct CMUXCLI {
               viewport <width> <height>
               geolocation|geo <latitude> <longitude>
               offline <true|false>
-              cert-bypass get
-              cert-bypass set <true|false>
+              cert-bypass [get | set <true|false>]
               trace <start|stop> [path]
               network <route|unroute|requests> ...
                 route <pattern> [--abort] [--body <text>]

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3823,6 +3823,9 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
            BrowserCertBypassSettings.isEnabled(),
            let serverTrust = challenge.protectionSpace.serverTrust {
+            #if DEBUG
+            dlog("browser.cert_bypass: accepting server trust for \(challenge.protectionSpace.host)")
+            #endif
             completionHandler(.useCredential, URLCredential(trust: serverTrust))
             return
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -527,6 +527,7 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
+@MainActor
 enum BrowserCertBypassSettings {
     static let defaultsKey = "browserIgnoreCertificateErrors"
     // Set by --ignore-certificate-errors at launch or by browser.cert_bypass set (session-only).

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3816,6 +3816,17 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
+        // When certificate bypass is active (--ignore-certificate-errors or browser.cert_bypass set true),
+        // unconditionally trust server certificates. This covers self-signed and unknown-root certs
+        // common in local development (e.g. https://localhost:8443). Only server trust challenges
+        // are bypassed; client cert and other challenge types still use default handling.
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+           BrowserCertBypassSettings.isEnabled(),
+           let serverTrust = challenge.protectionSpace.serverTrust {
+            completionHandler(.useCredential, URLCredential(trust: serverTrust))
+            return
+        }
+
         // WKWebView rejects all authentication challenges by default when this
         // delegate method is not implemented (.rejectProtectionSpace). This
         // breaks TLS client-certificate flows such as Microsoft Entra ID

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -527,6 +527,18 @@ func browserShouldOpenURLExternally(_ url: URL) -> Bool {
     return !browserEmbeddedNavigationSchemes.contains(scheme)
 }
 
+enum BrowserCertBypassSettings {
+    static let defaultsKey = "browserIgnoreCertificateErrors"
+    // Set by --ignore-certificate-errors at launch or by browser.cert_bypass set (session-only).
+    // Never written by this enum; callers set it directly.
+    static var runtimeOverride: Bool? = nil
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if let override = runtimeOverride { return override }
+        return defaults.bool(forKey: defaultsKey)
+    }
+}
+
 enum BrowserUserAgentSettings {
     // Force a Safari UA. Some WebKit builds return a minimal UA without Version/Safari tokens,
     // and some installs may have legacy Chrome UA overrides. Both can cause Google to serve

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7328,9 +7328,12 @@ class TerminalController {
 
     private func v2BrowserCertBypass(params: [String: Any]) -> V2CallResult {
         let action = (params["action"] as? String) ?? (params["args"] as? [String])?.first ?? ""
+        var result: V2CallResult = .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
         switch action {
         case "get":
-            return .ok(["enabled": BrowserCertBypassSettings.isEnabled()])
+            v2MainSync {
+                result = .ok(["enabled": BrowserCertBypassSettings.isEnabled()])
+            }
         case "set":
             let rawValue = (params["args"] as? [String])?.dropFirst().first
                 ?? (params["value"] as? String)
@@ -7340,17 +7343,18 @@ class TerminalController {
             }
             switch rawValue.lowercased() {
             case "true", "1", "yes":
-                DispatchQueue.main.async { BrowserCertBypassSettings.runtimeOverride = true }
-                return .ok(["enabled": true])
+                v2MainSync { BrowserCertBypassSettings.runtimeOverride = true }
+                result = .ok(["enabled": true])
             case "false", "0", "no":
-                DispatchQueue.main.async { BrowserCertBypassSettings.runtimeOverride = false }
-                return .ok(["enabled": false])
+                v2MainSync { BrowserCertBypassSettings.runtimeOverride = false }
+                result = .ok(["enabled": false])
             default:
                 return .err(code: "invalid_params", message: "Invalid value '\(rawValue)': use 'true' or 'false'", data: nil)
             }
         default:
-            return .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
+            break
         }
+        return result
     }
 
     private func v2BrowserFocusWebView(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1981,6 +1981,8 @@ class TerminalController {
             return v2Result(id: id, self.v2BrowserInputKeyboard(params: params))
         case "browser.input_touch":
             return v2Result(id: id, self.v2BrowserInputTouch(params: params))
+        case "browser.cert_bypass":
+            return v2Result(id: id, self.v2BrowserCertBypass(params: params))
 
         // Markdown
         case "markdown.open":
@@ -7322,6 +7324,33 @@ class TerminalController {
             ])
         }
         return result
+    }
+
+    private func v2BrowserCertBypass(params: [String: Any]) -> V2CallResult {
+        let action = (params["action"] as? String) ?? (params["args"] as? [String])?.first ?? ""
+        switch action {
+        case "get":
+            return .ok(["enabled": BrowserCertBypassSettings.isEnabled()])
+        case "set":
+            let rawValue = (params["args"] as? [String])?.dropFirst().first
+                ?? (params["value"] as? String)
+                ?? (params["enabled"] as? Bool).map { $0 ? "true" : "false" }
+            guard let rawValue else {
+                return .err(code: "invalid_params", message: "Missing value: use 'set true' or 'set false'", data: nil)
+            }
+            switch rawValue.lowercased() {
+            case "true", "1", "yes":
+                DispatchQueue.main.async { BrowserCertBypassSettings.runtimeOverride = true }
+                return .ok(["enabled": true])
+            case "false", "0", "no":
+                DispatchQueue.main.async { BrowserCertBypassSettings.runtimeOverride = false }
+                return .ok(["enabled": false])
+            default:
+                return .err(code: "invalid_params", message: "Invalid value '\(rawValue)': use 'true' or 'false'", data: nil)
+            }
+        default:
+            return .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
+        }
     }
 
     private func v2BrowserFocusWebView(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7328,12 +7328,13 @@ class TerminalController {
 
     private func v2BrowserCertBypass(params: [String: Any]) -> V2CallResult {
         let action = (params["action"] as? String) ?? (params["args"] as? [String])?.first ?? ""
-        var result: V2CallResult = .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
         switch action {
         case "get":
+            var result: V2CallResult = .err(code: "internal", message: "Unexpected", data: nil)
             v2MainSync {
                 result = .ok(["enabled": BrowserCertBypassSettings.isEnabled()])
             }
+            return result
         case "set":
             let rawValue = (params["args"] as? [String])?.dropFirst().first
                 ?? (params["value"] as? String)
@@ -7344,17 +7345,16 @@ class TerminalController {
             switch rawValue.lowercased() {
             case "true", "1", "yes":
                 v2MainSync { BrowserCertBypassSettings.runtimeOverride = true }
-                result = .ok(["enabled": true])
+                return .ok(["enabled": true])
             case "false", "0", "no":
                 v2MainSync { BrowserCertBypassSettings.runtimeOverride = false }
-                result = .ok(["enabled": false])
+                return .ok(["enabled": false])
             default:
                 return .err(code: "invalid_params", message: "Invalid value '\(rawValue)': use 'true' or 'false'", data: nil)
             }
         default:
-            break
+            return .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
         }
-        return result
     }
 
     private func v2BrowserFocusWebView(params: [String: Any]) -> V2CallResult {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -46,6 +46,10 @@ struct cmuxApp: App {
 
         Self.configureGhosttyEnvironment()
 
+        if CommandLine.arguments.contains("--ignore-certificate-errors") {
+            BrowserCertBypassSettings.runtimeOverride = true
+        }
+
         // Apply saved language preference before any UI loads
         LanguageSettings.apply(LanguageSettings.languageAtLaunch)
 

--- a/docs/superpowers/plans/2026-03-10-webkit-cert-bypass.md
+++ b/docs/superpowers/plans/2026-03-10-webkit-cert-bypass.md
@@ -1,0 +1,361 @@
+# WebKit Certificate Bypass Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--ignore-certificate-errors` CLI flag and `browser.cert_bypass` socket command to bypass WebKit TLS certificate validation for local dev servers.
+
+**Architecture:** A new `BrowserCertBypassSettings` enum in `BrowserPanel.swift` owns the flag state. The CLI flag sets an in-memory `runtimeOverride` at startup. The socket command also sets `runtimeOverride` (session-only, no persistence). UserDefaults provides an out-of-band persistence layer readable by `isEnabled()`. The existing `BrowserNavigationDelegate.didReceive challenge` method in `BrowserPanel.swift` checks the flag and accepts any server trust challenge when enabled.
+
+**Tech Stack:** Swift, WKWebView/WebKit, UserDefaults, NSURLAuthenticationMethodServerTrust
+
+**Spec:** `docs/superpowers/specs/2026-03-10-webkit-cert-bypass-design.md`
+
+---
+
+## Chunk 1: Core Flag + TLS Bypass
+
+### Task 1: Add `BrowserCertBypassSettings` to `BrowserPanel.swift`
+
+**Files:**
+- Modify: `Sources/Panels/BrowserPanel.swift` (insert after line 529, before `BrowserUserAgentSettings`)
+
+- [ ] **Step 1: Add the enum**
+
+In `Sources/Panels/BrowserPanel.swift`, after the closing `}` of `browserShouldOpenURLExternally` (line 528) and before `enum BrowserUserAgentSettings` (line 530), insert:
+
+```swift
+enum BrowserCertBypassSettings {
+    static let defaultsKey = "browserIgnoreCertificateErrors"
+    // Set by --ignore-certificate-errors at launch or by browser.cert_bypass set (session-only).
+    // Never written by this enum; callers set it directly.
+    static var runtimeOverride: Bool? = nil
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if let override = runtimeOverride { return override }
+        return defaults.bool(forKey: defaultsKey)
+    }
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-cert-bypass" build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Panels/BrowserPanel.swift
+git commit -m "feat: add BrowserCertBypassSettings enum"
+```
+
+---
+
+### Task 2: Apply CLI flag at app startup
+
+**Files:**
+- Modify: `Sources/cmuxApp.swift` (inside `init()`, after line ~47 `Self.configureGhosttyEnvironment()`)
+
+- [ ] **Step 1: Add CLI flag check to `cmuxApp.init()`**
+
+In `Sources/cmuxApp.swift`, inside `init()` (around line 47, after `Self.configureGhosttyEnvironment()`), add:
+
+```swift
+if CommandLine.arguments.contains("--ignore-certificate-errors") {
+    BrowserCertBypassSettings.runtimeOverride = true
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-cert-bypass" build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/cmuxApp.swift
+git commit -m "feat: apply --ignore-certificate-errors CLI flag at startup"
+```
+
+---
+
+### Task 3: Bypass TLS in `BrowserNavigationDelegate.didReceive challenge`
+
+**Files:**
+- Modify: `Sources/Panels/BrowserPanel.swift` (lines 3802–3818)
+
+- [ ] **Step 1: Modify the challenge handler**
+
+Replace the existing `webView(_:didReceive:completionHandler:)` implementation (lines 3802–3818 in `BrowserPanel.swift`):
+
+**Old:**
+```swift
+func webView(
+    _ webView: WKWebView,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+) {
+    // WKWebView rejects all authentication challenges by default when this
+    // delegate method is not implemented (.rejectProtectionSpace). This
+    // breaks TLS client-certificate flows such as Microsoft Entra ID
+    // Conditional Access, which verifies device compliance via a client
+    // certificate stored in the system keychain by MDM enrollment.
+    //
+    // By returning .performDefaultHandling the system's standard URL-loading
+    // behaviour takes over: the keychain is searched for matching client
+    // identities, MDM-installed root CAs are trusted, and any configured SSO
+    // extensions (e.g. Microsoft Enterprise SSO) can intercept the challenge.
+    completionHandler(.performDefaultHandling, nil)
+}
+```
+
+**New:**
+```swift
+func webView(
+    _ webView: WKWebView,
+    didReceive challenge: URLAuthenticationChallenge,
+    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+) {
+    // When certificate bypass is active (--ignore-certificate-errors or browser.cert_bypass set true),
+    // unconditionally trust server certificates. This covers self-signed and unknown-root certs
+    // common in local development (e.g. https://localhost:8443). Only server trust challenges
+    // are bypassed; client cert and other challenge types still use default handling.
+    if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+       BrowserCertBypassSettings.isEnabled(),
+       let serverTrust = challenge.protectionSpace.serverTrust {
+        completionHandler(.useCredential, URLCredential(trust: serverTrust))
+        return
+    }
+
+    // WKWebView rejects all authentication challenges by default when this
+    // delegate method is not implemented (.rejectProtectionSpace). This
+    // breaks TLS client-certificate flows such as Microsoft Entra ID
+    // Conditional Access, which verifies device compliance via a client
+    // certificate stored in the system keychain by MDM enrollment.
+    //
+    // By returning .performDefaultHandling the system's standard URL-loading
+    // behaviour takes over: the keychain is searched for matching client
+    // identities, MDM-installed root CAs are trusted, and any configured SSO
+    // extensions (e.g. Microsoft Enterprise SSO) can intercept the challenge.
+    completionHandler(.performDefaultHandling, nil)
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-cert-bypass" build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Smoke test with tagged build**
+
+```bash
+./scripts/reload.sh --tag cert-bypass
+```
+
+Launch the app and open a browser split with a self-signed HTTPS URL. With `--ignore-certificate-errors`, it should load; without it, the existing cert error page should appear.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Panels/BrowserPanel.swift
+git commit -m "feat: bypass TLS cert validation when BrowserCertBypassSettings.isEnabled()"
+```
+
+---
+
+## Chunk 2: Socket Command
+
+### Task 4: Add `browser.cert_bypass` socket commands
+
+**Files:**
+- Modify: `Sources/TerminalController.swift`
+  - Dispatch cases: around line 1983 (end of browser.* block)
+  - Handler function: near other `v2Browser*` helpers (around line 7300+)
+
+- [ ] **Step 1: Add dispatch cases**
+
+In `Sources/TerminalController.swift`, in the v2 command switch statement, after the last `browser.*` case (around line 1983), add:
+
+```swift
+case "browser.cert_bypass":
+    return v2Result(id: id, self.v2BrowserCertBypass(params: params))
+```
+
+- [ ] **Step 2: Add handler function**
+
+Near the other `v2Browser*` helper functions (around line 7300+), add:
+
+```swift
+private func v2BrowserCertBypass(params: [String: Any]) -> V2CallResult {
+    let action = (params["action"] as? String) ?? (params["args"] as? [String])?.first ?? ""
+    switch action {
+    case "get":
+        return .ok(["enabled": BrowserCertBypassSettings.isEnabled()])
+    case "set":
+        let rawValue = (params["args"] as? [String])?.dropFirst().first
+            ?? (params["value"] as? String)
+            ?? (params["enabled"] as? Bool).map { $0 ? "true" : "false" }
+        guard let rawValue else {
+            return .err(code: "invalid_params", message: "Missing value: use 'set true' or 'set false'", data: nil)
+        }
+        switch rawValue.lowercased() {
+        case "true", "1", "yes":
+            BrowserCertBypassSettings.runtimeOverride = true
+            return .ok(["enabled": true])
+        case "false", "0", "no":
+            BrowserCertBypassSettings.runtimeOverride = false
+            return .ok(["enabled": false])
+        default:
+            return .err(code: "invalid_params", message: "Invalid value '\(rawValue)': use 'true' or 'false'", data: nil)
+        }
+    default:
+        return .err(code: "invalid_params", message: "Unknown action '\(action)': use 'get' or 'set'", data: nil)
+    }
+}
+```
+
+**How callers invoke it via CLI:**
+```bash
+# Get current state
+cmux browser.cert_bypass --action get
+
+# Enable (session-only, does not persist)
+cmux browser.cert_bypass --action set --value true
+
+# Disable
+cmux browser.cert_bypass --action set --value false
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-cert-bypass" build 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TerminalController.swift
+git commit -m "feat: add browser.cert_bypass get/set socket command"
+```
+
+---
+
+### Task 5: Add socket test
+
+**Files:**
+- Create: `tests_v2/test_browser_cert_bypass.py`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests_v2/test_browser_cert_bypass.py`:
+
+```python
+#!/usr/bin/env python3
+"""Regression: browser.cert_bypass get/set socket commands."""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        # get returns a bool
+        result = c._call("browser.cert_bypass", {"action": "get"})
+        _must(isinstance(result.get("enabled"), bool),
+              f"browser.cert_bypass get should return enabled bool, got: {result}")
+
+        initial = result["enabled"]
+
+        # set true
+        r = c._call("browser.cert_bypass", {"action": "set", "value": "true"})
+        _must(r.get("enabled") is True, f"set true should return enabled=true, got: {r}")
+
+        # get reflects the change
+        r = c._call("browser.cert_bypass", {"action": "get"})
+        _must(r.get("enabled") is True, f"get after set true should return true, got: {r}")
+
+        # set false
+        r = c._call("browser.cert_bypass", {"action": "set", "value": "false"})
+        _must(r.get("enabled") is False, f"set false should return enabled=false, got: {r}")
+
+        r = c._call("browser.cert_bypass", {"action": "get"})
+        _must(r.get("enabled") is False, f"get after set false should return false, got: {r}")
+
+        # restore initial state
+        c._call("browser.cert_bypass", {"action": "set", "value": "true" if initial else "false"})
+
+        print("PASS: browser.cert_bypass get/set")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests_v2/test_browser_cert_bypass.py
+git commit -m "test: browser.cert_bypass get/set socket commands"
+```
+
+> **Note:** Do not run this test locally. It requires a running cmux instance. Trigger via CI: `gh workflow run test-e2e.yml` (see cmuxterm-hq CLAUDE.md).
+
+---
+
+## Final: Tag & PR
+
+- [ ] Push branch and open PR targeting `main`
+
+```bash
+git push origin HEAD
+gh pr create --title "feat: --ignore-certificate-errors flag for WebKit cert bypass" \
+  --body "Adds Chrome-style TLS cert bypass for local dev servers with self-signed certs.
+
+## Changes
+- \`BrowserCertBypassSettings\` enum in \`BrowserPanel.swift\` (runtime override + UserDefaults fallback)
+- \`--ignore-certificate-errors\` CLI flag (session-only, checked at startup in \`cmuxApp.init()\`)
+- \`BrowserNavigationDelegate.didReceive challenge\` bypasses server trust when flag is active
+- \`browser.cert_bypass get/set\` socket commands (session-only, no persistence)
+- Socket regression test in \`tests_v2/test_browser_cert_bypass.py\`
+
+## Usage
+\`\`\`bash
+# Launch with bypass active
+cmux --ignore-certificate-errors
+
+# Toggle at runtime (session-only)
+cmux browser.cert_bypass --action set --value true
+
+# Persistent bypass (external, survives restarts)
+defaults write ai.manaflow.cmux browserIgnoreCertificateErrors -bool true
+\`\`\`"
+```

--- a/docs/superpowers/specs/2026-03-10-webkit-cert-bypass-design.md
+++ b/docs/superpowers/specs/2026-03-10-webkit-cert-bypass-design.md
@@ -1,0 +1,76 @@
+# WebKit Certificate Bypass Flag
+
+**Date:** 2026-03-10
+**Status:** Approved
+**Use case:** Developer tooling — local dev servers with self-signed/unknown-root HTTPS certs
+
+## Summary
+
+Add an `--ignore-certificate-errors` CLI flag (analogous to Chrome's) that bypasses WebKit TLS validation. Also overridable at runtime via socket command `browser.cert_bypass set`.
+
+## Design
+
+### `BrowserCertBypassSettings` (new enum in `BrowserPanel.swift`)
+
+```swift
+enum BrowserCertBypassSettings {
+    static let defaultsKey = "browserIgnoreCertificateErrors"
+    static var runtimeOverride: Bool? = nil
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if let override = runtimeOverride { return override }
+        return defaults.bool(forKey: defaultsKey)
+    }
+
+    // Session-only — does not persist to UserDefaults
+    static func setRuntimeOverride(_ enabled: Bool) {
+        runtimeOverride = enabled
+    }
+}
+```
+
+**Precedence:**
+1. `runtimeOverride` — set by `--ignore-certificate-errors` at launch, or overwritten by socket `set` (both session-only)
+2. UserDefaults `browserIgnoreCertificateErrors` — persistent, written externally (e.g. `defaults write`)
+
+### CLI flag — app startup
+
+In `cmuxApp.swift` (app init):
+
+```swift
+if CommandLine.arguments.contains("--ignore-certificate-errors") {
+    BrowserCertBypassSettings.runtimeOverride = true
+}
+```
+
+### TLS bypass — `BrowserNavigationDelegate`
+
+Modify `webView(_:didReceive:completionHandler:)` in `BrowserPanel.swift`:
+
+```swift
+if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+   BrowserCertBypassSettings.isEnabled(),
+   let serverTrust = challenge.protectionSpace.serverTrust {
+    completionHandler(.useCredential, URLCredential(trust: serverTrust))
+    return
+}
+completionHandler(.performDefaultHandling, nil)
+```
+
+When bypass is active, cert challenges are accepted before WebKit fails the load — existing cert error pages are never triggered.
+
+### Socket command — `TerminalController.swift`
+
+```
+browser.cert_bypass get        → "true" or "false" (reflects effective state)
+browser.cert_bypass set true   → sets runtimeOverride = true (session only)
+browser.cert_bypass set false  → sets runtimeOverride = false (session only)
+```
+
+`set` does not write to UserDefaults. It overwrites the `--ignore-certificate-errors` CLI flag for the remainder of the session.
+
+## Out of scope
+
+- Settings UI toggle
+- Per-tab or per-host granularity (flag is app-global, matching Chrome behavior)
+- Certificate pinning or custom trust anchors

--- a/docs/superpowers/specs/2026-03-10-webkit-cert-bypass-design.md
+++ b/docs/superpowers/specs/2026-03-10-webkit-cert-bypass-design.md
@@ -21,11 +21,6 @@ enum BrowserCertBypassSettings {
         if let override = runtimeOverride { return override }
         return defaults.bool(forKey: defaultsKey)
     }
-
-    // Session-only — does not persist to UserDefaults
-    static func setRuntimeOverride(_ enabled: Bool) {
-        runtimeOverride = enabled
-    }
 }
 ```
 
@@ -62,9 +57,9 @@ When bypass is active, cert challenges are accepted before WebKit fails the load
 ### Socket command — `TerminalController.swift`
 
 ```
-browser.cert_bypass get        → "true" or "false" (reflects effective state)
-browser.cert_bypass set true   → sets runtimeOverride = true (session only)
-browser.cert_bypass set false  → sets runtimeOverride = false (session only)
+browser.cert_bypass get        → {"enabled": true|false}  (reflects effective state)
+browser.cert_bypass set true   → {"enabled": true}   (sets runtimeOverride, session only)
+browser.cert_bypass set false  → {"enabled": false}  (sets runtimeOverride, session only)
 ```
 
 `set` does not write to UserDefaults. It overwrites the `--ignore-certificate-errors` CLI flag for the remainder of the session.

--- a/tests_v2/test_browser_cert_bypass.py
+++ b/tests_v2/test_browser_cert_bypass.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Regression: browser.cert_bypass get/set socket commands."""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        # get returns a bool
+        result = c._call("browser.cert_bypass", {"action": "get"})
+        _must(isinstance(result.get("enabled"), bool),
+              f"browser.cert_bypass get should return enabled bool, got: {result}")
+
+        initial = result["enabled"]
+
+        try:
+            # set true
+            r = c._call("browser.cert_bypass", {"action": "set", "value": "true"})
+            _must(r.get("enabled") is True, f"set true should return enabled=true, got: {r}")
+
+            # get reflects the change
+            r = c._call("browser.cert_bypass", {"action": "get"})
+            _must(r.get("enabled") is True, f"get after set true should return true, got: {r}")
+
+            # set false
+            r = c._call("browser.cert_bypass", {"action": "set", "value": "false"})
+            _must(r.get("enabled") is False, f"set false should return enabled=false, got: {r}")
+
+            r = c._call("browser.cert_bypass", {"action": "get"})
+            _must(r.get("enabled") is False, f"get after set false should return false, got: {r}")
+        finally:
+            # restore initial state even if assertions fail
+            c._call("browser.cert_bypass", {"action": "set", "value": "true" if initial else "false"})
+
+        print("PASS: browser.cert_bypass get/set")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Chrome-style certificate bypass for local development against HTTPS servers with self-signed or unknown-root certificates.

- --ignore-certificate-errors launch flag sets the runtime override at startup (not persisted)
- browser cert-bypass get | set <true|false> CLI/socket command toggles at runtime (not persisted)
- User default `browserIgnoreCertificateErrors` for persistent default

### Usage
Launch with bypass active:
    cmux --ignore-certificate-errors

Toggle at runtime:
   cmux browser cert-bypass set true
   cmux browser cert-bypass get

Persist across restarts:
  defaults write ai.manaflow.cmux browserIgnoreCertificateErrors -bool true

### Implementation notes
  - BrowserCertBypassSettings enum owns the flag state: in-memory runtimeOverride (session-only) with a UserDefaults fallback for persistence
  - TLS bypass is scoped to NSURLAuthenticationMethodServerTrust challenges only — client cert flows, MDM/Entra CA, and SSO extensions are unaffected

## Testing

- Socket regression test in tests_v2/test_browser_cert_bypass.py
- manually testing:
  - changing bypass state from socket
  - using --ignore-certificate-errors at launch
  - changing user default, verifying that socket and flag has priority over user default.

## Demo Video
NA

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Chrome-style certificate bypass so the embedded browser can load self-signed or unknown-root HTTPS servers during local development. Only `NSURLAuthenticationMethodServerTrust` is bypassed; client cert flows, MDM/Entra CA trust, and SSO extensions are unaffected.

- **New Features**
  - `--ignore-certificate-errors` launch flag enables session-only bypass.
  - `browser cert-bypass get|set <true|false>` CLI/socket toggle at runtime (session-only).
  - Persistent default via `browserIgnoreCertificateErrors` in UserDefaults; runtime/flag take precedence.
  - WebKit trusts server certs when enabled; regression test added in `tests_v2/test_browser_cert_bypass.py`.

- **Migration**
  - Launch with bypass: `cmux --ignore-certificate-errors`
  - Toggle at runtime: `cmux browser cert-bypass set true` and `cmux browser cert-bypass get`
  - Persist across restarts: `defaults write ai.manaflow.cmux browserIgnoreCertificateErrors -bool true`

<sup>Written for commit 14d2322b9e71d612b178d6c1f7bf5d5b76085146. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added certificate bypass feature for WebKit TLS validation, controllable via the `--ignore-certificate-errors` CLI flag at startup or the `browser.cert_bypass` socket command at runtime (get/set actions).

* **Documentation**
  * Added feature documentation and design specifications for the certificate bypass functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->