### PR TITLE
feat: auto-resume AI coding agents on session restore

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -35,6 +35,34 @@ _cmux_restore_scrollback_once() {
 }
 _cmux_restore_scrollback_once
 
+_cmux_resume_agent_once() {
+    local cmd="${CMUX_RESTORE_AGENT_COMMAND:-}"
+    [[ -n "$cmd" ]] || return 0
+    unset CMUX_RESTORE_AGENT_COMMAND
+
+    # Validate against an allowlist to prevent command injection from a
+    # tampered snapshot JSON file. Only known safe resume commands are accepted.
+    case "$cmd" in
+        "claude --continue"|"codex --resume"|"aider"|"goose session resume") ;;
+        *)
+            printf '\033[33mcmux:\033[0m Unknown agent resume command, skipping.\n'
+            return 0 ;;
+    esac
+
+    # Extract the binary name and verify it is installed.
+    local bin="${cmd%% *}"
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    printf '\033[33mcmux:\033[0m Resuming previous \033[1m%s\033[0m session...\n' "$bin"
+    printf '\033[33mcmux:\033[0m Running: \033[1m%s\033[0m\n' "$cmd"
+    printf '\n'
+
+    eval "$cmd"
+}
+_cmux_resume_agent_once
+
 # Throttle heavy work to avoid prompt latency.
 _CMUX_PWD_LAST_PWD="${_CMUX_PWD_LAST_PWD:-}"
 _CMUX_GIT_LAST_PWD="${_CMUX_GIT_LAST_PWD:-}"

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -35,7 +35,13 @@ _cmux_restore_scrollback_once() {
 }
 _cmux_restore_scrollback_once
 
-_cmux_resume_agent_once() {
+_CMUX_AGENT_RESUME_PENDING="${_CMUX_AGENT_RESUME_PENDING:-1}"
+
+_cmux_resume_agent_on_first_prompt() {
+    # Fire once on the first PROMPT_COMMAND invocation, then disable.
+    [[ "$_CMUX_AGENT_RESUME_PENDING" == "1" ]] || return 0
+    _CMUX_AGENT_RESUME_PENDING=0
+
     local cmd="${CMUX_RESTORE_AGENT_COMMAND:-}"
     [[ -n "$cmd" ]] || return 0
     unset CMUX_RESTORE_AGENT_COMMAND
@@ -49,7 +55,7 @@ _cmux_resume_agent_once() {
             return 0 ;;
     esac
 
-    # Extract the binary name and verify it is installed.
+    # Verify the binary is installed.
     local bin="${cmd%% *}"
     if ! command -v "$bin" >/dev/null 2>&1; then
         return 0
@@ -61,7 +67,6 @@ _cmux_resume_agent_once() {
 
     eval "$cmd"
 }
-_cmux_resume_agent_once
 
 # Throttle heavy work to avoid prompt latency.
 _CMUX_PWD_LAST_PWD="${_CMUX_PWD_LAST_PWD:-}"
@@ -144,6 +149,8 @@ _cmux_ports_kick() {
 }
 
 _cmux_prompt_command() {
+    _cmux_resume_agent_on_first_prompt
+
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -36,6 +36,34 @@ _cmux_restore_scrollback_once() {
 }
 _cmux_restore_scrollback_once
 
+_cmux_resume_agent_once() {
+    local cmd="${CMUX_RESTORE_AGENT_COMMAND:-}"
+    [[ -n "$cmd" ]] || return 0
+    unset CMUX_RESTORE_AGENT_COMMAND
+
+    # Validate against an allowlist to prevent command injection from a
+    # tampered snapshot JSON file. Only known safe resume commands are accepted.
+    case "$cmd" in
+        "claude --continue"|"codex --resume"|"aider"|"goose session resume") ;;
+        *)
+            print -P "%F{yellow}cmux:%f Unknown agent resume command, skipping."
+            return 0 ;;
+    esac
+
+    # Extract the binary name and verify it is installed.
+    local bin="${cmd%% *}"
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    printf '\033[33mcmux:\033[0m Resuming previous \033[1m%s\033[0m session...\n' "$bin"
+    printf '\033[33mcmux:\033[0m Running: \033[1m%s\033[0m\n' "$cmd"
+    printf '\n'
+
+    eval "$cmd"
+}
+_cmux_resume_agent_once
+
 # Throttle heavy work to avoid prompt latency.
 typeset -g _CMUX_PWD_LAST_PWD=""
 typeset -g _CMUX_GIT_LAST_PWD=""

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -36,7 +36,10 @@ _cmux_restore_scrollback_once() {
 }
 _cmux_restore_scrollback_once
 
-_cmux_resume_agent_once() {
+_cmux_resume_agent_on_first_prompt() {
+    # Remove ourselves immediately — this must only fire once.
+    add-zsh-hook -d precmd _cmux_resume_agent_on_first_prompt
+
     local cmd="${CMUX_RESTORE_AGENT_COMMAND:-}"
     [[ -n "$cmd" ]] || return 0
     unset CMUX_RESTORE_AGENT_COMMAND
@@ -46,11 +49,11 @@ _cmux_resume_agent_once() {
     case "$cmd" in
         "claude --continue"|"codex --resume"|"aider"|"goose session resume") ;;
         *)
-            print -P "%F{yellow}cmux:%f Unknown agent resume command, skipping."
+            printf '\033[33mcmux:\033[0m Unknown agent resume command, skipping.\n'
             return 0 ;;
     esac
 
-    # Extract the binary name and verify it is installed.
+    # Verify the binary is installed.
     local bin="${cmd%% *}"
     if ! command -v "$bin" >/dev/null 2>&1; then
         return 0
@@ -62,7 +65,6 @@ _cmux_resume_agent_once() {
 
     eval "$cmd"
 }
-_cmux_resume_agent_once
 
 # Throttle heavy work to avoid prompt latency.
 typeset -g _CMUX_PWD_LAST_PWD=""
@@ -453,4 +455,5 @@ autoload -Uz add-zsh-hook
 add-zsh-hook preexec _cmux_preexec
 add-zsh-hook precmd _cmux_precmd
 add-zsh-hook precmd _cmux_fix_path
+add-zsh-hook precmd _cmux_resume_agent_on_first_prompt
 add-zsh-hook zshexit _cmux_zshexit

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -224,6 +224,9 @@ struct SessionGitBranchSnapshot: Codable, Sendable {
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var scrollback: String?
+    /// The command to resume a previously running AI coding agent (e.g. "claude --continue").
+    /// Populated at snapshot time by inspecting the terminal's foreground process tree.
+    var agentResumeCommand: String?
 }
 
 struct SessionBrowserPanelSnapshot: Codable, Sendable {
@@ -417,24 +420,89 @@ enum SessionPersistenceStore {
     }
 }
 
+enum AgentProcessDetector {
+    /// Known AI coding agent binary names mapped to their resume commands.
+    private static let agentResumeCommands: [(binaryNames: [String], command: String)] = [
+        (["claude"], "claude --continue"),
+        (["codex"], "codex --resume"),
+        (["aider"], "aider"),
+        (["goose"], "goose session resume"),
+    ]
+
+    /// Detect the foreground AI coding agent for a given TTY name (e.g. "ttys003").
+    /// Returns the appropriate resume command, or nil if no known agent is running.
+    static func detectAgentResumeCommand(ttyName: String?) -> String? {
+        guard let ttyName, !ttyName.isEmpty else { return nil }
+        guard let processes = foregroundProcessNames(ttyName: ttyName) else { return nil }
+
+        for entry in agentResumeCommands {
+            for binaryName in entry.binaryNames {
+                if processes.contains(where: { $0 == binaryName || $0.hasSuffix("/\(binaryName)") }) {
+                    return entry.command
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Match a list of process names against known AI agents.
+    /// Extracted for testability — callers provide the process list, this does pure matching.
+    static func matchAgentResumeCommand(processNames: [String]) -> String? {
+        for entry in agentResumeCommands {
+            for binaryName in entry.binaryNames {
+                if processNames.contains(where: { $0 == binaryName || $0.hasSuffix("/\(binaryName)") }) {
+                    return entry.command
+                }
+            }
+        }
+        return nil
+    }
+
+    /// List process command names running on the given TTY.
+    private static func foregroundProcessNames(ttyName: String) -> [String]? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-t", ttyName, "-o", "comm="]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        // Read pipe data before waitUntilExit to avoid potential deadlock
+        // if the pipe buffer fills up.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        guard let output = String(data: data, encoding: .utf8) else { return nil }
+        let names = output.split(separator: "\n").map { String($0).trimmingCharacters(in: .whitespaces) }
+        return names.isEmpty ? nil : names
+    }
+}
+
 enum SessionScrollbackReplayStore {
     static let environmentKey = "CMUX_RESTORE_SCROLLBACK_FILE"
+    static let agentResumeCommandKey = "CMUX_RESTORE_AGENT_COMMAND"
     private static let directoryName = "cmux-session-scrollback"
     private static let ansiEscape = "\u{001B}"
     private static let ansiReset = "\u{001B}[0m"
 
     static func replayEnvironment(
         for scrollback: String?,
+        agentResumeCommand: String? = nil,
         tempDirectory: URL = FileManager.default.temporaryDirectory
     ) -> [String: String] {
-        guard let replayText = normalizedScrollback(scrollback) else { return [:] }
-        guard let replayFileURL = writeReplayFile(
-            contents: replayText,
-            tempDirectory: tempDirectory
-        ) else {
-            return [:]
+        var env: [String: String] = [:]
+        if let replayText = normalizedScrollback(scrollback),
+           let replayFileURL = writeReplayFile(contents: replayText, tempDirectory: tempDirectory) {
+            env[environmentKey] = replayFileURL.path
         }
-        return [environmentKey: replayFileURL.path]
+        if let agentResumeCommand, !agentResumeCommand.isEmpty {
+            env[agentResumeCommandKey] = agentResumeCommand
+        }
+        return env
     }
 
     private static func normalizedScrollback(_ scrollback: String?) -> String? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -168,6 +168,7 @@ extension Workspace {
 
     func restoreSessionSnapshot(_ snapshot: SessionWorkspaceSnapshot) {
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
+        cachedAgentResumeCommandByPanelId.removeAll(keepingCapacity: false)
 
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedCurrentDirectory.isEmpty {
@@ -323,9 +324,21 @@ extension Workspace {
                 capturedScrollback: capturedScrollback,
                 includeScrollback: includeScrollback
             )
-            let agentResumeCommand = includeScrollback
-                ? AgentProcessDetector.detectAgentResumeCommand(ttyName: ttyName)
-                : nil
+            let agentResumeCommand: String? = {
+                if includeScrollback {
+                    // Full save: detect the live process and cache it.
+                    let detected = AgentProcessDetector.detectAgentResumeCommand(ttyName: ttyName)
+                    if let detected {
+                        cachedAgentResumeCommandByPanelId[panelId] = detected
+                    } else {
+                        cachedAgentResumeCommandByPanelId.removeValue(forKey: panelId)
+                    }
+                    return detected
+                }
+                // Lightweight autosave: reuse the cached value so we don't
+                // overwrite a previously detected agent with nil.
+                return cachedAgentResumeCommandByPanelId[panelId]
+            }()
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: panelDirectories[panelId],
                 scrollback: resolvedScrollback,
@@ -513,6 +526,11 @@ extension Workspace {
                 restoredTerminalScrollbackByPanelId[terminalPanel.id] = fallbackScrollback
             } else {
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: terminalPanel.id)
+            }
+            if let agentCmd = snapshot.terminal?.agentResumeCommand {
+                cachedAgentResumeCommandByPanelId[terminalPanel.id] = agentCmd
+            } else {
+                cachedAgentResumeCommandByPanelId.removeValue(forKey: terminalPanel.id)
             }
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
             return terminalPanel.id
@@ -999,6 +1017,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
+    private var cachedAgentResumeCommandByPanelId: [UUID: String] = [:]
 
     var focusedSurfaceId: UUID? { focusedPanelId }
     var surfaceDirectories: [UUID: String] {
@@ -2366,6 +2385,7 @@ final class Workspace: Identifiable, ObservableObject {
         panelSubscriptions.removeAll(keepingCapacity: false)
         pruneSurfaceMetadata(validSurfaceIds: [])
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
+        cachedAgentResumeCommandByPanelId.removeAll(keepingCapacity: false)
         terminalInheritanceFontPointsByPanelId.removeAll(keepingCapacity: false)
         lastTerminalConfigInheritancePanelId = nil
         lastTerminalConfigInheritanceFontPoints = nil
@@ -4547,6 +4567,7 @@ extension Workspace: BonsplitDelegate {
         panelSubscriptions.removeValue(forKey: panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+        cachedAgentResumeCommandByPanelId.removeValue(forKey: panelId)
         PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
         terminalInheritanceFontPointsByPanelId.removeValue(forKey: panelId)
         if lastTerminalConfigInheritancePanelId == panelId {
@@ -4726,6 +4747,7 @@ extension Workspace: BonsplitDelegate {
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+                cachedAgentResumeCommandByPanelId.removeValue(forKey: panelId)
                 PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
             }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -323,9 +323,13 @@ extension Workspace {
                 capturedScrollback: capturedScrollback,
                 includeScrollback: includeScrollback
             )
+            let agentResumeCommand = includeScrollback
+                ? AgentProcessDetector.detectAgentResumeCommand(ttyName: ttyName)
+                : nil
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: panelDirectories[panelId],
-                scrollback: resolvedScrollback
+                scrollback: resolvedScrollback,
+                agentResumeCommand: agentResumeCommand
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -493,7 +497,8 @@ extension Workspace {
         case .terminal:
             let workingDirectory = snapshot.terminal?.workingDirectory ?? snapshot.directory ?? currentDirectory
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
-                for: snapshot.terminal?.scrollback
+                for: snapshot.terminal?.scrollback,
+                agentResumeCommand: snapshot.terminal?.agentResumeCommand
             )
             guard let terminalPanel = newTerminalSurface(
                 inPane: paneId,


### PR DESCRIPTION
Hey! 👋

I've been using cmux as my daily driver and one thing that bugged me was losing my Claude Code / Codex sessions every time I restarted. The scrollback restore is great, but I'd always have to manually re-run `claude --continue` to pick up where I left off.

So I put together a lightweight approach — instead of a full daemon architecture, this just detects what agent was running at quit time and auto-resumes it on next launch.

## What it does

When you quit cmux while an AI agent is running in a terminal pane, it remembers which one. Next time you open cmux, it automatically runs the right resume command:

- Claude Code → `claude --continue`
- Codex → `codex --resume`
- Aider → `aider` (just restarts in same dir)
- Goose → `goose session resume`

## How

Pretty simple — during session save, I grab the foreground process list via `ps -t <tty>` and match against known agent binaries. The resume command gets stashed in the existing session JSON (`agentResumeCommand` field on the terminal panel snapshot). On restore, shell integration picks it up from an env var and runs it.

Kept it minimal:
- Only detects on full saves (quit/explicit), not the 8s autosave tick
- Allowlist validation in both Swift and shell layers so a tampered JSON can't inject arbitrary commands
- Optional field, so old snapshots still load fine
- If the agent binary isn't installed, silently skips

## Files changed

- `Sources/SessionPersistence.swift` — `AgentProcessDetector` + schema + env var plumbing
- `Sources/Workspace.swift` — hook into snapshot build + restore
- `Resources/shell-integration/cmux-{zsh,bash}-integration.{zsh,bash}` — `_cmux_resume_agent_once`

## Testing

- [x] Old session JSON without `agentResumeCommand` loads fine
- [x] Claude Code running → quit → relaunch → auto-resumes
- [x] Plain shell → quit → relaunch → no resume attempt
- [x] Unknown command in env var → rejected by allowlist
- [x] Agent not installed → graceful skip

Would love feedback on whether this approach makes sense or if you'd prefer a different design (e.g. storing an agent identifier instead of the raw command string).

---

*Code reviewed with GPT-5.4.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic resumption of AI agent processes when terminal sessions are restored from saved scrollback history. The system detects previously-running agents and provides seamless re-engagement on session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->