### PR TITLE
Remove per-keystroke terminal refresh

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4614,7 +4614,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Use accumulated text from insertText (for IME), or compute text for key
         let accumulatedText = keyTextAccumulator ?? []
-        var shouldRefreshAfterTextInput = false
         if !accumulatedText.isEmpty {
             // Accumulated text comes from insertText (IME composition result).
             // These never have "composing" set to true because these are the
@@ -4622,7 +4621,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.composing = false
             for text in accumulatedText {
                 if shouldSendText(text) {
-                    shouldRefreshAfterTextInput = true
                     text.withCString { ptr in
                         keyEvent.text = ptr
                         _ = ghostty_surface_key(surface, keyEvent)
@@ -4643,7 +4641,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 )
             if let text = textForKeyEvent(translationEvent) {
                 if shouldSendText(text), !suppressShiftSpaceFallbackText {
-                    shouldRefreshAfterTextInput = true
                     text.withCString { ptr in
                         keyEvent.text = ptr
                         _ = ghostty_surface_key(surface, keyEvent)
@@ -4656,10 +4653,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyEvent.text = nil
                 _ = ghostty_surface_key(surface, keyEvent)
             }
-        }
-
-        if shouldRefreshAfterTextInput {
-            terminalSurface?.forceRefresh(reason: "keyDown.textInput")
         }
 
         // Rendering is driven by Ghostty's wakeups/renderer.


### PR DESCRIPTION
## Summary
- remove the extra terminal surface refresh after normal text input
- keep the split-resize and focus-refresh paths unchanged for isolated dogfooding

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag lag-norefresh (build succeeded, app launched)
- Manual dogfood: terminal typing still works, no obvious regression seen yet

## Issues
- Related task: investigate typing lag vs upstream Ghostty by removing per-keystroke text-input refresh


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove per-keystroke terminal refresh on text input to reduce typing lag; rendering now relies on the existing wakeups/renderer. Split-resize and focus-triggered refresh paths remain unchanged for isolated dogfooding.

<sup>Written for commit 0a630c3ff1eb6879316770dad8069096a477f87a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized text input handling in the terminal by streamlining the refresh mechanism. The terminal now relies on standard event-driven rendering instead of forced refresh cycles, resulting in more efficient input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->