### PR TITLE
Add Khmer (README.km.md) localization

### DIFF
--- a/README.km.md
+++ b/README.km.md
@@ -3,7 +3,7 @@
 
 <p align="center">
   <a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">
-    <img src="https://github.com/manaflow-ai/cmux/raw/main/docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
+    <img src="./docs/assets/macos-badge.png" alt="Download cmux for macOS" width="180" />
   </a>
 </p>
 
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/manaflow-ai/cmux/raw/main/docs/assets/main-first-image.png" alt="cmux screenshot" width="900" />
+  <img src="./docs/assets/main-first-image.png" alt="cmux screenshot" width="900" />
 </p>
 
 <p align="center">
@@ -25,6 +25,45 @@
 </p>
 
 ## លក្ខណៈពិសេសនានា (Features)
+
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h3>Notification rings</h3>
+Panes get a blue ring and tabs light up when coding agents need your attention
+</td>
+<td width="60%">
+<img src="./docs/assets/notification-rings.png" alt="Notification rings" width="100%" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Notification panel</h3>
+See all pending notifications in one place, jump to the most recent unread
+</td>
+<td width="60%">
+<img src="./docs/assets/sidebar-notification-badge.png" alt="Sidebar notification badge" width="100%" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>In-app browser</h3>
+Split a browser alongside your terminal with a scriptable API ported from <a href="https://github.com/vercel-labs/agent-browser">agent-browser</a>
+</td>
+<td width="60%">
+<img src="./docs/assets/built-in-browser.png" alt="Built-in browser" width="100%" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h3>Vertical + horizontal tabs</h3>
+Sidebar shows git branch, linked PR status/number, working directory, listening ports, and latest notification text. Split horizontally and vertically.
+</td>
+<td width="60%">
+<img src="./docs/assets/vertical-horizontal-tabs-and-splits.png" alt="Vertical tabs and split panes" width="100%" />
+</td>
+</tr>
+</table>
 
 * **អាចសរសេរ Script បាន (Scriptable)** — CLI និង socket API ដើម្បីបង្កើត workspaces, បំបែក panes, បញ្ជូន keystrokes, និងធ្វើស្វ័យប្រវត្តិកម្មកម្មវិធីរុករក (browser)
 * **កម្មវិធីដើមរបស់ macOS (Native macOS app)** — បង្កើតឡើងដោយប្រើ Swift និង AppKit មិនមែន Electron ទេ។ ចាប់ផ្តើមលឿន, ស៊ីមេម៉ូរី (memory) តិច។
@@ -117,6 +156,8 @@ cmux គឺជាមូលដ្ឋានគ្រឹះ (primitive) មិន�
 
 ### កម្មវិធីរុករក (Browser)
 
+Browser developer-tool shortcuts follow Safari defaults and are customizable in `Settings → Keyboard Shortcuts`.
+
 | ផ្លូវកាត់ (Shortcut) | សកម្មភាព (Action) |
 |---|---|
 | ⌘ ⇧ L | បើកកម្មវិធីរុករកក្នុងលក្ខណៈបំបែក (split) |
@@ -178,6 +219,16 @@ cmux NIGHTLY គឺជាកម្មវិធីដាច់ដោយឡែក�
 * ប្រវត្តិរុករក និង URL របស់កម្មវិធីរុករក
 
 cmux **មិន** ស្ដារស្ថានភាពដំណើរការផ្ទាល់ (live process state) នៅក្នុងកម្មវិធី terminal ឡើយ។ ឧទាហរណ៍ session របស់ Claude Code/tmux/vim ដែលកំពុងដំណើរការ មិនទាន់អាចបន្តឡើងវិញបានទេបន្ទាប់ពីចាប់ផ្ដើមឡើងវិញ។
+
+## Star History
+
+<a href="https://star-history.com/#manaflow-ai/cmux&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=manaflow-ai/cmux&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=manaflow-ai/cmux&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=manaflow-ai/cmux&type=Date" width="600" />
+ </picture>
+</a>
 
 ## ការចូលរួមចំណែក (Contributing)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.pt-BR.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a>
+  English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.pt-BR.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.km.md">ភាសាខ្មែរ</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Supersedes https://github.com/manaflow-ai/cmux/pull/1186 by @im4tta with review fixes applied:

- Renamed `README-kh.md` to `README.km.md` (correct ISO 639-1 code `km`, dot separator)
- Added Khmer to main README.md language switcher
- Added feature screenshot table matching original structure
- Added browser keyboard shortcuts note
- Added Star History section
- Used relative image paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full Khmer (`km`) localization of the README and links it in the language switcher. Aligns the localized README with the main structure for consistency.

- **Documentation**
  - Added `README.km.md` (correct ISO 639-1 `km`, dot separator).
  - Linked Khmer in the main README language switcher.
  - Matched feature screenshot table; added browser shortcuts note and Star History.
  - Used relative image paths.

<sup>Written for commit 0b12caa15cb3ef8d6bab46970f1694e121ec8d5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

