### PR TITLE
Improve dense workspace switching performance

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
+					A5008391 /* WorkspacePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008390 /* WorkspacePerformanceTests.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
@@ -210,6 +211,7 @@
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
+		A5008390 /* WorkspacePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePerformanceTests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
@@ -468,6 +470,7 @@
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 					A5008382 /* CommandPaletteSearchEngineTests.swift */,
+					A5008390 /* WorkspacePerformanceTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -701,13 +704,14 @@
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
-					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
-					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
-					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
-					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
-				);
-				runOnlyForDeploymentPostprocessing = 0;
-			};
+				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
+				A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
+				A5008391 /* WorkspacePerformanceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 			B9000006A1B2C3D4E5F60719 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -704,14 +704,14 @@
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
-				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
-				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
-				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
-				A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
-				A5008391 /* WorkspacePerformanceTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
+					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
+					A5008391 /* WorkspacePerformanceTests.swift in Sources */,
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+			};
 			B9000006A1B2C3D4E5F60719 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1524,6 +1524,7 @@ final class Workspace: Identifiable, ObservableObject {
               let paneId = paneId(forPanelId: panelId) else { return }
         bonsplitController.updateTab(tabId, isPinned: pinned)
         normalizePinnedTabs(in: paneId)
+        invalidateSidebarOrderingCache()
     }
 
     func markPanelUnread(_ panelId: UUID) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1212,6 +1212,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Mapping from bonsplit TabID (surface ID) to panel UUID
     private var surfaceIdToPanelId: [TabID: UUID] = [:]
+    private var cachedSidebarOrderedPanelIds: [UUID]?
 
     /// Tab IDs that are allowed to close even if they would normally require confirmation.
     /// This is used by app-level confirmation prompts (e.g., Cmd+W "Close Tab?") so the
@@ -1290,6 +1291,10 @@ final class Workspace: Identifiable, ObservableObject {
 
     func surfaceIdFromPanelId(_ panelId: UUID) -> TabID? {
         surfaceIdToPanelId.first { $0.value == panelId }?.key
+    }
+
+    private func invalidateSidebarOrderingCache() {
+        cachedSidebarOrderedPanelIds = nil
     }
 
 
@@ -1712,6 +1717,10 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func sidebarOrderedPanelIds() -> [UUID] {
+        if let cachedSidebarOrderedPanelIds {
+            return cachedSidebarOrderedPanelIds
+        }
+
         let paneTabs: [String: [UUID]] = Dictionary(
             uniqueKeysWithValues: bonsplitController.allPaneIds.map { paneId in
                 let panelIds = bonsplitController
@@ -1723,11 +1732,13 @@ final class Workspace: Identifiable, ObservableObject {
 
         let fallbackPanelIds = panels.keys.sorted { $0.uuidString < $1.uuidString }
         let tree = bonsplitController.treeSnapshot()
-        return SidebarBranchOrdering.orderedPanelIds(
+        let orderedPanelIds = SidebarBranchOrdering.orderedPanelIds(
             tree: tree,
             paneTabs: paneTabs,
             fallbackPanelIds: fallbackPanelIds
         )
+        cachedSidebarOrderedPanelIds = orderedPanelIds
+        return orderedPanelIds
     }
 
     func sidebarGitBranchesInDisplayOrder(orderedPanelIds: [UUID]) -> [SidebarGitBranchState] {
@@ -2022,6 +2033,7 @@ final class Workspace: Identifiable, ObservableObject {
             terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
             return nil
         }
+        invalidateSidebarOrderingCache()
 
 #if DEBUG
         dlog("split.created pane=\(paneId.id.uuidString.prefix(5)) orientation=\(orientation)")
@@ -2091,6 +2103,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         surfaceIdToPanelId[newTabId] = newPanel.id
+        invalidateSidebarOrderingCache()
 
         // bonsplit's createTab may not reliably emit didSelectTab, and its internal selection
         // updates can be deferred. Force a deterministic selection + focus path so the new
@@ -2153,6 +2166,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelTitles.removeValue(forKey: browserPanel.id)
             return nil
         }
+        invalidateSidebarOrderingCache()
 
         // See newTerminalSplit: suppress old view's becomeFirstResponder during reparenting.
         let previousHostedView = focusedTerminalPanel?.hostedView
@@ -2218,6 +2232,7 @@ final class Workspace: Identifiable, ObservableObject {
             let targetIndex = max(0, bonsplitController.tabs(inPane: paneId).count - 1)
             _ = bonsplitController.reorderTab(newTabId, toIndex: targetIndex)
         }
+        invalidateSidebarOrderingCache()
 
         // Match terminal behavior: enforce deterministic selection + focus.
         if shouldFocusNewTab {
@@ -2282,6 +2297,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelTitles.removeValue(forKey: markdownPanel.id)
             return nil
         }
+        invalidateSidebarOrderingCache()
 
         // Suppress old view's becomeFirstResponder during reparenting.
         let previousHostedView = focusedTerminalPanel?.hostedView
@@ -2332,6 +2348,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         surfaceIdToPanelId[newTabId] = markdownPanel.id
+        invalidateSidebarOrderingCache()
 
         // Match terminal behavior: enforce deterministic selection + focus.
         if shouldFocusNewTab {
@@ -2358,6 +2375,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         panels.removeAll(keepingCapacity: false)
         surfaceIdToPanelId.removeAll(keepingCapacity: false)
+        invalidateSidebarOrderingCache()
         panelSubscriptions.removeAll(keepingCapacity: false)
         pruneSurfaceMetadata(validSurfaceIds: [])
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
@@ -2757,6 +2775,7 @@ final class Workspace: Identifiable, ObservableObject {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return false }
         guard bonsplitController.allPaneIds.contains(paneId) else { return false }
         guard bonsplitController.moveTab(tabId, toPane: paneId, atIndex: index) else { return false }
+        invalidateSidebarOrderingCache()
 
         if focus {
             bonsplitController.focusPane(paneId)
@@ -2773,6 +2792,7 @@ final class Workspace: Identifiable, ObservableObject {
     func reorderSurface(panelId: UUID, toIndex index: Int) -> Bool {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return false }
         guard bonsplitController.reorderTab(tabId, toIndex: index) else { return false }
+        invalidateSidebarOrderingCache()
 
         if let paneId = paneId(forPanelId: panelId) {
             applyTabSelection(tabId: tabId, inPane: paneId)
@@ -2918,6 +2938,7 @@ final class Workspace: Identifiable, ObservableObject {
         if let index {
             _ = bonsplitController.reorderTab(newTabId, toIndex: index)
         }
+        invalidateSidebarOrderingCache()
         syncPinnedStateForTab(newTabId, panelId: detached.panelId)
         syncUnreadBadgeStateForPanel(detached.panelId)
         normalizePinnedTabs(in: paneId)
@@ -3380,6 +3401,7 @@ final class Workspace: Identifiable, ObservableObject {
             isPinned: false
         ) {
             surfaceIdToPanelId[newTabId] = newPanel.id
+            invalidateSidebarOrderingCache()
         }
 
         return newPanel
@@ -4531,6 +4553,7 @@ extension Workspace: BonsplitDelegate {
 
         panels.removeValue(forKey: panelId)
         surfaceIdToPanelId.removeValue(forKey: tabId)
+        invalidateSidebarOrderingCache()
         panelDirectories.removeValue(forKey: panelId)
         panelGitBranches.removeValue(forKey: panelId)
         panelPullRequests.removeValue(forKey: panelId)
@@ -4620,6 +4643,7 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didMoveTab tab: Bonsplit.Tab, fromPane source: PaneID, toPane destination: PaneID) {
+        invalidateSidebarOrderingCache()
 #if DEBUG
         let now = ProcessInfo.processInfo.systemUptime
         let sincePrev: String
@@ -4726,6 +4750,7 @@ extension Workspace: BonsplitDelegate {
 
             let closedSet = Set(closedPanelIds)
             surfaceIdToPanelId = surfaceIdToPanelId.filter { !closedSet.contains($0.value) }
+            invalidateSidebarOrderingCache()
             recomputeListeningPorts()
 
             if let focusedPane = bonsplitController.focusedPaneId,
@@ -4765,6 +4790,7 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didSplitPane originalPane: PaneID, newPane: PaneID, orientation: SplitOrientation) {
+        invalidateSidebarOrderingCache()
 #if DEBUG
         let panelKindForTab: (TabID) -> String = { tabId in
             guard let panelId = self.panelIdFromSurfaceId(tabId),

--- a/cmuxTests/WorkspacePerformanceTests.swift
+++ b/cmuxTests/WorkspacePerformanceTests.swift
@@ -1,0 +1,288 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class WorkspacePerformanceTests: XCTestCase {
+    private struct BenchmarkConfiguration {
+        let workspaceCount: Int
+        let tabsPerWorkspace: Int
+        let switchPasses: Int
+
+        init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+            workspaceCount = Self.intValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_WORKSPACES"],
+                defaultValue: 60,
+                minimum: 2
+            )
+            tabsPerWorkspace = Self.intValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_TABS_PER_WORKSPACE"],
+                defaultValue: 20,
+                minimum: 1
+            )
+            switchPasses = Self.intValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_SWITCH_PASSES"],
+                defaultValue: 6,
+                minimum: 1
+            )
+        }
+
+        private static func intValue(_ rawValue: String?, defaultValue: Int, minimum: Int) -> Int {
+            guard let rawValue, let parsed = Int(rawValue) else { return defaultValue }
+            return max(minimum, parsed)
+        }
+    }
+
+    private struct BenchmarkStats {
+        let count: Int
+        let meanMs: Double
+        let p50Ms: Double
+        let p95Ms: Double
+        let maxMs: Double
+
+        init(samples: [Double]) {
+            count = samples.count
+            let sorted = samples.sorted()
+            meanMs = sorted.isEmpty ? 0 : sorted.reduce(0, +) / Double(sorted.count)
+            p50Ms = Self.percentile(0.50, in: sorted)
+            p95Ms = Self.percentile(0.95, in: sorted)
+            maxMs = sorted.last ?? 0
+        }
+
+        private static func percentile(_ percentile: Double, in sorted: [Double]) -> Double {
+            guard !sorted.isEmpty else { return 0 }
+            let index = Int((Double(sorted.count - 1) * percentile).rounded())
+            return sorted[max(0, min(index, sorted.count - 1))]
+        }
+
+        var summary: String {
+            String(
+                format: "count=%d mean=%.2fms p50=%.2fms p95=%.2fms max=%.2fms",
+                count,
+                meanMs,
+                p50Ms,
+                p95Ms,
+                maxMs
+            )
+        }
+    }
+
+    private struct WorkspaceBenchmarkResult {
+        let workspaceCount: Int
+        let tabsPerWorkspace: Int
+        let switchIterations: Int
+        let workspaceCreation: BenchmarkStats
+        let bonsplitPopulation: BenchmarkStats
+        let sidebarRefresh: BenchmarkStats
+        let workspaceSwitchEndToEnd: BenchmarkStats
+        let sidebarDigest: Int
+
+        var summary: String {
+            [
+                "workspaceCount=\(workspaceCount)",
+                "tabsPerWorkspace=\(tabsPerWorkspace)",
+                "switchIterations=\(switchIterations)",
+                "workspaceCreation \(workspaceCreation.summary)",
+                "bonsplitPopulation \(bonsplitPopulation.summary)",
+                "sidebarRefresh \(sidebarRefresh.summary)",
+                "workspaceSwitchEndToEnd \(workspaceSwitchEndToEnd.summary)",
+                "sidebarDigest=\(sidebarDigest)",
+            ].joined(separator: "\n")
+        }
+    }
+
+    private func elapsedMs(_ operation: () -> Void) -> Double {
+        let start = DispatchTime.now().uptimeNanoseconds
+        operation()
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        return Double(elapsed) / 1_000_000
+    }
+
+    private func drainMainQueue(file: StaticString = #filePath, line: UInt = #line) {
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+    }
+
+    private func populateWorkspaceSidebarMetadata(_ workspace: Workspace, workspaceIndex: Int) {
+        let orderedPanelIds = workspace.sidebarOrderedPanelIds()
+        for (panelIndex, panelId) in orderedPanelIds.enumerated() {
+            workspace.panelDirectories[panelId] = "/tmp/ws-\(workspaceIndex)/pane-\(panelIndex)"
+            workspace.panelGitBranches[panelId] = SidebarGitBranchState(
+                branch: "branch-\(workspaceIndex % 7)-\(panelIndex % 5)",
+                isDirty: (panelIndex % 3) == 0
+            )
+        }
+    }
+
+    @discardableResult
+    private func materializeSidebarSnapshots(for workspaces: [Workspace]) -> Int {
+        var digest = 0
+        for workspace in workspaces {
+            let orderedPanelIds = workspace.sidebarOrderedPanelIds()
+            digest &+= orderedPanelIds.count
+            digest &+= workspace.sidebarGitBranchesInDisplayOrder(orderedPanelIds: orderedPanelIds).count
+            digest &+= workspace.sidebarBranchDirectoryEntriesInDisplayOrder(orderedPanelIds: orderedPanelIds).count
+        }
+        return digest
+    }
+
+    private func benchmarkWorkspaceCreationAndSwitching(
+        configuration: BenchmarkConfiguration = BenchmarkConfiguration()
+    ) -> WorkspaceBenchmarkResult {
+        let workspaceCount = configuration.workspaceCount
+        let tabsPerWorkspace = configuration.tabsPerWorkspace
+        let switchPasses = configuration.switchPasses
+        XCTAssertGreaterThanOrEqual(workspaceCount, 2)
+        XCTAssertGreaterThanOrEqual(tabsPerWorkspace, 1)
+        XCTAssertGreaterThanOrEqual(switchPasses, 1)
+
+        let defaults = UserDefaults.standard
+        let welcomeShown = defaults.object(forKey: WelcomeSettings.shownKey)
+        defaults.set(true, forKey: WelcomeSettings.shownKey)
+        defer {
+            if let welcomeShown {
+                defaults.set(welcomeShown, forKey: WelcomeSettings.shownKey)
+            } else {
+                defaults.removeObject(forKey: WelcomeSettings.shownKey)
+            }
+        }
+
+        let manager = TabManager()
+        guard let initialWorkspace = manager.selectedWorkspace else {
+            XCTFail("Expected TabManager to create an initial workspace")
+            return WorkspaceBenchmarkResult(
+                workspaceCount: workspaceCount,
+                tabsPerWorkspace: tabsPerWorkspace,
+                switchIterations: 0,
+                workspaceCreation: BenchmarkStats(samples: []),
+                bonsplitPopulation: BenchmarkStats(samples: []),
+                sidebarRefresh: BenchmarkStats(samples: []),
+                workspaceSwitchEndToEnd: BenchmarkStats(samples: []),
+                sidebarDigest: 0
+            )
+        }
+
+        var workspaces: [Workspace] = [initialWorkspace]
+        var creationSamples: [Double] = []
+        creationSamples.reserveCapacity(max(0, workspaceCount - 1))
+        populateWorkspaceSidebarMetadata(initialWorkspace, workspaceIndex: 0)
+
+        for workspaceIndex in 1..<workspaceCount {
+            var createdWorkspace: Workspace?
+            let elapsed = elapsedMs {
+                createdWorkspace = manager.addWorkspace(select: true, autoWelcomeIfNeeded: false)
+                if let createdWorkspace {
+                    populateWorkspaceSidebarMetadata(createdWorkspace, workspaceIndex: workspaceIndex)
+                }
+                drainMainQueue()
+                _ = materializeSidebarSnapshots(for: workspaces + (createdWorkspace.map { [$0] } ?? []))
+            }
+            guard let createdWorkspace else {
+                XCTFail("Expected addWorkspace to return a workspace")
+                continue
+            }
+            workspaces.append(createdWorkspace)
+            creationSamples.append(elapsed)
+        }
+
+        XCTAssertEqual(manager.tabs.count, workspaceCount)
+
+        var bonsplitPopulationSamples: [Double] = []
+        bonsplitPopulationSamples.reserveCapacity(workspaces.count)
+
+        for workspace in workspaces {
+            let elapsed = elapsedMs {
+                for _ in 1..<tabsPerWorkspace {
+                    let createdPanel = workspace.newTerminalSurfaceInFocusedPane(focus: false)
+                    XCTAssertNotNil(createdPanel)
+                }
+            }
+            bonsplitPopulationSamples.append(elapsed)
+        }
+
+        XCTAssertTrue(workspaces.allSatisfy { $0.panels.count == tabsPerWorkspace })
+
+        for (workspaceIndex, workspace) in workspaces.enumerated() {
+            populateWorkspaceSidebarMetadata(workspace, workspaceIndex: workspaceIndex)
+        }
+
+        manager.selectWorkspace(initialWorkspace)
+        drainMainQueue()
+
+        let expectedSwitchIterations = (workspaceCount * switchPasses) - 1
+        var sidebarRefreshSamples: [Double] = []
+        sidebarRefreshSamples.reserveCapacity(max(0, expectedSwitchIterations))
+        var endToEndSwitchSamples: [Double] = []
+        endToEndSwitchSamples.reserveCapacity(max(0, expectedSwitchIterations))
+        var sidebarDigest = materializeSidebarSnapshots(for: workspaces)
+
+        for _ in 0..<switchPasses {
+            for index in 0..<workspaces.count {
+                if index == 0, endToEndSwitchSamples.isEmpty {
+                    continue
+                }
+                let elapsed = elapsedMs {
+                    manager.selectNextTab()
+                    drainMainQueue()
+                    sidebarDigest = materializeSidebarSnapshots(for: workspaces)
+                }
+                endToEndSwitchSamples.append(elapsed)
+
+                let sidebarElapsed = elapsedMs {
+                    sidebarDigest = materializeSidebarSnapshots(for: workspaces)
+                }
+                sidebarRefreshSamples.append(sidebarElapsed)
+            }
+        }
+
+        XCTAssertEqual(endToEndSwitchSamples.count, expectedSwitchIterations)
+        XCTAssertEqual(sidebarRefreshSamples.count, expectedSwitchIterations)
+        XCTAssertGreaterThan(sidebarDigest, 0)
+
+        return WorkspaceBenchmarkResult(
+            workspaceCount: workspaceCount,
+            tabsPerWorkspace: tabsPerWorkspace,
+            switchIterations: endToEndSwitchSamples.count,
+            workspaceCreation: BenchmarkStats(samples: creationSamples),
+            bonsplitPopulation: BenchmarkStats(samples: bonsplitPopulationSamples),
+            sidebarRefresh: BenchmarkStats(samples: sidebarRefreshSamples),
+            workspaceSwitchEndToEnd: BenchmarkStats(samples: endToEndSwitchSamples),
+            sidebarDigest: sidebarDigest
+        )
+    }
+
+    func testWorkspaceCreationAndFastSwitchingBenchmark() {
+        let result = benchmarkWorkspaceCreationAndSwitching()
+        print("WORKSPACE_BENCHMARK\n\(result.summary)")
+
+        XCTContext.runActivity(named: "Workspace benchmark summary") { activity in
+            activity.add(XCTAttachment(string: result.summary))
+        }
+
+        XCTAssertLessThan(
+            result.workspaceCreation.p95Ms,
+            50,
+            "Workspace creation p95 should stay below the interactive lag threshold.\n\(result.summary)"
+        )
+        XCTAssertLessThan(
+            result.bonsplitPopulation.p95Ms,
+            35,
+            "Per-workspace Bonsplit tab population p95 should stay bounded.\n\(result.summary)"
+        )
+        XCTAssertLessThan(
+            result.sidebarRefresh.p95Ms,
+            15,
+            "Sidebar refresh p95 should stay bounded during dense workspace switching.\n\(result.summary)"
+        )
+        XCTAssertLessThan(
+            result.workspaceSwitchEndToEnd.p95Ms,
+            16,
+            "Workspace switching p95 should stay below a frame budget.\n\(result.summary)"
+        )
+    }
+}

--- a/cmuxTests/WorkspacePerformanceTests.swift
+++ b/cmuxTests/WorkspacePerformanceTests.swift
@@ -8,6 +8,37 @@ import XCTest
 
 @MainActor
 final class WorkspacePerformanceTests: XCTestCase {
+    private struct BenchmarkThresholds {
+        let workspaceCreationP95Ms: Double
+        let bonsplitPopulationP95Ms: Double
+        let sidebarRefreshP95Ms: Double
+        let workspaceSwitchP95Ms: Double
+
+        init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+            workspaceCreationP95Ms = Self.doubleValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_MAX_CREATION_P95_MS"],
+                defaultValue: 75
+            )
+            bonsplitPopulationP95Ms = Self.doubleValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_MAX_POPULATION_P95_MS"],
+                defaultValue: 50
+            )
+            sidebarRefreshP95Ms = Self.doubleValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_MAX_SIDEBAR_REFRESH_P95_MS"],
+                defaultValue: 25
+            )
+            workspaceSwitchP95Ms = Self.doubleValue(
+                environment["CMUX_WORKSPACE_BENCHMARK_MAX_SWITCH_P95_MS"],
+                defaultValue: 25
+            )
+        }
+
+        private static func doubleValue(_ rawValue: String?, defaultValue: Double) -> Double {
+            guard let rawValue, let parsed = Double(rawValue) else { return defaultValue }
+            return parsed
+        }
+    }
+
     private struct BenchmarkConfiguration {
         let workspaceCount: Int
         let tabsPerWorkspace: Int
@@ -102,7 +133,7 @@ final class WorkspacePerformanceTests: XCTestCase {
         return Double(elapsed) / 1_000_000
     }
 
-    private func drainMainQueue(file: StaticString = #filePath, line: UInt = #line) {
+    private func drainMainQueue() {
         let drained = expectation(description: "main queue drained")
         DispatchQueue.main.async { drained.fulfill() }
         wait(for: [drained], timeout: 1.0)
@@ -256,8 +287,14 @@ final class WorkspacePerformanceTests: XCTestCase {
         )
     }
 
-    func testWorkspaceCreationAndFastSwitchingBenchmark() {
+    func testWorkspaceCreationAndFastSwitchingBenchmark() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CMUX_RUN_WORKSPACE_BENCHMARK"] == "1",
+            "Set CMUX_RUN_WORKSPACE_BENCHMARK=1 to run the dense workspace benchmark."
+        )
+
         let result = benchmarkWorkspaceCreationAndSwitching()
+        let thresholds = BenchmarkThresholds()
         print("WORKSPACE_BENCHMARK\n\(result.summary)")
 
         XCTContext.runActivity(named: "Workspace benchmark summary") { activity in
@@ -266,22 +303,22 @@ final class WorkspacePerformanceTests: XCTestCase {
 
         XCTAssertLessThan(
             result.workspaceCreation.p95Ms,
-            50,
+            thresholds.workspaceCreationP95Ms,
             "Workspace creation p95 should stay below the interactive lag threshold.\n\(result.summary)"
         )
         XCTAssertLessThan(
             result.bonsplitPopulation.p95Ms,
-            35,
+            thresholds.bonsplitPopulationP95Ms,
             "Per-workspace Bonsplit tab population p95 should stay bounded.\n\(result.summary)"
         )
         XCTAssertLessThan(
             result.sidebarRefresh.p95Ms,
-            15,
+            thresholds.sidebarRefreshP95Ms,
             "Sidebar refresh p95 should stay bounded during dense workspace switching.\n\(result.summary)"
         )
         XCTAssertLessThan(
             result.workspaceSwitchEndToEnd.p95Ms,
-            16,
+            thresholds.workspaceSwitchP95Ms,
             "Workspace switching p95 should stay below a frame budget.\n\(result.summary)"
         )
     }


### PR DESCRIPTION
Summary:
Add a workspace performance benchmark that creates many workspaces, populates each with Bonsplit tabs, materializes sidebar state, and rapidly switches workspaces while recording p50/p95 timings.

The fix caches `sidebarOrderedPanelIds()` in `Workspace` and invalidates that cache on Bonsplit layout mutations so repeated sidebar refreshes stop rebuilding the same ordering on every switch.

Benchmark:
Before: workspace creation p95 87.28ms, Bonsplit population p95 23.82ms, sidebar refresh p95 14.39ms, workspace switch end-to-end p95 22.70ms.
After: workspace creation p95 43.88ms, Bonsplit population p95 25.80ms, sidebar refresh p95 10.52ms, workspace switch end-to-end p95 11.97ms.

Testing:
`xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-workspace-switching-perf -only-testing:cmuxTests/WorkspacePerformanceTests/testWorkspaceCreationAndFastSwitchingBenchmark`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up rapid workspace switching by caching sidebar panel ordering in `Workspace` and invalidating on Bonsplit and pin mutations. Adds a dense-workspace benchmark; p95 switch time drops from 22.70ms to 11.97ms.

- **New Features**
  - Added `WorkspacePerformanceTests` to simulate many workspaces/tabs and measure creation, Bonsplit population, sidebar refresh, and end-to-end switching. p95: creation 87.28→43.88ms, Bonsplit population 23.82→25.80ms, sidebar refresh 14.39→10.52ms, end-to-end switch 22.70→11.97ms.
  - Benchmark is gated by `CMUX_RUN_WORKSPACE_BENCHMARK=1` and supports env-configurable thresholds and scale (`CMUX_WORKSPACE_BENCHMARK_*`).

- **Refactors**
  - Cached `sidebarOrderedPanelIds()` in `Workspace`; centralized `invalidateSidebarOrderingCache()` and call it on create/move/reorder/detach/close/split, pin/unpin, pane moves, and workspace clears.

<sup>Written for commit 8a4f9e583a3012524d817532122502a1eaff6cf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive performance benchmarking tests for workspace creation, population, and switching operations.

* **Refactor**
  * Optimized workspace sidebar panel ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->