### PR TITLE
Fix inactive split pane not rendering terminal output

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4265,6 +4265,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let deltaMs = (now - lastScrollEventTime) * 1000
             Self.focusLog("resignFirstResponder: surface=\(terminalSurface?.id.uuidString ?? "nil") deltaSinceScrollMs=\(String(format: "%.2f", deltaMs))")
             ghostty_surface_set_focus(surface, false)
+
+            // Keep the display link alive for unfocused split panes so they
+            // continue rendering. Mirrors the reassertion in setFocus(_:).
+            if let displayID = window?.screen?.displayID, displayID != 0 {
+                ghostty_surface_set_display_id(surface, displayID)
+            }
         }
         return result
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3076,16 +3076,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         guard let surface = surface else { return }
         ghostty_surface_set_focus(surface, focused)
 
-        // If we focus a surface while it is being rapidly reparented (closing splits, etc),
-        // Ghostty's CVDisplayLink can end up started before the display id is valid, leaving
-        // hasVsync() true but with no callbacks ("stuck-vsync-no-frames"). Reasserting the
-        // display id *after* focusing lets Ghostty restart the display link when needed.
-        if focused {
-            if let view = attachedView,
-               let displayID = (view.window?.screen ?? NSScreen.main)?.displayID,
-               displayID != 0 {
-                ghostty_surface_set_display_id(surface, displayID)
-            }
+        // Reassert the display id on every focus transition (both gain and loss).
+        // Ghostty's CVDisplayLink can end up started before the display id is valid,
+        // leaving hasVsync() true but with no callbacks ("stuck-vsync-no-frames").
+        // For unfocused split panes this keeps the display link running so the
+        // terminal output continues to render while the pane is visible.
+        if let view = attachedView,
+           let displayID = (view.window?.screen ?? NSScreen.main)?.displayID,
+           displayID != 0 {
+            ghostty_surface_set_display_id(surface, displayID)
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4268,7 +4268,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
             // Keep the display link alive for unfocused split panes so they
             // continue rendering. Mirrors the reassertion in setFocus(_:).
-            if let displayID = window?.screen?.displayID, displayID != 0 {
+            if let displayID = (window?.screen ?? NSScreen.main)?.displayID, displayID != 0 {
                 ghostty_surface_set_display_id(surface, displayID)
             }
         }


### PR DESCRIPTION
Fixes #2498

## Summary
- Reassert the display ID on both focus gain and loss transitions in `setFocus(_:)`
- Previously gated behind `if focused`, so unfocused split panes could end up with a stuck CVDisplayLink

## Root cause
When splitting a terminal pane, the unfocused side calls `ghostty_surface_set_focus(surface, false)`. The display-ID reassertion that restarts the CVDisplayLink was only performed on focus gain (`if focused`), leaving unfocused panes with no vsync callbacks and frozen output.

## Test plan
- [x] Split a terminal (Cmd+D) with a running command (`while true; do date; sleep 1; done`)
- [x] Move focus to the other pane
- [x] Confirm the unfocused pane continues rendering output
- [x] Verify no regressions when closing splits rapidly (Cmd+D → Ctrl+D)

Fixes #1205
