### PR TITLE
Fix browser pane refreshes on split and resize churn

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,8 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - name: Select Xcode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate Depot runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
@@ -35,10 +35,13 @@ jobs:
         working-directory: web
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+      - name: Install Bun
+        run: |
+          set -euo pipefail
+          curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.10
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -50,7 +53,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -157,7 +160,7 @@ jobs:
     runs-on: depot-macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2418,14 +2418,10 @@ final class WindowBrowserPortal: NSObject {
         webView.layoutSubtreeIfNeeded()
         if reattachRenderingState {
             webView.browserPortalReattachRenderingState(reason: "\(reason):\(phase)")
-            containerView.displayIfNeeded()
-            webView.displayIfNeeded()
-            (webView.window ?? hostView.window)?.displayIfNeeded()
-        } else {
-            containerView.displayIfNeeded()
-            webView.displayIfNeeded()
-            (webView.window ?? hostView.window)?.displayIfNeeded()
         }
+        containerView.displayIfNeeded()
+        webView.displayIfNeeded()
+        (webView.window ?? hostView.window)?.displayIfNeeded()
 #if DEBUG
         dlog(
             "\(reattachRenderingState ? "browser.portal.refresh" : "browser.portal.invalidate") " +
@@ -2506,9 +2502,9 @@ final class WindowBrowserPortal: NSObject {
             "anchor",
         ]
 
-        static func resolve(refreshReasons: [String]) -> Self {
-            guard !refreshReasons.isEmpty else { return .none }
-            let reasonSet = Set(refreshReasons)
+        static func resolve(reasons: [String]) -> Self {
+            guard !reasons.isEmpty else { return .none }
+            let reasonSet = Set(reasons)
             if !reasonSet.isDisjoint(with: Self.refreshReasons) {
                 return .refresh
             }
@@ -3337,7 +3333,7 @@ final class WindowBrowserPortal: NSObject {
             containerOwnsWebView &&
             hostView.reapplyHostedInspectorDividerIfNeeded(in: containerView, reason: "portal.sync")
         let presentationUpdateKind = HostedWebViewPresentationUpdateKind.resolve(
-            refreshReasons: refreshReasons
+            reasons: refreshReasons
         )
         if !shouldHide, containerOwnsWebView, presentationUpdateKind != .none {
             if presentationUpdateKind == .refresh &&

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -11448,11 +11448,6 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             super.displayIfNeeded()
         }
 
-        override func viewDidUnhide() {
-            reattachRenderingStateCount += 1
-            super.viewDidUnhide()
-        }
-
         @objc(_enterInWindow)
         func cmuxUnitTestEnterInWindow() {
             reattachRenderingStateCount += 1
@@ -12219,21 +12214,33 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.synchronizeWebViewForAnchor(anchor)
         advanceAnimations()
         let initialDisplayCount = webView.displayIfNeededCount
+        let initialReattachCount = webView.reattachRenderingStateCount
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: false, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
         advanceAnimations()
         let hiddenDisplayCount = webView.displayIfNeededCount
+        let hiddenReattachCount = webView.reattachRenderingStateCount
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: true, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
         advanceAnimations()
 
         XCTAssertGreaterThanOrEqual(hiddenDisplayCount, initialDisplayCount)
+        XCTAssertEqual(
+            hiddenReattachCount,
+            initialReattachCount,
+            "Hiding a portal-hosted browser should not itself trigger the WebKit reattach path"
+        )
         XCTAssertGreaterThan(
             webView.displayIfNeededCount,
             hiddenDisplayCount,
             "Revealing an existing portal-hosted browser should refresh WebKit presentation immediately"
+        )
+        XCTAssertGreaterThan(
+            webView.reattachRenderingStateCount,
+            hiddenReattachCount,
+            "Revealing an existing portal-hosted browser should trigger the WebKit reattach path"
         )
     }
 


### PR DESCRIPTION
## Summary
- add regression tests covering portal-hosted browser resize and split-divider churn
- keep geometry-only browser portal updates on a repaint path instead of the WebKit reattach path
- preserve full presentation refreshes for reveal, rebind, and transient-recovery cases

Closes #1223.

## Verification
- built and launched with `./scripts/reload.sh --tag fix-1223-browser-refresh`
- did not run tests locally (repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser pane flicker during split/resize churn by repainting on geometry-only changes and avoiding unnecessary WebKit reattach. Full refresh is preserved for reveal, sync attach, anchor, and transient recovery. Closes #1223.

- **Bug Fixes**
  - Consolidates portal update classification and routes pure frame/bounds/webFrame changes to a repaint path via `invalidateHostedWebViewGeometry`.
  - Controls WebKit reattach with a `reattachRenderingState` flag; skips refresh while the inspector divider is dragged.
  - Preserves refresh for reveal, sync attach, anchor, and transient recovery; tests verify reattach on reveal and repaint-only on anchor and external split resizes.

- **Dependencies**
  - Update `actions/checkout` to v6.0.2 and ensure PR head SHA is checked out in macOS compat CI.
  - Replace `oven-sh/setup-bun` with a pinned `Bun` install script (`bun-v1.3.10`) and set PATH.

<sup>Written for commit 27e598ca5a9d0ebd0a12b2c5b694ee59b384ef89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * WebView updates now distinguish geometry-only vs full refresh, reducing unnecessary reattachments and improving resize performance.

* **Tests**
  * Added tests that verify resize paths repaint without forcing full WebView reattachment.

* **Chores**
  * CI workflow checkout and tool-install steps updated for build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->