### PR TITLE
Fix browser pane reloads on tab switch

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -7,6 +7,7 @@ import WebKit
 private var cmuxWindowBrowserPortalKey: UInt8 = 0
 private var cmuxWindowBrowserPortalCloseObserverKey: UInt8 = 0
 private var cmuxBrowserSearchOverlayPanelIdAssociationKey: UInt8 = 0
+private var cmuxBrowserPortalNeedsRenderingStateReattachKey: UInt8 = 0
 
 #if DEBUG
 private func browserPortalDebugToken(_ view: NSView?) -> String {
@@ -44,7 +45,23 @@ private extension NSResponder {
 }
 
 private extension WKWebView {
+    private var browserPortalNeedsRenderingStateReattach: Bool {
+        get {
+            (objc_getAssociatedObject(self, &cmuxBrowserPortalNeedsRenderingStateReattachKey) as? NSNumber)?
+                .boolValue ?? false
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &cmuxBrowserPortalNeedsRenderingStateReattachKey,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
     func browserPortalNotifyHidden(reason: String) {
+        browserPortalNeedsRenderingStateReattach = true
         let firedSelectors = ["viewDidHide", "_exitInWindow"].filter {
             browserPortalCallVoidIfAvailable($0)
         }
@@ -59,7 +76,9 @@ private extension WKWebView {
     }
 
     func browserPortalReattachRenderingState(reason: String) {
+        guard browserPortalNeedsRenderingStateReattach else { return }
         guard window != nil else { return }
+        browserPortalNeedsRenderingStateReattach = false
 
         let firedSelectors = [
             "viewDidUnhide",
@@ -2918,7 +2937,11 @@ final class WindowBrowserPortal: NSObject {
             containerView.setPaneDropContext(nil)
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
-            if !containerView.isHidden, webView.superview === containerView {
+            // Tab/workspace visibility changes should hide the portal slot without forcing
+            // WebKit through `_exitInWindow`/`_enterInWindow`, which fires visibilitychange
+            // and can trigger page reloads. Reserve the full lifecycle notify for cases
+            // where the visible surface is actually leaving the window/render tree.
+            if entry.visibleInUI, !containerView.isHidden, webView.superview === containerView {
                 webView.browserPortalNotifyHidden(reason: reason)
             }
             containerView.isHidden = true


### PR DESCRIPTION
## Summary
- avoid calling the browser portal hide lifecycle for ordinary tab/workspace visibility hides
- only re-run WebKit rendering state reattach when a prior hide actually invoked the detach selectors
- keep the portal slot hidden on tab switches without firing WebKit visibilitychange reload triggers

Closes #1225.

## Testing
- `./scripts/reload.sh --tag fix-1225-tabs`
- Not run: automated tests (repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops unexpected page reloads when switching tabs/workspaces by skipping full WebKit hide/show lifecycles on visibility-only changes. Fixes #1225.

- **Bug Fixes**
  - Only call the portal hide lifecycle when the pane actually leaves the window/render tree.
  - Add a `browserPortalNeedsRenderingStateReattach` flag to reattach rendering state only if it was previously detached.
  - Keep the portal slot hidden on tab switches without firing `visibilitychange` and reload triggers.

<sup>Written for commit c52bd24e8538b3541686a2e72a03b759411684cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of portal visibility and rendering state management.
  * Reduced unnecessary reloading operations when portals are hidden or removed from view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->