### PR TITLE
Fix stale sidebar preview after workspace reset

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -103,6 +103,15 @@ _cmux_report_tty_once() {
     } >/dev/null 2>&1 & disown
 }
 
+_cmux_clear_sidebar_preview() {
+    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+    [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    {
+        _cmux_send "clear_sidebar_preview --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    } >/dev/null 2>&1 & disown
+}
+
 _cmux_ports_kick() {
     # Lightweight: just tell the app to run a batched scan for this panel.
     # The app coalesces kicks across all panels and runs a single ps+lsof.
@@ -320,6 +329,7 @@ _cmux_prompt_command() {
     fi
 
     _cmux_report_tty_once
+    _cmux_clear_sidebar_preview
 
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -110,6 +110,15 @@ _cmux_report_tty_once() {
     } >/dev/null 2>&1 &!
 }
 
+_cmux_clear_sidebar_preview() {
+    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+    [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    {
+        _cmux_send "clear_sidebar_preview --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    } >/dev/null 2>&1 &!
+}
+
 _cmux_ports_kick() {
     # Lightweight: just tell the app to run a batched scan for this panel.
     # The app coalesces kicks across all panels and runs a single ps+lsof.
@@ -393,6 +402,7 @@ _cmux_precmd() {
     fi
 
     _cmux_report_tty_once
+    _cmux_clear_sidebar_preview
 
     local now=$EPOCHSECONDS
     local pwd="$PWD"

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7182,12 +7182,6 @@ struct VerticalTabsSidebar: View {
                                     isActive: tabManager.selectedTabId == tab.id,
                                     tabCount: tabManager.tabs.count,
                                     unreadCount: notificationStore.unreadCount(forTabId: tab.id),
-                                    latestNotificationText: {
-                                        guard let notification = notificationStore.latestNotification(forTabId: tab.id) else { return nil }
-                                        let text = notification.body.isEmpty ? notification.title : notification.body
-                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        return trimmed.isEmpty ? nil : trimmed
-                                    }(),
                                     rowSpacing: tabRowSpacing,
                                     setSelectionToTabs: { selection = .tabs },
                                     selectedTabIds: $selectedTabIds,
@@ -9448,7 +9442,6 @@ private struct TabItemView: View, Equatable {
         lhs.isActive == rhs.isActive &&
         lhs.tabCount == rhs.tabCount &&
         lhs.unreadCount == rhs.unreadCount &&
-        lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints
     }
@@ -9464,7 +9457,6 @@ private struct TabItemView: View, Equatable {
     let isActive: Bool
     let tabCount: Int
     let unreadCount: Int
-    let latestNotificationText: String?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
     @Binding var selectedTabIds: Set<UUID>
@@ -9592,7 +9584,7 @@ private struct TabItemView: View, Equatable {
         let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
         let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
         let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
-        let latestNotificationSubtitle = latestNotificationText
+        let latestNotificationSubtitle = tab.sidebarPreviewText
         let orderedPanelIds: [UUID]? = (sidebarShowBranchDirectory || sidebarShowPullRequest)
             ? tab.sidebarOrderedPanelIds()
             : nil
@@ -10356,9 +10348,6 @@ private struct TabItemView: View, Equatable {
         selectedTabIds.subtract(orderedWorkspaceIds)
         syncSelectionAfterMutation()
     }
-
-    // latestNotificationText is now passed as a parameter from the parent view
-    // to avoid subscribing to notificationStore changes in every TabItemView.
 
     private func branchDirectoryRow(
         gitSummary: String?,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1459,6 +1459,9 @@ class TerminalController {
         case "report_pwd":
             return reportPwd(args)
 
+        case "clear_sidebar_preview":
+            return clearSidebarPreview(args)
+
         case "sidebar_state":
             return sidebarState(args)
 
@@ -4349,6 +4352,7 @@ class TerminalController {
                 return
             }
 
+            ws.clearSidebarPreviewIfSourceMatches(panelId: surfaceId, reason: "surface.clear_history")
             terminalPanel.surface.forceRefresh(reason: "terminalController.v2SurfaceClearHistory")
             let windowId = v2ResolveWindowId(tabManager: tabManager)
             result = .ok([
@@ -9700,6 +9704,7 @@ class TerminalController {
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
           ports_kick [--tab=X] [--panel=Y] - Request batched port scan for panel
           report_pwd <path> [--tab=X] [--panel=Y] - Report current working directory
+          clear_sidebar_preview [--tab=X] [--panel=Y] - Clear the workspace sidebar preview text
           clear_ports [--tab=X] [--panel=Y] - Clear listening ports
           sidebar_state [--tab=X] - Dump sidebar metadata
           reset_sidebar [--tab=X] - Clear sidebar metadata
@@ -13593,6 +13598,63 @@ class TerminalController {
             }
 
             tabManager.updateSurfaceDirectory(tabId: tab.id, surfaceId: surfaceId, directory: directory)
+        }
+        return result
+    }
+
+    private func clearSidebarPreview(_ args: String) -> String {
+        let parsed = parseOptions(args)
+
+        if let scope = Self.explicitSocketScope(options: parsed.options) {
+            DispatchQueue.main.async {
+                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceId),
+                      let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceId }) else {
+                    return
+                }
+                let validSurfaceIds = Set(tab.panels.keys)
+                tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+                let panelId = validSurfaceIds.contains(scope.panelId) ? scope.panelId : nil
+                tab.clearSidebarPreviewIfSourceMatches(
+                    panelId: panelId,
+                    reason: panelId == nil ? "sidebarPreview.clear.workspace" : "sidebarPreview.clear.surface"
+                )
+            }
+            return "OK"
+        }
+
+        var result = "OK"
+        DispatchQueue.main.sync {
+            guard let tab = resolveTabForReport(args) else {
+                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+                return
+            }
+
+            let validSurfaceIds = Set(tab.panels.keys)
+            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+
+            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
+            guard let panelArg else {
+                tab.clearSidebarPreview(reason: "sidebarPreview.clear.workspace")
+                return
+            }
+
+            if panelArg.isEmpty {
+                result = "ERROR: Missing panel id — usage: clear_sidebar_preview [--tab=X] [--panel=Y]"
+                return
+            }
+            guard let surfaceId = UUID(uuidString: panelArg) else {
+                result = "ERROR: Invalid panel id '\(panelArg)'"
+                return
+            }
+            guard validSurfaceIds.contains(surfaceId) else {
+                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+                return
+            }
+
+            tab.clearSidebarPreviewIfSourceMatches(
+                panelId: surfaceId,
+                reason: "sidebarPreview.clear.surface"
+            )
         }
         return result
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -829,6 +829,19 @@ final class TerminalNotificationStore: ObservableObject {
         return tabManager.tabs.first(where: { $0.id == tabId })
     }
 
+    private func updateSidebarPreviewAfterNotificationMutation(
+        forTabId tabId: UUID,
+        changedNotificationIds: Set<UUID>,
+        reason: String
+    ) {
+        guard !changedNotificationIds.isEmpty else { return }
+        workspace(forTabId: tabId)?.replaceSidebarPreviewIfNotificationMatches(
+            ids: changedNotificationIds,
+            replacement: latestNotification(forTabId: tabId),
+            reason: reason
+        )
+    }
+
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
         var updated = notifications
         var idsToClear: [String] = []
@@ -863,11 +876,13 @@ final class TerminalNotificationStore: ObservableObject {
         )
         updated.insert(notification, at: 0)
         notifications = updated
-        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+        let workspace = workspace(forTabId: tabId)
+        workspace?.replaceSidebarPreviewIfNotificationMatches(
             ids: removedNotificationIds,
+            replacement: notification,
             reason: "notification.replaced"
         )
-        workspace(forTabId: tabId)?.setSidebarPreview(
+        workspace?.setSidebarPreview(
             notificationId: notification.id,
             sourcePanelId: surfaceId,
             title: title,
@@ -886,22 +901,35 @@ final class TerminalNotificationStore: ObservableObject {
         var updated = notifications
         guard let index = updated.firstIndex(where: { $0.id == id }) else { return }
         guard !updated[index].isRead else { return }
+        let tabId = updated[index].tabId
         updated[index].isRead = true
         notifications = updated
+        updateSidebarPreviewAfterNotificationMutation(
+            forTabId: tabId,
+            changedNotificationIds: Set([id]),
+            reason: "notification.markRead"
+        )
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
     }
 
     func markRead(forTabId tabId: UUID) {
         var updated = notifications
         var idsToClear: [String] = []
+        var changedNotificationIds: Set<UUID> = []
         for index in updated.indices {
             if updated[index].tabId == tabId && !updated[index].isRead {
                 updated[index].isRead = true
                 idsToClear.append(updated[index].id.uuidString)
+                changedNotificationIds.insert(updated[index].id)
             }
         }
         if !idsToClear.isEmpty {
             notifications = updated
+            updateSidebarPreviewAfterNotificationMutation(
+                forTabId: tabId,
+                changedNotificationIds: changedNotificationIds,
+                reason: "notification.markRead.workspace"
+            )
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         }
     }
@@ -909,16 +937,23 @@ final class TerminalNotificationStore: ObservableObject {
     func markRead(forTabId tabId: UUID, surfaceId: UUID?) {
         var updated = notifications
         var idsToClear: [String] = []
+        var changedNotificationIds: Set<UUID> = []
         for index in updated.indices {
             if updated[index].tabId == tabId,
                updated[index].surfaceId == surfaceId,
                !updated[index].isRead {
                 updated[index].isRead = true
                 idsToClear.append(updated[index].id.uuidString)
+                changedNotificationIds.insert(updated[index].id)
             }
         }
         if !idsToClear.isEmpty {
             notifications = updated
+            updateSidebarPreviewAfterNotificationMutation(
+                forTabId: tabId,
+                changedNotificationIds: changedNotificationIds,
+                reason: "notification.markRead.surface"
+            )
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
@@ -927,28 +962,44 @@ final class TerminalNotificationStore: ObservableObject {
     func markUnread(forTabId tabId: UUID) {
         var updated = notifications
         var didChange = false
+        var changedNotificationIds: Set<UUID> = []
         for index in updated.indices {
             if updated[index].tabId == tabId, updated[index].isRead {
                 updated[index].isRead = false
                 didChange = true
+                changedNotificationIds.insert(updated[index].id)
             }
         }
         if didChange {
             notifications = updated
+            updateSidebarPreviewAfterNotificationMutation(
+                forTabId: tabId,
+                changedNotificationIds: changedNotificationIds,
+                reason: "notification.markUnread.workspace"
+            )
         }
     }
 
     func markAllRead() {
         var updated = notifications
         var idsToClear: [String] = []
+        var changedNotificationIdsByTabId: [UUID: Set<UUID>] = [:]
         for index in updated.indices {
             if !updated[index].isRead {
                 updated[index].isRead = true
                 idsToClear.append(updated[index].id.uuidString)
+                changedNotificationIdsByTabId[updated[index].tabId, default: []].insert(updated[index].id)
             }
         }
         if !idsToClear.isEmpty {
             notifications = updated
+            for (tabId, changedNotificationIds) in changedNotificationIdsByTabId {
+                updateSidebarPreviewAfterNotificationMutation(
+                    forTabId: tabId,
+                    changedNotificationIds: changedNotificationIds,
+                    reason: "notification.markRead.all"
+                )
+            }
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
@@ -968,8 +1019,9 @@ final class TerminalNotificationStore: ObservableObject {
         guard updated.count != originalCount else { return }
         notifications = updated
         for tabId in affectedTabIds {
-            workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
-                ids: removedIds,
+            updateSidebarPreviewAfterNotificationMutation(
+                forTabId: tabId,
+                changedNotificationIds: removedIds,
                 reason: "notification.removed"
             )
         }
@@ -983,8 +1035,9 @@ final class TerminalNotificationStore: ObservableObject {
         let affectedTabIds = Set(notifications.map(\.tabId))
         notifications.removeAll()
         for tabId in affectedTabIds {
-            workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
-                ids: removedNotificationIds,
+            updateSidebarPreviewAfterNotificationMutation(
+                forTabId: tabId,
+                changedNotificationIds: removedNotificationIds,
                 reason: "notification.clearAll"
             )
         }
@@ -1007,8 +1060,9 @@ final class TerminalNotificationStore: ObservableObject {
         }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
-        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
-            ids: removedNotificationIds,
+        updateSidebarPreviewAfterNotificationMutation(
+            forTabId: tabId,
+            changedNotificationIds: removedNotificationIds,
             reason: "notification.clearSurface"
         )
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1030,8 +1084,9 @@ final class TerminalNotificationStore: ObservableObject {
         }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
-        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
-            ids: removedNotificationIds,
+        updateSidebarPreviewAfterNotificationMutation(
+            forTabId: tabId,
+            changedNotificationIds: removedNotificationIds,
             reason: "notification.clearWorkspace"
         )
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -824,12 +824,19 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.latestUnreadByTabId[tabId] ?? indexes.latestByTabId[tabId]
     }
 
+    private func workspace(forTabId tabId: UUID) -> Workspace? {
+        guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) else { return nil }
+        return tabManager.tabs.first(where: { $0.id == tabId })
+    }
+
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
         var updated = notifications
         var idsToClear: [String] = []
+        var removedNotificationIds: Set<UUID> = []
         updated.removeAll { existing in
             guard existing.tabId == tabId, existing.surfaceId == surfaceId else { return false }
             idsToClear.append(existing.id.uuidString)
+            removedNotificationIds.insert(existing.id)
             return true
         }
 
@@ -856,6 +863,16 @@ final class TerminalNotificationStore: ObservableObject {
         )
         updated.insert(notification, at: 0)
         notifications = updated
+        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+            ids: removedNotificationIds,
+            reason: "notification.replaced"
+        )
+        workspace(forTabId: tabId)?.setSidebarPreview(
+            notificationId: notification.id,
+            sourcePanelId: surfaceId,
+            title: title,
+            body: body
+        )
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
@@ -940,16 +957,37 @@ final class TerminalNotificationStore: ObservableObject {
     func remove(id: UUID) {
         var updated = notifications
         let originalCount = updated.count
+        let removedIds: Set<UUID> = updated
+            .filter { $0.id == id }
+            .map(\.id)
+            .reduce(into: Set<UUID>()) { partialResult, next in
+                partialResult.insert(next)
+            }
+        let affectedTabIds = Set(updated.filter { $0.id == id }.map(\.tabId))
         updated.removeAll { $0.id == id }
         guard updated.count != originalCount else { return }
         notifications = updated
+        for tabId in affectedTabIds {
+            workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+                ids: removedIds,
+                reason: "notification.removed"
+            )
+        }
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
     }
 
     func clearAll() {
         guard !notifications.isEmpty else { return }
         let ids = notifications.map { $0.id.uuidString }
+        let removedNotificationIds = Set(notifications.map(\.id))
+        let affectedTabIds = Set(notifications.map(\.tabId))
         notifications.removeAll()
+        for tabId in affectedTabIds {
+            workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+                ids: removedNotificationIds,
+                reason: "notification.clearAll"
+            )
+        }
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: ids)
     }
@@ -958,15 +996,21 @@ final class TerminalNotificationStore: ObservableObject {
         var updated: [TerminalNotification] = []
         updated.reserveCapacity(notifications.count)
         var idsToClear: [String] = []
+        var removedNotificationIds: Set<UUID> = []
         for notification in notifications {
             if notification.tabId == tabId, notification.surfaceId == surfaceId {
                 idsToClear.append(notification.id.uuidString)
+                removedNotificationIds.insert(notification.id)
             } else {
                 updated.append(notification)
             }
         }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
+        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+            ids: removedNotificationIds,
+            reason: "notification.clearSurface"
+        )
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
     }
@@ -975,15 +1019,21 @@ final class TerminalNotificationStore: ObservableObject {
         var updated: [TerminalNotification] = []
         updated.reserveCapacity(notifications.count)
         var idsToClear: [String] = []
+        var removedNotificationIds: Set<UUID> = []
         for notification in notifications {
             if notification.tabId == tabId {
                 idsToClear.append(notification.id.uuidString)
+                removedNotificationIds.insert(notification.id)
             } else {
                 updated.append(notification)
             }
         }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
+        workspace(forTabId: tabId)?.clearSidebarPreviewIfNotificationMatches(
+            ids: removedNotificationIds,
+            reason: "notification.clearWorkspace"
+        )
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -995,10 +995,13 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
     @Published var pullRequest: SidebarPullRequestState?
     @Published var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
+    @Published private(set) var sidebarPreviewText: String?
     @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
     @Published var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
+    private var sidebarPreviewSourcePanelId: UUID?
+    private var sidebarPreviewNotificationId: UUID?
 
     var focusedSurfaceId: UUID? { focusedPanelId }
     var surfaceDirectories: [UUID: String] {
@@ -1605,10 +1608,72 @@ final class Workspace: Identifiable, ObservableObject {
         return !trimmed.isEmpty
     }
 
+    private static func resolvedSidebarPreviewText(title: String, body: String) -> String? {
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedBody.isEmpty {
+            return trimmedBody
+        }
+
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedTitle.isEmpty ? nil : trimmedTitle
+    }
+
+    func setSidebarPreview(notificationId: UUID, sourcePanelId: UUID?, title: String, body: String) {
+        guard let nextText = Self.resolvedSidebarPreviewText(title: title, body: body) else {
+            clearSidebarPreview(reason: "notification.empty")
+            return
+        }
+
+        sidebarPreviewNotificationId = notificationId
+        sidebarPreviewSourcePanelId = sourcePanelId
+        if sidebarPreviewText != nextText {
+            sidebarPreviewText = nextText
+        }
+    }
+
+    func clearSidebarPreview(reason: String) {
+        guard sidebarPreviewText != nil
+            || sidebarPreviewSourcePanelId != nil
+            || sidebarPreviewNotificationId != nil else {
+            return
+        }
+
+#if DEBUG
+        dlog(
+            "workspace.sidebarPreview.clear workspace=\(id.uuidString.prefix(5)) " +
+            "reason=\(reason) sourcePanel=\(sidebarPreviewSourcePanelId?.uuidString.prefix(5) ?? "nil")"
+        )
+#endif
+
+        sidebarPreviewText = nil
+        sidebarPreviewSourcePanelId = nil
+        sidebarPreviewNotificationId = nil
+    }
+
+    func clearSidebarPreviewIfSourceMatches(panelId: UUID?, reason: String) {
+        guard let sourcePanelId = sidebarPreviewSourcePanelId else {
+            clearSidebarPreview(reason: reason)
+            return
+        }
+        guard panelId == nil || sourcePanelId == panelId else { return }
+        clearSidebarPreview(reason: reason)
+    }
+
+    func clearSidebarPreviewIfNotificationMatches(ids: Set<UUID>, reason: String) {
+        guard let notificationId = sidebarPreviewNotificationId, ids.contains(notificationId) else {
+            return
+        }
+        clearSidebarPreview(reason: reason)
+    }
+
     func applyProcessTitle(_ title: String) {
+        let previousTitle = self.title
         processTitle = title
         guard customTitle == nil else { return }
         self.title = title
+        if previousTitle != self.title {
+            clearSidebarPreview(reason: "workspace.processTitle")
+        }
     }
 
     func setCustomColor(_ hex: String?) {
@@ -1620,6 +1685,8 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func setCustomTitle(_ title: String?) {
+        let previousCustomTitle = customTitle
+        let previousTitle = self.title
         let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {
             customTitle = nil
@@ -1627,6 +1694,9 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customTitle = trimmed
             self.title = trimmed
+        }
+        if previousCustomTitle != customTitle || previousTitle != self.title {
+            clearSidebarPreview(reason: "workspace.rename")
         }
     }
 
@@ -1649,6 +1719,7 @@ final class Workspace: Identifiable, ObservableObject {
         let existing = panelGitBranches[panelId]
         if existing?.branch != branch || existing?.isDirty != isDirty {
             panelGitBranches[panelId] = state
+            clearSidebarPreviewIfSourceMatches(panelId: panelId, reason: "gitBranch.changed")
         }
         if panelId == focusedPanelId {
             gitBranch = state
@@ -1656,7 +1727,10 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func clearPanelGitBranch(panelId: UUID) {
-        panelGitBranches.removeValue(forKey: panelId)
+        let removed = panelGitBranches.removeValue(forKey: panelId)
+        if removed != nil {
+            clearSidebarPreviewIfSourceMatches(panelId: panelId, reason: "gitBranch.cleared")
+        }
         if panelId == focusedPanelId {
             gitBranch = nil
         }
@@ -1697,6 +1771,7 @@ final class Workspace: Identifiable, ObservableObject {
         surfaceListeningPorts.removeAll()
         listeningPorts.removeAll()
         metadataBlocks.removeAll()
+        clearSidebarPreview(reason: "sidebarContext.\(reason)")
         resetBrowserPanelsForContextChange(reason: reason)
     }
 
@@ -1766,6 +1841,7 @@ final class Workspace: Identifiable, ObservableObject {
             if self.title != trimmed {
                 self.title = trimmed
                 didMutate = true
+                clearSidebarPreview(reason: "workspace.titleChanged")
             }
             if processTitle != trimmed {
                 processTitle = trimmed
@@ -1786,6 +1862,10 @@ final class Workspace: Identifiable, ObservableObject {
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
         surfaceTTYNames = surfaceTTYNames.filter { validSurfaceIds.contains($0.key) }
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
+        if let sourcePanelId = sidebarPreviewSourcePanelId,
+           !validSurfaceIds.contains(sourcePanelId) {
+            clearSidebarPreview(reason: "surface.pruned")
+        }
         recomputeListeningPorts()
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1666,6 +1666,26 @@ final class Workspace: Identifiable, ObservableObject {
         clearSidebarPreview(reason: reason)
     }
 
+    func replaceSidebarPreviewIfNotificationMatches(
+        ids: Set<UUID>,
+        replacement: TerminalNotification?,
+        reason: String
+    ) {
+        guard let notificationId = sidebarPreviewNotificationId, ids.contains(notificationId) else {
+            return
+        }
+        guard let replacement else {
+            clearSidebarPreview(reason: reason)
+            return
+        }
+        setSidebarPreview(
+            notificationId: replacement.id,
+            sourcePanelId: replacement.surfaceId,
+            title: replacement.title,
+            body: replacement.body
+        )
+    }
+
     func applyProcessTitle(_ title: String) {
         let previousTitle = self.title
         processTitle = title

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -8211,6 +8211,125 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
     }
 }
 
+@MainActor
+final class SidebarPreviewNotificationSyncTests: XCTestCase {
+    func testRemovingCurrentPreviewFallsBackToPreviousNotification() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let secondPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal) else {
+            XCTFail("Expected workspace with two terminal panels")
+            return
+        }
+
+        store.addNotification(
+            tabId: workspace.id,
+            surfaceId: firstPanelId,
+            title: "Older title",
+            subtitle: "",
+            body: "Older body"
+        )
+        store.addNotification(
+            tabId: workspace.id,
+            surfaceId: secondPanel.id,
+            title: "Newest title",
+            subtitle: "",
+            body: "Newest body"
+        )
+
+        XCTAssertEqual(workspace.sidebarPreviewText, "Newest body")
+
+        guard let newestNotificationId = store.notifications.first(where: { $0.surfaceId == secondPanel.id })?.id else {
+            XCTFail("Expected latest notification for second panel")
+            return
+        }
+
+        store.remove(id: newestNotificationId)
+
+        XCTAssertEqual(
+            workspace.sidebarPreviewText,
+            "Older body",
+            "Expected preview to fall back to the latest remaining workspace notification"
+        )
+    }
+
+    func testMarkingCurrentPreviewReadFallsBackToLatestUnreadNotification() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let secondPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal) else {
+            XCTFail("Expected workspace with two terminal panels")
+            return
+        }
+
+        store.addNotification(
+            tabId: workspace.id,
+            surfaceId: firstPanelId,
+            title: "Older title",
+            subtitle: "",
+            body: "Older unread body"
+        )
+        store.addNotification(
+            tabId: workspace.id,
+            surfaceId: secondPanel.id,
+            title: "Newest title",
+            subtitle: "",
+            body: "Newest unread body"
+        )
+
+        XCTAssertEqual(workspace.sidebarPreviewText, "Newest unread body")
+
+        guard let newestNotificationId = store.notifications.first(where: { $0.surfaceId == secondPanel.id })?.id else {
+            XCTFail("Expected latest notification for second panel")
+            return
+        }
+
+        store.markRead(id: newestNotificationId)
+
+        XCTAssertEqual(
+            workspace.sidebarPreviewText,
+            "Older unread body",
+            "Expected preview to switch to the latest unread notification after marking the current preview read"
+        )
+    }
+}
+
 
 final class MenuBarBadgeLabelFormatterTests: XCTestCase {
     func testBadgeLabelFormatting() {


### PR DESCRIPTION
Fixes #1232.

## Summary
- move the sidebar subtitle preview into workspace-owned ephemeral state instead of deriving it from the latest notification history entry
- clear the preview when workspace titles change, branch state changes, panels disappear, or sidebar context resets
- clear the preview when terminal history is cleared and when the shell returns to a prompt via shell integration hooks

## Verification
- ./scripts/reload.sh --tag fix-sidebar-preview-reset

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale sidebar preview by moving it into workspace state and keeping it in sync with workspace, terminal, and notification events. Prevents old subtitles from sticking after resets, panel changes, or notification updates.

- **Bug Fixes**
  - Store preview per workspace as `tab.sidebarPreviewText` and render it in the sidebar (no longer derived from the notification list).
  - Clear on workspace title/process changes, sidebar context resets, panel removal, git branch updates, terminal history clear, and at shell prompt via `clear_sidebar_preview` (wired into bash/zsh).
  - Sync with notifications: set from new notifications; when the current one is read/removed/cleared, fall back to the latest relevant (workspace or unread) notification or clear if none. Added regression tests for fallback.

<sup>Written for commit 66e64898833dc3757773ce8cc8f357fe706c6f43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar preview now dynamically shows notification and tab-derived text.
  * Shell integration clears the sidebar preview at prompt time.
  * New terminal command to clear the sidebar preview manually.

* **Bug Fixes**
  * Sidebar preview now stays in sync with notification, tab, and panel changes.

* **Tests**
  * Added tests verifying preview fallback behavior when previews are removed or marked read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->