### PR TITLE
Fix memory leak in GhosttySurfaceScrollView deinit

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5648,8 +5648,12 @@ final class GhosttySurfaceScrollView: NSView {
     private var lastDropZoneOverlayLogSignature: String?
     private var lastDragGeometryLogSignature: String?
     private var dragLayoutLogSequence: UInt64 = 0
+    /// Surface UUID captured at init time so deinit cleanup is unconditional
+    /// (the weak `terminalSurface` ref may already be nil by then).
+    private let debugStoredSurfaceId: UUID?
     private static let tabTransferPasteboardType = NSPasteboard.PasteboardType("com.splittabbar.tabtransfer")
     private static let sidebarTabReorderPasteboardType = NSPasteboard.PasteboardType("com.cmux.sidebar-tab-reorder")
+    private static var debugDictLock = os_unfair_lock()
     private static var flashCounts: [UUID: Int] = [:]
     private static var drawCounts: [UUID: Int] = [:]
     private static var lastDrawTimes: [UUID: CFTimeInterval] = [:]
@@ -5659,27 +5663,39 @@ final class GhosttySurfaceScrollView: NSView {
     private static var lastContentsKeys: [UUID: String] = [:]
 
     static func flashCount(for surfaceId: UUID) -> Int {
-        flashCounts[surfaceId, default: 0]
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
+        return flashCounts[surfaceId, default: 0]
     }
 
     static func resetFlashCounts() {
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         flashCounts.removeAll()
     }
 
     private static func recordFlash(for surfaceId: UUID) {
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         flashCounts[surfaceId, default: 0] += 1
     }
 
     static func drawStats(for surfaceId: UUID) -> (count: Int, last: CFTimeInterval) {
-        (drawCounts[surfaceId, default: 0], lastDrawTimes[surfaceId, default: 0])
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
+        return (drawCounts[surfaceId, default: 0], lastDrawTimes[surfaceId, default: 0])
     }
 
     static func resetDrawStats() {
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         drawCounts.removeAll()
         lastDrawTimes.removeAll()
     }
 
     static func recordSurfaceDraw(_ surfaceId: UUID) {
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         drawCounts[surfaceId, default: 0] += 1
         lastDrawTimes[surfaceId] = CACurrentMediaTime()
     }
@@ -5711,6 +5727,8 @@ final class GhosttySurfaceScrollView: NSView {
 
     private static func updatePresentStats(surfaceId: UUID, layer: CALayer?) -> (count: Int, last: CFTimeInterval, key: String) {
         let key = contentsKey(for: layer)
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         if lastContentsKeys[surfaceId] != key {
             presentCounts[surfaceId, default: 0] += 1
             lastPresentTimes[surfaceId] = CACurrentMediaTime()
@@ -5721,12 +5739,16 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func recordDropOverlayShowAnimation() {
         guard let surfaceId = surfaceView.terminalSurface?.id else { return }
+        os_unfair_lock_lock(&Self.debugDictLock)
+        defer { os_unfair_lock_unlock(&Self.debugDictLock) }
         Self.dropOverlayShowCounts[surfaceId, default: 0] += 1
     }
 
     /// Remove all debug counters associated with a specific surface to prevent
     /// unbounded growth of the static dictionaries over long-running sessions.
     static func removeDebugCounters(for surfaceId: UUID) {
+        os_unfair_lock_lock(&debugDictLock)
+        defer { os_unfair_lock_unlock(&debugDictLock) }
         flashCounts.removeValue(forKey: surfaceId)
         drawCounts.removeValue(forKey: surfaceId)
         lastDrawTimes.removeValue(forKey: surfaceId)
@@ -5741,7 +5763,11 @@ final class GhosttySurfaceScrollView: NSView {
             return (0, 0, bounds.size)
         }
 
-        let before = Self.dropOverlayShowCounts[surfaceId, default: 0]
+        let before: Int = {
+            os_unfair_lock_lock(&Self.debugDictLock)
+            defer { os_unfair_lock_unlock(&Self.debugDictLock) }
+            return Self.dropOverlayShowCounts[surfaceId, default: 0]
+        }()
 
         // Reset to a hidden baseline so each probe exercises an initial-show transition.
         dropZoneOverlayAnimationGeneration &+= 1
@@ -5758,7 +5784,11 @@ final class GhosttySurfaceScrollView: NSView {
             setDropZoneOverlay(zone: .left)
         }
 
-        let after = Self.dropOverlayShowCounts[surfaceId, default: 0]
+        let after: Int = {
+            os_unfair_lock_lock(&Self.debugDictLock)
+            defer { os_unfair_lock_unlock(&Self.debugDictLock) }
+            return Self.dropOverlayShowCounts[surfaceId, default: 0]
+        }()
         setDropZoneOverlay(zone: nil)
         return (before, after, bounds.size)
     }
@@ -5796,6 +5826,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     init(surfaceView: GhosttyNSView) {
         self.surfaceView = surfaceView
+#if DEBUG
+        self.debugStoredSurfaceId = surfaceView.terminalSurface?.id
+#endif
         backgroundView = NSView(frame: .zero)
         scrollView = GhosttyScrollView()
         inactiveOverlayView = GhosttyFlashOverlayView(frame: .zero)
@@ -6008,7 +6041,7 @@ final class GhosttySurfaceScrollView: NSView {
 
     deinit {
 #if DEBUG
-        let surfaceId = debugSurfaceId
+        let surfaceId = debugStoredSurfaceId
         dlog(
             "surface.hosted.deinit surface=\(surfaceId?.uuidString.prefix(5) ?? "nil") " +
             "inWindow=\(window != nil ? 1 : 0) hasSuperview=\(superview != nil ? 1 : 0) " +

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2414,7 +2414,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // intermediate frame on the first real resize.
         let view = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
         self.surfaceView = view
-        self.hostedView = GhosttySurfaceScrollView(surfaceView: view)
+        self.hostedView = GhosttySurfaceScrollView(surfaceView: view, surfaceId: id)
         // Surface is created when attached to a view
         hostedView.attachSurface(self)
     }
@@ -5824,10 +5824,10 @@ final class GhosttySurfaceScrollView: NSView {
         )
     }
 
-    init(surfaceView: GhosttyNSView) {
+    init(surfaceView: GhosttyNSView, surfaceId: UUID) {
         self.surfaceView = surfaceView
 #if DEBUG
-        self.debugStoredSurfaceId = surfaceView.terminalSurface?.id
+        self.debugStoredSurfaceId = surfaceId
 #endif
         backgroundView = NSView(frame: .zero)
         scrollView = GhosttyScrollView()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5724,6 +5724,18 @@ final class GhosttySurfaceScrollView: NSView {
         Self.dropOverlayShowCounts[surfaceId, default: 0] += 1
     }
 
+    /// Remove all debug counters associated with a specific surface to prevent
+    /// unbounded growth of the static dictionaries over long-running sessions.
+    static func removeDebugCounters(for surfaceId: UUID) {
+        flashCounts.removeValue(forKey: surfaceId)
+        drawCounts.removeValue(forKey: surfaceId)
+        lastDrawTimes.removeValue(forKey: surfaceId)
+        presentCounts.removeValue(forKey: surfaceId)
+        dropOverlayShowCounts.removeValue(forKey: surfaceId)
+        lastPresentTimes.removeValue(forKey: surfaceId)
+        lastContentsKeys.removeValue(forKey: surfaceId)
+    }
+
     func debugProbeDropOverlayAnimation(useDeferredPath: Bool) -> (before: Int, after: Int, bounds: CGSize) {
         guard let surfaceId = surfaceView.terminalSurface?.id else {
             return (0, 0, bounds.size)
@@ -5996,12 +6008,25 @@ final class GhosttySurfaceScrollView: NSView {
 
     deinit {
 #if DEBUG
+        let surfaceId = debugSurfaceId
         dlog(
-            "surface.hosted.deinit surface=\(debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
+            "surface.hosted.deinit surface=\(surfaceId?.uuidString.prefix(5) ?? "nil") " +
             "inWindow=\(window != nil ? 1 : 0) hasSuperview=\(superview != nil ? 1 : 0) " +
             "hidden=\(isHidden ? 1 : 0) frame=\(String(format: "%.1fx%.1f", frame.width, frame.height))"
         )
+        if let surfaceId {
+            Self.removeDebugCounters(for: surfaceId)
+        }
 #endif
+        // Clean up CA animations to release layer backing stores promptly.
+        flashLayer.removeAllAnimations()
+        dropZoneOverlayView.layer?.removeAllAnimations()
+
+        // Detach the search overlay's SwiftUI hosting view so the view hierarchy
+        // is released synchronously rather than waiting for the next layout pass.
+        searchOverlayHostingView?.removeFromSuperview()
+        searchOverlayHostingView = nil
+
         observers.forEach { NotificationCenter.default.removeObserver($0) }
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         dropZoneOverlayView.removeFromSuperview()


### PR DESCRIPTION
## Summary

- Static debug dictionaries (`flashCounts`, `drawCounts`, `lastDrawTimes`, `presentCounts`, `dropOverlayShowCounts`, `lastPresentTimes`, `lastContentsKeys`) in `GhosttySurfaceScrollView` accumulate UUID-keyed entries that are never removed when surfaces deallocate, causing unbounded memory growth over long sessions
- Add `removeDebugCounters(for:)` and call it in `deinit` to clean up all 7 static dictionaries per surface
- Remove CA animations on `flashLayer` and `dropZoneOverlayView` in `deinit` to release layer backing stores promptly
- Detach `searchOverlayHostingView` in `deinit` so the SwiftUI hosting view hierarchy is freed synchronously

## Context

After 26+ hours of use, cmux NIGHTLY memory grows to ~1GB. `sample` output showed:
- Physical footprint: 990MB (peak 1.2GB)
- 5 renderer thread sets accumulated
- `CA::Layer::collect_animations_` recursing 10+ levels deep

The static `[UUID: ...]` dictionaries add entries every time a surface is created but never remove them on deallocation, which is the most direct contributor to memory growth in debug/nightly builds.

## Test plan

- [x] Verify existing `CmuxWebViewKeyEquivalentTests` pass (they use `resetFlashCounts()` and `flashCount(for:)` which are unchanged)
- [x] Open multiple tabs, close them, and verify `removeDebugCounters` is called in deinit logs
- [x] Monitor memory over extended sessions to confirm growth is reduced