### PR TITLE
security: exec notification command directly without shell

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -493,10 +493,13 @@ enum NotificationSoundSettings {
 
     /// Split a shell-like command string into tokens without invoking a shell.
     /// Handles single-quoted, double-quoted, and backslash-escaped sequences.
-    /// Returns nil if the string is empty or contains only whitespace.
+    /// Empty quoted arguments (e.g. `""`) are preserved as empty strings.
+    /// Returns nil if the string is empty, contains only whitespace, or has
+    /// an unterminated quote.
     static func splitCommandTokens(_ command: String) -> [String]? {
         var tokens: [String] = []
         var current = ""
+        var tokenStarted = false  // true once we've entered a quote or seen a non-space char
         var inSingleQuote = false
         var inDoubleQuote = false
         var i = command.startIndex
@@ -515,21 +518,24 @@ enum NotificationSoundSettings {
                     }
                 } else { current.append(c) }
             } else {
-                if c == "'" { inSingleQuote = true }
-                else if c == "\"" { inDoubleQuote = true }
+                if c == "'" { inSingleQuote = true; tokenStarted = true }
+                else if c == "\"" { inDoubleQuote = true; tokenStarted = true }
                 else if c == "\\" {
                     let next = command.index(after: i)
                     if next < command.endIndex {
                         i = next
                         current.append(command[i])
+                        tokenStarted = true
                     }
                 } else if c.isWhitespace {
-                    if !current.isEmpty { tokens.append(current); current = "" }
-                } else { current.append(c) }
+                    if tokenStarted { tokens.append(current); current = ""; tokenStarted = false }
+                } else { current.append(c); tokenStarted = true }
             }
             i = command.index(after: i)
         }
-        if !current.isEmpty { tokens.append(current) }
+        // Unterminated quote is a parse error — bail out rather than silently accepting
+        if inSingleQuote || inDoubleQuote { return nil }
+        if tokenStarted { tokens.append(current) }
         return tokens.isEmpty ? nil : tokens
     }
 
@@ -542,8 +548,18 @@ enum NotificationSoundSettings {
             let process = Process()
             // Execute the binary directly instead of via /bin/sh -c to prevent
             // shell injection from a tampered UserDefaults entry.
-            process.executableURL = URL(fileURLWithPath: tokens[0])
-            process.arguments = Array(tokens.dropFirst())
+            // Expand leading ~ before treating the path as absolute.
+            let rawExe = tokens[0]
+            let expandedExe = (rawExe as NSString).expandingTildeInPath
+            if expandedExe.hasPrefix("/") || expandedExe.hasPrefix(".") {
+                // Absolute or explicitly relative path — invoke directly.
+                process.executableURL = URL(fileURLWithPath: expandedExe)
+                process.arguments = Array(tokens.dropFirst())
+            } else {
+                // Bare name (e.g. "say") — delegate PATH resolution to /usr/bin/env.
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process.arguments = tokens
+            }
             var env = ProcessInfo.processInfo.environment
             env["CMUX_NOTIFICATION_TITLE"] = title
             env["CMUX_NOTIFICATION_SUBTITLE"] = subtitle

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -491,14 +491,59 @@ enum NotificationSoundSettings {
         qos: .utility
     )
 
+    /// Split a shell-like command string into tokens without invoking a shell.
+    /// Handles single-quoted, double-quoted, and backslash-escaped sequences.
+    /// Returns nil if the string is empty or contains only whitespace.
+    static func splitCommandTokens(_ command: String) -> [String]? {
+        var tokens: [String] = []
+        var current = ""
+        var inSingleQuote = false
+        var inDoubleQuote = false
+        var i = command.startIndex
+        while i < command.endIndex {
+            let c = command[i]
+            if inSingleQuote {
+                if c == "'" { inSingleQuote = false }
+                else { current.append(c) }
+            } else if inDoubleQuote {
+                if c == "\"" { inDoubleQuote = false }
+                else if c == "\\" {
+                    let next = command.index(after: i)
+                    if next < command.endIndex {
+                        i = next
+                        current.append(command[i])
+                    }
+                } else { current.append(c) }
+            } else {
+                if c == "'" { inSingleQuote = true }
+                else if c == "\"" { inDoubleQuote = true }
+                else if c == "\\" {
+                    let next = command.index(after: i)
+                    if next < command.endIndex {
+                        i = next
+                        current.append(command[i])
+                    }
+                } else if c.isWhitespace {
+                    if !current.isEmpty { tokens.append(current); current = "" }
+                } else { current.append(c) }
+            }
+            i = command.index(after: i)
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens.isEmpty ? nil : tokens
+    }
+
     static func runCustomCommand(title: String, subtitle: String, body: String, defaults: UserDefaults = .standard) {
         let command = (defaults.string(forKey: customCommandKey) ?? defaultCustomCommand)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !command.isEmpty else { return }
+        guard let tokens = splitCommandTokens(command), !tokens.isEmpty else { return }
         customCommandQueue.async {
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/sh")
-            process.arguments = ["-c", command]
+            // Execute the binary directly instead of via /bin/sh -c to prevent
+            // shell injection from a tampered UserDefaults entry.
+            process.executableURL = URL(fileURLWithPath: tokens[0])
+            process.arguments = Array(tokens.dropFirst())
             var env = ProcessInfo.processInfo.environment
             env["CMUX_NOTIFICATION_TITLE"] = title
             env["CMUX_NOTIFICATION_SUBTITLE"] = subtitle


### PR DESCRIPTION
## Summary
- **Issue:** `TerminalNotificationStore.runCustomCommand` passed the user-configured notification command directly to `/bin/sh -c`, meaning a tampered `UserDefaults` entry could execute arbitrary shell expressions (pipes, subshells, redirects, etc.)
- **Fix:** Added `splitCommandTokens()` to parse the command string into an executable path + argument array (handles single/double quotes and backslash escapes), then `Process` execs the binary directly — no shell involved
- **Trade-off:** Shell features (pipes, `&&`, env var expansion) in the notification command string will no longer work; users must point to a script file that does those things instead

## Test plan
- [ ] Configure a notification custom command to a script path and verify it still fires on notification
- [ ] Verify a command with quoted arguments (e.g. `/usr/bin/say "hello world"`) works correctly
- [ ] Verify a command containing shell metacharacters (e.g. `; rm -rf ~`) does NOT execute the injected part

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Executes the notification command directly (no `/bin/sh -c`) to block shell injection. Adds safer tokenization and path lookup (tilde and PATH) for predictable exec.

- **Bug Fixes**
  - Replace shell with direct `Process` exec using parsed tokens; expands `~` and resolves bare names via `/usr/bin/env`.
  - Improve tokenizer: supports single/double quotes and backslashes; preserves empty quoted args; rejects unterminated quotes.

- **Migration**
  - Shell features (pipes, `&&`, redirects, env expansion) in the string no longer work.
  - If you relied on those, move them into a script and set the command to that script path.

<sup>Written for commit 8a0cef00d62300aa3e9bed3684037bd86f6c6563. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for custom notification commands by preventing potential shell injection vulnerabilities. Commands now execute directly without invoking a shell, improving safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->