### PR TITLE
security: store socket password in Keychain instead of plaintext file

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -62240,6 +62240,40 @@
         }
       }
     },
+    "socketControl.error.keychainDelete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to remove socket password from Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychain からソケットパスワードを削除できませんでした。"
+          }
+        }
+      }
+    },
+    "socketControl.error.keychainSave": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to save socket password to Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychain にソケットパスワードを保存できませんでした。"
+          }
+        }
+      }
+    },
     "socketControl.error.passwordFilePath": {
       "extractionState": "manual",
       "localizations": {
@@ -62585,13 +62619,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Require socket authentication with a password stored in a local file."
+            "value": "Require socket authentication with a password stored in Keychain."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ローカルファイルに保存されたパスワードでソケット認証を要求します。"
+            "value": "Keychain に保存されたパスワードでソケット認証を要求します。"
           }
         },
         "zh-Hans": {

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -39,7 +39,7 @@ enum SocketControlMode: String, CaseIterable, Identifiable {
         case .automation:
             return String(localized: "socketControl.automation.description", defaultValue: "Allow external local automation clients from this macOS user (no ancestry check).")
         case .password:
-            return String(localized: "socketControl.password.description", defaultValue: "Require socket authentication with a password stored in a local file.")
+            return String(localized: "socketControl.password.description", defaultValue: "Require socket authentication with a password stored in Keychain.")
         case .allowAll:
             return String(localized: "socketControl.allowAll.description", defaultValue: "Allow any local process and user to connect with no auth. Unsafe.")
         }
@@ -184,13 +184,16 @@ enum SocketControlPasswordStore {
         }
 
         // One-time migration: move old plaintext file into Keychain.
+        // Only delete the file if the Keychain save succeeds so a failed save
+        // retries on the next launch rather than losing the credential.
         if let oldFileURL = defaultPasswordFileURL(),
            FileManager.default.fileExists(atPath: oldFileURL.path),
            let data = try? Data(contentsOf: oldFileURL),
            let filePassword = String(data: data, encoding: .utf8),
            let migrated = normalized(filePassword) {
-            try? savePasswordToKeychain(migrated)
-            try? FileManager.default.removeItem(at: oldFileURL)
+            if (try? savePasswordToKeychain(migrated)) != nil {
+                try? FileManager.default.removeItem(at: oldFileURL)
+            }
             return migrated
         }
 
@@ -245,7 +248,7 @@ enum SocketControlPasswordStore {
         }
 
         // Production: Keychain.
-        deletePasswordFromKeychain()
+        try deletePasswordFromKeychain()
 
         if let oldFileURL = defaultPasswordFileURL(),
            FileManager.default.fileExists(atPath: oldFileURL.path) {
@@ -326,8 +329,7 @@ enum SocketControlPasswordStore {
 #endif
     }
 
-    @discardableResult
-    private static func deletePasswordFromKeychain() -> Bool {
+    private static func deletePasswordFromKeychain() throws {
 #if canImport(Security)
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -335,9 +337,13 @@ enum SocketControlPasswordStore {
             kSecAttrAccount: keychainAccount,
         ]
         let status = SecItemDelete(query as CFDictionary)
-        return status == errSecSuccess || status == errSecItemNotFound
-#else
-        return false
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw NSError(
+                domain: NSOSStatusErrorDomain,
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: String(localized: "socketControl.error.keychainDelete", defaultValue: "Unable to remove socket password from Keychain.")]
+            )
+        }
 #endif
     }
 

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -66,6 +66,9 @@ enum SocketControlPasswordStore {
     private static let keychainMigrationVersion = 1
     private static let legacyKeychainService = "com.cmuxterm.app.socket-control"
     private static let legacyKeychainAccount = "local-socket-password"
+    // Primary Keychain storage (replaces plaintext file).
+    private static let keychainService = "com.cmuxterm.app.socket-control"
+    private static let keychainAccount = "socket-password"
     private struct LazyKeychainFallbackCache {
         var hasLoaded = false
         var password: String?
@@ -158,20 +161,44 @@ enum SocketControlPasswordStore {
         }
     }
 
+    /// Load the socket password.
+    ///
+    /// When `fileURL` is non-nil (test seam), reads from that file directly.
+    /// In production (`fileURL == nil`) the password is read from Keychain.
+    /// If no Keychain entry exists but an old plaintext file is present, the
+    /// file is migrated into Keychain and then deleted.
     static func loadPassword(fileURL: URL? = nil) throws -> String? {
-        guard let fileURL = fileURL ?? defaultPasswordFileURL() else {
-            return nil
+        if let fileURL {
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+            let data = try Data(contentsOf: fileURL)
+            guard let password = String(data: data, encoding: .utf8) else { return nil }
+            return normalized(password)
         }
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return nil
+
+        // Production: Keychain is the primary store.
+        if let keychainPassword = loadPasswordFromKeychain() {
+            return normalized(keychainPassword)
         }
-        let data = try Data(contentsOf: fileURL)
-        guard let password = String(data: data, encoding: .utf8) else {
-            return nil
+
+        // One-time migration: move old plaintext file into Keychain.
+        if let oldFileURL = defaultPasswordFileURL(),
+           FileManager.default.fileExists(atPath: oldFileURL.path),
+           let data = try? Data(contentsOf: oldFileURL),
+           let filePassword = String(data: data, encoding: .utf8),
+           let migrated = normalized(filePassword) {
+            try? savePasswordToKeychain(migrated)
+            try? FileManager.default.removeItem(at: oldFileURL)
+            return migrated
         }
-        return normalized(password)
+
+        return nil
     }
 
+    /// Save the socket password.
+    ///
+    /// When `fileURL` is non-nil (test seam), writes to that file.
+    /// In production (`fileURL == nil`) the password is stored in Keychain and
+    /// any leftover plaintext file is removed.
     static func savePassword(_ password: String, fileURL: URL? = nil) throws {
         let normalized = password.trimmingCharacters(in: .newlines)
         if normalized.isEmpty {
@@ -179,32 +206,48 @@ enum SocketControlPasswordStore {
             return
         }
 
-        guard let fileURL = fileURL ?? defaultPasswordFileURL() else {
-            throw NSError(
-                domain: NSCocoaErrorDomain,
-                code: NSFileNoSuchFileError,
-                userInfo: [NSLocalizedDescriptionKey: String(localized: "socketControl.error.passwordFilePath", defaultValue: "Unable to resolve socket password file path.")]
+        if let fileURL {
+            let directory = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
             )
+            let data = Data(normalized.utf8)
+            try data.write(to: fileURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+            return
         }
-        let directory = fileURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
-        let data = Data(normalized.utf8)
-        try data.write(to: fileURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+
+        // Production: store in Keychain.
+        try savePasswordToKeychain(normalized)
+
+        // Remove any leftover plaintext file from a previous version.
+        if let oldFileURL = defaultPasswordFileURL(),
+           FileManager.default.fileExists(atPath: oldFileURL.path) {
+            try? FileManager.default.removeItem(at: oldFileURL)
+        }
     }
 
+    /// Clear the socket password.
+    ///
+    /// When `fileURL` is non-nil (test seam), removes that file.
+    /// In production (`fileURL == nil`) removes the Keychain entry and any
+    /// leftover plaintext file.
     static func clearPassword(fileURL: URL? = nil) throws {
-        guard let fileURL = fileURL ?? defaultPasswordFileURL() else {
+        if let fileURL {
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+            try FileManager.default.removeItem(at: fileURL)
             return
         }
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return
+
+        // Production: Keychain.
+        deletePasswordFromKeychain()
+
+        if let oldFileURL = defaultPasswordFileURL(),
+           FileManager.default.fileExists(atPath: oldFileURL.path) {
+            try? FileManager.default.removeItem(at: oldFileURL)
         }
-        try FileManager.default.removeItem(at: fileURL)
     }
 
     static func resetLazyKeychainFallbackCacheForTests() {
@@ -229,6 +272,73 @@ enum SocketControlPasswordStore {
             .appendingPathComponent(directoryName, isDirectory: true)
             .appendingPathComponent(fileName, isDirectory: false)
     }
+
+    // MARK: - Keychain storage (primary)
+
+    private static func loadPasswordFromKeychain() -> String? {
+#if canImport(Security)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: keychainService,
+            kSecAttrAccount: keychainAccount,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+#else
+        return nil
+#endif
+    }
+
+    private static func savePasswordToKeychain(_ password: String) throws {
+#if canImport(Security)
+        let data = Data(password.utf8)
+        let updateQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: keychainService,
+            kSecAttrAccount: keychainAccount,
+        ]
+        var status = SecItemUpdate(updateQuery as CFDictionary, [kSecValueData: data] as CFDictionary)
+        if status == errSecItemNotFound {
+            let addQuery: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: keychainService,
+                kSecAttrAccount: keychainAccount,
+                kSecValueData: data,
+                // Accessible after first unlock; never synced off device.
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            ]
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+        if status != errSecSuccess {
+            throw NSError(
+                domain: NSOSStatusErrorDomain,
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: String(localized: "socketControl.error.keychainSave", defaultValue: "Unable to save socket password to Keychain.")]
+            )
+        }
+#endif
+    }
+
+    @discardableResult
+    private static func deletePasswordFromKeychain() -> Bool {
+#if canImport(Security)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: keychainService,
+            kSecAttrAccount: keychainAccount,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+#else
+        return false
+#endif
+    }
+
+    // MARK: - Legacy Keychain storage
 
     private static func loadLegacyPasswordFromKeychain() -> String? {
 #if canImport(Security)

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -67,6 +67,9 @@ enum SocketControlPasswordStore {
     private static let legacyKeychainService = "com.cmuxterm.app.socket-control"
     private static let legacyKeychainAccount = "local-socket-password"
     // Primary Keychain storage (replaces plaintext file).
+    // NOTE: intentionally the same service string as the legacy store above;
+    // the two entries are differentiated solely by account name
+    // ("socket-password" vs the legacy "local-socket-password").
     private static let keychainService = "com.cmuxterm.app.socket-control"
     private static let keychainAccount = "socket-password"
     private struct LazyKeychainFallbackCache {


### PR DESCRIPTION
## Summary
- **Issue:** The socket-control password was stored as plain UTF-8 text in `~/.config/cmux/socket-control-password` (mode 0600). Any process that can read that path (backup tools, crash reporters, other user-space software) could exfiltrate the credential.
- **Fix:** Password is now stored in the macOS Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` — never synced off-device, never prompts the user, protected by the OS credential store.
- **Migration:** On first load, `loadPassword` transparently moves any existing plaintext file into Keychain and deletes the file. No user action required.
- **Test seam preserved:** The `fileURL` parameter on `loadPassword`/`savePassword`/`clearPassword` still works as before for unit tests — non-nil paths go through file I/O, nil goes through Keychain.

## Changes
- `SocketControlPasswordStore`: new private `loadPasswordFromKeychain`, `savePasswordToKeychain`, `deletePasswordFromKeychain` helpers
- `loadPassword(fileURL:nil)` → Keychain primary, file migration fallback
- `savePassword(fileURL:nil)` → Keychain, removes leftover file
- `clearPassword(fileURL:nil)` → Keychain delete + leftover file cleanup

## Test plan
- [ ] Set a socket password in Settings → verify it appears in Keychain Access under `com.cmuxterm.app.socket-control / socket-password`
- [ ] Verify the old `socket-control-password` file is absent after save
- [ ] Restart app and verify the password is still accepted (Keychain read on launch)
- [ ] Clear the password → verify Keychain entry is removed
- [ ] Place a plaintext file at the old path manually → launch app → verify it migrates to Keychain and the file is deleted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store the socket-control password in the macOS Keychain instead of a plaintext file to reduce exposure risk. Uses kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly and keeps the `fileURL` test seam.

- **Bug Fixes**
  - clearPassword() now throws on unexpected Keychain deletion errors.
  - One-time file→Keychain migration only deletes the file after a successful Keychain save.
  - Updated mode description to say “stored in Keychain”; added localized error messages for Keychain save/delete (en, ja).

- **Migration**
  - On first launch, move `~/.config/cmux/socket-control-password` to Keychain and delete the file after a successful save.
  - Keychain item uses service `com.cmuxterm.app.socket-control` (same as legacy) and account `socket-password` (legacy was `local-socket-password`). No user action needed.

<sup>Written for commit f600d06179e2afa834affd5b09cb5bfdf70dfe5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Moved password storage from plaintext files to secure device-encrypted storage by default.
  * Added a one-time automatic migration of existing passwords with cleanup of legacy plaintext data.
  * Ensured consistent, secure handling across legacy and new storage paths, including migration of older secure entries when detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->