### PR TITLE
security: app no longer accepts socket password from CMUX_SOCKET_PASSWORD env var

### DIFF
--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -74,7 +74,6 @@ enum SocketControlPasswordStore {
     private static var lazyKeychainFallbackCache = LazyKeychainFallbackCache()
 
     static func configuredPassword(
-        environment: [String: String] = ProcessInfo.processInfo.environment,
         fileURL: URL? = nil,
         allowLazyKeychainFallback: Bool = false,
         loadKeychainPassword: () -> String? = { loadLegacyPasswordFromKeychain() }
@@ -100,13 +99,11 @@ enum SocketControlPasswordStore {
     }
 
     static func hasConfiguredPassword(
-        environment: [String: String] = ProcessInfo.processInfo.environment,
         fileURL: URL? = nil,
         allowLazyKeychainFallback: Bool = false,
         loadKeychainPassword: () -> String? = { loadLegacyPasswordFromKeychain() }
     ) -> Bool {
         guard let configured = configuredPassword(
-            environment: environment,
             fileURL: fileURL,
             allowLazyKeychainFallback: allowLazyKeychainFallback,
             loadKeychainPassword: loadKeychainPassword
@@ -116,13 +113,11 @@ enum SocketControlPasswordStore {
 
     static func verify(
         password candidate: String,
-        environment: [String: String] = ProcessInfo.processInfo.environment,
         fileURL: URL? = nil,
         allowLazyKeychainFallback: Bool = false,
         loadKeychainPassword: () -> String? = { loadLegacyPasswordFromKeychain() }
     ) -> Bool {
         guard let expected = configuredPassword(
-            environment: environment,
             fileURL: fileURL,
             allowLazyKeychainFallback: allowLazyKeychainFallback,
             loadKeychainPassword: loadKeychainPassword

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -79,9 +79,11 @@ enum SocketControlPasswordStore {
         allowLazyKeychainFallback: Bool = false,
         loadKeychainPassword: () -> String? = { loadLegacyPasswordFromKeychain() }
     ) -> String? {
-        if let envPassword = normalized(environment[SocketControlSettings.socketPasswordEnvKey]) {
-            return envPassword
-        }
+        // Note: CMUX_SOCKET_PASSWORD is intentionally NOT read here. Accepting
+        // a credential from the process environment means it can be injected by
+        // a parent process and is visible to sibling processes. The CLI reads
+        // CMUX_SOCKET_PASSWORD for client-side authentication only; the app
+        // derives the expected password from the stored file/Keychain.
         let filePassword: String?
         do {
             filePassword = try loadPassword(fileURL: fileURL)

--- a/cmuxTests/SocketControlPasswordStoreTests.swift
+++ b/cmuxTests/SocketControlPasswordStoreTests.swift
@@ -25,21 +25,20 @@ final class SocketControlPasswordStoreTests: XCTestCase {
 
         let fileURL = tempDir.appendingPathComponent("socket-password.txt", isDirectory: false)
 
-        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(fileURL: fileURL))
 
         try SocketControlPasswordStore.savePassword("hunter2", fileURL: fileURL)
         XCTAssertEqual(try SocketControlPasswordStore.loadPassword(fileURL: fileURL), "hunter2")
-        XCTAssertTrue(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+        XCTAssertTrue(SocketControlPasswordStore.hasConfiguredPassword(fileURL: fileURL))
 
         try SocketControlPasswordStore.clearPassword(fileURL: fileURL)
         XCTAssertNil(try SocketControlPasswordStore.loadPassword(fileURL: fileURL))
-        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
+        XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(fileURL: fileURL))
     }
 
     func testConfiguredPasswordIgnoresEnvironmentVariable() throws {
-        // CMUX_SOCKET_PASSWORD must not influence the app-side accepted password.
-        // The env var is reserved for CLI client authentication only; accepting
-        // it on the app side would allow credential injection via the environment.
+        // When a file password is stored, it is returned regardless of whether
+        // CMUX_SOCKET_PASSWORD is set in the process environment.
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -48,20 +47,32 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         let fileURL = tempDir.appendingPathComponent("socket-password.txt", isDirectory: false)
         try SocketControlPasswordStore.savePassword("stored-secret", fileURL: fileURL)
 
-        let environment = [SocketControlSettings.socketPasswordEnvKey: "env-secret"]
-        let configured = SocketControlPasswordStore.configuredPassword(
-            environment: environment,
-            fileURL: fileURL
-        )
-        // The stored-file password wins; the env var is ignored.
+        // environment parameter removed — the env var is no longer consulted.
+        let configured = SocketControlPasswordStore.configuredPassword(fileURL: fileURL)
         XCTAssertEqual(configured, "stored-secret")
+    }
+
+    func testConfiguredPasswordReturnsNilWhenOnlyEnvVarIsSet() {
+        // When no file password exists, configuredPassword() must return nil even
+        // if CMUX_SOCKET_PASSWORD is set in the environment.  This is the core
+        // security guarantee: the env var cannot be used as a back-door credential.
+        let nonExistentFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)")
+            .appendingPathComponent("no-such-file.txt")
+
+        // CMUX_SOCKET_PASSWORD is in the real environment during CI runs; its
+        // presence must not change the outcome.
+        let configured = SocketControlPasswordStore.configuredPassword(
+            fileURL: nonExistentFileURL,
+            allowLazyKeychainFallback: false
+        )
+        XCTAssertNil(configured)
     }
 
     func testConfiguredPasswordLazyKeychainFallbackReadsOnlyOnceAndCaches() {
         var readCount = 0
 
         let withoutFallback = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: nil,
             allowLazyKeychainFallback: false,
             loadKeychainPassword: {
@@ -73,7 +84,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         XCTAssertEqual(readCount, 0)
 
         let firstWithFallback = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: nil,
             allowLazyKeychainFallback: true,
             loadKeychainPassword: {
@@ -85,7 +95,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         XCTAssertEqual(readCount, 1)
 
         let secondWithFallback = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: nil,
             allowLazyKeychainFallback: true,
             loadKeychainPassword: {
@@ -101,7 +110,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         var readCount = 0
 
         let first = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: nil,
             allowLazyKeychainFallback: true,
             loadKeychainPassword: {
@@ -113,7 +121,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         XCTAssertEqual(readCount, 1)
 
         let second = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: nil,
             allowLazyKeychainFallback: true,
             loadKeychainPassword: {
@@ -136,7 +143,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
 
         var readCount = 0
         let configured = SocketControlPasswordStore.configuredPassword(
-            environment: [:],
             fileURL: fileURL,
             allowLazyKeychainFallback: true,
             loadKeychainPassword: {
@@ -158,7 +164,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
 
         XCTAssertTrue(
             SocketControlPasswordStore.hasConfiguredPassword(
-                environment: [:],
                 fileURL: nil,
                 allowLazyKeychainFallback: true,
                 loadKeychainPassword: loader
@@ -169,7 +174,6 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         XCTAssertTrue(
             SocketControlPasswordStore.verify(
                 password: "legacy-secret",
-                environment: [:],
                 fileURL: nil,
                 allowLazyKeychainFallback: true,
                 loadKeychainPassword: loader

--- a/cmuxTests/SocketControlPasswordStoreTests.swift
+++ b/cmuxTests/SocketControlPasswordStoreTests.swift
@@ -36,7 +36,10 @@ final class SocketControlPasswordStoreTests: XCTestCase {
         XCTAssertFalse(SocketControlPasswordStore.hasConfiguredPassword(environment: [:], fileURL: fileURL))
     }
 
-    func testConfiguredPasswordPrefersEnvironmentOverStoredFile() throws {
+    func testConfiguredPasswordIgnoresEnvironmentVariable() throws {
+        // CMUX_SOCKET_PASSWORD must not influence the app-side accepted password.
+        // The env var is reserved for CLI client authentication only; accepting
+        // it on the app side would allow credential injection via the environment.
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-socket-password-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -50,7 +53,8 @@ final class SocketControlPasswordStoreTests: XCTestCase {
             environment: environment,
             fileURL: fileURL
         )
-        XCTAssertEqual(configured, "env-secret")
+        // The stored-file password wins; the env var is ignored.
+        XCTAssertEqual(configured, "stored-secret")
     }
 
     func testConfiguredPasswordLazyKeychainFallbackReadsOnlyOnceAndCaches() {


### PR DESCRIPTION
## Summary
- **Issue:** `configuredPassword()` read `CMUX_SOCKET_PASSWORD` from the process environment and used it as the accepted socket password. Environment variables are visible in crash dumps, log telemetry, and to sibling processes. A malicious parent process could inject an arbitrary password this way.
- **Fix:** Removed the env var lookup from `configuredPassword()` in the app. The accepted password is now derived exclusively from the stored file/Keychain.
- **Scope:** `CMUX_SOCKET_PASSWORD` is **not** removed from the CLI — the CLI binary still reads it as a convenience for passing the client-side auth token.

## Changes
- `Sources/SocketControlSettings.swift`: removed env var block from `configuredPassword()`; added comment explaining the intentional split
- `cmuxTests/SocketControlPasswordStoreTests.swift`: renamed test and flipped assertion to verify the stored password wins

## Test plan
- [ ] Unit test `testConfiguredPasswordIgnoresEnvironmentVariable` passes
- [ ] CLI `--password` / `CMUX_SOCKET_PASSWORD` still authenticates against a running cmux with password mode enabled
- [ ] Launching the app with `CMUX_SOCKET_PASSWORD=wrong` does not change the accepted password

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The app no longer accepts the socket password from the `CMUX_SOCKET_PASSWORD` env var. It now derives the expected password only from the stored file/Keychain to avoid env var injection and exposure.

- **Bug Fixes**
  - Removed env var read in `configuredPassword()` (`SocketControlSettings.swift`) and documented the app/CLI split.
  - Dropped the `environment` parameter from `configuredPassword`/`hasConfiguredPassword`/`verify` and updated all call sites; tests now assert the env var is ignored and that `configuredPassword()` returns nil when only the env var is set.
  - CLI behavior is unchanged: `CMUX_SOCKET_PASSWORD` and `--password` still send the client-side auth token.

<sup>Written for commit 3742e16a6c4fe57bb270f26c6b8ea02598094a3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Socket control password configuration now exclusively retrieves credentials from stored sources (file or Keychain) instead of environment variables, enhancing security by removing external credential injection paths.

* **Tests**
  * Updated test expectations to reflect that stored credentials take precedence over environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->