### PR TITLE
security: eliminate TOCTOU in privileged CLI symlink installation

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1311,7 +1311,8 @@ struct CmuxCLIPathInstaller {
         // no longer win the race to place a symlink at the destination between
         // removal and creation. `mv` on the same filesystem uses rename(2)
         // which is atomic even under admin privileges.
-        let tmpPath = destinationPath + ".cmux-install-tmp"
+        let tmpSuffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12).lowercased()
+        let tmpPath = destinationPath + ".tmp-\(tmpSuffix)"
         let command = "/bin/mkdir -p \(shellQuoted(parentPath)) && " +
             "/bin/rm -f \(shellQuoted(tmpPath)) && " +
             "/bin/ln -s \(shellQuoted(sourceURL.path)) \(shellQuoted(tmpPath)) && " +

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1305,9 +1305,17 @@ struct CmuxCLIPathInstaller {
     private static func installWithAdministratorPrivileges(sourceURL: URL, destinationURL: URL) throws {
         let destinationPath = destinationURL.path
         let parentPath = destinationURL.deletingLastPathComponent().path
+        // Create the symlink at a unique temp path, then atomically rename it
+        // into place with `mv -f`. This eliminates the TOCTOU window that
+        // existed between the old `rm -f` and `ln -s` steps: an attacker can
+        // no longer win the race to place a symlink at the destination between
+        // removal and creation. `mv` on the same filesystem uses rename(2)
+        // which is atomic even under admin privileges.
+        let tmpPath = destinationPath + ".cmux-install-tmp"
         let command = "/bin/mkdir -p \(shellQuoted(parentPath)) && " +
-            "/bin/rm -f \(shellQuoted(destinationPath)) && " +
-            "/bin/ln -s \(shellQuoted(sourceURL.path)) \(shellQuoted(destinationPath))"
+            "/bin/rm -f \(shellQuoted(tmpPath)) && " +
+            "/bin/ln -s \(shellQuoted(sourceURL.path)) \(shellQuoted(tmpPath)) && " +
+            "/bin/mv -f \(shellQuoted(tmpPath)) \(shellQuoted(destinationPath))"
         try runPrivilegedShellCommand(command)
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1305,12 +1305,16 @@ struct CmuxCLIPathInstaller {
     private static func installWithAdministratorPrivileges(sourceURL: URL, destinationURL: URL) throws {
         let destinationPath = destinationURL.path
         let parentPath = destinationURL.deletingLastPathComponent().path
-        // Create the symlink at a unique temp path, then atomically rename it
-        // into place with `mv -f`. This eliminates the TOCTOU window that
-        // existed between the old `rm -f` and `ln -s` steps: an attacker can
-        // no longer win the race to place a symlink at the destination between
-        // removal and creation. `mv` on the same filesystem uses rename(2)
-        // which is atomic even under admin privileges.
+        // Create the symlink at a per-invocation temp path (random suffix),
+        // then atomically rename it into the destination with `mv -f`.
+        // This closes the TOCTOU window at the *destination*: the final
+        // placement is a single rename(2) rather than a remove-then-create
+        // pair, so an attacker cannot win the race to place a file at the
+        // destination between those two steps.
+        // Note: a small TOCTOU window remains at the *temp* path itself
+        // (between the `rm -f` and `ln -s`), but the random suffix makes
+        // a pre-planted collision unpractical, and the temp path is not a
+        // security boundary — only the final destination is.
         let tmpSuffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12).lowercased()
         let tmpPath = destinationPath + ".tmp-\(tmpSuffix)"
         let command = "/bin/mkdir -p \(shellQuoted(parentPath)) && " +


### PR DESCRIPTION
## Summary
- **Issue:** The CLI symlink installer ran `rm -f <dest> && ln -s <src> <dest>` with administrator privileges. Between the two steps an attacker can place a file/symlink at `<dest>`.
- **Fix:** Create the symlink at a unique temp path first, then atomically replace the destination with `mv -f` (`rename(2)` — atomic on same filesystem). No window between removal and creation.

## Before
```
/bin/rm -f <dest> && /bin/ln -s <src> <dest>
```

## After
```
/bin/rm -f <tmp> && /bin/ln -s <src> <tmp> && /bin/mv -f <tmp> <dest>
```

## Test plan
- [ ] Install CLI via Settings → verify `/usr/local/bin/cmux` symlink points correctly
- [ ] Re-install → verify existing symlink is replaced atomically
- [ ] Uninstall → verify symlink is removed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a privileged install TOCTOU by staging the symlink at a per-invocation random temp path and atomically moving it into place with `mv -f` (`rename(2)`), eliminating the race at the destination. Clarifies in-code comments: a small window remains at the temp path, but the 12-character UUID suffix makes pre-planting impractical and blocks DoS during install.

<sup>Written for commit 2ba985ed1216921f25d11452cf932b1f634ea579. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink creation reliability and stability to ensure operations complete successfully without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->