### PR TITLE
feat: browser cookie import from Cookie-Editor JSON and Netscape format

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -5338,6 +5338,142 @@
         }
       }
     },
+    "browser.cookieImport.error.noPermission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permission denied reading the selected file."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したファイルの読み取りが拒否されました。"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート失敗"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.error.unrecognizedFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unrecognized cookie file format. Export cookies using the Cookie-Editor extension (JSON) or a Netscape-format exporter."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "認識できないCookieファイル形式です。Cookie-Editor拡張機能（JSON）またはNetscape形式のエクスポーターを使用してCookieをエクスポートしてください。"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.success.many": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d cookies imported successfully."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d件のCookieを正常にインポートしました。"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.success.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 cookie imported successfully."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1件のCookieを正常にインポートしました。"
+          }
+        }
+      }
+    },
+    "browser.cookieImport.success.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookies Imported"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookieをインポートしました"
+          }
+        }
+      }
+    },
+    "browser.importCookies.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Cookies"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookieをインポート"
+          }
+        }
+      }
+    },
     "browser.downloading": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserCookieImporter.swift
+++ b/Sources/Panels/BrowserCookieImporter.swift
@@ -1,0 +1,152 @@
+import Foundation
+import WebKit
+
+/// Parses and imports browser cookies from external files into WKHTTPCookieStore.
+///
+/// Supported export formats:
+/// - **Cookie-Editor JSON** — exported from the Cookie-Editor browser extension
+///   for Firefox/Chrome/Edge. Array of cookie objects.
+/// - **Netscape/Mozilla text** — the classic tab-separated format used by curl,
+///   wget, and most browser cookie exporters.
+enum BrowserCookieImporter {
+    struct ImportResult {
+        let imported: Int
+        let skipped: Int
+    }
+
+    enum ParseError: LocalizedError {
+        case unrecognizedFormat
+
+        var errorDescription: String? {
+            String(
+                localized: "browser.cookieImport.error.unrecognizedFormat",
+                defaultValue: "Unrecognized cookie file format. Export cookies using the Cookie-Editor extension (JSON) or a Netscape-format exporter."
+            )
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Parse cookies from a file's raw data. Tries JSON first, then Netscape text.
+    static func parseCookies(from data: Data) throws -> [HTTPCookie] {
+        if let cookies = parseAsJSON(data), !cookies.isEmpty {
+            return cookies
+        }
+        let text = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .isoLatin1)
+            ?? ""
+        let cookies = parseNetscapeFormat(text)
+        if !cookies.isEmpty { return cookies }
+        throw ParseError.unrecognizedFormat
+    }
+
+    /// Write cookies into the given store. Completion is called on the main queue.
+    static func importCookies(
+        _ cookies: [HTTPCookie],
+        into store: WKHTTPCookieStore,
+        completion: @escaping (ImportResult) -> Void
+    ) {
+        guard !cookies.isEmpty else {
+            DispatchQueue.main.async { completion(ImportResult(imported: 0, skipped: 0)) }
+            return
+        }
+        let group = DispatchGroup()
+        var imported = 0
+        for cookie in cookies {
+            group.enter()
+            store.setCookie(cookie) {
+                imported += 1
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            completion(ImportResult(imported: imported, skipped: cookies.count - imported))
+        }
+    }
+
+    // MARK: - Cookie-Editor JSON
+
+    /// Cookie-Editor format: JSON array of objects with name, value, domain, path,
+    /// secure, httpOnly, expirationDate, sameSite fields.
+    private static func parseAsJSON(_ data: Data) -> [HTTPCookie]? {
+        guard let array = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            return nil
+        }
+        return array.compactMap { cookieFromJSONObject($0) }
+    }
+
+    private static func cookieFromJSONObject(_ raw: [String: Any]) -> HTTPCookie? {
+        guard let name = raw["name"] as? String,
+              let value = raw["value"] as? String else { return nil }
+
+        var props: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: value,
+            .path: (raw["path"] as? String) ?? "/",
+        ]
+
+        if let domain = raw["domain"] as? String {
+            props[.domain] = domain
+        }
+
+        if let secure = raw["secure"] as? Bool, secure {
+            props[.secure] = "TRUE"
+        }
+
+        // Cookie-Editor uses "expirationDate"; some exporters use "expires".
+        let expiryRaw = raw["expirationDate"] ?? raw["expires"]
+        if let ts = expiryRaw as? TimeInterval {
+            props[.expires] = Date(timeIntervalSince1970: ts)
+        } else if let ts = expiryRaw as? Int {
+            props[.expires] = Date(timeIntervalSince1970: TimeInterval(ts))
+        }
+
+        if let sameSite = raw["sameSite"] as? String {
+            switch sameSite.lowercased() {
+            case "strict":
+                props[.sameSitePolicy] = HTTPCookieStringPolicy.sameSiteStrict
+            case "lax":
+                props[.sameSitePolicy] = HTTPCookieStringPolicy.sameSiteLax
+            default:
+                break
+            }
+        }
+
+        return HTTPCookie(properties: props)
+    }
+
+    // MARK: - Netscape format
+
+    /// Classic Netscape/Mozilla cookie file format (used by curl, wget, etc.).
+    /// Non-comment lines contain 7 tab-separated fields:
+    ///   domain  includeSubdomains  path  secureFlag  expiry  name  value
+    private static func parseNetscapeFormat(_ text: String) -> [HTTPCookie] {
+        var cookies: [HTTPCookie] = []
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            let fields = trimmed.components(separatedBy: "\t")
+            guard fields.count >= 7 else { continue }
+            let domain  = fields[0]
+            let path    = fields[2]
+            let secure  = fields[3].uppercased() == "TRUE"
+            let name    = fields[5]
+            let value   = fields[6]
+            guard !name.isEmpty else { continue }
+            var props: [HTTPCookiePropertyKey: Any] = [
+                .name: name,
+                .value: value,
+                .domain: domain,
+                .path: path,
+            ]
+            if secure { props[.secure] = "TRUE" }
+            if let ts = TimeInterval(fields[4]), ts > 0 {
+                props[.expires] = Date(timeIntervalSince1970: ts)
+            }
+            if let cookie = HTTPCookie(properties: props) {
+                cookies.append(cookie)
+            }
+        }
+        return cookies
+    }
+}

--- a/Sources/Panels/BrowserCookieImporter.swift
+++ b/Sources/Panels/BrowserCookieImporter.swift
@@ -27,16 +27,22 @@ enum BrowserCookieImporter {
 
     // MARK: - Public API
 
+    struct ParseResult {
+        let cookies: [HTTPCookie]
+        let skipped: Int
+    }
+
     /// Parse cookies from a file's raw data. Tries JSON first, then Netscape text.
-    static func parseCookies(from data: Data) throws -> [HTTPCookie] {
-        if let cookies = parseAsJSON(data), !cookies.isEmpty {
-            return cookies
+    /// Returns both the valid cookies and a count of entries that could not be parsed.
+    static func parseCookies(from data: Data) throws -> ParseResult {
+        if let result = parseAsJSON(data), !result.cookies.isEmpty || result.skipped > 0 {
+            return result
         }
         let text = String(data: data, encoding: .utf8)
             ?? String(data: data, encoding: .isoLatin1)
             ?? ""
-        let cookies = parseNetscapeFormat(text)
-        if !cookies.isEmpty { return cookies }
+        let result = parseNetscapeFormat(text)
+        if !result.cookies.isEmpty || result.skipped > 0 { return result }
         throw ParseError.unrecognizedFormat
     }
 
@@ -44,23 +50,27 @@ enum BrowserCookieImporter {
     static func importCookies(
         _ cookies: [HTTPCookie],
         into store: WKHTTPCookieStore,
+        skipped: Int = 0,
         completion: @escaping (ImportResult) -> Void
     ) {
         guard !cookies.isEmpty else {
-            DispatchQueue.main.async { completion(ImportResult(imported: 0, skipped: 0)) }
+            DispatchQueue.main.async { completion(ImportResult(imported: 0, skipped: skipped)) }
             return
         }
         let group = DispatchGroup()
+        let lock = NSLock()
         var imported = 0
         for cookie in cookies {
             group.enter()
             store.setCookie(cookie) {
+                lock.lock()
                 imported += 1
+                lock.unlock()
                 group.leave()
             }
         }
         group.notify(queue: .main) {
-            completion(ImportResult(imported: imported, skipped: cookies.count - imported))
+            completion(ImportResult(imported: imported, skipped: skipped))
         }
     }
 
@@ -68,11 +78,20 @@ enum BrowserCookieImporter {
 
     /// Cookie-Editor format: JSON array of objects with name, value, domain, path,
     /// secure, httpOnly, expirationDate, sameSite fields.
-    private static func parseAsJSON(_ data: Data) -> [HTTPCookie]? {
+    private static func parseAsJSON(_ data: Data) -> ParseResult? {
         guard let array = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
             return nil
         }
-        return array.compactMap { cookieFromJSONObject($0) }
+        var cookies: [HTTPCookie] = []
+        var skipped = 0
+        for obj in array {
+            if let cookie = cookieFromJSONObject(obj) {
+                cookies.append(cookie)
+            } else {
+                skipped += 1
+            }
+        }
+        return ParseResult(cookies: cookies, skipped: skipped)
     }
 
     private static func cookieFromJSONObject(_ raw: [String: Any]) -> HTTPCookie? {
@@ -99,6 +118,11 @@ enum BrowserCookieImporter {
             props[.expires] = Date(timeIntervalSince1970: ts)
         } else if let ts = expiryRaw as? Int {
             props[.expires] = Date(timeIntervalSince1970: TimeInterval(ts))
+        } else if let str = expiryRaw as? String {
+            // Some exporters encode the date as an ISO 8601 string.
+            if let date = ISO8601DateFormatter().date(from: str) {
+                props[.expires] = date
+            }
         }
 
         if let sameSite = raw["sameSite"] as? String {
@@ -120,19 +144,29 @@ enum BrowserCookieImporter {
     /// Classic Netscape/Mozilla cookie file format (used by curl, wget, etc.).
     /// Non-comment lines contain 7 tab-separated fields:
     ///   domain  includeSubdomains  path  secureFlag  expiry  name  value
-    private static func parseNetscapeFormat(_ text: String) -> [HTTPCookie] {
+    ///
+    /// Lines prefixed with `#HttpOnly_` are HttpOnly cookies, not comments.
+    /// The prefix is stripped from the domain field before parsing.
+    private static func parseNetscapeFormat(_ text: String) -> ParseResult {
+        let httpOnlyPrefix = "#HttpOnly_"
         var cookies: [HTTPCookie] = []
+        var skipped = 0
         for line in text.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
-            let fields = trimmed.components(separatedBy: "\t")
-            guard fields.count >= 7 else { continue }
+            guard !trimmed.isEmpty else { continue }
+            // Lines starting with # are comments, EXCEPT for #HttpOnly_ which
+            // encodes the HttpOnly flag as a domain prefix in the Netscape format.
+            let isHttpOnly = trimmed.hasPrefix(httpOnlyPrefix)
+            if trimmed.hasPrefix("#") && !isHttpOnly { continue }
+            let content = isHttpOnly ? String(trimmed.dropFirst(httpOnlyPrefix.count)) : trimmed
+            let fields = content.components(separatedBy: "\t")
+            guard fields.count >= 7 else { skipped += 1; continue }
             let domain  = fields[0]
             let path    = fields[2]
             let secure  = fields[3].uppercased() == "TRUE"
             let name    = fields[5]
             let value   = fields[6]
-            guard !name.isEmpty else { continue }
+            guard !name.isEmpty else { skipped += 1; continue }
             var props: [HTTPCookiePropertyKey: Any] = [
                 .name: name,
                 .value: value,
@@ -140,13 +174,16 @@ enum BrowserCookieImporter {
                 .path: path,
             ]
             if secure { props[.secure] = "TRUE" }
+            if isHttpOnly { props[.comment] = "HttpOnly" }
             if let ts = TimeInterval(fields[4]), ts > 0 {
                 props[.expires] = Date(timeIntervalSince1970: ts)
             }
             if let cookie = HTTPCookie(properties: props) {
                 cookies.append(cookie)
+            } else {
+                skipped += 1
             }
         }
-        return cookies
+        return ParseResult(cookies: cookies, skipped: skipped)
     }
 }

--- a/Sources/Panels/BrowserCookieImporter.swift
+++ b/Sources/Panels/BrowserCookieImporter.swift
@@ -57,20 +57,18 @@ enum BrowserCookieImporter {
             DispatchQueue.main.async { completion(ImportResult(imported: 0, skipped: skipped)) }
             return
         }
+        // WKHTTPCookieStore.setCookie always calls its completion handler — it
+        // provides no success/failure signal — so every cookie we submit counts
+        // as imported. Track the total before entering any callbacks to avoid
+        // any risk of unsynchronized mutation.
+        let total = cookies.count
         let group = DispatchGroup()
-        let lock = NSLock()
-        var imported = 0
         for cookie in cookies {
             group.enter()
-            store.setCookie(cookie) {
-                lock.lock()
-                imported += 1
-                lock.unlock()
-                group.leave()
-            }
+            store.setCookie(cookie) { group.leave() }
         }
         group.notify(queue: .main) {
-            completion(ImportResult(imported: imported, skipped: skipped))
+            completion(ImportResult(imported: total, skipped: skipped))
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3693,6 +3693,68 @@ private struct OmnibarSuggestionsView: View {
         .accessibilityIdentifier("BrowserOmnibarSuggestions")
         .accessibilityLabel(String(localized: "browser.addressBarSuggestions", defaultValue: "Address bar suggestions"))
     }
+
+    // MARK: - Cookie Import
+
+    private var cookieImportButton: some View {
+        Button(action: { cookieImportFilePickerShown = true }) {
+            Image(systemName: "square.and.arrow.down")
+                .symbolRenderingMode(.monochrome)
+                .cmuxFlatSymbolColorRendering()
+                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        }
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .safeHelp(String(localized: "browser.importCookies.help", defaultValue: "Import Cookies"))
+        .accessibilityIdentifier("BrowserImportCookiesButton")
+        .fileImporter(
+            isPresented: $cookieImportFilePickerShown,
+            allowedContentTypes: [.json, .plainText],
+            allowsMultipleSelection: false
+        ) { result in
+            handleCookieImportFile(result)
+        }
+        .alert(cookieImportAlertTitle, isPresented: $cookieImportAlertShown) {
+            Button(String(localized: "browser.cookieImport.ok", defaultValue: "OK")) {}
+        } message: {
+            Text(cookieImportAlertMessage)
+        }
+    }
+
+    private func handleCookieImportFile(_ result: Result<[URL], Error>) {
+        func showError(_ message: String) {
+            cookieImportAlertTitle = String(localized: "browser.cookieImport.error.title", defaultValue: "Import Failed")
+            cookieImportAlertMessage = message
+            cookieImportAlertShown = true
+        }
+        switch result {
+        case .failure(let error):
+            showError(error.localizedDescription)
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            guard url.startAccessingSecurityScopedResource() else {
+                showError(String(localized: "browser.cookieImport.error.noPermission", defaultValue: "Permission denied reading the selected file."))
+                return
+            }
+            defer { url.stopAccessingSecurityScopedResource() }
+            do {
+                let data = try Data(contentsOf: url)
+                let parseResult = try BrowserCookieImporter.parseCookies(from: data)
+                let store = panel.webView.configuration.websiteDataStore.httpCookieStore
+                BrowserCookieImporter.importCookies(parseResult.cookies, into: store, skipped: parseResult.skipped) { importResult in
+                    cookieImportAlertTitle = String(localized: "browser.cookieImport.success.title", defaultValue: "Cookies Imported")
+                    let n = importResult.imported
+                    cookieImportAlertMessage = n == 1
+                        ? String(localized: "browser.cookieImport.success.one", defaultValue: "1 cookie imported successfully.")
+                        : String(format: String(localized: "browser.cookieImport.success.many", defaultValue: "%d cookies imported successfully."), n)
+                    cookieImportAlertShown = true
+                }
+            } catch {
+                showError(error.localizedDescription)
+            }
+        }
+    }
 }
 
 /// NSViewRepresentable wrapper for WKWebView
@@ -5780,68 +5842,6 @@ struct WebViewRepresentable: NSViewRepresentable {
         BrowserWindowPortalRegistry.updateDropZoneOverlay(for: webView, zone: nil)
         coordinator.lastPortalHostId = nil
         coordinator.lastSynchronizedHostGeometryRevision = 0
-    }
-
-    // MARK: - Cookie Import
-
-    private var cookieImportButton: some View {
-        Button(action: { cookieImportFilePickerShown = true }) {
-            Image(systemName: "square.and.arrow.down")
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
-                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        }
-        .buttonStyle(OmnibarAddressButtonStyle())
-        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
-        .safeHelp(String(localized: "browser.importCookies.help", defaultValue: "Import Cookies"))
-        .accessibilityIdentifier("BrowserImportCookiesButton")
-        .fileImporter(
-            isPresented: $cookieImportFilePickerShown,
-            allowedContentTypes: [.json, .plainText],
-            allowsMultipleSelection: false
-        ) { result in
-            handleCookieImportFile(result)
-        }
-        .alert(cookieImportAlertTitle, isPresented: $cookieImportAlertShown) {
-            Button(String(localized: "browser.cookieImport.ok", defaultValue: "OK")) {}
-        } message: {
-            Text(cookieImportAlertMessage)
-        }
-    }
-
-    private func handleCookieImportFile(_ result: Result<[URL], Error>) {
-        func showError(_ message: String) {
-            cookieImportAlertTitle = String(localized: "browser.cookieImport.error.title", defaultValue: "Import Failed")
-            cookieImportAlertMessage = message
-            cookieImportAlertShown = true
-        }
-        switch result {
-        case .failure(let error):
-            showError(error.localizedDescription)
-        case .success(let urls):
-            guard let url = urls.first else { return }
-            guard url.startAccessingSecurityScopedResource() else {
-                showError(String(localized: "browser.cookieImport.error.noPermission", defaultValue: "Permission denied reading the selected file."))
-                return
-            }
-            defer { url.stopAccessingSecurityScopedResource() }
-            do {
-                let data = try Data(contentsOf: url)
-                let cookies = try BrowserCookieImporter.parseCookies(from: data)
-                let store = panel.webView.configuration.websiteDataStore.httpCookieStore
-                BrowserCookieImporter.importCookies(cookies, into: store) { importResult in
-                    cookieImportAlertTitle = String(localized: "browser.cookieImport.success.title", defaultValue: "Cookies Imported")
-                    let n = importResult.imported
-                    cookieImportAlertMessage = n == 1
-                        ? String(localized: "browser.cookieImport.success.one", defaultValue: "1 cookie imported successfully.")
-                        : String(format: String(localized: "browser.cookieImport.success.many", defaultValue: "%d cookies imported successfully."), n)
-                    cookieImportAlertShown = true
-                }
-            } catch {
-                showError(error.localizedDescription)
-            }
-        }
     }
 
     private func currentPaneDropContext() -> BrowserPaneDropContext? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -236,6 +236,10 @@ struct BrowserPanelView: View {
     @State private var pendingAddressBarFocusRetryRequestId: UUID?
     @State private var pendingAddressBarFocusRetryGeneration: UInt64 = 0
     @State private var isBrowserThemeMenuPresented = false
+    @State private var cookieImportFilePickerShown = false
+    @State private var cookieImportAlertShown = false
+    @State private var cookieImportAlertTitle = ""
+    @State private var cookieImportAlertMessage = ""
     @State private var ghosttyBackgroundGeneration: Int = 0
     // Keep this below half of the compact omnibar height so it reads as a squircle,
     // not a capsule.
@@ -565,6 +569,7 @@ struct BrowserPanelView: View {
                 .accessibilityLabel("Browser omnibar")
 
             if !panel.isShowingNewTabPage {
+                cookieImportButton
                 browserThemeModeButton
                 developerToolsButton
             }
@@ -5775,6 +5780,68 @@ struct WebViewRepresentable: NSViewRepresentable {
         BrowserWindowPortalRegistry.updateDropZoneOverlay(for: webView, zone: nil)
         coordinator.lastPortalHostId = nil
         coordinator.lastSynchronizedHostGeometryRevision = 0
+    }
+
+    // MARK: - Cookie Import
+
+    private var cookieImportButton: some View {
+        Button(action: { cookieImportFilePickerShown = true }) {
+            Image(systemName: "square.and.arrow.down")
+                .symbolRenderingMode(.monochrome)
+                .cmuxFlatSymbolColorRendering()
+                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        }
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .safeHelp(String(localized: "browser.importCookies.help", defaultValue: "Import Cookies"))
+        .accessibilityIdentifier("BrowserImportCookiesButton")
+        .fileImporter(
+            isPresented: $cookieImportFilePickerShown,
+            allowedContentTypes: [.json, .plainText],
+            allowsMultipleSelection: false
+        ) { result in
+            handleCookieImportFile(result)
+        }
+        .alert(cookieImportAlertTitle, isPresented: $cookieImportAlertShown) {
+            Button(String(localized: "browser.cookieImport.ok", defaultValue: "OK")) {}
+        } message: {
+            Text(cookieImportAlertMessage)
+        }
+    }
+
+    private func handleCookieImportFile(_ result: Result<[URL], Error>) {
+        func showError(_ message: String) {
+            cookieImportAlertTitle = String(localized: "browser.cookieImport.error.title", defaultValue: "Import Failed")
+            cookieImportAlertMessage = message
+            cookieImportAlertShown = true
+        }
+        switch result {
+        case .failure(let error):
+            showError(error.localizedDescription)
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            guard url.startAccessingSecurityScopedResource() else {
+                showError(String(localized: "browser.cookieImport.error.noPermission", defaultValue: "Permission denied reading the selected file."))
+                return
+            }
+            defer { url.stopAccessingSecurityScopedResource() }
+            do {
+                let data = try Data(contentsOf: url)
+                let cookies = try BrowserCookieImporter.parseCookies(from: data)
+                let store = panel.webView.configuration.websiteDataStore.httpCookieStore
+                BrowserCookieImporter.importCookies(cookies, into: store) { importResult in
+                    cookieImportAlertTitle = String(localized: "browser.cookieImport.success.title", defaultValue: "Cookies Imported")
+                    let n = importResult.imported
+                    cookieImportAlertMessage = n == 1
+                        ? String(localized: "browser.cookieImport.success.one", defaultValue: "1 cookie imported successfully.")
+                        : String(format: String(localized: "browser.cookieImport.success.many", defaultValue: "%d cookies imported successfully."), n)
+                    cookieImportAlertShown = true
+                }
+            } catch {
+                showError(error.localizedDescription)
+            }
+        }
     }
 
     private func currentPaneDropContext() -> BrowserPaneDropContext? {


### PR DESCRIPTION
## Summary

Adds a cookie import button to the browser pane toolbar so you can load session cookies exported from Firefox, Chrome, or any other browser without logging in again.

## How to use

1. In Firefox/Chrome, install the [Cookie-Editor](https://cookie-editor.com) extension
2. Navigate to the site, click Cookie-Editor → Export → Export as JSON → save the file
3. In cmux browser pane, click the **↓ (Import Cookies)** button in the toolbar
4. Pick the exported file — cookies are injected immediately, no reload needed

Netscape-format cookie files (e.g. from `curl --cookie-jar`) also work.

## Changes

| File | Change |
|------|--------|
| `Sources/Panels/BrowserCookieImporter.swift` | New — parser + `WKHTTPCookieStore` writer |
| `Sources/Panels/BrowserPanelView.swift` | Import button added to toolbar |
| `Resources/Localizable.xcstrings` | 8 new keys (en + ja) |

## Supported cookie fields
`name`, `value`, `domain`, `path`, `secure`, `expires` / `expirationDate`, `sameSite` (strict/lax)

## Test plan
- [ ] Export cookies from Firefox via Cookie-Editor → import → verify site stays logged in
- [ ] Import a Netscape-format file → verify cookies appear
- [ ] Import a malformed file → verify error alert
- [ ] Button hidden on new tab page (consistent with theme/devtools buttons)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Import Cookies button to the browser toolbar so users can load session cookies from Firefox/Chrome without logging in again. Supports Cookie-Editor JSON and Netscape cookie files, imported directly into the web view.

- **Bug Fixes**
  - Move import button and handler into `BrowserPanelView` to fix a compile error.
  - Parse Netscape `#HttpOnly_` lines and ISO 8601 `expires`; track skipped entries in results.
  - Simplify import count: remove `NSLock`; use `DispatchGroup` and `cookies.count` since `setCookie` always completes.

<sup>Written for commit 1f7b8b6a389d927389f45718d0b8cb7cf18288d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cookie import functionality added. Users can import cookies from external files in JSON (Cookie-Editor extension) or Netscape format. Import results are displayed with success or error alerts across multiple supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->