### PR TITLE
Fix version CLI fallback when the app socket hangs

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -457,11 +457,171 @@ private enum CLISocketPathSource {
     case implicitDefault
 }
 
+private func cliVersionSocketTimeoutSeconds(
+    processEnv: [String: String] = ProcessInfo.processInfo.environment
+) -> TimeInterval {
+    if let raw = processEnv["CMUXTERM_CLI_VERSION_TIMEOUT_SEC"],
+       let seconds = Double(raw),
+       seconds > 0 {
+        return seconds
+    }
+    return 2.5
+}
+
+private func cliDefaultResponseTimeoutSeconds(
+    processEnv: [String: String] = ProcessInfo.processInfo.environment
+) -> TimeInterval {
+    if let raw = processEnv["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"],
+       let seconds = Double(raw),
+       seconds > 0 {
+        return seconds
+    }
+    return 15.0
+}
+
+private func cliUnixSocketStat(_ path: String) -> stat? {
+    var st = stat()
+    guard lstat(path, &st) == 0 else { return nil }
+    guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else { return nil }
+    return st
+}
+
+private func cliIsUnixSocketFile(_ path: String) -> Bool {
+    cliUnixSocketStat(path) != nil
+}
+
+fileprivate struct SocketClientConfiguration {
+    let connectRetryWindowSeconds: TimeInterval
+    let connectAttemptTimeoutSeconds: TimeInterval
+    let responseTimeoutSeconds: TimeInterval
+
+    static func defaultConfig(
+        processEnv: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SocketClientConfiguration {
+        SocketClientConfiguration(
+            connectRetryWindowSeconds: 2.0,
+            connectAttemptTimeoutSeconds: 2.0,
+            responseTimeoutSeconds: cliDefaultResponseTimeoutSeconds(processEnv: processEnv)
+        )
+    }
+
+    static func versionQuery(
+        processEnv: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SocketClientConfiguration {
+        let timeout = cliVersionSocketTimeoutSeconds(processEnv: processEnv)
+        return SocketClientConfiguration(
+            connectRetryWindowSeconds: timeout,
+            connectAttemptTimeoutSeconds: timeout,
+            responseTimeoutSeconds: timeout
+        )
+    }
+}
+
+private enum UnixSocketConnector {
+    private static let inProgressErrnos: Set<Int32> = [EINPROGRESS, EAGAIN, EWOULDBLOCK, EINTR]
+
+    static func probe(path: String, timeoutSeconds: TimeInterval) -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return errno }
+        defer { Darwin.close(fd) }
+        return connect(fd: fd, path: path, timeoutSeconds: timeoutSeconds)
+    }
+
+    static func connect(fd: Int32, path: String, timeoutSeconds: TimeInterval) -> Int32 {
+        let flags = fcntl(fd, F_GETFL)
+        guard flags >= 0 else { return errno }
+        guard fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0 else { return errno }
+        defer { _ = fcntl(fd, F_SETFL, flags) }
+
+        let result = withSocketAddress(path: path) { sockaddrPtr, sockaddrLen in
+            Darwin.connect(fd, sockaddrPtr, sockaddrLen)
+        }
+        if result == 0 {
+            return 0
+        }
+
+        let connectErrno = errno
+        guard inProgressErrnos.contains(connectErrno) else {
+            return connectErrno
+        }
+
+        let deadline = Date().addingTimeInterval(max(0, timeoutSeconds))
+        let writableMask = Int16(POLLOUT)
+
+        while true {
+            let remaining = deadline.timeIntervalSinceNow
+            if remaining <= 0 {
+                return ETIMEDOUT
+            }
+
+            let timeoutMs = Int32(min(Double(Int32.max), ceil(remaining * 1000.0)))
+            var pollFD = pollfd(fd: fd, events: writableMask, revents: 0)
+            let ready = poll(&pollFD, 1, max(1, timeoutMs))
+            if ready > 0 {
+                var socketError: Int32 = 0
+                var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+                if getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) < 0 {
+                    return errno
+                }
+                return socketError
+            }
+            if ready == 0 {
+                return ETIMEDOUT
+            }
+            if errno == EINTR {
+                continue
+            }
+            return errno
+        }
+    }
+
+    private static func withSocketAddress<T>(
+        path: String,
+        _ body: (UnsafePointer<sockaddr>, socklen_t) -> T
+    ) -> T {
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let buf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                strncpy(buf, ptr, maxLength - 1)
+            }
+        }
+
+        return withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                body(sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+    }
+}
+
+private enum CLIStaleSocketFileCleaner {
+    private static let minimumAgeSeconds: TimeInterval = 5.0
+
+    @discardableResult
+    static func cleanupIfNeeded(path: String, connectErrno: Int32) -> Bool {
+        guard connectErrno == ECONNREFUSED else { return false }
+        guard path.hasPrefix("/tmp/cmux"), path.hasSuffix(".sock") else { return false }
+        guard let st = cliUnixSocketStat(path) else { return false }
+        guard st.st_uid == getuid() else { return false }
+
+        let modified = TimeInterval(st.st_mtimespec.tv_sec) + TimeInterval(st.st_mtimespec.tv_nsec) / 1_000_000_000
+        guard Date().timeIntervalSince1970 - modified >= minimumAgeSeconds else {
+            return false
+        }
+
+        return unlink(path) == 0
+    }
+}
+
 private enum CLISocketPathResolver {
     static let defaultSocketPath = "/tmp/cmux.sock"
     private static let fallbackSocketPath = "/tmp/cmux-debug.sock"
     private static let stagingSocketPath = "/tmp/cmux-staging.sock"
     private static let lastSocketPathFile = "/tmp/cmux-last-socket-path"
+    private static let connectProbeTimeoutSeconds: TimeInterval = 0.15
 
     static func resolve(
         requestedPath: String,
@@ -537,32 +697,17 @@ private enum CLISocketPathResolver {
     }
 
     private static func isSocketFile(_ path: String) -> Bool {
-        var st = stat()
-        return lstat(path, &st) == 0 && (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK)
+        cliIsUnixSocketFile(path)
     }
 
     private static func canConnect(to path: String) -> Bool {
         guard isSocketFile(path) else { return false }
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return false }
-        defer { Darwin.close(fd) }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
-        path.withCString { ptr in
-            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
-                let buf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
-                strncpy(buf, ptr, maxLength - 1)
-            }
+        let connectErrno = UnixSocketConnector.probe(path: path, timeoutSeconds: connectProbeTimeoutSeconds)
+        if connectErrno == 0 {
+            return true
         }
-
-        let result = withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                Darwin.connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        return result == 0
+        _ = CLIStaleSocketFileCleaner.cleanupIfNeeded(path: path, connectErrno: connectErrno)
+        return false
     }
 
     private static func sanitizeTagSlug(_ raw: String) -> String {
@@ -593,36 +738,28 @@ private enum CLISocketPathResolver {
     }
 }
 
-final class SocketClient {
+fileprivate final class SocketClient {
     private let path: String
+    private let configuration: SocketClientConfiguration
     private var socketFD: Int32 = -1
-    private static let connectRetryWindowSeconds: TimeInterval = 2.0
     private static let connectRetryIntervalSeconds: TimeInterval = 0.1
     private static let retriableConnectErrnos: Set<Int32> = [
         ENOENT,
         ECONNREFUSED,
         EAGAIN,
-        EINTR
+        EINTR,
+        ETIMEDOUT
     ]
-    private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
-    private static let responseTimeoutSeconds: TimeInterval = {
-        let env = ProcessInfo.processInfo.environment
-        if let raw = env["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"],
-           let seconds = Double(raw),
-           seconds > 0 {
-            return seconds
-        }
-        return defaultResponseTimeoutSeconds
-    }()
 
-    init(path: String) {
+    init(path: String, configuration: SocketClientConfiguration = .defaultConfig()) {
         self.path = path
+        self.configuration = configuration
     }
 
     func connect() throws {
         if socketFD >= 0 { return }
 
-        let deadline = Date().addingTimeInterval(Self.connectRetryWindowSeconds)
+        let deadline = Date().addingTimeInterval(configuration.connectRetryWindowSeconds)
         var lastError: CLIError?
 
         while true {
@@ -649,26 +786,16 @@ final class SocketClient {
                 throw CLIError(message: "Failed to create socket")
             }
 
-            var addr = sockaddr_un()
-            addr.sun_family = sa_family_t(AF_UNIX)
-            let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
-            path.withCString { ptr in
-                withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
-                    let buf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
-                    strncpy(buf, ptr, maxLength - 1)
-                }
-            }
-
-            let result = withUnsafePointer(to: &addr) { ptr in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                    Darwin.connect(socketFD, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
-                }
-            }
-            if result == 0 {
+            let remaining = max(0, deadline.timeIntervalSinceNow)
+            let connectErrno = UnixSocketConnector.connect(
+                fd: socketFD,
+                path: path,
+                timeoutSeconds: min(configuration.connectAttemptTimeoutSeconds, remaining)
+            )
+            if connectErrno == 0 {
                 return
             }
 
-            let connectErrno = errno
             Darwin.close(socketFD)
             socketFD = -1
 
@@ -680,6 +807,7 @@ final class SocketClient {
                 Thread.sleep(forTimeInterval: Self.connectRetryIntervalSeconds)
                 continue
             }
+            _ = CLIStaleSocketFileCleaner.cleanupIfNeeded(path: path, connectErrno: connectErrno)
             throw error
         }
 
@@ -717,7 +845,7 @@ final class SocketClient {
                 if sawNewline {
                     break
                 }
-                if Date().timeIntervalSince(start) > Self.responseTimeoutSeconds {
+                if Date().timeIntervalSince(start) > configuration.responseTimeoutSeconds {
                     throw CLIError(message: "Command timed out")
                 }
                 continue
@@ -857,7 +985,14 @@ struct CMUXCLI {
                 continue
             }
             if arg == "-v" || arg == "--version" {
-                print(versionSummary())
+                print(
+                    resolvedVersionSummary(
+                        requestedSocketPath: socketPath,
+                        socketPathSource: socketPathSource,
+                        explicitPassword: socketPasswordArg,
+                        processEnv: processEnv
+                    )
+                )
                 return
             }
             if arg == "-h" || arg == "--help" {
@@ -874,6 +1009,18 @@ struct CMUXCLI {
 
         let command = args[index]
         let commandArgs = Array(args[(index + 1)...])
+        if command == "version" {
+            print(
+                resolvedVersionSummary(
+                    requestedSocketPath: socketPath,
+                    socketPathSource: socketPathSource,
+                    explicitPassword: socketPasswordArg,
+                    processEnv: processEnv
+                )
+            )
+            return
+        }
+
         let cliTelemetry = CLISocketSentryTelemetry(
             command: command,
             commandArgs: commandArgs,
@@ -885,11 +1032,6 @@ struct CMUXCLI {
             source: socketPathSource,
             environment: processEnv
         )
-
-        if command == "version" {
-            print(versionSummary())
-            return
-        }
 
         // If the argument looks like a path (not a known command), open a workspace there.
         if looksLikePath(command) {
@@ -8016,7 +8158,10 @@ struct CMUXCLI {
     }
 
     private func versionSummary() -> String {
-        let info = resolvedVersionInfo()
+        versionSummary(from: resolvedVersionInfo())
+    }
+
+    private func versionSummary(from info: [String: String]) -> String {
         let commit = info["CMUXCommit"].flatMap { normalizedCommitHash($0) }
         let baseSummary: String
         if let version = info["CFBundleShortVersionString"], let build = info["CFBundleVersion"] {
@@ -8030,6 +8175,51 @@ struct CMUXCLI {
         }
         guard let commit else { return baseSummary }
         return "\(baseSummary) [\(commit)]"
+    }
+
+    private func resolvedVersionSummary(
+        requestedSocketPath: String,
+        socketPathSource: CLISocketPathSource,
+        explicitPassword: String?,
+        processEnv: [String: String]
+    ) -> String {
+        var info = resolvedVersionInfo()
+        let resolvedSocketPath = CLISocketPathResolver.resolve(
+            requestedPath: requestedSocketPath,
+            source: socketPathSource,
+            environment: processEnv
+        )
+
+        if let appInfo = runningAppVersionInfo(
+            socketPath: resolvedSocketPath,
+            explicitPassword: explicitPassword,
+            processEnv: processEnv
+        ) {
+            info.merge(appInfo, uniquingKeysWith: { _, new in new })
+        }
+
+        return versionSummary(from: info)
+    }
+
+    private func runningAppVersionInfo(
+        socketPath: String,
+        explicitPassword: String?,
+        processEnv: [String: String]
+    ) -> [String: String]? {
+        guard cliIsUnixSocketFile(socketPath) else {
+            return nil
+        }
+
+        let client = SocketClient(path: socketPath, configuration: .versionQuery(processEnv: processEnv))
+        do {
+            try client.connect()
+            defer { client.close() }
+            try authenticateClientIfNeeded(client, explicitPassword: explicitPassword)
+            let payload = try client.sendV2(method: "system.identify")
+            return versionInfo(from: payload["app_info"] as? [String: Any])
+        } catch {
+            return nil
+        }
     }
 
     private func printWelcome() {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -490,10 +490,16 @@ private func cliIsUnixSocketFile(_ path: String) -> Bool {
     cliUnixSocketStat(path) != nil
 }
 
+private func cliIsUnixSocketOwnedByCurrentUser(_ path: String) -> Bool {
+    guard let st = cliUnixSocketStat(path) else { return false }
+    return st.st_uid == getuid()
+}
+
 fileprivate struct SocketClientConfiguration {
     let connectRetryWindowSeconds: TimeInterval
     let connectAttemptTimeoutSeconds: TimeInterval
     let responseTimeoutSeconds: TimeInterval
+    let timeoutDeadline: Date?
 
     static func defaultConfig(
         processEnv: [String: String] = ProcessInfo.processInfo.environment
@@ -501,19 +507,27 @@ fileprivate struct SocketClientConfiguration {
         SocketClientConfiguration(
             connectRetryWindowSeconds: 2.0,
             connectAttemptTimeoutSeconds: 2.0,
-            responseTimeoutSeconds: cliDefaultResponseTimeoutSeconds(processEnv: processEnv)
+            responseTimeoutSeconds: cliDefaultResponseTimeoutSeconds(processEnv: processEnv),
+            timeoutDeadline: nil
+        )
+    }
+
+    static func versionQuery(
+        timeoutSeconds: TimeInterval,
+        deadline: Date? = nil
+    ) -> SocketClientConfiguration {
+        return SocketClientConfiguration(
+            connectRetryWindowSeconds: timeoutSeconds,
+            connectAttemptTimeoutSeconds: timeoutSeconds,
+            responseTimeoutSeconds: timeoutSeconds,
+            timeoutDeadline: deadline ?? Date().addingTimeInterval(max(0, timeoutSeconds))
         )
     }
 
     static func versionQuery(
         processEnv: [String: String] = ProcessInfo.processInfo.environment
     ) -> SocketClientConfiguration {
-        let timeout = cliVersionSocketTimeoutSeconds(processEnv: processEnv)
-        return SocketClientConfiguration(
-            connectRetryWindowSeconds: timeout,
-            connectAttemptTimeoutSeconds: timeout,
-            responseTimeoutSeconds: timeout
-        )
+        versionQuery(timeoutSeconds: cliVersionSocketTimeoutSeconds(processEnv: processEnv))
     }
 }
 
@@ -626,7 +640,8 @@ private enum CLISocketPathResolver {
     static func resolve(
         requestedPath: String,
         source: CLISocketPathSource,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        connectProbeDeadline: Date? = nil
     ) -> String {
         guard source == .implicitDefault else {
             return requestedPath
@@ -635,12 +650,17 @@ private enum CLISocketPathResolver {
         let candidates = dedupe(candidatePaths(requestedPath: requestedPath, environment: environment))
 
         // Prefer sockets that are currently accepting connections.
-        for path in candidates where canConnect(to: path) {
-            return path
+        for path in candidates {
+            guard let timeoutSeconds = remainingConnectProbeTimeout(until: connectProbeDeadline) else {
+                break
+            }
+            if canConnect(to: path, timeoutSeconds: timeoutSeconds) {
+                return path
+            }
         }
 
         // If the listener is still starting, prefer existing socket files.
-        for path in candidates where isSocketFile(path) {
+        for path in candidates where isOwnedSocketFile(path) {
             return path
         }
 
@@ -696,18 +716,28 @@ private enum CLISocketPathResolver {
         return discovered.prefix(limit).map(\.path)
     }
 
-    private static func isSocketFile(_ path: String) -> Bool {
-        cliIsUnixSocketFile(path)
+    private static func isOwnedSocketFile(_ path: String) -> Bool {
+        cliIsUnixSocketOwnedByCurrentUser(path)
     }
 
-    private static func canConnect(to path: String) -> Bool {
-        guard isSocketFile(path) else { return false }
-        let connectErrno = UnixSocketConnector.probe(path: path, timeoutSeconds: connectProbeTimeoutSeconds)
+    private static func canConnect(to path: String, timeoutSeconds: TimeInterval) -> Bool {
+        guard isOwnedSocketFile(path) else { return false }
+        let connectErrno = UnixSocketConnector.probe(path: path, timeoutSeconds: timeoutSeconds)
         if connectErrno == 0 {
             return true
         }
         _ = CLIStaleSocketFileCleaner.cleanupIfNeeded(path: path, connectErrno: connectErrno)
         return false
+    }
+
+    private static func remainingConnectProbeTimeout(until deadline: Date?) -> TimeInterval? {
+        guard let deadline else {
+            return connectProbeTimeoutSeconds
+        }
+
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return nil }
+        return min(connectProbeTimeoutSeconds, remaining)
     }
 
     private static func sanitizeTagSlug(_ raw: String) -> String {
@@ -759,7 +789,9 @@ fileprivate final class SocketClient {
     func connect() throws {
         if socketFD >= 0 { return }
 
-        let deadline = Date().addingTimeInterval(configuration.connectRetryWindowSeconds)
+        let deadline =
+            configuration.timeoutDeadline ??
+            Date().addingTimeInterval(configuration.connectRetryWindowSeconds)
         var lastError: CLIError?
 
         while true {
@@ -833,11 +865,19 @@ fileprivate final class SocketClient {
 
         var data = Data()
         var sawNewline = false
-        let start = Date()
+        let deadline =
+            configuration.timeoutDeadline ??
+            Date().addingTimeInterval(configuration.responseTimeoutSeconds)
 
         while true {
+            let remaining = deadline.timeIntervalSinceNow
+            if remaining <= 0, !sawNewline {
+                throw CLIError(message: "Command timed out")
+            }
+
+            let timeoutMs = Int32(min(Double(100), ceil(max(0.001, remaining) * 1000.0)))
             var pollFD = pollfd(fd: socketFD, events: Int16(POLLIN), revents: 0)
-            let ready = poll(&pollFD, 1, 100)
+            let ready = poll(&pollFD, 1, max(1, timeoutMs))
             if ready < 0 {
                 throw CLIError(message: "Socket read error")
             }
@@ -845,7 +885,7 @@ fileprivate final class SocketClient {
                 if sawNewline {
                     break
                 }
-                if Date().timeIntervalSince(start) > configuration.responseTimeoutSeconds {
+                if deadline.timeIntervalSinceNow <= 0 {
                     throw CLIError(message: "Command timed out")
                 }
                 continue
@@ -8184,16 +8224,18 @@ struct CMUXCLI {
         processEnv: [String: String]
     ) -> String {
         var info = resolvedVersionInfo()
+        let versionDeadline = Date().addingTimeInterval(cliVersionSocketTimeoutSeconds(processEnv: processEnv))
         let resolvedSocketPath = CLISocketPathResolver.resolve(
             requestedPath: requestedSocketPath,
             source: socketPathSource,
-            environment: processEnv
+            environment: processEnv,
+            connectProbeDeadline: versionDeadline
         )
 
         if let appInfo = runningAppVersionInfo(
             socketPath: resolvedSocketPath,
             explicitPassword: explicitPassword,
-            processEnv: processEnv
+            versionDeadline: versionDeadline
         ) {
             info.merge(appInfo, uniquingKeysWith: { _, new in new })
         }
@@ -8204,13 +8246,18 @@ struct CMUXCLI {
     private func runningAppVersionInfo(
         socketPath: String,
         explicitPassword: String?,
-        processEnv: [String: String]
+        versionDeadline: Date
     ) -> [String: String]? {
         guard cliIsUnixSocketFile(socketPath) else {
             return nil
         }
+        let remaining = versionDeadline.timeIntervalSinceNow
+        guard remaining > 0 else { return nil }
 
-        let client = SocketClient(path: socketPath, configuration: .versionQuery(processEnv: processEnv))
+        let client = SocketClient(
+            path: socketPath,
+            configuration: .versionQuery(timeoutSeconds: remaining, deadline: versionDeadline)
+        )
         do {
             try client.connect()
             defer { client.close() }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2352,11 +2352,45 @@ class TerminalController {
             }
         }
 
-        return [
+        var payload: [String: Any] = [
             "socket_path": socketPath,
             "focused": focused.isEmpty ? NSNull() : focused,
             "caller": v2OrNull(resolvedCaller)
         ]
+        if let appInfo = v2AppVersionInfo() {
+            payload["app_info"] = appInfo
+        }
+        return payload
+    }
+
+    private func v2AppVersionInfo() -> [String: String]? {
+        guard let infoDictionary = Bundle.main.infoDictionary else {
+            return nil
+        }
+
+        var appInfo: [String: String] = [:]
+
+        if let version = (infoDictionary["CFBundleShortVersionString"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !version.isEmpty {
+            appInfo["CFBundleShortVersionString"] = version
+        }
+
+        if let build = (infoDictionary["CFBundleVersion"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !build.isEmpty {
+            appInfo["CFBundleVersion"] = build
+        }
+
+        let rawCommit =
+            (infoDictionary["CMUXCommit"] as? String) ??
+            ProcessInfo.processInfo.environment["CMUX_COMMIT"]
+        if let commit = rawCommit?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !commit.isEmpty {
+            appInfo["CMUXCommit"] = commit
+        }
+
+        return appInfo.isEmpty ? nil : appInfo
     }
 
     private func v2SystemTree(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2275,11 +2275,15 @@ class TerminalController {
 
     private func v2Identify(params: [String: Any]) -> [String: Any] {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return [
+            var payload: [String: Any] = [
                 "socket_path": socketPath,
                 "focused": NSNull(),
                 "caller": NSNull()
             ]
+            if let appInfo = v2AppVersionInfo() {
+                payload["app_info"] = appInfo
+            }
+            return payload
         }
 
         var focused: [String: Any] = [:]

--- a/cmuxTests/SocketControlPasswordStoreTests.swift
+++ b/cmuxTests/SocketControlPasswordStoreTests.swift
@@ -358,6 +358,7 @@ private final class FakeVersionSocketServer {
     private let mode: FakeVersionSocketServerMode
     private let ready = DispatchSemaphore(value: 0)
     private let stateLock = NSLock()
+    private var readBuffer = Data()
     private var stopRequested = false
     private var thread: Thread?
     private var listenerFD: Int32 = -1
@@ -486,6 +487,9 @@ private final class FakeVersionSocketServer {
     }
 
     private func handleConnection(_ clientFD: Int32) {
+        readBuffer.removeAll(keepingCapacity: true)
+        defer { readBuffer.removeAll(keepingCapacity: true) }
+
         while !isStopRequested {
             guard let requestLine = readLine(from: clientFD, timeoutMilliseconds: 200) else {
                 return
@@ -554,9 +558,13 @@ private final class FakeVersionSocketServer {
     }
 
     private func readLine(from fd: Int32, timeoutMilliseconds: Int32) -> String? {
-        var data = Data()
-
         while !isStopRequested {
+            if let newlineIndex = readBuffer.firstIndex(of: UInt8(ascii: "\n")) {
+                let lineData = readBuffer.prefix(upTo: newlineIndex)
+                readBuffer.removeSubrange(readBuffer.startIndex...newlineIndex)
+                return String(data: lineData, encoding: .utf8)
+            }
+
             var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
             let ready = poll(&pollFD, 1, timeoutMilliseconds)
             if ready < 0 {
@@ -566,7 +574,7 @@ private final class FakeVersionSocketServer {
                 return nil
             }
             if ready == 0 {
-                if data.isEmpty {
+                if readBuffer.isEmpty {
                     return nil
                 }
                 continue
@@ -575,13 +583,12 @@ private final class FakeVersionSocketServer {
             var buffer = [UInt8](repeating: 0, count: 4096)
             let count = Darwin.read(fd, &buffer, buffer.count)
             if count <= 0 {
-                return data.isEmpty ? nil : String(data: data, encoding: .utf8)
+                guard !readBuffer.isEmpty else { return nil }
+                let line = String(data: readBuffer, encoding: .utf8)
+                readBuffer.removeAll(keepingCapacity: true)
+                return line
             }
-            data.append(buffer, count: count)
-            if let newlineIndex = data.firstIndex(of: UInt8(ascii: "\n")) {
-                let lineData = data.prefix(upTo: newlineIndex)
-                return String(data: lineData, encoding: .utf8)
-            }
+            readBuffer.append(buffer, count: count)
         }
 
         return nil

--- a/cmuxTests/SocketControlPasswordStoreTests.swift
+++ b/cmuxTests/SocketControlPasswordStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Darwin
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -329,5 +330,577 @@ final class CmuxCLIPathInstallerTests: XCTestCase {
         XCTAssertTrue(installOutcome.usedAdministratorPrivileges)
         XCTAssertEqual(privilegedInstallCallCount, 1)
         XCTAssertTrue(installer.isInstalled())
+    }
+}
+
+private struct CLIVersionInvocationResult {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+    let elapsed: TimeInterval
+    let timedOut: Bool
+}
+
+private enum FakeVersionSocketServerMode {
+    case responsive(appInfo: [String: String])
+    case unresponsive
+}
+
+private struct FakeVersionSocketServerError: Error, CustomStringConvertible {
+    let message: String
+
+    var description: String { message }
+}
+
+private final class FakeVersionSocketServer {
+    let socketPath: String
+
+    private let mode: FakeVersionSocketServerMode
+    private let ready = DispatchSemaphore(value: 0)
+    private let stateLock = NSLock()
+    private var stopRequested = false
+    private var thread: Thread?
+    private var listenerFD: Int32 = -1
+
+    private(set) var error: Error?
+
+    init(socketPath: String, mode: FakeVersionSocketServerMode) {
+        self.socketPath = socketPath
+        self.mode = mode
+    }
+
+    func start() throws {
+        let thread = Thread { [weak self] in
+            self?.run()
+        }
+        self.thread = thread
+        thread.start()
+
+        guard ready.wait(timeout: .now() + 2.0) == .success else {
+            throw FakeVersionSocketServerError(message: "Timed out waiting for socket server readiness")
+        }
+
+        if let error {
+            throw error
+        }
+    }
+
+    func stop() {
+        stateLock.lock()
+        stopRequested = true
+        let listenerFD = self.listenerFD
+        stateLock.unlock()
+
+        if listenerFD >= 0 {
+            Darwin.shutdown(listenerFD, SHUT_RDWR)
+            Darwin.close(listenerFD)
+        }
+
+        thread?.cancel()
+        while let thread, !thread.isFinished {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        unlink(socketPath)
+    }
+
+    private func run() {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: socketPath) {
+            unlink(socketPath)
+        }
+
+        let listenerFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listenerFD >= 0 else {
+            fail(FakeVersionSocketServerError(message: "Failed to create fake version socket"))
+            return
+        }
+
+        stateLock.lock()
+        self.listenerFD = listenerFD
+        stateLock.unlock()
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
+        socketPath.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let buf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                strncpy(buf, ptr, maxLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(listenerFD, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let err = errno
+            Darwin.close(listenerFD)
+            fail(FakeVersionSocketServerError(message: "Failed to bind fake version socket (errno \(err))"))
+            return
+        }
+
+        guard listen(listenerFD, 8) == 0 else {
+            let err = errno
+            Darwin.close(listenerFD)
+            fail(FakeVersionSocketServerError(message: "Failed to listen on fake version socket (errno \(err))"))
+            return
+        }
+
+        ready.signal()
+
+        while !isStopRequested {
+            var pollFD = pollfd(fd: listenerFD, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&pollFD, 1, 100)
+            if ready < 0 {
+                if errno == EINTR || isStopRequested {
+                    continue
+                }
+                fail(FakeVersionSocketServerError(message: "poll() failed while waiting for fake socket connections"))
+                return
+            }
+            if ready == 0 {
+                continue
+            }
+
+            let clientFD = accept(listenerFD, nil, nil)
+            if clientFD < 0 {
+                if errno == EINTR || isStopRequested {
+                    continue
+                }
+                fail(FakeVersionSocketServerError(message: "accept() failed for fake socket server"))
+                return
+            }
+
+            handleConnection(clientFD)
+            Darwin.close(clientFD)
+        }
+    }
+
+    private var isStopRequested: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return stopRequested
+    }
+
+    private func handleConnection(_ clientFD: Int32) {
+        while !isStopRequested {
+            guard let requestLine = readLine(from: clientFD, timeoutMilliseconds: 200) else {
+                return
+            }
+
+            if requestLine.isEmpty {
+                return
+            }
+
+            if requestLine.hasPrefix("auth ") {
+                _ = writeLine("OK", to: clientFD)
+                continue
+            }
+
+            if requestLine == "ping" {
+                _ = writeLine("PONG", to: clientFD)
+                continue
+            }
+
+            switch mode {
+            case .responsive(let appInfo):
+                guard
+                    let requestData = requestLine.data(using: .utf8),
+                    let request = try? JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                else {
+                    _ = writeLine("ERROR: invalid request", to: clientFD)
+                    continue
+                }
+                let requestId = request["id"] ?? UUID().uuidString
+                let response: [String: Any] = [
+                    "ok": true,
+                    "id": requestId,
+                    "result": [
+                        "socket_path": socketPath,
+                        "focused": NSNull(),
+                        "caller": NSNull(),
+                        "app_info": appInfo
+                    ]
+                ]
+                guard
+                    let data = try? JSONSerialization.data(withJSONObject: response, options: []),
+                    let line = String(data: data, encoding: .utf8)
+                else {
+                    _ = writeLine("ERROR: failed to encode response", to: clientFD)
+                    continue
+                }
+                _ = writeLine(line, to: clientFD)
+
+            case .unresponsive:
+                while !isStopRequested {
+                    var pollFD = pollfd(fd: clientFD, events: Int16(POLLHUP | POLLERR), revents: 0)
+                    let pollResult = poll(&pollFD, 1, 50)
+                    if pollResult < 0 {
+                        if errno == EINTR {
+                            continue
+                        }
+                        return
+                    }
+                    if pollResult > 0, (pollFD.revents & Int16(POLLHUP | POLLERR)) != 0 {
+                        return
+                    }
+                }
+                return
+            }
+        }
+    }
+
+    private func readLine(from fd: Int32, timeoutMilliseconds: Int32) -> String? {
+        var data = Data()
+
+        while !isStopRequested {
+            var pollFD = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&pollFD, 1, timeoutMilliseconds)
+            if ready < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                return nil
+            }
+            if ready == 0 {
+                if data.isEmpty {
+                    return nil
+                }
+                continue
+            }
+
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count <= 0 {
+                return data.isEmpty ? nil : String(data: data, encoding: .utf8)
+            }
+            data.append(buffer, count: count)
+            if let newlineIndex = data.firstIndex(of: UInt8(ascii: "\n")) {
+                let lineData = data.prefix(upTo: newlineIndex)
+                return String(data: lineData, encoding: .utf8)
+            }
+        }
+
+        return nil
+    }
+
+    private func writeLine(_ line: String, to fd: Int32) -> Bool {
+        let payload = line + "\n"
+        return payload.withCString { ptr in
+            Darwin.write(fd, ptr, strlen(ptr)) >= 0
+        }
+    }
+
+    private func fail(_ error: Error) {
+        self.error = error
+        ready.signal()
+    }
+}
+
+final class CLIVersionSocketFallbackTests: XCTestCase {
+    func testVersionCommandsPreferSocketReportedVersion() throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-cli-version-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let socketPath = "/tmp/cmux-version-\(UUID().uuidString).sock"
+        let server = FakeVersionSocketServer(
+            socketPath: socketPath,
+            mode: .responsive(
+                appInfo: [
+                    "CFBundleShortVersionString": "98.7.6",
+                    "CFBundleVersion": "123",
+                    "CMUXCommit": "abcdef1234567890"
+                ]
+            )
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let expected = "cmux 98.7.6 (123) [abcdef123456]"
+        let cliPath = try resolveCmuxCLIExecutable()
+
+        for args in [["--socket", socketPath, "--version"], ["--socket", socketPath, "version"]] {
+            let result = try runCLI(
+                executablePath: cliPath,
+                arguments: args,
+                environment: isolatedCLIEnvironment(homeRoot: tempRoot)
+            )
+
+            XCTAssertFalse(result.timedOut, "CLI timed out for arguments: \(args)")
+            XCTAssertEqual(result.exitCode, 0, "stderr=\(result.stderr)")
+            XCTAssertEqual(result.stdout, expected, "stderr=\(result.stderr)")
+        }
+    }
+
+    func testVersionCommandsAutoDiscoverTaggedSocketAndUseRunningAppVersion() throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-cli-version-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let tag = "version-auto-\(UUID().uuidString.lowercased())"
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+        let socketPath = "/tmp/cmux-debug-\(tag).sock"
+        let server = FakeVersionSocketServer(
+            socketPath: socketPath,
+            mode: .responsive(
+                appInfo: [
+                    "CFBundleShortVersionString": "77.7.7",
+                    "CFBundleVersion": "707",
+                    "CMUXCommit": "1234567890abcdef"
+                ]
+            )
+        )
+        try server.start()
+        defer { server.stop() }
+
+        let cliPath = try resolveCmuxCLIExecutable()
+        let expected = "cmux 77.7.7 (707) [1234567890ab]"
+        let environment = isolatedCLIEnvironment(
+            homeRoot: tempRoot,
+            overrides: [
+                "CMUX_TAG": tag,
+                "CMUX_SOCKET_PATH": "/tmp/cmux.sock"
+            ]
+        )
+
+        for args in [["--version"], ["version"]] {
+            let result = try runCLI(
+                executablePath: cliPath,
+                arguments: args,
+                environment: environment
+            )
+
+            XCTAssertFalse(result.timedOut, "CLI timed out for arguments: \(args)")
+            XCTAssertEqual(result.exitCode, 0, "stderr=\(result.stderr)")
+            XCTAssertEqual(result.stdout, expected, "stderr=\(result.stderr)")
+        }
+    }
+
+    func testVersionFallbackRemovesStaleSocketFile() throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-cli-version-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let cliPath = try resolveCmuxCLIExecutable()
+        let baseEnvironment = isolatedCLIEnvironment(homeRoot: tempRoot)
+        let baseline = try runCLI(
+            executablePath: cliPath,
+            arguments: ["--version"],
+            environment: baseEnvironment
+        )
+        XCTAssertFalse(baseline.timedOut)
+        XCTAssertEqual(baseline.exitCode, 0, "stderr=\(baseline.stderr)")
+
+        let socketPath = "/tmp/cmux-stale-\(UUID().uuidString).sock"
+        try createStaleUnixSocket(at: socketPath)
+        try fileManager.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -60)], ofItemAtPath: socketPath)
+        XCTAssertTrue(fileManager.fileExists(atPath: socketPath))
+        defer { unlink(socketPath) }
+
+        let result = try runCLI(
+            executablePath: cliPath,
+            arguments: ["--socket", socketPath, "--version"],
+            environment: baseEnvironment
+        )
+
+        XCTAssertFalse(result.timedOut)
+        XCTAssertEqual(result.exitCode, 0, "stderr=\(result.stderr)")
+        XCTAssertEqual(result.stdout, baseline.stdout, "stderr=\(result.stderr)")
+        XCTAssertFalse(fileManager.fileExists(atPath: socketPath), "Expected stale socket file to be removed")
+    }
+
+    func testVersionFallsBackQuicklyWhenSocketStopsResponding() throws {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-cli-version-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let socketPath = "/tmp/cmux-version-timeout-\(UUID().uuidString).sock"
+        let server = FakeVersionSocketServer(socketPath: socketPath, mode: .unresponsive)
+        try server.start()
+        defer { server.stop() }
+
+        let cliPath = try resolveCmuxCLIExecutable()
+        let baseline = try runCLI(
+            executablePath: cliPath,
+            arguments: ["--version"],
+            environment: isolatedCLIEnvironment(homeRoot: tempRoot)
+        )
+        XCTAssertFalse(baseline.timedOut)
+        XCTAssertEqual(baseline.exitCode, 0, "stderr=\(baseline.stderr)")
+
+        let result = try runCLI(
+            executablePath: cliPath,
+            arguments: ["--socket", socketPath, "version"],
+            environment: isolatedCLIEnvironment(
+                homeRoot: tempRoot,
+                overrides: ["CMUXTERM_CLI_VERSION_TIMEOUT_SEC": "0.35"]
+            ),
+            timeout: 2.0
+        )
+
+        XCTAssertFalse(result.timedOut, "CLI should fall back instead of hanging")
+        XCTAssertEqual(result.exitCode, 0, "stderr=\(result.stderr)")
+        XCTAssertEqual(result.stdout, baseline.stdout, "stderr=\(result.stderr)")
+        XCTAssertLessThan(result.elapsed, 1.5, "Expected fallback within a short timeout window")
+    }
+
+    private func resolveCmuxCLIExecutable() throws -> String {
+        let fileManager = FileManager.default
+        let env = ProcessInfo.processInfo.environment
+        var candidates: [String] = []
+
+        if let builtProductsDir = env["BUILT_PRODUCTS_DIR"], !builtProductsDir.isEmpty {
+            candidates.append(contentsOf: cliCandidates(productsDirectory: builtProductsDir))
+        }
+
+        if let hostPath = env["TEST_HOST"], !hostPath.isEmpty {
+            let productsDirectory = URL(fileURLWithPath: hostPath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .path
+            candidates.append(contentsOf: cliCandidates(productsDirectory: productsDirectory))
+        }
+
+        for candidate in uniquePaths(candidates) where fileManager.isExecutableFile(atPath: candidate) {
+            return URL(fileURLWithPath: candidate).resolvingSymlinksInPath().path
+        }
+
+        throw FakeVersionSocketServerError(message: "Unable to resolve built cmux CLI executable")
+    }
+
+    private func cliCandidates(productsDirectory: String) -> [String] {
+        [
+            "\(productsDirectory)/cmux DEV.app/Contents/Resources/bin/cmux",
+            "\(productsDirectory)/cmux.app/Contents/Resources/bin/cmux",
+            "\(productsDirectory)/cmux"
+        ]
+    }
+
+    private func uniquePaths(_ paths: [String]) -> [String] {
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
+    }
+
+    private func isolatedCLIEnvironment(
+        homeRoot: URL,
+        overrides: [String: String] = [:]
+    ) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        for key in [
+            "CMUX_SOCKET_PATH",
+            "CMUX_SOCKET",
+            "CMUX_TAG",
+            "CMUX_SOCKET_PASSWORD",
+            "CMUX_COMMIT",
+            "CMUXTERM_CLI_VERSION_TIMEOUT_SEC"
+        ] {
+            environment.removeValue(forKey: key)
+        }
+
+        environment["HOME"] = homeRoot.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        for (key, value) in overrides {
+            environment[key] = value
+        }
+        return environment
+    }
+
+    private func runCLI(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval = 3.0
+    ) throws -> CLIVersionInvocationResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let started = Date()
+        try process.run()
+
+        while process.isRunning && Date().timeIntervalSince(started) < timeout {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        let timedOut = process.isRunning
+        if timedOut {
+            process.interrupt()
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+        }
+
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        return CLIVersionInvocationResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            elapsed: Date().timeIntervalSince(started),
+            timedOut: timedOut
+        )
+    }
+
+    private func createStaleUnixSocket(at path: String) throws {
+        unlink(path)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw FakeVersionSocketServerError(message: "Failed to create stale Unix socket")
+        }
+        defer { Darwin.close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let buf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                strncpy(buf, ptr, maxLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw FakeVersionSocketServerError(message: "Failed to bind stale Unix socket at \(path)")
+        }
+        guard listen(fd, 1) == 0 else {
+            throw FakeVersionSocketServerError(message: "Failed to listen on stale Unix socket at \(path)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add regression coverage for `cmux version` / `cmux --version` against responsive, stale, and unresponsive Unix sockets
- query `system.identify` with a bounded version-specific socket timeout, then fall back to compiled-in version metadata when the app is unavailable
- bound autodiscovery socket probes and remove stale `/tmp/cmux*.sock` files after refused version connections

Closes #1245

## Verification
- `./scripts/reload.sh --tag issue-1245-version-crash-hang`
- manual CLI smoke against the rebuilt binary:
  - responsive fake socket returned `cmux 88.8.8 (888) [abcdef123456]` in about 0.4s
  - stale socket fell back in about 2.6s and the socket file was removed
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1245-version-crash-hang-unit build`

## Commit Structure
- `a51faedf` Add CLI version socket regression tests
- `970aadf7` Fix CLI version socket fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux --version` and `cmux version` hanging on stale or unresponsive Unix sockets by using a single, short deadline across discovery and connection, with a quick fallback to compiled version info. Also prefers the running app’s version via `system.identify` and cleans up stale `/tmp/cmux*.sock` files.

- **Bug Fixes**
  - Apply a single version timeout (default 2.5s via `CMUXTERM_CLI_VERSION_TIMEOUT_SEC`) across autodiscovery, connect, and response; other commands still use `CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC`.
  - Bound socket probes (~150ms each, capped by remaining deadline), use non-blocking connect with poll-based deadlines/`ETIMEDOUT`, and remove only current-user stale `/tmp/cmux*.sock` after refused connects (min age 5s).

- **New Features**
  - `system.identify` returns `app_info` (version, build, commit); the CLI uses it for accurate `version` when the app is running.
  - Added regression tests for responsive, stale, unresponsive sockets and tagged autodiscovery.

<sup>Written for commit 0ddf3a5f39edff2619d703c8134ec81f53a2376c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version command now merges local and running-app info and displays richer app details; probing selects an actively accepting socket and timeouts are configurable via environment.

* **Bug Fixes**
  * Improved socket probing/failover for faster fallback, clearer error reporting, and automatic removal of stale socket files on connection failures.

* **Tests**
  * Added end-to-end tests covering socket-based version retrieval, auto-discovery, cleanup, and timeout/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->