### PR TITLE
Add Cmd+T (New tab) to welcome screen shortcuts

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8074,6 +8074,7 @@ struct CMUXCLI {
           \(bold)Shortcuts\(reset)
 
           \(bold)\u{2318}N\(reset)\(subdued)                  New workspace\(reset)
+          \(bold)\u{2318}T\(reset)\(subdued)                  New tab\(reset)
           \(bold)\u{2318}P\(reset)\(subdued)                  Go to workspace\(reset)
           \(bold)\u{2318}D\(reset)\(subdued)                  Split right\(reset)
           \(bold)\u{2318}\u{21E7}D\(reset)\(subdued)                 Split down\(reset)


### PR DESCRIPTION
## Summary
- Add `⌘T  New tab` to the `cmux welcome` shortcuts section, placed after `⌘N  New workspace`

## Testing
- Visual: run `cmux welcome` and verify `⌘T  New tab` appears between `⌘N` and `⌘P`

## Related
- Task: add Cmd+T for new tab to `cmux welcome` screen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `⌘T  New tab` to the `cmux welcome` shortcuts to improve discoverability of opening a new tab. It appears after `⌘N  New workspace` and before `⌘P  Go to workspace`.

<sup>Written for commit d286f6f6fc5cbed136b0c829841b00d7aafcc1a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

