### PR TITLE
Fix Return on Cmd+Ctrl+W close confirmation

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4451,7 +4451,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             alertWindow.defaultButtonCell = closeButton.cell as? NSButtonCell
             alertWindow.initialFirstResponder = closeButton
             DispatchQueue.main.async {
-                alertWindow.makeKeyAndOrderFront(nil)
                 _ = alertWindow.makeFirstResponder(closeButton)
             }
         }

--- a/cmuxUITests/CloseWindowConfirmDialogUITests.swift
+++ b/cmuxUITests/CloseWindowConfirmDialogUITests.swift
@@ -49,13 +49,16 @@ final class CloseWindowConfirmDialogUITests: XCTestCase {
             "Expected Cmd+Ctrl+W to show the close window confirmation alert"
         )
 
-        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+        app.typeKey(.return, modifierFlags: [])
 
         XCTAssertTrue(
             waitForCloseWindowAlertToDismiss(app: app, timeout: 5.0),
             "Expected Return to dismiss the close window confirmation alert"
         )
-        XCTAssertFalse(app.windows.firstMatch.exists, "Expected Return to confirm window close")
+        XCTAssertTrue(
+            waitForMainWindowToClose(app: app, timeout: 5.0),
+            "Expected Return to confirm window close"
+        )
     }
 
     private func isCloseWindowAlertPresent(app: XCUIApplication) -> Bool {
@@ -84,6 +87,17 @@ final class CloseWindowConfirmDialogUITests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
         return !isCloseWindowAlertPresent(app: app)
+    }
+
+    private func waitForMainWindowToClose(app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !app.windows.firstMatch.exists {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return !app.windows.firstMatch.exists
     }
 
     private func clickCancelOnCloseWindowAlert(app: XCUIApplication) {


### PR DESCRIPTION
## Summary
- add a regression XCUITest that verifies Return confirms the Cmd+Ctrl+W close-window dialog
- keep the close-window alert on the standard Return default-button path and explicitly focus the close button when the alert opens

## Testing
- `./scripts/reload.sh --tag task-close-dialog-enter-focus`
- Regression proof, failing test-only run: https://github.com/manaflow-ai/cmux/actions/runs/23000483375
- Passing fix run: https://github.com/manaflow-ai/cmux/actions/runs/23001067815

## Task
- after Cmd+Ctrl+W we fail to focus on the dialog so pressing Enter doesn't work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where pressing Return didn’t confirm the close-window dialog after Cmd+Ctrl+W. The Close button is now focused so Return works, and a UI test verifies the alert dismisses and the window closes.

- **Bug Fixes**
  - Use the NSAlert default button path: set Close as the default and initial first responder, then make it first responder on open (removed custom Cmd+D shortcut).
  - Added `testReturnConfirmsCloseWindowDialog` XCUITest with helpers to wait for the alert to dismiss and the main window to close.

<sup>Written for commit 529008cb9df5b1f9d3310099c6128ebc361c6220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close-window confirmation dialog: keyboard focus is now set correctly, the close button is focused before presentation, and pressing Return confirms closing without altering shortcut behavior.
* **Tests**
  * Added UI tests that verify pressing Return confirms the dialog and the main window closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->