### PR TITLE
Include project name in Claude hook notification subtitles

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7799,6 +7799,13 @@ struct CMUXCLI {
         return nil
     }
 
+    private func projectName(fromCWD cwd: String?) -> String? {
+        guard let cwd = cwd, !cwd.isEmpty else { return nil }
+        let path = NSString(string: cwd).expandingTildeInPath
+        let tail = URL(fileURLWithPath: path).lastPathComponent
+        return tail.isEmpty ? path : tail
+    }
+
     private func summarizeClaudeHookStop(
         parsedInput: ClaudeHookParsedInput,
         sessionRecord: ClaudeHookSessionRecord?
@@ -7806,12 +7813,7 @@ struct CMUXCLI {
         let cwd = parsedInput.cwd ?? sessionRecord?.cwd
         let transcriptPath = parsedInput.transcriptPath
 
-        let projectName: String? = {
-            guard let cwd = cwd, !cwd.isEmpty else { return nil }
-            let path = NSString(string: cwd).expandingTildeInPath
-            let tail = URL(fileURLWithPath: path).lastPathComponent
-            return tail.isEmpty ? path : tail
-        }()
+        let projectName = projectName(fromCWD: cwd)
 
         // Try reading the transcript JSONL for a richer summary.
         let transcript = transcriptPath.flatMap { readTranscriptSummary(path: $0) }
@@ -7904,12 +7906,7 @@ struct CMUXCLI {
         }
 
         let cwd = extractClaudeHookCWD(from: object)
-        let projectName: String? = {
-            guard let cwd = cwd, !cwd.isEmpty else { return nil }
-            let path = NSString(string: cwd).expandingTildeInPath
-            let tail = URL(fileURLWithPath: path).lastPathComponent
-            return tail.isEmpty ? path : tail
-        }()
+        let projectName = projectName(fromCWD: cwd)
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
         let signalParts = [
@@ -7941,7 +7938,7 @@ struct CMUXCLI {
 
     private func classifyClaudeNotification(signal: String, message: String, projectName: String?) -> (subtitle: String, body: String) {
         let lower = "\(signal) \(message)".lowercased()
-        let suffix = projectName.map { " in \($0)" } ?? ""
+        let suffix = projectName.flatMap { $0.isEmpty ? nil : $0 }.map { " in \($0)" } ?? ""
         if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") {
             let body = message.isEmpty ? "Approval needed" : message
             return ("Permission\(suffix)", body)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7900,8 +7900,16 @@ struct CMUXCLI {
               let json = try? JSONSerialization.jsonObject(with: data, options: []),
               let object = json as? [String: Any] else {
             let fallback = truncate(normalizedSingleLine(trimmed), maxLength: 180)
-            return classifyClaudeNotification(signal: fallback, message: fallback)
+            return classifyClaudeNotification(signal: fallback, message: fallback, projectName: nil)
         }
+
+        let cwd = extractClaudeHookCWD(from: object)
+        let projectName: String? = {
+            guard let cwd = cwd, !cwd.isEmpty else { return nil }
+            let path = NSString(string: cwd).expandingTildeInPath
+            let tail = URL(fileURLWithPath: path).lastPathComponent
+            return tail.isEmpty ? path : tail
+        }()
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
         let signalParts = [
@@ -7918,7 +7926,7 @@ struct CMUXCLI {
         let dedupedMessage = dedupeBranchContextLines(message)
         let normalizedMessage = normalizedSingleLine(dedupedMessage)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
-        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
+        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage, projectName: projectName)
 
         if let session, !session.isEmpty {
             let shortSession = String(session.prefix(8))
@@ -7931,22 +7939,23 @@ struct CMUXCLI {
         return classified
     }
 
-    private func classifyClaudeNotification(signal: String, message: String) -> (subtitle: String, body: String) {
+    private func classifyClaudeNotification(signal: String, message: String, projectName: String?) -> (subtitle: String, body: String) {
         let lower = "\(signal) \(message)".lowercased()
+        let suffix = projectName.map { " in \($0)" } ?? ""
         if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") {
             let body = message.isEmpty ? "Approval needed" : message
-            return ("Permission", body)
+            return ("Permission\(suffix)", body)
         }
         if lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
             let body = message.isEmpty ? "Claude reported an error" : message
-            return ("Error", body)
+            return ("Error\(suffix)", body)
         }
         if lower.contains("idle") || lower.contains("wait") || lower.contains("input") || lower.contains("prompt") {
             let body = message.isEmpty ? "Claude is waiting for your input" : message
-            return ("Waiting", body)
+            return ("Waiting\(suffix)", body)
         }
         let body = message.isEmpty ? "Claude needs your input" : message
-        return ("Attention", body)
+        return ("Attention\(suffix)", body)
     }
 
     private func dedupeBranchContextLines(_ value: String) -> String {


### PR DESCRIPTION
Extract cwd from the notification hook JSON input and derive the project directory name, matching the approach already used by `summarizeClaudeHookStop`. The project name is appended to the notification subtitle so users can identify which project needs attention (e.g. "Permission in my-project" instead of "Permission").

## Summary
Claude Code hook notifications (permission_prompt, idle_prompt, errors, etc.) now include the project directory name in the subtitle. For example, "Permission" becomes "Permission in my-project".
   
- summarizeClaudeHookNotification now extracts cwd from the hook JSON input and derives the project name from it, using `extractClaudeHookCWD`  the same approach already used by summarizeClaudeHookStop.
- `classifyClaudeNotification` accepts a new projectName parameter and appends it as a suffix to the subtitle (e.g. "Permission in my-project", "Waiting in api-server").
- When cwd is absent or empty, behavior is unchanged.

## Testing
- ```echo '{"notification_type":"permission_prompt","message":"Permission to use Bash","cwd":"/Users/me/Work/my-project","session_id":"test1234"}' > /tmp/test-payload.json```
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-cli -configuration Debug build SYMROOT=/tmp/cmux-build`
- `cat /tmp/test-payload.json | /tmp/cmux-build/Debug/cmux claude-hook notification`

<img width="377" height="85" alt="image" src="https://github.com/user-attachments/assets/63ff6003-f50c-4e7c-b6b8-bfe84b83f055" />


## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claude hook notifications now include the project directory name in the subtitle (e.g., “Permission in my-project”) for clearer context. Behavior is unchanged when `cwd` is missing or empty.

- **New Features**
  - Extract `cwd` from hook JSON and derive the project name, aligned with `summarizeClaudeHookStop`.
  - Update `classifyClaudeNotification` to accept an optional project name and suffix it to “Permission”, “Error”, “Waiting”, and “Attention”.

- **Refactors**
  - Add `projectName(fromCWD:)` helper shared by stop and notification paths.
  - Guard against empty project names before appending the subtitle suffix.

<sup>Written for commit 823837e5a4d8fcaa295368885221db24d2f3db6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Claude notifications now include project-scoped context, appending "in <project>" to labels (e.g., Permission, Error, Waiting, Attention) for clearer identification.
  * Stop summaries from the Claude hook now suffix subtitles/bodies with "in <project>" when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->