### PR TITLE
feat: add cwd to surface list API responses

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3654,7 +3654,8 @@ class TerminalController {
                     "pane_id": v2OrNull(paneUUID?.uuidString),
                     "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
                     "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
-                    "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id])
+                    "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
+                    "cwd": v2OrNull(ws.panelDirectories[panel.id])
                 ]
                 return item
             }
@@ -4738,7 +4739,8 @@ class TerminalController {
                     "index": index,
                     "title": tab.title,
                     "type": v2OrNull(panel?.panelType.rawValue),
-                    "selected": tab.id == selectedTab?.id
+                    "selected": tab.id == selectedTab?.id,
+                    "cwd": v2OrNull(panelId.flatMap { ws.panelDirectories[$0] })
                 ]
             }
 


### PR DESCRIPTION
## Summary

- Expose per-surface working directory (tracked via OSC 7) in `surface.list` and `pane.surfaces` v2 JSON-RPC responses as a new `cwd` field
- Motivation: callers need CWD of all surfaces for workspace-aware tooling (e.g., agent orchestration)

## Changes

All in `Sources/TerminalController.swift`:

1. **`v2SurfaceList`** — added `"cwd": v2OrNull(ws.panelDirectories[panel.id])`
2. **`v2PaneSurfaces`** — added `"cwd": v2OrNull(panelId.flatMap { ws.panelDirectories[$0] })`

The v1 `list_surfaces` text format is intentionally left unchanged to avoid breaking existing parsers in `tests/cmux.py` and `cmuxUITests/MultiWindowNotificationsUITests.swift` that extract UUIDs by splitting on whitespace.

## Test plan

- [ ] Verify `surface.list` response includes `cwd` field with correct path
- [ ] Verify `pane.surfaces` response includes `cwd` field
- [ ] Verify `cwd` is `null` when OSC 7 hasn't reported yet
- [ ] Verify v1 `list_surfaces` output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-surface current working directory metadata to the surface list payload.
  * Added per-surface current working directory metadata to the workspace view payload.
  * Added per-surface current working directory metadata to pane surfaces payloads.
  * These additions provide clearer context for each surface, improving location awareness and navigation without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->