### PR TITLE
fix: Handle `-r` short flag for `--resume` in Claude wrapper

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -69,7 +69,7 @@ unset CLAUDECODE
 SKIP_SESSION_ID=false
 for arg in "$@"; do
     case "$arg" in
-        --resume|--resume=*|--session-id|--session-id=*|--continue|-c)
+        --resume|--resume=*|-r|--session-id|--session-id=*|--continue|-c)
             SKIP_SESSION_ID=true
             break
             ;;

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -166,11 +166,29 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
 
 
+def test_short_resume_flag_skips_session_id_injection(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _ = run_wrapper(
+        socket_state="live", argv=["-r", "some-session-id"]
+    )
+    expect(code == 0, f"-r flag: wrapper exited {code}: {stderr}", failures)
+    expect(
+        "--session-id" not in real_argv,
+        f"-r flag: --session-id should not be injected, got {real_argv}",
+        failures,
+    )
+    expect(
+        "-r" in real_argv,
+        f"-r flag: original -r arg should pass through, got {real_argv}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_short_resume_flag_skips_session_id_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -181,6 +181,11 @@ def test_short_resume_flag_skips_session_id_injection(failures: list[str]) -> No
         f"-r flag: original -r arg should pass through, got {real_argv}",
         failures,
     )
+    expect(
+        "some-session-id" in real_argv,
+        f"-r flag: resume value should pass through, got {real_argv}",
+        failures,
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
# Summary

- The Claude wrapper's `SKIP_SESSION_ID` check matches `--resume` and `-c` (short for `--continue`), but not `-r` (short for `--resume`)
- When using `claude -r <session-id>` inside cmux, the wrapper injects `--session-id` alongside `--resume`, causing Claude Code to error with:
  - `--session-id can only be used with --continue or --resume if --fork-session is also specified`
- This doesn't happen in standalone Ghostty because the wrapper is bypassed when `CMUX_SURFACE_ID` is unset
- Add `-r` to the existing case pattern on line 72


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle the -r short flag for --resume in the Claude wrapper so it skips injecting --session-id and avoids resume errors (e.g., in cmux). Tests confirm both -r and its value pass through unchanged, and --session-id is not injected.

<sup>Written for commit c92c3457a80b281917458a740e41973d329e52eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a short alias (-r) for the resume option; using -r resumes a session and prevents automatic insertion of a session ID while preserving the original argument.
* **Tests**
  * Added a test to confirm that -r skips session-ID injection and is passed through unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->