### PR TITLE
Restore main window size after reopening

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2063,6 +2063,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    private func resolvedCreateMainWindowFrame(
+        sessionWindowSnapshot: SessionWindowSnapshot?
+    ) -> NSRect? {
+        let displays = currentDisplayGeometries()
+        let fallbackGeometry = persistedWindowGeometry()
+        return Self.resolvedNewMainWindowFrame(
+            sessionWindowSnapshot: sessionWindowSnapshot,
+            persistedFallbackFrame: fallbackGeometry?.frame,
+            persistedFallbackDisplaySnapshot: fallbackGeometry?.display,
+            existingMainWindowCount: mainWindowContexts.count,
+            availableDisplays: displays.available,
+            fallbackDisplay: displays.fallback
+        )
+    }
+
     nonisolated static func resolvedStartupPrimaryWindowFrame(
         primarySnapshot: SessionWindowSnapshot?,
         fallbackFrame: SessionRectSnapshot?,
@@ -2082,6 +2097,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return resolvedWindowFrame(
             from: fallbackFrame,
             display: fallbackDisplaySnapshot,
+            availableDisplays: availableDisplays,
+            fallbackDisplay: fallbackDisplay
+        )
+    }
+
+    nonisolated static func resolvedNewMainWindowFrame(
+        sessionWindowSnapshot: SessionWindowSnapshot?,
+        persistedFallbackFrame: SessionRectSnapshot?,
+        persistedFallbackDisplaySnapshot: SessionDisplaySnapshot?,
+        existingMainWindowCount: Int,
+        availableDisplays: [SessionDisplayGeometry],
+        fallbackDisplay: SessionDisplayGeometry?
+    ) -> CGRect? {
+        if let restored = resolvedWindowFrame(
+            from: sessionWindowSnapshot?.frame,
+            display: sessionWindowSnapshot?.display,
+            availableDisplays: availableDisplays,
+            fallbackDisplay: fallbackDisplay
+        ) {
+            return restored
+        }
+
+        guard existingMainWindowCount == 0 else { return nil }
+        return resolvedWindowFrame(
+            from: persistedFallbackFrame,
+            display: persistedFallbackDisplaySnapshot,
             availableDisplays: availableDisplays,
             fallbackDisplay: fallbackDisplay
         )
@@ -4660,7 +4701,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
         window.isMovable = false
-        let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
+        let restoredFrame = resolvedCreateMainWindowFrame(sessionWindowSnapshot: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)
         } else {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -581,6 +581,61 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(restored.height, 700, accuracy: 0.001)
     }
 
+    func testResolvedNewMainWindowFrameFallsBackToPersistedGeometryWhenNoWindowsRemain() {
+        let fallbackFrame = SessionRectSnapshot(x: 180, y: 140, width: 900, height: 640)
+        let fallbackDisplay = SessionDisplaySnapshot(
+            displayID: 1,
+            frame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000),
+            visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000)
+        )
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        )
+
+        let restored = AppDelegate.resolvedNewMainWindowFrame(
+            sessionWindowSnapshot: nil,
+            persistedFallbackFrame: fallbackFrame,
+            persistedFallbackDisplaySnapshot: fallbackDisplay,
+            existingMainWindowCount: 0,
+            availableDisplays: [display],
+            fallbackDisplay: display
+        )
+
+        XCTAssertNotNil(restored)
+        guard let restored else { return }
+        XCTAssertEqual(restored.minX, 180, accuracy: 0.001)
+        XCTAssertEqual(restored.minY, 140, accuracy: 0.001)
+        XCTAssertEqual(restored.width, 900, accuracy: 0.001)
+        XCTAssertEqual(restored.height, 640, accuracy: 0.001)
+    }
+
+    func testResolvedNewMainWindowFrameSkipsPersistedGeometryWhenOtherWindowsExist() {
+        let fallbackFrame = SessionRectSnapshot(x: 180, y: 140, width: 900, height: 640)
+        let fallbackDisplay = SessionDisplaySnapshot(
+            displayID: 1,
+            frame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000),
+            visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000)
+        )
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        )
+
+        let restored = AppDelegate.resolvedNewMainWindowFrame(
+            sessionWindowSnapshot: nil,
+            persistedFallbackFrame: fallbackFrame,
+            persistedFallbackDisplaySnapshot: fallbackDisplay,
+            existingMainWindowCount: 1,
+            availableDisplays: [display],
+            fallbackDisplay: display
+        )
+
+        XCTAssertNil(restored)
+    }
+
     func testResolvedWindowFrameCentersInFallbackDisplayWhenOffscreen() {
         let savedFrame = SessionRectSnapshot(x: 4_000, y: 4_000, width: 900, height: 700)
         let display = AppDelegate.SessionDisplayGeometry(


### PR DESCRIPTION
Fixes #1246

## Summary
- restore persisted main-window geometry when creating a new main window from an empty app state
- keep additional new windows on the existing default placement path
- add regression coverage for the persisted-geometry fallback resolver

## Testing
- ./scripts/reload.sh --tag issue-1246-window-size-restore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the main window’s last size and position when reopening the app, matching the behavior requested in #1246. Additional new windows keep the default placement.

- **Bug Fixes**
  - Use persisted geometry for the first new main window when no other main windows exist.
  - Skip persisted geometry for additional windows to maintain default placement.
  - Add tests for persisted-geometry fallback and for skipping when other windows exist.

<sup>Written for commit d49f88daa676c0b1e17190ef9a927b4de6439636. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved window positioning and restoration when multiple windows are open and display configurations change.
  * Enhanced fallback behavior to better preserve window layout across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->