### PR TITLE
Fix About Panel Newline Escaping

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -575,31 +575,31 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "세로 탭과 알림 패널을 갖춘\\nGhostty 기반 macOS 터미널."
+            "value": "세로 탭과 알림 패널을 갖춘\nGhostty 기반 macOS 터미널."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ein Ghostty-basiertes Terminal mit vertikalen Tabs\\nund einem Benachrichtigungsfeld für macOS."
+            "value": "Ein Ghostty-basiertes Terminal mit vertikalen Tabs\nund einem Benachrichtigungsfeld für macOS."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminal basado en Ghostty con pestañas verticales\\ny un panel de notificaciones para macOS."
+            "value": "Un terminal basado en Ghostty con pestañas verticales\ny un panel de notificaciones para macOS."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminal basé sur Ghostty avec des onglets verticaux\\net un panneau de notifications pour macOS."
+            "value": "Un terminal basé sur Ghostty avec des onglets verticaux\net un panneau de notifications pour macOS."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminale basato su Ghostty con schede verticali\\ne un pannello notifiche per macOS."
+            "value": "Un terminale basato su Ghostty con schede verticali\ne un pannello notifiche per macOS."
           }
         },
         "da": {
@@ -617,43 +617,43 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Терминал на базе Ghostty с вертикальными вкладками\\nи панелью уведомлений для macOS."
+            "value": "Терминал на базе Ghostty с вертикальными вкладками\nи панелью уведомлений для macOS."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Terminal zasnovan na Ghostty sa vertikalnim tabovima\\ni panelom za obavještenja za macOS."
+            "value": "Terminal zasnovan na Ghostty sa vertikalnim tabovima\ni panelom za obavještenja za macOS."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "طرفية مبنية على Ghostty مع ألسنة عمودية\\nولوحة إشعارات لنظام macOS."
+            "value": "طرفية مبنية على Ghostty مع ألسنة عمودية\nولوحة إشعارات لنظام macOS."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "En Ghostty-basert terminal med vertikale faner\\nog et varselpanel for macOS."
+            "value": "En Ghostty-basert terminal med vertikale faner\nog et varselpanel for macOS."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Um terminal baseado no Ghostty com abas verticais\\ne um painel de notificações para macOS."
+            "value": "Um terminal baseado no Ghostty com abas verticais\ne um painel de notificações para macOS."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เทอร์มินัลบน Ghostty พร้อมแท็บแนวตั้ง\\nและแผงการแจ้งเตือนสำหรับ macOS"
+            "value": "เทอร์มินัลบน Ghostty พร้อมแท็บแนวตั้ง\nและแผงการแจ้งเตือนสำหรับ macOS"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS için dikey sekmeli ve bildirim panelli\\nGhostty tabanlı terminal."
+            "value": "macOS için dikey sekmeli ve bildirim panelli\nGhostty tabanlı terminal."
           }
         }
       }


### PR DESCRIPTION
## Summary

- What changed?
The About panel description in `Resources/Localizable.xcstrings` was updated for the key `about.description`. The literal sequence `\\n` was replaced with a real newline `\n` in affected language entries.
- Why?
In the xcstrings JSON, `\\n` is stored as the two characters \ and n, so the UI showed “tabs\nand” on one line. Using a single \n stores an actual newline, so the About panel shows the description on two lines (“…vertical tabs” / “and a notification panel…”).

## Testing

- How did you test this change?
Built the app and opened the About panel
- What did you verify manually?
Correct newline behavior in About panel

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the About panel description by replacing the literal `\\n` with a real newline `\n` so the text renders on two lines. Updates `about.description` in `Resources/Localizable.xcstrings` across affected locales, including `en`, `zh-Hans`, `zh-Hant`, `ko`, `de`, `es`, `fr`, `it`, `ru`, `bs`, `ar`, `nb`, `pt-BR`, `th`, and `tr`.

<sup>Written for commit 16f4620e9c89ad8a5f186f22061fb8d5a04b9b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Fixed text formatting so newline escape sequences display as actual line breaks across all supported languages.
  * Refined and clarified numerous UI strings (titles, prompts, notifications, labels) for English, Japanese, Chinese, Korean, German, Spanish, French, Italian, Danish, Polish, Russian, Bosnian, Arabic, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->