### PR TITLE
Release v0.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to cmux are documented here.
 
+## [0.62.1] - 2026-03-13
+
+### Added
+- Cmd+T (New tab) shortcut on the welcome screen ([#1258](https://github.com/manaflow-ai/cmux/pull/1258))
+
+### Fixed
+- Cmd+backtick window cycling skipping windows
+- Titlebar shortcut hint clipping ([#1259](https://github.com/manaflow-ai/cmux/pull/1259))
+- Terminal portals desyncing after sidebar changes ([#1253](https://github.com/manaflow-ai/cmux/pull/1253))
+- Background terminal focus retries reordering windows
+- Pure-style multiline prompt redraws in Ghostty
+- Return key not working on Cmd+Ctrl+W close confirmation ([#1279](https://github.com/manaflow-ai/cmux/pull/1279))
+- Concurrent remote daemon RPC calls timing out ([#1281](https://github.com/manaflow-ai/cmux/pull/1281))
+
+### Removed
+- SSH remote port proxying (reverted, will return in a future release)
+
 ## [0.62.0] - 2026-03-12
 
 ### Added

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -814,7 +814,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -823,7 +823,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -853,7 +853,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -862,7 +862,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -929,10 +929,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -946,10 +946,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -963,10 +963,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -982,10 +982,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 75;
+				CURRENT_PROJECT_VERSION = 76;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.0;
+				MARKETING_VERSION = 0.62.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary
- Bump version to 0.62.1 (build 76)
- Changelog for v0.62.1: Cmd+backtick fix, titlebar hint clipping, terminal portal sync, Pure prompt redraws, close confirmation Return key, concurrent daemon RPC fix, SSH remote revert

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.62.1 (build 76) bumps app versions and updates the changelog. Adds Cmd+T on the welcome screen and temporarily removes SSH remote port proxying.

- **Bug Fixes**
  - Window cycling and focus behavior corrected (Cmd+backtick and background focus retries).
  - Titlebar shortcut hint no longer clips.
  - Terminal portals stay in sync after sidebar changes; Pure-style multiline prompts redraw correctly in Ghostty.
  - Close confirmation accepts Return; concurrent remote daemon RPCs no longer time out.

<sup>Written for commit f33e08273d055d0553c49c38dc91819878c98495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cmd+T shortcut on the welcome screen

* **Bug Fixes**
  * Fixed window cycling, titlebar hints, portal desyncs, focus retries, prompt redraws, close confirmation, and remote RPC timeout issues

* **Revert**
  * Removed SSH remote port proxying (returning in a future release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->