### PR TITLE
Avoid redundant browser portal redraws on resize

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2140,19 +2140,10 @@ final class WindowBrowserPortal: NSObject {
         installedReferenceView?.layoutSubtreeIfNeeded()
         hostView.superview?.layoutSubtreeIfNeeded()
         hostView.layoutSubtreeIfNeeded()
+        // `synchronizeWebView` already performs the necessary frame/bounds invalidation
+        // when portal geometry actually changes. Avoid a second unconditional redraw pass
+        // here, which stalls divider drags/window resizes without improving correctness.
         synchronizeAllWebViews(excluding: nil, source: "externalGeometry")
-
-        for entry in entriesByWebViewId.values {
-            guard let webView = entry.webView,
-                  let containerView = entry.containerView,
-                  !containerView.isHidden else { continue }
-            guard webView.superview === containerView else { continue }
-            invalidateHostedWebViewGeometry(
-                webView,
-                in: containerView,
-                reason: "externalGeometry"
-            )
-        }
     }
 
     @discardableResult
@@ -2420,14 +2411,14 @@ final class WindowBrowserPortal: NSObject {
         return created
     }
 
-    private func runHostedWebViewRefreshPass(
+    private func prepareHostedWebViewRefreshPass(
         _ webView: WKWebView,
         in containerView: WindowBrowserSlotView,
         reason: String,
         phase: String,
         reattachRenderingState: Bool
-    ) {
-        guard !containerView.isHidden else { return }
+    ) -> Bool {
+        guard !containerView.isHidden else { return false }
         guard !containerView.isHostedInspectorDividerDragActive else {
 #if DEBUG
             dlog(
@@ -2436,7 +2427,7 @@ final class WindowBrowserPortal: NSObject {
                 "drag=1 reattach=\(reattachRenderingState ? 1 : 0)"
             )
 #endif
-            return
+            return false
         }
 
         containerView.needsLayout = true
@@ -2454,6 +2445,25 @@ final class WindowBrowserPortal: NSObject {
         webView.needsLayout = true
         webView.needsDisplay = true
         webView.setNeedsDisplay(webView.bounds)
+        return true
+    }
+
+    private func runHostedWebViewRefreshPass(
+        _ webView: WKWebView,
+        in containerView: WindowBrowserSlotView,
+        reason: String,
+        phase: String,
+        reattachRenderingState: Bool
+    ) {
+        guard prepareHostedWebViewRefreshPass(
+            webView,
+            in: containerView,
+            reason: reason,
+            phase: phase,
+            reattachRenderingState: reattachRenderingState
+        ) else {
+            return
+        }
 
         containerView.layoutSubtreeIfNeeded()
         if let scrollView = webView.enclosingScrollView {
@@ -2483,13 +2493,33 @@ final class WindowBrowserPortal: NSObject {
         in containerView: WindowBrowserSlotView,
         reason: String
     ) {
-        runHostedWebViewRefreshPass(
+        guard prepareHostedWebViewRefreshPass(
             webView,
             in: containerView,
             reason: reason,
             phase: "geometry",
             reattachRenderingState: false
+        ) else {
+            return
+        }
+
+        // Plain frame/bounds changes should not force a synchronous WebKit/window redraw.
+        // Let AppKit coalesce the actual paint while still nudging the hosted hierarchy to
+        // reconcile its scroll/content layout immediately.
+        containerView.layoutSubtreeIfNeeded()
+        if let scrollView = webView.enclosingScrollView {
+            scrollView.layoutSubtreeIfNeeded()
+            scrollView.contentView.layoutSubtreeIfNeeded()
+        }
+        webView.layoutSubtreeIfNeeded()
+#if DEBUG
+        dlog(
+            "browser.portal.invalidate " +
+            "web=\(browserPortalDebugToken(webView)) " +
+            "container=\(browserPortalDebugToken(containerView)) reason=\(reason) " +
+            "phase=geometry frame=\(browserPortalDebugFrame(containerView.frame))"
         )
+#endif
     }
 
     private func refreshHostedWebViewPresentation(


### PR DESCRIPTION
## Summary
- remove the unconditional second hosted browser invalidation pass from external geometry sync
- split geometry-only invalidation from the heavier refresh path so resize/divider churn does not force synchronous WebKit redraws
- keep the existing refresh/reattach behavior for reveal and anchor-change cases

## Verification
- built and launched with `./scripts/reload.sh --tag issue-1294-browser-slow-load`
- did not run tests locally per repo policy

Closes #1294

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces browser pane stalls during window resize and divider drags by eliminating redundant redraws and introducing a geometry-only invalidation path. Full refresh still runs for reveal and anchor changes. Fixes #1294.

- **Bug Fixes**
  - Removed the second, unconditional hosted web view invalidation during external geometry sync to avoid extra redraws.
  - Added a geometry-only invalidation path that updates layout without forcing synchronous WebKit paints; keep refresh/reattach for reveal/anchor updates.

<sup>Written for commit 3557fe70f064c531292cac5e21116c4f7c7f8ece. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized web view refresh logic to reduce unnecessary redraw cycles during window operations like divider drags and resizing, improving rendering efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->