### PR TITLE
Support broadcast input across workspace panes

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36272,6 +36272,23 @@
         }
       }
     },
+    "menu.view.broadcastInput": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Broadcast Input to All Panes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのペインへ入力をブロードキャスト"
+          }
+        }
+      }
+    },
     "menu.view.clearBrowserHistory": {
       "extractionState": "manual",
       "localizations": {
@@ -59835,6 +59852,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Terminal Kopyalama Modunu Aç/Kapat"
+          }
+        }
+      }
+    },
+    "shortcut.toggleWorkspaceInputBroadcast.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Broadcast Input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力ブロードキャストを切替"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3563,6 +3563,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               let destinationManager = tabManagerFor(windowId: windowId) else {
             return false
         }
+        let broadcastInputEnabled = sourceManager.isBroadcastInputEnabled(for: workspaceId)
 
         if sourceManager === destinationManager {
             if focus {
@@ -3575,6 +3576,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         guard let workspace = sourceManager.detachWorkspace(tabId: workspaceId) else { return false }
         destinationManager.attachWorkspace(workspace, select: focus)
+        destinationManager.setBroadcastInputEnabled(broadcastInputEnabled, for: workspaceId)
 
         if focus {
             _ = focusMainWindow(windowId: windowId)
@@ -8180,6 +8182,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             // Only consume when a focused terminal actually handled the toggle.
             // Otherwise allow the event to continue through the responder chain.
+            return handled
+        }
+
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleWorkspaceInputBroadcast)) {
+            let handled = tabManager?.toggleSelectedWorkspaceInputBroadcast() ?? false
+#if DEBUG
+            dlog(
+                "shortcut.action name=toggleWorkspaceInputBroadcast handled=\(handled ? 1 : 0) " +
+                "\(debugShortcutRouteSnapshot(event: event))"
+            )
+#endif
             return handled
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2296,6 +2296,79 @@ final class GhosttyMetalLayer: CAMetalLayer {
 
 // MARK: - Terminal Surface (owns the ghostty_surface_t lifecycle)
 
+enum TerminalBroadcastDelivery {
+    case key
+    case text
+}
+
+struct TerminalBroadcastInputPayload {
+    let delivery: TerminalBroadcastDelivery
+    let action: ghostty_input_action_e
+    let keycode: UInt32
+    let mods: ghostty_input_mods_e
+    let consumedMods: ghostty_input_mods_e
+    let composing: Bool
+    let unshiftedCodepoint: UInt32
+    let text: String?
+    let forceRefreshAfterSend: Bool
+
+    init(
+        delivery: TerminalBroadcastDelivery = .key,
+        action: ghostty_input_action_e,
+        keycode: UInt32,
+        mods: ghostty_input_mods_e,
+        consumedMods: ghostty_input_mods_e,
+        composing: Bool,
+        unshiftedCodepoint: UInt32,
+        text: String?,
+        forceRefreshAfterSend: Bool
+    ) {
+        self.delivery = delivery
+        self.action = action
+        self.keycode = keycode
+        self.mods = mods
+        self.consumedMods = consumedMods
+        self.composing = composing
+        self.unshiftedCodepoint = unshiftedCodepoint
+        self.text = text
+        self.forceRefreshAfterSend = forceRefreshAfterSend
+    }
+
+    fileprivate func send(to surface: ghostty_surface_t) -> Bool {
+        switch delivery {
+        case .text:
+            guard let text, let data = text.data(using: .utf8), !data.isEmpty else {
+                return false
+            }
+            data.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+                ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+            }
+            return true
+        case .key:
+            break
+        }
+
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = action
+        keyEvent.keycode = keycode
+        keyEvent.mods = mods
+        keyEvent.consumed_mods = consumedMods
+        keyEvent.composing = composing
+        keyEvent.unshifted_codepoint = unshiftedCodepoint
+
+        if let text {
+            return text.withCString { ptr in
+                keyEvent.text = ptr
+                return ghostty_surface_key(surface, keyEvent)
+            }
+        }
+
+        keyEvent.text = nil
+        return ghostty_surface_key(surface, keyEvent)
+    }
+}
+
 final class TerminalSurface: Identifiable, ObservableObject {
     final class SearchState: ObservableObject {
         @Published var needle: String
@@ -2344,6 +2417,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var pendingTextQueue: [Data] = []
     private var pendingTextBytes: Int = 0
     private let maxPendingTextBytes = 1_048_576
+    private var inputBroadcastRelay: ((TerminalBroadcastInputPayload) -> Void)?
     private var backgroundSurfaceStartQueued = false
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
     private enum PortalLifecycleState: String {
@@ -3140,6 +3214,54 @@ final class TerminalSurface: Identifiable, ObservableObject {
     func needsConfirmClose() -> Bool {
         guard let surface = surface else { return false }
         return ghostty_surface_needs_confirm_quit(surface)
+    }
+
+    func setInputBroadcastRelay(_ relay: ((TerminalBroadcastInputPayload) -> Void)?) {
+        inputBroadcastRelay = relay
+    }
+
+    func broadcastInputToPeers(_ payload: TerminalBroadcastInputPayload) {
+        inputBroadcastRelay?(payload)
+    }
+
+    func broadcastTextToPeers(_ text: String) {
+        inputBroadcastRelay?(
+            TerminalBroadcastInputPayload(
+                delivery: .text,
+                action: GHOSTTY_ACTION_PRESS,
+                keycode: 0,
+                mods: GHOSTTY_MODS_NONE,
+                consumedMods: GHOSTTY_MODS_NONE,
+                composing: false,
+                unshiftedCodepoint: 0,
+                text: text,
+                forceRefreshAfterSend: false
+            )
+        )
+    }
+
+    func sendBroadcastInput(_ payload: TerminalBroadcastInputPayload) {
+        guard let surface else { return }
+        _ = payload.send(to: surface)
+        if payload.forceRefreshAfterSend {
+            forceRefresh(reason: "broadcast.textInput")
+        }
+    }
+
+    func sendBroadcastText(_ text: String) {
+        sendBroadcastInput(
+            TerminalBroadcastInputPayload(
+                delivery: .text,
+                action: GHOSTTY_ACTION_PRESS,
+                keycode: 0,
+                mods: GHOSTTY_MODS_NONE,
+                consumedMods: GHOSTTY_MODS_NONE,
+                composing: false,
+                unshiftedCodepoint: 0,
+                text: text,
+                forceRefreshAfterSend: false
+            )
+        )
     }
 
     func sendText(_ text: String) {
@@ -4138,12 +4260,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // MARK: - Clipboard paste
 
     @IBAction func paste(_ sender: Any?) {
-        _ = performBindingAction("paste_from_clipboard")
+        if !pasteClipboardContentsIntoSurfaceAndPeers() {
+            _ = performBindingAction("paste_from_clipboard")
+        }
     }
 
     /// Pastes clipboard text as plain text, stripping any rich formatting.
     @IBAction func pasteAsPlainText(_ sender: Any?) {
-        _ = performBindingAction("paste_from_clipboard")
+        if !pasteClipboardContentsIntoSurfaceAndPeers() {
+            _ = performBindingAction("paste_from_clipboard")
+        }
     }
 
     /// Validates whether edit menu items (copy, paste, split) should be enabled.
@@ -4649,7 +4775,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // If Ghostty handled the key (action/encoding), we're done.
             // If not (e.g. `ignore` keybind), fall through to interpretKeyEvents
             // so the IME gets a chance to process this event.
-            if handled { return }
+            if handled {
+                broadcastInputIfNeeded(
+                    TerminalBroadcastInputPayload(
+                        action: keyEvent.action,
+                        keycode: keyEvent.keycode,
+                        mods: keyEvent.mods,
+                        consumedMods: keyEvent.consumed_mods,
+                        composing: keyEvent.composing,
+                        unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                        text: text.isEmpty ? nil : text,
+                        forceRefreshAfterSend: false
+                    )
+                )
+                return
+            }
         }
 
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
@@ -4787,6 +4927,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         keyEvent.text = ptr
                         _ = ghostty_surface_key(surface, keyEvent)
                     }
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: text,
+                            forceRefreshAfterSend: true
+                        )
+                    )
 #if DEBUG
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     CmuxTypingTiming.logDuration(
@@ -4806,9 +4958,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         path: "terminal.keyDown.accumulatedGhosttySend",
                         event: event
                     )
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     #else
                     _ = ghostty_surface_key(surface, keyEvent)
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
                     #endif
                 }
             }
@@ -4832,6 +5008,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         keyEvent.text = ptr
                         _ = ghostty_surface_key(surface, keyEvent)
                     }
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: text,
+                            forceRefreshAfterSend: true
+                        )
+                    )
 #if DEBUG
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     CmuxTypingTiming.logDuration(
@@ -4851,25 +5039,73 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         path: "terminal.keyDown.ghosttySend",
                         event: event
                     )
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     #else
                     _ = ghostty_surface_key(surface, keyEvent)
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
                     #endif
                 }
             } else {
                 keyEvent.text = nil
                 #if DEBUG
                 let ghosttySendStart = ProcessInfo.processInfo.systemUptime
-                _ = sendTimedGhosttyKey(
-                    surface,
-                    keyEvent,
-                    path: "terminal.keyDown.ghosttySend",
-                    event: event
-                )
-                ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
-                #else
-                _ = ghostty_surface_key(surface, keyEvent)
-                #endif
+                    _ = sendTimedGhosttyKey(
+                        surface,
+                        keyEvent,
+                        path: "terminal.keyDown.ghosttySend",
+                        event: event
+                    )
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
+                    ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+                    #else
+                    _ = ghostty_surface_key(surface, keyEvent)
+                    broadcastInputIfNeeded(
+                        TerminalBroadcastInputPayload(
+                            action: keyEvent.action,
+                            keycode: keyEvent.keycode,
+                            mods: keyEvent.mods,
+                            consumedMods: keyEvent.consumed_mods,
+                            composing: keyEvent.composing,
+                            unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                            text: nil,
+                            forceRefreshAfterSend: false
+                        )
+                    )
+                    #endif
             }
         }
 
@@ -4884,6 +5120,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         // Rendering is driven by Ghostty's wakeups/renderer.
+    }
+
+    private func broadcastInputIfNeeded(_ payload: TerminalBroadcastInputPayload) {
+        terminalSurface?.broadcastInputToPeers(payload)
     }
 
     @discardableResult
@@ -4945,6 +5185,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.text = nil
         keyEvent.composing = false
         _ = sendGhosttyKey(surface, keyEvent)
+        broadcastInputIfNeeded(
+            TerminalBroadcastInputPayload(
+                action: keyEvent.action,
+                keycode: keyEvent.keycode,
+                mods: keyEvent.mods,
+                consumedMods: keyEvent.consumed_mods,
+                composing: keyEvent.composing,
+                unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                text: nil,
+                forceRefreshAfterSend: false
+            )
+        )
     }
 
     override func flagsChanged(with event: NSEvent) {
@@ -4961,6 +5213,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.text = nil
         keyEvent.composing = false
         _ = ghostty_surface_key(surface, keyEvent)
+        broadcastInputIfNeeded(
+            TerminalBroadcastInputPayload(
+                action: keyEvent.action,
+                keycode: keyEvent.keycode,
+                mods: keyEvent.mods,
+                consumedMods: keyEvent.consumed_mods,
+                composing: keyEvent.composing,
+                unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                text: nil,
+                forceRefreshAfterSend: false
+            )
+        )
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
@@ -5501,7 +5765,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Use the text/paste path (ghostty_surface_text) instead of the key event
         // path (ghostty_surface_key) so bracketed paste mode is triggered and the
         // insertion is instant, matching upstream Ghostty behaviour.
-        terminalSurface?.sendText(content)
+        sendTextToSurfaceAndPeers(content)
+        return true
+    }
+
+    fileprivate func sendTextToSurfaceAndPeers(_ text: String) {
+        terminalSurface?.sendText(text)
+        terminalSurface?.broadcastTextToPeers(text)
+    }
+
+    private func pasteClipboardContentsIntoSurfaceAndPeers() -> Bool {
+        let pasteboard = GhosttyPasteboardHelper.pasteboard(for: GHOSTTY_CLIPBOARD_STANDARD)
+        var value = pasteboard.flatMap { GhosttyPasteboardHelper.stringContents(from: $0) } ?? ""
+        if value.isEmpty, let imagePath = GhosttyPasteboardHelper.saveClipboardImageIfNeeded() {
+            value = imagePath
+        }
+        guard !value.isEmpty else { return false }
+        sendTextToSurfaceAndPeers(value)
         return true
     }
 
@@ -6914,7 +7194,7 @@ final class GhosttySurfaceScrollView: NSView {
         #if DEBUG
         dlog("terminal.swiftUIDrop surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") urls=\(urls.map(\.lastPathComponent))")
         #endif
-        surfaceView.terminalSurface?.sendText(content)
+        surfaceView.sendTextToSurfaceAndPeers(content)
         return true
     }
 
@@ -7864,6 +8144,18 @@ extension GhosttyNSView: NSTextInputClient {
             keyEvent.composing = false
             _ = ghostty_surface_key(surface, keyEvent)
         }
+        terminalSurface?.broadcastInputToPeers(
+            TerminalBroadcastInputPayload(
+                action: GHOSTTY_ACTION_PRESS,
+                keycode: 0,
+                mods: GHOSTTY_MODS_NONE,
+                consumedMods: GHOSTTY_MODS_NONE,
+                composing: false,
+                unshiftedCodepoint: 0,
+                text: chars,
+                forceRefreshAfterSend: false
+            )
+        )
 #if DEBUG
         CmuxTypingTiming.logDuration(
             path: "terminal.sendTextToSurface",

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -25,6 +25,7 @@ enum KeyboardShortcutSettings {
         case closeWorkspace
         case newSurface
         case toggleTerminalCopyMode
+        case toggleWorkspaceInputBroadcast
 
         // Panes / splits
         case focusLeft
@@ -64,6 +65,7 @@ enum KeyboardShortcutSettings {
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
+            case .toggleWorkspaceInputBroadcast: return String(localized: "shortcut.toggleWorkspaceInputBroadcast.label", defaultValue: "Toggle Broadcast Input")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -108,10 +110,11 @@ enum KeyboardShortcutSettings {
             case .prevSurface: return "shortcut.prevSurface"
             case .newSurface: return "shortcut.newSurface"
             case .toggleTerminalCopyMode: return "shortcut.toggleTerminalCopyMode"
+            case .toggleWorkspaceInputBroadcast: return "shortcut.toggleWorkspaceInputBroadcast"
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
-            }
+        }
         }
 
         var defaultShortcut: StoredShortcut {
@@ -170,6 +173,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
+            case .toggleWorkspaceInputBroadcast:
+                return StoredShortcut(key: "b", command: true, shift: true, option: false, control: false)
             case .openBrowser:
                 return StoredShortcut(key: "l", command: true, shift: true, option: false, control: false)
             case .toggleBrowserDeveloperTools:
@@ -247,6 +252,7 @@ enum KeyboardShortcutSettings {
     static func nextSurfaceShortcut() -> StoredShortcut { shortcut(for: .nextSurface) }
     static func prevSurfaceShortcut() -> StoredShortcut { shortcut(for: .prevSurface) }
     static func newSurfaceShortcut() -> StoredShortcut { shortcut(for: .newSurface) }
+    static func toggleWorkspaceInputBroadcastShortcut() -> StoredShortcut { shortcut(for: .toggleWorkspaceInputBroadcast) }
 
     static func openBrowserShortcut() -> StoredShortcut { shortcut(for: .openBrowser) }
     static func toggleBrowserDeveloperToolsShortcut() -> StoredShortcut { shortcut(for: .toggleBrowserDeveloperTools) }

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -199,6 +199,10 @@ final class TerminalPanel: Panel, ObservableObject {
         surface.sendText(text)
     }
 
+    func setInputBroadcastRelay(_ relay: ((TerminalBroadcastInputPayload) -> Void)?) {
+        surface.setInputBroadcastRelay(relay)
+    }
+
     func performBindingAction(_ action: String) -> Bool {
         surface.performBindingAction(action)
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -577,6 +577,7 @@ class TabManager: ObservableObject {
     weak var window: NSWindow?
 
     @Published var tabs: [Workspace] = []
+    @Published private(set) var broadcastInputWorkspaceIds: Set<UUID> = []
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
@@ -720,6 +721,31 @@ class TabManager: ObservableObject {
         workspace.onClosedBrowserPanel = nil
     }
 
+    private func wireTerminalInputBroadcast(for workspace: Workspace) {
+        workspace.onTerminalPanelRegistered = { [weak self, weak workspace] terminalPanel in
+            guard let self, let workspace else { return }
+            terminalPanel.setInputBroadcastRelay { [weak self, weak workspace, weak terminalPanel] payload in
+                guard let self, let workspace, let terminalPanel else { return }
+                self.broadcastTerminalInputIfEnabled(
+                    in: workspace.id,
+                    from: terminalPanel.id,
+                    payload: payload
+                )
+            }
+        }
+
+        for terminalPanel in workspace.panels.values.compactMap({ $0 as? TerminalPanel }) {
+            workspace.bindTerminalInputRelayIfNeeded(terminalPanel)
+        }
+    }
+
+    private func unwireTerminalInputBroadcast(for workspace: Workspace) {
+        workspace.onTerminalPanelRegistered = nil
+        for terminalPanel in workspace.panels.values.compactMap({ $0 as? TerminalPanel }) {
+            terminalPanel.setInputBroadcastRelay(nil)
+        }
+    }
+
     var selectedWorkspace: Workspace? {
         guard let selectedTabId else { return nil }
         return tabs.first(where: { $0.id == selectedTabId })
@@ -738,6 +764,11 @@ class TabManager: ObservableObject {
     /// Returns the focused panel's terminal panel (if it is a terminal)
     var selectedTerminalPanel: TerminalPanel? {
         selectedWorkspace?.focusedTerminalPanel
+    }
+
+    var isSelectedWorkspaceInputBroadcastEnabled: Bool {
+        guard let workspaceId = selectedWorkspace?.id else { return false }
+        return broadcastInputWorkspaceIds.contains(workspaceId)
     }
 
     var isFindVisible: Bool {
@@ -796,6 +827,38 @@ class TabManager: ObservableObject {
         return panel.surface.toggleKeyboardCopyMode()
     }
 
+    func isBroadcastInputEnabled(for workspaceId: UUID) -> Bool {
+        broadcastInputWorkspaceIds.contains(workspaceId)
+    }
+
+    func setBroadcastInputEnabled(_ enabled: Bool, for workspaceId: UUID) {
+        if enabled {
+            broadcastInputWorkspaceIds.insert(workspaceId)
+        } else {
+            broadcastInputWorkspaceIds.remove(workspaceId)
+        }
+    }
+
+    @discardableResult
+    func toggleSelectedWorkspaceInputBroadcast() -> Bool {
+        guard let workspaceId = selectedWorkspace?.id else { return false }
+        let next = !isBroadcastInputEnabled(for: workspaceId)
+        setBroadcastInputEnabled(next, for: workspaceId)
+        return true
+    }
+
+    func broadcastTerminalInputIfEnabled(
+        in workspaceId: UUID,
+        from sourcePanelId: UUID,
+        payload: TerminalBroadcastInputPayload
+    ) {
+        guard broadcastInputWorkspaceIds.contains(workspaceId),
+              let workspace = tabs.first(where: { $0.id == workspaceId }) else {
+            return
+        }
+        workspace.broadcastTerminalInput(payload, from: sourcePanelId)
+    }
+
     func hideFind() {
         if let panel = selectedTerminalPanel {
             panel.searchState = nil
@@ -829,6 +892,7 @@ class TabManager: ObservableObject {
             initialTerminalEnvironment: initialTerminalEnvironment
         )
         wireClosedBrowserTracking(for: newWorkspace)
+        wireTerminalInputBroadcast(for: newWorkspace)
         let insertIndex = newTabInsertIndex(placementOverride: placementOverride)
         if insertIndex >= 0 && insertIndex <= tabs.count {
             tabs.insert(newWorkspace, at: insertIndex)
@@ -1265,6 +1329,8 @@ class TabManager: ObservableObject {
         workspace.teardownAllPanels()
         workspace.teardownRemoteConnection()
         unwireClosedBrowserTracking(for: workspace)
+        unwireTerminalInputBroadcast(for: workspace)
+        broadcastInputWorkspaceIds.remove(workspace.id)
 
         if let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
             tabs.remove(at: index)
@@ -1287,7 +1353,9 @@ class TabManager: ObservableObject {
 
         let removed = tabs.remove(at: index)
         unwireClosedBrowserTracking(for: removed)
+        unwireTerminalInputBroadcast(for: removed)
         lastFocusedPanelByTab.removeValue(forKey: removed.id)
+        broadcastInputWorkspaceIds.remove(removed.id)
 
         if tabs.isEmpty {
             // The UI assumes each window always has at least one workspace.
@@ -1306,6 +1374,7 @@ class TabManager: ObservableObject {
     /// Attach an existing workspace to this window.
     func attachWorkspace(_ workspace: Workspace, at index: Int? = nil, select: Bool = true) {
         wireClosedBrowserTracking(for: workspace)
+        wireTerminalInputBroadcast(for: workspace)
         let insertIndex: Int = {
             guard let index else { return tabs.count }
             return max(0, min(index, tabs.count))
@@ -3784,6 +3853,7 @@ extension TabManager {
     func restoreSessionSnapshot(_ snapshot: SessionTabManagerSnapshot) {
         for tab in tabs {
             unwireClosedBrowserTracking(for: tab)
+            unwireTerminalInputBroadcast(for: tab)
         }
 
         // Clear non-@Published state without touching tabs/selectedTabId yet.
@@ -3798,6 +3868,7 @@ extension TabManager {
         isWorkspaceCycleHot = false
         selectionSideEffectsGeneration &+= 1
         recentlyClosedBrowsers = RecentlyClosedBrowserStack(capacity: 20)
+        broadcastInputWorkspaceIds.removeAll()
 
         // Build the new workspace list locally to avoid intermediate @Published
         // emissions (empty tabs, nil selectedTabId) that can leave SwiftUI's
@@ -3815,6 +3886,7 @@ extension TabManager {
             )
             workspace.restoreSessionSnapshot(workspaceSnapshot)
             wireClosedBrowserTracking(for: workspace)
+            wireTerminalInputBroadcast(for: workspace)
             newTabs.append(workspace)
         }
 
@@ -3823,6 +3895,7 @@ extension TabManager {
             Self.nextPortOrdinal += 1
             let fallback = Workspace(title: "Terminal 1", portOrdinal: ordinal)
             wireClosedBrowserTracking(for: fallback)
+            wireTerminalInputBroadcast(for: fallback)
             newTabs.append(fallback)
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4265,6 +4265,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Callback used by TabManager to capture recently closed browser panels for Cmd+Shift+T restore.
     var onClosedBrowserPanel: ((ClosedBrowserPanelRestoreSnapshot) -> Void)?
+    var onTerminalPanelRegistered: ((TerminalPanel) -> Void)?
 
 
     // Closing tabs mutates split layout immediately; terminal views handle their own AppKit
@@ -4505,9 +4506,7 @@ final class Workspace: Identifiable, ObservableObject {
             initialCommand: initialTerminalCommand,
             initialEnvironmentOverrides: initialTerminalEnvironment
         )
-        panels[terminalPanel.id] = terminalPanel
-        panelTitles[terminalPanel.id] = terminalPanel.displayTitle
-        seedTerminalInheritanceFontPoints(panelId: terminalPanel.id, configTemplate: configTemplate)
+        registerTerminalPanel(terminalPanel, configTemplate: configTemplate)
 
         // Create initial tab in bonsplit and store the mapping
         var initialTabId: TabID?
@@ -4552,6 +4551,20 @@ final class Workspace: Identifiable, ObservableObject {
             }
             bonsplitController.selectTab(initialTabId)
         }
+    }
+
+    private func registerTerminalPanel(
+        _ terminalPanel: TerminalPanel,
+        configTemplate: ghostty_surface_config_s?
+    ) {
+        panels[terminalPanel.id] = terminalPanel
+        panelTitles[terminalPanel.id] = terminalPanel.displayTitle
+        seedTerminalInheritanceFontPoints(panelId: terminalPanel.id, configTemplate: configTemplate)
+        onTerminalPanelRegistered?(terminalPanel)
+    }
+
+    func bindTerminalInputRelayIfNeeded(_ terminalPanel: TerminalPanel) {
+        onTerminalPanelRegistered?(terminalPanel)
     }
 
     deinit {
@@ -5773,12 +5786,10 @@ final class Workspace: Identifiable, ObservableObject {
             portOrdinal: portOrdinal,
             initialCommand: remoteTerminalStartupCommand
         )
-        panels[newPanel.id] = newPanel
-        panelTitles[newPanel.id] = newPanel.displayTitle
+        registerTerminalPanel(newPanel, configTemplate: inheritedConfig)
         if remoteTerminalStartupCommand != nil {
             trackRemoteTerminalSurface(newPanel.id)
         }
-        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
 
         // Pre-generate the bonsplit tab ID so we can install the panel mapping before bonsplit
         // mutates layout state (avoids transient "Empty Panel" flashes during split).
@@ -5860,12 +5871,10 @@ final class Workspace: Identifiable, ObservableObject {
             initialCommand: remoteTerminalStartupCommand,
             additionalEnvironment: startupEnvironment
         )
-        panels[newPanel.id] = newPanel
-        panelTitles[newPanel.id] = newPanel.displayTitle
+        registerTerminalPanel(newPanel, configTemplate: inheritedConfig)
         if remoteTerminalStartupCommand != nil {
             trackRemoteTerminalSurface(newPanel.id)
         }
-        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
 
         // Create tab in bonsplit
         guard let newTabId = bonsplitController.createTab(
@@ -6611,6 +6620,7 @@ final class Workspace: Identifiable, ObservableObject {
         panels[detached.panelId] = detached.panel
         if let terminalPanel = detached.panel as? TerminalPanel {
             terminalPanel.updateWorkspaceId(id)
+            bindTerminalInputRelayIfNeeded(terminalPanel)
         } else if let browserPanel = detached.panel as? BrowserPanel {
             browserPanel.updateWorkspaceId(id)
             browserPanel.setRemoteProxyEndpoint(remoteProxyEndpoint)
@@ -7119,9 +7129,7 @@ final class Workspace: Identifiable, ObservableObject {
             configTemplate: inheritedConfig,
             portOrdinal: portOrdinal
         )
-        panels[newPanel.id] = newPanel
-        panelTitles[newPanel.id] = newPanel.displayTitle
-        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
+        registerTerminalPanel(newPanel, configTemplate: inheritedConfig)
 
         // Create tab in bonsplit
         if let newTabId = bonsplitController.createTab(
@@ -7315,6 +7323,23 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         return visiblePanelIds
+    }
+
+    func broadcastTerminalInput(_ payload: TerminalBroadcastInputPayload, from sourcePanelId: UUID) {
+        let renderedPaneIds = bonsplitController.zoomedPaneId.map { [$0] } ?? bonsplitController.allPaneIds
+        var deliveredPanelIds: Set<UUID> = []
+
+        for paneId in renderedPaneIds {
+            let selectedTab = bonsplitController.selectedTab(inPane: paneId) ?? bonsplitController.tabs(inPane: paneId).first
+            guard let selectedTab,
+                  let panelId = panelIdFromSurfaceId(selectedTab.id),
+                  panelId != sourcePanelId,
+                  deliveredPanelIds.insert(panelId).inserted,
+                  let terminalPanel = terminalPanel(for: panelId) else {
+                continue
+            }
+            terminalPanel.surface.sendBroadcastInput(payload)
+        }
     }
 
     private func reconcileTerminalPortalVisibilityForCurrentRenderedLayout() {
@@ -8575,9 +8600,7 @@ extension Workspace: BonsplitDelegate {
                         configTemplate: inheritedConfig,
                         portOrdinal: portOrdinal
                     )
-                    panels[replacementPanel.id] = replacementPanel
-                    panelTitles[replacementPanel.id] = replacementPanel.displayTitle
-                    seedTerminalInheritanceFontPoints(panelId: replacementPanel.id, configTemplate: inheritedConfig)
+                    registerTerminalPanel(replacementPanel, configTemplate: inheritedConfig)
                     surfaceIdToPanelId[replacementTab.id] = replacementPanel.id
 
                     bonsplitController.updateTab(
@@ -8641,9 +8664,7 @@ extension Workspace: BonsplitDelegate {
             configTemplate: inheritedConfig,
             portOrdinal: portOrdinal
         )
-        panels[newPanel.id] = newPanel
-        panelTitles[newPanel.id] = newPanel.displayTitle
-        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
+        registerTerminalPanel(newPanel, configTemplate: inheritedConfig)
 
         guard let newTabId = bonsplitController.createTab(
             title: newPanel.displayTitle,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -37,6 +37,8 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.toggleWorkspaceInputBroadcast.defaultsKey)
+    private var toggleWorkspaceInputBroadcastShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {
@@ -618,6 +620,15 @@ struct cmuxApp: App {
 
                 Divider()
 
+                splitCommandToggle(
+                    title: String(localized: "menu.view.broadcastInput", defaultValue: "Broadcast Input to All Panes"),
+                    shortcut: toggleWorkspaceInputBroadcastMenuShortcut,
+                    isOn: selectedWorkspaceBroadcastInputBinding(in: activeTabManager)
+                )
+                .disabled(activeTabManager.selectedWorkspace == nil)
+
+                Divider()
+
                 // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
                 ForEach(1...9, id: \.self) { number in
                     Button(String(localized: "menu.view.workspace", defaultValue: "Workspace \(number)")) {
@@ -787,6 +798,13 @@ struct cmuxApp: App {
         )
     }
 
+    private var toggleWorkspaceInputBroadcastMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: toggleWorkspaceInputBroadcastShortcutData,
+            fallback: KeyboardShortcutSettings.Action.toggleWorkspaceInputBroadcast.defaultShortcut
+        )
+    }
+
     private var notificationMenuSnapshot: NotificationMenuSnapshot {
         NotificationMenuSnapshotBuilder.make(notifications: notificationStore.notifications)
     }
@@ -928,6 +946,16 @@ struct cmuxApp: App {
         notificationStore.markUnread(forTabId: workspaceId)
     }
 
+    private func selectedWorkspaceBroadcastInputBinding(in manager: TabManager) -> Binding<Bool> {
+        Binding(
+            get: { manager.isSelectedWorkspaceInputBroadcastEnabled },
+            set: { enabled in
+                guard let workspaceId = manager.selectedWorkspace?.id else { return }
+                manager.setBroadcastInputEnabled(enabled, for: workspaceId)
+            }
+        )
+    }
+
     @ViewBuilder
     private func workspaceCommandMenuContent(manager: TabManager) -> some View {
         let workspace = manager.selectedWorkspace
@@ -1032,6 +1060,16 @@ struct cmuxApp: App {
                 .keyboardShortcut(key, modifiers: shortcut.eventModifiers)
         } else {
             Button(title, action: action)
+        }
+    }
+
+    @ViewBuilder
+    private func splitCommandToggle(title: String, shortcut: StoredShortcut, isOn: Binding<Bool>) -> some View {
+        if let key = shortcut.keyEquivalent {
+            Toggle(title, isOn: isOn)
+                .keyboardShortcut(key, modifiers: shortcut.eventModifiers)
+        } else {
+            Toggle(title, isOn: isOn)
         }
     }
 


### PR DESCRIPTION
## Summary
- add a workspace-level broadcast input toggle, menu item, and configurable shortcut
- relay terminal key, IME, paste, and drop input from the focused pane to the other visible terminal panes in the same workspace
- preserve broadcast state when a workspace moves between windows and localize the new UI strings

## Verification
- ran `./scripts/setup.sh`
- ran `./scripts/reload.sh --tag issue-1290-broadcast-input`

Closes #1290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workspace-level “Broadcast Input to All Panes” toggle to mirror input from the focused terminal to other visible panes in the same workspace (closes #1290). Includes a View menu item and a configurable shortcut (default Cmd+Shift+B), and preserves state when moving workspaces between windows.

- **New Features**
  - Broadcasts keys, IME text, paste (incl. image path), and file drops to all visible terminal panes; excludes the source pane.
  - Respects current layout (works with zoomed and multi-pane views).
  - Toggle is in View as “Broadcast Input to All Panes” and via shortcut; localized in English and Japanese.
  - State is per-workspace and persists across window moves and session restore.

<sup>Written for commit 1824e74873722d2dd31fcad5bf990ad228074d89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Broadcast Input to All Panes" toggle in the View menu to simultaneously send terminal input to all workspace panes.
  * Added keyboard shortcut to quickly toggle input broadcast for the active workspace.
  * Broadcast input state is now preserved when moving workspaces between windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->