### PR TITLE
Suppress notifications for focused workspaces

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4754,6 +4754,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return mainWindowContexts[ObjectIdentifier(window)]
     }
 
+    private func focusedMainWindowContextForNotificationSuppression() -> MainWindowContext? {
+        if let context = contextForMainWindow(NSApp.keyWindow) {
+            return context
+        }
+        if let context = contextForMainWindow(NSApp.mainWindow) {
+            return context
+        }
+        return nil
+    }
+
+    /// Notification suppression is scoped to the currently focused main terminal window
+    /// and its selected workspace, not whichever tab manager last became globally active.
+    func shouldSuppressNotification(forTabId tabId: UUID) -> Bool {
+        if let overrideIsFocused = AppFocusState.overrideIsFocused {
+            guard overrideIsFocused else { return false }
+            if let context = focusedMainWindowContextForNotificationSuppression() {
+                return context.tabManager.selectedTabId == tabId
+            }
+            if let owner = tabManagerFor(tabId: tabId) {
+                return owner.selectedTabId == tabId
+            }
+            return tabManager?.selectedTabId == tabId
+        }
+
+        guard NSApp.isActive else { return false }
+        guard let context = focusedMainWindowContextForNotificationSuppression() else { return false }
+        return context.tabManager.selectedTabId == tabId
+    }
+
 #if DEBUG
     private func debugManagerToken(_ manager: TabManager?) -> String {
         guard let manager else { return "nil" }
@@ -9614,11 +9643,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        if let tabId = notificationWorkspaceId(from: notification.request.content.userInfo),
+           shouldSuppressNotification(forTabId: tabId) {
+            completionHandler([])
+            return
+        }
+
         var options: UNNotificationPresentationOptions = [.banner, .list]
         if notification.request.content.sound != nil {
             options.insert(.sound)
         }
         completionHandler(options)
+    }
+
+    private func notificationWorkspaceId(from userInfo: [AnyHashable: Any]) -> UUID? {
+        if let tabIdString = userInfo["tabId"] as? String,
+           let tabId = UUID(uuidString: tabIdString) {
+            return tabId
+        }
+
+        if let surfaceIdString = userInfo["surfaceId"] as? String,
+           let surfaceId = UUID(uuidString: surfaceIdString),
+           let located = locateSurface(surfaceId: surfaceId) {
+            return located.workspaceId
+        }
+
+        if let surfaceIdString = userInfo["surface"] as? String,
+           let surfaceId = UUID(uuidString: surfaceIdString),
+           let located = locateSurface(surfaceId: surfaceId) {
+            return located.workspaceId
+        }
+
+        return nil
     }
 
     private func handleNotificationResponse(_ response: UNNotificationResponse) {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -825,6 +825,11 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
+        let shouldSuppressNotification = AppDelegate.shared?.shouldSuppressNotification(forTabId: tabId) ?? false
+        if shouldSuppressNotification {
+            return
+        }
+
         var updated = notifications
         var idsToClear: [String] = []
         updated.removeAll { existing in
@@ -832,13 +837,6 @@ final class TerminalNotificationStore: ObservableObject {
             idsToClear.append(existing.id.uuidString)
             return true
         }
-
-        let isActiveTab = AppDelegate.shared?.tabManager?.selectedTabId == tabId
-        let focusedSurfaceId = AppDelegate.shared?.tabManager?.focusedSurfaceId(for: tabId)
-        let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId
-        let isFocusedPanel = isActiveTab && isFocusedSurface
-        let isAppFocused = AppFocusState.isAppFocused()
-        let shouldSuppressExternalDelivery = isAppFocused && isFocusedPanel
 
         if WorkspaceAutoReorderSettings.isEnabled() {
             AppDelegate.shared?.tabManager?.moveTabToTopForNotification(tabId)
@@ -860,9 +858,7 @@ final class TerminalNotificationStore: ObservableObject {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
-        if !shouldSuppressExternalDelivery {
-            notificationDeliveryHandler(self, notification)
-        }
+        notificationDeliveryHandler(self, notification)
     }
 
     func markRead(id: UUID) {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -984,6 +984,74 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         XCTAssertTrue(app.tabManager === manager)
     }
 
+    func testFocusedWindowBeatsStaleActiveManagerWhenSuppressingNotification() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+        let store = TerminalNotificationStore.shared
+
+        let windowAId = UUID()
+        let windowBId = UUID()
+        let windowA = makeMainWindow(id: windowAId)
+        let windowB = makeMainWindow(id: windowBId)
+        let originalNotificationStore = app.notificationStore
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+        var deliveredNotifications: [TerminalNotification] = []
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+            app.notificationStore = originalNotificationStore
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+            windowA.close()
+            windowB.close()
+        }
+
+        let managerA = TabManager()
+        let managerB = TabManager()
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, notification in
+            deliveredNotifications.append(notification)
+        }
+        app.notificationStore = store
+        app.registerMainWindow(
+            windowA,
+            windowId: windowAId,
+            tabManager: managerA,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+        app.registerMainWindow(
+            windowB,
+            windowId: windowBId,
+            tabManager: managerB,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+
+        windowA.makeKeyAndOrderFront(nil)
+        app.tabManager = managerB
+        AppFocusState.overrideIsFocused = true
+
+        store.addNotification(
+            tabId: managerA.tabs[0].id,
+            surfaceId: nil,
+            title: "Window A",
+            subtitle: "",
+            body: ""
+        )
+        XCTAssertTrue(store.notifications.isEmpty)
+        XCTAssertTrue(deliveredNotifications.isEmpty)
+
+        store.addNotification(
+            tabId: managerB.tabs[0].id,
+            surfaceId: nil,
+            title: "Window B",
+            subtitle: "",
+            body: ""
+        )
+        XCTAssertEqual(store.notifications.map(\.title), ["Window B"])
+        XCTAssertEqual(deliveredNotifications.map(\.title), ["Window B"])
+    }
+
     func testAddWorkspaceWithoutBringToFrontPreservesActiveWindowAndSelection() {
         _ = NSApplication.shared
         let app = AppDelegate()
@@ -4951,6 +5019,83 @@ final class WorkspaceNotificationReorderTests: XCTestCase {
         )
 
         XCTAssertEqual(manager.tabs.map(\.id), expectedOrder)
+    }
+
+    func testFocusedWorkspaceSuppressesNotificationForUnfocusedSurface() {
+        _ = NSApplication.shared
+        let appDelegate = AppDelegate()
+        let manager = TabManager()
+        let notificationStore = TerminalNotificationStore.shared
+        let windowId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalAutoReorderSetting = UserDefaults.standard.object(forKey: WorkspaceAutoReorderSettings.key)
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+        var deliveredNotifications: [TerminalNotification] = []
+
+        notificationStore.replaceNotificationsForTesting([])
+        notificationStore.configureNotificationDeliveryHandlerForTesting { _, notification in
+            deliveredNotifications.append(notification)
+        }
+        appDelegate.notificationStore = notificationStore
+        appDelegate.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+        appDelegate.tabManager = manager
+        AppFocusState.overrideIsFocused = true
+        window.makeKeyAndOrderFront(nil)
+
+        defer {
+            notificationStore.replaceNotificationsForTesting([])
+            notificationStore.resetNotificationDeliveryHandlerForTesting()
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+            if let originalAutoReorderSetting {
+                UserDefaults.standard.set(originalAutoReorderSetting, forKey: WorkspaceAutoReorderSettings.key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: WorkspaceAutoReorderSettings.key)
+            }
+            window.close()
+        }
+
+        UserDefaults.standard.set(false, forKey: WorkspaceAutoReorderSettings.key)
+
+        guard let workspace = manager.selectedWorkspace,
+              let initialPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial selected workspace and focused panel")
+            return
+        }
+
+        _ = manager.newSplit(tabId: workspace.id, surfaceId: initialPanelId, direction: .right)
+        guard let focusedPanelId = workspace.focusedPanelId,
+              let unfocusedPanelId = workspace.panels.keys.first(where: { $0 != focusedPanelId }) else {
+            XCTFail("Expected split workspace with an unfocused panel")
+            return
+        }
+
+        notificationStore.addNotification(
+            tabId: workspace.id,
+            surfaceId: unfocusedPanelId,
+            title: "Build finished",
+            subtitle: "",
+            body: "Visible workspace notifications should be suppressed"
+        )
+
+        XCTAssertTrue(notificationStore.notifications.isEmpty)
+        XCTAssertTrue(deliveredNotifications.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary
- suppress notifications before they are stored or presented when the focused main cmux window is already showing the source workspace
- resolve suppression from the focused window context instead of the last active tab manager, so stale window routing no longer leaks notifications
- add regression coverage for stale active-manager routing and notifications emitted from an unfocused surface inside the focused workspace

Closes #1004

## Testing
- ./scripts/reload.sh --tag issue1004
- local tests not run (repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress notifications for workspaces visible in the focused main window to avoid redundant alerts (Linear issue #1004). The decision now uses the focused window context instead of the last active tab manager to prevent leaks from stale routing.

- **Bug Fixes**
  - Suppress before storage and presentation via `AppDelegate.shouldSuppressNotification` and the `UNUserNotificationCenter` delegate.
  - Resolve the focused window/workspace and extract IDs from `tabId`, `surfaceId`, or `surface` payload fields.
  - Add regression tests for stale active-manager routing and notifications from an unfocused panel in a focused workspace.

<sup>Written for commit 436c073028f3ebb5248d37bb64c6cb52e6fa0c35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved notification suppression to intelligently target the currently focused window or tab, preventing notifications from appearing in unfocused contexts.

* **Tests**
  * Added tests to verify notification suppression behavior across multiple windows and workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->