### PR TITLE
Add copy-on-select setting

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -40193,6 +40193,159 @@
         }
       }
     },
+    "settings.app.copyOnSelect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy on Select"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択時にコピー"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.clipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clipboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボード"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.clipboard.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-copy selected terminal text to the macOS clipboard and Ghostty's selection clipboard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したターミナルテキストをmacOSのクリップボードとGhosttyの選択クリップボードに自動コピーします。"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.disabled.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not auto-copy terminal selections."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルの選択を自動コピーしません。"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.inherit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inherit Ghostty Config"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty設定に従う"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.inherit.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use your Ghostty config file or Ghostty's platform default."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghosttyの設定ファイルまたはGhosttyのプラットフォーム既定値を使います。"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.selection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selection Clipboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択クリップボード"
+          }
+        }
+      }
+    },
+    "settings.app.copyOnSelect.selection.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-copy selected terminal text to Ghostty's selection clipboard only."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したターミナルテキストをGhosttyの選択クリップボードだけに自動コピーします。"
+          }
+        }
+      }
+    },
     "settings.app.dockBadge": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1030,7 +1030,43 @@ class GhosttyApp {
         loadLegacyGhosttyConfigIfNeeded(config)
         ghostty_config_load_recursive_files(config)
         loadCJKFontFallbackIfNeeded(config)
+        // App-level Preferences should win when the user explicitly overrides Ghostty.
+        loadCopyOnSelectOverrideIfNeeded(config)
         ghostty_config_finalize(config)
+    }
+
+    private func loadInlineGhosttyConfig(
+        _ contents: String,
+        into config: ghostty_config_t,
+        prefix: String,
+        logLabel: String
+    ) {
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString).conf")
+        do {
+            try trimmed.write(to: tmpURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: tmpURL) }
+            tmpURL.path.withCString { path in
+                ghostty_config_load_file(config, path)
+            }
+        } catch {
+            #if DEBUG
+            Self.initLog("failed to write \(logLabel) config: \(error)")
+            #endif
+        }
+    }
+
+    private func loadCopyOnSelectOverrideIfNeeded(_ config: ghostty_config_t) {
+        guard let line = TerminalCopyOnSelectSettings.overrideConfigLine() else { return }
+        loadInlineGhosttyConfig(
+            line,
+            into: config,
+            prefix: "cmux-copy-on-select",
+            logLabel: "copy-on-select override"
+        )
     }
 
     /// When the user has not configured `font-codepoint-map` for CJK ranges,
@@ -1050,20 +1086,12 @@ class GhosttyApp {
         let lines = mappings.map { range, font in
             "font-codepoint-map = \(range)=\(font)"
         }.joined(separator: "\n")
-
-        let tmpURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-cjk-font-fallback-\(UUID().uuidString).conf")
-        do {
-            try lines.write(to: tmpURL, atomically: true, encoding: .utf8)
-            defer { try? FileManager.default.removeItem(at: tmpURL) }
-            tmpURL.path.withCString { path in
-                ghostty_config_load_file(config, path)
-            }
-        } catch {
-            #if DEBUG
-            Self.initLog("failed to write CJK font fallback config: \(error)")
-            #endif
-        }
+        loadInlineGhosttyConfig(
+            lines,
+            into: config,
+            prefix: "cmux-cjk-font-fallback",
+            logLabel: "CJK font fallback"
+        )
     }
 
     /// Unicode ranges shared by all CJK languages (Han ideographs, symbols, fullwidth forms).

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3009,6 +3009,103 @@ enum CommandPaletteRenameSelectionSettings {
     }
 }
 
+enum TerminalCopyOnSelectSettings {
+    static let modeKey = "terminalCopyOnSelectMode"
+    static let defaultMode: Mode = .inherit
+
+    enum Mode: String, CaseIterable, Identifiable {
+        case inherit
+        case selection
+        case clipboard
+        case disabled
+
+        var id: Self { self }
+
+        var displayName: String {
+            switch self {
+            case .inherit:
+                return String(
+                    localized: "settings.app.copyOnSelect.inherit",
+                    defaultValue: "Inherit Ghostty Config"
+                )
+            case .selection:
+                return String(
+                    localized: "settings.app.copyOnSelect.selection",
+                    defaultValue: "Selection Clipboard"
+                )
+            case .clipboard:
+                return String(
+                    localized: "settings.app.copyOnSelect.clipboard",
+                    defaultValue: "Clipboard"
+                )
+            case .disabled:
+                return String(
+                    localized: "settings.app.copyOnSelect.disabled",
+                    defaultValue: "Off"
+                )
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .inherit:
+                return String(
+                    localized: "settings.app.copyOnSelect.inherit.subtitle",
+                    defaultValue: "Use your Ghostty config file or Ghostty's platform default."
+                )
+            case .selection:
+                return String(
+                    localized: "settings.app.copyOnSelect.selection.subtitle",
+                    defaultValue: "Auto-copy selected terminal text to Ghostty's selection clipboard only."
+                )
+            case .clipboard:
+                return String(
+                    localized: "settings.app.copyOnSelect.clipboard.subtitle",
+                    defaultValue: "Auto-copy selected terminal text to the macOS clipboard and Ghostty's selection clipboard."
+                )
+            case .disabled:
+                return String(
+                    localized: "settings.app.copyOnSelect.disabled.subtitle",
+                    defaultValue: "Do not auto-copy terminal selections."
+                )
+            }
+        }
+
+        // Keep the cmux picker aligned with Ghostty's upstream `copy-on-select` values.
+        var ghosttyConfigValue: String? {
+            switch self {
+            case .inherit:
+                return nil
+            case .selection:
+                return "true"
+            case .clipboard:
+                return "clipboard"
+            case .disabled:
+                return "false"
+            }
+        }
+
+        var ghosttyConfigLine: String? {
+            ghosttyConfigValue.map { "copy-on-select = \($0)" }
+        }
+    }
+
+    static func mode(defaults: UserDefaults = .standard) -> Mode {
+        mode(for: defaults.string(forKey: modeKey))
+    }
+
+    static func mode(for rawValue: String?) -> Mode {
+        guard let rawValue, let mode = Mode(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+
+    static func overrideConfigLine(defaults: UserDefaults = .standard) -> String? {
+        mode(defaults: defaults).ghosttyConfigLine
+    }
+}
+
 enum ClaudeCodeIntegrationSettings {
     static let hooksEnabledKey = "claudeCodeHooksEnabled"
     static let defaultHooksEnabled = true
@@ -3073,6 +3170,8 @@ struct SettingsView: View {
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
+    @AppStorage(TerminalCopyOnSelectSettings.modeKey)
+    private var terminalCopyOnSelectMode = TerminalCopyOnSelectSettings.defaultMode.rawValue
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey)
     private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
@@ -3145,6 +3244,19 @@ struct SettingsView: View {
             get: { browserThemeMode },
             set: { newValue in
                 browserThemeMode = BrowserThemeSettings.mode(for: newValue).rawValue
+            }
+        )
+    }
+
+    private var selectedTerminalCopyOnSelectMode: TerminalCopyOnSelectSettings.Mode {
+        TerminalCopyOnSelectSettings.mode(for: terminalCopyOnSelectMode)
+    }
+
+    private var terminalCopyOnSelectModeSelection: Binding<String> {
+        Binding(
+            get: { selectedTerminalCopyOnSelectMode.rawValue },
+            set: { newValue in
+                terminalCopyOnSelectMode = TerminalCopyOnSelectSettings.mode(for: newValue).rawValue
             }
         )
     }
@@ -3648,6 +3760,19 @@ struct SettingsView: View {
                             Toggle("", isOn: $commandPaletteRenameSelectAllOnFocus)
                                 .labelsHidden()
                                 .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.app.copyOnSelect", defaultValue: "Copy on Select"),
+                            subtitle: selectedTerminalCopyOnSelectMode.description,
+                            controlWidth: pickerColumnWidth,
+                            selection: terminalCopyOnSelectModeSelection
+                        ) {
+                            ForEach(TerminalCopyOnSelectSettings.Mode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
                         }
 
                         SettingsCardDivider()
@@ -4292,6 +4417,14 @@ struct SettingsView: View {
         .onChange(of: notificationSoundCustomFilePath) { _, _ in
             refreshNotificationCustomSoundStatus()
         }
+        .onChange(of: terminalCopyOnSelectMode) { _, newValue in
+            let normalized = TerminalCopyOnSelectSettings.mode(for: newValue).rawValue
+            if normalized != newValue {
+                terminalCopyOnSelectMode = normalized
+                return
+            }
+            GhosttyApp.shared.reloadConfiguration(source: "settings.copy_on_select")
+        }
         .onChange(of: browserInsecureHTTPAllowlist) { oldValue, newValue in
             // Keep draft in sync with external changes unless the user has local unsaved edits.
             if browserInsecureHTTPAllowlistDraft == oldValue {
@@ -4409,6 +4542,7 @@ struct SettingsView: View {
         notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
         warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
+        terminalCopyOnSelectMode = TerminalCopyOnSelectSettings.defaultMode.rawValue
         ShortcutHintDebugSettings.resetVisibilityDefaults()
         alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
         newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -536,6 +536,55 @@ final class WorkspaceChromeThemeTests: XCTestCase {
     }
 }
 
+final class TerminalCopyOnSelectSettingsTests: XCTestCase {
+    func testCopyOnSelectSettingDefaultsToInheritWhenUnset() {
+        let defaults = makeCopyOnSelectDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+
+        XCTAssertEqual(TerminalCopyOnSelectSettings.mode(defaults: defaults), .inherit)
+        XCTAssertNil(TerminalCopyOnSelectSettings.overrideConfigLine(defaults: defaults))
+    }
+
+    func testCopyOnSelectSettingMapsModesToGhosttyConfigValues() {
+        XCTAssertNil(TerminalCopyOnSelectSettings.Mode.inherit.ghosttyConfigLine)
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.Mode.selection.ghosttyConfigLine,
+            "copy-on-select = true"
+        )
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.Mode.clipboard.ghosttyConfigLine,
+            "copy-on-select = clipboard"
+        )
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.Mode.disabled.ghosttyConfigLine,
+            "copy-on-select = false"
+        )
+    }
+
+    func testCopyOnSelectSettingReadsStoredClipboardOverride() {
+        let defaults = makeCopyOnSelectDefaults()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        defaults.set(
+            TerminalCopyOnSelectSettings.Mode.clipboard.rawValue,
+            forKey: TerminalCopyOnSelectSettings.modeKey
+        )
+
+        XCTAssertEqual(TerminalCopyOnSelectSettings.mode(defaults: defaults), .clipboard)
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.overrideConfigLine(defaults: defaults),
+            "copy-on-select = clipboard"
+        )
+    }
+
+    private let defaultsSuiteName = "TerminalCopyOnSelectSettingsTests"
+
+    private func makeCopyOnSelectDefaults() -> UserDefaults {
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        return defaults
+    }
+}
+
 final class WorkspaceAppearanceConfigResolutionTests: XCTestCase {
     func testResolvedAppearanceConfigPrefersGhosttyRuntimeBackgroundOverLoadedConfig() {
         guard let loadedBackground = NSColor(hex: "#112233"),


### PR DESCRIPTION
## Summary
- add a Preferences picker for Ghostty's upstream `copy-on-select` modes, with an `Inherit Ghostty Config` default so cmux preserves current Ghostty behavior unless the user overrides it
- load the selected override after Ghostty config files so the cmux setting maps directly to upstream `true`, `clipboard`, and `false` values
- add focused unit coverage for the mode-to-config mapping

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-feat-copy-on-select-option-unit -only-testing:cmuxTests/TerminalCopyOnSelectSettingsTests -only-testing:cmuxTests/GhosttyConfigTests test`
- `./scripts/reload.sh --tag feat-copy-on-select-option`

## Issues
- Related task: Feature request: add copy-on-select option so double-click/selection automatically copies to clipboard, and compare the implementation with upstream Ghostty support


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Copy on Select preference that mirrors upstream Ghostty modes and preserves current behavior by default. The setting overrides Ghostty config only when changed and applies immediately.

- **New Features**
  - Preferences picker for copy-on-select with modes: Inherit Ghostty Config, Selection Clipboard, Clipboard, Off.
  - Maps to Ghostty `copy-on-select` values: selection → `true`, clipboard → `clipboard`, off → `false`; inherit leaves config unchanged.
  - Applies override after loading Ghostty config and reloads on change for immediate effect.
  - Adds localized labels and descriptions (en, ja).

- **Refactors**
  - Added a reusable helper to load inline Ghostty config snippets; reused for CJK font fallback loading.

<sup>Written for commit 618b1f6d2a2548d15624a5304c5cc908574eca16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy on Select" setting in preferences with configurable modes: inherit, selection, clipboard, or disabled to control text copy behavior.

* **Localization**
  * Added comprehensive multilingual support for the new "Copy on Select" feature across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->