### PR TITLE
Add cleaner titlebar visibility options

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 		A5002000 /* THIRD_PARTY_LICENSES.md in Resources */ = {isa = PBXBuildFile; fileRef = A5002001 /* THIRD_PARTY_LICENSES.md */; };
 			B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
+			D4A1B2C3D4E5F60718000002 /* BonsplitTabDragUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A1B2C3D4E5F60718000001 /* BonsplitTabDragUITests.swift */; };
 			B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
@@ -211,8 +212,9 @@
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
-		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
-		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
+			818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
+			D4A1B2C3D4E5F60718000001 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
+			B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -448,6 +450,7 @@
 				isa = PBXGroup;
 						children = (
 							B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */,
+							D4A1B2C3D4E5F60718000001 /* BonsplitTabDragUITests.swift */,
 							B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 							B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
 							B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */,
@@ -688,6 +691,7 @@
 				buildActionMask = 2147483647;
 						files = (
 							B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
+							D4A1B2C3D4E5F60718000002 /* BonsplitTabDragUITests.swift in Sources */,
 							B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 							B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
 							B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 			A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 			E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 			B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */; };
+			C9A10001A1B2C3D4E5F60719 /* TitlebarVisibilitySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A10002A1B2C3D4E5F60719 /* TitlebarVisibilitySettings.swift */; };
 			A5001003 /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001013 /* TabManager.swift */; };
 			A5001004 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001014 /* GhosttyConfig.swift */; };
 			A5001005 /* GhosttyTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001015 /* GhosttyTerminalView.swift */; };
@@ -158,6 +159,7 @@
 			A5001012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 			9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 			B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandleView.swift; sourceTree = "<group>"; };
+			C9A10002A1B2C3D4E5F60719 /* TitlebarVisibilitySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlebarVisibilitySettings.swift; sourceTree = "<group>"; };
 			A5001013 /* TabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 			A5001014 /* GhosttyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfig.swift; sourceTree = "<group>"; };
 			A5001015 /* GhosttyTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalView.swift; sourceTree = "<group>"; };
@@ -357,6 +359,7 @@
 					A5001012 /* ContentView.swift */,
 					9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */,
 					B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */,
+					C9A10002A1B2C3D4E5F60719 /* TitlebarVisibilitySettings.swift */,
 					A50012F0 /* Backport.swift */,
 					A50012F2 /* KeyboardShortcutSettings.swift */,
 					A50012F4 /* KeyboardLayout.swift */,
@@ -628,6 +631,7 @@
 					A5001002 /* ContentView.swift in Sources */,
 					E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
 					B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */,
+					C9A10001A1B2C3D4E5F60719 /* TitlebarVisibilitySettings.swift in Sources */,
 					A50012F1 /* Backport.swift in Sources */,
 					A50012F3 /* KeyboardShortcutSettings.swift in Sources */,
 					A50012F5 /* KeyboardLayout.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -73093,6 +73093,142 @@
           }
         }
       }
+    },
+    "settings.app.showWorkspaceTitlebar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Workspace Title Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのタイトルバーを表示"
+          }
+        }
+      }
+    },
+    "settings.app.showWorkspaceTitlebar.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide the folder/title strip and drag from empty space in the top pane tab bar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダとタイトルの帯を隠し、上部のペインタブバーの空き領域からウィンドウをドラッグできます。"
+          }
+        }
+      }
+    },
+    "settings.app.showWorkspaceTitlebar.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the folder and active title above pane tabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブの上にフォルダ名と現在のタイトルを表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.titlebarControls": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titlebar Controls"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイトルバーのコントロール"
+          }
+        }
+      }
+    },
+    "settings.app.titlebarControls.always": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always Visible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常に表示"
+          }
+        }
+      }
+    },
+    "settings.app.titlebarControls.hover": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show on Hover"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホバー時に表示"
+          }
+        }
+      }
+    },
+    "settings.app.titlebarControls.subtitleAlways": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the sidebar, notifications, and new workspace buttons visible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバー、通知、新規ワークスペースのボタンを常に表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.titlebarControls.subtitleHover": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide titlebar buttons until the pointer reaches them."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ポインタが近づくまでタイトルバーのボタンを隠します。"
+          }
+        }
+      }
     }
   }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -73229,6 +73229,57 @@
           }
         }
       }
+    },
+    "settings.app.paneTabBarControls": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pane Tab Bar Controls"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブバーのコントロール"
+          }
+        }
+      }
+    },
+    "settings.app.paneTabBarControls.subtitleAlways": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the pane tab bar's new tab and split buttons visible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブバーの新規タブボタンと分割ボタンを常に表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.paneTabBarControls.subtitleHover": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide the pane tab bar's new tab and split buttons until you hover the bar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブバーにホバーするまで、新規タブボタンと分割ボタンを隠します。"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1994,6 +1994,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var jumpUnreadFocusExpectation: (tabId: UUID, surfaceId: UUID)?
     private var jumpUnreadFocusObserver: NSObjectProtocol?
     private var didSetupGotoSplitUITest = false
+    private var didSetupBonsplitTabDragUITest = false
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
     private var didSetupMultiWindowNotificationsUITest = false
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
@@ -2367,6 +2368,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         setupJumpUnreadUITestIfNeeded()
         setupGotoSplitUITestIfNeeded()
+        setupBonsplitTabDragUITestIfNeeded()
         setupMultiWindowNotificationsUITestIfNeeded()
 
         // UI tests sometimes don't run SwiftUI `.onAppear` soon enough (or at all) on the VM.
@@ -6441,6 +6443,93 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard self != nil else { return }
             runSetupWhenWindowReady()
         }
+    }
+
+    private func setupBonsplitTabDragUITestIfNeeded() {
+        guard !didSetupBonsplitTabDragUITest else { return }
+        didSetupBonsplitTabDragUITest = true
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" else { return }
+        guard tabManager != nil else { return }
+
+        let deadline = Date().addingTimeInterval(20.0)
+        func hasMainTerminalWindow() -> Bool {
+            NSApp.windows.contains { window in
+                guard let raw = window.identifier?.rawValue else { return false }
+                return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
+            }
+        }
+
+        func runSetupWhenWindowReady() {
+            guard Date() < deadline else {
+                writeBonsplitTabDragUITestData(["setupError": "Timed out waiting for main window"])
+                return
+            }
+            guard hasMainTerminalWindow() else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    runSetupWhenWindowReady()
+                }
+                return
+            }
+            guard let tabManager = self.tabManager,
+                  let workspace = tabManager.selectedWorkspace ?? tabManager.tabs.first,
+                  let alphaPanelId = workspace.focusedPanelId else {
+                self.writeBonsplitTabDragUITestData(["setupError": "Missing initial workspace or panel"])
+                return
+            }
+
+            let alphaTitle = "UITest Alpha"
+            let betaTitle = "UITest Beta"
+            workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
+            tabManager.newSurface()
+
+            guard let betaPanelId = workspace.focusedPanelId, betaPanelId != alphaPanelId else {
+                self.writeBonsplitTabDragUITestData(["setupError": "Failed to create second surface"])
+                return
+            }
+
+            workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
+            self.writeBonsplitTabDragUITestData([
+                "ready": "1",
+                "alphaTitle": alphaTitle,
+                "betaTitle": betaTitle,
+                "alphaPanelId": alphaPanelId.uuidString,
+                "betaPanelId": betaPanelId.uuidString,
+            ])
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            guard self != nil else { return }
+            runSetupWhenWindowReady()
+        }
+    }
+
+    private func bonsplitTabDragUITestDataPath() -> String? {
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1",
+              let path = env["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"],
+              !path.isEmpty else {
+            return nil
+        }
+        return path
+    }
+
+    private func writeBonsplitTabDragUITestData(_ updates: [String: String]) {
+        guard let path = bonsplitTabDragUITestDataPath() else { return }
+        var payload = loadBonsplitTabDragUITestData(at: path)
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    private func loadBonsplitTabDragUITestData(at path: String) -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
     }
 
     private func isGotoSplitUITestRecordingEnabled() -> Bool {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9,6 +9,30 @@ import Combine
 import ObjectiveC.runtime
 import Darwin
 
+final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
+    private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
+
+    override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+    override var safeAreaRect: NSRect { bounds }
+    override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
+
+    required init(rootView: Content) {
+        super.init(rootView: rootView)
+        addLayoutGuide(zeroSafeAreaLayoutGuide)
+        NSLayoutConstraint.activate([
+            zeroSafeAreaLayoutGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
+            zeroSafeAreaLayoutGuide.trailingAnchor.constraint(equalTo: trailingAnchor),
+            zeroSafeAreaLayoutGuide.topAnchor.constraint(equalTo: topAnchor),
+            zeroSafeAreaLayoutGuide.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 #if DEBUG
 enum CmuxTypingTiming {
     static let isEnabled: Bool = {
@@ -5371,7 +5395,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } else {
             window.center()
         }
-        window.contentView = NSHostingView(rootView: root)
+        window.contentView = MainWindowHostingView(rootView: root)
 
         // Apply shared window styling.
         attachUpdateAccessory(to: window)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1996,6 +1996,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var jumpUnreadFocusObserver: NSObjectProtocol?
     private var didSetupGotoSplitUITest = false
     private var didSetupBonsplitTabDragUITest = false
+    private var bonsplitTabDragUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
     private var didSetupMultiWindowNotificationsUITest = false
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
@@ -6517,6 +6518,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "alphaPanelId": alphaPanelId.uuidString,
                 "betaPanelId": betaPanelId.uuidString,
             ])
+            self.startBonsplitTabDragUITestRecorder(
+                workspaceId: workspace.id,
+                alphaPanelId: alphaPanelId,
+                betaPanelId: betaPanelId
+            )
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
@@ -6533,6 +6539,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return nil
         }
         return path
+    }
+
+    private func startBonsplitTabDragUITestRecorder(
+        workspaceId: UUID,
+        alphaPanelId: UUID,
+        betaPanelId: UUID
+    ) {
+        bonsplitTabDragUITestRecorder?.cancel()
+        bonsplitTabDragUITestRecorder = nil
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            self?.recordBonsplitTabDragUITestState(
+                workspaceId: workspaceId,
+                alphaPanelId: alphaPanelId,
+                betaPanelId: betaPanelId
+            )
+        }
+        bonsplitTabDragUITestRecorder = timer
+        timer.resume()
+    }
+
+    private func recordBonsplitTabDragUITestState(
+        workspaceId: UUID,
+        alphaPanelId: UUID,
+        betaPanelId: UUID
+    ) {
+        guard let tabManager else { return }
+        guard let workspace = (tabManager.tabs.first { $0.id == workspaceId } ?? tabManager.selectedWorkspace ?? tabManager.tabs.first) else {
+            return
+        }
+
+        let trackedPaneId = workspace.paneId(forPanelId: alphaPanelId)
+            ?? workspace.paneId(forPanelId: betaPanelId)
+            ?? workspace.bonsplitController.focusedPaneId
+            ?? workspace.bonsplitController.allPaneIds.first
+        guard let trackedPaneId else { return }
+
+        let titles: [String] = workspace.bonsplitController.tabs(inPane: trackedPaneId).compactMap { tab in
+            guard let panelId = workspace.panelIdFromSurfaceId(tab.id) else { return nil }
+            return workspace.panelTitle(panelId: panelId)
+        }
+        let selectedTitle = workspace.bonsplitController.selectedTab(inPane: trackedPaneId)
+            .flatMap { workspace.panelIdFromSurfaceId($0.id) }
+            .flatMap { workspace.panelTitle(panelId: $0) } ?? ""
+
+        writeBonsplitTabDragUITestData([
+            "trackedPaneId": trackedPaneId.description,
+            "trackedPaneTabTitles": titles.joined(separator: "|"),
+            "trackedPaneTabCount": String(titles.count),
+            "trackedPaneSelectedTitle": selectedTitle,
+        ])
     }
 
     private func writeBonsplitTabDragUITestData(_ updates: [String: String]) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -15,6 +15,7 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
+    override var mouseDownCanMoveWindow: Bool { false }
 
     required init(rootView: Content) {
         super.init(rootView: rootView)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6512,6 +6512,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
             self.writeBonsplitTabDragUITestData([
                 "ready": "1",
+                "workspaceId": workspace.id.uuidString,
                 "workspaceTitle": workspaceTitle,
                 "alphaTitle": alphaTitle,
                 "betaTitle": betaTitle,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6471,6 +6471,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 }
                 return
             }
+            if let mainWindow = NSApp.windows.first(where: { window in
+                guard let raw = window.identifier?.rawValue else { return false }
+                return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
+            }) {
+                let screenFrame = mainWindow.screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+                if let screenFrame {
+                    let targetSize = NSSize(width: min(960, screenFrame.width - 80), height: min(720, screenFrame.height - 80))
+                    let targetOrigin = NSPoint(
+                        x: screenFrame.minX + 40,
+                        y: screenFrame.maxY - 40 - targetSize.height
+                    )
+                    let targetFrame = NSRect(origin: targetOrigin, size: targetSize)
+                    if !mainWindow.frame.equalTo(targetFrame) {
+                        mainWindow.setFrame(targetFrame, display: true)
+                    }
+                }
+            }
             guard let tabManager = self.tabManager,
                   let workspace = tabManager.selectedWorkspace ?? tabManager.tabs.first,
                   let alphaPanelId = workspace.focusedPanelId else {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3486,6 +3486,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             setActiveMainWindow(window)
         }
 
+        refreshTitlebarAccessory(for: window)
+
         attemptStartupSessionRestoreIfNeeded(primaryWindow: window)
         if !isTerminatingApp {
             _ = saveSessionSnapshot(includeScrollback: false)
@@ -4977,6 +4979,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func sidebarVisibility(windowId: UUID) -> Bool? {
         mainWindowContexts.values.first(where: { $0.windowId == windowId })?.sidebarState.isVisible
+    }
+
+    func sidebarVisibility(for window: NSWindow?) -> Bool? {
+        guard let window else { return nil }
+        return mainWindowContexts.values.first(where: { $0.window === window })?.sidebarState.isVisible
     }
 
     @objc func openNewMainWindow(_ sender: Any?) {
@@ -6513,6 +6520,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
             if startWithHiddenSidebar {
                 self.sidebarState?.isVisible = false
+                if let mainWindow = NSApp.windows.first(where: { window in
+                    guard let raw = window.identifier?.rawValue else { return false }
+                    return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
+                }) {
+                    self.refreshTitlebarAccessory(for: mainWindow)
+                }
             }
             self.writeBonsplitTabDragUITestData([
                 "ready": "1",
@@ -7567,6 +7580,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func attachUpdateAccessory(to window: NSWindow) {
         titlebarAccessoryController.start()
         titlebarAccessoryController.attach(to: window)
+    }
+
+    func refreshTitlebarAccessory(for window: NSWindow) {
+        titlebarAccessoryController.refresh(for: window)
     }
 
     func applyWindowDecorations(to window: NSWindow) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6496,8 +6496,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return
             }
 
+            let workspaceTitle = "UITest Workspace"
             let alphaTitle = "UITest Alpha"
             let betaTitle = "UITest Beta"
+            tabManager.setCustomTitle(tabId: workspace.id, title: workspaceTitle)
             workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
             tabManager.newSurface()
 
@@ -6509,6 +6511,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
             self.writeBonsplitTabDragUITestData([
                 "ready": "1",
+                "workspaceTitle": workspaceTitle,
                 "alphaTitle": alphaTitle,
                 "betaTitle": betaTitle,
                 "alphaPanelId": alphaPanelId.uuidString,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6453,6 +6453,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let env = ProcessInfo.processInfo.environment
         guard env["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] == "1" else { return }
         guard tabManager != nil else { return }
+        let startWithHiddenSidebar = env["CMUX_UI_TEST_BONSPLIT_START_WITH_HIDDEN_SIDEBAR"] == "1"
 
         let deadline = Date().addingTimeInterval(20.0)
         func hasMainTerminalWindow() -> Bool {
@@ -6510,8 +6511,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
 
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
+            if startWithHiddenSidebar {
+                self.sidebarState?.isVisible = false
+            }
             self.writeBonsplitTabDragUITestData([
                 "ready": "1",
+                "sidebarVisible": startWithHiddenSidebar ? "0" : "1",
                 "workspaceId": workspace.id.uuidString,
                 "workspaceTitle": workspaceTitle,
                 "alphaTitle": alphaTitle,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1931,9 +1931,9 @@ struct ContentView: View {
         .frame(width: sidebarWidth)
     }
 
-    /// Space at top of content area for the titlebar. This must be at least the actual titlebar
-    /// height; otherwise controls like Bonsplit tab dragging can be interpreted as window drags.
+    /// Space at top of content area reserved for the custom workspace titlebar.
     @State private var titlebarPadding: CGFloat = 32
+    private let collapsedTitlebarDragHandleHeight: CGFloat = 30
 
     private var terminalContent: some View {
         let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
@@ -1941,56 +1941,65 @@ struct ContentView: View {
         let selectedWorkspaceId = tabManager.selectedTabId
         let retiringWorkspaceId = self.retiringWorkspaceId
 
-        return ZStack {
+        return ZStack(alignment: .top) {
             ZStack {
-                ForEach(mountedWorkspaces) { tab in
-                    let isSelectedWorkspace = selectedWorkspaceId == tab.id
-                    let isRetiringWorkspace = retiringWorkspaceId == tab.id
-                    let shouldPrimeInBackground = tabManager.pendingBackgroundWorkspaceLoadIds.contains(tab.id)
-                    // Keep the retiring workspace visible during handoff, but never input-active.
-                    // Allowing both selected+retiring workspaces to be input-active lets the
-                    // old workspace steal first responder (notably with WKWebView), which can
-                    // delay handoff completion and make browser returns feel laggy.
-                    let isInputActive = isSelectedWorkspace
-                    let isVisible = isSelectedWorkspace || isRetiringWorkspace
-                    let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
-                    WorkspaceContentView(
-                        workspace: tab,
-                        isWorkspaceVisible: isVisible,
-                        isWorkspaceInputActive: isInputActive,
-                        workspacePortalPriority: portalPriority,
-                        onThemeRefreshRequest: { reason, eventId, source, payloadHex in
-                            scheduleTitlebarThemeRefreshFromWorkspace(
-                                workspaceId: tab.id,
-                                reason: reason,
-                                backgroundEventId: eventId,
-                                backgroundSource: source,
-                                notificationPayloadHex: payloadHex
-                            )
+                ZStack {
+                    ForEach(mountedWorkspaces) { tab in
+                        let isSelectedWorkspace = selectedWorkspaceId == tab.id
+                        let isRetiringWorkspace = retiringWorkspaceId == tab.id
+                        let shouldPrimeInBackground = tabManager.pendingBackgroundWorkspaceLoadIds.contains(tab.id)
+                        // Keep the retiring workspace visible during handoff, but never input-active.
+                        // Allowing both selected+retiring workspaces to be input-active lets the
+                        // old workspace steal first responder (notably with WKWebView), which can
+                        // delay handoff completion and make browser returns feel laggy.
+                        let isInputActive = isSelectedWorkspace
+                        let isVisible = isSelectedWorkspace || isRetiringWorkspace
+                        let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
+                        WorkspaceContentView(
+                            workspace: tab,
+                            isWorkspaceVisible: isVisible,
+                            isWorkspaceInputActive: isInputActive,
+                            workspacePortalPriority: portalPriority,
+                            onThemeRefreshRequest: { reason, eventId, source, payloadHex in
+                                scheduleTitlebarThemeRefreshFromWorkspace(
+                                    workspaceId: tab.id,
+                                    reason: reason,
+                                    backgroundEventId: eventId,
+                                    backgroundSource: source,
+                                    notificationPayloadHex: payloadHex
+                                )
+                            }
+                        )
+                        .opacity(isVisible ? 1 : 0)
+                        .allowsHitTesting(isSelectedWorkspace)
+                        .accessibilityHidden(!isVisible)
+                        .zIndex(isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0))
+                        .task(id: shouldPrimeInBackground ? tab.id : nil) {
+                            await primeBackgroundWorkspaceIfNeeded(workspaceId: tab.id)
                         }
-                    )
-                    .opacity(isVisible ? 1 : 0)
-                    .allowsHitTesting(isSelectedWorkspace)
-                    .accessibilityHidden(!isVisible)
-                    .zIndex(isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0))
-                    .task(id: shouldPrimeInBackground ? tab.id : nil) {
-                        await primeBackgroundWorkspaceIfNeeded(workspaceId: tab.id)
                     }
                 }
-            }
-            .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
-            .allowsHitTesting(sidebarSelectionState.selection == .tabs)
-            .accessibilityHidden(sidebarSelectionState.selection != .tabs)
+                .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
+                .allowsHitTesting(sidebarSelectionState.selection == .tabs)
+                .accessibilityHidden(sidebarSelectionState.selection != .tabs)
 
-            NotificationsPage(selection: $sidebarSelectionState.selection)
-                .opacity(sidebarSelectionState.selection == .notifications ? 1 : 0)
-                .allowsHitTesting(sidebarSelectionState.selection == .notifications)
-                .accessibilityHidden(sidebarSelectionState.selection != .notifications)
-        }
-        .padding(.top, titlebarPadding)
-        .overlay(alignment: .top) {
-            // Titlebar overlay is only over terminal content, not the sidebar.
-            customTitlebar
+                NotificationsPage(selection: $sidebarSelectionState.selection)
+                    .opacity(sidebarSelectionState.selection == .notifications ? 1 : 0)
+                    .allowsHitTesting(sidebarSelectionState.selection == .notifications)
+                    .accessibilityHidden(sidebarSelectionState.selection != .notifications)
+            }
+            .padding(.top, titlebarPadding)
+
+            if showWorkspaceTitlebar {
+                // Titlebar overlay is only over terminal content, not the sidebar.
+                customTitlebar
+            } else {
+                // When the custom titlebar is hidden, keep empty space in the top pane tab bar
+                // draggable without turning the full content area into a window drag target.
+                WindowDragHandleView()
+                    .frame(height: collapsedTitlebarDragHandleHeight)
+                    .frame(maxWidth: .infinity)
+            }
         }
     }
 
@@ -2007,6 +2016,8 @@ struct ContentView: View {
     @AppStorage("bgGlassTintHex") private var bgGlassTintHex = "#000000"
     @AppStorage("bgGlassTintOpacity") private var bgGlassTintOpacity = 0.03
     @AppStorage("bgGlassEnabled") private var bgGlassEnabled = false
+    @AppStorage(WorkspaceTitlebarSettings.showTitlebarKey)
+    private var showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
     @AppStorage("debugTitlebarLeadingExtra") private var debugTitlebarLeadingExtra: Double = 0
 
     @State private var titlebarLeadingInset: CGFloat = 12
@@ -2623,7 +2634,7 @@ struct ContentView: View {
             removeSidebarResizerPointerMonitor()
         })
 
-        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
+        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity, showWorkspaceTitlebar] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
             // Do not make the entire background draggable; it interferes with drag gestures
@@ -2646,10 +2657,11 @@ struct ContentView: View {
                 }
             }
 
-            // Keep content below the titlebar so drags on Bonsplit's tab bar don't
-            // get interpreted as window drags.
+            // Reserve space for the custom titlebar only when it is enabled. When hidden, the
+            // top Bonsplit tab bar moves into this strip and its empty space gets an explicit
+            // drag handle overlay instead.
             let computedTitlebarHeight = window.frame.height - window.contentLayoutRect.height
-            let nextPadding = max(28, min(72, computedTitlebarHeight))
+            let nextPadding = showWorkspaceTitlebar ? max(28, min(72, computedTitlebarHeight)) : 0
             if abs(titlebarPadding - nextPadding) > 0.5 {
                 DispatchQueue.main.async {
                     titlebarPadding = nextPadding

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7266,10 +7266,8 @@ struct VerticalTabsSidebar: View {
                     .frame(width: 0, height: 0)
                 )
                 .overlay(alignment: .top) {
-                    if showWorkspaceTitlebar {
-                        SidebarTopScrim(height: trafficLightPadding + 20)
-                            .allowsHitTesting(false)
-                    }
+                    SidebarTopScrim(height: effectiveTrafficLightPadding + 20)
+                        .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
                     if showWorkspaceTitlebar {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1934,6 +1934,10 @@ struct ContentView: View {
     /// Space at top of content area reserved for the custom workspace titlebar.
     @State private var titlebarPadding: CGFloat = 32
 
+    private var effectiveTitlebarPadding: CGFloat {
+        showWorkspaceTitlebar ? titlebarPadding : 0
+    }
+
     private var terminalContent: some View {
         let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
         let mountedWorkspaces = tabManager.tabs.filter { mountedWorkspaceIdSet.contains($0.id) }
@@ -1987,7 +1991,7 @@ struct ContentView: View {
                     .allowsHitTesting(sidebarSelectionState.selection == .notifications)
                     .accessibilityHidden(sidebarSelectionState.selection != .notifications)
             }
-            .padding(.top, titlebarPadding)
+            .padding(.top, effectiveTitlebarPadding)
 
             if showWorkspaceTitlebar {
                 // Titlebar overlay is only over terminal content, not the sidebar.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7282,13 +7282,15 @@ struct VerticalTabsSidebar: View {
         .background(
             WindowAccessor { window in
                 modifierKeyMonitor.setHostWindow(window)
+            }
+            .frame(width: 0, height: 0)
+        )
+        .background(
+            WindowTrafficLightMetricsReader { metrics in
                 guard !showWorkspaceTitlebar else { return }
-                let computedTitlebarHeight = window.frame.height - window.contentLayoutRect.height
-                let nextPadding = max(trafficLightPadding, min(52, computedTitlebarHeight + 6))
+                let nextPadding = max(trafficLightPadding, min(64, metrics.topInset))
                 if abs(hiddenTitlebarTrafficLightPadding - nextPadding) > 0.5 {
-                    DispatchQueue.main.async {
-                        hiddenTitlebarTrafficLightPadding = nextPadding
-                    }
+                    hiddenTitlebarTrafficLightPadding = nextPadding
                 }
             }
             .frame(width: 0, height: 0)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7175,10 +7175,16 @@ struct VerticalTabsSidebar: View {
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarWorkspaceDetailSettings.showNotificationMessageKey)
     private var sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
+    @AppStorage("workspaceTitlebarVisible")
+    private var showWorkspaceTitlebar = true
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
     private let tabRowSpacing: CGFloat = 2
+
+    private var effectiveTrafficLightPadding: CGFloat {
+        showWorkspaceTitlebar ? trafficLightPadding : 0
+    }
 
     private var showsSidebarNotificationMessage: Bool {
         SidebarWorkspaceDetailSettings.resolvedNotificationMessageVisibility(
@@ -7194,7 +7200,7 @@ struct VerticalTabsSidebar: View {
                     VStack(spacing: 0) {
                         // Space for traffic lights / fullscreen controls
                         Spacer()
-                            .frame(height: trafficLightPadding)
+                            .frame(height: effectiveTrafficLightPadding)
 
                         LazyVStack(spacing: tabRowSpacing) {
                             ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
@@ -7227,7 +7233,8 @@ struct VerticalTabsSidebar: View {
                                 .equatable()
                             }
                         }
-                        .padding(.vertical, 8)
+                        .padding(.top, showWorkspaceTitlebar ? 8 : 0)
+                        .padding(.bottom, 8)
 
                         SidebarEmptyArea(
                             rowSpacing: tabRowSpacing,
@@ -7249,14 +7256,18 @@ struct VerticalTabsSidebar: View {
                     .frame(width: 0, height: 0)
                 )
                 .overlay(alignment: .top) {
-                    SidebarTopScrim(height: trafficLightPadding + 20)
-                        .allowsHitTesting(false)
+                    if showWorkspaceTitlebar {
+                        SidebarTopScrim(height: trafficLightPadding + 20)
+                            .allowsHitTesting(false)
+                    }
                 }
                 .overlay(alignment: .top) {
-                    // Match native titlebar behavior in the sidebar top strip:
-                    // drag-to-move and double-click action (zoom/minimize).
-                    WindowDragHandleView()
-                        .frame(height: trafficLightPadding)
+                    if showWorkspaceTitlebar {
+                        // Match native titlebar behavior in the sidebar top strip:
+                        // drag-to-move and double-click action (zoom/minimize).
+                        WindowDragHandleView()
+                            .frame(height: trafficLightPadding)
+                    }
                 }
                 .background(Color.clear)
                 .modifier(ClearScrollBackground())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7180,7 +7180,7 @@ struct VerticalTabsSidebar: View {
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
-    private let hiddenTitlebarTrafficLightPadding: CGFloat = 18
+    @State private var hiddenTitlebarTrafficLightPadding: CGFloat = 30
     private let tabRowSpacing: CGFloat = 2
 
     private var effectiveTrafficLightPadding: CGFloat {
@@ -7282,6 +7282,14 @@ struct VerticalTabsSidebar: View {
         .background(
             WindowAccessor { window in
                 modifierKeyMonitor.setHostWindow(window)
+                guard !showWorkspaceTitlebar else { return }
+                let computedTitlebarHeight = window.frame.height - window.contentLayoutRect.height
+                let nextPadding = max(trafficLightPadding, min(52, computedTitlebarHeight + 6))
+                if abs(hiddenTitlebarTrafficLightPadding - nextPadding) > 0.5 {
+                    DispatchQueue.main.async {
+                        hiddenTitlebarTrafficLightPadding = nextPadding
+                    }
+                }
             }
             .frame(width: 0, height: 0)
         )
@@ -9997,6 +10005,7 @@ private struct TabItemView: View, Equatable {
             isHovering = hovering
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
         .accessibilityLabel(Text(accessibilityTitle))
         .accessibilityHint(Text(accessibilityHintText))
         .accessibilityAction(named: Text(moveUpActionText)) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1933,7 +1933,6 @@ struct ContentView: View {
 
     /// Space at top of content area reserved for the custom workspace titlebar.
     @State private var titlebarPadding: CGFloat = 32
-    private let collapsedTitlebarDragHandleHeight: CGFloat = 30
 
     private var terminalContent: some View {
         let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
@@ -1993,12 +1992,6 @@ struct ContentView: View {
             if showWorkspaceTitlebar {
                 // Titlebar overlay is only over terminal content, not the sidebar.
                 customTitlebar
-            } else {
-                // When the custom titlebar is hidden, keep empty space in the top pane tab bar
-                // draggable without turning the full content area into a window drag target.
-                WindowDragHandleView()
-                    .frame(height: collapsedTitlebarDragHandleHeight)
-                    .frame(maxWidth: .infinity)
             }
         }
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7180,10 +7180,11 @@ struct VerticalTabsSidebar: View {
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
+    private let hiddenTitlebarTrafficLightPadding: CGFloat = 18
     private let tabRowSpacing: CGFloat = 2
 
     private var effectiveTrafficLightPadding: CGFloat {
-        showWorkspaceTitlebar ? trafficLightPadding : 0
+        showWorkspaceTitlebar ? trafficLightPadding : hiddenTitlebarTrafficLightPadding
     }
 
     private var showsSidebarNotificationMessage: Bool {
@@ -7233,7 +7234,7 @@ struct VerticalTabsSidebar: View {
                                 .equatable()
                             }
                         }
-                        .padding(.top, showWorkspaceTitlebar ? 8 : 0)
+                        .padding(.top, showWorkspaceTitlebar ? 8 : 4)
                         .padding(.bottom, 8)
 
                         SidebarEmptyArea(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -282,8 +282,17 @@ struct TitlebarLayerBackground: NSViewRepresentable {
     }
 }
 
+extension Notification.Name {
+    static let cmuxSidebarVisibilityDidChange = Notification.Name("cmuxSidebarVisibilityDidChange")
+}
+
 final class SidebarState: ObservableObject {
-    @Published var isVisible: Bool
+    @Published var isVisible: Bool {
+        didSet {
+            guard oldValue != isVisible else { return }
+            NotificationCenter.default.post(name: .cmuxSidebarVisibilityDidChange, object: self)
+        }
+    }
     @Published var persistedWidth: CGFloat
 
     init(isVisible: Bool = true, persistedWidth: CGFloat = CGFloat(SessionPersistencePolicy.defaultSidebarWidth)) {

--- a/Sources/TitlebarVisibilitySettings.swift
+++ b/Sources/TitlebarVisibilitySettings.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum TitlebarControlsVisibilityMode: String, CaseIterable, Identifiable {
+    case always
+    case onHover
+
+    var id: String { rawValue }
+}
+
+enum TitlebarControlsVisibilitySettings {
+    static let modeKey = "titlebarControlsVisibilityMode"
+    static let defaultMode: TitlebarControlsVisibilityMode = .always
+
+    static func mode(for rawValue: String?) -> TitlebarControlsVisibilityMode {
+        guard let rawValue, let mode = TitlebarControlsVisibilityMode(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+}
+
+enum WorkspaceTitlebarSettings {
+    static let showTitlebarKey = "workspaceTitlebarVisible"
+    static let defaultShowTitlebar = true
+
+    static func isVisible(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: showTitlebarKey) == nil {
+            return defaultShowTitlebar
+        }
+        return defaults.bool(forKey: showTitlebarKey)
+    }
+}

--- a/Sources/TitlebarVisibilitySettings.swift
+++ b/Sources/TitlebarVisibilitySettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum TitlebarControlsVisibilityMode: String, CaseIterable, Identifiable {
+enum ChromeControlsVisibilityMode: String, CaseIterable, Identifiable {
     case always
     case onHover
 
@@ -9,10 +9,22 @@ enum TitlebarControlsVisibilityMode: String, CaseIterable, Identifiable {
 
 enum TitlebarControlsVisibilitySettings {
     static let modeKey = "titlebarControlsVisibilityMode"
-    static let defaultMode: TitlebarControlsVisibilityMode = .always
+    static let defaultMode: ChromeControlsVisibilityMode = .always
 
-    static func mode(for rawValue: String?) -> TitlebarControlsVisibilityMode {
-        guard let rawValue, let mode = TitlebarControlsVisibilityMode(rawValue: rawValue) else {
+    static func mode(for rawValue: String?) -> ChromeControlsVisibilityMode {
+        guard let rawValue, let mode = ChromeControlsVisibilityMode(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+}
+
+enum PaneTabBarControlsVisibilitySettings {
+    static let modeKey = "paneTabBarControlsVisibilityMode"
+    static let defaultMode: ChromeControlsVisibilityMode = .always
+
+    static func mode(for rawValue: String?) -> ChromeControlsVisibilityMode {
+        guard let rawValue, let mode = ChromeControlsVisibilityMode(rawValue: rawValue) else {
             return defaultMode
         }
         return mode

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -241,10 +241,13 @@ struct TitlebarControlsView: View {
     let onToggleNotifications: () -> Void
     let onNewTab: () -> Void
     @AppStorage("titlebarControlsStyle") private var styleRawValue = TitlebarControlsStyle.classic.rawValue
+    @AppStorage(TitlebarControlsVisibilitySettings.modeKey)
+    private var visibilityModeRawValue = TitlebarControlsVisibilitySettings.defaultMode.rawValue
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
     @AppStorage(ShortcutHintDebugSettings.titlebarHintYKey) private var titlebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultTitlebarHintY
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @State private var shortcutRefreshTick = 0
+    @State private var isHoveringControls = false
     @StateObject private var modifierKeyMonitor = TitlebarShortcutHintModifierMonitor()
     private let titlebarHintRightSafetyShift: CGFloat = 10
     private let titlebarHintBaseXShift: CGFloat = -10
@@ -279,6 +282,19 @@ struct TitlebarControlsView: View {
         alwaysShowShortcutHints || modifierKeyMonitor.isModifierPressed
     }
 
+    private var visibilityMode: TitlebarControlsVisibilityMode {
+        TitlebarControlsVisibilitySettings.mode(for: visibilityModeRawValue)
+    }
+
+    private var shouldShowControls: Bool {
+        switch visibilityMode {
+        case .always:
+            return true
+        case .onHover:
+            return isHoveringControls || shouldShowTitlebarShortcutHints
+        }
+    }
+
     var body: some View {
         // Force the `.safeHelp(...)` tooltips to re-evaluate when shortcuts are changed in settings.
         // (The titlebar controls don't otherwise re-render on UserDefaults changes.)
@@ -288,12 +304,18 @@ struct TitlebarControlsView: View {
         controlsGroup(config: config)
             .padding(.leading, 4)
             .padding(.trailing, titlebarHintTrailingInset)
+            .contentShape(Rectangle())
+            .opacity(shouldShowControls ? 1 : 0)
+            .animation(.easeInOut(duration: 0.14), value: shouldShowControls)
             .background(
                 WindowAccessor { window in
                     modifierKeyMonitor.setHostWindow(window)
                 }
                 .frame(width: 0, height: 0)
             )
+            .onHover { hovering in
+                isHoveringControls = hovering
+            }
             .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
                 shortcutRefreshTick &+= 1
             }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1112,6 +1112,7 @@ private struct NotificationPopoverRow: View {
     }
 }
 
+@MainActor
 final class UpdateTitlebarAccessoryController {
     private weak var updateViewModel: UpdateViewModel?
     private var didStart = false
@@ -1197,7 +1198,6 @@ final class UpdateTitlebarAccessoryController {
     }
 
     private func attachIfNeeded(to window: NSWindow) {
-        guard !attachedWindows.contains(window) else { return }
         guard !isSettingsWindow(window) else { return }
 
         // Window identifiers are assigned by SwiftUI via WindowAccessor, which can run
@@ -1220,6 +1220,13 @@ final class UpdateTitlebarAccessoryController {
 
         pendingAttachRetries.removeValue(forKey: ObjectIdentifier(window))
 
+        guard WorkspaceTitlebarSettings.isVisible() else {
+            removeAccessoryIfPresent(from: window)
+            return
+        }
+
+        guard !attachedWindows.contains(window) else { return }
+
         if !window.titlebarAccessoryViewControllers.contains(where: { $0.view.identifier == controlsIdentifier }) {
             let controls = TitlebarControlsAccessoryViewController(
                 notificationStore: TerminalNotificationStore.shared
@@ -1237,6 +1244,37 @@ final class UpdateTitlebarAccessoryController {
         if env["CMUX_UI_TEST_MODE"] == "1" {
             let ident = window.identifier?.rawValue ?? "<nil>"
             UpdateLogStore.shared.append("attached titlebar accessories to window id=\(ident)")
+        }
+#endif
+    }
+
+    private func removeAccessoryIfPresent(from window: NSWindow) {
+        let matchingIndices = window.titlebarAccessoryViewControllers.indices.reversed().filter { index in
+            window.titlebarAccessoryViewControllers[index].view.identifier == controlsIdentifier
+        }
+        guard !matchingIndices.isEmpty || attachedWindows.contains(window) else { return }
+
+        for index in matchingIndices {
+            let accessory = window.titlebarAccessoryViewControllers[index]
+            if let controls = accessory as? TitlebarControlsAccessoryViewController {
+                controls.dismissNotificationsPopover()
+            }
+            window.removeTitlebarAccessoryViewController(at: index)
+        }
+
+        attachedWindows.remove(window)
+        pendingAttachRetries.removeValue(forKey: ObjectIdentifier(window))
+        window.contentView?.needsLayout = true
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.contentView?.superview?.needsLayout = true
+        window.contentView?.superview?.layoutSubtreeIfNeeded()
+        window.invalidateShadow()
+
+#if DEBUG
+        let env = ProcessInfo.processInfo.environment
+        if env["CMUX_UI_TEST_MODE"] == "1" {
+            let ident = window.identifier?.rawValue ?? "<nil>"
+            UpdateLogStore.shared.append("removed titlebar accessories from window id=\(ident)")
         }
 #endif
     }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -282,7 +282,7 @@ struct TitlebarControlsView: View {
         alwaysShowShortcutHints || modifierKeyMonitor.isModifierPressed
     }
 
-    private var visibilityMode: TitlebarControlsVisibilityMode {
+    private var visibilityMode: ChromeControlsVisibilityMode {
         TitlebarControlsVisibilitySettings.mode(for: visibilityModeRawValue)
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -117,6 +117,7 @@ struct TitlebarControlsStyleConfig {
 
 final class TitlebarControlsViewModel: ObservableObject {
     weak var notificationsAnchorView: NSView?
+    @Published var canRevealControls = true
 }
 
 struct NotificationsAnchorView: NSViewRepresentable {
@@ -287,6 +288,7 @@ struct TitlebarControlsView: View {
     }
 
     private var shouldShowControls: Bool {
+        guard viewModel.canRevealControls else { return false }
         switch visibilityMode {
         case .always:
             return true
@@ -306,6 +308,7 @@ struct TitlebarControlsView: View {
             .padding(.trailing, titlebarHintTrailingInset)
             .contentShape(Rectangle())
             .opacity(shouldShowControls ? 1 : 0)
+            .allowsHitTesting(viewModel.canRevealControls)
             .animation(.easeInOut(duration: 0.14), value: shouldShowControls)
             .background(
                 WindowAccessor { window in
@@ -723,6 +726,13 @@ func titlebarControlsShouldApplyLayout(
         || abs(previous.yOffset - next.yOffset) > tolerance
 }
 
+func titlebarControlsShouldReserveAccessorySpace(
+    showWorkspaceTitlebar: Bool,
+    sidebarVisible: Bool
+) -> Bool {
+    showWorkspaceTitlebar || sidebarVisible
+}
+
 final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewController, NSPopoverDelegate {
     private let hostingView: NonDraggableHostingView<TitlebarControlsView>
     private let containerView = NSView()
@@ -733,8 +743,10 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     private var cachedFittingSize: NSSize?
     private var lastObservedViewSize: NSSize = .zero
     private var lastAppliedLayoutSnapshot: TitlebarControlsLayoutSnapshot?
+    private var shouldReserveAccessorySpace = true
     private let viewModel = TitlebarControlsViewModel()
     private var userDefaultsObserver: NSObjectProtocol?
+    private var sidebarVisibilityObserver: NSObjectProtocol?
     var popoverIsShownForTesting: Bool { notificationsPopover.isShown }
 
     init(notificationStore: TerminalNotificationStore) {
@@ -771,7 +783,16 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            self?.refreshVisibility()
             self?.scheduleSizeUpdate(invalidateFittingSize: true)
+        }
+
+        sidebarVisibilityObserver = NotificationCenter.default.addObserver(
+            forName: .cmuxSidebarVisibilityDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshVisibility()
         }
 
         scheduleSizeUpdate(invalidateFittingSize: true)
@@ -785,10 +806,14 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         if let userDefaultsObserver {
             NotificationCenter.default.removeObserver(userDefaultsObserver)
         }
+        if let sidebarVisibilityObserver {
+            NotificationCenter.default.removeObserver(sidebarVisibilityObserver)
+        }
     }
 
     override func viewDidAppear() {
         super.viewDidAppear()
+        refreshVisibility()
         scheduleSizeUpdate(invalidateFittingSize: true)
     }
 
@@ -817,7 +842,33 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         }
     }
 
+    func refreshVisibility() {
+        let next = titlebarControlsShouldReserveAccessorySpace(
+            showWorkspaceTitlebar: WorkspaceTitlebarSettings.isVisible(),
+            sidebarVisible: AppDelegate.shared?.sidebarVisibility(for: view.window) ?? true
+        )
+        viewModel.canRevealControls = next
+        if !next {
+            dismissNotificationsPopover()
+        }
+        guard next != shouldReserveAccessorySpace else { return }
+        shouldReserveAccessorySpace = next
+        scheduleSizeUpdate(invalidateFittingSize: true)
+    }
+
     private func updateSize() {
+        guard shouldReserveAccessorySpace else {
+            lastAppliedLayoutSnapshot = nil
+            preferredContentSize = .zero
+            isHidden = true
+            view.isHidden = true
+            containerView.isHidden = true
+            hostingView.isHidden = true
+            containerView.frame = .zero
+            hostingView.frame = .zero
+            return
+        }
+
         let contentSize: NSSize
         if fittingSizeNeedsRefresh || cachedFittingSize == nil {
             hostingView.invalidateIntrinsicContentSize()
@@ -828,6 +879,10 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         contentSize = cachedFittingSize ?? .zero
 
         guard contentSize.width > 0, contentSize.height > 0 else { return }
+        isHidden = false
+        view.isHidden = false
+        containerView.isHidden = false
+        hostingView.isHidden = false
         let titlebarHeight = view.window.map { window in
             window.frame.height - window.contentLayoutRect.height
         } ?? contentSize.height
@@ -1145,6 +1200,11 @@ final class UpdateTitlebarAccessoryController {
         attachIfNeeded(to: window)
     }
 
+    func refresh(for window: NSWindow) {
+        attachIfNeeded(to: window)
+        controlsControllers.allObjects.first(where: { $0.view.window === window })?.refreshVisibility()
+    }
+
     private func installObservers() {
         let center = NotificationCenter.default
         observers.append(center.addObserver(
@@ -1233,6 +1293,7 @@ final class UpdateTitlebarAccessoryController {
         }
 
         attachedWindows.add(window)
+        controlsControllers.allObjects.first(where: { $0.view.window === window })?.refreshVisibility()
 
 #if DEBUG
         let env = ProcessInfo.processInfo.environment

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1220,11 +1220,6 @@ final class UpdateTitlebarAccessoryController {
 
         pendingAttachRetries.removeValue(forKey: ObjectIdentifier(window))
 
-        guard WorkspaceTitlebarSettings.isVisible() else {
-            removeAccessoryIfPresent(from: window)
-            return
-        }
-
         guard !attachedWindows.contains(window) else { return }
 
         if !window.titlebarAccessoryViewControllers.contains(where: { $0.view.identifier == controlsIdentifier }) {

--- a/Sources/WindowAccessor.swift
+++ b/Sources/WindowAccessor.swift
@@ -59,3 +59,100 @@ final class WindowObservingView: NSView {
         }
     }
 }
+
+struct WindowTrafficLightMetrics: Equatable {
+    let leadingInset: CGFloat
+    let topInset: CGFloat
+}
+
+struct WindowTrafficLightMetricsReader: NSViewRepresentable {
+    let onMetrics: (WindowTrafficLightMetrics) -> Void
+
+    func makeNSView(context: Context) -> WindowTrafficLightMetricsView {
+        let view = WindowTrafficLightMetricsView()
+        view.onMetrics = onMetrics
+        return view
+    }
+
+    func updateNSView(_ nsView: WindowTrafficLightMetricsView, context: Context) {
+        nsView.onMetrics = onMetrics
+        nsView.publishMetricsIfPossible()
+    }
+}
+
+final class WindowTrafficLightMetricsView: NSView {
+    var onMetrics: ((WindowTrafficLightMetrics) -> Void)?
+
+    private weak var observedWindow: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+    private var lastPublishedMetrics: WindowTrafficLightMetrics?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window !== observedWindow {
+            reinstallObservers(for: window)
+        }
+        publishMetricsIfPossible()
+    }
+
+    override func layout() {
+        super.layout()
+        publishMetricsIfPossible()
+    }
+
+    deinit {
+        removeObservers()
+    }
+
+    func publishMetricsIfPossible() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let window = self.window ?? self.observedWindow,
+                  let contentView = window.contentView else {
+                return
+            }
+
+            let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+            let frames = buttonTypes.compactMap { type -> CGRect? in
+                guard let button = window.standardWindowButton(type), !button.isHidden else { return nil }
+                return contentView.convert(button.bounds, from: button)
+            }
+            guard !frames.isEmpty else { return }
+
+            let metrics = WindowTrafficLightMetrics(
+                leadingInset: (frames.map(\.maxX).max() ?? 0) + 14,
+                topInset: (frames.map { max(0, contentView.bounds.maxY - $0.minY) }.max() ?? 0) + 8
+            )
+            guard metrics != self.lastPublishedMetrics else { return }
+            self.lastPublishedMetrics = metrics
+            self.onMetrics?(metrics)
+        }
+    }
+
+    private func reinstallObservers(for window: NSWindow?) {
+        removeObservers()
+        observedWindow = window
+        guard let window else { return }
+
+        let center = NotificationCenter.default
+        let names: [Notification.Name] = [
+            NSWindow.didResizeNotification,
+            NSWindow.didEndLiveResizeNotification,
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+        ]
+        observers = names.map { name in
+            center.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                self?.publishMetricsIfPossible()
+            }
+        }
+    }
+
+    private func removeObservers() {
+        let center = NotificationCenter.default
+        for observer in observers {
+            center.removeObserver(observer)
+        }
+        observers.removeAll()
+    }
+}

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -16,6 +16,8 @@ struct WorkspaceContentView: View {
         _ notificationPayloadHex: String?
     ) -> Void)?
     @State private var config = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "stateInit")
+    @AppStorage(WorkspaceTitlebarSettings.showTitlebarKey)
+    private var showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject var notificationStore: TerminalNotificationStore
 
@@ -52,7 +54,7 @@ struct WorkspaceContentView: View {
             }
         }()
 
-        BonsplitView(controller: workspace.bonsplitController) { tab, paneId in
+        let bonsplitView = BonsplitView(controller: workspace.bonsplitController) { tab, paneId in
             // Content for each tab in bonsplit
             let _ = Self.debugPanelLookup(tab: tab, workspace: workspace)
             if let panel = workspace.panel(for: tab.id) {
@@ -105,6 +107,14 @@ struct WorkspaceContentView: View {
                 .onTapGesture {
                     workspace.bonsplitController.focusPane(paneId)
                 }
+        }
+        Group {
+            if showWorkspaceTitlebar {
+                bonsplitView
+            } else {
+                bonsplitView
+                    .ignoresSafeArea(.container, edges: .top)
+            }
         }
         .internalOnlyTabDrag()
         // Split zoom swaps Bonsplit between the full split tree and a single pane view.

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3040,6 +3040,17 @@ enum TelemetrySettings {
     static let enabledForCurrentLaunch = isEnabled()
 }
 
+private extension TitlebarControlsVisibilityMode {
+    var displayName: String {
+        switch self {
+        case .always:
+            return String(localized: "settings.app.titlebarControls.always", defaultValue: "Always Visible")
+        case .onHover:
+            return String(localized: "settings.app.titlebarControls.hover", defaultValue: "Show on Hover")
+        }
+    }
+}
+
 struct SettingsView: View {
     private let contentTopInset: CGFloat = 8
     private let pickerColumnWidth: CGFloat = 196
@@ -3048,6 +3059,10 @@ struct SettingsView: View {
     @AppStorage(LanguageSettings.languageKey) private var appLanguage = LanguageSettings.defaultLanguage.rawValue
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage(AppIconSettings.modeKey) private var appIconMode = AppIconSettings.defaultMode.rawValue
+    @AppStorage(TitlebarControlsVisibilitySettings.modeKey)
+    private var titlebarControlsVisibilityMode = TitlebarControlsVisibilitySettings.defaultMode.rawValue
+    @AppStorage(WorkspaceTitlebarSettings.showTitlebarKey)
+    private var showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
@@ -3119,6 +3134,45 @@ struct SettingsView: View {
 
     private var selectedWorkspacePlacement: NewWorkspacePlacement {
         NewWorkspacePlacement(rawValue: newWorkspacePlacement) ?? WorkspacePlacementSettings.defaultPlacement
+    }
+
+    private var selectedTitlebarControlsVisibilityMode: TitlebarControlsVisibilityMode {
+        TitlebarControlsVisibilitySettings.mode(for: titlebarControlsVisibilityMode)
+    }
+
+    private var titlebarControlsVisibilitySelection: Binding<String> {
+        Binding(
+            get: { selectedTitlebarControlsVisibilityMode.rawValue },
+            set: { titlebarControlsVisibilityMode = TitlebarControlsVisibilitySettings.mode(for: $0).rawValue }
+        )
+    }
+
+    private var titlebarControlsVisibilitySubtitle: String {
+        switch selectedTitlebarControlsVisibilityMode {
+        case .always:
+            return String(
+                localized: "settings.app.titlebarControls.subtitleAlways",
+                defaultValue: "Keep the sidebar, notifications, and new workspace buttons visible."
+            )
+        case .onHover:
+            return String(
+                localized: "settings.app.titlebarControls.subtitleHover",
+                defaultValue: "Hide titlebar buttons until the pointer reaches them."
+            )
+        }
+    }
+
+    private var workspaceTitlebarSubtitle: String {
+        if showWorkspaceTitlebar {
+            return String(
+                localized: "settings.app.showWorkspaceTitlebar.subtitleOn",
+                defaultValue: "Show the folder and active title above pane tabs."
+            )
+        }
+        return String(
+            localized: "settings.app.showWorkspaceTitlebar.subtitleOff",
+            defaultValue: "Hide the folder/title strip and drag from empty space in the top pane tab bar."
+        )
     }
 
     private var selectedSidebarActiveTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
@@ -3472,6 +3526,30 @@ struct SettingsView: View {
                                 AppIconSettings.applyIcon(mode)
                             }
                         )
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.app.titlebarControls", defaultValue: "Titlebar Controls"),
+                            subtitle: titlebarControlsVisibilitySubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: titlebarControlsVisibilitySelection
+                        ) {
+                            ForEach(TitlebarControlsVisibilityMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.showWorkspaceTitlebar", defaultValue: "Show Workspace Title Bar"),
+                            subtitle: workspaceTitlebarSubtitle
+                        ) {
+                            Toggle("", isOn: $showWorkspaceTitlebar)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
 
                         SettingsCardDivider()
 
@@ -4386,6 +4464,8 @@ struct SettingsView: View {
         }
         appearanceMode = AppearanceSettings.defaultMode.rawValue
         appIconMode = AppIconSettings.defaultMode.rawValue
+        titlebarControlsVisibilityMode = TitlebarControlsVisibilitySettings.defaultMode.rawValue
+        showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3040,7 +3040,7 @@ enum TelemetrySettings {
     static let enabledForCurrentLaunch = isEnabled()
 }
 
-private extension TitlebarControlsVisibilityMode {
+private extension ChromeControlsVisibilityMode {
     var displayName: String {
         switch self {
         case .always:
@@ -3061,6 +3061,8 @@ struct SettingsView: View {
     @AppStorage(AppIconSettings.modeKey) private var appIconMode = AppIconSettings.defaultMode.rawValue
     @AppStorage(TitlebarControlsVisibilitySettings.modeKey)
     private var titlebarControlsVisibilityMode = TitlebarControlsVisibilitySettings.defaultMode.rawValue
+    @AppStorage(PaneTabBarControlsVisibilitySettings.modeKey)
+    private var paneTabBarControlsVisibilityMode = PaneTabBarControlsVisibilitySettings.defaultMode.rawValue
     @AppStorage(WorkspaceTitlebarSettings.showTitlebarKey)
     private var showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
@@ -3136,7 +3138,7 @@ struct SettingsView: View {
         NewWorkspacePlacement(rawValue: newWorkspacePlacement) ?? WorkspacePlacementSettings.defaultPlacement
     }
 
-    private var selectedTitlebarControlsVisibilityMode: TitlebarControlsVisibilityMode {
+    private var selectedTitlebarControlsVisibilityMode: ChromeControlsVisibilityMode {
         TitlebarControlsVisibilitySettings.mode(for: titlebarControlsVisibilityMode)
     }
 
@@ -3158,6 +3160,32 @@ struct SettingsView: View {
             return String(
                 localized: "settings.app.titlebarControls.subtitleHover",
                 defaultValue: "Hide titlebar buttons until the pointer reaches them."
+            )
+        }
+    }
+
+    private var selectedPaneTabBarControlsVisibilityMode: ChromeControlsVisibilityMode {
+        PaneTabBarControlsVisibilitySettings.mode(for: paneTabBarControlsVisibilityMode)
+    }
+
+    private var paneTabBarControlsVisibilitySelection: Binding<String> {
+        Binding(
+            get: { selectedPaneTabBarControlsVisibilityMode.rawValue },
+            set: { paneTabBarControlsVisibilityMode = PaneTabBarControlsVisibilitySettings.mode(for: $0).rawValue }
+        )
+    }
+
+    private var paneTabBarControlsVisibilitySubtitle: String {
+        switch selectedPaneTabBarControlsVisibilityMode {
+        case .always:
+            return String(
+                localized: "settings.app.paneTabBarControls.subtitleAlways",
+                defaultValue: "Keep the pane tab bar's new tab and split buttons visible."
+            )
+        case .onHover:
+            return String(
+                localized: "settings.app.paneTabBarControls.subtitleHover",
+                defaultValue: "Hide the pane tab bar's new tab and split buttons until you hover the bar."
             )
         }
     }
@@ -3535,7 +3563,20 @@ struct SettingsView: View {
                             controlWidth: pickerColumnWidth,
                             selection: titlebarControlsVisibilitySelection
                         ) {
-                            ForEach(TitlebarControlsVisibilityMode.allCases) { mode in
+                            ForEach(ChromeControlsVisibilityMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.app.paneTabBarControls", defaultValue: "Pane Tab Bar Controls"),
+                            subtitle: paneTabBarControlsVisibilitySubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: paneTabBarControlsVisibilitySelection
+                        ) {
+                            ForEach(ChromeControlsVisibilityMode.allCases) { mode in
                                 Text(mode.displayName).tag(mode.rawValue)
                             }
                         }
@@ -4465,6 +4506,7 @@ struct SettingsView: View {
         appearanceMode = AppearanceSettings.defaultMode.rawValue
         appIconMode = AppIconSettings.defaultMode.rawValue
         titlebarControlsVisibilityMode = TitlebarControlsVisibilitySettings.defaultMode.rawValue
+        paneTabBarControlsVisibilityMode = PaneTabBarControlsVisibilitySettings.defaultMode.rawValue
         showWorkspaceTitlebar = WorkspaceTitlebarSettings.defaultShowTitlebar
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -192,3 +192,24 @@ final class TitlebarControlsHoverPolicyTests: XCTestCase {
         XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.softButtons.config))
     }
 }
+
+final class TitlebarControlsVisibilityPolicyTests: XCTestCase {
+    func testAccessorySpaceCollapsesOnlyWhenHiddenTitlebarAndHiddenSidebarCoincide() {
+        XCTAssertTrue(titlebarControlsShouldReserveAccessorySpace(
+            showWorkspaceTitlebar: true,
+            sidebarVisible: true
+        ))
+        XCTAssertTrue(titlebarControlsShouldReserveAccessorySpace(
+            showWorkspaceTitlebar: true,
+            sidebarVisible: false
+        ))
+        XCTAssertTrue(titlebarControlsShouldReserveAccessorySpace(
+            showWorkspaceTitlebar: false,
+            sidebarVisible: true
+        ))
+        XCTAssertFalse(titlebarControlsShouldReserveAccessorySpace(
+            showWorkspaceTitlebar: false,
+            sidebarVisible: false
+        ))
+    }
+}

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import Foundation
+
+final class BonsplitTabDragUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testHiddenWorkspaceTitlebarKeepsTabReorderWorking() {
+        let (app, dataPath) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for Bonsplit tab drag UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let alphaTab = app.buttons[alphaTitle]
+        let betaTab = app.buttons[betaTitle]
+
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertLessThan(alphaTab.frame.minX, betaTab.frame.minX, "Expected beta tab to start to the right of alpha")
+
+        let start = betaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let destination = alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
+        start.press(forDuration: 0.2, thenDragTo: destination)
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { betaTab.frame.minX < alphaTab.frame.minX },
+            "Expected dragging beta onto alpha to reorder tabs. alpha=\(alphaTab.frame) beta=\(betaTab.frame)"
+        )
+    }
+
+    func testPaneTabBarControlsRevealOnlyOnTrailingHover() {
+        let (app, _) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
+        )
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+
+        let controlsRegion = app.otherElements["paneTabBarControlsRegion"]
+        XCTAssertTrue(controlsRegion.waitForExistence(timeout: 5.0), "Expected pane tab bar controls region to exist")
+
+        let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
+        XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
+
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
+            "Expected pane tab bar controls to hide away from the trailing hover zone. button=\(newTerminalButton.debugDescription)"
+        )
+
+        controlsRegion.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
+            "Expected pane tab bar controls to reveal when hovering the trailing controls zone. button=\(newTerminalButton.debugDescription)"
+        )
+
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
+            "Expected pane tab bar controls to hide again after leaving the hover zone. button=\(newTerminalButton.debugDescription)"
+        )
+    }
+
+    private func launchConfiguredApp() -> (XCUIApplication, String) {
+        let app = XCUIApplication()
+        let dataPath = "/tmp/cmux-ui-test-bonsplit-tab-drag-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: dataPath)
+
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
+        app.launchArguments += ["-workspaceTitlebarVisible", "NO"]
+        app.launchArguments += ["-paneTabBarControlsVisibilityMode", "onHover"]
+        app.launch()
+        app.activate()
+        return (app, dataPath)
+    }
+
+    private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) {
+            return true
+        }
+        if app.state == .runningBackground {
+            app.activate()
+            return app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        return false
+    }
+
+    private func waitForAnyJSON(atPath path: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if loadJSON(atPath: path) != nil { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return loadJSON(atPath: path) != nil
+    }
+
+    private func waitForJSONKey(_ key: String, equals expected: String, atPath path: String, timeout: TimeInterval) -> [String: String]? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let data = loadJSON(atPath: path), data[key] == expected {
+                return data
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        if let data = loadJSON(atPath: path), data[key] == expected {
+            return data
+        }
+        return nil
+    }
+
+    private func loadJSON(atPath path: String) -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return object
+    }
+
+    private func waitForCondition(timeout: TimeInterval, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return condition()
+    }
+}

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -27,12 +27,15 @@ final class BonsplitTabDragUITests: XCTestCase {
 
         let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
         let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let window = app.windows.element(boundBy: 0)
         let alphaTab = app.buttons[alphaTitle]
         let betaTab = app.buttons[betaTitle]
 
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
         XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
         XCTAssertLessThan(alphaTab.frame.minX, betaTab.frame.minX, "Expected beta tab to start to the right of alpha")
+        let windowFrameBeforeDrag = window.frame
 
         let start = betaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         let destination = alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
@@ -42,6 +45,8 @@ final class BonsplitTabDragUITests: XCTestCase {
             waitForCondition(timeout: 5.0) { betaTab.frame.minX < alphaTab.frame.minX },
             "Expected dragging beta onto alpha to reorder tabs. alpha=\(alphaTab.frame) beta=\(betaTab.frame)"
         )
+        XCTAssertEqual(window.frame.origin.x, windowFrameBeforeDrag.origin.x, accuracy: 2.0, "Expected tab drag not to move the window horizontally")
+        XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected tab drag not to move the window vertically")
     }
 
     func testHiddenWorkspaceTitlebarPlacesPaneTabBarAtTopEdge() {

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -59,11 +59,13 @@ final class BonsplitTabDragUITests: XCTestCase {
         let alphaTab = app.buttons["UITest Alpha"]
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
 
-        let topGap = max(0, window.frame.maxY - alphaTab.frame.maxY)
+        let gapIfOriginIsBottomLeft = abs(window.frame.maxY - alphaTab.frame.maxY)
+        let gapIfOriginIsTopLeft = abs(alphaTab.frame.minY - window.frame.minY)
+        let topGap = min(gapIfOriginIsBottomLeft, gapIfOriginIsTopLeft)
         XCTAssertLessThanOrEqual(
             topGap,
             8,
-            "Expected the selected pane tab to reach the top edge when the workspace titlebar is hidden. window=\(window.frame) alphaTab=\(alphaTab.frame) gap=\(topGap)"
+            "Expected the selected pane tab to reach the top edge when the workspace titlebar is hidden. window=\(window.frame) alphaTab=\(alphaTab.frame) gap.bottomLeft=\(gapIfOriginIsBottomLeft) gap.topLeft=\(gapIfOriginIsTopLeft)"
         )
     }
 
@@ -80,6 +82,8 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
         let alphaTab = app.buttons["UITest Alpha"]
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        let betaTab = app.buttons["UITest Beta"]
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -90,10 +94,16 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        hover(
+            in: window,
+            at: CGPoint(
+                x: min(window.frame.maxX - 140, betaTab.frame.maxX + 80),
+                y: alphaTab.frame.midY
+            )
+        )
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
-            "Expected pane tab bar controls to reveal when hovering inside the pane tab bar. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to reveal when hovering inside empty pane-tab-bar space. window=\(window.frame) alphaTab=\(alphaTab.frame) betaTab=\(betaTab.frame) button=\(newTerminalButton.debugDescription)"
         )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
@@ -166,5 +176,15 @@ final class BonsplitTabDragUITests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
         return condition()
+    }
+
+    private func hover(in window: XCUIElement, at point: CGPoint) {
+        let origin = window.coordinate(withNormalizedOffset: .zero)
+        origin.withOffset(
+            CGVector(
+                dx: point.x - window.frame.minX,
+                dy: point.y - window.frame.minY
+            )
+        ).hover()
     }
 }

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -44,7 +44,7 @@ final class BonsplitTabDragUITests: XCTestCase {
         )
     }
 
-    func testPaneTabBarControlsRevealOnlyOnTrailingHover() {
+    func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
         let (app, _) = launchConfiguredApp()
 
         XCTAssertTrue(
@@ -55,8 +55,8 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let controlsRegion = app.otherElements["paneTabBarControlsRegion"]
-        XCTAssertTrue(controlsRegion.waitForExistence(timeout: 5.0), "Expected pane tab bar controls region to exist")
+        let paneTabBar = app.otherElements["paneTabBar"]
+        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -64,19 +64,19 @@ final class BonsplitTabDragUITests: XCTestCase {
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
-            "Expected pane tab bar controls to hide away from the trailing hover zone. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        controlsRegion.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        paneTabBar.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.5)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
-            "Expected pane tab bar controls to reveal when hovering the trailing controls zone. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to reveal when hovering anywhere on the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
-            "Expected pane tab bar controls to hide again after leaving the hover zone. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to hide again after leaving the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
     }
 

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -45,39 +45,41 @@ final class BonsplitTabDragUITests: XCTestCase {
     }
 
     func testHiddenWorkspaceTitlebarPlacesPaneTabBarAtTopEdge() {
-        let (app, _) = launchConfiguredApp()
+        let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for hidden titlebar top-gap UI test. state=\(app.state.rawValue)"
         )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
 
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let paneTabBar = app.otherElements["paneTabBar"]
-        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
+        let alphaTab = app.buttons["UITest Alpha"]
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
 
-        let topGap = max(0, window.frame.maxY - paneTabBar.frame.maxY)
+        let topGap = max(0, window.frame.maxY - alphaTab.frame.maxY)
         XCTAssertLessThanOrEqual(
             topGap,
             8,
-            "Expected pane tab bar to reach the top edge when the workspace titlebar is hidden. window=\(window.frame) paneTabBar=\(paneTabBar.frame) gap=\(topGap)"
+            "Expected the selected pane tab to reach the top edge when the workspace titlebar is hidden. window=\(window.frame) alphaTab=\(alphaTab.frame) gap=\(topGap)"
         )
     }
 
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
-        let (app, _) = launchConfiguredApp()
+        let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
         )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
 
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
-        let paneTabBar = app.otherElements["paneTabBar"]
-        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
+        let alphaTab = app.buttons["UITest Alpha"]
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -88,7 +90,7 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        paneTabBar.coordinate(withNormalizedOffset: CGVector(dx: 0.25, dy: 0.5)).hover()
+        alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
             "Expected pane tab bar controls to reveal when hovering inside the pane tab bar. button=\(newTerminalButton.debugDescription)"

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -39,20 +39,36 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         let alphaTab = app.buttons[alphaTitle]
         let betaTab = app.buttons[betaTitle]
+        let initialOrder = "\(alphaTitle)|\(betaTitle)"
+        let reorderedOrder = "\(betaTitle)|\(alphaTitle)"
 
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
         XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: initialOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected initial tracked tab order to be \(initialOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
         XCTAssertLessThan(alphaTab.frame.minX, betaTab.frame.minX, "Expected beta tab to start to the right of alpha")
         let windowFrameBeforeDrag = window.frame
 
         let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
-        let destination = CGPoint(x: alphaTab.frame.minX + 10, y: alphaTab.frame.midY)
-        dragMouse(fromAccessibilityPoint: start, toAccessibilityPoint: destination)
+        let destination = CGPoint(x: alphaTab.frame.midX - 14, y: alphaTab.frame.midY)
+        dragMouse(
+            fromAccessibilityPoint: start,
+            toAccessibilityPoint: destination,
+            steps: 28,
+            holdDuration: 0.20,
+            dragDuration: 0.45
+        )
 
         XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: reorderedOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected tracked tab order to become \(reorderedOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertTrue(
             waitForCondition(timeout: 5.0) { betaTab.frame.minX < alphaTab.frame.minX },
-            "Expected dragging beta onto alpha to reorder tabs. alpha=\(alphaTab.frame) beta=\(betaTab.frame)"
+            "Expected dragging beta onto alpha to reorder tab frames. alpha=\(alphaTab.frame) beta=\(betaTab.frame)"
         )
         XCTAssertEqual(window.frame.origin.x, windowFrameBeforeDrag.origin.x, accuracy: 2.0, "Expected tab drag not to move the window horizontally")
         XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected tab drag not to move the window vertically")

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -4,20 +4,27 @@ import AppKit
 import CoreGraphics
 
 final class BonsplitTabDragUITests: XCTestCase {
+    private let launchTimeout: TimeInterval = 20.0
+    private let setupTimeout: TimeInterval = 25.0
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+
+        let cleanup = XCUIApplication()
+        cleanup.terminate()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
     }
 
     func testHiddenWorkspaceTitlebarKeepsTabReorderWorking() {
         let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
             "Expected app to launch for Bonsplit tab drag UI test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
             XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
@@ -55,11 +62,11 @@ final class BonsplitTabDragUITests: XCTestCase {
         let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
             "Expected app to launch for hidden titlebar top-gap UI test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
             XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
@@ -90,11 +97,11 @@ final class BonsplitTabDragUITests: XCTestCase {
         let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
             "Expected app to launch for hidden titlebar sidebar inset UI test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
             XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
@@ -108,7 +115,7 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
         let workspaceTitle = ready["workspaceTitle"] ?? "UITest Workspace"
-        let workspaceRow = app.buttons[workspaceTitle]
+        let workspaceRow = app.descendants(matching: .any).matching(NSPredicate(format: "label == %@", workspaceTitle)).firstMatch
         XCTAssertTrue(workspaceRow.waitForExistence(timeout: 5.0), "Expected workspace row to exist")
 
         let topInset = distanceToTopEdge(of: workspaceRow, in: window)
@@ -123,11 +130,11 @@ final class BonsplitTabDragUITests: XCTestCase {
         let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
             "Expected app to launch for hidden titlebar titlebar-controls hover UI test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
             XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
@@ -140,12 +147,9 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let toggleSidebarButton = app.buttons["titlebarControl.toggleSidebar"]
-        let notificationsButton = app.buttons["titlebarControl.showNotifications"]
-        let newWorkspaceButton = app.buttons["titlebarControl.newTab"]
-        XCTAssertTrue(toggleSidebarButton.waitForExistence(timeout: 5.0), "Expected sidebar titlebar control to exist")
-        XCTAssertTrue(notificationsButton.waitForExistence(timeout: 5.0), "Expected notifications titlebar control to exist")
-        XCTAssertTrue(newWorkspaceButton.waitForExistence(timeout: 5.0), "Expected new workspace titlebar control to exist")
+        let toggleSidebarButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.toggleSidebar").firstMatch
+        let notificationsButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.showNotifications").firstMatch
+        let newWorkspaceButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.newTab").firstMatch
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(
@@ -155,10 +159,12 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected hidden-titlebar controls to stay hidden away from the titlebar hover zone."
         )
 
-        newWorkspaceButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        hover(in: window, at: CGPoint(x: window.frame.maxX - 48, y: window.frame.minY + 18))
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) {
-                toggleSidebarButton.isHittable && notificationsButton.isHittable && newWorkspaceButton.isHittable
+                toggleSidebarButton.exists && toggleSidebarButton.isHittable &&
+                    notificationsButton.exists && notificationsButton.isHittable &&
+                    newWorkspaceButton.exists && newWorkspaceButton.isHittable
             },
             "Expected hidden-titlebar controls to reveal when hovering the titlebar controls area."
         )
@@ -168,11 +174,11 @@ final class BonsplitTabDragUITests: XCTestCase {
         let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
-            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
             "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
             XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
@@ -191,12 +197,11 @@ final class BonsplitTabDragUITests: XCTestCase {
         let betaTab = app.buttons[betaTitle]
         XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
 
-        let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
-        XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
+        let newTerminalButton = app.descendants(matching: .any).matching(identifier: "paneTabBarControl.newTerminal").firstMatch
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(
-            waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
+            waitForCondition(timeout: 2.0) { !newTerminalButton.exists || !newTerminalButton.isHittable },
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
@@ -208,13 +213,13 @@ final class BonsplitTabDragUITests: XCTestCase {
             )
         )
         XCTAssertTrue(
-            waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
+            waitForCondition(timeout: 2.0) { newTerminalButton.exists && newTerminalButton.isHittable },
             "Expected pane tab bar controls to reveal when hovering inside empty pane-tab-bar space. window=\(window.frame) alphaTab=\(alphaTab.frame) betaTab=\(betaTab.frame) button=\(newTerminalButton.debugDescription)"
         )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(
-            waitForCondition(timeout: 2.0) { !newTerminalButton.isHittable },
+            waitForCondition(timeout: 2.0) { !newTerminalButton.exists || !newTerminalButton.isHittable },
             "Expected pane tab bar controls to hide again after leaving the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
     }

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -45,30 +45,18 @@ final class BonsplitTabDragUITests: XCTestCase {
     }
 
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
-        let (app, dataPath) = launchConfiguredApp()
+        let (app, _) = launchConfiguredApp()
 
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
         )
 
-        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
-        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
-            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
-            return
-        }
-
-        if let setupError = ready["setupError"], !setupError.isEmpty {
-            XCTFail("Setup failed: \(setupError)")
-            return
-        }
-
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
-        let alphaTab = app.buttons[alphaTitle]
-        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        let terminalTab = app.buttons["Terminal"]
+        XCTAssertTrue(terminalTab.waitForExistence(timeout: 5.0), "Expected terminal tab to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -79,7 +67,7 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        terminalTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
             "Expected pane tab bar controls to reveal when hovering a tab inside the pane tab bar. button=\(newTerminalButton.debugDescription)"

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -52,11 +52,21 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected app to launch for hidden titlebar top-gap UI test. state=\(app.state.rawValue)"
         )
         XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
 
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let alphaTab = app.buttons["UITest Alpha"]
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let alphaTab = app.buttons[alphaTitle]
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
 
         let gapIfOriginIsBottomLeft = abs(window.frame.maxY - alphaTab.frame.maxY)
@@ -77,12 +87,23 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
         )
         XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
 
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
-        let alphaTab = app.buttons["UITest Alpha"]
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let alphaTab = app.buttons[alphaTitle]
         XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
-        let betaTab = app.buttons["UITest Beta"]
+        let betaTab = app.buttons[betaTitle]
         XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -45,18 +45,30 @@ final class BonsplitTabDragUITests: XCTestCase {
     }
 
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
-        let (app, _) = launchConfiguredApp()
+        let (app, dataPath) = launchConfiguredApp()
 
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for Bonsplit controls hover UI test. state=\(app.state.rawValue)"
         )
 
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let paneTabBar = app.otherElements["paneTabBar"]
-        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let alphaTab = app.buttons[alphaTitle]
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -67,10 +79,10 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        paneTabBar.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.5)).hover()
+        alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
-            "Expected pane tab bar controls to reveal when hovering anywhere on the pane tab bar. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to reveal when hovering a tab inside the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -39,6 +39,7 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         let alphaTab = app.buttons[alphaTitle]
         let betaTab = app.buttons[betaTitle]
+        let dropIndicator = app.descendants(matching: .any).matching(identifier: "paneTabBar.dropIndicator").firstMatch
         let initialOrder = "\(alphaTitle)|\(betaTitle)"
         let reorderedOrder = "\(betaTitle)|\(alphaTitle)"
 
@@ -54,13 +55,24 @@ final class BonsplitTabDragUITests: XCTestCase {
 
         let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
         let destination = CGPoint(x: alphaTab.frame.midX - 14, y: alphaTab.frame.midY)
-        dragMouse(
+        guard let dragSession = beginMouseDrag(
             fromAccessibilityPoint: start,
+            holdDuration: 0.20
+        ) else {
+            XCTFail("Expected raw mouse drag session to start")
+            return
+        }
+        continueMouseDrag(
+            dragSession,
             toAccessibilityPoint: destination,
             steps: 28,
-            holdDuration: 0.20,
             dragDuration: 0.45
         )
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) { dropIndicator.exists },
+            "Expected dragging beta onto alpha to reveal the Bonsplit drop indicator."
+        )
+        endMouseDrag(dragSession, atAccessibilityPoint: destination)
 
         XCTAssertTrue(
             waitForJSONKey("trackedPaneTabTitles", equals: reorderedOrder, atPath: dataPath, timeout: 5.0) != nil,
@@ -130,14 +142,15 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let workspaceTitle = ready["workspaceTitle"] ?? "UITest Workspace"
-        let workspaceRow = app.descendants(matching: .any).matching(NSPredicate(format: "label == %@", workspaceTitle)).firstMatch
+        let workspaceId = ready["workspaceId"] ?? ""
+        let workspaceRowIdentifier = "sidebarWorkspace.\(workspaceId)"
+        let workspaceRow = app.descendants(matching: .any).matching(identifier: workspaceRowIdentifier).firstMatch
         XCTAssertTrue(workspaceRow.waitForExistence(timeout: 5.0), "Expected workspace row to exist")
 
         let topInset = distanceToTopEdge(of: workspaceRow, in: window)
         XCTAssertGreaterThanOrEqual(
             topInset,
-            14,
+            30,
             "Expected hidden-titlebar sidebar rows to stay below the traffic lights. window=\(window.frame) workspaceRow=\(workspaceRow.frame) topInset=\(topInset)"
         )
     }
@@ -322,38 +335,54 @@ final class BonsplitTabDragUITests: XCTestCase {
         return min(gapIfOriginIsBottomLeft, gapIfOriginIsTopLeft)
     }
 
-    private func dragMouse(
+    private struct RawMouseDragSession {
+        let source: CGEventSource
+    }
+
+    private func beginMouseDrag(
         fromAccessibilityPoint start: CGPoint,
-        toAccessibilityPoint end: CGPoint,
-        steps: Int = 20,
-        holdDuration: TimeInterval = 0.15,
-        dragDuration: TimeInterval = 0.30
-    ) {
+        holdDuration: TimeInterval = 0.15
+    ) -> RawMouseDragSession? {
         let source = CGEventSource(stateID: .hidSystemState)
         XCTAssertNotNil(source, "Expected CGEventSource for raw mouse drag")
-        guard let source else { return }
+        guard let source else { return nil }
 
         let quartzStart = quartzPoint(fromAccessibilityPoint: start)
-        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
 
         postMouseEvent(type: .mouseMoved, at: quartzStart, source: source)
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         postMouseEvent(type: .leftMouseDown, at: quartzStart, source: source)
         RunLoop.current.run(until: Date().addingTimeInterval(holdDuration))
+        return RawMouseDragSession(source: source)
+    }
 
+    private func continueMouseDrag(
+        _ session: RawMouseDragSession,
+        toAccessibilityPoint end: CGPoint,
+        steps: Int = 20,
+        dragDuration: TimeInterval = 0.30
+    ) {
+        let currentLocation = NSEvent.mouseLocation
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
         let clampedSteps = max(2, steps)
         for step in 1...clampedSteps {
             let progress = CGFloat(step) / CGFloat(clampedSteps)
             let point = CGPoint(
-                x: quartzStart.x + ((quartzEnd.x - quartzStart.x) * progress),
-                y: quartzStart.y + ((quartzEnd.y - quartzStart.y) * progress)
+                x: currentLocation.x + ((quartzEnd.x - currentLocation.x) * progress),
+                y: currentLocation.y + ((quartzEnd.y - currentLocation.y) * progress)
             )
-            postMouseEvent(type: .leftMouseDragged, at: point, source: source)
+            postMouseEvent(type: .leftMouseDragged, at: point, source: session.source)
             RunLoop.current.run(until: Date().addingTimeInterval(dragDuration / Double(clampedSteps)))
         }
+    }
 
-        postMouseEvent(type: .leftMouseUp, at: quartzEnd, source: source)
+    private func endMouseDrag(
+        _ session: RawMouseDragSession,
+        atAccessibilityPoint end: CGPoint
+    ) {
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+        postMouseEvent(type: .leftMouseUp, at: quartzEnd, source: session.source)
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
     }
 

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -79,6 +79,84 @@ final class BonsplitTabDragUITests: XCTestCase {
         )
     }
 
+    func testHiddenWorkspaceTitlebarKeepsSidebarRowsBelowTrafficLights() {
+        let (app, dataPath) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for hidden titlebar sidebar inset UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+
+        let workspaceTitle = ready["workspaceTitle"] ?? "UITest Workspace"
+        let workspaceRow = app.buttons[workspaceTitle]
+        XCTAssertTrue(workspaceRow.waitForExistence(timeout: 5.0), "Expected workspace row to exist")
+
+        let topInset = distanceToTopEdge(of: workspaceRow, in: window)
+        XCTAssertGreaterThanOrEqual(
+            topInset,
+            14,
+            "Expected hidden-titlebar sidebar rows to stay below the traffic lights. window=\(window.frame) workspaceRow=\(workspaceRow.frame) topInset=\(topInset)"
+        )
+    }
+
+    func testHiddenWorkspaceTitlebarTitlebarControlsRevealOnHover() {
+        let (app, dataPath) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for hidden titlebar titlebar-controls hover UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: 12.0), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: 12.0) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+
+        let toggleSidebarButton = app.buttons["titlebarControl.toggleSidebar"]
+        let notificationsButton = app.buttons["titlebarControl.showNotifications"]
+        let newWorkspaceButton = app.buttons["titlebarControl.newTab"]
+        XCTAssertTrue(toggleSidebarButton.waitForExistence(timeout: 5.0), "Expected sidebar titlebar control to exist")
+        XCTAssertTrue(notificationsButton.waitForExistence(timeout: 5.0), "Expected notifications titlebar control to exist")
+        XCTAssertTrue(newWorkspaceButton.waitForExistence(timeout: 5.0), "Expected new workspace titlebar control to exist")
+
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) {
+                !toggleSidebarButton.isHittable && !notificationsButton.isHittable && !newWorkspaceButton.isHittable
+            },
+            "Expected hidden-titlebar controls to stay hidden away from the titlebar hover zone."
+        )
+
+        newWorkspaceButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) {
+                toggleSidebarButton.isHittable && notificationsButton.isHittable && newWorkspaceButton.isHittable
+            },
+            "Expected hidden-titlebar controls to reveal when hovering the titlebar controls area."
+        )
+    }
+
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
         let (app, dataPath) = launchConfiguredApp()
 
@@ -142,6 +220,7 @@ final class BonsplitTabDragUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
         app.launchArguments += ["-workspaceTitlebarVisible", "NO"]
+        app.launchArguments += ["-titlebarControlsVisibilityMode", "onHover"]
         app.launchArguments += ["-paneTabBarControlsVisibilityMode", "onHover"]
         app.launch()
         app.activate()
@@ -207,5 +286,11 @@ final class BonsplitTabDragUITests: XCTestCase {
                 dy: point.y - window.frame.minY
             )
         ).hover()
+    }
+
+    private func distanceToTopEdge(of element: XCUIElement, in window: XCUIElement) -> CGFloat {
+        let gapIfOriginIsBottomLeft = abs(window.frame.maxY - element.frame.maxY)
+        let gapIfOriginIsTopLeft = abs(element.frame.minY - window.frame.minY)
+        return min(gapIfOriginIsBottomLeft, gapIfOriginIsTopLeft)
     }
 }

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -55,9 +55,6 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
-        let terminalTab = app.buttons["Terminal"]
-        XCTAssertTrue(terminalTab.waitForExistence(timeout: 5.0), "Expected terminal tab to exist")
-
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
 
@@ -67,10 +64,10 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        terminalTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.06)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
-            "Expected pane tab bar controls to reveal when hovering a tab inside the pane tab bar. button=\(newTerminalButton.debugDescription)"
+            "Expected pane tab bar controls to reveal when hovering inside the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -199,6 +199,55 @@ final class BonsplitTabDragUITests: XCTestCase {
         )
     }
 
+    func testHiddenWorkspaceTitlebarCollapsedSidebarKeepsControlsSuppressed() {
+        let (app, dataPath) = launchConfiguredApp(startWithHiddenSidebar: true)
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for collapsed-sidebar hidden-titlebar controls UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        XCTAssertEqual(ready["sidebarVisible"], "0", "Expected hidden-sidebar UI test setup to collapse the sidebar. data=\(ready)")
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let alphaTab = app.buttons[alphaTitle]
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+
+        let toggleSidebarButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.toggleSidebar").firstMatch
+        let notificationsButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.showNotifications").firstMatch
+        let newWorkspaceButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.newTab").firstMatch
+
+        hover(in: window, at: CGPoint(x: window.frame.maxX - 48, y: window.frame.minY + 18))
+        XCTAssertTrue(
+            waitForCondition(timeout: 2.0) {
+                (!toggleSidebarButton.exists || !toggleSidebarButton.isHittable) &&
+                    (!notificationsButton.exists || !notificationsButton.isHittable) &&
+                    (!newWorkspaceButton.exists || !newWorkspaceButton.isHittable)
+            },
+            "Expected collapsed-sidebar hidden-titlebar mode to keep titlebar controls suppressed. toggle=\(toggleSidebarButton.debugDescription) notifications=\(notificationsButton.debugDescription) new=\(newWorkspaceButton.debugDescription)"
+        )
+
+        let leadingInset = alphaTab.frame.minX - window.frame.minX
+        XCTAssertLessThan(
+            leadingInset,
+            96,
+            "Expected pane tabs to stay near the leading edge when collapsed-sidebar hidden-titlebar mode removes the titlebar accessory lane. window=\(window.frame) alphaTab=\(alphaTab.frame) leadingInset=\(leadingInset)"
+        )
+    }
+
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
         let (app, dataPath) = launchConfiguredApp()
 
@@ -253,13 +302,16 @@ final class BonsplitTabDragUITests: XCTestCase {
         )
     }
 
-    private func launchConfiguredApp() -> (XCUIApplication, String) {
+    private func launchConfiguredApp(startWithHiddenSidebar: Bool = false) -> (XCUIApplication, String) {
         let app = XCUIApplication()
         let dataPath = "/tmp/cmux-ui-test-bonsplit-tab-drag-\(UUID().uuidString).json"
         try? FileManager.default.removeItem(atPath: dataPath)
 
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
+        if startWithHiddenSidebar {
+            app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_START_WITH_HIDDEN_SIDEBAR"] = "1"
+        }
         app.launchArguments += ["-workspaceTitlebarVisible", "NO"]
         app.launchArguments += ["-titlebarControlsVisibilityMode", "onHover"]
         app.launchArguments += ["-paneTabBarControlsVisibilityMode", "onHover"]

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import Foundation
+import AppKit
+import CoreGraphics
 
 final class BonsplitTabDragUITests: XCTestCase {
     override func setUp() {
@@ -37,9 +39,9 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertLessThan(alphaTab.frame.minX, betaTab.frame.minX, "Expected beta tab to start to the right of alpha")
         let windowFrameBeforeDrag = window.frame
 
-        let start = betaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        let destination = alphaTab.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.5))
-        start.press(forDuration: 0.2, thenDragTo: destination)
+        let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
+        let destination = CGPoint(x: alphaTab.frame.minX + 10, y: alphaTab.frame.midY)
+        dragMouse(fromAccessibilityPoint: start, toAccessibilityPoint: destination)
 
         XCTAssertTrue(
             waitForCondition(timeout: 5.0) { betaTab.frame.minX < alphaTab.frame.minX },
@@ -297,5 +299,68 @@ final class BonsplitTabDragUITests: XCTestCase {
         let gapIfOriginIsBottomLeft = abs(window.frame.maxY - element.frame.maxY)
         let gapIfOriginIsTopLeft = abs(element.frame.minY - window.frame.minY)
         return min(gapIfOriginIsBottomLeft, gapIfOriginIsTopLeft)
+    }
+
+    private func dragMouse(
+        fromAccessibilityPoint start: CGPoint,
+        toAccessibilityPoint end: CGPoint,
+        steps: Int = 20,
+        holdDuration: TimeInterval = 0.15,
+        dragDuration: TimeInterval = 0.30
+    ) {
+        let source = CGEventSource(stateID: .hidSystemState)
+        XCTAssertNotNil(source, "Expected CGEventSource for raw mouse drag")
+        guard let source else { return }
+
+        let quartzStart = quartzPoint(fromAccessibilityPoint: start)
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+
+        postMouseEvent(type: .mouseMoved, at: quartzStart, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        postMouseEvent(type: .leftMouseDown, at: quartzStart, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(holdDuration))
+
+        let clampedSteps = max(2, steps)
+        for step in 1...clampedSteps {
+            let progress = CGFloat(step) / CGFloat(clampedSteps)
+            let point = CGPoint(
+                x: quartzStart.x + ((quartzEnd.x - quartzStart.x) * progress),
+                y: quartzStart.y + ((quartzEnd.y - quartzStart.y) * progress)
+            )
+            postMouseEvent(type: .leftMouseDragged, at: point, source: source)
+            RunLoop.current.run(until: Date().addingTimeInterval(dragDuration / Double(clampedSteps)))
+        }
+
+        postMouseEvent(type: .leftMouseUp, at: quartzEnd, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+    }
+
+    private func postMouseEvent(
+        type: CGEventType,
+        at point: CGPoint,
+        source: CGEventSource
+    ) {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else {
+            XCTFail("Expected CGEvent for mouse type \(type.rawValue) at \(point)")
+            return
+        }
+
+        event.setIntegerValueField(.mouseEventClickState, value: 1)
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func quartzPoint(fromAccessibilityPoint point: CGPoint) -> CGPoint {
+        let desktopBounds = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+        XCTAssertFalse(desktopBounds.isNull, "Expected at least one screen when converting raw mouse coordinates")
+        guard !desktopBounds.isNull else { return point }
+        return CGPoint(x: point.x, y: desktopBounds.maxY - point.y)
     }
 }

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -44,6 +44,28 @@ final class BonsplitTabDragUITests: XCTestCase {
         )
     }
 
+    func testHiddenWorkspaceTitlebarPlacesPaneTabBarAtTopEdge() {
+        let (app, _) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for hidden titlebar top-gap UI test. state=\(app.state.rawValue)"
+        )
+
+        let window = app.windows.element(boundBy: 0)
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+
+        let paneTabBar = app.otherElements["paneTabBar"]
+        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
+
+        let topGap = max(0, window.frame.maxY - paneTabBar.frame.maxY)
+        XCTAssertLessThanOrEqual(
+            topGap,
+            8,
+            "Expected pane tab bar to reach the top edge when the workspace titlebar is hidden. window=\(window.frame) paneTabBar=\(paneTabBar.frame) gap=\(topGap)"
+        )
+    }
+
     func testPaneTabBarControlsRevealWhenHoveringAnywhereOnPaneTabBar() {
         let (app, _) = launchConfiguredApp()
 
@@ -54,6 +76,8 @@ final class BonsplitTabDragUITests: XCTestCase {
 
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+        let paneTabBar = app.otherElements["paneTabBar"]
+        XCTAssertTrue(paneTabBar.waitForExistence(timeout: 5.0), "Expected pane tab bar to exist")
 
         let newTerminalButton = app.buttons["paneTabBarControl.newTerminal"]
         XCTAssertTrue(newTerminalButton.waitForExistence(timeout: 5.0), "Expected new terminal control to exist")
@@ -64,7 +88,7 @@ final class BonsplitTabDragUITests: XCTestCase {
             "Expected pane tab bar controls to hide away from the pane tab bar. button=\(newTerminalButton.debugDescription)"
         )
 
-        window.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.06)).hover()
+        paneTabBar.coordinate(withNormalizedOffset: CGVector(dx: 0.25, dy: 0.5)).hover()
         XCTAssertTrue(
             waitForCondition(timeout: 2.0) { newTerminalButton.isHittable },
             "Expected pane tab bar controls to reveal when hovering inside the pane tab bar. button=\(newTerminalButton.debugDescription)"

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -176,9 +176,23 @@ final class BonsplitTabDragUITests: XCTestCase {
         let window = app.windows.element(boundBy: 0)
         XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
 
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let alphaTab = app.buttons[alphaTitle]
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+
+        let sidebar = app.descendants(matching: .any).matching(identifier: "Sidebar").firstMatch
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 5.0), "Expected sidebar to exist")
+
         let toggleSidebarButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.toggleSidebar").firstMatch
         let notificationsButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.showNotifications").firstMatch
         let newWorkspaceButton = app.descendants(matching: .any).matching(identifier: "titlebarControl.newTab").firstMatch
+
+        let paneLeadingGap = alphaTab.frame.minX - sidebar.frame.maxX
+        XCTAssertLessThan(
+            paneLeadingGap,
+            28,
+            "Expected visible-sidebar hidden-titlebar mode to keep pane tabs tight to the sidebar edge while the traffic lights sit over the sidebar. window=\(window.frame) sidebar=\(sidebar.frame) alphaTab=\(alphaTab.frame) paneLeadingGap=\(paneLeadingGap)"
+        )
 
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).hover()
         XCTAssertTrue(


### PR DESCRIPTION
## Summary
- add separate hover-visibility settings for titlebar controls and Bonsplit pane tab bar controls
- make the workspace titlebar disappear with no extra top band, and use empty Bonsplit tab bar space as the drag region when that titlebar is hidden

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-hover-icons-hide-titlebar` (build succeeded and the tagged app launched)

## Issues
- Related: feedback email from `timo.lins@vercel.com` on 2026-03-13 requesting hover-only icons and a hideable directory titlebar
- Related: https://github.com/manaflow-ai/bonsplit/pull/23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-workspace titlebar visibility and controls: show/hide workspace titlebar; controls modes: Always or On Hover. Controls animate, respond to hover, and a collapsed drag-handle remains when hidden.

* **Settings**
  * Settings UI to pick titlebar and pane/tab-bar visibility modes and toggle workspace titlebar; reset restores new defaults.

* **Localization**
  * Large expansion of localized strings for workspace, window, theme, and update UI.

* **Tests**
  * New UI tests covering tab drag/reorder and pane tab-bar control reveal on hover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->