### PR TITLE
Follow-up: build only universal nightly artifacts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -154,16 +154,7 @@ jobs:
           echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
           echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
-      - name: Build Apple Silicon app (Release)
-        run: |
-          xcodebuild -scheme cmux -configuration Release -derivedDataPath build-arm \
-            -destination 'platform=macOS,arch=arm64' \
-            -clonedSourcePackagesDirPath .spm-cache \
-            ARCHS="arm64" \
-            ONLY_ACTIVE_ARCH=YES \
-            CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
-
-      - name: Build universal app (Release)
+      - name: Build universal nightly app (Release)
         run: |
           xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
@@ -175,20 +166,12 @@ jobs:
       - name: Verify nightly binary architectures
         run: |
           set -euo pipefail
-          ARM_APP_BINARY="build-arm/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
-          ARM_CLI_BINARY="build-arm/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
           APP_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
           CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
-          ARM_APP_ARCHS="$(lipo -archs "$ARM_APP_BINARY")"
-          ARM_CLI_ARCHS="$(lipo -archs "$ARM_CLI_BINARY")"
           APP_ARCHS="$(lipo -archs "$APP_BINARY")"
           CLI_ARCHS="$(lipo -archs "$CLI_BINARY")"
-          echo "Arm app binary architectures: $ARM_APP_ARCHS"
-          echo "Arm CLI binary architectures: $ARM_CLI_ARCHS"
           echo "App binary architectures: $APP_ARCHS"
           echo "CLI binary architectures: $CLI_ARCHS"
-          [[ "$ARM_APP_ARCHS" == "arm64" ]]
-          [[ "$ARM_CLI_ARCHS" == "arm64" ]]
           [[ "$APP_ARCHS" == *arm64* && "$APP_ARCHS" == *x86_64* ]]
           [[ "$CLI_ARCHS" == *arm64* && "$CLI_ARCHS" == *x86_64* ]]
 
@@ -225,10 +208,9 @@ jobs:
         run: |
           set -euo pipefail
           SHORT_SHA="${{ needs.decide.outputs.short_sha }}"
-          ARM_APP_DIR="build-arm/Build/Products/Release"
-          UNIVERSAL_APP_DIR="build-universal/Build/Products/Release"
+          APP_DIR="build-universal/Build/Products/Release"
 
-          BASE_MARKETING=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${ARM_APP_DIR}/cmux.app/Contents/Info.plist")
+          BASE_MARKETING=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${APP_DIR}/cmux.app/Contents/Info.plist")
           NIGHTLY_DATE=$(date -u +%Y%m%d)
 
           # Build number: unique/monotonic per workflow run attempt so same-day
@@ -241,10 +223,8 @@ jobs:
           fi
           echo "NIGHTLY_BUILD=${NIGHTLY_BUILD}" >> "$GITHUB_ENV"
 
-          ARM_DMG_IMMUTABLE="cmux-nightly-macos-${NIGHTLY_BUILD}.dmg"
-          UNIVERSAL_DMG_IMMUTABLE="cmux-nightly-universal-macos-${NIGHTLY_BUILD}.dmg"
-          echo "NIGHTLY_DMG_IMMUTABLE=${ARM_DMG_IMMUTABLE}" >> "$GITHUB_ENV"
-          echo "NIGHTLY_UNIVERSAL_DMG_IMMUTABLE=${UNIVERSAL_DMG_IMMUTABLE}" >> "$GITHUB_ENV"
+          NIGHTLY_DMG_IMMUTABLE="cmux-nightly-macos-${NIGHTLY_BUILD}.dmg"
+          echo "NIGHTLY_DMG_IMMUTABLE=${NIGHTLY_DMG_IMMUTABLE}" >> "$GITHUB_ENV"
 
           prepare_variant() {
             local app_dir="$1"
@@ -267,21 +247,15 @@ jobs:
           }
 
           prepare_variant \
-            "$ARM_APP_DIR" \
+            "$APP_DIR" \
             "com.cmuxterm.app.nightly" \
             "https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast.xml"
-          prepare_variant \
-            "$UNIVERSAL_APP_DIR" \
-            "com.cmuxterm.app.nightly.universal" \
-            "https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast-universal.xml"
 
           echo "Nightly app name: cmux NIGHTLY"
-          echo "Nightly arm64 bundle ID: com.cmuxterm.app.nightly"
-          echo "Nightly universal bundle ID: com.cmuxterm.app.nightly.universal"
+          echo "Nightly bundle ID: com.cmuxterm.app.nightly"
           echo "Nightly marketing version: ${BASE_MARKETING}-nightly.${NIGHTLY_DATE}"
           echo "Nightly build number: ${NIGHTLY_BUILD}"
-          echo "Nightly arm64 immutable DMG: ${ARM_DMG_IMMUTABLE}"
-          echo "Nightly universal immutable DMG: ${UNIVERSAL_DMG_IMMUTABLE}"
+          echo "Nightly immutable DMG: ${NIGHTLY_DMG_IMMUTABLE}"
           echo "Commit SHA: ${SHORT_SHA}"
 
       - name: Import signing cert
@@ -319,7 +293,6 @@ jobs:
           fi
           ENTITLEMENTS="cmux.entitlements"
           for APP_PATH in \
-            "build-arm/Build/Products/Release/cmux NIGHTLY.app" \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
@@ -391,13 +364,9 @@ jobs:
           }
 
           notarize_and_package \
-            "build-arm/Build/Products/Release/cmux NIGHTLY.app" \
+            "build-universal/Build/Products/Release/cmux NIGHTLY.app" \
             "cmux-nightly-macos.dmg" \
             "$NIGHTLY_DMG_IMMUTABLE"
-          notarize_and_package \
-            "build-universal/Build/Products/Release/cmux NIGHTLY.app" \
-            "cmux-nightly-universal-macos.dmg" \
-            "$NIGHTLY_UNIVERSAL_DMG_IMMUTABLE"
 
       - name: Upload dSYMs to Sentry
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head.outputs.still_current == 'true'
@@ -412,7 +381,6 @@ jobs:
           fi
           brew install getsentry/tools/sentry-cli || true
           sentry-cli debug-files upload --include-sources \
-            build-arm/Build/Products/Release/ \
             build-universal/Build/Products/Release/
 
       - name: Generate Sparkle appcasts (nightly)
@@ -425,7 +393,6 @@ jobs:
             exit 1
           fi
           ./scripts/sparkle_generate_appcast.sh "$NIGHTLY_DMG_IMMUTABLE" nightly appcast.xml
-          ./scripts/sparkle_generate_appcast.sh "$NIGHTLY_UNIVERSAL_DMG_IMMUTABLE" nightly appcast-universal.xml
 
       - name: Upload branch nightly artifacts
         if: needs.decide.outputs.should_publish != 'true'
@@ -434,9 +401,7 @@ jobs:
           name: cmux-nightly-${{ needs.decide.outputs.short_sha }}
           path: |
             cmux-nightly-macos*.dmg
-            cmux-nightly-universal-macos*.dmg
             appcast.xml
-            appcast-universal.xml
           if-no-files-found: error
 
       - name: Move nightly tag to built commit
@@ -459,19 +424,15 @@ jobs:
           body: |
             Automated nightly build for `${{ needs.decide.outputs.short_sha }}`.
 
-            **cmux NIGHTLY** has two update tracks:
-            - Apple Silicon: bundle ID `com.cmuxterm.app.nightly`, feed `appcast.xml`
-            - Universal: bundle ID `com.cmuxterm.app.nightly.universal`, feed `appcast-universal.xml`
+            **cmux NIGHTLY** is published as a universal app:
+            - bundle ID `com.cmuxterm.app.nightly`
+            - feed `appcast.xml`
 
             [Download cmux-nightly-macos.dmg](https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg)
-            [Download cmux-nightly-universal-macos.dmg](https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-universal-macos.dmg)
           files: |
             cmux-nightly-macos-${{ github.run_id }}*.dmg
             cmux-nightly-macos.dmg
-            cmux-nightly-universal-macos-${{ github.run_id }}*.dmg
-            cmux-nightly-universal-macos.dmg
             appcast.xml
-            appcast-universal.xml
           overwrite_files: true
 
       - name: Cleanup keychain


### PR DESCRIPTION
## Summary
- remove the separate Apple Silicon nightly lane and build only the universal nightly app
- keep the existing `cmux-nightly-macos.dmg` and `appcast.xml` track, but make it universal
- stop signing, notarizing, appcasting, and publishing the extra universal-specific nightly artifacts

## Testing
- `ruby -e '''require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); puts "YAML OK"'''`
- `git diff --check`

## Issues
- Follow-up to https://github.com/manaflow-ai/cmux/pull/1316


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build only the universal nightly app and publish it under the existing nightly track to simplify CI and remove duplicate artifacts. Users now get a single universal DMG via `appcast.xml`.

- **Refactors**
  - Removed the Apple Silicon-only build lane and artifacts.
  - Kept `cmux-nightly-macos.dmg` and `appcast.xml`, now produced from the universal build.
  - Deleted universal-specific DMG and feed (`cmux-nightly-universal-macos.dmg`, `appcast-universal.xml`).
  - Simplified arch checks, packaging, notarization, Sentry upload, and artifact uploads to use only the universal output.
  - Updated release notes to reflect a single universal update track.

<sup>Written for commit aa96222aa06d5cdbebf1150c7b9f8bc10b2405c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined nightly build process to produce a single universal macOS build, consolidating separate architecture-specific build steps.
  * Simplified release artifact distribution and update mechanism to a single universal package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->