### PR TITLE
Capture agent exit output before quit session snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,3 +316,16 @@ jobs:
           CMUX_LAG_MAX_CHURN_P95_MS=35 \
           CMUX_LAG_KEY_EVENTS=180 \
           python3 tests/test_workspace_churn_up_arrow_lag.py
+
+      - name: Run quit session-restore resume-hint regression
+        run: |
+          set -euo pipefail
+
+          APP="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Debug/cmux DEV.app" -print -quit)"
+          if [ -z "${APP:-}" ] || [ ! -d "$APP" ]; then
+            echo "cmux DEV.app not found in DerivedData" >&2
+            exit 1
+          fi
+
+          CMUX_APP_PATH="$APP" \
+          python3 tests/test_quit_session_restore_resume_hint_cycle.py

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2058,7 +2058,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private static let commandPalettePendingOpenMaxAge: TimeInterval = 8.0
     private static let sessionAutosaveTypingQuietPeriod: TimeInterval = 0.65
     private static let quitSessionRestoreSecondInterruptDelay: TimeInterval = 0.08
-    private static let quitSessionRestoreSnapshotDelay: TimeInterval = 0.35
+    private static let quitSessionRestorePollInterval: TimeInterval = 0.12
+    private static let quitSessionRestoreQuietPeriod: TimeInterval = 0.35
+    private static let quitSessionRestoreMaximumWait: TimeInterval = 2.5
 
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
@@ -3148,6 +3150,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         interruptTargetCount > 0
     }
 
+    private struct QuitSessionRestoreObservation {
+        var lastScrollbackByPanelId: [UUID: String?]
+        var lastActivityAt: TimeInterval
+    }
+
     private func prepareQuitSessionRestoreSnapshotIfNeeded() -> Bool {
         if quitSessionRestoreTerminationPending {
             return true
@@ -3164,19 +3171,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
         sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: 1)
 
+        let deadlineUptime = ProcessInfo.processInfo.systemUptime + Self.quitSessionRestoreMaximumWait
+        let observation = QuitSessionRestoreObservation(
+            lastScrollbackByPanelId: captureQuitSessionRestoreScrollback(for: targetPanelIds),
+            lastActivityAt: ProcessInfo.processInfo.systemUptime
+        )
+
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestoreSecondInterruptDelay) { [weak self] in
             guard let self, self.quitSessionRestoreTerminationPending else { return }
             self.sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: 2)
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestoreSnapshotDelay) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestorePollInterval) { [weak self] in
             guard let self, self.quitSessionRestoreTerminationPending else { return }
-            self.quitSessionRestoreTerminationPending = false
-#if DEBUG
-            dlog("session.quit_prepare.capture targets=\(targetPanelIds.count)")
-#endif
-            _ = self.saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
-            NSApp.reply(toApplicationShouldTerminate: true)
+            self.pollQuitSessionRestoreSnapshot(
+                panelIds: targetPanelIds,
+                observation: observation,
+                deadlineUptime: deadlineUptime
+            )
         }
 
         return true
@@ -3210,6 +3222,90 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         dlog("session.quit_prepare.interrupt attempt=\(attempt) sent=\(sentCount)")
 #endif
+    }
+
+    private func captureQuitSessionRestoreScrollback(for panelIds: [UUID]) -> [UUID: String?] {
+        var scrollbackByPanelId: [UUID: String?] = [:]
+        scrollbackByPanelId.reserveCapacity(panelIds.count)
+        for panelId in panelIds {
+            guard let (workspace, _) = workspaceContainingPanel(panelId: panelId),
+                  let terminalPanel = workspace.terminalPanel(for: panelId) else {
+                scrollbackByPanelId[panelId] = nil
+                continue
+            }
+            scrollbackByPanelId[panelId] = TerminalController.shared.readTerminalTextForSnapshot(
+                terminalPanel: terminalPanel,
+                includeScrollback: true,
+                lineLimit: SessionPersistencePolicy.maxScrollbackLinesPerTerminal
+            )
+        }
+        return scrollbackByPanelId
+    }
+
+    private func pollQuitSessionRestoreSnapshot(
+        panelIds: [UUID],
+        observation: QuitSessionRestoreObservation,
+        deadlineUptime: TimeInterval
+    ) {
+        guard quitSessionRestoreTerminationPending else { return }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        var nextObservation = observation
+        var busyCount = 0
+        var changedCount = 0
+
+        for panelId in panelIds {
+            guard let (workspace, _) = workspaceContainingPanel(panelId: panelId),
+                  let terminalPanel = workspace.terminalPanel(for: panelId) else {
+                continue
+            }
+            if terminalPanel.needsConfirmClose() {
+                busyCount += 1
+            }
+
+            let currentScrollback = TerminalController.shared.readTerminalTextForSnapshot(
+                terminalPanel: terminalPanel,
+                includeScrollback: true,
+                lineLimit: SessionPersistencePolicy.maxScrollbackLinesPerTerminal
+            )
+            if currentScrollback != nextObservation.lastScrollbackByPanelId[panelId] {
+                nextObservation.lastScrollbackByPanelId[panelId] = currentScrollback
+                nextObservation.lastActivityAt = now
+                changedCount += 1
+            }
+        }
+
+        let quietEnough = (now - nextObservation.lastActivityAt) >= Self.quitSessionRestoreQuietPeriod
+        if busyCount == 0, quietEnough {
+            finishQuitSessionRestoreSnapshot(reason: "settled", busyCount: busyCount, changedCount: changedCount)
+            return
+        }
+
+        if now >= deadlineUptime {
+            finishQuitSessionRestoreSnapshot(reason: "timeout", busyCount: busyCount, changedCount: changedCount)
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestorePollInterval) { [weak self] in
+            guard let self, self.quitSessionRestoreTerminationPending else { return }
+            self.pollQuitSessionRestoreSnapshot(
+                panelIds: panelIds,
+                observation: nextObservation,
+                deadlineUptime: deadlineUptime
+            )
+        }
+    }
+
+    private func finishQuitSessionRestoreSnapshot(reason: String, busyCount: Int, changedCount: Int) {
+        guard quitSessionRestoreTerminationPending else { return }
+        quitSessionRestoreTerminationPending = false
+#if DEBUG
+        dlog(
+            "session.quit_prepare.capture reason=\(reason) busy=\(busyCount) changed=\(changedCount)"
+        )
+#endif
+        _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
+        NSApp.reply(toApplicationShouldTerminate: true)
     }
 
     private func remainingSessionAutosaveTypingQuietPeriod(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2057,7 +2057,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private static let commandPaletteRequestGraceInterval: TimeInterval = 1.25
     private static let commandPalettePendingOpenMaxAge: TimeInterval = 8.0
     private static let sessionAutosaveTypingQuietPeriod: TimeInterval = 0.65
-    private static let quitSessionRestoreSecondInterruptDelay: TimeInterval = 0.08
+    private static let quitSessionRestoreFollowupInterruptDelays: [TimeInterval] = [0.6, 1.2]
     private static let quitSessionRestorePollInterval: TimeInterval = 0.12
     private static let quitSessionRestoreQuietPeriod: TimeInterval = 0.35
     private static let quitSessionRestoreMaximumWait: TimeInterval = 2.5
@@ -3177,9 +3177,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             lastActivityAt: ProcessInfo.processInfo.systemUptime
         )
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestoreSecondInterruptDelay) { [weak self] in
-            guard let self, self.quitSessionRestoreTerminationPending else { return }
-            self.sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: 2)
+        for (offset, delay) in Self.quitSessionRestoreFollowupInterruptDelays.enumerated() {
+            let attempt = offset + 2
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self, self.quitSessionRestoreTerminationPending else { return }
+                self.sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: attempt)
+            }
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestorePollInterval) { [weak self] in
@@ -3215,8 +3218,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                   terminalPanel.needsConfirmClose() else {
                 continue
             }
-            guard terminalPanel.sendNamedKey(.ctrlC) else { continue }
-            terminalPanel.surface.forceRefresh(reason: "sessionQuitRestore.ctrlC.\(attempt)")
+            guard terminalPanel.sendControlCharacter(.etx) else { continue }
+            terminalPanel.surface.forceRefresh(reason: "sessionQuitRestore.etx.\(attempt)")
             sentCount += 1
         }
 #if DEBUG

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2044,6 +2044,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lastTypingActivityAt: TimeInterval = 0
     private var didHandleExplicitOpenIntentAtStartup = false
     private var isTerminatingApp = false
+    private var quitSessionRestoreTerminationPending = false
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -2056,6 +2057,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private static let commandPaletteRequestGraceInterval: TimeInterval = 1.25
     private static let commandPalettePendingOpenMaxAge: TimeInterval = 8.0
     private static let sessionAutosaveTypingQuietPeriod: TimeInterval = 0.65
+    private static let quitSessionRestoreSecondInterruptDelay: TimeInterval = 0.08
+    private static let quitSessionRestoreSnapshotDelay: TimeInterval = 0.35
 
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
@@ -2302,6 +2305,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         isTerminatingApp = true
+        if prepareQuitSessionRestoreSnapshotIfNeeded() {
+            return .terminateLater
+        }
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         return .terminateNow
     }
@@ -3136,6 +3142,74 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     nonisolated static func shouldRunSessionAutosaveTick(isTerminatingApp: Bool) -> Bool {
         !isTerminatingApp
+    }
+
+    nonisolated static func shouldDelayQuitTerminationForSessionRestore(interruptTargetCount: Int) -> Bool {
+        interruptTargetCount > 0
+    }
+
+    private func prepareQuitSessionRestoreSnapshotIfNeeded() -> Bool {
+        if quitSessionRestoreTerminationPending {
+            return true
+        }
+
+        let targetPanelIds = quitSessionRestoreInterruptTargetPanelIds()
+        guard Self.shouldDelayQuitTerminationForSessionRestore(interruptTargetCount: targetPanelIds.count) else {
+            return false
+        }
+
+        quitSessionRestoreTerminationPending = true
+#if DEBUG
+        dlog("session.quit_prepare.begin targets=\(targetPanelIds.count)")
+#endif
+        sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: 1)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestoreSecondInterruptDelay) { [weak self] in
+            guard let self, self.quitSessionRestoreTerminationPending else { return }
+            self.sendQuitSessionRestoreInterrupts(to: targetPanelIds, attempt: 2)
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.quitSessionRestoreSnapshotDelay) { [weak self] in
+            guard let self, self.quitSessionRestoreTerminationPending else { return }
+            self.quitSessionRestoreTerminationPending = false
+#if DEBUG
+            dlog("session.quit_prepare.capture targets=\(targetPanelIds.count)")
+#endif
+            _ = self.saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+
+        return true
+    }
+
+    private func quitSessionRestoreInterruptTargetPanelIds() -> [UUID] {
+        var panelIds: [UUID] = []
+        var seen = Set<UUID>()
+        forEachTerminalPanel { terminalPanel in
+            guard terminalPanel.surface.surface != nil else { return }
+            guard terminalPanel.needsConfirmClose() else { return }
+            guard seen.insert(terminalPanel.id).inserted else { return }
+            panelIds.append(terminalPanel.id)
+        }
+        panelIds.sort { $0.uuidString < $1.uuidString }
+        return panelIds
+    }
+
+    private func sendQuitSessionRestoreInterrupts(to panelIds: [UUID], attempt: Int) {
+        var sentCount = 0
+        for panelId in panelIds {
+            guard let (workspace, _) = workspaceContainingPanel(panelId: panelId),
+                  let terminalPanel = workspace.terminalPanel(for: panelId),
+                  terminalPanel.needsConfirmClose() else {
+                continue
+            }
+            guard terminalPanel.sendNamedKey(.ctrlC) else { continue }
+            terminalPanel.surface.forceRefresh(reason: "sessionQuitRestore.ctrlC.\(attempt)")
+            sentCount += 1
+        }
+#if DEBUG
+        dlog("session.quit_prepare.interrupt attempt=\(attempt) sent=\(sentCount)")
+#endif
     }
 
     private func remainingSessionAutosaveTypingQuietPeriod(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2303,6 +2303,20 @@ final class TerminalSurface: Identifiable, ObservableObject {
         case ctrlD
     }
 
+    enum ControlCharacter {
+        case etx
+        case eot
+
+        var byte: UInt8 {
+            switch self {
+            case .etx:
+                return 0x03
+            case .eot:
+                return 0x04
+            }
+        }
+    }
+
     final class SearchState: ObservableObject {
         @Published var needle: String
         @Published var selected: UInt?
@@ -3123,6 +3137,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return true
     }
 
+    @discardableResult
+    func sendControlCharacter(_ control: ControlCharacter) -> Bool {
+        guard let surface else { return false }
+        sendTextEvent(String(UnicodeScalar(control.byte)), to: surface)
+        return true
+    }
+
     func sendText(_ text: String) {
         guard let data = text.data(using: .utf8), !data.isEmpty else { return }
         guard let surface = surface else {
@@ -3165,6 +3186,20 @@ final class TerminalSurface: Identifiable, ObservableObject {
         data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
             ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+        }
+    }
+
+    private func sendTextEvent(_ text: String, to surface: ghostty_surface_t) {
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = GHOSTTY_ACTION_PRESS
+        keyEvent.keycode = 0
+        keyEvent.mods = GHOSTTY_MODS_NONE
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.unshifted_codepoint = 0
+        keyEvent.composing = false
+        text.withCString { ptr in
+            keyEvent.text = ptr
+            _ = ghostty_surface_key(surface, keyEvent)
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import AppKit
+import Carbon.HIToolbox
 import Metal
 import QuartzCore
 import Combine
@@ -2297,6 +2298,11 @@ final class GhosttyMetalLayer: CAMetalLayer {
 // MARK: - Terminal Surface (owns the ghostty_surface_t lifecycle)
 
 final class TerminalSurface: Identifiable, ObservableObject {
+    enum NamedKey {
+        case ctrlC
+        case ctrlD
+    }
+
     final class SearchState: ObservableObject {
         @Published var needle: String
         @Published var selected: UInt?
@@ -3092,6 +3098,29 @@ final class TerminalSurface: Identifiable, ObservableObject {
     func needsConfirmClose() -> Bool {
         guard let surface = surface else { return false }
         return ghostty_surface_needs_confirm_quit(surface)
+    }
+
+    @discardableResult
+    func sendNamedKey(_ key: NamedKey) -> Bool {
+        guard let surface else { return false }
+
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = GHOSTTY_ACTION_PRESS
+        keyEvent.mods = GHOSTTY_MODS_CTRL
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.unshifted_codepoint = 0
+        keyEvent.composing = false
+        keyEvent.text = nil
+
+        switch key {
+        case .ctrlC:
+            keyEvent.keycode = UInt32(kVK_ANSI_C)
+        case .ctrlD:
+            keyEvent.keycode = UInt32(kVK_ANSI_D)
+        }
+
+        _ = ghostty_surface_key(surface, keyEvent)
+        return true
     }
 
     func sendText(_ text: String) {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -191,6 +191,11 @@ final class TerminalPanel: Panel, ObservableObject {
         surface.sendNamedKey(key)
     }
 
+    @discardableResult
+    func sendControlCharacter(_ control: TerminalSurface.ControlCharacter) -> Bool {
+        surface.sendControlCharacter(control)
+    }
+
     func triggerFlash() {
         hostedView.triggerFlash()
     }

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -186,6 +186,11 @@ final class TerminalPanel: Panel, ObservableObject {
         surface.needsConfirmClose()
     }
 
+    @discardableResult
+    func sendNamedKey(_ key: TerminalSurface.NamedKey) -> Bool {
+        surface.sendNamedKey(key)
+    }
+
     func triggerFlash() {
         hostedView.triggerFlash()
     }

--- a/tests/test_quit_session_restore_resume_hint_cycle.py
+++ b/tests/test_quit_session_restore_resume_hint_cycle.py
@@ -91,11 +91,14 @@ import sys
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        raise SystemExit("usage: launcher.py <binary> <prompt>")
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: launcher.py <cwd> <binary> <prompt>")
 
-    binary = sys.argv[1]
-    prompt = sys.argv[2]
+    cwd = sys.argv[1]
+    binary = sys.argv[2]
+    prompt = sys.argv[3]
+    os.makedirs(cwd, exist_ok=True)
+    os.chdir(cwd)
     sys.stdout.write(f"CMUX_REAL_AGENT_LAUNCHED_{binary}\r\n")
     sys.stdout.flush()
     os.execvp(binary, [binary, prompt])
@@ -296,6 +299,12 @@ def _real_agent_launcher_path() -> Path:
     return path
 
 
+def _real_agent_workdir() -> Path:
+    path = Path("/tmp") / f"cmux-real-agent-workdir-{os.getpid()}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def _fixture_command(fixture_path: Path, label: str, required_interrupts: int) -> str:
     return (
         f"python3 {fixture_path} "
@@ -371,6 +380,7 @@ def main() -> int:
     snapshot = _snapshot_path(bundle_id)
     fixture_path = _fixture_script_path()
     real_agent_launcher_path = _real_agent_launcher_path()
+    real_agent_workdir = _real_agent_workdir()
     failures: list[str] = []
 
     cases: list[dict[str, object]] = [
@@ -397,7 +407,7 @@ def main() -> int:
         cases.extend([
             {
                 "label": "real-codex",
-                "command": f'python3 {real_agent_launcher_path} codex "say hi in one sentence and then wait for more input"',
+                "command": f'python3 {real_agent_launcher_path} {real_agent_workdir} codex "say hi in one sentence and then wait for more input"',
                 "ready_marker": "CMUX_REAL_AGENT_LAUNCHED_codex",
                 "expected_markers": ["To continue this session, run codex resume"],
                 "ready_timeout": 8.0,
@@ -406,7 +416,7 @@ def main() -> int:
             },
             {
                 "label": "real-claude",
-                "command": f'python3 {real_agent_launcher_path} claude "say hi in one sentence and then wait for more input"',
+                "command": f'python3 {real_agent_launcher_path} {real_agent_workdir} claude "say hi in one sentence and then wait for more input"',
                 "ready_marker": "CMUX_REAL_AGENT_LAUNCHED_claude",
                 "expected_markers": ["Resume this session with:", "claude --resume"],
                 "ready_timeout": 8.0,
@@ -441,6 +451,7 @@ def main() -> int:
     finally:
         fixture_path.unlink(missing_ok=True)
         real_agent_launcher_path.unlink(missing_ok=True)
+        shutil.rmtree(real_agent_workdir, ignore_errors=True)
 
     if failures:
         print("FAIL:")

--- a/tests/test_quit_session_restore_resume_hint_cycle.py
+++ b/tests/test_quit_session_restore_resume_hint_cycle.py
@@ -19,6 +19,7 @@ import json
 import os
 import plistlib
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -241,7 +242,11 @@ def _session_json_contains(snapshot: Path, marker: str) -> bool:
     return marker in snapshot.read_text(encoding="utf-8", errors="replace")
 
 
-def _restored_scrollback_contains(client: cmux, marker: str, timeout: float = 10.0) -> str | None:
+def _session_json_contains_all(snapshot: Path, markers: list[str]) -> bool:
+    return all(_session_json_contains(snapshot, marker) for marker in markers)
+
+
+def _restored_scrollback_contains_all(client: cmux, markers: list[str], timeout: float = 10.0) -> str | None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         for _index, workspace_id, _title, _selected in client.list_workspaces():
@@ -249,7 +254,7 @@ def _restored_scrollback_contains(client: cmux, marker: str, timeout: float = 10
             time.sleep(0.2)
             for _surface_index, surface_id, _focused in client.list_surfaces(workspace_id):
                 text = _read_scrollback(client, surface_id)
-                if marker in text:
+                if all(marker in text for marker in markers):
                     return text
         time.sleep(0.3)
     return None
@@ -262,11 +267,26 @@ def _fixture_script_path() -> Path:
     return path
 
 
-def _run_case(app_path: Path, bundle_id: str, snapshot: Path, fixture_path: Path, label: str, required_interrupts: int) -> None:
-    socket_path = Path(f"/tmp/cmux-quit-restore-{label}-{os.getpid()}.sock")
-    expected = f"{label} --resume fixture-{required_interrupts}"
-    ready_marker = f"FIXTURE_READY {label}"
+def _fixture_command(fixture_path: Path, label: str, required_interrupts: int) -> str:
+    return (
+        f"python3 {fixture_path} "
+        f"--required-interrupts {required_interrupts} "
+        f"--label {label}"
+    )
 
+
+def _run_case(
+    app_path: Path,
+    bundle_id: str,
+    snapshot: Path,
+    label: str,
+    command: str,
+    ready_marker: str,
+    expected_markers: list[str],
+    ready_timeout: float = 8.0,
+    restore_timeout: float = 12.0,
+) -> None:
+    socket_path = Path(f"/tmp/cmux-quit-restore-{label}-{os.getpid()}.sock")
     snapshot.unlink(missing_ok=True)
     _kill_existing(app_path)
 
@@ -277,27 +297,22 @@ def _run_case(app_path: Path, bundle_id: str, snapshot: Path, fixture_path: Path
             workspace_id = client.new_workspace()
             client.select_workspace(workspace_id)
             surface_id = _current_surface_id(client, workspace_id)
-            command = (
-                f"python3 {fixture_path} "
-                f"--required-interrupts {required_interrupts} "
-                f"--label {label}"
-            )
             client.send_surface(surface_id, command + "\n")
-            _wait_for_marker(client, workspace_id, surface_id, ready_marker)
+            _wait_for_marker(client, workspace_id, surface_id, ready_marker, timeout=ready_timeout)
         finally:
             client.close()
 
         _quit(bundle_id, socket_path)
         _must(snapshot.exists(), f"snapshot missing after quit for {label}")
         _must(
-            _session_json_contains(snapshot, expected),
+            _session_json_contains_all(snapshot, expected_markers),
             f"snapshot missing resume marker for {label}",
         )
 
         socket_path = _launch(app_path, socket_path)
         client = _connect(socket_path)
         try:
-            restored = _restored_scrollback_contains(client, expected, timeout=12.0)
+            restored = _restored_scrollback_contains_all(client, expected_markers, timeout=restore_timeout)
             _must(restored is not None, f"restored scrollback missing resume marker for {label}")
         finally:
             client.close()
@@ -325,15 +340,65 @@ def main() -> int:
     fixture_path = _fixture_script_path()
     failures: list[str] = []
 
-    cases = [
-        ("fixture-codex", 1),
-        ("fixture-claude", 3),
+    cases: list[dict[str, object]] = [
+        {
+            "label": "fixture-codex",
+            "command": _fixture_command(fixture_path, "fixture-codex", 1),
+            "ready_marker": "FIXTURE_READY fixture-codex",
+            "expected_markers": ["fixture-codex --resume fixture-1"],
+        },
+        {
+            "label": "fixture-claude",
+            "command": _fixture_command(fixture_path, "fixture-claude", 3),
+            "ready_marker": "FIXTURE_READY fixture-claude",
+            "expected_markers": ["fixture-claude --resume fixture-3"],
+        },
     ]
 
+    include_real_agents = os.environ.get("CMUX_INCLUDE_REAL_AGENTS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if include_real_agents:
+        cases.extend([
+            {
+                "label": "real-codex",
+                "command": "codex 'Print exactly CMUX_REAL_CODEX_READY on one line and then wait for more input.'",
+                "ready_marker": "CMUX_REAL_CODEX_READY",
+                "expected_markers": ["To continue this session, run codex resume"],
+                "ready_timeout": 90.0,
+                "restore_timeout": 20.0,
+            },
+            {
+                "label": "real-claude",
+                "command": "claude 'Print exactly CMUX_REAL_CLAUDE_READY on one line and then wait for more input.'",
+                "ready_marker": "CMUX_REAL_CLAUDE_READY",
+                "expected_markers": ["Resume this session with:", "claude --resume"],
+                "ready_timeout": 90.0,
+                "restore_timeout": 20.0,
+            },
+        ])
+
     try:
-        for label, required_interrupts in cases:
+        if include_real_agents:
+            for binary in ("codex", "claude"):
+                _must(shutil.which(binary) is not None, f"{binary} not found in PATH")
+
+        for case in cases:
+            label = str(case["label"])
             try:
-                _run_case(app_path, bundle_id, snapshot, fixture_path, label, required_interrupts)
+                _run_case(
+                    app_path=app_path,
+                    bundle_id=bundle_id,
+                    snapshot=snapshot,
+                    label=label,
+                    command=str(case["command"]),
+                    ready_marker=str(case["ready_marker"]),
+                    expected_markers=[str(marker) for marker in case["expected_markers"]],
+                    ready_timeout=float(case.get("ready_timeout", 8.0)),
+                    restore_timeout=float(case.get("restore_timeout", 12.0)),
+                )
                 print(f"PASS: {label}")
             except Exception as exc:
                 failures.append(f"{label}: {exc}")

--- a/tests/test_quit_session_restore_resume_hint_cycle.py
+++ b/tests/test_quit_session_restore_resume_hint_cycle.py
@@ -108,6 +108,12 @@ if __name__ == "__main__":
     raise SystemExit(main())
 """
 
+ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+class CaseSkipped(RuntimeError):
+    pass
+
 
 def _must(condition: bool, message: str) -> None:
     if not condition:
@@ -264,7 +270,28 @@ def _wait_for_marker(client: cmux, workspace_id: str, surface_id: str, marker: s
 def _session_json_contains(snapshot: Path, marker: str) -> bool:
     if not snapshot.exists():
         return False
-    return marker in snapshot.read_text(encoding="utf-8", errors="replace")
+    raw = snapshot.read_text(encoding="utf-8", errors="replace")
+    if marker in raw:
+        return True
+
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return marker in ANSI_ESCAPE_RE.sub("", raw)
+
+    stack: list[object] = [payload]
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            stack.extend(value.values())
+            continue
+        if isinstance(value, list):
+            stack.extend(value)
+            continue
+        if isinstance(value, str):
+            if marker in ANSI_ESCAPE_RE.sub("", value):
+                return True
+    return False
 
 
 def _session_json_contains_all(snapshot: Path, markers: list[str]) -> bool:
@@ -324,6 +351,10 @@ def _run_case(
     ready_timeout: float = 8.0,
     restore_timeout: float = 12.0,
     settle_delay: float = 0.0,
+    startup_inputs: list[str] | None = None,
+    post_ready_marker: str | None = None,
+    post_ready_timeout: float = 0.0,
+    skip_markers: list[str] | None = None,
 ) -> None:
     socket_path = Path(f"/tmp/cmux-quit-restore-{label}-{os.getpid()}.sock")
     snapshot.unlink(missing_ok=True)
@@ -338,8 +369,22 @@ def _run_case(
             surface_id = _current_surface_id(client, workspace_id)
             client.send_surface(surface_id, command + "\n")
             _wait_for_marker(client, workspace_id, surface_id, ready_marker, timeout=ready_timeout)
+            for input_text in startup_inputs or []:
+                client.send_surface(surface_id, input_text)
+            if post_ready_marker:
+                _wait_for_marker(
+                    client,
+                    workspace_id,
+                    surface_id,
+                    post_ready_marker,
+                    timeout=post_ready_timeout or ready_timeout,
+                )
             if settle_delay > 0:
                 time.sleep(settle_delay)
+            scrollback = _read_scrollback(client, surface_id)
+            for marker in skip_markers or []:
+                if marker in scrollback:
+                    raise CaseSkipped(marker)
         finally:
             client.close()
 
@@ -412,7 +457,10 @@ def main() -> int:
                 "expected_markers": ["To continue this session, run codex resume"],
                 "ready_timeout": 8.0,
                 "restore_timeout": 20.0,
-                "settle_delay": 12.0,
+                "startup_inputs": ["\r"],
+                "post_ready_marker": "OpenAI Codex",
+                "post_ready_timeout": 30.0,
+                "settle_delay": 5.0,
             },
             {
                 "label": "real-claude",
@@ -422,6 +470,7 @@ def main() -> int:
                 "ready_timeout": 8.0,
                 "restore_timeout": 20.0,
                 "settle_delay": 12.0,
+                "skip_markers": ["Invalid API key", "Run /login"],
             },
         ])
 
@@ -444,8 +493,14 @@ def main() -> int:
                     ready_timeout=float(case.get("ready_timeout", 8.0)),
                     restore_timeout=float(case.get("restore_timeout", 12.0)),
                     settle_delay=float(case.get("settle_delay", 0.0)),
+                    startup_inputs=[str(value) for value in case.get("startup_inputs", [])],
+                    post_ready_marker=str(case["post_ready_marker"]) if "post_ready_marker" in case else None,
+                    post_ready_timeout=float(case.get("post_ready_timeout", 0.0)),
+                    skip_markers=[str(value) for value in case.get("skip_markers", [])],
                 )
                 print(f"PASS: {label}")
+            except CaseSkipped as exc:
+                print(f"SKIP: {label} ({exc})")
             except Exception as exc:
                 failures.append(f"{label}: {exc}")
     finally:

--- a/tests/test_quit_session_restore_resume_hint_cycle.py
+++ b/tests/test_quit_session_restore_resume_hint_cycle.py
@@ -83,6 +83,28 @@ if __name__ == "__main__":
     raise SystemExit(main())
 """
 
+REAL_AGENT_LAUNCHER_SOURCE = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: launcher.py <binary> <prompt>")
+
+    binary = sys.argv[1]
+    prompt = sys.argv[2]
+    sys.stdout.write(f"CMUX_REAL_AGENT_LAUNCHED_{binary}\r\n")
+    sys.stdout.flush()
+    os.execvp(binary, [binary, prompt])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""
+
 
 def _must(condition: bool, message: str) -> None:
     if not condition:
@@ -267,6 +289,13 @@ def _fixture_script_path() -> Path:
     return path
 
 
+def _real_agent_launcher_path() -> Path:
+    path = Path("/tmp") / f"cmux-real-agent-launcher-{os.getpid()}.py"
+    path.write_text(REAL_AGENT_LAUNCHER_SOURCE, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
 def _fixture_command(fixture_path: Path, label: str, required_interrupts: int) -> str:
     return (
         f"python3 {fixture_path} "
@@ -285,6 +314,7 @@ def _run_case(
     expected_markers: list[str],
     ready_timeout: float = 8.0,
     restore_timeout: float = 12.0,
+    settle_delay: float = 0.0,
 ) -> None:
     socket_path = Path(f"/tmp/cmux-quit-restore-{label}-{os.getpid()}.sock")
     snapshot.unlink(missing_ok=True)
@@ -299,6 +329,8 @@ def _run_case(
             surface_id = _current_surface_id(client, workspace_id)
             client.send_surface(surface_id, command + "\n")
             _wait_for_marker(client, workspace_id, surface_id, ready_marker, timeout=ready_timeout)
+            if settle_delay > 0:
+                time.sleep(settle_delay)
         finally:
             client.close()
 
@@ -338,6 +370,7 @@ def main() -> int:
     bundle_id = _bundle_id(app_path)
     snapshot = _snapshot_path(bundle_id)
     fixture_path = _fixture_script_path()
+    real_agent_launcher_path = _real_agent_launcher_path()
     failures: list[str] = []
 
     cases: list[dict[str, object]] = [
@@ -364,19 +397,21 @@ def main() -> int:
         cases.extend([
             {
                 "label": "real-codex",
-                "command": "codex 'Print exactly CMUX_REAL_CODEX_READY on one line and then wait for more input.'",
-                "ready_marker": "CMUX_REAL_CODEX_READY",
+                "command": f'python3 {real_agent_launcher_path} codex "say hi in one sentence and then wait for more input"',
+                "ready_marker": "CMUX_REAL_AGENT_LAUNCHED_codex",
                 "expected_markers": ["To continue this session, run codex resume"],
-                "ready_timeout": 90.0,
+                "ready_timeout": 8.0,
                 "restore_timeout": 20.0,
+                "settle_delay": 12.0,
             },
             {
                 "label": "real-claude",
-                "command": "claude 'Print exactly CMUX_REAL_CLAUDE_READY on one line and then wait for more input.'",
-                "ready_marker": "CMUX_REAL_CLAUDE_READY",
+                "command": f'python3 {real_agent_launcher_path} claude "say hi in one sentence and then wait for more input"',
+                "ready_marker": "CMUX_REAL_AGENT_LAUNCHED_claude",
                 "expected_markers": ["Resume this session with:", "claude --resume"],
-                "ready_timeout": 90.0,
+                "ready_timeout": 8.0,
                 "restore_timeout": 20.0,
+                "settle_delay": 12.0,
             },
         ])
 
@@ -398,12 +433,14 @@ def main() -> int:
                     expected_markers=[str(marker) for marker in case["expected_markers"]],
                     ready_timeout=float(case.get("ready_timeout", 8.0)),
                     restore_timeout=float(case.get("restore_timeout", 12.0)),
+                    settle_delay=float(case.get("settle_delay", 0.0)),
                 )
                 print(f"PASS: {label}")
             except Exception as exc:
                 failures.append(f"{label}: {exc}")
     finally:
         fixture_path.unlink(missing_ok=True)
+        real_agent_launcher_path.unlink(missing_ok=True)
 
     if failures:
         print("FAIL:")

--- a/tests/test_quit_session_restore_resume_hint_cycle.py
+++ b/tests/test_quit_session_restore_resume_hint_cycle.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Regression: quit/session restore should capture agent-style resume hints.
+
+The fixture runs in raw TTY mode and only reacts to literal ETX bytes. This
+matches full-screen agent CLIs more closely than a normal shell trap:
+`surface.send_key ctrl-c` is not sufficient, but injected ETX text is.
+
+The second case requires three ETX bytes to model Claude Code's staged quit:
+1. interrupt active work
+2. show "Press Ctrl-C again to exit"
+3. print the final resume hint and exit
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import plistlib
+import re
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests_v2"))
+
+from cmux import cmux  # type: ignore
+
+
+FIXTURE_SOURCE = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import termios
+import tty
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--required-interrupts", type=int, required=True)
+    parser.add_argument("--label", required=True)
+    args = parser.parse_args()
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    count = 0
+    tty.setraw(fd)
+    try:
+        sys.stdout.write(f"FIXTURE_READY {args.label}\r\n")
+        sys.stdout.flush()
+
+        while True:
+            chunk = os.read(fd, 1)
+            if not chunk:
+                return 1
+            if chunk != b"\x03":
+                continue
+
+            count += 1
+            if count < args.required_interrupts:
+                if count == 1:
+                    sys.stdout.write("FIXTURE_INTERRUPTED What should the agent do instead?\r\n")
+                else:
+                    sys.stdout.write("FIXTURE_PRESS_CTRL_C_AGAIN\r\n")
+                sys.stdout.flush()
+                continue
+
+            sys.stdout.write("Resume this session with:\r\n")
+            sys.stdout.write(f"{args.label} --resume fixture-{args.required_interrupts}\r\n")
+            sys.stdout.flush()
+            return 0
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""
+
+
+def _must(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _bundle_id(app_path: Path) -> str:
+    info_path = app_path / "Contents" / "Info.plist"
+    if not info_path.exists():
+        raise RuntimeError(f"Missing Info.plist at {info_path}")
+    with info_path.open("rb") as f:
+        info = plistlib.load(f)
+    bundle_id = str(info.get("CFBundleIdentifier", "")).strip()
+    if not bundle_id:
+        raise RuntimeError("Missing CFBundleIdentifier")
+    return bundle_id
+
+
+def _snapshot_path(bundle_id: str) -> Path:
+    safe_bundle = re.sub(r"[^A-Za-z0-9._-]", "_", bundle_id)
+    return Path.home() / "Library/Application Support/cmux" / f"session-{safe_bundle}.json"
+
+
+def _sanitize_tag_slug(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", (raw or "").strip().lower())
+    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
+    return cleaned or "agent"
+
+
+def _socket_candidates(app_path: Path, preferred: Path) -> list[Path]:
+    candidates = [preferred]
+    app_name = app_path.stem
+    prefix = "cmux DEV "
+    if app_name.startswith(prefix):
+        tag = app_name[len(prefix):]
+        slug = _sanitize_tag_slug(tag)
+        candidates.append(Path(f"/tmp/cmux-debug-{slug}.sock"))
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def _socket_reachable(socket_path: Path) -> bool:
+    if not socket_path.exists():
+        return False
+    try:
+        client = cmux(socket_path=str(socket_path))
+        client.connect()
+        return bool(client.ping())
+    except Exception:
+        return False
+
+
+def _wait_for_socket(candidates: list[Path], timeout: float = 20.0) -> Path:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for candidate in candidates:
+            if _socket_reachable(candidate):
+                return candidate
+        time.sleep(0.2)
+    joined = ", ".join(str(path) for path in candidates)
+    raise RuntimeError(f"Socket did not become reachable: {joined}")
+
+
+def _wait_for_socket_closed(socket_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _socket_reachable(socket_path):
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Socket still reachable after quit: {socket_path}")
+
+
+def _kill_existing(app_path: Path) -> None:
+    exe = app_path / "Contents" / "MacOS" / "cmux DEV"
+    subprocess.run(["pkill", "-f", str(exe)], capture_output=True, text=True)
+    time.sleep(1.0)
+
+
+def _launch(app_path: Path, preferred_socket_path: Path) -> Path:
+    preferred_socket_path.unlink(missing_ok=True)
+    exe = app_path / "Contents" / "MacOS" / "cmux DEV"
+    _must(exe.exists(), f"Missing app binary at {exe}")
+
+    env = os.environ.copy()
+    env["CMUX_SOCKET_PATH"] = str(preferred_socket_path)
+    env["CMUX_SOCKET_MODE"] = "allowAll"
+    env["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+    subprocess.Popen(
+        [str(exe)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    resolved_socket_path = _wait_for_socket(_socket_candidates(app_path, preferred_socket_path))
+    time.sleep(1.5)
+    return resolved_socket_path
+
+
+def _quit(bundle_id: str, socket_path: Path) -> None:
+    subprocess.run(
+        ["osascript", "-e", f'tell application id "{bundle_id}" to quit'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _wait_for_socket_closed(socket_path)
+    socket_path.unlink(missing_ok=True)
+    time.sleep(0.8)
+
+
+def _connect(socket_path: Path) -> cmux:
+    client = cmux(socket_path=str(socket_path))
+    client.connect()
+    _must(client.ping(), "ping failed")
+    return client
+
+
+def _read_scrollback(client: cmux, surface_id: str, lines: int = 320) -> str:
+    result = client._call(
+        "surface.read_text",
+        {"surface_id": surface_id, "scrollback": True, "lines": lines},
+    ) or {}
+    if "text" in result:
+        return str(result.get("text") or "")
+    raw = base64.b64decode(str(result.get("base64") or ""))
+    return raw.decode("utf-8", errors="replace")
+
+
+def _current_surface_id(client: cmux, workspace_id: str) -> str:
+    surfaces = client.list_surfaces(workspace_id)
+    _must(bool(surfaces), f"workspace {workspace_id} has no surfaces")
+    return str(surfaces[0][1])
+
+
+def _wait_for_marker(client: cmux, workspace_id: str, surface_id: str, marker: str, timeout: float = 8.0) -> str:
+    client.select_workspace(workspace_id)
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        last = _read_scrollback(client, surface_id)
+        if marker in last:
+            return last
+        time.sleep(0.25)
+    raise RuntimeError(f"Marker {marker!r} missing from scrollback. Tail:\n{last[-1200:]}")
+
+
+def _session_json_contains(snapshot: Path, marker: str) -> bool:
+    if not snapshot.exists():
+        return False
+    return marker in snapshot.read_text(encoding="utf-8", errors="replace")
+
+
+def _restored_scrollback_contains(client: cmux, marker: str, timeout: float = 10.0) -> str | None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for _index, workspace_id, _title, _selected in client.list_workspaces():
+            client.select_workspace(workspace_id)
+            time.sleep(0.2)
+            for _surface_index, surface_id, _focused in client.list_surfaces(workspace_id):
+                text = _read_scrollback(client, surface_id)
+                if marker in text:
+                    return text
+        time.sleep(0.3)
+    return None
+
+
+def _fixture_script_path() -> Path:
+    path = Path("/tmp") / f"cmux-quit-resume-fixture-{os.getpid()}.py"
+    path.write_text(FIXTURE_SOURCE, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _run_case(app_path: Path, bundle_id: str, snapshot: Path, fixture_path: Path, label: str, required_interrupts: int) -> None:
+    socket_path = Path(f"/tmp/cmux-quit-restore-{label}-{os.getpid()}.sock")
+    expected = f"{label} --resume fixture-{required_interrupts}"
+    ready_marker = f"FIXTURE_READY {label}"
+
+    snapshot.unlink(missing_ok=True)
+    _kill_existing(app_path)
+
+    try:
+        socket_path = _launch(app_path, socket_path)
+        client = _connect(socket_path)
+        try:
+            workspace_id = client.new_workspace()
+            client.select_workspace(workspace_id)
+            surface_id = _current_surface_id(client, workspace_id)
+            command = (
+                f"python3 {fixture_path} "
+                f"--required-interrupts {required_interrupts} "
+                f"--label {label}"
+            )
+            client.send_surface(surface_id, command + "\n")
+            _wait_for_marker(client, workspace_id, surface_id, ready_marker)
+        finally:
+            client.close()
+
+        _quit(bundle_id, socket_path)
+        _must(snapshot.exists(), f"snapshot missing after quit for {label}")
+        _must(
+            _session_json_contains(snapshot, expected),
+            f"snapshot missing resume marker for {label}",
+        )
+
+        socket_path = _launch(app_path, socket_path)
+        client = _connect(socket_path)
+        try:
+            restored = _restored_scrollback_contains(client, expected, timeout=12.0)
+            _must(restored is not None, f"restored scrollback missing resume marker for {label}")
+        finally:
+            client.close()
+
+        _quit(bundle_id, socket_path)
+    finally:
+        _kill_existing(app_path)
+        socket_path.unlink(missing_ok=True)
+        snapshot.unlink(missing_ok=True)
+
+
+def main() -> int:
+    app_path_str = os.environ.get("CMUX_APP_PATH", "").strip()
+    if not app_path_str:
+        print("SKIP: set CMUX_APP_PATH to a built cmux DEV .app path")
+        return 0
+
+    app_path = Path(app_path_str)
+    if not app_path.exists():
+        print(f"SKIP: CMUX_APP_PATH does not exist: {app_path}")
+        return 0
+
+    bundle_id = _bundle_id(app_path)
+    snapshot = _snapshot_path(bundle_id)
+    fixture_path = _fixture_script_path()
+    failures: list[str] = []
+
+    cases = [
+        ("fixture-codex", 1),
+        ("fixture-claude", 3),
+    ]
+
+    try:
+        for label, required_interrupts in cases:
+            try:
+                _run_case(app_path, bundle_id, snapshot, fixture_path, label, required_interrupts)
+                print(f"PASS: {label}")
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+    finally:
+        fixture_path.unlink(missing_ok=True)
+
+    if failures:
+        print("FAIL:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: quit/session restore captures raw-control resume hints")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- delay quit just long enough to send best-effort Ctrl+C to terminal panels that still report a running child
- capture the final session scrollback after those interrupts so agent CLIs can print their resume hints before restore is saved

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag task-quit-session-restore-kill-before-scrollback

## Task
- Plain-text request: on quit, for session restore, before we capture final scrollback, we should send two ctrl+c or ctrl+d to try to kill the running process, since it'll help us get "resume this session with" that claude code and codex outputs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On quit, we now send raw ETX interrupts to running terminal panels and wait for output to settle before saving the final scrollback so agent CLIs can print resume hints. This fulfills the Linear task and adds CI coverage; optional smoke tests for real `codex`/`claude` can be enabled with `CMUX_INCLUDE_REAL_AGENTS`.

- **New Features**
  - If a panel needs close confirmation, delay termination and inject ETX as text events (not key combos), up to three attempts at 0s, 0.6s, and 1.2s.
  - Poll scrollback every 120ms and wait 350ms of quiet (max 2.5s) before snapshot, then finish quitting.
  - Added `TerminalSurface.ControlCharacter` and `sendControlCharacter` for raw ETX/EOT injection; `TerminalPanel` forwards these calls.

- **Bug Fixes**
  - Stabilized real-agent smoke tests on Mac minis with longer settle delays, stricter socket checks, and a clean workdir.
  - Improved harness to reliably launch `codex`/`claude` and detect readiness when `CMUX_INCLUDE_REAL_AGENTS` is set.

<sup>Written for commit 17ff663e9956d01267930d3b058c29cb93f7ebf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session restoration when quitting the application with coordinated terminal panel handling
  * Enhanced terminal control with support for sending specific keyboard commands to active panels
  * Session snapshots captured during application shutdown for better state preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->