### PR TITLE
Keep Cmd+W from closing the last workspace

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -3,6 +3,7 @@
 Cross-project tracking (features, bugs, backlog) for cmux.
 
 ## Done
+- 2026-03-13: Cmd+W on the last surface now matches the tab close button, it closes and replaces the focused surface while keeping the workspace open. Added regression coverage for the keyboard path.
 - 2026-02-14: Fixed updater release regression path: made `.github/workflows/release.yml` Sparkle Info.plist key injection idempotent (re-running tags no longer fails with "Entry Already Exists"), and hardened `scripts/bump-version.sh` to keep `CURRENT_PROJECT_VERSION` above the latest published Sparkle appcast build number so upgrades from `0.27.0` can be detected.
 - 2026-02-14: Relicensed the repository to strong copyleft (`AGPL-3.0-or-later`), added canonical `LICENSE` text, and updated project/package metadata to advertise AGPL consistently.
 - 2026-02-14: Added an opt-in nightly update channel in Settings (`Receive nightly builds`) that routes Sparkle feed selection between stable and nightly appcasts, plus a scheduled GitHub Actions nightly pipeline (`.github/workflows/nightly.yml`) that only rebuilds when `main` has new commits since `nightly` (or when manually forced).

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1650,9 +1650,6 @@ class TabManager: ObservableObject {
     }
 
     private func closePanelWithConfirmation(tab: Workspace, panelId: UUID) {
-        let bonsplitTabCount = tab.bonsplitController.allPaneIds.reduce(0) { partial, paneId in
-            partial + tab.bonsplitController.tabs(inPane: paneId).count
-        }
         let panelKind: String = {
             guard let panel = tab.panels[panelId] else { return "missing" }
             if panel is TerminalPanel { return "terminal" }
@@ -1663,51 +1660,15 @@ class TabManager: ObservableObject {
         dlog(
             "surface.close.shortcut.begin tab=\(tab.id.uuidString.prefix(5)) " +
             "panel=\(panelId.uuidString.prefix(5)) kind=\(panelKind) " +
-            "panelCount=\(tab.panels.count) bonsplitTabs=\(bonsplitTabCount)"
+            "panelCount=\(tab.panels.count)"
         )
 #endif
 
-        // Cmd+W closes the focused Bonsplit tab (a "tab" in the UI). When the workspace only has
-        // a single tab left, closing it should close the workspace (and possibly the window),
-        // rather than creating a replacement terminal.
-        let effectiveSurfaceCount = max(tab.panels.count, bonsplitTabCount)
-        let isLastTabInWorkspace = effectiveSurfaceCount <= 1
-        if isLastTabInWorkspace {
-            let willCloseWindow = tabs.count <= 1
-            let needsConfirm = workspaceNeedsConfirmClose(tab)
-            if needsConfirm {
-                let message = willCloseWindow
-                    ? String(localized: "dialog.closeLastTabWindow.message", defaultValue: "This will close the last tab and close the window.")
-                    : String(localized: "dialog.closeLastTabWorkspace.message", defaultValue: "This will close the last tab and close its workspace.")
-#if DEBUG
-                dlog(
-                    "surface.close.shortcut.confirm tab=\(tab.id.uuidString.prefix(5)) " +
-                    "panel=\(panelId.uuidString.prefix(5)) reason=lastTab"
-                )
-#endif
-                guard confirmClose(
-                    title: String(localized: "dialog.closeTab.title", defaultValue: "Close tab?"),
-                    message: message,
-                    acceptCmdD: willCloseWindow
-                ) else {
-#if DEBUG
-                    dlog(
-                        "surface.close.shortcut.cancel tab=\(tab.id.uuidString.prefix(5)) " +
-                        "panel=\(panelId.uuidString.prefix(5)) reason=lastTabConfirmDismissed"
-                    )
-#endif
-                    return
-                }
-            }
+        guard tab.panels[panelId] != nil else { return }
 
-            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id)
-            if willCloseWindow {
-                AppDelegate.shared?.closeMainWindowContainingTabId(tab.id)
-            } else {
-                closeWorkspace(tab)
-            }
-            return
-        }
+        // Keep the keyboard shortcut aligned with the tab close button: close only the addressed
+        // surface and let Workspace maintain the replacement-surface invariant when needed.
+        reconcileFocusedPanelFromFirstResponderForKeyboard()
 
         if let terminalPanel = tab.terminalPanel(for: panelId),
            terminalPanel.needsConfirmClose() {
@@ -1741,6 +1702,7 @@ class TabManager: ObservableObject {
             "panelsAfterCall=\(tab.panels.count)"
         )
 #endif
+        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: panelId)
     }
 
     func closePanelWithConfirmation(tabId: UUID, surfaceId: UUID) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -452,8 +452,8 @@ struct cmuxApp: App {
                 Divider()
 
                 // Terminal semantics:
-                // Cmd+W closes the focused tab (with confirmation if needed). If this is the last
-                // tab in the last workspace, it closes the window.
+                // Cmd+W closes the focused surface (with confirmation if needed) and keeps the
+                // workspace open, matching the tab close button behavior.
                 Button(String(localized: "menu.file.closeTab", defaultValue: "Close Tab")) {
                     closePanelOrWindow()
                 }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -5222,6 +5222,27 @@ final class TabManagerPendingUnfocusPolicyTests: XCTestCase {
 }
 
 @MainActor
+final class TabManagerClosePanelWithConfirmationTests: XCTestCase {
+    func testCloseCurrentPanelWithConfirmationKeepsWorkspaceWhenClosingLastSurface() {
+        let manager = TabManager()
+        let originalWorkspace = try? XCTUnwrap(manager.selectedWorkspace)
+        let secondWorkspace = manager.addWorkspace()
+        let closedWorkspaceId = secondWorkspace.id
+        let originalPanelIds = Set(secondWorkspace.panels.keys)
+
+        manager.confirmCloseHandler = { _, _, _ in true }
+        manager.closeCurrentPanelWithConfirmation()
+
+        XCTAssertEqual(manager.tabs.count, 2, "Expected Cmd+W to preserve the workspace when closing its last surface")
+        XCTAssertTrue(manager.tabs.contains(where: { $0.id == closedWorkspaceId }), "Expected workspace to remain after Cmd+W")
+        XCTAssertEqual(manager.selectedTabId, closedWorkspaceId, "Expected Cmd+W to keep the current workspace selected")
+        XCTAssertEqual(secondWorkspace.panels.count, 1, "Expected Cmd+W to leave one replacement surface in the workspace")
+        XCTAssertNotEqual(Set(secondWorkspace.panels.keys), originalPanelIds, "Expected the original last surface to be replaced")
+        XCTAssertEqual(manager.tabs.first?.id, originalWorkspace?.id, "Expected unrelated workspaces to remain untouched")
+    }
+}
+
+@MainActor
 final class TabManagerSurfaceCreationTests: XCTestCase {
     func testNewSurfaceFocusesCreatedSurface() {
         let manager = TabManager()

--- a/cmuxUITests/CloseWorkspaceCmdDUITests.swift
+++ b/cmuxUITests/CloseWorkspaceCmdDUITests.swift
@@ -2,9 +2,13 @@ import XCTest
 import Foundation
 
 final class CloseWorkspaceCmdDUITests: XCTestCase {
+    private var socketPath = ""
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        socketPath = "/tmp/cmux-ui-test-close-workspace-cmdui-\(UUID().uuidString).sock"
+        try? FileManager.default.removeItem(atPath: socketPath)
     }
 
     func testCmdDConfirmsCloseWhenClosingLastWorkspaceClosesWindow() {
@@ -27,23 +31,48 @@ final class CloseWorkspaceCmdDUITests: XCTestCase {
         )
     }
 
-    func testCmdDConfirmsCloseWhenClosingLastTabClosesWindow() {
+    func testCmdWOnLastTabKeepsWorkspaceOpen() {
         let app = XCUIApplication()
-        // Closing the last tab should also present a confirmation and accept Cmd+D when it would close the window.
-        app.launchEnvironment["CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launch()
         app.activate()
 
-        // Close current tab (Cmd+W). With a single workspace and a single tab, this will close the window after confirmation.
-        app.typeKey("w", modifierFlags: [.command])
-        XCTAssertTrue(waitForCloseTabAlert(app: app, timeout: 5.0))
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket to respond at \(socketPath)")
+        XCTAssertEqual(workspaceCount(), 1, "Expected a single workspace before Cmd+W")
+        let surfaceIdBefore = try XCTUnwrap(firstSurfaceId(), "Expected a focused surface before Cmd+W")
 
-        // Cmd+D should accept the destructive close and close the window.
-        app.typeKey("d", modifierFlags: [.command])
+        app.typeKey("w", modifierFlags: [.command])
+
+        if waitForCloseTabAlert(app: app, timeout: 5.0) {
+            XCTAssertFalse(
+                app.staticTexts["This will close the last tab and close the window."].exists,
+                "Cmd+W should not warn that closing the last surface closes the window"
+            )
+            XCTAssertFalse(
+                app.staticTexts["This will close the last tab and close its workspace."].exists,
+                "Cmd+W should not warn that closing the last surface closes the workspace"
+            )
+            clickCloseOnAlert(app: app)
+        }
 
         XCTAssertTrue(
-            waitForNoWindowsOrAppNotRunningForeground(app: app, timeout: 6.0),
-            "Expected Cmd+D to confirm close and close the last window"
+            waitForWindowCount(app: app, atLeast: 1, timeout: 6.0),
+            "Expected Cmd+W on the last surface to keep the window open"
+        )
+        XCTAssertTrue(
+            waitForWorkspaceCount(1, timeout: 6.0),
+            "Expected Cmd+W on the last surface to keep the workspace open. list=\(socketCommand(\"list_workspaces\") ?? \"<nil>\")"
+        )
+        XCTAssertTrue(
+            waitForSurfaceCount(1, timeout: 6.0),
+            "Expected Cmd+W on the last surface to leave a single replacement surface. list=\(socketCommand(\"list_surfaces\") ?? \"<nil>\")"
+        )
+
+        let surfaceIdAfter = try XCTUnwrap(firstSurfaceId(), "Expected a focused surface after Cmd+W")
+        XCTAssertNotEqual(
+            surfaceIdAfter,
+            surfaceIdBefore,
+            "Expected Cmd+W on the last surface to close and replace the focused surface, not keep it open"
         )
     }
 
@@ -616,6 +645,28 @@ final class CloseWorkspaceCmdDUITests: XCTestCase {
         return false
     }
 
+    private func clickCloseOnAlert(app: XCUIApplication) {
+        let dialog = app.dialogs.containing(.staticText, identifier: "Close tab?").firstMatch
+        if dialog.exists {
+            dialog.buttons["Close"].firstMatch.click()
+            return
+        }
+        let alert = app.alerts.containing(.staticText, identifier: "Close tab?").firstMatch
+        if alert.exists {
+            alert.buttons["Close"].firstMatch.click()
+            return
+        }
+        let anyDialog = app.dialogs.firstMatch
+        if anyDialog.exists, anyDialog.buttons["Close"].exists {
+            anyDialog.buttons["Close"].firstMatch.click()
+            return
+        }
+        let anyAlert = app.alerts.firstMatch
+        if anyAlert.exists, anyAlert.buttons["Close"].exists {
+            anyAlert.buttons["Close"].firstMatch.click()
+        }
+    }
+
     private func waitForWindowCount(app: XCUIApplication, toBe count: Int, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -632,6 +683,106 @@ final class CloseWorkspaceCmdDUITests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
         return app.windows.count >= count
+    }
+
+    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if socketCommand("ping") == "PONG" {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return socketCommand("ping") == "PONG"
+    }
+
+    private func waitForWorkspaceCount(_ expectedCount: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if workspaceCount() == expectedCount {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return workspaceCount() == expectedCount
+    }
+
+    private func waitForSurfaceCount(_ expectedCount: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if surfaceCount() == expectedCount {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return surfaceCount() == expectedCount
+    }
+
+    private func workspaceCount() -> Int {
+        guard let response = socketCommand("list_workspaces") else { return -1 }
+        if response == "No workspaces" {
+            return 0
+        }
+        return response
+            .split(separator: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .count
+    }
+
+    private func surfaceCount() -> Int {
+        guard let response = socketCommand("list_surfaces") else { return -1 }
+        if response == "No surfaces" {
+            return 0
+        }
+        return response
+            .split(separator: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .count
+    }
+
+    private func firstSurfaceId() -> String? {
+        guard let response = socketCommand("list_surfaces"), response != "No surfaces" else { return nil }
+        guard let firstLine = response
+            .split(separator: "\n")
+            .map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+            .first(where: { !$0.isEmpty }) else {
+            return nil
+        }
+        guard let uuidComponent = firstLine.split(separator: " ").last else { return nil }
+        return String(uuidComponent)
+    }
+
+    private func socketCommand(_ cmd: String) -> String? {
+        let nc = "/usr/bin/nc"
+        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: nc)
+        proc.arguments = ["-U", socketPath, "-w", "2"]
+
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardInput = inPipe
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+
+        do {
+            try proc.run()
+        } catch {
+            return nil
+        }
+
+        if let data = (cmd + "\n").data(using: .utf8) {
+            inPipe.fileHandleForWriting.write(data)
+        }
+        inPipe.fileHandleForWriting.closeFile()
+
+        proc.waitUntilExit()
+
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
+        return outStr.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func waitForNoWindowsOrAppNotRunningForeground(app: XCUIApplication, timeout: TimeInterval) -> Bool {

--- a/cmuxUITests/CloseWorkspaceCmdDUITests.swift
+++ b/cmuxUITests/CloseWorkspaceCmdDUITests.swift
@@ -31,7 +31,7 @@ final class CloseWorkspaceCmdDUITests: XCTestCase {
         )
     }
 
-    func testCmdWOnLastTabKeepsWorkspaceOpen() {
+    func testCmdWOnLastTabKeepsWorkspaceOpen() throws {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launch()

--- a/cmuxUITests/CloseWorkspaceCmdDUITests.swift
+++ b/cmuxUITests/CloseWorkspaceCmdDUITests.swift
@@ -61,11 +61,11 @@ final class CloseWorkspaceCmdDUITests: XCTestCase {
         )
         XCTAssertTrue(
             waitForWorkspaceCount(1, timeout: 6.0),
-            "Expected Cmd+W on the last surface to keep the workspace open. list=\(socketCommand(\"list_workspaces\") ?? \"<nil>\")"
+            "Expected Cmd+W on the last surface to keep the workspace open. list=" + (socketCommand("list_workspaces") ?? "<nil>")
         )
         XCTAssertTrue(
             waitForSurfaceCount(1, timeout: 6.0),
-            "Expected Cmd+W on the last surface to leave a single replacement surface. list=\(socketCommand(\"list_surfaces\") ?? \"<nil>\")"
+            "Expected Cmd+W on the last surface to leave a single replacement surface. list=" + (socketCommand("list_surfaces") ?? "<nil>")
         )
 
         let surfaceIdAfter = try XCTUnwrap(firstSurfaceId(), "Expected a focused surface after Cmd+W")


### PR DESCRIPTION
## Summary
- keep Cmd+W aligned with the tab close button when closing the last surface
- preserve the workspace and replacement surface instead of auto-closing the workspace or window
- add unit and UI regression coverage for the last-surface keyboard path

## Testing
- ./scripts/reload.sh --tag task-cmdw-preserve-empty-workspace
- GitHub Actions: test-e2e.yml ref=task-cmdw-preserve-empty-workspace test_filter="CloseWorkspaceCmdDUITests/testCmdWOnLastTabKeepsWorkspaceOpen" record_video=true

## Issues
- Related task: Cmd+W (sf-close) should not auto-close the workspace when closing the last surface
- Follow-up to https://github.com/manaflow-ai/cmux/pull/1329

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+W now matches the tab close button: it closes the focused surface and keeps the workspace open, even when it’s the last surface. This prevents accidental window/workspace closes and completes the task: Cmd+W should not auto-close the workspace.

- **Bug Fixes**
  - Removed last-surface auto-close in `TabManager`; Cmd+W closes only the addressed surface and relies on the replacement-surface invariant.
  - Reconciles focus before closing, ignores missing panels, and clears notifications for the closed surface; updated File > Close Tab menu comment.
  - Added a unit test for `closeCurrentPanelWithConfirmation` to ensure workspace preservation and replacement; rewrote the UI test to verify no “close window/workspace” alert and assert window/workspace/surface counts via the control socket; fixed test throws handling.

<sup>Written for commit e3b5e89fd3efa72e34d3715ba9e835688f1753e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Cmd+W on the last surface now closes the focused surface while keeping the workspace open, aligning with the surface close button behavior.

* **Tests**
  * Added regression test coverage for keyboard-based surface closing to verify workspace preservation.

* **Documentation**
  * Updated terminal close action documentation to reflect current Cmd+W keyboard shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->