### PR TITLE
Shrink Cmd+P empty state height

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1634,6 +1634,10 @@ struct ContentView: View {
     private static let commandPaletteCommandsPrefix = ">"
     private static let commandPaletteVisiblePreviewResultLimit = 48
     private static let commandPaletteVisiblePreviewCandidateLimit = 192
+    private static let commandPaletteListMaxHeight: CGFloat = 450
+    private static let commandPaletteRowHeight: CGFloat = 24
+    private static let commandPaletteEmptyStateHeight: CGFloat = 44
+    private static let commandPaletteEmptyStateVerticalPadding: CGFloat = 12
     private static let minimumSidebarWidth: CGFloat = 186
     private static let maximumSidebarWidthRatio: CGFloat = 1.0 / 3.0
 
@@ -3006,13 +3010,9 @@ struct ContentView: View {
     private var commandPaletteCommandListView: some View {
         let visibleResults = commandPaletteVisibleResults
         let selectedIndex = commandPaletteSelectedIndex(resultCount: visibleResults.count)
-        let commandPaletteListMaxHeight: CGFloat = 450
-        let commandPaletteRowHeight: CGFloat = 24
-        let commandPaletteEmptyStateHeight: CGFloat = 44
-        let commandPaletteListContentHeight = visibleResults.isEmpty
-            ? commandPaletteEmptyStateHeight
-            : CGFloat(visibleResults.count) * commandPaletteRowHeight
-        let commandPaletteListHeight = min(commandPaletteListMaxHeight, commandPaletteListContentHeight)
+        let commandPaletteListHeight = Self.commandPaletteListViewportHeight(
+            resultCount: visibleResults.count
+        )
         return VStack(spacing: 0) {
             HStack(spacing: 8) {
                 TextField(commandPaletteSearchPlaceholder, text: $commandPaletteQuery)
@@ -3057,13 +3057,15 @@ struct ContentView: View {
                             Text(commandPaletteEmptyStateText)
                                 .font(.system(size: 13, weight: .regular))
                                 .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, 12)
-                                .padding(.vertical, 12)
+                                .padding(.vertical, Self.commandPaletteEmptyStateVerticalPadding)
                         } else {
                             Color.clear
                                 .frame(maxWidth: .infinity)
-                                .frame(height: commandPaletteEmptyStateHeight)
+                                .frame(height: Self.commandPaletteEmptyStateHeight)
                         }
                     } else {
                         ForEach(Array(visibleResults.enumerated()), id: \.element.id) { index, result in
@@ -3550,6 +3552,16 @@ struct ContentView: View {
         hasVisibleResultsForScope: Bool
     ) -> Bool {
         !hasVisibleResultsForScope
+    }
+
+    static func commandPaletteListViewportHeight(resultCount: Int) -> CGFloat {
+        let contentHeight: CGFloat
+        if resultCount > 0 {
+            contentHeight = CGFloat(resultCount) * Self.commandPaletteRowHeight
+        } else {
+            contentHeight = Self.commandPaletteEmptyStateHeight
+        }
+        return min(Self.commandPaletteListMaxHeight, contentHeight)
     }
 
     private func scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: Bool = false) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3461,7 +3461,7 @@ struct ContentView: View {
         let nextVisibleResultIDs = Self.commandPalettePendingVisibleResultIDs(
             previewResultIDs: previewResults.map(\.id),
             currentVisibleResultIDs: commandPaletteVisibleResults.map(\.id),
-            canReuseCurrentVisibleResults: canReuseCurrentVisibleResults
+            preserveCurrentVisibleResultsOnEmptyPreview: canReuseCurrentVisibleResults && scope == .switcher
         )
         let nextVisibleResults: [CommandPaletteSearchResult]
         if nextVisibleResultIDs == previewResults.map(\.id) {
@@ -3564,9 +3564,9 @@ struct ContentView: View {
     static func commandPalettePendingVisibleResultIDs(
         previewResultIDs: [String],
         currentVisibleResultIDs: [String],
-        canReuseCurrentVisibleResults: Bool
+        preserveCurrentVisibleResultsOnEmptyPreview: Bool
     ) -> [String] {
-        guard canReuseCurrentVisibleResults else {
+        guard preserveCurrentVisibleResultsOnEmptyPreview else {
             return previewResultIDs
         }
         if previewResultIDs.isEmpty, !currentVisibleResultIDs.isEmpty {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1636,8 +1636,8 @@ struct ContentView: View {
     private static let commandPaletteVisiblePreviewCandidateLimit = 192
     private static let commandPaletteListMaxHeight: CGFloat = 450
     private static let commandPaletteRowHeight: CGFloat = 24
-    private static let commandPaletteEmptyStateHeight: CGFloat = 44
-    private static let commandPaletteEmptyStateVerticalPadding: CGFloat = 12
+    private static let commandPaletteEmptyStateHeight: CGFloat = 30
+    private static let commandPaletteEmptyStateVerticalPadding: CGFloat = 7
     private static let minimumSidebarWidth: CGFloat = 186
     private static let maximumSidebarWidthRatio: CGFloat = 1.0 / 3.0
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1635,7 +1635,7 @@ struct ContentView: View {
     private static let commandPaletteVisiblePreviewResultLimit = 48
     private static let commandPaletteVisiblePreviewCandidateLimit = 192
     private static let commandPaletteListMaxHeight: CGFloat = 450
-    private static let commandPaletteRowHeight: CGFloat = 24
+    private static let commandPaletteRowHeight: CGFloat = 20
     private static let commandPaletteEmptyStateHeight: CGFloat = 30
     private static let commandPaletteEmptyStateVerticalPadding: CGFloat = 7
     private static let minimumSidebarWidth: CGFloat = 186
@@ -3106,6 +3106,7 @@ struct ContentView: View {
                                 }
                                 .padding(.horizontal, 9)
                                 .padding(.vertical, 2)
+                                .frame(minHeight: Self.commandPaletteRowHeight, alignment: .leading)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .background(rowBackground)
                                 .contentShape(Rectangle())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3548,6 +3548,14 @@ struct ContentView: View {
         return Array(resultIDs.prefix(limit))
     }
 
+    static func commandPalettePendingVisibleResultIDs(
+        previewResultIDs: [String],
+        currentVisibleResultIDs: [String],
+        canReuseCurrentVisibleResults: Bool
+    ) -> [String] {
+        previewResultIDs
+    }
+
     static func commandPaletteShouldSynchronouslySeedResults(
         hasVisibleResultsForScope: Bool
     ) -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3430,9 +3430,10 @@ struct ContentView: View {
         queryIsEmpty: Bool,
         historyTimestamp: TimeInterval
     ) {
+        let canReuseCurrentVisibleResults = commandPaletteVisibleResultsScope == scope
+            && commandPaletteVisibleResultsFingerprint == fingerprint
         let candidateCommandIDs: [String]
-        if commandPaletteVisibleResultsScope == scope,
-           commandPaletteVisibleResultsFingerprint == fingerprint {
+        if canReuseCurrentVisibleResults {
             candidateCommandIDs = Self.commandPalettePreviewCandidateCommandIDs(
                 resultIDs: commandPaletteVisibleResults.map(\.id),
                 limit: Self.commandPaletteVisiblePreviewCandidateLimit
@@ -3456,8 +3457,19 @@ struct ContentView: View {
             matches: previewMatches,
             commandsByID: commandPaletteSearchCommandsByID
         )
+        let nextVisibleResultIDs = Self.commandPalettePendingVisibleResultIDs(
+            previewResultIDs: previewResults.map(\.id),
+            currentVisibleResultIDs: commandPaletteVisibleResults.map(\.id),
+            canReuseCurrentVisibleResults: canReuseCurrentVisibleResults
+        )
+        let nextVisibleResults: [CommandPaletteSearchResult]
+        if nextVisibleResultIDs == previewResults.map(\.id) {
+            nextVisibleResults = previewResults
+        } else {
+            nextVisibleResults = commandPaletteVisibleResults
+        }
         setCommandPaletteVisibleResults(
-            previewResults,
+            nextVisibleResults,
             scope: scope,
             fingerprint: fingerprint
         )
@@ -3553,7 +3565,13 @@ struct ContentView: View {
         currentVisibleResultIDs: [String],
         canReuseCurrentVisibleResults: Bool
     ) -> [String] {
-        previewResultIDs
+        guard canReuseCurrentVisibleResults else {
+            return previewResultIDs
+        }
+        if previewResultIDs.isEmpty, !currentVisibleResultIDs.isEmpty {
+            return currentVisibleResultIDs
+        }
+        return previewResultIDs
     }
 
     static func commandPaletteShouldSynchronouslySeedResults(

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -434,6 +434,28 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
+    func testCommandPaletteEmptyListViewportUsesCompactHeight() {
+        XCTAssertEqual(
+            ContentView.commandPaletteListViewportHeight(resultCount: 0),
+            30
+        )
+        XCTAssertEqual(
+            ContentView.commandPaletteListViewportHeight(resultCount: 1),
+            24
+        )
+    }
+
+    func testCommandPaletteListViewportCapsAtMaximumHeight() {
+        XCTAssertEqual(
+            ContentView.commandPaletteListViewportHeight(resultCount: 32),
+            450
+        )
+        XCTAssertEqual(
+            ContentView.commandPaletteListViewportHeight(resultCount: 80),
+            450
+        )
+    }
+
     func testCommandContextFingerprintTracksExactContextValues() {
         let base = ContentView.commandPaletteContextFingerprint(
             boolValues: [

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -421,12 +421,23 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         XCTAssertEqual(previewCandidateIDs.last, "command.191")
     }
 
-    func testPendingVisibleResultsPreserveCurrentRowsWhenPreviewIsEmpty() {
+    func testPendingVisibleResultsClearStaleRowsForCommandResultsWhenPreviewIsEmpty() {
         XCTAssertEqual(
             ContentView.commandPalettePendingVisibleResultIDs(
                 previewResultIDs: [],
                 currentVisibleResultIDs: ["workspace.1", "workspace.2"],
-                canReuseCurrentVisibleResults: true
+                preserveCurrentVisibleResultsOnEmptyPreview: false
+            ),
+            []
+        )
+    }
+
+    func testPendingVisibleResultsPreserveCurrentRowsForSwitcherWhenPreviewIsEmpty() {
+        XCTAssertEqual(
+            ContentView.commandPalettePendingVisibleResultIDs(
+                previewResultIDs: [],
+                currentVisibleResultIDs: ["workspace.1", "workspace.2"],
+                preserveCurrentVisibleResultsOnEmptyPreview: true
             ),
             ["workspace.1", "workspace.2"]
         )
@@ -437,7 +448,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
             ContentView.commandPalettePendingVisibleResultIDs(
                 previewResultIDs: [],
                 currentVisibleResultIDs: ["workspace.1", "workspace.2"],
-                canReuseCurrentVisibleResults: false
+                preserveCurrentVisibleResultsOnEmptyPreview: false
             ),
             []
         )
@@ -448,7 +459,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
             ContentView.commandPalettePendingVisibleResultIDs(
                 previewResultIDs: ["workspace.9"],
                 currentVisibleResultIDs: ["workspace.1", "workspace.2"],
-                canReuseCurrentVisibleResults: true
+                preserveCurrentVisibleResultsOnEmptyPreview: true
             ),
             ["workspace.9"]
         )

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -421,6 +421,39 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         XCTAssertEqual(previewCandidateIDs.last, "command.191")
     }
 
+    func testPendingVisibleResultsPreserveCurrentRowsWhenPreviewIsEmpty() {
+        XCTAssertEqual(
+            ContentView.commandPalettePendingVisibleResultIDs(
+                previewResultIDs: [],
+                currentVisibleResultIDs: ["workspace.1", "workspace.2"],
+                canReuseCurrentVisibleResults: true
+            ),
+            ["workspace.1", "workspace.2"]
+        )
+    }
+
+    func testPendingVisibleResultsDoNotPreserveRowsAcrossScopeRefresh() {
+        XCTAssertEqual(
+            ContentView.commandPalettePendingVisibleResultIDs(
+                previewResultIDs: [],
+                currentVisibleResultIDs: ["workspace.1", "workspace.2"],
+                canReuseCurrentVisibleResults: false
+            ),
+            []
+        )
+    }
+
+    func testPendingVisibleResultsPreferFreshPreviewMatches() {
+        XCTAssertEqual(
+            ContentView.commandPalettePendingVisibleResultIDs(
+                previewResultIDs: ["workspace.9"],
+                currentVisibleResultIDs: ["workspace.1", "workspace.2"],
+                canReuseCurrentVisibleResults: true
+            ),
+            ["workspace.9"]
+        )
+    }
+
     func testSynchronousSeedRunsOnlyWhenScopeChanges() {
         XCTAssertTrue(
             ContentView.commandPaletteShouldSynchronouslySeedResults(

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -467,14 +467,18 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testCommandPaletteEmptyListViewportUsesCompactHeight() {
+    func testCommandPaletteListViewportUsesCompactRenderedRowHeight() {
         XCTAssertEqual(
             ContentView.commandPaletteListViewportHeight(resultCount: 0),
             30
         )
         XCTAssertEqual(
             ContentView.commandPaletteListViewportHeight(resultCount: 1),
-            24
+            20
+        )
+        XCTAssertEqual(
+            ContentView.commandPaletteListViewportHeight(resultCount: 17),
+            340
         )
     }
 


### PR DESCRIPTION
## Summary
- shrink the command palette empty-state viewport so Cmd+P no-result states stay compact
- add regression coverage for the command palette list viewport height

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-cmd-p-empty-state-height-tests -only-testing:cmuxTests/CommandPaletteSearchEngineTests test` passed
- `./scripts/reload.sh --tag task-cmd-p-empty-state-height` built and launched

## Issues
- Related: task summary `cmd p empty state height too tall`
- Remote run on `cmux-macmini` was blocked by SSH auth (`Permission denied (publickey,password,keyboard-interactive)`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks the Cmd+P command palette: empty state is 30px and rows are 20px, capped at 450px, for a compact and stable list. Addresses Linear task “Cmd+P empty state height too tall” and reduces flicker by preserving rows during pending search.

- **Bug Fixes**
  - Centralized viewport height: 20px rows; 30px empty state with 7px vertical padding, single-line tail truncation; capped at 450; added compact-viewport tests.
  - Preserve current rows when preview is empty and scope unchanged; prefer fresh preview matches when present; added pending-results and empty-state tests.

<sup>Written for commit 5a09d62df9024516df9763f2e8d0278cd1cb11bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized viewport height handling for the command palette list, yielding more consistent and bounded list sizing.
  * Improved result-preservation logic so visible rows are reused when appropriate, reducing flicker during updates.

* **Bug Fixes**
  * Enhanced empty-state rendering with single-line truncation and standardized vertical padding.
  * Fixed list height behavior to respect compact and maximum height limits.

* **Tests**
  * Added unit tests covering viewport height calculations and pending-visible-results behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->