### PR TITLE
Add global hotkey popup terminal

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5328,6 +5328,24 @@ struct CMUXCLI {
               cmux markdown ~/project/CHANGELOG.md
               cmux markdown open ./docs/design.md --workspace 0
             """
+        case "popup-terminal-toggle":
+            return """
+            Usage: cmux popup-terminal-toggle
+
+            Toggle the global popup terminal.
+            """
+        case "popup-terminal-show":
+            return """
+            Usage: cmux popup-terminal-show
+
+            Show the global popup terminal.
+            """
+        case "popup-terminal-hide":
+            return """
+            Usage: cmux popup-terminal-hide
+
+            Hide the global popup terminal.
+            """
         default:
             return nil
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1767,6 +1767,19 @@ struct CMUXCLI {
         case "markdown":
             try runMarkdownCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        // Popup terminal commands
+        case "popup-terminal-toggle":
+            let payload = try client.sendV2(method: "popup-terminal.toggle", params: [:])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+
+        case "popup-terminal-show":
+            let payload = try client.sendV2(method: "popup-terminal.show", params: [:])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+
+        case "popup-terminal-hide":
+            let payload = try client.sendV2(method: "popup-terminal.hide", params: [:])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+
         default:
             print(usage())
             throw CLIError(message: "Unknown command: \(command)")
@@ -8458,6 +8471,10 @@ struct CMUXCLI {
 
           set-app-focus <active|inactive|clear>
           simulate-app-active
+
+          popup-terminal-toggle     Toggle the popup terminal
+          popup-terminal-show       Show the popup terminal
+          popup-terminal-hide       Hide the popup terminal
 
           # tmux compatibility commands
           capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
-				F9000000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */; };
+				FB900000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB900001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
@@ -247,7 +247,7 @@
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 					A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 				A5008382 /* CommandPaletteSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchEngineTests.swift; sourceTree = "<group>"; };
-				F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTerminalSettingsTests.swift; sourceTree = "<group>"; };
+				FB900001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTerminalSettingsTests.swift; sourceTree = "<group>"; };
 					DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
@@ -485,7 +485,7 @@
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 					A5008382 /* CommandPaletteSearchEngineTests.swift */,
-					F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */,
+					FB900001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -728,7 +728,7 @@
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
-					F9000000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */,
+					FB900000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 			A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 			A50012F3 /* KeyboardShortcutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F2 /* KeyboardShortcutSettings.swift */; };
 			A50012F5 /* KeyboardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F4 /* KeyboardLayout.swift */; };
+			A5008391 /* PopupTerminalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008390 /* PopupTerminalController.swift */; };
+			A5008393 /* PopupTerminalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008392 /* PopupTerminalSettings.swift */; };
 			A5001521 /* PostHogAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001520 /* PostHogAnalytics.swift */; };
 			A5001201 /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001211 /* UpdateController.swift */; };
 		A5001202 /* UpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001212 /* UpdateDelegate.swift */; };
@@ -96,6 +98,7 @@
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
+				F9000000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
@@ -194,6 +197,8 @@
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A50012F2 /* KeyboardShortcutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettings.swift; sourceTree = "<group>"; };
 		A50012F4 /* KeyboardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayout.swift; sourceTree = "<group>"; };
+		A5008390 /* PopupTerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTerminalController.swift; sourceTree = "<group>"; };
+		A5008392 /* PopupTerminalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTerminalSettings.swift; sourceTree = "<group>"; };
 		A5001211 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateController.swift; sourceTree = "<group>"; };
 		A5001212 /* UpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateDelegate.swift; sourceTree = "<group>"; };
 		A5001213 /* UpdateDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateDriver.swift; sourceTree = "<group>"; };
@@ -242,6 +247,7 @@
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 					A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 				A5008382 /* CommandPaletteSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchEngineTests.swift; sourceTree = "<group>"; };
+				F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTerminalSettingsTests.swift; sourceTree = "<group>"; };
 					DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
@@ -362,6 +368,8 @@
 					A50012F0 /* Backport.swift */,
 					A50012F2 /* KeyboardShortcutSettings.swift */,
 					A50012F4 /* KeyboardLayout.swift */,
+					A5008390 /* PopupTerminalController.swift */,
+					A5008392 /* PopupTerminalSettings.swift */,
 					A5001013 /* TabManager.swift */,
 					A5001511 /* UITestRecorder.swift */,
 					A5001520 /* PostHogAnalytics.swift */,
@@ -477,6 +485,7 @@
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 					A5008382 /* CommandPaletteSearchEngineTests.swift */,
+					F9000001A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -634,6 +643,8 @@
 					A50012F1 /* Backport.swift in Sources */,
 					A50012F3 /* KeyboardShortcutSettings.swift in Sources */,
 					A50012F5 /* KeyboardLayout.swift in Sources */,
+					A5008391 /* PopupTerminalController.swift in Sources */,
+					A5008393 /* PopupTerminalSettings.swift in Sources */,
 						A5001003 /* TabManager.swift in Sources */,
 						A5001501 /* UITestRecorder.swift in Sources */,
 						A5001521 /* PostHogAnalytics.swift in Sources */,
@@ -717,6 +728,7 @@
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
+					F9000000A1B2C3D4E5F60718 /* PopupTerminalSettingsTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7543,13 +7543,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let shortcut = KeyboardShortcutSettings.shortcut(for: .togglePopupTerminal)
         let key = shortcut.key.lowercased()
 
-        guard let fkCode = Self.functionKeyCodeMap[key] else {
+        guard let vkCode = Self.hotKeyCodeMap[key] else {
             #if DEBUG
-            dlog("popupTerminal.hotkey skipped reason=nonFunctionKey key=\(shortcut.key)")
+            dlog("popupTerminal.hotkey skipped reason=unknownKey key=\(shortcut.key)")
             #endif
             return
         }
-        let keyCode = UInt32(fkCode)
+        let keyCode = UInt32(vkCode)
 
         var mods: UInt32 = 0
         if shortcut.command { mods |= UInt32(cmdKey) }
@@ -9376,6 +9376,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
         "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
     ]
+
+    /// Reverse of StoredShortcut.storedKey(from:) — maps stored key strings
+    /// to macOS virtual keycodes for Carbon RegisterEventHotKey.
+    private static let hotKeyCodeMap: [String: UInt16] = {
+        var map: [String: UInt16] = [
+            // Function keys
+            "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+            "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+            // Special keys
+            "←": 123, "→": 124, "↓": 125, "↑": 126,
+            "\t": 48, "\r": 36,
+            "[": 33, "]": 30, "-": 27, "=": 24,
+            ",": 43, ".": 47, "/": 44, ";": 41, "'": 39, "`": 50, "\\": 42,
+            // Alphanumeric (ANSI layout)
+            "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
+            "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
+            "y": 16, "t": 17, "1": 18, "2": 19, "3": 20, "4": 21, "6": 22,
+            "5": 23, "9": 25, "7": 26, "8": 28, "0": 29, "o": 31, "u": 32,
+            "i": 34, "p": 35, "l": 37, "j": 38, "k": 40, "n": 45, "m": 46,
+            " ": 49,
+        ]
+        return map
+    }()
 
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
         // Some keys can include extra flags (e.g. .function) depending on the responder chain.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7544,7 +7544,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let key = shortcut.key.lowercased()
 
         guard let fkCode = Self.functionKeyCodeMap[key] else {
-            print("[PopupTerminal] Shortcut key '\(shortcut.key)' is not a function key; hotkey not registered")
+            #if DEBUG
+            dlog("popupTerminal.hotkey skipped reason=nonFunctionKey key=\(shortcut.key)")
+            #endif
             return
         }
         let keyCode = UInt32(fkCode)
@@ -7563,7 +7565,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if status == noErr, let ref {
             globalHotkeyRef = ref
         } else {
-            print("[PopupTerminal] Failed to register hotkey '\(shortcut.key)': OSStatus \(status)")
+            #if DEBUG
+            dlog("popupTerminal.hotkey registerFailed key=\(shortcut.key) status=\(status)")
+            #endif
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7543,7 +7543,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let shortcut = KeyboardShortcutSettings.shortcut(for: .togglePopupTerminal)
         let key = shortcut.key.lowercased()
 
-        guard let fkCode = Self.functionKeyCodeMap[key] else { return }
+        guard let fkCode = Self.functionKeyCodeMap[key] else {
+            print("[PopupTerminal] Shortcut key '\(shortcut.key)' is not a function key; hotkey not registered")
+            return
+        }
         let keyCode = UInt32(fkCode)
 
         var mods: UInt32 = 0
@@ -7559,6 +7562,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let status = RegisterEventHotKey(keyCode, mods, hotKeyID, GetApplicationEventTarget(), 0, &ref)
         if status == noErr, let ref {
             globalHotkeyRef = ref
+        } else {
+            print("[PopupTerminal] Failed to register hotkey '\(shortcut.key)': OSStatus \(status)")
         }
     }
 
@@ -7593,8 +7598,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
                 // Check if this is our popup terminal hotkey.
                 // Carbon RegisterEventHotKey consumes the key event at the system
-                // level, so no window (local or popup) ever sees F10 as a keyDown.
-                // This handler is the sole toggle path for the popup terminal.
+                // level, so no window (local or popup) ever sees the registered
+                // hotkey as a keyDown. This handler is the sole toggle path for
+                // the popup terminal.
                 if hotKeyID.signature == AppDelegate.popupTerminalHotKeyID.signature,
                    hotKeyID.id == AppDelegate.popupTerminalHotKeyID.id {
                     // Carbon event handlers on GetApplicationEventTarget() run

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Bonsplit
+import Carbon
 import CoreServices
 import UserNotifications
 import Sentry
@@ -1905,6 +1906,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lifecycleSnapshotObservers: [NSObjectProtocol] = []
     private var windowKeyObserver: NSObjectProtocol?
     private var shortcutMonitor: Any?
+    private var globalHotkeyRef: EventHotKeyRef?
     private var shortcutDefaultsObserver: NSObjectProtocol?
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var splitButtonTooltipRefreshScheduled = false
@@ -2321,6 +2323,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         notificationStore?.clearAll()
         enableSuddenTerminationIfNeeded()
+        unregisterPopupTerminalHotKey()
     }
 
     func applicationWillResignActive(_ notification: Notification) {
@@ -7523,6 +7526,92 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return event
         }
+        registerPopupTerminalHotKey()
+    }
+
+    // MARK: - Global hotkey (Carbon RegisterEventHotKey)
+
+    private static let popupTerminalHotKeyID = EventHotKeyID(
+        signature: OSType(0x636D7578), // "cmux"
+        id: 1
+    )
+
+    func registerPopupTerminalHotKey() {
+        unregisterPopupTerminalHotKey()
+
+        guard PopupTerminalSettings.isEnabled else { return }
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .togglePopupTerminal)
+        let key = shortcut.key.lowercased()
+
+        guard let fkCode = Self.functionKeyCodeMap[key] else { return }
+        let keyCode = UInt32(fkCode)
+
+        var mods: UInt32 = 0
+        if shortcut.command { mods |= UInt32(cmdKey) }
+        if shortcut.shift { mods |= UInt32(shiftKey) }
+        if shortcut.option { mods |= UInt32(optionKey) }
+        if shortcut.control { mods |= UInt32(controlKey) }
+
+        installCarbonHotKeyHandler()
+
+        var hotKeyID = Self.popupTerminalHotKeyID
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(keyCode, mods, hotKeyID, GetApplicationEventTarget(), 0, &ref)
+        if status == noErr, let ref {
+            globalHotkeyRef = ref
+        }
+    }
+
+    func unregisterPopupTerminalHotKey() {
+        if let ref = globalHotkeyRef {
+            UnregisterEventHotKey(ref)
+            globalHotkeyRef = nil
+        }
+    }
+
+    /// One-time installation of the Carbon event handler that dispatches hotkey events.
+    private static var carbonHandlerInstalled = false
+    private func installCarbonHotKeyHandler() {
+        guard !Self.carbonHandlerInstalled else { return }
+        Self.carbonHandlerInstalled = true
+
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, event, _ -> OSStatus in
+                var hotKeyID = EventHotKeyID()
+                let status = GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &hotKeyID
+                )
+                guard status == noErr else { return status }
+
+                // Check if this is our popup terminal hotkey.
+                // Carbon RegisterEventHotKey consumes the key event at the system
+                // level, so no window (local or popup) ever sees F10 as a keyDown.
+                // This handler is the sole toggle path for the popup terminal.
+                if hotKeyID.signature == AppDelegate.popupTerminalHotKeyID.signature,
+                   hotKeyID.id == AppDelegate.popupTerminalHotKeyID.id {
+                    // Carbon event handlers on GetApplicationEventTarget() run
+                    // on the main thread, so we can call toggle directly.
+                    if PopupTerminalSettings.isEnabled {
+                        PopupTerminalController.shared.toggle()
+                    }
+                    return noErr
+                }
+
+                return OSStatus(eventNotHandledErr)
+            },
+            1,
+            &eventType,
+            nil,
+            nil
+        )
     }
 
     private func installShortcutDefaultsObserver() {
@@ -8105,7 +8194,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        // Primary UI shortcuts
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleSidebar)) {
             _ = toggleSidebarInActiveMainWindow()
             return true
@@ -9274,7 +9362,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return false
     }
 
-    /// Match a shortcut against an event, handling normal keys.
+    private static let functionKeyCodeMap: [String: UInt16] = [
+        "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+        "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+    ]
+
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
         // Some keys can include extra flags (e.g. .function) depending on the responder chain.
         // Strip those for consistent matching across first responders (terminal, WebKit, etc).
@@ -9283,6 +9375,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard flags == shortcut.modifierFlags else { return false }
 
         let shortcutKey = shortcut.key.lowercased()
+
+        // Function keys: match by keyCode since charactersIgnoringModifiers
+        // returns special Unicode characters that don't match "F11" etc.
+        if let expectedKeyCode = Self.functionKeyCodeMap[shortcutKey] {
+            return event.keyCode == expectedKeyCode
+        }
+
         if shortcutKey == "\r" {
             return event.keyCode == 36 || event.keyCode == 76
         }
@@ -11063,6 +11162,7 @@ private extension NSWindow {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }
         if let ghosttyView = firstResponderGhosttyView {
+
             // If the IME is composing and the key has no Cmd modifier, don't intercept —
             // let it flow through normal AppKit event dispatch so the input method can
             // process it. Cmd-based shortcuts should still work during composition since

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -42,6 +42,9 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
+        // Popup terminal
+        case togglePopupTerminal
+
         var id: String { rawValue }
 
         var label: String {
@@ -76,6 +79,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
+            case .togglePopupTerminal: return String(localized: "shortcut.togglePopupTerminal.label", defaultValue: "Toggle Popup Terminal")
             }
         }
 
@@ -111,6 +115,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
+            case .togglePopupTerminal: return "shortcut.togglePopupTerminal"
             }
         }
 
@@ -178,6 +183,8 @@ enum KeyboardShortcutSettings {
             case .showBrowserJavaScriptConsole:
                 // Safari default: Show JavaScript Console.
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
+            case .togglePopupTerminal:
+                return StoredShortcut(key: "F10", command: false, shift: false, option: false, control: false)
             }
         }
 
@@ -368,7 +375,9 @@ struct StoredShortcut: Codable, Equatable {
         )
 
         // Avoid recording plain typing; require at least one modifier.
-        if !shortcut.command && !shortcut.shift && !shortcut.option && !shortcut.control {
+        // Exception: function keys (F1-F12) are allowed without modifiers.
+        let isFunctionKey = key.lowercased().hasPrefix("f") && key.count <= 3 && Int(key.dropFirst()) != nil
+        if !isFunctionKey && !shortcut.command && !shortcut.shift && !shortcut.option && !shortcut.control {
             return nil
         }
         return shortcut
@@ -394,6 +403,19 @@ struct StoredShortcut: Codable, Equatable {
         case 39: return "'"  // kVK_ANSI_Quote
         case 50: return "`"  // kVK_ANSI_Grave
         case 42: return "\\" // kVK_ANSI_Backslash
+        // Function keys
+        case 122: return "F1"
+        case 120: return "F2"
+        case 99:  return "F3"
+        case 118: return "F4"
+        case 96:  return "F5"
+        case 97:  return "F6"
+        case 98:  return "F7"
+        case 100: return "F8"
+        case 101: return "F9"
+        case 109: return "F10"
+        case 103: return "F11"
+        case 111: return "F12"
         default:
             break
         }

--- a/Sources/PopupTerminalController.swift
+++ b/Sources/PopupTerminalController.swift
@@ -1,0 +1,303 @@
+import AppKit
+import SwiftUI
+
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │ Popup Terminal – Window Management Design Notes                         │
+// │                                                                         │
+// │ The popup is a floating NSPanel that appears over everything via F10.   │
+// │ Getting this right on macOS requires careful coordination of three      │
+// │ AppKit subsystems that interact in non-obvious ways:                    │
+// │                                                                         │
+// │ 1. ACTIVATION POLICY (.accessory vs .regular)                          │
+// │    • .accessory hides the app from menu bar and Dock.                  │
+// │    • We switch to .accessory on show so NSApp.activate doesn't raise   │
+// │      regular cmux windows (only the popup should appear).              │
+// │    • We switch back to .regular on hide so the dock icon works.        │
+// │                                                                         │
+// │ 2. WINDOW VISIBILITY                                                   │
+// │    • On show: we orderOut all non-NSPanel windows. This hides regular  │
+// │      terminal windows so only the popup is visible. We do NOT restore  │
+// │      them on hide — the user gets them back via the dock icon.         │
+// │    • The popup panel uses .transient + .ignoresCycle collection        │
+// │      behavior so macOS won't restore it on dock click or Cmd+`.       │
+// │                                                                         │
+// │ 3. FOCUS RESTORATION                                                   │
+// │    • On show: we record which app was frontmost (previousApp).         │
+// │    • On hide: if previousApp exists, activate it. If cmux was          │
+// │      already focused (previousApp is nil), call NSApp.hide to          │
+// │      fully deactivate.                                                 │
+// │                                                                         │
+// │ Key invariant: F10 always toggles ONLY the popup. Regular windows      │
+// │ are hidden as a side effect of show but never restored by hide.        │
+// └──────────────────────────────────────────────────────────────────────────┘
+
+/// Singleton controller managing the popup terminal panel.
+@MainActor
+final class PopupTerminalController: NSObject {
+
+    // MARK: - Singleton
+
+    static let shared = PopupTerminalController()
+
+    // MARK: - Private state
+
+    private var panel: NSPanel?
+    private var deactivationObserver: NSObjectProtocol?
+    private(set) var isVisible = false
+    private var isAnimating = false
+
+    /// The app that was frontmost before the popup was shown.
+    /// nil means cmux itself was focused — hide() uses this to decide
+    /// whether to activate another app or fully deactivate cmux.
+    private var previousApp: NSRunningApplication?
+
+    // MARK: - Init
+
+    private override init() {
+        super.init()
+    }
+
+    // MARK: - Public API
+
+    func toggle() {
+        if isAnimating { return }
+        if isVisible {
+            hide()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        isAnimating = true
+        let panel = getOrCreatePanel()
+
+        let targetFrame = computeTargetFrame()
+        let offscreenFrame = computeOffscreenFrame(for: targetFrame)
+
+        if !isVisible {
+            panel.setFrame(offscreenFrame, display: false)
+        }
+
+        capturePreviousApp()
+        hideRegularWindows(excluding: panel)
+        activatePopup(panel)
+
+        isVisible = true
+
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = PopupTerminalSettings.animationDuration
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().setFrame(targetFrame, display: true)
+        }, completionHandler: { [weak self] in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.isAnimating = false
+                self.installFocusLossObserver()
+            }
+        })
+    }
+
+    func hide() {
+        guard let panel, isVisible else { return }
+
+        isVisible = false
+        removeFocusLossObserver()
+
+        let appToRestore = previousApp
+        previousApp = nil
+
+        // Order out immediately — no animation on hide. This prevents the
+        // panel from reappearing if the user clicks the dock icon.
+        panel.orderOut(nil)
+
+        restoreFocus(to: appToRestore)
+    }
+
+    func reposition() {
+        guard let panel, isVisible else { return }
+        let targetFrame = computeTargetFrame()
+        panel.setFrame(targetFrame, display: true)
+    }
+
+    // MARK: - Show/hide helpers
+
+    /// Record which app was frontmost so we can restore it on hide.
+    /// If cmux is already frontmost, leaves previousApp as nil so hide()
+    /// knows to fully deactivate instead.
+    private func capturePreviousApp() {
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        if frontmost?.bundleIdentifier != Bundle.main.bundleIdentifier {
+            previousApp = frontmost
+        }
+    }
+
+    /// Hide all regular (non-panel) cmux windows. These stay hidden until
+    /// the user clicks the dock icon — hide() intentionally does not
+    /// restore them, keeping the popup fully independent.
+    private func hideRegularWindows(excluding popup: NSPanel) {
+        for window in NSApp.windows where window !== popup {
+            if window.isVisible && !(window is NSPanel) {
+                window.orderOut(nil)
+            }
+        }
+    }
+
+    /// Switch to accessory policy (hides from menu bar/Dock), then
+    /// activate the app and make the popup key. The popup's .floating
+    /// level keeps it above everything.
+    private func activatePopup(_ panel: NSPanel) {
+        NSApp.setActivationPolicy(.accessory)
+        panel.orderFrontRegardless()
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    /// Restore activation policy to .regular (so dock icon works) and
+    /// hand focus back. If another app was focused before, activate it.
+    /// If cmux was focused before, fully deactivate via NSApp.hide.
+    private func restoreFocus(to appToRestore: NSRunningApplication?) {
+        NSApp.setActivationPolicy(.regular)
+
+        if let appToRestore {
+            appToRestore.activate()
+        } else {
+            NSApp.hide(nil)
+        }
+    }
+
+    // MARK: - Panel lifecycle
+
+    private func getOrCreatePanel() -> NSPanel {
+        if let existing = panel {
+            return existing
+        }
+
+        let windowId = UUID()
+        let tabManager = TabManager()
+        let sidebarState = SidebarState()
+        let sidebarSelectionState = SidebarSelectionState()
+        let notificationStore = TerminalNotificationStore.shared
+
+        guard let appDelegate = AppDelegate.shared else {
+            return panel ?? NSPanel()
+        }
+
+        let root = ContentView(updateViewModel: appDelegate.updateViewModel, windowId: windowId)
+            .environmentObject(tabManager)
+            .environmentObject(notificationStore)
+            .environmentObject(sidebarState)
+            .environmentObject(sidebarSelectionState)
+
+        let targetFrame = computeTargetFrame()
+
+        let newPanel = PopupTerminalPanel(
+            contentRect: targetFrame,
+            styleMask: [
+                .titled,
+                .closable,
+                .resizable,
+                .fullSizeContentView,
+            ],
+            backing: .buffered,
+            defer: false
+        )
+        newPanel.title = ""
+        newPanel.titleVisibility = .hidden
+        newPanel.titlebarAppearsTransparent = true
+        newPanel.isMovableByWindowBackground = false
+        newPanel.isMovable = false
+        newPanel.isFloatingPanel = true
+        newPanel.level = .floating
+        newPanel.hidesOnDeactivate = false
+        // .transient: macOS won't restore this window on dock click.
+        // .ignoresCycle: excluded from Cmd+` window cycling.
+        newPanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient, .ignoresCycle]
+        newPanel.becomesKeyOnlyIfNeeded = false
+        newPanel.contentView = NSHostingView(rootView: root)
+        newPanel.delegate = self
+
+        appDelegate.applyWindowDecorations(to: newPanel)
+
+        panel = newPanel
+        return newPanel
+    }
+
+    // MARK: - Frame computation
+
+    private func targetScreen() -> NSScreen {
+        switch PopupTerminalSettings.screen {
+        case .activeScreen:
+            return NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+                ?? NSScreen.main
+                ?? NSScreen.screens[0]
+        case .primaryScreen:
+            return NSScreen.main ?? NSScreen.screens[0]
+        }
+    }
+
+    private func computeTargetFrame() -> NSRect {
+        let screen = targetScreen()
+        return PopupTerminalSettings.computeTargetFrame(
+            position: PopupTerminalSettings.position,
+            widthPercent: PopupTerminalSettings.widthPercent,
+            heightPercent: PopupTerminalSettings.heightPercent,
+            visibleFrame: screen.visibleFrame
+        )
+    }
+
+    private func computeOffscreenFrame(for targetFrame: NSRect) -> NSRect {
+        let screen = targetScreen()
+        return PopupTerminalSettings.computeOffscreenFrame(
+            for: targetFrame,
+            position: PopupTerminalSettings.position,
+            screenFrame: screen.frame
+        )
+    }
+
+    // MARK: - Auto-hide on focus loss
+
+    private func installFocusLossObserver() {
+        guard PopupTerminalSettings.autoHideOnFocusLoss else { return }
+        removeFocusLossObserver()
+
+        // didResignActiveNotification fires only when the user switches
+        // to another app (not on intra-app focus changes).
+        deactivationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                self.hide()
+            }
+        }
+    }
+
+    private func removeFocusLossObserver() {
+        if let observer = deactivationObserver {
+            NotificationCenter.default.removeObserver(observer)
+            deactivationObserver = nil
+        }
+    }
+}
+
+// MARK: - NSWindowDelegate
+
+extension PopupTerminalController: NSWindowDelegate {
+    nonisolated func windowWillClose(_ notification: Notification) {
+        Task { @MainActor in
+            self.removeFocusLossObserver()
+            self.panel = nil
+            self.isVisible = false
+        }
+    }
+}
+
+// MARK: - Panel subclass
+
+private class PopupTerminalPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}

--- a/Sources/PopupTerminalController.swift
+++ b/Sources/PopupTerminalController.swift
@@ -99,20 +99,30 @@ final class PopupTerminalController: NSObject {
         })
     }
 
-    func hide() {
+    /// Hide the popup. When `autoHideTriggered` is true (focus loss), we skip
+    /// restoring previousApp because the user already switched to a new app.
+    func hide(autoHideTriggered: Bool = false) {
         guard let panel, isVisible else { return }
 
         isVisible = false
         removeFocusLossObserver()
 
-        let appToRestore = previousApp
+        let appToRestore = autoHideTriggered ? nil : previousApp
         previousApp = nil
 
-        // Order out immediately — no animation on hide. This prevents the
-        // panel from reappearing if the user clicks the dock icon.
+        // Order out immediately — no animation on hide.
         panel.orderOut(nil)
 
         restoreFocus(to: appToRestore)
+    }
+
+    func refreshAutoHideBehavior() {
+        guard isVisible else { return }
+        if PopupTerminalSettings.autoHideOnFocusLoss {
+            installFocusLossObserver()
+        } else {
+            removeFocusLossObserver()
+        }
     }
 
     func reposition() {
@@ -271,7 +281,7 @@ final class PopupTerminalController: NSObject {
         ) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
-                self.hide()
+                self.hide(autoHideTriggered: true)
             }
         }
     }
@@ -288,10 +298,11 @@ final class PopupTerminalController: NSObject {
 
 extension PopupTerminalController: NSWindowDelegate {
     nonisolated func windowWillClose(_ notification: Notification) {
-        Task { @MainActor in
-            self.removeFocusLossObserver()
+        MainActor.assumeIsolated {
+            if self.isVisible {
+                self.hide()
+            }
             self.panel = nil
-            self.isVisible = false
         }
     }
 }

--- a/Sources/PopupTerminalController.swift
+++ b/Sources/PopupTerminalController.swift
@@ -4,18 +4,19 @@ import SwiftUI
 // ┌──────────────────────────────────────────────────────────────────────────┐
 // │ Popup Terminal – Window Management Design Notes                         │
 // │                                                                         │
-// │ The popup is a floating NSPanel that appears over everything via F10.   │
+// │ The popup is a floating NSPanel toggled via a configurable global       │
+// │ hotkey (default: F10), registered through Carbon RegisterEventHotKey.  │
 // │ Getting this right on macOS requires careful coordination of three      │
 // │ AppKit subsystems that interact in non-obvious ways:                    │
 // │                                                                         │
 // │ 1. ACTIVATION POLICY (.accessory vs .regular)                          │
-// │    • .accessory hides the app from menu bar and Dock.                  │
+// │    • .accessory hides the app from Dock and app switcher.              │
 // │    • We switch to .accessory on show so NSApp.activate doesn't raise   │
 // │      regular cmux windows (only the popup should appear).              │
 // │    • We switch back to .regular on hide so the dock icon works.        │
 // │                                                                         │
 // │ 2. WINDOW VISIBILITY                                                   │
-// │    • On show: we orderOut all non-NSPanel windows. This hides regular  │
+// │    • On show: we orderOut all visible non-NSPanel windows. This hides  │
 // │      terminal windows so only the popup is visible. We do NOT restore  │
 // │      them on hide — the user gets them back via the dock icon.         │
 // │    • The popup panel uses .transient + .ignoresCycle collection        │

--- a/Sources/PopupTerminalSettings.swift
+++ b/Sources/PopupTerminalSettings.swift
@@ -1,0 +1,182 @@
+import Foundation
+import SwiftUI
+
+/// Persisted settings for the popup terminal.
+enum PopupTerminalSettings {
+
+    // MARK: - Enums
+
+    enum Position: String, CaseIterable, Identifiable {
+        case top, bottom, left, right
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .top: return String(localized: "popupTerminal.position.top", defaultValue: "Pin to top")
+            case .bottom: return String(localized: "popupTerminal.position.bottom", defaultValue: "Pin to bottom")
+            case .left: return String(localized: "popupTerminal.position.left", defaultValue: "Pin to left")
+            case .right: return String(localized: "popupTerminal.position.right", defaultValue: "Pin to right")
+            }
+        }
+
+    }
+
+    enum ScreenSelection: String, CaseIterable, Identifiable {
+        case activeScreen
+        case primaryScreen
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .activeScreen: return String(localized: "popupTerminal.screen.active", defaultValue: "Active Screen")
+            case .primaryScreen: return String(localized: "popupTerminal.screen.primary", defaultValue: "Primary Screen")
+            }
+        }
+    }
+
+    // MARK: - UserDefaults keys
+
+    static let enabledKey = "popupTerminal.enabled"
+    static let positionKey = "popupTerminal.position"
+    static let screenKey = "popupTerminal.screen"
+    static let widthPercentKey = "popupTerminal.widthPercent"
+    static let heightPercentKey = "popupTerminal.heightPercent"
+    static let autoHideOnFocusLossKey = "popupTerminal.autoHideOnFocusLoss"
+    static let animationDurationKey = "popupTerminal.animationDuration"
+
+    // MARK: - Defaults
+
+    static let defaultEnabled = true
+    static let defaultPosition = Position.top
+    static let defaultScreen = ScreenSelection.activeScreen
+    static let defaultWidthPercent: Double = 100
+    static let defaultHeightPercent: Double = 50
+    static let defaultAutoHideOnFocusLoss = true
+    static let defaultAnimationDuration: Double = 0.08
+
+    // MARK: - Accessors
+
+    static var isEnabled: Bool {
+        get { isEnabled(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
+    }
+
+    static var position: Position {
+        get { position(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: positionKey) }
+    }
+
+    static var screen: ScreenSelection {
+        get { screen(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: screenKey) }
+    }
+
+    static var widthPercent: Double {
+        get { widthPercent(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue, forKey: widthPercentKey) }
+    }
+
+    static var heightPercent: Double {
+        get { heightPercent(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue, forKey: heightPercentKey) }
+    }
+
+    static var autoHideOnFocusLoss: Bool {
+        get { autoHideOnFocusLoss(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue, forKey: autoHideOnFocusLossKey) }
+    }
+
+    static var animationDuration: Double {
+        get { animationDuration(defaults: .standard) }
+        set { UserDefaults.standard.set(newValue, forKey: animationDurationKey) }
+    }
+
+    // MARK: - Testable accessors
+
+    static func isEnabled(defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+
+    static func position(defaults: UserDefaults) -> Position {
+        guard let raw = defaults.string(forKey: positionKey) else { return defaultPosition }
+        return Position(rawValue: raw) ?? defaultPosition
+    }
+
+    static func screen(defaults: UserDefaults) -> ScreenSelection {
+        guard let raw = defaults.string(forKey: screenKey) else { return defaultScreen }
+        return ScreenSelection(rawValue: raw) ?? defaultScreen
+    }
+
+    static func widthPercent(defaults: UserDefaults) -> Double {
+        let val = defaults.double(forKey: widthPercentKey)
+        return val > 0 ? val : defaultWidthPercent
+    }
+
+    static func heightPercent(defaults: UserDefaults) -> Double {
+        let val = defaults.double(forKey: heightPercentKey)
+        return val > 0 ? val : defaultHeightPercent
+    }
+
+    static func autoHideOnFocusLoss(defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: autoHideOnFocusLossKey) as? Bool ?? defaultAutoHideOnFocusLoss
+    }
+
+    static func animationDuration(defaults: UserDefaults) -> Double {
+        let val = defaults.double(forKey: animationDurationKey)
+        return val > 0 ? val : defaultAnimationDuration
+    }
+
+    // MARK: - Frame computation (pure, testable)
+
+    static func computeTargetFrame(
+        position: Position,
+        widthPercent: Double,
+        heightPercent: Double,
+        visibleFrame: NSRect
+    ) -> NSRect {
+        let widthFraction = max(0.1, min(1.0, widthPercent / 100.0))
+        let heightFraction = max(0.1, min(1.0, heightPercent / 100.0))
+
+        let panelWidth = visibleFrame.width * widthFraction
+        let panelHeight = visibleFrame.height * heightFraction
+
+        switch position {
+        case .top:
+            let x = visibleFrame.minX + (visibleFrame.width - panelWidth) / 2
+            let y = visibleFrame.maxY - panelHeight
+            return NSRect(x: x, y: y, width: panelWidth, height: panelHeight)
+
+        case .bottom:
+            let x = visibleFrame.minX + (visibleFrame.width - panelWidth) / 2
+            let y = visibleFrame.minY
+            return NSRect(x: x, y: y, width: panelWidth, height: panelHeight)
+
+        case .left:
+            let x = visibleFrame.minX
+            let y = visibleFrame.minY + (visibleFrame.height - panelHeight) / 2
+            return NSRect(x: x, y: y, width: panelWidth, height: panelHeight)
+
+        case .right:
+            let x = visibleFrame.maxX - panelWidth
+            let y = visibleFrame.minY + (visibleFrame.height - panelHeight) / 2
+            return NSRect(x: x, y: y, width: panelWidth, height: panelHeight)
+        }
+    }
+
+    static func computeOffscreenFrame(
+        for targetFrame: NSRect,
+        position: Position,
+        screenFrame: NSRect
+    ) -> NSRect {
+        switch position {
+        case .top:
+            return targetFrame.offsetBy(dx: 0, dy: targetFrame.height)
+        case .bottom:
+            return targetFrame.offsetBy(dx: 0, dy: -targetFrame.height)
+        case .left:
+            return targetFrame.offsetBy(dx: -(targetFrame.maxX - screenFrame.minX), dy: 0)
+        case .right:
+            return targetFrame.offsetBy(dx: screenFrame.maxX - targetFrame.minX, dy: 0)
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2236,6 +2236,9 @@ class TerminalController {
             "browser.input_mouse",
             "browser.input_keyboard",
             "browser.input_touch",
+            "popup-terminal.toggle",
+            "popup-terminal.show",
+            "popup-terminal.hide",
         ]
 #if DEBUG
         methods.append(contentsOf: [

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1992,6 +1992,14 @@ class TerminalController {
         case "browser.input_touch":
             return v2Result(id: id, self.v2BrowserInputTouch(params: params))
 
+        // Popup terminal
+        case "popup-terminal.toggle":
+            return v2Result(id: id, self.v2PopupTerminalToggle(params: params))
+        case "popup-terminal.show":
+            return v2Result(id: id, self.v2PopupTerminalShow(params: params))
+        case "popup-terminal.hide":
+            return v2Result(id: id, self.v2PopupTerminalHide(params: params))
+
         // Markdown
         case "markdown.open":
             return v2Result(id: id, self.v2MarkdownOpen(params: params))
@@ -2859,6 +2867,23 @@ class TerminalController {
                 "window_id": windowId.uuidString,
                 "window_ref": v2Ref(kind: .window, uuid: windowId)
             ])
+    }
+
+    // MARK: - V2 Popup Terminal Methods
+
+    private func v2PopupTerminalToggle(params _: [String: Any]) -> V2CallResult {
+        v2MainSync { PopupTerminalController.shared.toggle() }
+        return .ok(["visible": v2MainSync { PopupTerminalController.shared.isVisible }])
+    }
+
+    private func v2PopupTerminalShow(params _: [String: Any]) -> V2CallResult {
+        v2MainSync { PopupTerminalController.shared.show() }
+        return .ok(["visible": true])
+    }
+
+    private func v2PopupTerminalHide(params _: [String: Any]) -> V2CallResult {
+        v2MainSync { PopupTerminalController.shared.hide() }
+        return .ok(["visible": false])
     }
 
     // MARK: - V2 Workspace Methods

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3503,6 +3503,13 @@ struct SettingsView: View {
         .onChange(of: popupScreen) { _ in PopupTerminalController.shared.reposition() }
         .onChange(of: popupWidth) { _ in PopupTerminalController.shared.reposition() }
         .onChange(of: popupHeight) { _ in PopupTerminalController.shared.reposition() }
+        .onChange(of: popupAutoHide) { _ in PopupTerminalController.shared.refreshAutoHideBehavior() }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            // Re-register hotkey when the popup shortcut changes in ShortcutSettingRow.
+            // This fires on any UserDefaults change but registerPopupTerminalHotKey is
+            // idempotent (unregister + register), so the cost is negligible.
+            AppDelegate.shared?.registerPopupTerminalHotKey()
+        }
     }
 
     var body: some View {
@@ -4575,6 +4582,14 @@ struct SettingsView: View {
         socketPasswordDraft = ""
         socketPasswordStatusMessage = nil
         socketPasswordStatusIsError = false
+        popupEnabled = PopupTerminalSettings.defaultEnabled
+        popupPosition = PopupTerminalSettings.defaultPosition.rawValue
+        popupScreen = PopupTerminalSettings.defaultScreen.rawValue
+        popupWidth = PopupTerminalSettings.defaultWidthPercent
+        popupHeight = PopupTerminalSettings.defaultHeightPercent
+        popupAutoHide = PopupTerminalSettings.defaultAutoHideOnFocusLoss
+        AppDelegate.shared?.registerPopupTerminalHotKey()
+        PopupTerminalController.shared.reposition()
         KeyboardShortcutSettings.resetAll()
         WorkspaceTabColorSettings.reset()
         reloadWorkspaceTabColorSettings()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3103,6 +3103,7 @@ struct SettingsView: View {
     @AppStorage(PopupTerminalSettings.widthPercentKey) private var popupWidth = PopupTerminalSettings.defaultWidthPercent
     @AppStorage(PopupTerminalSettings.heightPercentKey) private var popupHeight = PopupTerminalSettings.defaultHeightPercent
     @AppStorage(PopupTerminalSettings.autoHideOnFocusLossKey) private var popupAutoHide = PopupTerminalSettings.defaultAutoHideOnFocusLoss
+    @State private var popupShortcut = KeyboardShortcutSettings.shortcut(for: .togglePopupTerminal)
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @State private var shortcutResetToken = UUID()
     @State private var topBlurOpacity: Double = 0
@@ -3505,10 +3506,11 @@ struct SettingsView: View {
         .onChange(of: popupHeight) { _ in PopupTerminalController.shared.reposition() }
         .onChange(of: popupAutoHide) { _ in PopupTerminalController.shared.refreshAutoHideBehavior() }
         .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
-            // Re-register hotkey when the popup shortcut changes in ShortcutSettingRow.
-            // This fires on any UserDefaults change but registerPopupTerminalHotKey is
-            // idempotent (unregister + register), so the cost is negligible.
-            AppDelegate.shared?.registerPopupTerminalHotKey()
+            let latest = KeyboardShortcutSettings.shortcut(for: .togglePopupTerminal)
+            if latest != popupShortcut {
+                popupShortcut = latest
+                AppDelegate.shared?.registerPopupTerminalHotKey()
+            }
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3097,6 +3097,12 @@ struct SettingsView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
+    @AppStorage(PopupTerminalSettings.enabledKey) private var popupEnabled = PopupTerminalSettings.defaultEnabled
+    @AppStorage(PopupTerminalSettings.positionKey) private var popupPosition = PopupTerminalSettings.defaultPosition.rawValue
+    @AppStorage(PopupTerminalSettings.screenKey) private var popupScreen = PopupTerminalSettings.defaultScreen.rawValue
+    @AppStorage(PopupTerminalSettings.widthPercentKey) private var popupWidth = PopupTerminalSettings.defaultWidthPercent
+    @AppStorage(PopupTerminalSettings.heightPercentKey) private var popupHeight = PopupTerminalSettings.defaultHeightPercent
+    @AppStorage(PopupTerminalSettings.autoHideOnFocusLossKey) private var popupAutoHide = PopupTerminalSettings.defaultAutoHideOnFocusLoss
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @State private var shortcutResetToken = UUID()
     @State private var topBlurOpacity: Double = 0
@@ -3433,6 +3439,70 @@ struct SettingsView: View {
             socketPasswordStatusMessage = String(localized: "settings.automation.socketPassword.clearFailed", defaultValue: "Failed to clear password (\(error.localizedDescription)).")
             socketPasswordStatusIsError = true
         }
+    }
+
+    @ViewBuilder
+    private var popupTerminalSettingsSection: some View {
+        SettingsSectionHeader(title: String(localized: "settings.section.popupTerminal", defaultValue: "Popup Terminal"))
+
+        SettingsCard {
+            VStack(spacing: 0) {
+                SettingsCardRow(String(localized: "popupTerminal.settings.enabled", defaultValue: "Enable popup terminal")) {
+                    Toggle("", isOn: $popupEnabled)
+                        .labelsHidden()
+                }
+
+                SettingsCardDivider()
+
+                ShortcutSettingRow(action: .togglePopupTerminal)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+
+                SettingsCardDivider()
+
+                SettingsPickerRow(String(localized: "popupTerminal.settings.position", defaultValue: "Position"), controlWidth: 160, selection: $popupPosition) {
+                    ForEach(PopupTerminalSettings.Position.allCases) { pos in
+                        Text(pos.label).tag(pos.rawValue)
+                    }
+                }
+
+                SettingsCardDivider()
+
+                SettingsPickerRow(String(localized: "popupTerminal.settings.screen", defaultValue: "Screen"), controlWidth: 160, selection: $popupScreen) {
+                    ForEach(PopupTerminalSettings.ScreenSelection.allCases) { sel in
+                        Text(sel.label).tag(sel.rawValue)
+                    }
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(String(localized: "popupTerminal.settings.widthPercent", defaultValue: "Width %")) {
+                    TextField("", value: $popupWidth, format: .number)
+                        .frame(width: 60)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(String(localized: "popupTerminal.settings.heightPercent", defaultValue: "Height %")) {
+                    TextField("", value: $popupHeight, format: .number)
+                        .frame(width: 60)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(String(localized: "popupTerminal.settings.autoHide", defaultValue: "Auto-hide on focus loss")) {
+                    Toggle("", isOn: $popupAutoHide)
+                        .labelsHidden()
+                }
+            }
+        }
+        .onChange(of: popupEnabled) { _ in AppDelegate.shared?.registerPopupTerminalHotKey() }
+        .onChange(of: popupPosition) { _ in PopupTerminalController.shared.reposition() }
+        .onChange(of: popupScreen) { _ in PopupTerminalController.shared.reposition() }
+        .onChange(of: popupWidth) { _ in PopupTerminalController.shared.reposition() }
+        .onChange(of: popupHeight) { _ in PopupTerminalController.shared.reposition() }
     }
 
     var body: some View {
@@ -4254,6 +4324,8 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                         .padding(.leading, 2)
                         .accessibilityIdentifier("ShortcutRecordingHint")
+
+                    popupTerminalSettingsSection
 
                     SettingsSectionHeader(title: String(localized: "settings.section.reset", defaultValue: "Reset"))
                     SettingsCard {

--- a/cmuxTests/PopupTerminalSettingsTests.swift
+++ b/cmuxTests/PopupTerminalSettingsTests.swift
@@ -1,0 +1,279 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class PopupTerminalSettingsTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "PopupTerminalSettingsTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Default values
+
+    func testDefaultsReturnExpectedValuesWhenNothingIsSet() {
+        XCTAssertTrue(PopupTerminalSettings.isEnabled(defaults: defaults))
+        XCTAssertEqual(PopupTerminalSettings.position(defaults: defaults), .top)
+        XCTAssertEqual(PopupTerminalSettings.screen(defaults: defaults), .activeScreen)
+        XCTAssertEqual(PopupTerminalSettings.widthPercent(defaults: defaults), 100)
+        XCTAssertEqual(PopupTerminalSettings.heightPercent(defaults: defaults), 50)
+        XCTAssertTrue(PopupTerminalSettings.autoHideOnFocusLoss(defaults: defaults))
+        XCTAssertEqual(PopupTerminalSettings.animationDuration(defaults: defaults), 0.08)
+    }
+
+    // MARK: - Bool round-trips
+
+    func testIsEnabledPersistsValue() {
+        defaults.set(false, forKey: PopupTerminalSettings.enabledKey)
+        XCTAssertFalse(PopupTerminalSettings.isEnabled(defaults: defaults))
+
+        defaults.set(true, forKey: PopupTerminalSettings.enabledKey)
+        XCTAssertTrue(PopupTerminalSettings.isEnabled(defaults: defaults))
+    }
+
+    func testAutoHideOnFocusLossPersistsValue() {
+        defaults.set(false, forKey: PopupTerminalSettings.autoHideOnFocusLossKey)
+        XCTAssertFalse(PopupTerminalSettings.autoHideOnFocusLoss(defaults: defaults))
+
+        defaults.set(true, forKey: PopupTerminalSettings.autoHideOnFocusLossKey)
+        XCTAssertTrue(PopupTerminalSettings.autoHideOnFocusLoss(defaults: defaults))
+    }
+
+    // MARK: - Enum round-trips
+
+    func testPositionPersistsAllCases() {
+        for position in PopupTerminalSettings.Position.allCases {
+            defaults.set(position.rawValue, forKey: PopupTerminalSettings.positionKey)
+            XCTAssertEqual(PopupTerminalSettings.position(defaults: defaults), position)
+        }
+    }
+
+    func testPositionFallsBackToDefaultForInvalidRawValue() {
+        defaults.set("diagonal", forKey: PopupTerminalSettings.positionKey)
+        XCTAssertEqual(PopupTerminalSettings.position(defaults: defaults), .top)
+    }
+
+    func testScreenSelectionPersistsAllCases() {
+        for screen in PopupTerminalSettings.ScreenSelection.allCases {
+            defaults.set(screen.rawValue, forKey: PopupTerminalSettings.screenKey)
+            XCTAssertEqual(PopupTerminalSettings.screen(defaults: defaults), screen)
+        }
+    }
+
+    func testScreenSelectionFallsBackToDefaultForInvalidRawValue() {
+        defaults.set("thirdMonitor", forKey: PopupTerminalSettings.screenKey)
+        XCTAssertEqual(PopupTerminalSettings.screen(defaults: defaults), .activeScreen)
+    }
+
+    // MARK: - Double round-trips
+
+    func testWidthPercentPersistsValue() {
+        defaults.set(75.0, forKey: PopupTerminalSettings.widthPercentKey)
+        XCTAssertEqual(PopupTerminalSettings.widthPercent(defaults: defaults), 75.0)
+    }
+
+    func testHeightPercentPersistsValue() {
+        defaults.set(30.0, forKey: PopupTerminalSettings.heightPercentKey)
+        XCTAssertEqual(PopupTerminalSettings.heightPercent(defaults: defaults), 30.0)
+    }
+
+    func testAnimationDurationPersistsValue() {
+        defaults.set(0.2, forKey: PopupTerminalSettings.animationDurationKey)
+        XCTAssertEqual(PopupTerminalSettings.animationDuration(defaults: defaults), 0.2)
+    }
+
+    func testZeroDoubleFallsBackToDefault() {
+        defaults.set(0.0, forKey: PopupTerminalSettings.widthPercentKey)
+        XCTAssertEqual(PopupTerminalSettings.widthPercent(defaults: defaults), 100)
+
+        defaults.set(0.0, forKey: PopupTerminalSettings.heightPercentKey)
+        XCTAssertEqual(PopupTerminalSettings.heightPercent(defaults: defaults), 50)
+
+        defaults.set(0.0, forKey: PopupTerminalSettings.animationDurationKey)
+        XCTAssertEqual(PopupTerminalSettings.animationDuration(defaults: defaults), 0.08)
+    }
+
+    // MARK: - Enum labels
+
+    func testPositionLabelsAreNonEmpty() {
+        for position in PopupTerminalSettings.Position.allCases {
+            XCTAssertFalse(position.label.isEmpty, "\(position) has empty label")
+        }
+    }
+
+    func testScreenSelectionLabelsAreNonEmpty() {
+        for screen in PopupTerminalSettings.ScreenSelection.allCases {
+            XCTAssertFalse(screen.label.isEmpty, "\(screen) has empty label")
+        }
+    }
+}
+
+// MARK: - Frame computation tests
+
+final class PopupTerminalFrameComputationTests: XCTestCase {
+
+    /// A 1920x1080 visible frame starting at (0, 0).
+    private let standardScreen = NSRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    /// A screen offset from origin (e.g. secondary monitor).
+    private let offsetScreen = NSRect(x: 1920, y: 200, width: 1440, height: 900)
+
+    // MARK: - Target frame positions
+
+    func testTopPositionFramePinsToTopCenter() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 100, heightPercent: 50,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 1920)
+        XCTAssertEqual(frame.height, 540)
+        XCTAssertEqual(frame.minX, 0)
+        XCTAssertEqual(frame.maxY, 1080)
+    }
+
+    func testBottomPositionFramePinsToBottomCenter() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .bottom, widthPercent: 100, heightPercent: 50,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 1920)
+        XCTAssertEqual(frame.height, 540)
+        XCTAssertEqual(frame.minX, 0)
+        XCTAssertEqual(frame.minY, 0)
+    }
+
+    func testLeftPositionFramePinsToLeftCenter() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .left, widthPercent: 50, heightPercent: 100,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 960)
+        XCTAssertEqual(frame.height, 1080)
+        XCTAssertEqual(frame.minX, 0)
+        XCTAssertEqual(frame.midY, 540, accuracy: 1)
+    }
+
+    func testRightPositionFramePinsToRightCenter() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .right, widthPercent: 50, heightPercent: 100,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 960)
+        XCTAssertEqual(frame.height, 1080)
+        XCTAssertEqual(frame.maxX, 1920)
+        XCTAssertEqual(frame.midY, 540, accuracy: 1)
+    }
+
+    // MARK: - Centering with partial width
+
+    func testTopPositionCentersHorizontallyWithPartialWidth() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 80, heightPercent: 50,
+            visibleFrame: standardScreen
+        )
+        let expectedWidth = 1920 * 0.8
+        XCTAssertEqual(frame.width, expectedWidth, accuracy: 0.01)
+        XCTAssertEqual(frame.midX, 960, accuracy: 0.01)
+    }
+
+    // MARK: - Offset screen
+
+    func testTargetFrameRespectsScreenOffset() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 100, heightPercent: 50,
+            visibleFrame: offsetScreen
+        )
+        XCTAssertEqual(frame.minX, 1920)
+        XCTAssertEqual(frame.maxY, 1100)
+        XCTAssertEqual(frame.width, 1440)
+        XCTAssertEqual(frame.height, 450)
+    }
+
+    // MARK: - Percentage clamping
+
+    func testWidthPercentClampedToMinimum10Percent() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 1, heightPercent: 50,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 1920 * 0.1, accuracy: 0.01)
+    }
+
+    func testHeightPercentClampedToMinimum10Percent() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 50, heightPercent: 5,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.height, 1080 * 0.1, accuracy: 0.01)
+    }
+
+    func testPercentAbove100ClampedTo100() {
+        let frame = PopupTerminalSettings.computeTargetFrame(
+            position: .top, widthPercent: 200, heightPercent: 150,
+            visibleFrame: standardScreen
+        )
+        XCTAssertEqual(frame.width, 1920)
+        XCTAssertEqual(frame.height, 1080)
+    }
+
+    // MARK: - Offscreen frame computation
+
+    func testTopOffscreenFrameMovesAboveScreen() {
+        let target = NSRect(x: 0, y: 540, width: 1920, height: 540)
+        let offscreen = PopupTerminalSettings.computeOffscreenFrame(
+            for: target, position: .top, screenFrame: standardScreen
+        )
+        XCTAssertEqual(offscreen.minY, target.minY + target.height)
+        XCTAssertGreaterThanOrEqual(offscreen.minY, standardScreen.maxY)
+    }
+
+    func testBottomOffscreenFrameMovesBelow() {
+        let target = NSRect(x: 0, y: 0, width: 1920, height: 540)
+        let offscreen = PopupTerminalSettings.computeOffscreenFrame(
+            for: target, position: .bottom, screenFrame: standardScreen
+        )
+        XCTAssertEqual(offscreen.maxY, 0)
+    }
+
+    func testLeftOffscreenFrameMovesOffLeft() {
+        let target = NSRect(x: 0, y: 0, width: 960, height: 1080)
+        let offscreen = PopupTerminalSettings.computeOffscreenFrame(
+            for: target, position: .left, screenFrame: standardScreen
+        )
+        XCTAssertLessThanOrEqual(offscreen.maxX, standardScreen.minX)
+    }
+
+    func testRightOffscreenFrameMovesOffRight() {
+        let target = NSRect(x: 960, y: 0, width: 960, height: 1080)
+        let offscreen = PopupTerminalSettings.computeOffscreenFrame(
+            for: target, position: .right, screenFrame: standardScreen
+        )
+        XCTAssertGreaterThanOrEqual(offscreen.minX, standardScreen.maxX)
+    }
+
+    func testOffscreenFramePreservesSize() {
+        for position in PopupTerminalSettings.Position.allCases {
+            let target = NSRect(x: 100, y: 100, width: 800, height: 600)
+            let offscreen = PopupTerminalSettings.computeOffscreenFrame(
+                for: target, position: position, screenFrame: standardScreen
+            )
+            XCTAssertEqual(offscreen.width, target.width, "\(position) changed width")
+            XCTAssertEqual(offscreen.height, target.height, "\(position) changed height")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hey all. I wanted to build this feature because it was the only thing keeping me from switching to cmux.

What it does is add a global hotkey popup terminal, similar to what Guake on Linux and Warp on macOS offer. Press F10 from anywhere (even when cmux isn't focused) and a terminal slides in from the top of the screen. Press F10 again and it slides away, restoring focus to whatever app you were using before.

### How it works

- Uses the Carbon `RegisterEventHotKey` API to capture the hotkey globally. This is the same approach macOS apps like Warp use, and it doesn't require Accessibility or Input Monitoring permissions.
- The popup is an `NSPanel` with `.floating` level that appears above all other windows. When shown, cmux switches to `.accessory` activation policy so it doesn't appear in the Dock or app switcher.
- Regular cmux windows are hidden when the popup appears and stay hidden when it dismisses. They come back when you click the dock icon. This keeps the popup fully independent from normal windows.
- If another app was focused before F10, that app regains focus on hide. If cmux was focused, the app fully deactivates.
- Auto-hides when you switch to another app (configurable).
- The panel uses `.transient` and `.ignoresCycle` collection behavior so it won't reappear on dock click or Cmd+` cycling.

### Settings

All configurable in Preferences:

- **Position**: top, bottom, left, or right edge
- **Screen**: active screen (follows mouse) or primary screen
- **Width/Height**: percentage of screen (10%-100%)
- **Auto-hide on focus loss**: on/off
- **Keyboard shortcut**: F10 by default, remappable to any function key with optional modifiers
- **Animation duration**: 80ms default

### What's included

- `PopupTerminalController` - singleton managing the panel lifecycle, activation policy, and focus restoration. Includes design notes documenting the three AppKit subsystems that interact and why each step is needed.
- `PopupTerminalSettings` - UserDefaults-backed settings with testable accessors (accept injected `UserDefaults`) and pure frame computation functions extracted for unit testing
- Carbon hotkey registration in `AppDelegate`
- Settings UI in Preferences (matches existing patterns with `SettingsCardRow`, `SettingsPickerRow`, `ShortcutSettingRow`)
- Socket commands: `popup-terminal.toggle`, `popup-terminal.show`, `popup-terminal.hide`
- CLI commands: `popup-terminal-toggle`, `popup-terminal-show`, `popup-terminal-hide`
- Unit tests for settings persistence, enum fallbacks, zero-value defaults, and frame computation for all four positions

## Testing

- Tested locally on macOS with `./scripts/reload.sh --tag popup-terminal`
- Verified all manual test scenarios below
- Unit tests pass (`xcodebuild -scheme cmux-unit`)

### Manual test plan

- [ ] Press F10 with cmux unfocused: popup should appear and receive keyboard focus
- [ ] Press F10 again: popup should slide away, previous app regains focus
- [ ] With cmux window focused, press F10: regular window hides, popup appears
- [ ] Press F10 again: popup hides, cmux fully deactivates (no windows visible)
- [ ] Press F10 a third time: only popup appears (regular window stays hidden)
- [ ] Click dock icon after hiding popup: regular cmux window comes back
- [ ] Click on another app while popup is visible: popup auto-hides
- [ ] Change position in settings: popup slides from new edge
- [ ] Change shortcut in settings: new shortcut works globally
- [ ] Disable popup terminal in settings: hotkey stops working

## Demo Video

- Video URL or attachment:

https://github.com/user-attachments/assets/96d29710-3208-4669-a76c-b3a1910e80b2



## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global popup terminal toggled by F10 (or any remapped key) that slides in from any screen edge and stays independent of normal windows. Includes Preferences, socket/CLI commands, tests, and fixes for focus and hotkey behavior.

- **New Features**
  - Global hotkey via Carbon `RegisterEventHotKey` (default F10; remappable to any key with optional modifiers; F-keys allowed without modifiers; no Accessibility/Input Monitoring). Logs registration failures.
  - Floating `NSPanel` above all apps; app switches to `.accessory` on show and back on hide. Regular windows hide on show and aren’t restored by the hotkey; focus returns to the previous app on hide. Optional auto-hide on app switch.
  - Preferences: position (top/bottom/left/right), screen (active/primary), width/height %, auto-hide, enable/disable. Live repositioning and auto-hide updates; included in Reset All.
  - API/CLI: socket `popup-terminal.toggle|show|hide` and CLI `popup-terminal-toggle|show|hide`. Shortcut handling adds keycode matching for function/special keys and supports non‑F keys. Unit tests for settings persistence and frame computation.

- **Bug Fixes**
  - Auto-hide on focus loss no longer restores focus to the wrong app (skips restore when auto-hide triggers).
  - Closing the panel (e.g., Cmd+W) now restores activation policy and focus by routing through `hide()`.
  - Global hotkey now re-registers only when the popup shortcut actually changes (and when enable/disable toggles); CLI help entries and capabilities list updated.

<sup>Written for commit 03230a239a08b4567f488a149b78ae5cfd96282b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popup terminal: show/hide/toggle panel with animations, focus restoration, and repositioning.

* **Settings**
  * Configurable popup: enable/disable, position, target screen, size, animation duration, auto-hide on app switch; integrated into Settings UI and reset flow.

* **Keyboard Shortcuts**
  * Global hotkey support (default F10) with function-key handling and lifecycle management.

* **CLI**
  * New commands: popup-terminal-toggle, popup-terminal-show, popup-terminal-hide.

* **Tests**
  * Comprehensive unit tests for settings persistence and frame computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->