### PR TITLE
Defer portal geometry sync out of layout passes

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8037,6 +8037,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         var onGeometryChanged: (() -> Void)?
         private(set) var geometryRevision: UInt64 = 0
         private var lastReportedGeometryState: GeometryState?
+        private var geometryChangedWorkItem: DispatchWorkItem?
 
         private struct GeometryState: Equatable {
             let frame: CGRect
@@ -8059,7 +8060,18 @@ struct GhosttyTerminalView: NSViewRepresentable {
             guard state != lastReportedGeometryState else { return }
             lastReportedGeometryState = state
             geometryRevision &+= 1
-            onGeometryChanged?()
+            geometryChangedWorkItem?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.geometryChangedWorkItem = nil
+                self.onGeometryChanged?()
+            }
+            geometryChangedWorkItem = workItem
+            DispatchQueue.main.async(execute: workItem)
+        }
+
+        deinit {
+            geometryChangedWorkItem?.cancel()
         }
 
         override func viewDidMoveToWindow() {
@@ -8099,6 +8111,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
         var lastBoundHostId: ObjectIdentifier?
         var lastPaneDropZone: DropZone?
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
+        var pendingGeometrySyncRevision: UInt64 = 0
+        var pendingGeometrySyncWorkItem: DispatchWorkItem?
         weak var hostedView: GhosttySurfaceScrollView?
     }
 
@@ -8217,40 +8231,27 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
 
-        if let host = hostContainer {
-            host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
+        func scheduleGeometrySynchronize(
+            host: HostContainerView,
+            hostedView: GhosttySurfaceScrollView,
+            coordinator: Coordinator
+        ) {
+            let targetRevision = host.geometryRevision
+            guard coordinator.lastSynchronizedHostGeometryRevision != targetRevision else { return }
+            coordinator.pendingGeometrySyncWorkItem?.cancel()
+            coordinator.pendingGeometrySyncRevision = targetRevision
+            let workItem = DispatchWorkItem { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }
+                coordinator.pendingGeometrySyncWorkItem = nil
                 guard coordinator.attachGeneration == generation else { return }
+                guard coordinator.pendingGeometrySyncRevision == targetRevision else { return }
                 guard terminalSurface.claimPortalHost(
                     hostId: ObjectIdentifier(host),
                     inWindow: host.window != nil,
                     bounds: host.bounds,
-                    reason: "didMoveToWindow"
+                    reason: "geometryChanged.async"
                 ) else { return }
-                guard host.window != nil else { return }
-                TerminalWindowPortalRegistry.bind(
-                    hostedView: hostedView,
-                    to: host,
-                    visibleInUI: coordinator.desiredIsVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority,
-                    expectedSurfaceId: portalExpectedSurfaceId,
-                    expectedGeneration: portalExpectedGeneration
-                )
-                coordinator.lastBoundHostId = ObjectIdentifier(host)
-                coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
-                hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
-                hostedView.setActive(coordinator.desiredIsActive)
-                hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
-            }
-            host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
-                guard let host, let hostedView, let coordinator else { return }
-                guard coordinator.attachGeneration == generation else { return }
-                guard terminalSurface.claimPortalHost(
-                    hostId: ObjectIdentifier(host),
-                    inWindow: host.window != nil,
-                    bounds: host.bounds,
-                    reason: "geometryChanged"
-                ) else { return }
+
                 let hostId = ObjectIdentifier(host)
                 if host.window != nil,
                    (coordinator.lastBoundHostId != hostId ||
@@ -8275,8 +8276,46 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     hostedView.setActive(coordinator.desiredIsActive)
                     hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
                 }
+                guard host.window != nil else { return }
                 TerminalWindowPortalRegistry.synchronizeForAnchor(host)
+                coordinator.lastSynchronizedHostGeometryRevision = targetRevision
+            }
+            coordinator.pendingGeometrySyncWorkItem = workItem
+            DispatchQueue.main.async(execute: workItem)
+        }
+
+        if let host = hostContainer {
+            host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
+                guard let host, let hostedView, let coordinator else { return }
+                guard coordinator.attachGeneration == generation else { return }
+                guard terminalSurface.claimPortalHost(
+                    hostId: ObjectIdentifier(host),
+                    inWindow: host.window != nil,
+                    bounds: host.bounds,
+                    reason: "didMoveToWindow"
+                ) else { return }
+                guard host.window != nil else { return }
+                TerminalWindowPortalRegistry.bind(
+                    hostedView: hostedView,
+                    to: host,
+                    visibleInUI: coordinator.desiredIsVisibleInUI,
+                    zPriority: coordinator.desiredPortalZPriority,
+                    expectedSurfaceId: portalExpectedSurfaceId,
+                    expectedGeneration: portalExpectedGeneration
+                )
+                coordinator.lastBoundHostId = ObjectIdentifier(host)
                 coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                coordinator.pendingGeometrySyncWorkItem?.cancel()
+                coordinator.pendingGeometrySyncWorkItem = nil
+                coordinator.pendingGeometrySyncRevision = host.geometryRevision
+                hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
+                hostedView.setActive(coordinator.desiredIsActive)
+                hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+            }
+            host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
+                guard let host, let hostedView, let coordinator else { return }
+                guard coordinator.attachGeneration == generation else { return }
+                scheduleGeometrySynchronize(host: host, hostedView: hostedView, coordinator: coordinator)
             }
 
             if host.window != nil, hostOwnsPortalNow {
@@ -8310,9 +8349,11 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     )
                     coordinator.lastBoundHostId = hostId
                     coordinator.lastSynchronizedHostGeometryRevision = geometryRevision
+                    coordinator.pendingGeometrySyncWorkItem?.cancel()
+                    coordinator.pendingGeometrySyncWorkItem = nil
+                    coordinator.pendingGeometrySyncRevision = geometryRevision
                 } else if coordinator.lastSynchronizedHostGeometryRevision != geometryRevision {
-                    TerminalWindowPortalRegistry.synchronizeForAnchor(host)
-                    coordinator.lastSynchronizedHostGeometryRevision = geometryRevision
+                    scheduleGeometrySynchronize(host: host, hostedView: hostedView, coordinator: coordinator)
                 }
             } else if hostOwnsPortalNow {
                 // Bind is deferred until host moves into a window. Update the
@@ -8371,6 +8412,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.desiredShowsUnreadNotificationRing = false
         coordinator.desiredPortalZPriority = 0
         coordinator.lastBoundHostId = nil
+        coordinator.pendingGeometrySyncWorkItem?.cancel()
+        coordinator.pendingGeometrySyncWorkItem = nil
+        coordinator.pendingGeometrySyncRevision = 0
         let hostedView = coordinator.hostedView
 #if DEBUG
         if let hostedView {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3711,6 +3711,8 @@ struct WebViewRepresentable: NSViewRepresentable {
         var desiredPortalZPriority: Int = 0
         var lastPortalHostId: ObjectIdentifier?
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
+        var pendingGeometrySyncRevision: UInt64 = 0
+        var pendingGeometrySyncWorkItem: DispatchWorkItem?
     }
 
     final class HostContainerView: NSView {
@@ -3739,6 +3741,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         var onGeometryChanged: (() -> Void)?
         private(set) var geometryRevision: UInt64 = 0
         private var lastReportedGeometryState: GeometryState?
+        private var geometryChangedWorkItem: DispatchWorkItem?
         private weak var hostedWebView: WKWebView?
         private var hostedWebViewConstraints: [NSLayoutConstraint] = []
         private weak var localInlineSlotView: WindowBrowserSlotView?
@@ -3803,6 +3806,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
 
         deinit {
+            geometryChangedWorkItem?.cancel()
             hostedInspectorReapplyWorkItem?.cancel()
             hostedInspectorDockConfigurationSyncWorkItem?.cancel()
             if let trackingArea {
@@ -4078,7 +4082,14 @@ struct WebViewRepresentable: NSViewRepresentable {
             guard state != lastReportedGeometryState else { return }
             lastReportedGeometryState = state
             geometryRevision &+= 1
-            onGeometryChanged?()
+            geometryChangedWorkItem?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.geometryChangedWorkItem = nil
+                self.onGeometryChanged?()
+            }
+            geometryChangedWorkItem = workItem
+            DispatchQueue.main.async(execute: workItem)
         }
 
         func ensureLocalInlineSlotView() -> WindowBrowserSlotView {
@@ -5477,6 +5488,56 @@ struct WebViewRepresentable: NSViewRepresentable {
             Self.installPortalAnchorView(portalAnchorView, in: host)
         }
 
+        func schedulePortalSynchronize(
+            host: HostContainerView,
+            webView: WKWebView,
+            coordinator: Coordinator,
+            portalAnchorView: NSView,
+            browserPanel: BrowserPanel
+        ) {
+            let targetRevision = host.geometryRevision
+            guard coordinator.lastSynchronizedHostGeometryRevision != targetRevision else { return }
+            coordinator.pendingGeometrySyncWorkItem?.cancel()
+            coordinator.pendingGeometrySyncRevision = targetRevision
+            let workItem = DispatchWorkItem {
+                coordinator.pendingGeometrySyncWorkItem = nil
+                guard coordinator.attachGeneration == generation else { return }
+                guard coordinator.pendingGeometrySyncRevision == targetRevision else { return }
+                guard currentPaneDropContext()?.paneId.id == paneId.id else { return }
+                guard browserPanel.claimPortalHost(
+                    hostId: ObjectIdentifier(host),
+                    paneId: paneId,
+                    inWindow: host.window != nil,
+                    bounds: host.bounds,
+                    reason: "geometryChanged.async"
+                ) else { return }
+                guard host.window != nil else { return }
+
+                let hostId = ObjectIdentifier(host)
+                Self.installPortalAnchorView(portalAnchorView, in: host)
+                if coordinator.lastPortalHostId != hostId ||
+                   !BrowserWindowPortalRegistry.isWebView(webView, boundTo: portalAnchorView) {
+                    BrowserWindowPortalRegistry.bind(
+                        webView: webView,
+                        to: portalAnchorView,
+                        visibleInUI: coordinator.desiredPortalVisibleInUI,
+                        zPriority: coordinator.desiredPortalZPriority
+                    )
+                    BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
+                        for: webView,
+                        height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
+                    )
+                    BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
+                    BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
+                    coordinator.lastPortalHostId = hostId
+                }
+                BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
+                coordinator.lastSynchronizedHostGeometryRevision = targetRevision
+            }
+            coordinator.pendingGeometrySyncWorkItem = workItem
+            DispatchQueue.main.async(execute: workItem)
+        }
+
         host.onDidMoveToWindow = { [weak host, weak webView, weak coordinator, weak portalAnchorView, weak browserPanel = panel] in
             guard let host, let webView, let coordinator, let portalAnchorView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
@@ -5504,39 +5565,20 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             coordinator.lastPortalHostId = ObjectIdentifier(host)
             coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+            coordinator.pendingGeometrySyncWorkItem?.cancel()
+            coordinator.pendingGeometrySyncWorkItem = nil
+            coordinator.pendingGeometrySyncRevision = host.geometryRevision
         }
         host.onGeometryChanged = { [weak host, weak webView, weak coordinator, weak portalAnchorView, weak browserPanel = panel] in
             guard let host, let webView, let coordinator, let portalAnchorView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
-            guard currentPaneDropContext()?.paneId.id == paneId.id else { return }
-            guard browserPanel.claimPortalHost(
-                hostId: ObjectIdentifier(host),
-                paneId: paneId,
-                inWindow: host.window != nil,
-                bounds: host.bounds,
-                reason: "geometryChanged"
-            ) else { return }
-            guard host.window != nil else { return }
-            let hostId = ObjectIdentifier(host)
-            Self.installPortalAnchorView(portalAnchorView, in: host)
-            if coordinator.lastPortalHostId != hostId ||
-               !BrowserWindowPortalRegistry.isWebView(webView, boundTo: portalAnchorView) {
-                BrowserWindowPortalRegistry.bind(
-                    webView: webView,
-                    to: portalAnchorView,
-                    visibleInUI: coordinator.desiredPortalVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority
-                )
-                BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
-                    for: webView,
-                    height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
-                )
-                BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: activePaneDropContext)
-                BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
-                coordinator.lastPortalHostId = hostId
-            }
-            BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
-            coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+            schedulePortalSynchronize(
+                host: host,
+                webView: webView,
+                coordinator: coordinator,
+                portalAnchorView: portalAnchorView,
+                browserPanel: browserPanel
+            )
         }
 
         if !shouldAttachWebView {
@@ -5566,6 +5608,9 @@ struct WebViewRepresentable: NSViewRepresentable {
                 )
                 coordinator.lastPortalHostId = hostId
                 coordinator.lastSynchronizedHostGeometryRevision = geometryRevision
+                coordinator.pendingGeometrySyncWorkItem?.cancel()
+                coordinator.pendingGeometrySyncWorkItem = nil
+                coordinator.pendingGeometrySyncRevision = geometryRevision
             }
             BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                 for: webView,
@@ -5574,8 +5619,13 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             if !shouldBindNow,
                coordinator.lastSynchronizedHostGeometryRevision != geometryRevision {
-                BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
-                coordinator.lastSynchronizedHostGeometryRevision = geometryRevision
+                schedulePortalSynchronize(
+                    host: host,
+                    webView: webView,
+                    coordinator: coordinator,
+                    portalAnchorView: portalAnchorView,
+                    browserPanel: panel
+                )
             }
         } else if portalHostAccepted {
             // Bind is deferred until host moves into a window. Keep the current
@@ -5735,6 +5785,9 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         coordinator.attachGeneration += 1
+        coordinator.pendingGeometrySyncWorkItem?.cancel()
+        coordinator.pendingGeometrySyncWorkItem = nil
+        coordinator.pendingGeometrySyncRevision = 0
         clearPortalCallbacks(for: nsView)
         if let panel = coordinator.panel, let host = nsView as? HostContainerView {
             panel.releasePortalHostIfOwned(


### PR DESCRIPTION
## Summary
- coalesce terminal portal geometry updates onto the next main-queue turn instead of synchronizing during synchronous layout callbacks
- do the same for browser portal geometry updates so browser and terminal portal hosts stop re-entering SwiftUI/AppKit layout work on every geometry churn
- cancel stale pending portal sync work on rebinding and teardown so only the latest geometry revision is applied

## Testing
- `./scripts/reload.sh --tag task-sentry-portal-layout-hangs`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-sentry-portal-layout-hangs-unit test -only-testing:cmuxTests/TerminalWindowPortalLifecycleTests -only-testing:cmuxTests/BrowserWindowPortalLifecycleTests` (fails in pre-existing portal lifecycle tests)
- baseline check on `task-sentry-socket-listener-fallback` reproduces the same individual failures for `BrowserWindowPortalLifecycleTests.testPortalRevealRefreshesHostedWebViewWithoutFrameDelta()`, `BrowserWindowPortalLifecycleTests.testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind()`, and `TerminalWindowPortalLifecycleTests.testPruneDeadEntriesDetachesAnchorlessHostedView()`

## Issues
- Related: https://manaflow.sentry.io/issues/7294829202/
- Related: https://manaflow.sentry.io/issues/7332641257/
- Related: https://manaflow.sentry.io/issues/7287503035/
- Related: https://manaflow.sentry.io/issues/7287535598/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move portal geometry sync out of synchronous layout callbacks and onto the next main-queue turn for terminal and browser hosts. This avoids SwiftUI/AppKit re-entry during geometry churn and reduces layout hangs reported in Sentry.

- **Bug Fixes**
  - Coalesce geometry changes and schedule sync via `DispatchWorkItem` on the main queue.
  - Cancel pending sync on rebind, teardown, and deinit so only the latest revision applies.
  - Gate `synchronizeForAnchor` behind the async sync; update last synchronized revision after applying.

<sup>Written for commit d986dce1fdee43cdc716d5f88251bf0195856590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

