### PR TITLE
Fix stress workspace geometry hang

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5713,6 +5713,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var observers: [NSObjectProtocol] = []
     private var windowObservers: [NSObjectProtocol] = []
     private var isLiveScrolling = false
+    private var isPerformingLayoutPass = false
     private var lastSentRow: Int?
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
@@ -5736,6 +5737,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
 #if DEBUG
+    private var debugForceLayoutPassInProgress = false
     private var lastDropZoneOverlayLogSignature: String?
     private var lastDragGeometryLogSignature: String?
     private var dragLayoutLogSequence: UInt64 = 0
@@ -5773,6 +5775,10 @@ final class GhosttySurfaceScrollView: NSView {
     static func recordSurfaceDraw(_ surfaceId: UUID) {
         drawCounts[surfaceId, default: 0] += 1
         lastDrawTimes[surfaceId] = CACurrentMediaTime()
+    }
+
+    func debugSetLayoutPassInProgressForTesting(_ inProgress: Bool) {
+        debugForceLayoutPassInProgress = inProgress
     }
 
     private static func contentsKey(for layer: CALayer?) -> String {
@@ -6105,8 +6111,18 @@ final class GhosttySurfaceScrollView: NSView {
     override var acceptsFirstResponder: Bool { false }
 
     override func layout() {
+        isPerformingLayoutPass = true
+        defer { isPerformingLayoutPass = false }
         super.layout()
         synchronizeGeometryAndContent()
+    }
+
+    var isGeometryReconcileLayoutInProgress: Bool {
+#if DEBUG
+        debugForceLayoutPassInProgress || isPerformingLayoutPass
+#else
+        isPerformingLayoutPass
+#endif
     }
 
     override func viewDidMoveToSuperview() {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3557,16 +3557,32 @@ final class Workspace: Identifiable, ObservableObject {
     /// Reconcile remaining terminal view geometries after split topology changes.
     /// This keeps AppKit bounds and Ghostty surface sizes in sync in the next runloop turn.
     private func reconcileTerminalGeometryPass() -> Bool {
+        let terminalPanels = panels.values.compactMap { $0 as? TerminalPanel }
+        guard !terminalPanels.isEmpty else { return false }
+
         var needsFollowUpPass = false
 
-        // Flush pending AppKit layout first so terminal-host bounds reflect latest split topology.
-        for window in NSApp.windows {
-            window.contentView?.layoutSubtreeIfNeeded()
+        let activeWindows = Set(terminalPanels.compactMap { $0.hostedView.window })
+        let layoutInFlight = terminalPanels.contains { $0.hostedView.isGeometryReconcileLayoutInProgress }
+
+        // Skip the forced window layout flush while one of this workspace's terminals is already
+        // inside AppKit layout. Re-entering layout from the debug stress-workspaces flow can wedge
+        // SwiftUI/AppKit for minutes; defer one pass and let the current layout finish first.
+        if layoutInFlight {
+            needsFollowUpPass = true
+        } else {
+            // Flush pending AppKit layout first so terminal-host bounds reflect latest split topology.
+            for window in activeWindows {
+                window.contentView?.layoutSubtreeIfNeeded()
+            }
         }
 
-        for panel in panels.values {
-            guard let terminalPanel = panel as? TerminalPanel else { continue }
+        for terminalPanel in terminalPanels {
             let hostedView = terminalPanel.hostedView
+            if hostedView.isGeometryReconcileLayoutInProgress {
+                needsFollowUpPass = true
+                continue
+            }
             let hasUsableBounds = hostedView.bounds.width > 1 && hostedView.bounds.height > 1
             let hasSurface = terminalPanel.surface.surface != nil
             let isAttached = hostedView.window != nil && hostedView.superview != nil

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -12196,6 +12196,15 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         }
     }
 
+    private final class LayoutCountingContentView: NSView {
+        private(set) var layoutCallCount = 0
+
+        override func layout() {
+            layoutCallCount += 1
+            super.layout()
+        }
+    }
+
     private func realizeWindowLayout(_ window: NSWindow) {
         window.makeKeyAndOrderFront(nil)
         window.displayIfNeeded()
@@ -12279,6 +12288,55 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         terminalPortal.synchronizeHostedViewForAnchor(anchor)
 
         assertHostOrder("Terminal portal bind/sync should not rise above the browser portal host")
+    }
+
+    func testWorkspaceGeometryReconcileDefersForcedWindowLayoutWhileTerminalLayoutIsInFlight() throws {
+#if DEBUG
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        let contentView = LayoutCountingContentView(frame: NSRect(x: 0, y: 0, width: 500, height: 320))
+        contentView.autoresizingMask = [.width, .height]
+        window.contentView = contentView
+
+        let anchor = NSView(frame: NSRect(x: 24, y: 24, width: 220, height: 150))
+        contentView.addSubview(anchor)
+
+        let workspace = Workspace()
+        let portal = WindowTerminalPortal(window: window)
+        let terminalPanel = try XCTUnwrap(workspace.focusedTerminalPanel)
+        let hostedView = terminalPanel.hostedView
+
+        portal.bind(hostedView: hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        realizeWindowLayout(window)
+
+        XCTAssertNotNil(hostedView.window)
+        XCTAssertNotNil(hostedView.superview)
+
+        let baselineLayoutCallCount = contentView.layoutCallCount
+        hostedView.debugSetLayoutPassInProgressForTesting(true)
+        defer { hostedView.debugSetLayoutPassInProgressForTesting(false) }
+
+        workspace.scheduleDebugStressTerminalGeometryReconcile()
+        for _ in 0..<8 {
+            drainMainQueue()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+
+        XCTAssertEqual(
+            contentView.layoutCallCount,
+            baselineLayoutCallCount,
+            "Geometry reconcile should wait for the active terminal layout pass instead of forcing nested window layout"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
     }
 
     func testRegistryPrunesPortalWhenWindowCloses() {


### PR DESCRIPTION
## Summary
- add a regression test for the Debug -> Open Stress Workspaces hang by asserting workspace geometry reconcile does not force a nested content-view layout while a terminal layout pass is already in flight
- defer workspace terminal geometry reconciliation until active terminal layout passes finish, and only flush windows that actually host that workspace's terminal views

## Testing
- `./scripts/setup.sh`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-open-stress-workspaces-hang-unit build`
- `./scripts/reload.sh --tag task-open-stress-workspaces-hang`

## Issues
- Related task: local crash log `mac-crash-open-debug-workspaces.txt` for Debug -> Open Stress Workspaces and Load All Terminals


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang when running Debug → Open Stress Workspaces by deferring workspace terminal geometry reconciliation during active layout and limiting window flushes to only relevant windows.

- **Bug Fixes**
  - Track active terminal layout with `isGeometryReconcileLayoutInProgress` in `GhosttySurfaceScrollView`.
  - Defer geometry reconcile and skip forced `layoutSubtreeIfNeeded` while a terminal layout is in flight.
  - Flush layout only for windows that host this workspace’s terminal views.
  - Add a debug-only regression test to prevent nested window layout during terminal layout.

<sup>Written for commit bc5c5cc6cf958e81a965698f4d60e293bdd3b0bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

