### PR TITLE
Support attachment-only RTFD image paste fallback

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -203,28 +203,43 @@ private enum GhosttyPasteboardHelper {
             guard let attachment = value as? NSTextAttachment else { return }
 
             if let fileWrapper = attachment.fileWrapper,
-               let data = fileWrapper.regularFileContents {
-                let fileExtension =
-                    (fileWrapper.preferredFilename as NSString?)?.pathExtension ?? ""
-                if !fileExtension.isEmpty {
-                    result = (data, fileExtension)
-                    stop.pointee = true
-                    return
-                }
+               let data = fileWrapper.regularFileContents,
+               let imageRepresentation = imageAttachmentRepresentation(
+                data: data,
+                preferredFilename: fileWrapper.preferredFilename
+               ) {
+                result = imageRepresentation
+                stop.pointee = true
             }
-
-            guard let image = attachment.image(
-                forBounds: .zero,
-                textContainer: nil,
-                characterIndex: 0
-            ),
-            let tiffData = image.tiffRepresentation else { return }
-
-            result = (tiffData, "tiff")
-            stop.pointee = true
         }
 
         return result
+    }
+
+    private static func imageAttachmentRepresentation(
+        data: Data,
+        preferredFilename: String?
+    ) -> (data: Data, fileExtension: String)? {
+        let pathExtension =
+            (preferredFilename as NSString?)?.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? ""
+        if let type = !pathExtension.isEmpty ? UTType(filenameExtension: pathExtension) : nil,
+           type.conforms(to: .image),
+           let fileExtension = type.preferredFilenameExtension ?? nonEmpty(pathExtension) {
+            return (data, fileExtension)
+        }
+
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+              let typeIdentifier = CGImageSourceGetType(imageSource) as String?,
+              let type = UTType(typeIdentifier),
+              type.conforms(to: .image),
+              let fileExtension = type.preferredFilenameExtension else { return nil }
+        return (data, fileExtension)
+    }
+
+    private static func nonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func hasImageData(in pasteboard: NSPasteboard) -> Bool {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -985,6 +985,25 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: imagePath))
     }
 
+    func testAttachmentOnlyRTFDNonImageClipboardDoesNotFallBackToImagePath() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-rtfd-non-image-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+
+        let wrapper = FileWrapper(regularFileWithContents: Data("hello".utf8))
+        wrapper.preferredFilename = "note.txt"
+
+        let attachment = NSTextAttachment(fileWrapper: wrapper)
+        let attributed = NSAttributedString(attachment: attachment)
+        let data = try attributed.data(
+            from: NSRange(location: 0, length: attributed.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtfd]
+        )
+        pasteboard.setData(data, forType: .rtfd)
+
+        XCTAssertNil(cmuxPasteboardStringContentsForTesting(pasteboard))
+        XCTAssertNil(cmuxPasteboardImagePathForTesting(pasteboard))
+    }
+
     func testRTFDClipboardWithVisibleTextPrefersText() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-rtfd-text-\(UUID().uuidString)"))
         pasteboard.clearContents()


### PR DESCRIPTION
## Summary
- add regression tests for attachment-only and mixed-text RTFD clipboard payloads
- extract the first image attachment from attachment-only RTFD payloads
- keep existing text-preferred behavior when the rich text contains visible text

## Testing
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination "platform=macOS" -derivedDataPath /tmp/cmux-task-paste-rtfd-attachment-fallback-unit -only-testing:cmuxTests/GhosttyPasteboardHelperTests test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add attachment-only RTFD paste fallback: when RTFD has no visible text, extract the first image attachment and save it as a temp file. Non-image attachments are ignored, and text-first behavior stays when RTFD contains visible text.

- **Bug Fixes**
  - Restrict fallback to image attachments only; skip non-image RTFD files.
  - Detect the correct file extension from type or filename (or image data); default to `.tiff` when needed.
  - Update `saveClipboardImageIfNeeded` to use RTFD image data when no plain image types exist, and add tests for image-only, non-image, and mixed text+attachment cases.

<sup>Written for commit 880bc27d180b9b7739ab844d98416dd1267abd12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard now prefers embedded images from rich rich-text pasteboard entries and sanitizes extracted text to remove replacement characters/extra whitespace.

* **Tests**
  * Added coverage for rich-text pasteboard scenarios: image-only attachments, non-image attachments, and mixed text+image to validate extraction and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->