### PR TITLE
add terminal autosuggestion provider detection and settings

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -45692,6 +45692,142 @@
         }
       }
     },
+    "settings.automation.terminalAutosuggestions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal Autosuggestions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル自動提案"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.mode.automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.mode.forceOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Force On"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常にオン"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.mode.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic is the safest default. cmux only renders terminal autosuggestions when the shell reports that no external autosuggestion provider owns the current session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既定値として最も安全なのは「自動」です。シェルが現在のセッションを所有する外部の自動提案プロバイダーがいないと報告した場合にのみ、cmux はターミナル自動提案を表示します。"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.subtitleAutomatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux backs off when the shell reports an external autosuggestion provider."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルが外部の自動提案プロバイダーを報告した場合、cmux は引き下がります。"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.subtitleForceOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux keeps terminal autosuggestions enabled even when the shell reports another provider."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルが別のプロバイダーを報告しても、cmux はターミナル自動提案を有効のままにします。"
+          }
+        }
+      }
+    },
+    "settings.automation.terminalAutosuggestions.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux terminal autosuggestions stay disabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux のターミナル自動提案は無効のままです。"
+          }
+        }
+      }
+    },
     "settings.automation.openAccess.dialog.cancel": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -190,17 +190,26 @@ _cmux_detect_unknown_autosuggestion_provider() {
         return 0
     fi
 
-    if _cmux_assoc_contains_match functions \
-        "_*autosuggest*" \
-        "_*autocomplete*" \
-        "_*auto-suggest*" \
-        ".autocomplete*" \
-        "*autosuggest*" \
-        "*autocomplete*" \
-        "*auto-suggest*"; then
-        print -r -- "external:unknown"
-        return 0
-    fi
+    local key
+    for key in "${(@k)functions}"; do
+        case "$key" in
+            _cmux_*)
+                continue
+                ;;
+        esac
+        if _cmux_name_matches_any \
+            "$key" \
+            "_*autosuggest*" \
+            "_*autocomplete*" \
+            "_*auto-suggest*" \
+            ".autocomplete*" \
+            "*autosuggest*" \
+            "*autocomplete*" \
+            "*auto-suggest*"; then
+            print -r -- "external:unknown"
+            return 0
+        fi
+    done
 
     return 1
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -58,6 +58,8 @@ typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
 typeset -g _CMUX_AUTOSUGGEST_PROVIDER_LAST=""
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="${TMPDIR:-/tmp}/cmux-autosuggest-provider.$$.ack"
+/bin/rm -f -- "$_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE" >/dev/null 2>&1 || true
 
 _cmux_normalize_autosuggestion_provider() {
     local value="$1"
@@ -215,15 +217,30 @@ _cmux_autosuggestion_provider() {
     print -r -- "none"
 }
 
+_cmux_sync_autosuggestion_provider_ack() {
+    local path="${_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE:-}"
+    [[ -n "$path" && -r "$path" ]] || return 0
+
+    local provider=""
+    provider="$(/bin/cat -- "$path" 2>/dev/null || true)"
+    /bin/rm -f -- "$path" >/dev/null 2>&1 || true
+    provider="$(_cmux_normalize_autosuggestion_provider "$provider" 2>/dev/null || true)"
+    [[ -n "$provider" ]] || return 0
+    _CMUX_AUTOSUGGEST_PROVIDER_LAST="$provider"
+}
+
 _cmux_report_autosuggestion_provider() {
+    _cmux_sync_autosuggestion_provider_ack
+
     local provider
     provider="$(_cmux_autosuggestion_provider 2>/dev/null || true)"
-    [[ -n "$provider" ]] || provider="external:unknown"
     [[ "$provider" == "$_CMUX_AUTOSUGGEST_PROVIDER_LAST" ]] && return 0
 
-    _CMUX_AUTOSUGGEST_PROVIDER_LAST="$provider"
+    local ack_path="${_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE:-}"
     {
-        _cmux_send "report_autosuggestion_provider $provider --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+        if _cmux_send "report_autosuggestion_provider $provider --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" >/dev/null 2>&1; then
+            print -r -- "$provider" >| "$ack_path"
+        fi
     } >/dev/null 2>&1 &!
 }
 

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -57,6 +57,175 @@ typeset -g _CMUX_PORTS_LAST_RUN=0
 typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_LAST=""
+
+_cmux_normalize_autosuggestion_provider() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    value="${value:l}"
+    [[ -n "$value" ]] || return 1
+
+    case "$value" in
+        none|cmux)
+            print -r -- "$value"
+            return 0
+            ;;
+        external:*)
+            local suffix="${value#external:}"
+            suffix="${suffix//[^[:alnum:]:._-]/}"
+            if [[ -z "$suffix" ]]; then
+                print -r -- "external:unknown"
+            else
+                print -r -- "external:$suffix"
+            fi
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+_cmux_name_matches_any() {
+    local name="$1"
+    shift
+
+    local pattern
+    for pattern in "$@"; do
+        case "$name" in
+            $pattern)
+                return 0
+                ;;
+        esac
+    done
+
+    return 1
+}
+
+_cmux_assoc_contains_match() {
+    local assoc_name="$1"
+    shift
+
+    local key
+    local -a keys
+    case "$assoc_name" in
+        functions)
+            keys=("${(@k)functions}")
+            ;;
+        parameters)
+            keys=("${(@k)parameters}")
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    for key in "${keys[@]}"; do
+        if _cmux_name_matches_any "$key" "$@"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_cmux_widgets_contain_match() {
+    local widget
+    local -a widgets
+    widgets=("${(@f)$(builtin zle -la 2>/dev/null)}")
+
+    for widget in "${widgets[@]}"; do
+        if _cmux_name_matches_any "$widget" "$@"; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+_cmux_detect_known_autosuggestion_provider() {
+    if (( $+parameters[ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE] )) \
+        || (( $+parameters[ZSH_AUTOSUGGEST_STRATEGY] )) \
+        || (( $+parameters[ZSH_AUTOSUGGEST_USE_ASYNC] )) \
+        || (( $+parameters[ZSH_AUTOSUGGEST_MANUAL_REBIND] )) \
+        || (( $+functions[_zsh_autosuggest_start] )) \
+        || (( $+functions[_zsh_autosuggest_bind_widgets] )) \
+        || (( $+functions[_zsh_autosuggest_widget_accept] )) \
+        || _cmux_widgets_contain_match autosuggest-accept autosuggest-disable autosuggest-toggle; then
+        print -r -- "external:zsh-autosuggestions"
+        return 0
+    fi
+
+    if (( $+functions[_autocomplete__main] )) \
+        || _cmux_assoc_contains_match functions "_autocomplete__*"; then
+        print -r -- "external:zsh-autocomplete"
+        return 0
+    fi
+
+    return 1
+}
+
+_cmux_detect_unknown_autosuggestion_provider() {
+    if _cmux_widgets_contain_match "*autosuggest*" "*autocomplete*" "*auto-suggest*"; then
+        print -r -- "external:unknown"
+        return 0
+    fi
+
+    if _cmux_assoc_contains_match parameters "*AUTOSUGGEST*" "*AUTOCOMPLETE*" "*AUTO_SUGGEST*"; then
+        print -r -- "external:unknown"
+        return 0
+    fi
+
+    if _cmux_assoc_contains_match functions \
+        "_*autosuggest*" \
+        "_*autocomplete*" \
+        "_*auto-suggest*" \
+        ".autocomplete*" \
+        "*autosuggest*" \
+        "*autocomplete*" \
+        "*auto-suggest*"; then
+        print -r -- "external:unknown"
+        return 0
+    fi
+
+    return 1
+}
+
+_cmux_autosuggestion_provider() {
+    local override
+    override="$(_cmux_normalize_autosuggestion_provider "${CMUX_AUTOSUGGEST_PROVIDER_OVERRIDE:-}" 2>/dev/null || true)"
+    if [[ -n "$override" ]]; then
+        print -r -- "$override"
+        return 0
+    fi
+
+    local provider
+    provider="$(_cmux_detect_known_autosuggestion_provider 2>/dev/null || true)"
+    if [[ -n "$provider" ]]; then
+        print -r -- "$provider"
+        return 0
+    fi
+
+    provider="$(_cmux_detect_unknown_autosuggestion_provider 2>/dev/null || true)"
+    if [[ -n "$provider" ]]; then
+        print -r -- "$provider"
+        return 0
+    fi
+
+    print -r -- "none"
+}
+
+_cmux_report_autosuggestion_provider() {
+    local provider
+    provider="$(_cmux_autosuggestion_provider 2>/dev/null || true)"
+    [[ -n "$provider" ]] || provider="external:unknown"
+    [[ "$provider" == "$_CMUX_AUTOSUGGEST_PROVIDER_LAST" ]] && return 0
+
+    _CMUX_AUTOSUGGEST_PROVIDER_LAST="$provider"
+    {
+        _cmux_send "report_autosuggestion_provider $provider --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    } >/dev/null 2>&1 &!
+}
 
 _cmux_git_resolve_head_path() {
     # Resolve the HEAD file path without invoking git (fast; works for worktrees).
@@ -393,6 +562,7 @@ _cmux_precmd() {
     fi
 
     _cmux_report_tty_once
+    _cmux_report_autosuggestion_provider
 
     local now=$EPOCHSECONDS
     local pwd="$PWD"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -59,6 +59,8 @@ typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
 typeset -g _CMUX_AUTOSUGGEST_PROVIDER_LAST=""
 typeset -g _CMUX_AUTOSUGGEST_PROVIDER_DETECTED=""
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_LAST_SENT_AT=0
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_RETRY_SECS=30
 typeset -g _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE=""
 if [[ -x /usr/bin/mktemp ]]; then
     _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="$(
@@ -185,12 +187,27 @@ _cmux_detect_unknown_autosuggestion_provider() {
         return 0
     fi
 
-    if _cmux_assoc_contains_match parameters "*AUTOSUGGEST*" "*AUTOCOMPLETE*" "*AUTO_SUGGEST*"; then
-        print -r -- "external:unknown"
-        return 0
-    fi
-
     local key
+    for key in "${(@k)parameters}"; do
+        case "$key" in
+            _CMUX_*|CMUX_*)
+                continue
+                ;;
+        esac
+        if _cmux_name_matches_any \
+            "$key" \
+            "*AUTOSUGGEST*" \
+            "*AUTOCOMPLETE*" \
+            "*AUTO_SUGGEST*" \
+            "*autosuggest*" \
+            "*autocomplete*" \
+            "*auto_suggest*" \
+            "*auto-suggest*"; then
+            print -r -- "external:unknown"
+            return 0
+        fi
+    done
+
     for key in "${(@k)functions}"; do
         case "$key" in
             _cmux_*)
@@ -249,12 +266,7 @@ _cmux_sync_autosuggestion_provider_ack() {
     local path="${_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE:-}"
     [[ -n "$path" && -r "$path" ]] || return 0
 
-    local provider=""
-    provider="$(/bin/cat -- "$path" 2>/dev/null || true)"
     /bin/rm -f -- "$path" >/dev/null 2>&1 || true
-    provider="$(_cmux_normalize_autosuggestion_provider "$provider" 2>/dev/null || true)"
-    [[ -n "$provider" ]] || return 0
-    _CMUX_AUTOSUGGEST_PROVIDER_LAST="$provider"
 }
 
 _cmux_report_autosuggestion_provider() {
@@ -262,7 +274,13 @@ _cmux_report_autosuggestion_provider() {
 
     local provider
     provider="$(_cmux_autosuggestion_provider 2>/dev/null || true)"
-    [[ "$provider" == "$_CMUX_AUTOSUGGEST_PROVIDER_LAST" ]] && return 0
+    local now=$EPOCHSECONDS
+    if [[ "$provider" == "$_CMUX_AUTOSUGGEST_PROVIDER_LAST" ]] \
+        && (( now - _CMUX_AUTOSUGGEST_PROVIDER_LAST_SENT_AT < _CMUX_AUTOSUGGEST_PROVIDER_RETRY_SECS )); then
+        return 0
+    fi
+    _CMUX_AUTOSUGGEST_PROVIDER_LAST="$provider"
+    _CMUX_AUTOSUGGEST_PROVIDER_LAST_SENT_AT=$now
 
     local ack_path="${_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE:-}"
     {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -58,7 +58,19 @@ typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
 typeset -g _CMUX_AUTOSUGGEST_PROVIDER_LAST=""
-typeset -g _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="${TMPDIR:-/tmp}/cmux-autosuggest-provider.$$.ack"
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_DETECTED=""
+typeset -g _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE=""
+if [[ -x /usr/bin/mktemp ]]; then
+    _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="$(
+        /usr/bin/mktemp -t cmux-autosuggest-provider 2>/dev/null || true
+    )"
+fi
+if [[ -z "$_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE" ]] && command -v mktemp >/dev/null 2>&1; then
+    _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="$(
+        mktemp "${TMPDIR:-/tmp}/cmux-autosuggest-provider.XXXXXXXX" 2>/dev/null || true
+    )"
+fi
+[[ -n "$_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE" ]] || _CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE="${TMPDIR:-/tmp}/cmux-autosuggest-provider.$$.ack"
 /bin/rm -f -- "$_CMUX_AUTOSUGGEST_PROVIDER_ACK_FILE" >/dev/null 2>&1 || true
 
 _cmux_normalize_autosuggestion_provider() {
@@ -201,15 +213,22 @@ _cmux_autosuggestion_provider() {
         return 0
     fi
 
+    if [[ -n "$_CMUX_AUTOSUGGEST_PROVIDER_DETECTED" ]]; then
+        print -r -- "$_CMUX_AUTOSUGGEST_PROVIDER_DETECTED"
+        return 0
+    fi
+
     local provider
     provider="$(_cmux_detect_known_autosuggestion_provider 2>/dev/null || true)"
     if [[ -n "$provider" ]]; then
+        [[ "$provider" == "none" ]] || _CMUX_AUTOSUGGEST_PROVIDER_DETECTED="$provider"
         print -r -- "$provider"
         return 0
     fi
 
     provider="$(_cmux_detect_unknown_autosuggestion_provider 2>/dev/null || true)"
     if [[ -n "$provider" ]]; then
+        [[ "$provider" == "none" ]] || _CMUX_AUTOSUGGEST_PROVIDER_DETECTED="$provider"
         print -r -- "$provider"
         return 0
     fi

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2982,6 +2982,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         if !claudeHooksEnabled {
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
         }
+        env["CMUX_TERMINAL_AUTOSUGGESTIONS_MODE"] = TerminalAutosuggestionSettings.mode().rawValue
 
         if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
             let currentPath = env["PATH"]

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3998,6 +3998,7 @@ extension TabManager {
             hasher.combine(workspace.panelTitles.count)
             hasher.combine(workspace.panelPullRequests.count)
             hasher.combine(workspace.panelGitBranches.count)
+            hasher.combine(workspace.panelAutosuggestionProviders.count)
             hasher.combine(workspace.surfaceListeningPorts.count)
 
             if let progress = workspace.progress {
@@ -4014,6 +4015,8 @@ extension TabManager {
                 hasher.combine("")
                 hasher.combine(false)
             }
+
+            hasher.combine(workspace.autosuggestionProvider?.provider ?? "")
         }
 
         return hasher.finalize()

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -312,6 +312,23 @@ class TerminalController {
         return currentSorted != nextSorted
     }
 
+    nonisolated static func normalizeAutosuggestionProvider(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return nil }
+        switch trimmed {
+        case "none", "cmux":
+            return trimmed
+        default:
+            guard trimmed.hasPrefix("external:") else { return nil }
+            let suffix = trimmed.dropFirst("external:".count)
+            let cleaned = suffix.filter {
+                $0.isLetter || $0.isNumber || $0 == ":" || $0 == "." || $0 == "_" || $0 == "-"
+            }
+            guard !cleaned.isEmpty else { return "external:unknown" }
+            return "external:\(cleaned)"
+        }
+    }
+
     private struct SocketSurfaceKey: Hashable {
         let workspaceId: UUID
         let panelId: UUID
@@ -1458,6 +1475,9 @@ class TerminalController {
 
         case "report_pwd":
             return reportPwd(args)
+
+        case "report_autosuggestion_provider":
+            return reportAutosuggestionProvider(args)
 
         case "sidebar_state":
             return sidebarState(args)
@@ -9702,6 +9722,7 @@ class TerminalController {
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
           ports_kick [--tab=X] [--panel=Y] - Request batched port scan for panel
           report_pwd <path> [--tab=X] [--panel=Y] - Report current working directory
+          report_autosuggestion_provider <provider> [--tab=X] [--panel=Y] - Report terminal autosuggestion owner
           clear_ports [--tab=X] [--panel=Y] - Clear listening ports
           sidebar_state [--tab=X] - Dump sidebar metadata
           reset_sidebar [--tab=X] - Clear sidebar metadata
@@ -13599,6 +13620,67 @@ class TerminalController {
         return result
     }
 
+    private func reportAutosuggestionProvider(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        guard let rawProvider = parsed.positional.first,
+              let provider = Self.normalizeAutosuggestionProvider(rawProvider) else {
+            return "ERROR: Missing or invalid provider — usage: report_autosuggestion_provider <none|cmux|external:name> [--tab=X] [--panel=Y]"
+        }
+
+        if let scope = Self.explicitSocketScope(options: parsed.options) {
+            DispatchQueue.main.async {
+                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceId),
+                      let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceId }) else {
+                    return
+                }
+                let validSurfaceIds = Set(tab.panels.keys)
+                tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+                guard validSurfaceIds.contains(scope.panelId) else { return }
+                tab.updatePanelAutosuggestionProvider(panelId: scope.panelId, provider: provider)
+            }
+            return "OK"
+        }
+
+        var result = "OK"
+        DispatchQueue.main.sync {
+            guard let tab = resolveTabForReport(args) else {
+                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+                return
+            }
+
+            let validSurfaceIds = Set(tab.panels.keys)
+            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+
+            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
+            let surfaceId: UUID
+            if let panelArg {
+                if panelArg.isEmpty {
+                    result = "ERROR: Missing panel id — usage: report_autosuggestion_provider <none|cmux|external:name> [--tab=X] [--panel=Y]"
+                    return
+                }
+                guard let parsedId = UUID(uuidString: panelArg) else {
+                    result = "ERROR: Invalid panel id '\(panelArg)'"
+                    return
+                }
+                surfaceId = parsedId
+            } else {
+                guard let focused = tab.focusedPanelId else {
+                    result = "ERROR: Missing panel id (no focused surface)"
+                    return
+                }
+                surfaceId = focused
+            }
+
+            guard validSurfaceIds.contains(surfaceId) else {
+                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+                return
+            }
+
+            tab.updatePanelAutosuggestionProvider(panelId: surfaceId, provider: provider)
+        }
+        return result
+    }
+
     private func clearPorts(_ args: String) -> String {
         let parsed = parseOptions(args)
         var result = "OK"
@@ -13785,6 +13867,17 @@ class TerminalController {
             } else {
                 lines.append("progress=none")
             }
+
+            if let autosuggestionProvider = tab.autosuggestionProvider {
+                lines.append("autosuggestion_provider=\(autosuggestionProvider.provider)")
+            } else {
+                lines.append("autosuggestion_provider=unknown")
+            }
+            let autosuggestionMode = TerminalAutosuggestionSettings.mode()
+            lines.append("autosuggestion_mode=\(autosuggestionMode.rawValue)")
+            lines.append(
+                "autosuggestion_rendering=\(TerminalAutosuggestionSettings.shouldRender(mode: autosuggestionMode, reportedProvider: tab.autosuggestionProvider?.provider) ? "enabled" : "disabled")"
+            )
 
             let statusEntries = tab.sidebarStatusEntriesInDisplayOrder()
             lines.append("status_count=\(statusEntries.count)")

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13627,6 +13627,20 @@ class TerminalController {
             return "ERROR: Missing or invalid provider — usage: report_autosuggestion_provider <none|cmux|external:name> [--tab=X] [--panel=Y]"
         }
 
+        let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
+        let requestedSurfaceId: UUID?
+        if let panelArg {
+            if panelArg.isEmpty {
+                return "ERROR: Missing panel id — usage: report_autosuggestion_provider <none|cmux|external:name> [--tab=X] [--panel=Y]"
+            }
+            guard let parsedId = UUID(uuidString: panelArg) else {
+                return "ERROR: Invalid panel id '\(panelArg)'"
+            }
+            requestedSurfaceId = parsedId
+        } else {
+            requestedSurfaceId = nil
+        }
+
         if let scope = Self.explicitSocketScope(options: parsed.options) {
             DispatchQueue.main.async {
                 guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceId),
@@ -13641,44 +13655,22 @@ class TerminalController {
             return "OK"
         }
 
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+        DispatchQueue.main.async {
+            guard let tab = self.resolveTabForReport(args) else {
                 return
             }
 
             let validSurfaceIds = Set(tab.panels.keys)
             tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
 
-            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
-            let surfaceId: UUID
-            if let panelArg {
-                if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_autosuggestion_provider <none|cmux|external:name> [--tab=X] [--panel=Y]"
-                    return
-                }
-                guard let parsedId = UUID(uuidString: panelArg) else {
-                    result = "ERROR: Invalid panel id '\(panelArg)'"
-                    return
-                }
-                surfaceId = parsedId
-            } else {
-                guard let focused = tab.focusedPanelId else {
-                    result = "ERROR: Missing panel id (no focused surface)"
-                    return
-                }
-                surfaceId = focused
-            }
-
-            guard validSurfaceIds.contains(surfaceId) else {
-                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+            let surfaceId = requestedSurfaceId ?? tab.focusedPanelId
+            guard let surfaceId, validSurfaceIds.contains(surfaceId) else {
                 return
             }
 
             tab.updatePanelAutosuggestionProvider(panelId: surfaceId, provider: provider)
         }
-        return result
+        return "OK"
     }
 
     private func clearPorts(_ args: String) -> String {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -651,6 +651,14 @@ struct SidebarPullRequestState: Equatable {
     let status: SidebarPullRequestStatus
 }
 
+struct SidebarAutosuggestionProviderState: Equatable {
+    let provider: String
+
+    var isExternal: Bool {
+        provider.hasPrefix("external:")
+    }
+}
+
 enum SidebarBranchOrdering {
     struct BranchEntry: Equatable {
         let name: String
@@ -996,6 +1004,8 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
     @Published var pullRequest: SidebarPullRequestState?
     @Published var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
+    @Published var autosuggestionProvider: SidebarAutosuggestionProviderState?
+    @Published var panelAutosuggestionProviders: [UUID: SidebarAutosuggestionProviderState] = [:]
     @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
     @Published var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
@@ -1687,6 +1697,23 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    func updatePanelAutosuggestionProvider(panelId: UUID, provider: String) {
+        let state = SidebarAutosuggestionProviderState(provider: provider)
+        if panelAutosuggestionProviders[panelId] != state {
+            panelAutosuggestionProviders[panelId] = state
+        }
+        if panelId == focusedPanelId {
+            autosuggestionProvider = state
+        }
+    }
+
+    func clearPanelAutosuggestionProvider(panelId: UUID) {
+        panelAutosuggestionProviders.removeValue(forKey: panelId)
+        if panelId == focusedPanelId {
+            autosuggestionProvider = nil
+        }
+    }
+
     func resetSidebarContext(reason: String = "unspecified") {
         statusEntries.removeAll()
         logEntries.removeAll()
@@ -1695,6 +1722,8 @@ final class Workspace: Identifiable, ObservableObject {
         panelGitBranches.removeAll()
         pullRequest = nil
         panelPullRequests.removeAll()
+        autosuggestionProvider = nil
+        panelAutosuggestionProviders.removeAll()
         surfaceListeningPorts.removeAll()
         listeningPorts.removeAll()
         metadataBlocks.removeAll()
@@ -1787,6 +1816,7 @@ final class Workspace: Identifiable, ObservableObject {
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
         surfaceTTYNames = surfaceTTYNames.filter { validSurfaceIds.contains($0.key) }
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
+        panelAutosuggestionProviders = panelAutosuggestionProviders.filter { validSurfaceIds.contains($0.key) }
         recomputeListeningPorts()
     }
 
@@ -3535,6 +3565,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
         gitBranch = panelGitBranches[targetPanelId]
         pullRequest = panelPullRequests[targetPanelId]
+        autosuggestionProvider = panelAutosuggestionProviders[targetPanelId]
     }
 
     /// Reconcile focus/first-responder convergence.
@@ -4344,6 +4375,7 @@ extension Workspace: BonsplitDelegate {
         }
         gitBranch = panelGitBranches[panelId]
         pullRequest = panelPullRequests[panelId]
+        autosuggestionProvider = panelAutosuggestionProviders[panelId]
 
         // Post notification
         NotificationCenter.default.post(
@@ -4654,6 +4686,7 @@ extension Workspace: BonsplitDelegate {
         panelDirectories.removeValue(forKey: panelId)
         panelGitBranches.removeValue(forKey: panelId)
         panelPullRequests.removeValue(forKey: panelId)
+        panelAutosuggestionProviders.removeValue(forKey: panelId)
         panelTitles.removeValue(forKey: panelId)
         panelCustomTitles.removeValue(forKey: panelId)
         pinnedPanelIds.remove(panelId)
@@ -4834,6 +4867,7 @@ extension Workspace: BonsplitDelegate {
                 panelDirectories.removeValue(forKey: panelId)
                 panelGitBranches.removeValue(forKey: panelId)
                 panelPullRequests.removeValue(forKey: panelId)
+                panelAutosuggestionProviders.removeValue(forKey: panelId)
                 panelTitles.removeValue(forKey: panelId)
                 panelCustomTitles.removeValue(forKey: panelId)
                 pinnedPanelIds.remove(panelId)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3080,13 +3080,16 @@ enum TerminalAutosuggestionSettings {
         mode: TerminalAutosuggestionMode,
         reportedProvider: String?
     ) -> Bool {
+        let provider = reportedProvider?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
         switch mode {
         case .off:
             return false
         case .forceOn:
             return true
         case .automatic:
-            return reportedProvider == "none" || reportedProvider == "cmux"
+            return provider == "none" || provider == "cmux"
         }
     }
 }
@@ -3228,6 +3231,13 @@ struct SettingsView: View {
 
     private var selectedTerminalAutosuggestionMode: TerminalAutosuggestionMode {
         TerminalAutosuggestionSettings.mode(for: terminalAutosuggestionMode)
+    }
+
+    private var terminalAutosuggestionModeSelection: Binding<String> {
+        Binding(
+            get: { TerminalAutosuggestionSettings.mode(for: terminalAutosuggestionMode).rawValue },
+            set: { terminalAutosuggestionMode = TerminalAutosuggestionSettings.mode(for: $0).rawValue }
+        )
     }
 
     private var selectedBrowserThemeMode: BrowserThemeMode {
@@ -4098,7 +4108,7 @@ struct SettingsView: View {
                             String(localized: "settings.automation.terminalAutosuggestions", defaultValue: "Terminal Autosuggestions"),
                             subtitle: selectedTerminalAutosuggestionMode.description,
                             controlWidth: pickerColumnWidth,
-                            selection: $terminalAutosuggestionMode
+                            selection: terminalAutosuggestionModeSelection
                         ) {
                             ForEach(TerminalAutosuggestionMode.allCases) { mode in
                                 Text(mode.displayName).tag(mode.rawValue)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3019,6 +3019,78 @@ enum ClaudeCodeIntegrationSettings {
     }
 }
 
+enum TerminalAutosuggestionMode: String, CaseIterable, Identifiable {
+    case off
+    case automatic
+    case forceOn = "force_on"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .off:
+            return String(localized: "settings.automation.terminalAutosuggestions.mode.off", defaultValue: "Off")
+        case .automatic:
+            return String(localized: "settings.automation.terminalAutosuggestions.mode.automatic", defaultValue: "Automatic")
+        case .forceOn:
+            return String(localized: "settings.automation.terminalAutosuggestions.mode.forceOn", defaultValue: "Force On")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .off:
+            return String(
+                localized: "settings.automation.terminalAutosuggestions.subtitleOff",
+                defaultValue: "cmux terminal autosuggestions stay disabled."
+            )
+        case .automatic:
+            return String(
+                localized: "settings.automation.terminalAutosuggestions.subtitleAutomatic",
+                defaultValue: "cmux backs off when the shell reports an external autosuggestion provider."
+            )
+        case .forceOn:
+            return String(
+                localized: "settings.automation.terminalAutosuggestions.subtitleForceOn",
+                defaultValue: "cmux keeps terminal autosuggestions enabled even when the shell reports another provider."
+            )
+        }
+    }
+}
+
+enum TerminalAutosuggestionSettings {
+    static let modeKey = "terminalAutosuggestionMode"
+    static let defaultMode: TerminalAutosuggestionMode = .automatic
+
+    static func mode(for rawValue: String?) -> TerminalAutosuggestionMode {
+        guard let rawValue, let mode = TerminalAutosuggestionMode(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+
+    static func mode(defaults: UserDefaults = .standard) -> TerminalAutosuggestionMode {
+        if defaults.string(forKey: modeKey) != nil {
+            return mode(for: defaults.string(forKey: modeKey))
+        }
+        return defaultMode
+    }
+
+    static func shouldRender(
+        mode: TerminalAutosuggestionMode,
+        reportedProvider: String?
+    ) -> Bool {
+        switch mode {
+        case .off:
+            return false
+        case .forceOn:
+            return true
+        case .automatic:
+            return reportedProvider == "none" || reportedProvider == "cmux"
+        }
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }
@@ -3049,6 +3121,8 @@ struct SettingsView: View {
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+    @AppStorage(TerminalAutosuggestionSettings.modeKey)
+    private var terminalAutosuggestionMode = TerminalAutosuggestionSettings.defaultMode.rawValue
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
@@ -3150,6 +3224,10 @@ struct SettingsView: View {
 
     private var selectedSocketControlMode: SocketControlMode {
         SocketControlSettings.migrateMode(socketControlMode)
+    }
+
+    private var selectedTerminalAutosuggestionMode: TerminalAutosuggestionMode {
+        TerminalAutosuggestionSettings.mode(for: terminalAutosuggestionMode)
     }
 
     private var selectedBrowserThemeMode: BrowserThemeMode {
@@ -4016,6 +4094,28 @@ struct SettingsView: View {
                     }
 
                     SettingsCard {
+                        SettingsPickerRow(
+                            String(localized: "settings.automation.terminalAutosuggestions", defaultValue: "Terminal Autosuggestions"),
+                            subtitle: selectedTerminalAutosuggestionMode.description,
+                            controlWidth: pickerColumnWidth,
+                            selection: $terminalAutosuggestionMode
+                        ) {
+                            ForEach(TerminalAutosuggestionMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardNote(
+                            String(
+                                localized: "settings.automation.terminalAutosuggestions.note",
+                                defaultValue: "Automatic is the safest default. cmux only renders terminal autosuggestions when the shell reports that no external autosuggestion provider owns the current session."
+                            )
+                        )
+                    }
+
+                    SettingsCard {
                         SettingsCardRow(String(localized: "settings.automation.portBase", defaultValue: "Port Base"), subtitle: String(localized: "settings.automation.portBase.subtitle", defaultValue: "Starting port for CMUX_PORT env var."), controlWidth: pickerColumnWidth) {
                             TextField("", value: $cmuxPortBase, format: .number)
                                 .textFieldStyle(.roundedBorder)
@@ -4458,6 +4558,7 @@ struct SettingsView: View {
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+        terminalAutosuggestionMode = TerminalAutosuggestionSettings.defaultMode.rawValue
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -554,6 +554,7 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .forceOn, reportedProvider: "external:zsh-autosuggestions"))
         XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "none"))
         XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "cmux"))
+        XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: " NONE "))
         XCTAssertFalse(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: nil))
         XCTAssertFalse(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "external:unknown"))
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -518,6 +518,65 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertFalse(ClaudeCodeIntegrationSettings.hooksEnabled(defaults: defaults))
     }
 
+    func testTerminalAutosuggestionModeDefaultsToAutomaticWhenUnset() {
+        let suiteName = "cmux.tests.terminal-autosuggestions.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated user defaults suite")
+            return
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.removeObject(forKey: TerminalAutosuggestionSettings.modeKey)
+        XCTAssertEqual(TerminalAutosuggestionSettings.mode(defaults: defaults), .automatic)
+    }
+
+    func testTerminalAutosuggestionModeRespectsStoredPreference() {
+        let suiteName = "cmux.tests.terminal-autosuggestions.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated user defaults suite")
+            return
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(TerminalAutosuggestionMode.off.rawValue, forKey: TerminalAutosuggestionSettings.modeKey)
+        XCTAssertEqual(TerminalAutosuggestionSettings.mode(defaults: defaults), .off)
+
+        defaults.set(TerminalAutosuggestionMode.forceOn.rawValue, forKey: TerminalAutosuggestionSettings.modeKey)
+        XCTAssertEqual(TerminalAutosuggestionSettings.mode(defaults: defaults), .forceOn)
+    }
+
+    func testTerminalAutosuggestionRenderingPolicyMatchesModeAndProvider() {
+        XCTAssertFalse(TerminalAutosuggestionSettings.shouldRender(mode: .off, reportedProvider: "none"))
+        XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .forceOn, reportedProvider: "external:zsh-autosuggestions"))
+        XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "none"))
+        XCTAssertTrue(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "cmux"))
+        XCTAssertFalse(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: nil))
+        XCTAssertFalse(TerminalAutosuggestionSettings.shouldRender(mode: .automatic, reportedProvider: "external:unknown"))
+    }
+
+    func testNormalizeAutosuggestionProviderAcceptsKnownValues() {
+        XCTAssertEqual(TerminalController.normalizeAutosuggestionProvider("none"), "none")
+        XCTAssertEqual(TerminalController.normalizeAutosuggestionProvider(" cmux "), "cmux")
+        XCTAssertEqual(
+            TerminalController.normalizeAutosuggestionProvider("external:Zsh-Autosuggestions"),
+            "external:zsh-autosuggestions"
+        )
+        XCTAssertEqual(
+            TerminalController.normalizeAutosuggestionProvider("external:"),
+            "external:unknown"
+        )
+    }
+
+    func testNormalizeAutosuggestionProviderRejectsInvalidValues() {
+        XCTAssertNil(TerminalController.normalizeAutosuggestionProvider(""))
+        XCTAssertNil(TerminalController.normalizeAutosuggestionProvider("external provider"))
+        XCTAssertNil(TerminalController.normalizeAutosuggestionProvider("maybe"))
+    }
+
     func testTelemetryDefaultsToEnabledWhenUnset() {
         let suiteName = "cmux.tests.telemetry.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -1514,7 +1573,12 @@ final class GhosttyMouseFocusTests: XCTestCase {
 
 final class ZshShellIntegrationHandoffTests: XCTestCase {
     func testGhosttyPromptHooksLoadWhenCmuxRequestsZshIntegration() throws {
-        let output = try runInteractiveZsh(cmuxLoadGhosttyIntegration: true)
+        let output = try runInteractiveZsh(
+            command: "(( $+functions[_ghostty_deferred_init] )) && _ghostty_deferred_init >/dev/null 2>&1; " +
+                "print -r -- \"PRECMD=${+functions[_ghostty_precmd]} " +
+                "PREEXEC=${+functions[_ghostty_preexec]} PRECMDS=${(j:,:)precmd_functions}\"",
+            cmuxLoadGhosttyIntegration: true
+        )
 
         XCTAssertTrue(output.contains("PRECMD=1"), output)
         XCTAssertTrue(output.contains("PREEXEC=1"), output)
@@ -1522,13 +1586,86 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
     }
 
     func testGhosttyPromptHooksDoNotLoadWithoutCmuxHandoffFlag() throws {
-        let output = try runInteractiveZsh(cmuxLoadGhosttyIntegration: false)
+        let output = try runInteractiveZsh(
+            command: "(( $+functions[_ghostty_deferred_init] )) && _ghostty_deferred_init >/dev/null 2>&1; " +
+                "print -r -- \"PRECMD=${+functions[_ghostty_precmd]} " +
+                "PREEXEC=${+functions[_ghostty_preexec]} PRECMDS=${(j:,:)precmd_functions}\""
+        )
 
         XCTAssertTrue(output.contains("PRECMD=0"), output)
         XCTAssertTrue(output.contains("PREEXEC=0"), output)
     }
 
-    private func runInteractiveZsh(cmuxLoadGhosttyIntegration: Bool) throws -> String {
+    func testAutosuggestionProviderDefaultsToNoneWithoutMarkers() throws {
+        let provider = try detectAutosuggestionProvider()
+        XCTAssertEqual(provider, "none")
+    }
+
+    func testAutosuggestionProviderDetectsZshAutosuggestions() throws {
+        let provider = try detectAutosuggestionProvider(
+            userZshrc: """
+            typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+            """
+        )
+
+        XCTAssertEqual(provider, "external:zsh-autosuggestions")
+    }
+
+    func testAutosuggestionProviderDetectsZshAutocomplete() throws {
+        let provider = try detectAutosuggestionProvider(
+            userZshrc: """
+            function _autocomplete__main() { :; }
+            """
+        )
+
+        XCTAssertEqual(provider, "external:zsh-autocomplete")
+    }
+
+    func testAutosuggestionProviderTreatsUnknownMarkersAsExternalUnknown() throws {
+        let provider = try detectAutosuggestionProvider(
+            userZshrc: """
+            function _custom_autosuggest_preview() { :; }
+            """
+        )
+
+        XCTAssertEqual(provider, "external:unknown")
+    }
+
+    func testAutosuggestionProviderOverrideWins() throws {
+        let provider = try detectAutosuggestionProvider(
+            userZshrc: """
+            typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+            """,
+            environmentOverrides: [
+                "CMUX_AUTOSUGGEST_PROVIDER_OVERRIDE": "none"
+            ]
+        )
+
+        XCTAssertEqual(provider, "none")
+    }
+
+    private func detectAutosuggestionProvider(
+        userZshenv: String = "\n",
+        userZshrc: String = "\n",
+        environmentOverrides: [String: String] = [:]
+    ) throws -> String {
+        try runInteractiveZsh(
+            command: "print -r -- \"$(_cmux_autosuggestion_provider)\"",
+            cmuxShellIntegration: true,
+            userZshenv: userZshenv,
+            userZshrc: userZshrc,
+            environmentOverrides: environmentOverrides
+        )
+    }
+
+    private func runInteractiveZsh(
+        command: String,
+        cmuxLoadGhosttyIntegration: Bool = false,
+        cmuxShellIntegration: Bool = false,
+        userZshenv: String = "\n",
+        userZshrc: String = "\n",
+        environmentOverrides: [String: String] = [:]
+    ) throws -> String {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("cmux-zsh-shell-integration-\(UUID().uuidString)")
@@ -1537,7 +1674,8 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
 
         let userZdotdir = root.appendingPathComponent("zdotdir")
         try fileManager.createDirectory(at: userZdotdir, withIntermediateDirectories: true)
-        try "\n".write(to: userZdotdir.appendingPathComponent(".zshenv"), atomically: true, encoding: .utf8)
+        try userZshenv.write(to: userZdotdir.appendingPathComponent(".zshenv"), atomically: true, encoding: .utf8)
+        try userZshrc.write(to: userZdotdir.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
 
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -1550,9 +1688,7 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         process.arguments = [
             "-i",
             "-c",
-            "(( $+functions[_ghostty_deferred_init] )) && _ghostty_deferred_init >/dev/null 2>&1; " +
-            "print -r -- \"PRECMD=${+functions[_ghostty_precmd]} " +
-            "PREEXEC=${+functions[_ghostty_preexec]} PRECMDS=${(j:,:)precmd_functions}\""
+            command
         ]
         process.environment = [
             "HOME": root.path,
@@ -1561,11 +1697,15 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
             "USER": NSUserName(),
             "ZDOTDIR": cmuxZdotdir.path,
             "CMUX_ZSH_ZDOTDIR": userZdotdir.path,
-            "CMUX_SHELL_INTEGRATION": "0",
+            "CMUX_SHELL_INTEGRATION": cmuxShellIntegration ? "1" : "0",
+            "CMUX_SHELL_INTEGRATION_DIR": cmuxZdotdir.path,
             "GHOSTTY_RESOURCES_DIR": ghosttyResources.path,
         ]
         if cmuxLoadGhosttyIntegration {
             process.environment?["CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION"] = "1"
+        }
+        for (key, value) in environmentOverrides {
+            process.environment?[key] = value
         }
 
         let stdout = Pipe()

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -219,6 +219,21 @@ For other providers, add markers as we learn them, but keep the fallback conserv
 2. if zsh shows evidence that an external autosuggestion layer owns suggestion rendering or accept widgets but the provider is not recognized, report `external:unknown`
 3. if detection is ambiguous, prefer `external:unknown` over `none`
 
+## Local Probe Helper
+
+For local dogfooding without touching the user's real `~/.zshrc`, use:
+
+`./scripts/probe-terminal-autosuggestions.sh`
+
+This launches a nested zsh with a temporary `ZDOTDIR`, leaves the current cmux panel and socket in place, and adds a `cas` alias inside the nested shell that prints the autosuggestion fields from `cmux sidebar-state`.
+
+Useful presets:
+
+1. `./scripts/probe-terminal-autosuggestions.sh --once`
+2. `./scripts/probe-terminal-autosuggestions.sh --provider zsh-autosuggestions --once`
+3. `./scripts/probe-terminal-autosuggestions.sh --provider zsh-autocomplete --once`
+4. `./scripts/probe-terminal-autosuggestions.sh --provider unknown --override none --once`
+
 This avoids double suggestions without requiring exhaustive support for every plugin manager or custom zle script on day one.
 
 ### Default policy

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -145,6 +145,75 @@ That keeps the integration honest:
 
 If the design works, add bash support later through a different shell-side contract. Do not force a fake shell-agnostic abstraction too early.
 
+## Coexistence and Settings
+
+cmux should not blindly enable its own autosuggestions when the user already has `zsh-autosuggestions` or a similar zle-based plugin active.
+
+There are two constraints in the current startup flow:
+
+1. cmux injects its zsh wrapper before the user's normal interactive startup completes.
+2. the user's `zsh-autosuggestions` plugin usually loads from their real `.zshrc`.
+
+That means startup-time detection in the app is too early. The decision has to come from zsh after the user's startup files have finished.
+
+### Recommended setting
+
+Expose a dedicated setting in Settings, under Automation:
+
+1. `Off`
+2. `Automatic`
+3. `Force On`
+
+Behavior:
+
+1. `Off`: cmux never renders terminal autosuggestions and never binds accept/dismiss actions for them.
+2. `Automatic`: cmux enables autosuggestions only if the shell reports that no external autosuggestion plugin owns the command line.
+3. `Force On`: cmux enables its autosuggestions even if the shell reports another autosuggestion plugin. This is mainly for testing and advanced users.
+
+This should be a new setting key. Do not reuse the existing shell integration kill switch, because that would also disable unrelated sidebar features like cwd, git, PR, and port reporting.
+
+### Recommended detection contract
+
+Add a one-time or low-frequency zsh handshake after user startup, for example on the first prompt and whenever widget bindings are rebuilt.
+
+The shell should report whether external autosuggestions are active for the current shell session:
+
+`report_autosuggestion_provider --shell=zsh --provider=external:zsh-autosuggestions --tab=<id> --panel=<id>`
+
+or
+
+`report_autosuggestion_provider --shell=zsh --provider=cmux --tab=<id> --panel=<id>`
+
+At minimum, `Automatic` mode should back off when zsh reports a known external provider.
+
+### What to detect in zsh
+
+Prefer behavior-level detection over dotfile-string matching.
+
+Good signals:
+
+1. known autosuggestion widgets such as `autosuggest-accept`, `autosuggest-disable`, or `autosuggest-toggle`
+2. known autosuggestion variables such as `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE`
+3. other future provider markers if we add support for more plugins
+
+Weak signals to avoid:
+
+1. grepping `.zshrc` for plugin names
+2. checking install paths under Oh My Zsh, Homebrew, or plugin managers
+3. assuming that a sourced file path means the plugin is actually active
+
+The official `zsh-autosuggestions` README documents both the `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` variable and widgets such as `autosuggest-accept`, `autosuggest-disable`, and `autosuggest-toggle`, which makes them reasonable runtime markers for `Automatic` mode.
+
+### Default policy
+
+The safest default is:
+
+1. Settings default = `Automatic`
+2. Per-shell default provider = external plugin wins
+3. cmux shows nothing unless it has positive ownership for that session
+
+This avoids double ghost text, conflicting acceptance bindings, and user confusion.
+
 ## Risks
 
 1. Input latency if shell hooks report too often or the app does expensive ranking on every change.

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -12,7 +12,7 @@ The right first version is shell-assisted:
 2. Extend cmux shell integration to report the live editable command line for shells that can expose it cleanly.
 3. Render suggestions in cmux as an overlay, not by mutating shell state until the user accepts.
 
-This fits the current architecture better than a renderer-only approach and avoids a lot of prompt parsing edge cases.
+This fits the current architecture better than a renderer-only approach and avoids a lot of prompt-parsing edge cases.
 
 ## Why This Fits cmux
 
@@ -108,7 +108,7 @@ Show a suggestion only when:
 
 1. the shell says the prompt is editable
 2. the cursor is at the end of the buffer
-3. there is no IME marked text
+3. there is no IME-marked text
 4. terminal copy mode is off
 5. there is no active completion menu/search mode from the shell
 

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -186,6 +186,15 @@ or
 
 At minimum, `Automatic` mode should back off when zsh reports a known external provider.
 
+Do not make the app hard-code one plugin name as the only coexistence case. Treat this as a generic provider contract:
+
+1. `provider=none`
+2. `provider=cmux`
+3. `provider=external:<known-name>`
+4. `provider=external:unknown`
+
+In `Automatic`, cmux should render only for `provider=none`. Every external provider, including unknown ones, should win by default.
+
 ### What to detect in zsh
 
 Prefer behavior-level detection over dotfile-string matching.
@@ -203,6 +212,14 @@ Weak signals to avoid:
 3. assuming that a sourced file path means the plugin is actually active
 
 The official `zsh-autosuggestions` README documents both the `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` variable and widgets such as `autosuggest-accept`, `autosuggest-disable`, and `autosuggest-toggle`, which makes them reasonable runtime markers for `Automatic` mode.
+
+For other providers, add markers as we learn them, but keep the fallback conservative:
+
+1. if a known provider marker is present, report that provider by name
+2. if zsh shows evidence that an external autosuggestion layer owns suggestion rendering or accept widgets but the provider is not recognized, report `external:unknown`
+3. if detection is ambiguous, prefer `external:unknown` over `none`
+
+This avoids double suggestions without requiring exhaustive support for every plugin manager or custom zle script on day one.
 
 ### Default policy
 

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -1,0 +1,170 @@
+# Terminal Autosuggestions
+
+Last updated: March 13, 2026
+
+## Recommendation
+
+cmux should have its own terminal autosuggestions, but it should not try to clone `zsh-autosuggestions` by scraping the rendered terminal.
+
+The right first version is shell-assisted:
+
+1. Keep suggestion ranking and UI in cmux.
+2. Extend cmux shell integration to report the live editable command line for shells that can expose it cleanly.
+3. Render suggestions in cmux as an overlay, not by mutating shell state until the user accepts.
+
+This fits the current architecture better than a renderer-only approach and avoids a lot of prompt parsing edge cases.
+
+## Why This Fits cmux
+
+cmux already injects shell integration and gives each terminal surface stable IDs plus a socket path. The zsh integration already reports prompt-adjacent metadata like cwd, git branch, PR state, TTY, and port scan hints back into the app.
+
+That matters because autosuggestions need two things:
+
+1. A reliable view of the user's editable buffer.
+2. A reliable place to render and accept the suggestion.
+
+cmux already has the second half:
+
+1. The terminal view can ask Ghostty for the live cursor/IME rect, which is enough to anchor ghost text or a small popup.
+2. The app already has inline completion logic in the browser omnibar that can be reused as a ranking and acceptance model.
+
+cmux does not yet have the first half:
+
+1. `preexec` and `precmd` tell us when a command starts and when the prompt comes back.
+2. They do not tell us what is currently inside the zle edit buffer while the user is typing.
+
+## Why Screen Scraping Is the Wrong Default
+
+cmux can read visible terminal text from Ghostty. That is useful for snapshots and debugging, but it is a weak foundation for autosuggestions.
+
+Problems:
+
+1. Multiline prompts and wrapped commands make it hard to recover the true editable buffer.
+2. Right prompts, hidden prompt markers, and redraws already have shell-integration-specific edge cases.
+3. Vi mode, partial completion menus, history search, and bracketed paste all change what the screen means.
+4. A renderer-driven parser would need shell-specific heuristics anyway, but with less trustworthy data.
+5. It would be easy to show the wrong suggestion or accept text into the wrong place.
+
+Screen inference is still useful as a fallback or debug aid. It should not be the primary contract.
+
+## Proposed Architecture
+
+### 1. Add live command-line reporting to shell integration
+
+For zsh, use zle hooks or wrapped widgets to report:
+
+1. `BUFFER`
+2. `CURSOR`
+3. current keymap (`viins`, `vicmd`, etc.)
+4. whether a completion menu or incremental search is active
+5. whether the shell is at an editable prompt
+
+Add a new socket command shaped roughly like:
+
+`report_commandline "<buffer>" --cursor=<n> --mode=<mode> --shell=zsh --tab=<id> --panel=<id>`
+
+Also add:
+
+1. `clear_commandline` on `preexec`
+2. rate limiting or coalescing so fast typing does not flood the socket
+3. a versioned payload if we expect to expand the contract
+
+This keeps shell-specific state acquisition in the shell, where the truth already exists.
+
+### 2. Store per-panel command-line state in cmux
+
+Treat it like existing per-panel metadata such as cwd and git branch:
+
+1. store it by panel ID
+2. keep focused-panel mirrors if needed
+3. clear it when the panel exits or command execution starts
+
+This should live off the typing hot path, similar to existing shell-reported metadata.
+
+### 3. Build the suggestion engine in cmux
+
+Keep ranking and history ownership in the app.
+
+Initial sources:
+
+1. shell history
+2. cwd-sensitive command frequency
+3. git-aware suggestions for common repo commands
+4. recent accepted suggestions
+
+Initial ranking:
+
+1. exact prefix match
+2. token-prefix match on the current word
+3. same-directory boost
+4. recent use boost
+5. shorter completion tie-breaker
+
+The first cut should stay local and deterministic. Do not involve remote or LLM-backed suggestions in the base feature.
+
+### 4. Render as cmux-owned ghost text
+
+Show a suggestion only when:
+
+1. the shell says the prompt is editable
+2. the cursor is at the end of the buffer
+3. there is no IME marked text
+4. terminal copy mode is off
+5. there is no active completion menu/search mode from the shell
+
+First UI:
+
+1. inline ghost text only
+2. one best suggestion
+3. explicit accept shortcut
+4. dismiss on normal edits, cursor movement, or mode changes
+
+Later UI:
+
+1. popup list under the cursor
+2. next/previous suggestion navigation
+3. per-source badges if that becomes useful
+
+### 5. Accept suggestions without breaking shell behavior
+
+Acceptance should send only the suffix beyond what the user typed.
+
+Avoid pretending the suggestion is already in the shell buffer unless we have shell confirmation that it was accepted. The shell remains the source of truth.
+
+The acceptance shortcut should be customizable through `KeyboardShortcutSettings`.
+
+## Suggested Scope for v1
+
+Build only for zsh first.
+
+That keeps the integration honest:
+
+1. zsh already has cmux shell integration
+2. zle exposes the buffer directly
+3. the user expectation is explicitly anchored to `zsh-autosuggestions`
+
+If the design works, add bash support later through a different shell-side contract. Do not force a fake shell-agnostic abstraction too early.
+
+## Risks
+
+1. Input latency if shell hooks report too often or the app does expensive ranking on every change.
+2. Wrong suggestions during IME composition or vi-mode transitions.
+3. Keybinding conflicts with shell-native bindings, especially Tab and Right Arrow.
+4. History reads becoming expensive if we re-scan large histfiles on every update.
+5. Users expecting plugin-level parity immediately, including async completion sources and advanced widgets.
+
+## Implementation Notes
+
+1. Reuse the browser omnibar inline completion model for ranking, suffix display, and acceptance semantics where possible.
+2. Keep all expensive work off the terminal key event path.
+3. Add UI tests only after the shell-to-app contract is stable enough to avoid test flake.
+4. Prefer a tiny, explicit shell protocol over trying to infer shell state from renderer output.
+
+## Milestones
+
+1. Add shell protocol for live command line state in zsh.
+2. Store per-panel command line state in cmux and surface it in debug output.
+3. Render inline ghost text for one best suggestion.
+4. Add accept and dismiss actions, with customizable shortcut.
+5. Add history store, ranking, and tests.
+6. Decide whether a popup list is worth the added complexity.

--- a/docs/terminal-autosuggestions.md
+++ b/docs/terminal-autosuggestions.md
@@ -178,11 +178,11 @@ Add a one-time or low-frequency zsh handshake after user startup, for example on
 
 The shell should report whether external autosuggestions are active for the current shell session:
 
-`report_autosuggestion_provider --shell=zsh --provider=external:zsh-autosuggestions --tab=<id> --panel=<id>`
+`report_autosuggestion_provider external:zsh-autosuggestions --tab=<id> --panel=<id>`
 
 or
 
-`report_autosuggestion_provider --shell=zsh --provider=cmux --tab=<id> --panel=<id>`
+`report_autosuggestion_provider cmux --tab=<id> --panel=<id>`
 
 At minimum, `Automatic` mode should back off when zsh reports a known external provider.
 

--- a/scripts/probe-terminal-autosuggestions.sh
+++ b/scripts/probe-terminal-autosuggestions.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+INTEGRATION_DIR="$PROJECT_DIR/Resources/shell-integration"
+DEFAULT_GHOSTTY_RESOURCES_DIR="$PROJECT_DIR/ghostty/src"
+
+PROVIDER_PRESET="none"
+OVERRIDE_PROVIDER=""
+ONCE=0
+KEEP_TEMP=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/probe-terminal-autosuggestions.sh [options]
+
+Launch an isolated nested zsh in the current cmux panel without loading your real
+~/.zshrc. The nested shell reports its autosuggestion provider to the current
+panel so you can inspect the result through `cmux sidebar-state`.
+
+Options:
+  --provider <preset>    Simulate a provider in the isolated .zshrc.
+                         Presets: none, zsh-autosuggestions, zsh-autocomplete, unknown
+                         Default: none
+  --override <provider>  Set CMUX_AUTOSUGGEST_PROVIDER_OVERRIDE for the nested shell.
+                         Examples: none, cmux, external:unknown
+  --once                 Print autosuggestion sidebar state and exit.
+  --keep-temp            Keep the temporary ZDOTDIR directory for inspection.
+  -h, --help             Show this help.
+
+Examples:
+  ./scripts/probe-terminal-autosuggestions.sh
+  ./scripts/probe-terminal-autosuggestions.sh --provider zsh-autosuggestions --once
+  ./scripts/probe-terminal-autosuggestions.sh --provider zsh-autocomplete
+  ./scripts/probe-terminal-autosuggestions.sh --provider unknown --override none --once
+EOF
+}
+
+require_cmux_panel() {
+  if [[ -z "${CMUX_TAB_ID:-}" || -z "${CMUX_PANEL_ID:-}" ]]; then
+    echo "error: run this from a cmux terminal panel so the nested shell can report back to the active panel" >&2
+    exit 1
+  fi
+}
+
+validate_provider_preset() {
+  case "$1" in
+    none|zsh-autosuggestions|zsh-autocomplete|unknown)
+      ;;
+    *)
+      echo "error: unsupported --provider preset '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+provider_marker_block() {
+  case "$1" in
+    none)
+      ;;
+    zsh-autosuggestions)
+      cat <<'EOF'
+typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+EOF
+      ;;
+    zsh-autocomplete)
+      cat <<'EOF'
+function _autocomplete__main() { :; }
+EOF
+      ;;
+    unknown)
+      cat <<'EOF'
+function _custom_autosuggest_preview() { :; }
+EOF
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider)
+      PROVIDER_PRESET="${2:-}"
+      if [[ -z "$PROVIDER_PRESET" ]]; then
+        echo "error: --provider requires a value" >&2
+        exit 1
+      fi
+      validate_provider_preset "$PROVIDER_PRESET"
+      shift 2
+      ;;
+    --override)
+      OVERRIDE_PROVIDER="${2:-}"
+      if [[ -z "$OVERRIDE_PROVIDER" ]]; then
+        echo "error: --override requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --once)
+      ONCE=1
+      shift
+      ;;
+    --keep-temp)
+      KEEP_TEMP=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmux_panel
+
+if [[ ! -d "$INTEGRATION_DIR" ]]; then
+  echo "error: missing shell integration directory at $INTEGRATION_DIR" >&2
+  exit 1
+fi
+
+GHOSTTY_RESOURCES_DIR="${GHOSTTY_RESOURCES_DIR:-$DEFAULT_GHOSTTY_RESOURCES_DIR}"
+if [[ ! -d "$GHOSTTY_RESOURCES_DIR" ]]; then
+  echo "error: missing Ghostty resources directory at $GHOSTTY_RESOURCES_DIR" >&2
+  exit 1
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cmux-autosuggest-probe.XXXXXX")"
+cleanup() {
+  if [[ "$KEEP_TEMP" -eq 1 ]]; then
+    echo "kept temporary ZDOTDIR at $TMP_ROOT"
+    return
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat > "$TMP_ROOT/.zshenv" <<'EOF'
+
+EOF
+
+cat > "$TMP_ROOT/.zshrc" <<EOF
+export HISTFILE="$TMP_ROOT/.zsh_history"
+SAVEHIST=0
+HISTSIZE=0
+PROMPT='autosuggest-probe(${PROVIDER_PRESET}) %1~ %# '
+
+cmux_autosuggest_state() {
+    if ! command -v cmux >/dev/null 2>&1; then
+        print -r -- 'cmux CLI not found in PATH'
+        return 1
+    fi
+
+    local output
+    if ! output="\$(cmux sidebar-state 2>/dev/null)"; then
+        print -r -- 'Failed to read sidebar state. Make sure this shell is running inside the tagged cmux build.'
+        return 1
+    fi
+
+    if command -v rg >/dev/null 2>&1; then
+        print -r -- "\$output" | rg '^autosuggestion_'
+    else
+        print -r -- "\$output" | grep '^autosuggestion_'
+    fi
+}
+
+alias cas='cmux_autosuggest_state'
+
+print -P "%F{cyan}[cmux autosuggest probe]%f isolated zshrc active"
+print -P "%F{cyan}[cmux autosuggest probe]%f preset=${PROVIDER_PRESET}"
+if [[ -n "${OVERRIDE_PROVIDER}" ]]; then
+    print -P "%F{cyan}[cmux autosuggest probe]%f override=${OVERRIDE_PROVIDER}"
+fi
+print -P "%F{cyan}[cmux autosuggest probe]%f run 'cas' to inspect sidebar autosuggestion state"
+EOF
+
+provider_marker_block "$PROVIDER_PRESET" >> "$TMP_ROOT/.zshrc"
+
+if [[ "$ONCE" -eq 1 ]]; then
+  env_args=(
+    ZDOTDIR="$INTEGRATION_DIR"
+    CMUX_ZSH_ZDOTDIR="$TMP_ROOT"
+    CMUX_SHELL_INTEGRATION=1
+    CMUX_SHELL_INTEGRATION_DIR="$INTEGRATION_DIR"
+    GHOSTTY_RESOURCES_DIR="$GHOSTTY_RESOURCES_DIR"
+  )
+  if [[ -n "$OVERRIDE_PROVIDER" ]]; then
+    env_args+=(CMUX_AUTOSUGGEST_PROVIDER_OVERRIDE="$OVERRIDE_PROVIDER")
+  fi
+
+  env "${env_args[@]}" /bin/zsh -i -c '_cmux_report_autosuggestion_provider; sleep 0.2; cmux_autosuggest_state'
+  exit 0
+fi
+
+echo "Launching isolated nested zsh. Exit it to return to your normal shell."
+env_args=(
+  ZDOTDIR="$INTEGRATION_DIR"
+  CMUX_ZSH_ZDOTDIR="$TMP_ROOT"
+  CMUX_SHELL_INTEGRATION=1
+  CMUX_SHELL_INTEGRATION_DIR="$INTEGRATION_DIR"
+  GHOSTTY_RESOURCES_DIR="$GHOSTTY_RESOURCES_DIR"
+)
+if [[ -n "$OVERRIDE_PROVIDER" ]]; then
+  env_args+=(CMUX_AUTOSUGGEST_PROVIDER_OVERRIDE="$OVERRIDE_PROVIDER")
+fi
+
+env "${env_args[@]}" /bin/zsh -i


### PR DESCRIPTION
## Summary
- add an Off / Automatic / Force On terminal autosuggestion setting and persist the selection in app defaults
- pass terminal autosuggestion mode into shell sessions, detect autosuggestion providers in zsh after user startup files load, and report the provider over the existing socket path
- track per-panel autosuggestion providers in workspace state, expose the current provider in `sidebar_state`, and add unit plus zsh handoff coverage for detection and mode policy
- add `scripts/probe-terminal-autosuggestions.sh` for isolated local testing without loading the user's real `~/.zshrc`

## Testing
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `jq empty Resources/Localizable.xcstrings`
- interactive zsh smoke checks for `_cmux_autosuggestion_provider`: `none`, `external:zsh-autosuggestions`, `external:zsh-autocomplete`, and override `none`
- `./scripts/reload.sh --tag task-built-in-zsh-autosuggestions`
- `bash -n scripts/probe-terminal-autosuggestions.sh`
- `./scripts/probe-terminal-autosuggestions.sh --help`
- Added tests in `cmuxTests/GhosttyConfigTests.swift`, not run locally per repo policy

## Issues
- Related: task summary `built-in zsh autosuggestions in cmux`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal Autosuggestions with selectable modes (Off, Automatic, Force On); per-panel provider tracking and detection surfaced in UI/status.

* **Localization**
  * Added localized UI strings for the new autosuggestions setting and related UI labels/status messages.

* **Tools**
  * New probe utility to inspect autosuggestion provider behavior from a nested shell session.

* **Documentation**
  * Added design doc describing autosuggestions architecture and rollout plan.

* **Tests**
  * Expanded tests for settings, provider detection, and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->