### PR TITLE
Add never-ask-again option to notification prompt

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -28255,13 +28255,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Notifications are disabled for cmux. Enable them in System Settings to see alerts."
+            "value": "Notifications are off for cmux. Turn them on in System Settings to get alerts. If you want to revisit this later, open Settings > Notifications in cmux anytime."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxの通知が無効になっています。アラートを表示するにはシステム設定で有効にしてください。"
+            "value": "cmuxの通知はオフになっています。通知を受け取るには、システム設定で有効にしてください。後で見直す場合は、cmuxの「設定 > 通知」からいつでも開けます。"
           }
         },
         "zh-Hans": {
@@ -28471,6 +28471,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Şimdi Değil"
+          }
+        }
+      }
+    },
+    "dialog.enableNotifications.neverAskAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never Ask Again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後は表示しない"
           }
         }
       }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -651,6 +651,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
+    private static let notificationSettingsPromptSuppressedKey = "notifications.enablePromptSuppressed"
     private enum AuthorizationRequestOrigin: String {
         case notificationDelivery = "notification_delivery"
         case settingsButton = "settings_button"
@@ -759,6 +760,17 @@ final class TerminalNotificationStore: ObservableObject {
         @unknown default:
             return "unknown(\(status.rawValue))"
         }
+    }
+
+    private static func isNotificationSettingsPromptSuppressed(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: notificationSettingsPromptSuppressedKey)
+    }
+
+    private static func setNotificationSettingsPromptSuppressed(
+        _ isSuppressed: Bool,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(isSuppressed, forKey: notificationSettingsPromptSuppressedKey)
     }
 
     func refreshAuthorizationStatus() {
@@ -1066,8 +1078,14 @@ final class TerminalNotificationStore: ObservableObject {
                 case .authorized, .provisional, .ephemeral:
                     completion(true)
                 case .denied:
-                    self.logAuthorization("ensure denied origin=\(origin.rawValue) prompting_settings")
-                    self.promptToEnableNotifications()
+                    switch origin {
+                    case .notificationDelivery:
+                        self.logAuthorization("ensure denied origin=\(origin.rawValue) prompting_settings")
+                        self.promptToEnableNotifications()
+                    case .settingsButton, .settingsTest:
+                        self.logAuthorization("ensure denied origin=\(origin.rawValue) opening_settings")
+                        self.openNotificationSettings()
+                    }
                     completion(false)
                 case .notDetermined:
                     if Self.shouldDeferAutomaticAuthorizationRequest(
@@ -1128,7 +1146,12 @@ final class TerminalNotificationStore: ObservableObject {
 
     private func promptToEnableNotifications() {
         DispatchQueue.main.async { [weak self] in
-            guard let self, !self.hasPromptedForSettings else { return }
+            guard let self else { return }
+            guard !Self.isNotificationSettingsPromptSuppressed() else {
+                self.logAuthorization("prompt settings skipped suppressed=1")
+                return
+            }
+            guard !self.hasPromptedForSettings else { return }
             self.logAuthorization("prompt settings shown")
             self.hasPromptedForSettings = true
             self.presentNotificationSettingsPrompt(attempt: 0)
@@ -1151,14 +1174,24 @@ final class TerminalNotificationStore: ObservableObject {
 
         let alert = notificationSettingsAlertFactory()
         alert.messageText = String(localized: "dialog.enableNotifications.title", defaultValue: "Enable Notifications for cmux")
-        alert.informativeText = String(localized: "dialog.enableNotifications.message", defaultValue: "Notifications are disabled for cmux. Enable them in System Settings to see alerts.")
+        alert.informativeText = String(
+            localized: "dialog.enableNotifications.message",
+            defaultValue: "Notifications are off for cmux. Turn them on in System Settings to get alerts. If you want to revisit this later, open Settings > Notifications in cmux anytime."
+        )
         alert.addButton(withTitle: String(localized: "dialog.enableNotifications.openSettings", defaultValue: "Open Settings"))
         alert.addButton(withTitle: String(localized: "dialog.enableNotifications.notNow", defaultValue: "Not Now"))
+        alert.addButton(withTitle: String(localized: "dialog.enableNotifications.neverAskAgain", defaultValue: "Never Ask Again"))
         alert.beginSheetModal(for: window) { [weak self] response in
-            guard response == .alertFirstButtonReturn else {
-                return
+            guard let self else { return }
+            switch response {
+            case .alertFirstButtonReturn:
+                self.openNotificationSettings()
+            case .alertThirdButtonReturn:
+                Self.setNotificationSettingsPromptSuppressed(true)
+                self.logAuthorization("prompt settings never_ask_again")
+            default:
+                self.logAuthorization("prompt settings dismissed response=\(response.rawValue)")
             }
-            self?.openNotificationSettings()
         }
     }
 
@@ -1248,6 +1281,14 @@ final class TerminalNotificationStore: ObservableObject {
             NSWorkspace.shared.open(url)
         }
         hasPromptedForSettings = false
+    }
+
+    func setNotificationSettingsPromptSuppressedForTesting(_ isSuppressed: Bool) {
+        Self.setNotificationSettingsPromptSuppressed(isSuppressed)
+    }
+
+    func isNotificationSettingsPromptSuppressedForTesting() -> Bool {
+        Self.isNotificationSettingsPromptSuppressed()
     }
 
     func configureNotificationDeliveryHandlerForTesting(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -770,7 +770,11 @@ final class TerminalNotificationStore: ObservableObject {
         _ isSuppressed: Bool,
         defaults: UserDefaults = .standard
     ) {
-        defaults.set(isSuppressed, forKey: notificationSettingsPromptSuppressedKey)
+        if isSuppressed {
+            defaults.set(true, forKey: notificationSettingsPromptSuppressedKey)
+        } else {
+            defaults.removeObject(forKey: notificationSettingsPromptSuppressedKey)
+        }
     }
 
     func refreshAuthorizationStatus() {
@@ -1281,6 +1285,7 @@ final class TerminalNotificationStore: ObservableObject {
             NSWorkspace.shared.open(url)
         }
         hasPromptedForSettings = false
+        Self.setNotificationSettingsPromptSuppressed(false)
     }
 
     func setNotificationSettingsPromptSuppressedForTesting(_ isSuppressed: Bool) {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -8206,7 +8206,14 @@ final class NotificationDockBadgeTests: XCTestCase {
     private final class NotificationSettingsAlertSpy: NSAlert {
         private(set) var beginSheetModalCallCount = 0
         private(set) var runModalCallCount = 0
+        private(set) var addedButtonTitles: [String] = []
         var nextResponse: NSApplication.ModalResponse = .alertFirstButtonReturn
+
+        @discardableResult
+        override func addButton(withTitle title: String) -> NSButton {
+            addedButtonTitles.append(title)
+            return super.addButton(withTitle: title)
+        }
 
         override func beginSheetModal(
             for sheetWindow: NSWindow,
@@ -8224,6 +8231,7 @@ final class NotificationDockBadgeTests: XCTestCase {
 
     override func tearDown() {
         TerminalNotificationStore.shared.resetNotificationSettingsPromptHooksForTesting()
+        TerminalNotificationStore.shared.setNotificationSettingsPromptSuppressedForTesting(false)
         TerminalNotificationStore.shared.replaceNotificationsForTesting([])
         super.tearDown()
     }
@@ -8671,6 +8679,10 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(alertSpy.beginSheetModalCallCount, 1)
         XCTAssertEqual(alertSpy.runModalCallCount, 0)
         XCTAssertEqual(
+            alertSpy.addedButtonTitles,
+            ["Open Settings", "Not Now", "Never Ask Again"]
+        )
+        XCTAssertEqual(
             openedURL?.absoluteString,
             "x-apple.systempreferences:com.apple.preference.notifications"
         )
@@ -8709,6 +8721,48 @@ final class NotificationDockBadgeTests: XCTestCase {
 
         XCTAssertEqual(alertSpy.beginSheetModalCallCount, 1)
         XCTAssertEqual(alertSpy.runModalCallCount, 0)
+    }
+
+    func testNotificationSettingsPromptNeverAskAgainSuppressesFuturePrompts() {
+        let store = TerminalNotificationStore.shared
+        let firstAlertSpy = NotificationSettingsAlertSpy()
+        firstAlertSpy.nextResponse = .alertThirdButtonReturn
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+
+        store.configureNotificationSettingsPromptHooksForTesting(
+            windowProvider: { window },
+            alertFactory: { firstAlertSpy },
+            scheduler: { _, block in block() },
+            urlOpener: { _ in XCTFail("Should not open settings for Never Ask Again response") }
+        )
+
+        store.promptToEnableNotificationsForTesting()
+        let firstDrain = expectation(description: "first main queue drain")
+        DispatchQueue.main.async { firstDrain.fulfill() }
+        wait(for: [firstDrain], timeout: 1.0)
+
+        XCTAssertEqual(firstAlertSpy.beginSheetModalCallCount, 1)
+        XCTAssertTrue(store.isNotificationSettingsPromptSuppressedForTesting())
+
+        let secondAlertSpy = NotificationSettingsAlertSpy()
+        store.configureNotificationSettingsPromptHooksForTesting(
+            windowProvider: { window },
+            alertFactory: { secondAlertSpy },
+            scheduler: { _, block in block() },
+            urlOpener: { _ in XCTFail("Prompt should stay suppressed") }
+        )
+
+        store.promptToEnableNotificationsForTesting()
+        let secondDrain = expectation(description: "second main queue drain")
+        DispatchQueue.main.async { secondDrain.fulfill() }
+        wait(for: [secondDrain], timeout: 1.0)
+
+        XCTAssertEqual(secondAlertSpy.beginSheetModalCallCount, 0)
     }
 
     func testNotificationIndexesTrackUnreadCountsByTabAndSurface() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -8765,6 +8765,17 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(secondAlertSpy.beginSheetModalCallCount, 0)
     }
 
+    func testNotificationSettingsPromptResetClearsSuppressionState() {
+        let store = TerminalNotificationStore.shared
+
+        store.setNotificationSettingsPromptSuppressedForTesting(true)
+        XCTAssertTrue(store.isNotificationSettingsPromptSuppressedForTesting())
+
+        store.resetNotificationSettingsPromptHooksForTesting()
+
+        XCTAssertFalse(store.isNotificationSettingsPromptSuppressedForTesting())
+    }
+
     func testNotificationIndexesTrackUnreadCountsByTabAndSurface() {
         let tabA = UUID()
         let tabB = UUID()


### PR DESCRIPTION
## Summary

- Add a persistent `Never Ask Again` option to the notification enable sheet.
- Clarify the denied-permission copy so users know they can revisit `Settings > Notifications` in cmux later.

## Testing

- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination "platform=macOS" -derivedDataPath /tmp/cmux-task-notification-dialog-never-ask-again-tests -only-testing:cmuxTests/NotificationDockBadgeTests test`
- `./scripts/reload.sh --tag task-notification-dialog-never-ask-again`
- Verified the prompt buttons and suppression/reset behavior through `NotificationDockBadgeTests`.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not recorded.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved
