### PR TITLE
Add Discord link to help menu

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -873,6 +873,23 @@
         }
       }
     },
+    "sidebar.help.discord": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord"
+          }
+        }
+      }
+    },
     "sidebar.help.githubIssues": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8437,6 +8437,7 @@ private enum SidebarHelpMenuAction {
     case changelog
     case github
     case githubIssues
+    case discord
     case checkForUpdates
     case sendFeedback
     case welcome
@@ -8937,6 +8938,7 @@ private struct SidebarHelpMenuButton: View {
     private let changelogURL = URL(string: "https://cmux.dev/docs/changelog")
     private let githubURL = URL(string: "https://github.com/manaflow-ai/cmux")
     private let githubIssuesURL = URL(string: "https://github.com/manaflow-ai/cmux/issues")
+    private let discordURL = URL(string: "https://discord.gg/xsgFEVrWCZ")
     private let helpTitle = String(localized: "sidebar.help.button", defaultValue: "Help")
     private let buttonSize: CGFloat = 22
     private let iconSize: CGFloat = 11
@@ -9032,6 +9034,14 @@ private struct SidebarHelpMenuButton: View {
                     isExternalLink: true
                 )
             }
+            if discordURL != nil {
+                helpOptionButton(
+                    title: String(localized: "sidebar.help.discord", defaultValue: "Discord"),
+                    action: .discord,
+                    accessibilityIdentifier: "SidebarHelpMenuOptionDiscord",
+                    isExternalLink: true
+                )
+            }
             helpOptionButton(
                 title: String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates"),
                 action: .checkForUpdates,
@@ -9122,6 +9132,9 @@ private struct SidebarHelpMenuButton: View {
         case .githubIssues:
             guard let githubIssuesURL else { return }
             NSWorkspace.shared.open(githubIssuesURL)
+        case .discord:
+            guard let discordURL else { return }
+            NSWorkspace.shared.open(discordURL)
         case .checkForUpdates:
             Task { @MainActor in
                 AppDelegate.shared?.checkForUpdates(nil)


### PR DESCRIPTION
## Summary
- Adds a Discord link to the "?" help menu in the sidebar footer, between GitHub Issues and Check for Updates
- Links to the existing invite: https://discord.gg/xsgFEVrWCZ
- Includes English and Japanese localizations

## Testing
- Built and launched with `./scripts/reload.sh --tag add-discord`
- Verified Discord item appears in help menu with external link icon

## Related
- Task: add Discord to ? in bottom left

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Discord link to the sidebar “?” help menu between GitHub Issues and Check for Updates. Opens our invite (https://discord.gg/xsgFEVrWCZ) in the default browser.

- **New Features**
  - Adds "Discord" help option with en/ja localization (`sidebar.help.discord`).
  - Implements `.discord` action to open the invite via `NSWorkspace.shared.open`.
  - Aligns with task: add Discord to ? in bottom left.

<sup>Written for commit 65593c645968581bcb949bdd01fbed0bfc03b317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

