### PR TITLE
Add VoiceOver traits to pickers, reorder settings

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3442,15 +3442,6 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     SettingsSectionHeader(title: String(localized: "settings.section.app", defaultValue: "App"))
                     SettingsCard {
-                        ThemePickerRow(
-                            selectedMode: appearanceMode,
-                            onSelect: { mode in
-                                appearanceMode = mode.rawValue
-                            }
-                        )
-
-                        SettingsCardDivider()
-
                         SettingsCardRow(
                             String(localized: "settings.app.language", defaultValue: "Language"),
                             subtitle: appLanguage != LanguageSettings.languageAtLaunch.rawValue
@@ -3479,6 +3470,15 @@ struct SettingsView: View {
                                 }
                             }
                         }
+
+                        SettingsCardDivider()
+
+                        ThemePickerRow(
+                            selectedMode: appearanceMode,
+                            onSelect: { mode in
+                                appearanceMode = mode.rawValue
+                            }
+                        )
 
                         SettingsCardDivider()
 
@@ -4933,6 +4933,7 @@ private struct ThemePickerRow: View {
                     }
                     .buttonStyle(.plain)
                     .focusable(false)
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
             .layoutPriority(1)
@@ -5014,6 +5015,7 @@ private struct AppIconPickerRow: View {
                     }
                     .buttonStyle(.plain)
                     .focusable(false)
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
             .layoutPriority(1)


### PR DESCRIPTION
## Summary
- Added `accessibilityAddTraits(.isSelected)` to Theme and App Icon picker buttons for VoiceOver support
- Reordered top of App section: Language, Theme, App Icon

## Testing
- Build verified with `xcodebuild`

## Related
- Follow-up to https://github.com/manaflow-ai/cmux/pull/1367

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add VoiceOver selected-state traits to the Theme and App Icon pickers so the active option is announced. Reorder the App settings to: Language, Theme, App Icon.

<sup>Written for commit a54c27930a87beef55c078339dae771714e8e720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility: Theme and app icon selection options now properly announce their selected state to assistive technologies for better screen reader support.

* **Style**
  * Reorganized settings layout for improved visual flow, including repositioned theme preferences with updated dividers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->