### PR TITLE
feat: strip YAML frontmatter in markdown panel

### DIFF
--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -14,10 +14,13 @@ final class MarkdownPanel: Panel, ObservableObject {
     /// The workspace this panel belongs to.
     private(set) var workspaceId: UUID
 
-    /// Current markdown content read from the file.
+    /// Current markdown content read from the file (frontmatter stripped).
     @Published private(set) var content: String = ""
 
-    /// Title shown in the tab bar (filename).
+    /// Parsed YAML frontmatter key-value pairs, if present.
+    @Published private(set) var frontmatter: [String: String] = [:]
+
+    /// Title shown in the tab bar (frontmatter title or filename).
     @Published private(set) var displayTitle: String = ""
 
     /// SF Symbol icon for the tab bar.
@@ -83,21 +86,98 @@ final class MarkdownPanel: Panel, ObservableObject {
     // MARK: - File I/O
 
     private func loadFileContent() {
+        let rawContent: String
         do {
-            let newContent = try String(contentsOfFile: filePath, encoding: .utf8)
-            content = newContent
-            isFileUnavailable = false
+            rawContent = try String(contentsOfFile: filePath, encoding: .utf8)
         } catch {
             // Fallback: try ISO Latin-1, which accepts all 256 byte values,
             // covering legacy encodings like Windows-1252.
             if let data = FileManager.default.contents(atPath: filePath),
                let decoded = String(data: data, encoding: .isoLatin1) {
-                content = decoded
+                let (meta, body) = Self.stripFrontmatter(decoded)
+                frontmatter = meta
+                content = body
+                updateTitleFromFrontmatter()
                 isFileUnavailable = false
             } else {
                 isFileUnavailable = true
             }
+            return
         }
+
+        let (meta, body) = Self.stripFrontmatter(rawContent)
+        frontmatter = meta
+        content = body
+        updateTitleFromFrontmatter()
+        isFileUnavailable = false
+    }
+
+    /// Update the display title from frontmatter `title` key, falling back
+    /// to the filename.
+    private func updateTitleFromFrontmatter() {
+        if let title = frontmatter["title"], !title.isEmpty {
+            displayTitle = title
+        } else {
+            displayTitle = (filePath as NSString).lastPathComponent
+        }
+    }
+
+    // MARK: - Frontmatter parsing
+
+    /// Strips a leading YAML frontmatter block (`---` … `---`) from the
+    /// given string. Returns the parsed key-value pairs and the remaining
+    /// markdown body. Only simple `key: value` pairs are supported;
+    /// nested YAML structures are ignored to avoid a heavyweight dependency.
+    static func stripFrontmatter(_ text: String) -> (metadata: [String: String], body: String) {
+        // Frontmatter must start at the very beginning of the file.
+        guard text.hasPrefix("---") else { return ([:], text) }
+
+        // Find the closing `---` delimiter. We skip the opening line and
+        // search for a line that is exactly `---` (with optional trailing
+        // whitespace).
+        let lines = text.components(separatedBy: "\n")
+        guard lines.count >= 2 else { return ([:], text) }
+
+        var closingIndex: Int?
+        for i in 1..<lines.count {
+            if lines[i].trimmingCharacters(in: .whitespaces) == "---" {
+                closingIndex = i
+                break
+            }
+        }
+
+        guard let endIndex = closingIndex else { return ([:], text) }
+
+        // Parse simple `key: value` pairs from the frontmatter block.
+        var metadata: [String: String] = [:]
+        for i in 1..<endIndex {
+            let line = lines[i]
+            guard let colonRange = line.range(of: ":") else { continue }
+            let key = line[line.startIndex..<colonRange.lowerBound]
+                .trimmingCharacters(in: .whitespaces)
+            var value = line[colonRange.upperBound...]
+                .trimmingCharacters(in: .whitespaces)
+            // Strip surrounding quotes if present.
+            if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+               (value.hasPrefix("'") && value.hasSuffix("'")) {
+                value = String(value.dropFirst().dropLast())
+            }
+            if !key.isEmpty {
+                metadata[key] = value
+            }
+        }
+
+        // The body starts after the closing `---` line.
+        let bodyLines = Array(lines[(endIndex + 1)...])
+        // Trim a single leading blank line that often follows the closing delimiter.
+        let body: String
+        if let first = bodyLines.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+            body = bodyLines.dropFirst().joined(separator: "\n")
+        } else {
+            body = bodyLines.joined(separator: "\n")
+        }
+
+        return (metadata, body)
     }
 
     // MARK: - File watcher via DispatchSource

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -68,16 +68,49 @@ struct MarkdownPanelView: View {
     }
 
     private var filePathHeader: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "doc.richtext")
-                .foregroundColor(.secondary)
-                .font(.system(size: 12))
-            Text(panel.filePath)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Spacer()
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.richtext")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+                Text(panel.filePath)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+            }
+
+            if !panel.frontmatter.isEmpty {
+                frontmatterTagsView
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var frontmatterTagsView: some View {
+        let isDark = colorScheme == .dark
+        // Display select frontmatter fields as inline tags.
+        let displayKeys = panel.frontmatter
+            .filter { $0.key != "title" && !$0.value.isEmpty }
+            .sorted { $0.key < $1.key }
+
+        if !displayKeys.isEmpty {
+            FlowLayout(spacing: 4) {
+                ForEach(displayKeys, id: \.key) { key, value in
+                    Text("\(key): \(value)")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(isDark ? .white.opacity(0.6) : .secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(isDark
+                                    ? Color.white.opacity(0.08)
+                                    : Color.black.opacity(0.06))
+                        )
+                }
+            }
         }
     }
 
@@ -351,5 +384,57 @@ final class MarkdownPanelPointerObserverView: NSView {
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
             self?.handleEventIfNeeded(event) ?? event
         }
+    }
+}
+
+// MARK: - FlowLayout
+
+/// A simple horizontal flow layout that wraps children to the next line
+/// when they exceed the available width.
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var height: CGFloat = 0
+        for (i, row) in rows.enumerated() {
+            let rowHeight = row.map { $0.sizeThatFits(.unspecified).height }.max() ?? 0
+            height += rowHeight
+            if i < rows.count - 1 { height += spacing }
+        }
+        return CGSize(width: proposal.width ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for (i, row) in rows.enumerated() {
+            var x = bounds.minX
+            let rowHeight = row.map { $0.sizeThatFits(.unspecified).height }.max() ?? 0
+            for subview in row {
+                let size = subview.sizeThatFits(.unspecified)
+                subview.place(at: CGPoint(x: x, y: y), proposal: .init(width: size.width, height: size.height))
+                x += size.width + spacing
+            }
+            y += rowHeight
+            if i < rows.count - 1 { y += spacing }
+        }
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutSubviews.Element]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[LayoutSubviews.Element]] = [[]]
+        var currentWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentWidth + size.width > maxWidth, !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                currentWidth = 0
+            }
+            rows[rows.count - 1].append(subview)
+            currentWidth += size.width + spacing
+        }
+        return rows
     }
 }


### PR DESCRIPTION
## Summary

- Strip YAML frontmatter (`---`…`---`) from markdown content before rendering in `MarkdownPanel`
- Parse simple `key: value` pairs and expose them via `@Published frontmatter` property
- Override tab title with frontmatter `title` key when present
- Display non-title frontmatter fields as inline tags in the file path header
- Add `FlowLayout` for wrapping frontmatter tags

## Motivation

Many markdown files used in agent workflows (plans, notes, docs) include YAML frontmatter for metadata. Without stripping, the raw YAML block renders as plain text, which looks broken. This is a lightweight improvement that makes the markdown panel work correctly with frontmatter-heavy files (Obsidian, Jekyll, Hugo, etc.).

Closes no existing issue, but related to the markdown panel added in #883.

## Changes

| File | Change |
|------|--------|
| `Sources/Panels/MarkdownPanel.swift` | Add `stripFrontmatter()` static method, `frontmatter` property, title override logic |
| `Sources/Panels/MarkdownPanelView.swift` | Display frontmatter tags in header, add `FlowLayout` |

## Test plan

- [ ] Open a `.md` file with YAML frontmatter — frontmatter should not appear in rendered content
- [ ] Verify frontmatter `title` overrides the tab title
- [ ] Open a `.md` file without frontmatter — no behavior change
- [ ] Verify frontmatter metadata tags display in the header area
- [ ] Test with files using `---` as thematic breaks (not at file start) — should not be stripped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips leading YAML frontmatter from markdown in `MarkdownPanel`, parses simple metadata, sets the tab title from `title`, and shows other fields as tags in the header.

- **New Features**
  - Remove only leading `--- ... ---` frontmatter; thematic breaks later in the file are ignored.
  - Parse simple `key: value` pairs and expose them via `frontmatter: [String: String]`.
  - Use `frontmatter.title` to override the tab title; fallback to filename.
  - Show non-title fields as inline tags in the file path header.
  - Add a lightweight `FlowLayout` to wrap tags.

<sup>Written for commit 4dbe3fe2fa3313c2fb48150261a64d9921ff83ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added frontmatter support to markdown files for defining custom metadata
  * Document titles can now be customized via frontmatter
  * Frontmatter metadata displays as visual tags beneath file information with intelligent text wrapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->