### PR TITLE
Change help menu Welcome to Welcome to cmux!

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -845,13 +845,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Welcome"
+            "value": "Welcome to cmux!"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ようこそ"
+            "value": "cmuxへようこそ！"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8983,7 +8983,7 @@ private struct SidebarHelpMenuButton: View {
     private var helpPopover: some View {
         VStack(alignment: .leading, spacing: 2) {
             helpOptionButton(
-                title: String(localized: "sidebar.help.welcome", defaultValue: "Welcome"),
+                title: String(localized: "sidebar.help.welcome", defaultValue: "Welcome to cmux!"),
                 action: .welcome,
                 accessibilityIdentifier: "SidebarHelpMenuOptionWelcome",
                 isExternalLink: false


### PR DESCRIPTION
## Summary
- Changed the "Welcome" label in the sidebar help menu (bottom-left `?` button) to "Welcome to cmux!"
- Updated English and Japanese localizations

## Testing
- Tagged build: `./scripts/reload.sh --tag welcome-to-cmux` (compiled and launched successfully)
- Click the `?` button in the bottom-left of the sidebar, verify the first menu item reads "Welcome to cmux!"

## Related
- Task: Change "Welcome in ?" in bottom left to "Welcome to cmux!"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the sidebar help menu label to "Welcome to cmux!" in the bottom-left "?" menu to clarify branding. Updated localized strings (en, ja) and the Swift default fallback so the new text always appears, matching the task requirement.

<sup>Written for commit 5a12a8d575a6fe8217b245a24658efc300c58112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization Updates**
  * The welcome message has been updated to explicitly include the application name, providing users with a more personalized greeting across all supported languages. This enhancement creates a more branded and welcoming experience when users interact with the help section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->