### PR TITLE
Add browser keyboard capture mode

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7937,6 +7937,74 @@
         }
       }
     },
+    "browser.keyboardCapture.active": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard captured, Esc twice to exit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードをキャプチャ中、Esc を2回押すと終了"
+          }
+        }
+      }
+    },
+    "browser.keyboardCapture.armed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Esc again to exit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了するにはもう一度 Esc を押す"
+          }
+        }
+      }
+    },
+    "browser.keyboardCapture.capture": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture webview keyboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webview のキーボードをキャプチャ"
+          }
+        }
+      }
+    },
+    "browser.keyboardCapture.release": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release webview keyboard capture"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webview のキーボードキャプチャを解除"
+          }
+        }
+      }
+    },
     "cli.install.adminRequired": {
       "extractionState": "manual",
       "localizations": {
@@ -9519,6 +9587,23 @@
         }
       }
     },
+    "command.browserCaptureKeyboard.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Webview Keyboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webview のキーボードをキャプチャ"
+          }
+        }
+      }
+    },
     "command.browserClearHistory.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -11097,6 +11182,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geliştirici Araçlarını Aç/Kapat"
+          }
+        }
+      }
+    },
+    "command.browserReleaseKeyboardCapture.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release Webview Keyboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webview のキーボードキャプチャを解除"
           }
         }
       }
@@ -36381,6 +36483,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tarayıcı Geçmişini Temizle"
+          }
+        }
+      }
+    },
+    "menu.view.captureWebviewKeyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Webview Keyboard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Webview のキーボードをキャプチャ"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1972,6 +1972,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var jumpUnreadFocusObserver: NSObjectProtocol?
     private var didSetupGotoSplitUITest = false
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
+    private var gotoSplitUITestKeyboardCapturePollGeneration: UInt64 = 0
+    private var gotoSplitUITestKeyboardCapturePanelId: UUID?
     private var didSetupMultiWindowNotificationsUITest = false
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
@@ -4026,6 +4028,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         markPending: Bool
     ) {
         let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        if let targetWindow,
+           let context = contextForMainWindow(targetWindow) {
+            _ = context.tabManager.setFocusedBrowserKeyboardCaptureActive(
+                false,
+                reason: "commandPaletteRequest.\(name.rawValue)"
+            )
+        }
         if markPending {
             markCommandPaletteOpenRequested(for: targetWindow)
         }
@@ -6540,6 +6549,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_GOTO_SPLIT_INPUT_SETUP"] == "1" {
                 setupFocusedInputForGotoSplitUITest(panel: browserPanel)
             }
+            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BROWSER_KEY_CAPTURE_SETUP"] == "1" {
+                setupBrowserKeyboardCaptureUITest(panel: browserPanel)
+            }
             return
         }
 
@@ -6572,6 +6584,163 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         guard let browserPane, let terminalPane else { return nil }
         return (browserPane, terminalPane)
+    }
+
+    private func browserPanelAcrossContexts(for panelId: UUID) -> BrowserPanel? {
+        if let panel = tabManager?.tabs.compactMap({ $0.browserPanel(for: panelId) }).first {
+            return panel
+        }
+        for context in mainWindowContexts.values {
+            if let panel = context.tabManager.tabs.compactMap({ $0.browserPanel(for: panelId) }).first {
+                return panel
+            }
+        }
+        return nil
+    }
+
+    private func setupBrowserKeyboardCaptureUITest(panel: BrowserPanel, attempt: Int = 0) {
+        let maxAttempts = 80
+        guard attempt < maxAttempts else {
+            writeGotoSplitTestData([
+                "browserKeyboardCapturePageTrackerInstalled": "false",
+                "setupError": "Timed out installing browser keyboard capture test tracker"
+            ])
+            return
+        }
+
+        let script = """
+        (() => {
+          try {
+            const readyState = String(document.readyState || "");
+            if (readyState !== "complete") {
+              return { installed: false, readyState };
+            }
+
+            if (!window.__cmuxKeyboardCaptureState || window.__cmuxKeyboardCaptureState.version !== 1) {
+              window.__cmuxKeyboardCaptureState = {
+                version: 1,
+                keydownCount: 0,
+                lastKey: "",
+                lastCode: "",
+                lastMeta: false,
+                lastShift: false,
+                lastControl: false,
+                lastOption: false,
+                lastRepeat: false,
+                lastTargetTag: "",
+                lastInputValue: ""
+              };
+            }
+
+            if (window.__cmuxKeyboardCaptureHandlerInstalled !== true) {
+              window.__cmuxKeyboardCaptureHandlerInstalled = true;
+              window.addEventListener("keydown", event => {
+                const state = window.__cmuxKeyboardCaptureState;
+                const active = document.activeElement;
+                state.keydownCount = (Number(state.keydownCount) || 0) + 1;
+                state.lastKey = String(event.key || "");
+                state.lastCode = String(event.code || "");
+                state.lastMeta = !!event.metaKey;
+                state.lastShift = !!event.shiftKey;
+                state.lastControl = !!event.ctrlKey;
+                state.lastOption = !!event.altKey;
+                state.lastRepeat = !!event.repeat;
+                state.lastTargetTag = active && active.tagName ? String(active.tagName).toLowerCase() : "";
+                state.lastInputValue =
+                  active && typeof active.value === "string" ? active.value : "";
+              }, true);
+            }
+
+            return {
+              installed: window.__cmuxKeyboardCaptureHandlerInstalled === true,
+              readyState,
+              keydownCount: Number(window.__cmuxKeyboardCaptureState.keydownCount || 0)
+            };
+          } catch (_) {
+            return { installed: false, readyState: "error" };
+          }
+        })();
+        """
+
+        panel.webView.evaluateJavaScript(script) { [weak self] result, _ in
+            guard let self else { return }
+            let payload = result as? [String: Any]
+            let installed = (payload?["installed"] as? Bool) ?? false
+            let readyState = (payload?["readyState"] as? String) ?? ""
+            if installed {
+                self.writeGotoSplitTestData([
+                    "browserKeyboardCapturePageTrackerInstalled": "true",
+                    "browserKeyboardCapturePageReadyState": readyState
+                ])
+                self.startBrowserKeyboardCaptureUITestPolling(panelId: panel.id)
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.setupBrowserKeyboardCaptureUITest(panel: panel, attempt: attempt + 1)
+            }
+        }
+    }
+
+    private func startBrowserKeyboardCaptureUITestPolling(panelId: UUID) {
+        gotoSplitUITestKeyboardCapturePanelId = panelId
+        gotoSplitUITestKeyboardCapturePollGeneration &+= 1
+        pollBrowserKeyboardCaptureUITestState(panelId: panelId, generation: gotoSplitUITestKeyboardCapturePollGeneration)
+    }
+
+    private func pollBrowserKeyboardCaptureUITestState(panelId: UUID, generation: UInt64) {
+        guard gotoSplitUITestKeyboardCapturePanelId == panelId,
+              gotoSplitUITestKeyboardCapturePollGeneration == generation else {
+            return
+        }
+        guard let panel = browserPanelAcrossContexts(for: panelId) else { return }
+
+        let script = """
+        (() => {
+          try {
+            const state = window.__cmuxKeyboardCaptureState;
+            if (!state) {
+              return { installed: false };
+            }
+            return {
+              installed: window.__cmuxKeyboardCaptureHandlerInstalled === true,
+              keydownCount: Number(state.keydownCount || 0),
+              lastKey: String(state.lastKey || ""),
+              lastCode: String(state.lastCode || ""),
+              lastMeta: !!state.lastMeta,
+              lastShift: !!state.lastShift,
+              lastControl: !!state.lastControl,
+              lastOption: !!state.lastOption,
+              lastRepeat: !!state.lastRepeat,
+              lastTargetTag: String(state.lastTargetTag || ""),
+              lastInputValue: String(state.lastInputValue || "")
+            };
+          } catch (_) {
+            return { installed: false };
+          }
+        })();
+        """
+
+        panel.webView.evaluateJavaScript(script) { [weak self] result, _ in
+            guard let self else { return }
+            let payload = result as? [String: Any]
+            self.writeGotoSplitTestData([
+                "browserKeyboardCapturePageTrackerInstalled": ((payload?["installed"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageKeydownCount": String((payload?["keydownCount"] as? NSNumber)?.intValue ?? 0),
+                "browserKeyboardCapturePageLastKey": (payload?["lastKey"] as? String) ?? "",
+                "browserKeyboardCapturePageLastCode": (payload?["lastCode"] as? String) ?? "",
+                "browserKeyboardCapturePageLastMeta": ((payload?["lastMeta"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageLastShift": ((payload?["lastShift"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageLastControl": ((payload?["lastControl"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageLastOption": ((payload?["lastOption"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageLastRepeat": ((payload?["lastRepeat"] as? Bool) ?? false) ? "true" : "false",
+                "browserKeyboardCapturePageLastTargetTag": (payload?["lastTargetTag"] as? String) ?? "",
+                "browserKeyboardCapturePageLastInputValue": (payload?["lastInputValue"] as? String) ?? ""
+            ])
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.pollBrowserKeyboardCaptureUITestState(panelId: panelId, generation: generation)
+            }
+        }
     }
 
     private func installGotoSplitUITestFocusObserversIfNeeded() {
@@ -7947,6 +8116,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
+        if let handled = handleCapturedBrowserKeyboardShortcutBypass(event: event) {
+            return handled
+        }
+
         // Guard against stale browserAddressBarFocusedPanelId after focus transitions
         // (e.g., split that doesn't properly blur the address bar). If the first responder
         // is a terminal surface, the address bar can't be focused.
@@ -8667,6 +8840,80 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 #endif
 
+    private var browserKeyboardCaptureExitTimeout: TimeInterval { 1.25 }
+
+    private func focusedBrowserPanel(in context: MainWindowContext) -> BrowserPanel? {
+        guard let workspace = context.tabManager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            return nil
+        }
+        return workspace.browserPanel(for: panelId)
+    }
+
+    private func browserPanelOwningWebView(_ webView: WKWebView) -> BrowserPanel? {
+        for context in mainWindowContexts.values {
+            for workspace in context.tabManager.tabs {
+                for panel in workspace.panels.values {
+                    guard let browser = panel as? BrowserPanel, browser.webView === webView else { continue }
+                    return browser
+                }
+            }
+        }
+        if let tabManager {
+            for workspace in tabManager.tabs {
+                for panel in workspace.panels.values {
+                    guard let browser = panel as? BrowserPanel, browser.webView === webView else { continue }
+                    return browser
+                }
+            }
+        }
+        return nil
+    }
+
+    private func capturedBrowserPanelForShortcutEvent(_ event: NSEvent) -> BrowserPanel? {
+        guard !titlebarAccessoryController.isNotificationsPopoverShown() else { return nil }
+        guard let context = preferredMainWindowContextForShortcutRouting(event: event),
+              let panel = focusedBrowserPanel(in: context),
+              panel.isKeyboardCaptureActive else {
+            return nil
+        }
+        return panel
+    }
+
+    func shouldBypassCmuxShortcutRoutingForCapturedBrowser(
+        event: NSEvent,
+        webView: CmuxWebView? = nil
+    ) -> Bool {
+        if let webView,
+           let panel = browserPanelOwningWebView(webView) {
+            return panel.isKeyboardCaptureActive
+        }
+        return capturedBrowserPanelForShortcutEvent(event) != nil
+    }
+
+    private func handleCapturedBrowserKeyboardShortcutBypass(event: NSEvent) -> Bool? {
+        guard let panel = capturedBrowserPanelForShortcutEvent(event) else { return nil }
+        let normalizedFlags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+
+        guard normalizedFlags.isEmpty, event.keyCode == 53 else {
+            panel.clearKeyboardCaptureExitArm(reason: "nonEscape")
+            return false
+        }
+
+        if panel.isKeyboardCaptureExitArmed {
+            panel.clearKeyboardCapture(reason: "escapeDouble")
+#if DEBUG
+            dlog("browser.keyboardCapture.exit panel=\(panel.id.uuidString.prefix(5)) via=escapeDouble")
+#endif
+            return true
+        }
+
+        panel.armKeyboardCaptureExit(timeout: browserKeyboardCaptureExitTimeout, reason: "escapeFirst")
+        return false
+    }
+
     @discardableResult
     private func focusBrowserAddressBar(panelId: UUID) -> Bool {
         guard let tabManager,
@@ -8728,6 +8975,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func focusBrowserAddressBar(in panel: BrowserPanel) {
+        panel.clearKeyboardCapture(reason: "addressBarRequest")
 #if DEBUG
         let requestId = panel.requestAddressBarFocus()
         dlog(
@@ -9179,7 +9427,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// through the same app-level shortcut handler used by the local key monitor.
     @discardableResult
     func handleBrowserSurfaceKeyEquivalent(_ event: NSEvent) -> Bool {
-        handleCustomShortcut(event: event)
+        if capturedBrowserPanelForShortcutEvent(event) != nil {
+            return false
+        }
+        return handleCustomShortcut(event: event)
     }
 
     @discardableResult
@@ -11122,6 +11373,18 @@ private extension NSWindow {
 #endif
             self.firstResponder?.keyDown(with: event)
             return true
+        }
+
+        if let firstResponderWebView,
+           AppDelegate.shared?.shouldBypassCmuxShortcutRoutingForCapturedBrowser(
+            event: event,
+            webView: firstResponderWebView
+           ) == true {
+            let result = firstResponderWebView.performKeyEquivalent(with: event)
+#if DEBUG
+            dlog("  → captured browser direct: \(result)")
+#endif
+            return result
         }
 
         if AppDelegate.shared?.handleBrowserSurfaceKeyEquivalent(event) == true {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4049,6 +4049,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func requestCommandPaletteCommands(preferredWindow: NSWindow? = nil, source: String = "api.commandPalette") {
+#if DEBUG
+        UITestRecorder.incrementInt("commandPaletteCommandsRequests")
+#endif
         postCommandPaletteRequest(
             name: .commandPaletteRequested,
             preferredWindow: preferredWindow,
@@ -4058,6 +4061,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func requestCommandPaletteSwitcher(preferredWindow: NSWindow? = nil, source: String = "api.commandPaletteSwitcher") {
+#if DEBUG
+        UITestRecorder.incrementInt("commandPaletteSwitcherRequests")
+#endif
         postCommandPaletteRequest(
             name: .commandPaletteSwitcherRequested,
             preferredWindow: preferredWindow,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6558,6 +6558,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BROWSER_KEY_CAPTURE_SETUP"] == "1" {
                 setupBrowserKeyboardCaptureUITest(panel: browserPanel)
             }
+            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_BROWSER_KEY_CAPTURE_AUTO_ENTER"] == "1" {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak browserPanel] in
+                    _ = browserPanel?.setKeyboardCaptureActive(
+                        true,
+                        reason: "uiTest.autoEnter",
+                        focusWebView: true
+                    )
+                }
+            }
             return
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6703,10 +6703,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let script = """
         (() => {
           try {
-            const state = window.__cmuxKeyboardCaptureState;
-            if (!state) {
+            const readyState = String(document.readyState || "");
+            if (readyState !== "complete") {
               return { installed: false };
             }
+            if (!window.__cmuxKeyboardCaptureState || window.__cmuxKeyboardCaptureState.version !== 1) {
+              window.__cmuxKeyboardCaptureState = {
+                version: 1,
+                keydownCount: 0,
+                lastKey: "",
+                lastCode: "",
+                lastMeta: false,
+                lastShift: false,
+                lastControl: false,
+                lastOption: false,
+                lastRepeat: false,
+                lastTargetTag: "",
+                lastInputValue: ""
+              };
+            }
+            if (window.__cmuxKeyboardCaptureHandlerInstalled !== true) {
+              window.__cmuxKeyboardCaptureHandlerInstalled = true;
+              window.addEventListener("keydown", event => {
+                const state = window.__cmuxKeyboardCaptureState;
+                const active = document.activeElement;
+                state.keydownCount = (Number(state.keydownCount) || 0) + 1;
+                state.lastKey = String(event.key || "");
+                state.lastCode = String(event.code || "");
+                state.lastMeta = !!event.metaKey;
+                state.lastShift = !!event.shiftKey;
+                state.lastControl = !!event.ctrlKey;
+                state.lastOption = !!event.altKey;
+                state.lastRepeat = !!event.repeat;
+                state.lastTargetTag = active && active.tagName ? String(active.tagName).toLowerCase() : "";
+                state.lastInputValue =
+                  active && typeof active.value === "string" ? active.value : "";
+              }, true);
+            }
+            const state = window.__cmuxKeyboardCaptureState;
             return {
               installed: window.__cmuxKeyboardCaptureHandlerInstalled === true,
               keydownCount: Number(state.keydownCount || 0),

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8116,10 +8116,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
-        if let handled = handleCapturedBrowserKeyboardShortcutBypass(event: event) {
-            return handled
-        }
-
         // Guard against stale browserAddressBarFocusedPanelId after focus transitions
         // (e.g., split that doesn't properly blur the address bar). If the first responder
         // is a terminal surface, the address bar can't be focused.
@@ -8135,6 +8131,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             browserAddressBarFocusedPanelId = nil
             stopBrowserOmnibarSelectionRepeat()
+        }
+
+        if let handled = handleCapturedBrowserKeyboardShortcutBypass(event: event) {
+            return handled
         }
 
         // Keep Cmd+P/Cmd+N inside the focused browser omnibar for Chrome-like

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11555,17 +11555,32 @@ private extension NSWindow {
                let portalWebView = cmuxUniqueBrowserWebView(in: candidate) {
                 // Portal-hosted browser chrome (for example the Cmd+F overlay) is a
                 // sibling of the hosted WKWebView inside WindowBrowserSlotView, not a
-                // descendant of it. Treating every view in that slot as "web-owned"
-                // blocks legitimate first-responder changes to overlay text fields.
+                // descendant of it. Keep actual text-input chrome independent so
+                // omnibar/find fields can still focus, but continue treating other
+                // portal siblings (for example hosted inspector views) as web-owned.
                 if view === portalWebView || view.isDescendant(of: portalWebView) {
                     return portalWebView
                 }
-                return nil
+                return cmuxIsPortalTextInputChrome(view) ? nil : portalWebView
             }
             current = candidate.superview
         }
 
         return nil
+    }
+
+    private static func cmuxIsPortalTextInputChrome(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            if candidate is NSTextField || candidate is NSTextView {
+                return true
+            }
+            if String(describing: type(of: candidate)).contains("WindowBrowserSlotView") {
+                break
+            }
+            current = candidate.superview
+        }
+        return false
     }
 
     private static func cmuxUniqueBrowserWebView(in root: NSView) -> CmuxWebView? {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1539,6 +1539,7 @@ struct ContentView: View {
         static let panelName = "panel.name"
         static let panelIsBrowser = "panel.isBrowser"
         static let panelIsTerminal = "panel.isTerminal"
+        static let panelBrowserKeyboardCaptured = "panel.browserKeyboardCaptured"
         static let panelHasCustomName = "panel.hasCustomName"
         static let panelShouldPin = "panel.shouldPin"
         static let panelHasUnread = "panel.hasUnread"
@@ -4126,6 +4127,10 @@ struct ContentView: View {
                 panelDisplayName(workspace: workspace, panelId: panelId, fallback: panelContext.panel.displayTitle)
             )
             snapshot.setBool(CommandPaletteContextKeys.panelIsBrowser, panelContext.panel.panelType == .browser)
+            snapshot.setBool(
+                CommandPaletteContextKeys.panelBrowserKeyboardCaptured,
+                (panelContext.panel as? BrowserPanel)?.isKeyboardCaptureActive ?? false
+            )
             snapshot.setBool(CommandPaletteContextKeys.panelIsTerminal, panelIsTerminal)
             snapshot.setBool(CommandPaletteContextKeys.panelHasCustomName, workspace.panelCustomTitles[panelId] != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelShouldPin, !workspace.isPanelPinned(panelId))
@@ -4614,6 +4619,19 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.browserToggleKeyboardCapture",
+                title: { context in
+                    context.bool(CommandPaletteContextKeys.panelBrowserKeyboardCaptured)
+                        ? String(localized: "command.browserReleaseKeyboardCapture.title", defaultValue: "Release Webview Keyboard")
+                        : String(localized: "command.browserCaptureKeyboard.title", defaultValue: "Capture Webview Keyboard")
+                },
+                subtitle: browserPanelSubtitle,
+                keywords: ["browser", "webview", "keyboard", "capture", "release", "vscode"],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.browserToggleDevTools",
                 title: constant(String(localized: "command.browserToggleDevTools.title", defaultValue: "Toggle Developer Tools")),
                 subtitle: browserPanelSubtitle,
@@ -5068,6 +5086,11 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.browserFocusAddressBar") {
             if !focusFocusedBrowserAddressBar() {
+                NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.browserToggleKeyboardCapture") {
+            if !tabManager.toggleFocusedBrowserKeyboardCapture(reason: "commandPalette.toggle", focusWebView: true) {
                 NSSound.beep()
             }
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1680,6 +1680,12 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Increment to request a UI-only flash highlight (e.g. from a keyboard shortcut).
     @Published private(set) var focusFlashToken: Int = 0
 
+    /// True when this browser pane should own keyboard shortcuts instead of cmux.
+    @Published private(set) var isKeyboardCaptureActive: Bool = false
+
+    /// True after the first Escape press while keyboard capture is active.
+    @Published private(set) var isKeyboardCaptureExitArmed: Bool = false
+
     /// Sticky omnibar-focus intent. This survives view mount timing races and is
     /// cleared only after BrowserPanelView acknowledges handling it.
     @Published private(set) var pendingAddressBarFocusRequestId: UUID?
@@ -1694,6 +1700,7 @@ final class BrowserPanel: Panel, ObservableObject {
     @Published var searchState: BrowserSearchState? = nil {
         didSet {
             if let searchState {
+                clearKeyboardCapture(reason: "searchStateCreated")
                 preferredFocusIntent = .findField
                 NSLog("Find: browser search state created panel=%@", id.uuidString)
                 searchNeedleCancellable = searchState.$needle
@@ -1755,6 +1762,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private var loadingStartedAt: Date?
     private var loadingEndWorkItem: DispatchWorkItem?
     private var loadingGeneration: Int = 0
+    private var keyboardCaptureExitResetWorkItem: DispatchWorkItem?
 
     private var faviconTask: Task<Void, Never>?
     private var faviconRefreshGeneration: Int = 0
@@ -2352,6 +2360,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func unfocus() {
+        clearKeyboardCapture(reason: "panelUnfocus")
         invalidateSearchFocusRequests(reason: "panelUnfocus")
         guard let window = webView.window else { return }
         if Self.responderChainContains(window.firstResponder, target: webView) {
@@ -2363,6 +2372,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
+        clearKeyboardCapture(reason: "panelClose")
         webView.stopLoading()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -2726,6 +2736,8 @@ final class BrowserPanel: Panel, ObservableObject {
         developerToolsRestoreRetryWorkItem = nil
         developerToolsTransitionSettleWorkItem?.cancel()
         developerToolsTransitionSettleWorkItem = nil
+        keyboardCaptureExitResetWorkItem?.cancel()
+        keyboardCaptureExitResetWorkItem = nil
         if let detachedDeveloperToolsWindowCloseObserver {
             NotificationCenter.default.removeObserver(detachedDeveloperToolsWindowCloseObserver)
         }
@@ -2744,6 +2756,8 @@ extension BrowserPanel {
         currentURL != nil ||
         !pageTitle.isEmpty ||
         faviconPNGData != nil ||
+        isKeyboardCaptureActive ||
+        isKeyboardCaptureExitArmed ||
         searchState != nil ||
         nativeCanGoBack ||
         nativeCanGoForward ||
@@ -2804,6 +2818,7 @@ extension BrowserPanel {
 
         pendingAddressBarFocusRequestId = nil
         preferredFocusIntent = .addressBar
+        clearKeyboardCapture(reason: "contextReset")
         suppressOmnibarAutofocusUntil = nil
         suppressWebViewFocusUntil = nil
         endSuppressWebViewFocusForAddressBar()
@@ -3741,14 +3756,101 @@ extension BrowserPanel {
     }
 
     func noteAddressBarFocused() {
+        clearKeyboardCapture(reason: "addressBarFocused")
         guard preferredFocusIntent != .addressBar else { return }
         preferredFocusIntent = .addressBar
         invalidateSearchFocusRequests(reason: "addressBarFocused")
     }
 
     func noteFindFieldFocused() {
+        clearKeyboardCapture(reason: "findFieldFocused")
         guard preferredFocusIntent != .findField else { return }
         preferredFocusIntent = .findField
+    }
+
+    @discardableResult
+    func setKeyboardCaptureActive(
+        _ active: Bool,
+        reason: String,
+        focusWebView: Bool = false
+    ) -> Bool {
+        if active {
+            guard shouldRenderWebView else { return false }
+            guard searchState == nil else { return false }
+            endSuppressWebViewFocusForAddressBar()
+            isKeyboardCaptureActive = true
+            clearKeyboardCaptureExitArm(reason: "\(reason).activate")
+            if focusWebView {
+                focus()
+            }
+        } else {
+            clearKeyboardCapture(reason: reason)
+        }
+#if DEBUG
+        dlog(
+            "browser.keyboardCapture panel=\(id.uuidString.prefix(5)) " +
+            "active=\(isKeyboardCaptureActive ? 1 : 0) armed=\(isKeyboardCaptureExitArmed ? 1 : 0) " +
+            "reason=\(reason)"
+        )
+#endif
+        recordKeyboardCaptureUITestState()
+        return true
+    }
+
+    @discardableResult
+    func toggleKeyboardCapture(reason: String, focusWebView: Bool = false) -> Bool {
+        setKeyboardCaptureActive(!isKeyboardCaptureActive, reason: reason, focusWebView: focusWebView)
+    }
+
+    func armKeyboardCaptureExit(timeout: TimeInterval, reason: String) {
+        guard isKeyboardCaptureActive else { return }
+        keyboardCaptureExitResetWorkItem?.cancel()
+        isKeyboardCaptureExitArmed = true
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.clearKeyboardCaptureExitArm(reason: "timeout")
+        }
+        keyboardCaptureExitResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: workItem)
+#if DEBUG
+        dlog(
+            "browser.keyboardCapture.exitArm panel=\(id.uuidString.prefix(5)) " +
+            "armed=1 timeoutMs=\(Int(timeout * 1000)) reason=\(reason)"
+        )
+#endif
+        recordKeyboardCaptureUITestState()
+    }
+
+    func clearKeyboardCapture(reason: String) {
+        guard isKeyboardCaptureActive || isKeyboardCaptureExitArmed else { return }
+        keyboardCaptureExitResetWorkItem?.cancel()
+        keyboardCaptureExitResetWorkItem = nil
+        isKeyboardCaptureExitArmed = false
+        isKeyboardCaptureActive = false
+#if DEBUG
+        dlog("browser.keyboardCapture.clear panel=\(id.uuidString.prefix(5)) reason=\(reason)")
+#endif
+        recordKeyboardCaptureUITestState()
+    }
+
+    func clearKeyboardCaptureExitArm(reason: String) {
+        keyboardCaptureExitResetWorkItem?.cancel()
+        keyboardCaptureExitResetWorkItem = nil
+        guard isKeyboardCaptureExitArmed else { return }
+        isKeyboardCaptureExitArmed = false
+#if DEBUG
+        dlog("browser.keyboardCapture.exitArm panel=\(id.uuidString.prefix(5)) armed=0 reason=\(reason)")
+#endif
+        recordKeyboardCaptureUITestState()
+    }
+
+    private func recordKeyboardCaptureUITestState() {
+#if DEBUG
+        UITestRecorder.record([
+            "browserKeyboardCaptureActive": isKeyboardCaptureActive ? "1" : "0",
+            "browserKeyboardCaptureExitArmed": isKeyboardCaptureExitArmed ? "1" : "0",
+            "browserKeyboardCapturePanelId": isKeyboardCaptureActive ? id.uuidString : ""
+        ])
+#endif
     }
 
     func canApplySearchFocusRequest(_ generation: UInt64) -> Bool {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -357,6 +357,14 @@ struct BrowserPanelView: View {
             }
         }
         .overlay {
+            if panel.isKeyboardCaptureActive && isFocused {
+                RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
+                    .stroke(Color(nsColor: .systemOrange).opacity(0.9), lineWidth: 2)
+                    .padding(FocusFlashPattern.ringInset + 2)
+                    .allowsHitTesting(false)
+            }
+        }
+        .overlay {
             RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
                 .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
                 .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
@@ -564,6 +572,8 @@ struct BrowserPanelView: View {
                 .accessibilityIdentifier("BrowserOmnibarPill")
                 .accessibilityLabel("Browser omnibar")
 
+            keyboardCaptureControl
+
             if !panel.isShowingNewTabPage {
                 browserThemeModeButton
                 developerToolsButton
@@ -584,6 +594,77 @@ struct BrowserPanelView: View {
         // Keep the omnibar stack above WKWebView so the suggestions popup is visible.
         .zIndex(1)
         .environment(\.colorScheme, browserChromeColorScheme)
+    }
+
+    @ViewBuilder
+    private var keyboardCaptureControl: some View {
+        if panel.isKeyboardCaptureActive {
+            Button(action: {
+                panel.clearKeyboardCapture(reason: "chromePillClick")
+            }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "keyboard")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text(keyboardCaptureIndicatorText)
+                        .font(.system(size: 11, weight: .semibold))
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 10)
+                .frame(height: addressBarButtonSize)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color(nsColor: .systemOrange).opacity(0.18))
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(Color(nsColor: .systemOrange).opacity(0.55), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .safeHelp(String(localized: "browser.keyboardCapture.release", defaultValue: "Release webview keyboard capture"))
+            .accessibilityIdentifier("BrowserKeyboardCaptureButton")
+        } else if !panel.isShowingNewTabPage {
+            Button(action: {
+                activateKeyboardCaptureFromChrome()
+            }) {
+                Image(systemName: "keyboard")
+                    .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            }
+            .buttonStyle(OmnibarAddressButtonStyle())
+            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            .safeHelp(String(localized: "browser.keyboardCapture.capture", defaultValue: "Capture webview keyboard"))
+            .accessibilityIdentifier("BrowserKeyboardCaptureButton")
+        }
+    }
+
+    private var keyboardCaptureIndicatorText: String {
+        if panel.isKeyboardCaptureExitArmed {
+            return String(
+                localized: "browser.keyboardCapture.armed",
+                defaultValue: "Press Esc again to exit"
+            )
+        }
+        return String(
+            localized: "browser.keyboardCapture.active",
+            defaultValue: "Keyboard captured, Esc twice to exit"
+        )
+    }
+
+    private func activateKeyboardCaptureFromChrome() {
+        if addressBarFocused {
+            setAddressBarFocused(false, reason: "keyboardCapture.chromeButton")
+        }
+        if !isFocused {
+            onRequestPanelFocus()
+        }
+        DispatchQueue.main.async {
+            _ = panel.setKeyboardCaptureActive(
+                true,
+                reason: "chromeButton",
+                focusWebView: true
+            )
+        }
     }
 
     private var addressBarButtonBar: some View {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -143,6 +143,17 @@ final class CmuxWebView: WKWebView {
             return result
         }
 
+        if AppDelegate.shared?.shouldBypassCmuxShortcutRoutingForCapturedBrowser(
+            event: event,
+            webView: self
+        ) == true {
+            let result = super.performKeyEquivalent(with: event)
+#if DEBUG
+            handled = result
+#endif
+            return result
+        }
+
         if !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
             let result = super.performKeyEquivalent(with: event)
 #if DEBUG
@@ -191,6 +202,10 @@ final class CmuxWebView: WKWebView {
         // Some Cmd-based key paths in WebKit don't consistently invoke performKeyEquivalent.
         // Route them through the same app-level shortcut handler as a fallback.
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command),
+           AppDelegate.shared?.shouldBypassCmuxShortcutRoutingForCapturedBrowser(
+            event: event,
+            webView: self
+           ) != true,
            AppDelegate.shared?.handleBrowserSurfaceKeyEquivalent(event) == true {
 #if DEBUG
             route = "appShortcut"

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1881,6 +1881,16 @@ class TabManager: ObservableObject {
         focusedBrowserPanel?.showDeveloperToolsConsole() ?? false
     }
 
+    @discardableResult
+    func setFocusedBrowserKeyboardCaptureActive(_ active: Bool, reason: String, focusWebView: Bool = false) -> Bool {
+        focusedBrowserPanel?.setKeyboardCaptureActive(active, reason: reason, focusWebView: focusWebView) ?? false
+    }
+
+    @discardableResult
+    func toggleFocusedBrowserKeyboardCapture(reason: String, focusWebView: Bool = false) -> Bool {
+        focusedBrowserPanel?.toggleKeyboardCapture(reason: reason, focusWebView: focusWebView) ?? false
+    }
+
     /// Backwards compatibility: returns the focused surface ID
     func focusedSurfaceId(for tabId: UUID) -> UUID? {
         focusedPanelId(for: tabId)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -555,6 +555,12 @@ struct cmuxApp: App {
                 }
                 .keyboardShortcut("r", modifiers: .command)
 
+                Toggle(
+                    String(localized: "menu.view.captureWebviewKeyboard", defaultValue: "Capture Webview Keyboard"),
+                    isOn: focusedBrowserKeyboardCaptureBinding
+                )
+                .disabled(activeTabManager.focusedBrowserPanel == nil)
+
                 splitCommandButton(title: String(localized: "menu.view.toggleDevTools", defaultValue: "Toggle Developer Tools"), shortcut: toggleBrowserDeveloperToolsMenuShortcut) {
                     let manager = activeTabManager
                     if !manager.toggleDeveloperToolsFocusedBrowser() {
@@ -797,6 +803,19 @@ struct cmuxApp: App {
         AppDelegate.shared?.synchronizeActiveMainWindowContext(
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
+    }
+
+    private var focusedBrowserKeyboardCaptureBinding: Binding<Bool> {
+        Binding(
+            get: { activeTabManager.focusedBrowserPanel?.isKeyboardCaptureActive ?? false },
+            set: { enabled in
+                _ = activeTabManager.setFocusedBrowserKeyboardCaptureActive(
+                    enabled,
+                    reason: "mainMenu.toggle",
+                    focusWebView: enabled
+                )
+            }
+        )
     }
 
     private func decodeShortcut(from data: Data, fallback: StoredShortcut) -> StoredShortcut {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1939,6 +1939,59 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 #endif
     }
 
+    func testCapturedBrowserBypassesAllShortcutProbes() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              manager.openBrowser(url: URL(string: "https://example.com/keyboard-capture"), insertAtEnd: true) != nil,
+              let browserPanel = manager.focusedBrowserPanel else {
+            XCTFail("Expected focused browser panel in test window")
+            return
+        }
+
+        manager.confirmCloseHandler = { _, _, _ in false }
+        appDelegate.debugCloseMainWindowConfirmationHandler = { _ in false }
+
+        XCTAssertTrue(
+            manager.setFocusedBrowserKeyboardCaptureActive(true, reason: "test.matrix"),
+            "Expected keyboard capture to activate for focused browser"
+        )
+
+        for probe in capturedBrowserShortcutProbes() {
+            guard let event = probe.makeEvent(windowNumber: window.windowNumber) else {
+                XCTFail("Failed to construct \(probe.name) event")
+                continue
+            }
+
+#if DEBUG
+            XCTAssertFalse(
+                appDelegate.debugHandleCustomShortcut(event: event),
+                "\(probe.name) should bypass cmux shortcut handling while keyboard capture is active"
+            )
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+            XCTAssertTrue(
+                browserPanel.isKeyboardCaptureActive,
+                "\(probe.name) should not release keyboard capture"
+            )
+            XCTAssertFalse(
+                browserPanel.isKeyboardCaptureExitArmed,
+                "\(probe.name) should not arm keyboard-capture exit"
+            )
+        }
+    }
+
     func testEscapeKeyUpIsConsumedAfterCmdPSwitcherDismiss() {
         assertEscapeKeyUpIsConsumedAfterCommandPaletteOpenRequest { appDelegate, window in
             appDelegate.requestCommandPaletteSwitcher(
@@ -2272,6 +2325,186 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
         KeyboardShortcutSettings.setShortcut(shortcut ?? action.defaultShortcut, for: action)
         body()
+    }
+
+    private struct BrowserCaptureShortcutProbe {
+        let name: String
+        let key: String
+        let keyCode: UInt16
+        let modifiers: NSEvent.ModifierFlags
+
+        init(name: String, key: String, keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
+            self.name = name
+            self.key = key
+            self.keyCode = keyCode
+            self.modifiers = modifiers
+        }
+
+        init?(name: String, shortcut: StoredShortcut) {
+            guard let keyCode = Self.keyCode(for: shortcut.key) else { return nil }
+            self.init(
+                name: name,
+                key: shortcut.key,
+                keyCode: keyCode,
+                modifiers: shortcut.modifierFlags
+            )
+        }
+
+        func makeEvent(windowNumber: Int) -> NSEvent? {
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: modifiers,
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: windowNumber,
+                context: nil,
+                characters: key,
+                charactersIgnoringModifiers: key,
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        }
+
+        private static func keyCode(for key: String) -> UInt16? {
+            switch key {
+            case "a": return 0
+            case "s": return 1
+            case "d": return 2
+            case "f": return 3
+            case "h": return 4
+            case "g": return 5
+            case "z": return 6
+            case "x": return 7
+            case "c": return 8
+            case "v": return 9
+            case "b": return 11
+            case "q": return 12
+            case "w": return 13
+            case "e": return 14
+            case "r": return 15
+            case "y": return 16
+            case "t": return 17
+            case "1": return 18
+            case "2": return 19
+            case "3": return 20
+            case "4": return 21
+            case "6": return 22
+            case "5": return 23
+            case "=": return 24
+            case "9": return 25
+            case "7": return 26
+            case "-": return 27
+            case "8": return 28
+            case "0": return 29
+            case "]": return 30
+            case "o": return 31
+            case "u": return 32
+            case "[": return 33
+            case "i": return 34
+            case "p": return 35
+            case "\r": return 36
+            case "l": return 37
+            case "j": return 38
+            case "'": return 39
+            case "k": return 40
+            case ";": return 41
+            case "\\": return 42
+            case ",": return 43
+            case "/": return 44
+            case "n": return 45
+            case "m": return 46
+            case ".": return 47
+            case "\t": return 48
+            case "`": return 50
+            case "←": return 123
+            case "→": return 124
+            case "↓": return 125
+            case "↑": return 126
+            default:
+                return nil
+            }
+        }
+    }
+
+    private func capturedBrowserShortcutProbes() -> [BrowserCaptureShortcutProbe] {
+        let actionProbes = KeyboardShortcutSettings.Action.allCases.compactMap { action in
+            BrowserCaptureShortcutProbe(name: "action.\(action.rawValue)", shortcut: action.defaultShortcut)
+        }
+        let fixedProbes = [
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserBack",
+                key: "[",
+                keyCode: 33,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserForward",
+                key: "]",
+                keyCode: 30,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserFocusAddressBar",
+                key: "l",
+                keyCode: 37,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.commandPaletteSwitcher",
+                key: "p",
+                keyCode: 35,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.commandPaletteCommands",
+                key: "p",
+                keyCode: 35,
+                modifiers: [.command, .shift]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.closePanel",
+                key: "w",
+                keyCode: 13,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.selectWorkspace1",
+                key: "1",
+                keyCode: 18,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.selectSurface1",
+                key: "1",
+                keyCode: 18,
+                modifiers: [.control]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.nextSurfaceLegacy",
+                key: "\t",
+                keyCode: 48,
+                modifiers: [.control]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.previousSurfaceLegacy",
+                key: "\t",
+                keyCode: 48,
+                modifiers: [.control, .shift]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.closeOtherTabs",
+                key: "t",
+                keyCode: 17,
+                modifiers: [.command, .option]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.quit",
+                key: "q",
+                keyCode: 12,
+                modifiers: [.command]
+            )
+        ]
+        return actionProbes + fixedProbes
     }
 
     private func assertEscapeKeyUpIsConsumedAfterCommandPaletteOpenRequest(

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -418,8 +418,11 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 #endif
 
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
-
-        XCTAssertNil(self.window(withId: windowId), "Confirming Cmd+Ctrl+W should close the window")
+        XCTAssertNil(appDelegate.tabManagerFor(windowId: windowId), "Confirming Cmd+Ctrl+W should unregister the window context")
+        XCTAssertFalse(
+            self.window(withId: windowId)?.isVisible ?? false,
+            "Confirming Cmd+Ctrl+W should leave no visible main window behind"
+        )
     }
 
     func testCmdPhysicalIWithDvorakCharactersDoesNotTriggerShowNotifications() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -221,6 +221,7 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertFalse(spy.invoked)
     }
 
+    @MainActor
     func testCapturedBrowserDoesNotRouteShortcutProbesToMainMenu() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -221,6 +221,65 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertFalse(spy.invoked)
     }
 
+    func testCapturedBrowserDoesNotRouteShortcutProbesToMainMenu() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let originalTabManager = appDelegate.tabManager
+        let manager = TabManager()
+        appDelegate.tabManager = manager
+        defer {
+            appDelegate.tabManager = originalTabManager
+        }
+
+        guard manager.openBrowser(
+            url: URL(string: "https://example.com/keyboard-capture-menu"),
+            insertAtEnd: true
+        ) != nil, let browserPanel = manager.focusedBrowserPanel else {
+            XCTFail("Expected focused browser panel")
+            return
+        }
+
+        manager.confirmCloseHandler = { _, _, _ in false }
+        XCTAssertTrue(
+            browserPanel.setKeyboardCaptureActive(true, reason: "test.menuMatrix"),
+            "Expected keyboard capture to activate for browser panel"
+        )
+
+        for probe in capturedBrowserShortcutMenuProbes() {
+            let spy = ActionSpy()
+            installMenu(spy: spy, key: probe.key, modifiers: probe.modifiers)
+
+            guard let event = makeKeyDownEvent(
+                key: probe.key,
+                modifiers: probe.modifiers,
+                keyCode: probe.keyCode
+            ) else {
+                XCTFail("Failed to construct \(probe.name) event")
+                continue
+            }
+
+            XCTAssertFalse(
+                browserPanel.webView.performKeyEquivalent(with: event),
+                "\(probe.name) should not be consumed by the app menu while keyboard capture is active"
+            )
+            XCTAssertFalse(
+                spy.invoked,
+                "\(probe.name) should not route to NSApp.mainMenu while keyboard capture is active"
+            )
+            XCTAssertTrue(
+                browserPanel.isKeyboardCaptureActive,
+                "\(probe.name) should not release keyboard capture"
+            )
+            XCTAssertFalse(
+                browserPanel.isKeyboardCaptureExitArmed,
+                "\(probe.name) should not arm keyboard-capture exit"
+            )
+        }
+    }
+
     func testCmdReturnDoesNotRouteToMainMenuWhenWebViewIsFirstResponder() {
         let spy = ActionSpy()
         installMenu(spy: spy, key: "\r", modifiers: [.command])
@@ -900,6 +959,171 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         // Ensure NSApp exists and has a menu for performKeyEquivalent to consult.
         _ = NSApplication.shared
         NSApp.mainMenu = mainMenu
+    }
+
+    private struct BrowserCaptureShortcutProbe {
+        let name: String
+        let key: String
+        let keyCode: UInt16
+        let modifiers: NSEvent.ModifierFlags
+
+        init(name: String, key: String, keyCode: UInt16, modifiers: NSEvent.ModifierFlags) {
+            self.name = name
+            self.key = key
+            self.keyCode = keyCode
+            self.modifiers = modifiers
+        }
+
+        init?(name: String, shortcut: StoredShortcut) {
+            guard let keyCode = Self.keyCode(for: shortcut.key) else { return nil }
+            self.init(
+                name: name,
+                key: shortcut.key,
+                keyCode: keyCode,
+                modifiers: shortcut.modifierFlags
+            )
+        }
+
+        private static func keyCode(for key: String) -> UInt16? {
+            switch key {
+            case "a": return 0
+            case "s": return 1
+            case "d": return 2
+            case "f": return 3
+            case "h": return 4
+            case "g": return 5
+            case "z": return 6
+            case "x": return 7
+            case "c": return 8
+            case "v": return 9
+            case "b": return 11
+            case "q": return 12
+            case "w": return 13
+            case "e": return 14
+            case "r": return 15
+            case "y": return 16
+            case "t": return 17
+            case "1": return 18
+            case "2": return 19
+            case "3": return 20
+            case "4": return 21
+            case "6": return 22
+            case "5": return 23
+            case "=": return 24
+            case "9": return 25
+            case "7": return 26
+            case "-": return 27
+            case "8": return 28
+            case "0": return 29
+            case "]": return 30
+            case "o": return 31
+            case "u": return 32
+            case "[": return 33
+            case "i": return 34
+            case "p": return 35
+            case "\r": return 36
+            case "l": return 37
+            case "j": return 38
+            case "'": return 39
+            case "k": return 40
+            case ";": return 41
+            case "\\": return 42
+            case ",": return 43
+            case "/": return 44
+            case "n": return 45
+            case "m": return 46
+            case ".": return 47
+            case "\t": return 48
+            case "`": return 50
+            case "←": return 123
+            case "→": return 124
+            case "↓": return 125
+            case "↑": return 126
+            default:
+                return nil
+            }
+        }
+    }
+
+    private func capturedBrowserShortcutMenuProbes() -> [BrowserCaptureShortcutProbe] {
+        let actionProbes = KeyboardShortcutSettings.Action.allCases.compactMap { action in
+            BrowserCaptureShortcutProbe(name: "action.\(action.rawValue)", shortcut: action.defaultShortcut)
+        }
+        let fixedProbes = [
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserBack",
+                key: "[",
+                keyCode: 33,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserForward",
+                key: "]",
+                keyCode: 30,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.browserFocusAddressBar",
+                key: "l",
+                keyCode: 37,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.commandPaletteSwitcher",
+                key: "p",
+                keyCode: 35,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.commandPaletteCommands",
+                key: "p",
+                keyCode: 35,
+                modifiers: [.command, .shift]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.closePanel",
+                key: "w",
+                keyCode: 13,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.selectWorkspace1",
+                key: "1",
+                keyCode: 18,
+                modifiers: [.command]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.selectSurface1",
+                key: "1",
+                keyCode: 18,
+                modifiers: [.control]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.nextSurfaceLegacy",
+                key: "\t",
+                keyCode: 48,
+                modifiers: [.control]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.previousSurfaceLegacy",
+                key: "\t",
+                keyCode: 48,
+                modifiers: [.control, .shift]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.closeOtherTabs",
+                key: "t",
+                keyCode: 17,
+                modifiers: [.command, .option]
+            ),
+            BrowserCaptureShortcutProbe(
+                name: "fixed.quit",
+                key: "q",
+                keyCode: 12,
+                modifiers: [.command]
+            )
+        ]
+        return actionProbes + fixedProbes
     }
 
     private func makeKeyDownEvent(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -585,6 +585,56 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
     }
 
     @MainActor
+    func testWindowFirstResponderGuardAllowsPortalHostedTextFieldSiblingWithoutPointerClickContext() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = contentView
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            AppDelegate.clearWindowFirstResponderGuardTesting()
+            window.orderOut(nil)
+        }
+
+        guard let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let slot = WindowBrowserSlotView(frame: host.bounds)
+        slot.autoresizingMask = [.width, .height]
+        host.addSubview(slot)
+
+        let webView = CmuxWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        slot.addSubview(webView)
+
+        let textField = NSTextField(frame: NSRect(x: 40, y: 40, width: 220, height: 24))
+        textField.isEditable = true
+        slot.addSubview(textField)
+
+        webView.allowsFirstResponderAcquisition = false
+        _ = window.makeFirstResponder(nil)
+        XCTAssertTrue(
+            window.makeFirstResponder(textField),
+            "Expected editable portal chrome to remain focusable when web capture policy is blocked"
+        )
+    }
+
+    @MainActor
     func testWindowFirstResponderGuardAvoidsTextViewDelegateLookupForWebViewResolution() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()

--- a/cmuxUITests/BrowserKeyboardCaptureUITests.swift
+++ b/cmuxUITests/BrowserKeyboardCaptureUITests.swift
@@ -143,6 +143,44 @@ final class BrowserKeyboardCaptureUITests: XCTestCase {
         )
     }
 
+    func testBracketWorkspaceAndSurfaceShortcutsRouteToPageWhenKeyboardCaptured() {
+        let app = launchWithBrowserSetup()
+
+        guard let setup = loadData() else {
+            XCTFail("Missing goto_split setup data")
+            return
+        }
+        guard let expectedBrowserPaneId = setup["browserPaneId"], !expectedBrowserPaneId.isEmpty else {
+            XCTFail("Missing browserPaneId in goto_split setup data")
+            return
+        }
+
+        enterKeyboardCaptureMode(app)
+
+        for probe in bracketShortcutProbes() {
+            let baselineKeydownCount = pageKeydownCount()
+            app.typeKey(probe.key, modifierFlags: probe.modifiers)
+
+            XCTAssertTrue(
+                waitForDataMatch(timeout: 5.0) { data in
+                    let count = Int(data["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+                    return count >= baselineKeydownCount + 1 &&
+                        data["browserKeyboardCapturePageLastMeta"] == "true" &&
+                        data["browserKeyboardCapturePageLastShift"] == (probe.expectShift ? "true" : "false") &&
+                        data["browserKeyboardCapturePageLastControl"] == (probe.expectControl ? "true" : "false")
+                },
+                "Expected \(probe.name) to reach the page while keyboard capture is active. data=\(String(describing: loadData()))"
+            )
+
+            let snapshot = loadData() ?? [:]
+            XCTAssertEqual(
+                snapshot["focusedPaneId"],
+                expectedBrowserPaneId,
+                "Expected browser pane focus to remain unchanged for \(probe.name). data=\(snapshot)"
+            )
+        }
+    }
+
     private func launchWithBrowserSetup(enableFocusShortcuts: Bool = false) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
@@ -205,6 +243,47 @@ final class BrowserKeyboardCaptureUITests: XCTestCase {
 
     private func pageKeydownCount() -> Int {
         Int(loadData()?["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+    }
+
+    private struct BracketShortcutProbe {
+        let name: String
+        let key: String
+        let modifiers: XCUIElement.KeyModifierFlags
+        let expectShift: Bool
+        let expectControl: Bool
+    }
+
+    private func bracketShortcutProbes() -> [BracketShortcutProbe] {
+        [
+            BracketShortcutProbe(
+                name: "Cmd+Shift+[",
+                key: "[",
+                modifiers: [.command, .shift],
+                expectShift: true,
+                expectControl: false
+            ),
+            BracketShortcutProbe(
+                name: "Cmd+Shift+]",
+                key: "]",
+                modifiers: [.command, .shift],
+                expectShift: true,
+                expectControl: false
+            ),
+            BracketShortcutProbe(
+                name: "Cmd+Ctrl+[",
+                key: "[",
+                modifiers: [.command, .control],
+                expectShift: false,
+                expectControl: true
+            ),
+            BracketShortcutProbe(
+                name: "Cmd+Ctrl+]",
+                key: "]",
+                modifiers: [.command, .control],
+                expectShift: false,
+                expectControl: true
+            )
+        ]
     }
 
     private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {

--- a/cmuxUITests/BrowserKeyboardCaptureUITests.swift
+++ b/cmuxUITests/BrowserKeyboardCaptureUITests.swift
@@ -24,6 +24,7 @@ final class BrowserKeyboardCaptureUITests: XCTestCase {
 
         enterKeyboardCaptureMode(app)
         let baselineKeydownCount = pageKeydownCount()
+        let baselinePaletteRequests = Int(loadKeyequiv()["commandPaletteCommandsRequests"] ?? "") ?? 0
 
         app.typeKey("p", modifierFlags: [.command, .shift])
 
@@ -38,9 +39,11 @@ final class BrowserKeyboardCaptureUITests: XCTestCase {
             "Expected Cmd+Shift+P to reach the page while keyboard capture is active. data=\(String(describing: loadData()))"
         )
 
-        XCTAssertFalse(
-            app.textFields["CommandPaletteSearchField"].waitForExistence(timeout: 1.0),
-            "Expected cmux command palette to stay closed while keyboard capture is active"
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        XCTAssertEqual(
+            Int(loadKeyequiv()["commandPaletteCommandsRequests"] ?? "") ?? 0,
+            baselinePaletteRequests,
+            "Expected Cmd+Shift+P to bypass cmux command palette while keyboard capture is active. keyequiv=\(loadKeyequiv())"
         )
     }
 
@@ -87,10 +90,14 @@ final class BrowserKeyboardCaptureUITests: XCTestCase {
             "Expected second Esc to be consumed by cmux instead of the page"
         )
 
+        let baselinePaletteRequests = Int(loadKeyequiv()["commandPaletteCommandsRequests"] ?? "") ?? 0
         app.typeKey("p", modifierFlags: [.command, .shift])
         XCTAssertTrue(
-            app.textFields["CommandPaletteSearchField"].waitForExistence(timeout: 5.0),
-            "Expected Cmd+Shift+P to open cmux command palette after exiting capture mode"
+            waitForKeyequivMatch(timeout: 5.0) { data in
+                let requests = Int(data["commandPaletteCommandsRequests"] ?? "") ?? 0
+                return requests >= baselinePaletteRequests + 1
+            },
+            "Expected Cmd+Shift+P to route back to cmux command palette after exiting capture mode. keyequiv=\(loadKeyequiv())"
         )
     }
 

--- a/cmuxUITests/BrowserKeyboardCaptureUITests.swift
+++ b/cmuxUITests/BrowserKeyboardCaptureUITests.swift
@@ -1,0 +1,268 @@
+import XCTest
+import Foundation
+
+final class BrowserKeyboardCaptureUITests: XCTestCase {
+    private var gotoSplitPath = ""
+    private var keyequivPath = ""
+    private var socketPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        gotoSplitPath = "/tmp/cmux-ui-test-goto-split-\(UUID().uuidString).json"
+        keyequivPath = "/tmp/cmux-ui-test-keyequiv-\(UUID().uuidString).json"
+        socketPath = "/tmp/cmux-ui-test-socket-\(UUID().uuidString).sock"
+
+        try? FileManager.default.removeItem(atPath: gotoSplitPath)
+        try? FileManager.default.removeItem(atPath: keyequivPath)
+        try? FileManager.default.removeItem(atPath: socketPath)
+    }
+
+    func testCmdShiftPRoutesToPageWhenKeyboardCaptured() {
+        let app = launchWithBrowserSetup()
+
+        enterKeyboardCaptureMode(app)
+        let baselineKeydownCount = pageKeydownCount()
+
+        app.typeKey("p", modifierFlags: [.command, .shift])
+
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 5.0) { data in
+                let count = Int(data["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+                return count >= baselineKeydownCount + 1 &&
+                    (data["browserKeyboardCapturePageLastKey"] ?? "").lowercased() == "p" &&
+                    data["browserKeyboardCapturePageLastMeta"] == "true" &&
+                    data["browserKeyboardCapturePageLastShift"] == "true"
+            },
+            "Expected Cmd+Shift+P to reach the page while keyboard capture is active. data=\(String(describing: loadData()))"
+        )
+
+        XCTAssertFalse(
+            app.textFields["CommandPaletteSearchField"].waitForExistence(timeout: 1.0),
+            "Expected cmux command palette to stay closed while keyboard capture is active"
+        )
+    }
+
+    func testEscapeTwiceExitsAndRestoresCmuxShortcuts() {
+        let app = launchWithBrowserSetup()
+
+        enterKeyboardCaptureMode(app)
+        let baselineKeydownCount = pageKeydownCount()
+
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForKeyequivMatch(timeout: 5.0) { data in
+                data["browserKeyboardCaptureActive"] == "1" &&
+                    data["browserKeyboardCaptureExitArmed"] == "1"
+            },
+            "Expected first Esc to arm keyboard-capture exit. keyequiv=\(loadKeyequiv())"
+        )
+
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 5.0) { data in
+                let count = Int(data["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+                return count >= baselineKeydownCount + 1 &&
+                    (data["browserKeyboardCapturePageLastKey"] ?? "") == "Escape"
+            },
+            "Expected first Esc to still reach the page while capture stays active. data=\(String(describing: loadData()))"
+        )
+
+        let afterFirstEscapeCount = pageKeydownCount()
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForKeyequivMatch(timeout: 5.0) { data in
+                data["browserKeyboardCaptureActive"] == "0" &&
+                    data["browserKeyboardCaptureExitArmed"] != "1"
+            },
+            "Expected second Esc to release keyboard capture. keyequiv=\(loadKeyequiv())"
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        XCTAssertEqual(
+            pageKeydownCount(),
+            afterFirstEscapeCount,
+            "Expected second Esc to be consumed by cmux instead of the page"
+        )
+
+        app.typeKey("p", modifierFlags: [.command, .shift])
+        XCTAssertTrue(
+            app.textFields["CommandPaletteSearchField"].waitForExistence(timeout: 5.0),
+            "Expected Cmd+Shift+P to open cmux command palette after exiting capture mode"
+        )
+    }
+
+    func testPaneNavigationShortcutDoesNotMoveFocusWhenKeyboardCaptured() {
+        let app = launchWithBrowserSetup(enableFocusShortcuts: true)
+
+        guard let setup = loadData() else {
+            XCTFail("Missing goto_split setup data")
+            return
+        }
+        guard let expectedBrowserPaneId = setup["browserPaneId"], !expectedBrowserPaneId.isEmpty else {
+            XCTFail("Missing browserPaneId in goto_split setup data")
+            return
+        }
+
+        enterKeyboardCaptureMode(app)
+        let baselineKeydownCount = pageKeydownCount()
+
+        app.typeKey("h", modifierFlags: [.command, .control])
+
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 5.0) { data in
+                let count = Int(data["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+                return count >= baselineKeydownCount + 1 &&
+                    (data["browserKeyboardCapturePageLastKey"] ?? "").lowercased() == "h" &&
+                    data["browserKeyboardCapturePageLastMeta"] == "true" &&
+                    data["browserKeyboardCapturePageLastControl"] == "true"
+            },
+            "Expected Cmd+Ctrl+H to stay in the page while capture is active. data=\(String(describing: loadData()))"
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        let snapshot = loadData() ?? [:]
+        XCTAssertEqual(
+            snapshot["focusedPaneId"],
+            expectedBrowserPaneId,
+            "Expected browser pane focus to remain unchanged while capture is active. data=\(snapshot)"
+        )
+        XCTAssertNotEqual(
+            snapshot["lastMoveDirection"],
+            "left",
+            "Expected pane-navigation shortcut to be suppressed while capture is active. data=\(snapshot)"
+        )
+    }
+
+    private func launchWithBrowserSetup(enableFocusShortcuts: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = gotoSplitPath
+        app.launchEnvironment["CMUX_UI_TEST_KEYEQUIV_PATH"] = keyequivPath
+        app.launchEnvironment["CMUX_UI_TEST_BROWSER_KEY_CAPTURE_SETUP"] = "1"
+        if enableFocusShortcuts {
+            app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
+        }
+        app.launch()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch in foreground. state=\(app.state.rawValue)"
+        )
+
+        XCTAssertTrue(
+            waitForData(
+                keys: [
+                    "browserPanelId",
+                    "browserPaneId",
+                    "terminalPaneId",
+                    "webViewFocused",
+                    "browserKeyboardCapturePageTrackerInstalled"
+                ],
+                timeout: 12.0
+            ),
+            "Expected browser setup and page key tracker to be written"
+        )
+
+        guard let setup = loadData() else {
+            XCTFail("Missing goto_split setup data")
+            return app
+        }
+
+        XCTAssertEqual(setup["webViewFocused"], "true", "Expected WKWebView to be first responder for this test")
+        XCTAssertEqual(
+            setup["browserKeyboardCapturePageTrackerInstalled"],
+            "true",
+            "Expected page keyboard tracker to be installed"
+        )
+
+        return app
+    }
+
+    private func enterKeyboardCaptureMode(_ app: XCUIApplication) {
+        let button = app.buttons["BrowserKeyboardCaptureButton"]
+        XCTAssertTrue(button.waitForExistence(timeout: 5.0), "Expected keyboard capture button to exist")
+        button.click()
+
+        XCTAssertTrue(
+            waitForKeyequivMatch(timeout: 5.0) { data in
+                data["browserKeyboardCaptureActive"] == "1" &&
+                    data["browserKeyboardCaptureExitArmed"] != "1"
+            },
+            "Expected keyboard capture mode to become active. keyequiv=\(loadKeyequiv())"
+        )
+    }
+
+    private func pageKeydownCount() -> Int {
+        Int(loadData()?["browserKeyboardCapturePageKeydownCount"] ?? "") ?? 0
+    }
+
+    private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) {
+            return true
+        }
+        if app.state == .runningBackground {
+            app.activate()
+            return app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        return false
+    }
+
+    private func waitForData(keys: [String], timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let data = loadData(), keys.allSatisfy({ data[$0] != nil }) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        if let data = loadData(), keys.allSatisfy({ data[$0] != nil }) {
+            return true
+        }
+        return false
+    }
+
+    private func waitForDataMatch(timeout: TimeInterval, predicate: ([String: String]) -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let data = loadData(), predicate(data) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        if let data = loadData(), predicate(data) {
+            return true
+        }
+        return false
+    }
+
+    private func waitForKeyequivMatch(timeout: TimeInterval, predicate: ([String: String]) -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let data = loadKeyequiv()
+            if predicate(data) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return predicate(loadKeyequiv())
+    }
+
+    private func loadData() -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: gotoSplitPath)) else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+
+    private func loadKeyequiv() -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: keyequivPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return [:]
+        }
+        return object
+    }
+}


### PR DESCRIPTION
## Summary
- add browser keyboard capture mode for browser panes so web apps can keep their own Cmd-based shortcuts
- show a persistent capture indicator with Esc twice to exit, and bypass cmux shortcut routing while captured
- add unit and UI regression coverage for browser keyboard capture and portal focus ownership

## Testing
- `xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-webview-focus-mode-local-webkey -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests`
- `ssh cmux-macmini "env -i HOME=/Users/cmux PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin bash --noprofile --norc -lc 'cd ~/fun/cmux-worktrees/task-webview-focus-mode && xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination \"platform=macOS\" -derivedDataPath /tmp/cmux-task-webview-focus-mode-ssh-unit -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests'"`
- `ssh cmux-macmini "env -i HOME=/Users/cmux PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin bash --noprofile --norc -lc 'cd ~/fun/cmux-worktrees/task-webview-focus-mode && xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination \"platform=macOS\" -derivedDataPath /tmp/cmux-task-webview-focus-mode-ssh-unit-routing -only-testing:cmuxTests/AppDelegateShortcutRoutingTests'"` (existing unrelated failure: `testCmdCtrlWClosesWindowAfterConfirmation`)
- `https://github.com/manaflow-ai/cmux/actions/runs/23056385686` queued for `BrowserKeyboardCaptureUITests` on `macos-26`
- `https://github.com/manaflow-ai/cmux/actions/runs/23058388096` queued for `BrowserKeyboardCaptureUITests` on `macos-15`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a browser keyboard capture mode so web apps can use their own Cmd-based shortcuts by sending keys directly to `WKWebView`. Shows a persistent capture indicator, supports Esc twice to exit, and auto-releases on address/find focus, Command Palette open, and panel unfocus/close.

- **New Features**
  - Bypasses cmux shortcut routing and app menu accelerators while captured; delivers key equivalents straight to `WKWebView`.
  - Controls: omnibar keyboard pill (toggle), Command Palette command with dynamic title, and `View > Capture Webview Keyboard` menu toggle; optional webview focus on activate.
  - UX: Esc-twice exit (1.25s arming), orange focus ring on the active pane, pill text updates; EN/JA strings; added UI and unit tests verifying app/window/menu bypass and page routing.

- **Bug Fixes**
  - Portal focus ownership: allow portal-hosted text inputs to focus while treating non-input siblings as web-owned.
  - Stabilized Cmd+Ctrl+W close-window test by asserting window context unregister and no visible main window.

<sup>Written for commit 8035ff78adb2198471fe0ddbc315df9c72fd6683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

