### PR TITLE
fix: correct Claude Code hooks config to match actual schema

### DIFF
--- a/web/app/[locale]/docs/notifications/page.tsx
+++ b/web/app/[locale]/docs/notifications/page.tsx
@@ -158,7 +158,7 @@ printf '\\e]99;i=1;e=1;d=1;p=body:All tests passed\\e\\\\'`}</CodeBlock>
 [ -S /tmp/cmux.sock ] || exit 0
 
 EVENT=$(cat)
-EVENT_TYPE=$(echo "$EVENT" | jq -r '.event // "unknown"')
+EVENT_TYPE=$(echo "$EVENT" | jq -r '.hook_event_name // "unknown"')
 TOOL=$(echo "$EVENT" | jq -r '.tool_name // ""')
 
 case "$EVENT_TYPE" in
@@ -174,11 +174,26 @@ esac`}</CodeBlock>
       <h3>{t("configureClaude")}</h3>
       <CodeBlock title="~/.claude/settings.json" lang="json">{`{
   "hooks": {
-    "Stop": ["~/.claude/hooks/cmux-notify.sh"],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cmux-notify.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Task",
-        "hooks": ["~/.claude/hooks/cmux-notify.sh"]
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cmux-notify.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION

The hooks configuration example used a format that was valid when originally written but broke across two Claude Code releases:

- v1.0.41: Added `hook_event_name` to hook input, replacing the previous field name. The hook script was still reading `.event`, causing the case statement to always fall through to unknown.

- v2.1.63: Added HTTP hooks with `{ "type": "command", "command": "..." }` object format. Bare string paths in the hooks array are no longer valid now that hook type disambiguation is required.

Changes:
- Stop hooks now use the full matcher/hooks object structure
- PostToolUse inner hooks use typed command objects
- Hook script reads `hook_event_name` instead of `event`

Ref: https://docs.anthropic.com/en/docs/claude-code/hooks

## Summary

- **What changed?** Updated the Claude Code hooks configuration example and hook shell script on the notifications docs page to match the current Claude Code settings schema.
- **Why?** The existing examples silently fail with current Claude Code versions. Users copying the config from the docs would get hooks that never fire.

## Testing

- Verified the updated `settings.json` structure matches the schema documented at https://docs.anthropic.com/en/docs/claude-code/hooks
- Confirmed `hook_event_name` is the correct field by cross-referencing the Claude Code hooks reference and changelog (v1.0.41)
- Confirmed `{ "type": "command", "command": "..." }` object format is required by cross-referencing the hooks reference and changelog (v2.1.63)

## Demo Video

N/A — docs-only change, no UI or behavior changes.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Claude Code hooks configuration and example hook script to match the latest schema so hooks fire correctly on current versions.

- **Bug Fixes**
  - Shell script reads `hook_event_name` instead of `event`.
  - `Stop` and `PostToolUse` examples use the full matcher/hooks structure with typed `{ "type": "command", "command": "..." }` objects instead of bare string paths.

<sup>Written for commit 18c3adb20566b4c72cb7c484225e85da67429c55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hook configuration structure for improved clarity and flexibility.
  * Refined event type detection mechanism to enhance system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->