### PR TITLE
Add Claude session fork and restore

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2304,6 +2304,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         isTerminatingApp = true
+        populateClaudeSessionIdsFromHookStore()
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         return .terminateNow
     }
@@ -2500,6 +2501,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         startupSessionSnapshot = nil
         isApplyingStartupSessionRestore = false
         _ = saveSessionSnapshot(includeScrollback: false)
+
+        // Resume any Claude sessions that were active when cmux last quit
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.resumeClaudeSessionsAfterRestore()
+        }
     }
 
     private func applySessionWindowSnapshot(
@@ -8442,6 +8448,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Fork Claude session: Ctrl+Shift+F
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .forkClaudeSession)) {
+            performForkClaudeSession()
+            return true
+        }
+
         // Surface navigation (legacy Ctrl+Tab support)
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: false, option: false, control: true)) {
             tabManager?.selectNextSurface()
@@ -9133,6 +9145,142 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         recordGotoSplitSplitIfNeeded(direction: direction)
 #endif
         return true
+    }
+
+    /// Fork the current Claude Code session into a new tab.
+    /// Creates a new terminal surface and sends `claude --continue --fork-session` to it.
+    func performForkClaudeSession() {
+        _ = synchronizeActiveMainWindowContext(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow)
+        guard let tabManager else { return }
+
+        // Create a new terminal tab (surface) in the focused pane
+        tabManager.newSurface()
+
+        // Wait for the new surface to become ready, then send the fork command
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.sendForkCommandToFocusedSurface(attempt: 0)
+        }
+    }
+
+    private func sendForkCommandToFocusedSurface(attempt: Int) {
+        guard attempt < 20 else { return }
+        guard let tab = tabManager?.selectedWorkspace,
+              let terminalPanel = tab.focusedTerminalPanel,
+              let surface = terminalPanel.surface.surface else {
+            // Surface not ready yet, retry
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.sendForkCommandToFocusedSurface(attempt: attempt + 1)
+            }
+            return
+        }
+
+        // Send the command text
+        terminalPanel.sendText("claude --continue --fork-session")
+
+        // Send Enter as a proper key event (keycode 36 = Return)
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = GHOSTTY_ACTION_PRESS
+        keyEvent.keycode = 36
+        keyEvent.mods = GHOSTTY_MODS_NONE
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.text = nil
+        keyEvent.composing = false
+        _ = ghostty_surface_key(surface, keyEvent)
+    }
+
+    // MARK: - Claude Session Save/Restore
+
+    /// Lightweight read-only structs for decoding the Claude hook session store.
+    private struct ClaudeSessionMapping: Codable {
+        var sessionId: String
+        var workspaceId: String
+        var surfaceId: String
+    }
+
+    private struct ClaudeSessionMappingFile: Codable {
+        var version: Int?
+        var sessions: [String: ClaudeSessionMapping]
+    }
+
+    /// Read the Claude hook session store and populate `surfaceClaudeSessionIds`
+    /// on each workspace so that the next snapshot save includes Claude session IDs.
+    func populateClaudeSessionIdsFromHookStore() {
+        let statePath = NSString(string: "~/.cmuxterm/claude-hook-sessions.json").expandingTildeInPath
+        guard FileManager.default.fileExists(atPath: statePath),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: statePath)),
+              let store = try? JSONDecoder().decode(ClaudeSessionMappingFile.self, from: data) else {
+            return
+        }
+
+        for context in mainWindowContexts.values {
+            for workspace in context.tabManager.tabs {
+                for (panelId, _) in workspace.panels {
+                    // Match by surfaceId (panel UUID)
+                    let panelIdString = panelId.uuidString.lowercased()
+                    for (_, record) in store.sessions {
+                        if record.surfaceId.lowercased() == panelIdString {
+                            workspace.surfaceClaudeSessionIds[panelId] = record.sessionId
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// After session restore completes, send `claude --resume <id>` to panels
+    /// that had active Claude sessions.
+    func resumeClaudeSessionsAfterRestore() {
+        for context in mainWindowContexts.values {
+            for workspace in context.tabManager.tabs {
+                for (panelId, sessionId) in workspace.pendingClaudeResumes {
+                    sendClaudeResumeCommand(
+                        to: workspace,
+                        panelId: panelId,
+                        sessionId: sessionId
+                    )
+                }
+                workspace.pendingClaudeResumes.removeAll()
+            }
+        }
+    }
+
+    private func sendClaudeResumeCommand(
+        to workspace: Workspace,
+        panelId: UUID,
+        sessionId: String,
+        attempt: Int = 0
+    ) {
+        let maxAttempts = 60
+        guard attempt < maxAttempts else { return }
+        guard let terminalPanel = workspace.terminalPanel(for: panelId),
+              let surface = terminalPanel.surface.surface else {
+            // Surface not ready yet, retry
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.sendClaudeResumeCommand(
+                    to: workspace,
+                    panelId: panelId,
+                    sessionId: sessionId,
+                    attempt: attempt + 1
+                )
+            }
+            return
+        }
+
+        // Sanitize session ID to prevent command injection (UUIDs are [a-zA-Z0-9-])
+        let sanitized = sessionId.filter { $0.isLetter || $0.isNumber || $0 == "-" }
+        guard !sanitized.isEmpty else { return }
+
+        terminalPanel.sendText("claude --resume \(sanitized)")
+
+        // Send Enter as a proper key event (keycode 36 = Return)
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = GHOSTTY_ACTION_PRESS
+        keyEvent.keycode = 36
+        keyEvent.mods = GHOSTTY_MODS_NONE
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.text = nil
+        keyEvent.composing = false
+        _ = ghostty_surface_key(surface, keyEvent)
     }
 
     @discardableResult

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4037,6 +4037,8 @@ struct ContentView: View {
             return .toggleSplitZoom
         case "palette.triggerFlash":
             return .triggerFlash
+        case "palette.forkClaudeSession":
+            return .forkClaudeSession
         default:
             return nil
         }
@@ -4839,6 +4841,16 @@ struct ContentView: View {
             )
         )
 
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.forkClaudeSession",
+                title: constant(String(localized: "command.forkClaudeSession.title", defaultValue: "Fork Claude Session")),
+                subtitle: constant(String(localized: "command.forkClaudeSession.subtitle", defaultValue: "AI Agent")),
+                keywords: ["claude", "fork", "session", "branch", "agent"],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
+            )
+        )
+
         return contributions
     }
 
@@ -5145,6 +5157,9 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.terminalSplitDown") {
             tabManager.createSplit(direction: .down)
+        }
+        registry.register(commandId: "palette.forkClaudeSession") {
+            AppDelegate.shared?.performForkClaudeSession()
         }
         registry.register(commandId: "palette.terminalSplitBrowserRight") {
             _ = tabManager.createBrowserSplit(direction: .right)

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -42,6 +42,9 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
+        // AI Agent Actions
+        case forkClaudeSession
+
         var id: String { rawValue }
 
         var label: String {
@@ -76,6 +79,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
+            case .forkClaudeSession: return String(localized: "shortcut.forkClaudeSession.label", defaultValue: "Fork Claude Session")
             }
         }
 
@@ -111,6 +115,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
+            case .forkClaudeSession: return "shortcut.forkClaudeSession"
             }
         }
 
@@ -178,6 +183,9 @@ enum KeyboardShortcutSettings {
             case .showBrowserJavaScriptConsole:
                 // Safari default: Show JavaScript Console.
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
+            case .forkClaudeSession:
+                // Cmd+Shift+F: Fork the current Claude Code session into a new tab
+                return StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
             }
         }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -250,6 +250,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var gitBranch: SessionGitBranchSnapshot?
     var listeningPorts: [Int]
     var ttyName: String?
+    var claudeSessionId: String?
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -304,6 +304,7 @@ extension Workspace {
         }
         let listeningPorts = (surfaceListeningPorts[panelId] ?? []).sorted()
         let ttyName = surfaceTTYNames[panelId]
+        let claudeSessionId = surfaceClaudeSessionIds[panelId]
 
         let terminalSnapshot: SessionTerminalPanelSnapshot?
         let browserSnapshot: SessionBrowserPanelSnapshot?
@@ -360,6 +361,7 @@ extension Workspace {
             gitBranch: branchSnapshot,
             listeningPorts: listeningPorts,
             ttyName: ttyName,
+            claudeSessionId: claudeSessionId,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
             markdown: markdownSnapshot
@@ -510,6 +512,10 @@ extension Workspace {
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: terminalPanel.id)
             }
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
+            if let claudeSessionId = snapshot.claudeSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !claudeSessionId.isEmpty {
+                pendingClaudeResumes[terminalPanel.id] = claudeSessionId
+            }
             return terminalPanel.id
         case .browser:
             let initialURL = snapshot.browser?.urlString.flatMap { URL(string: $0) }
@@ -568,6 +574,13 @@ extension Workspace {
             surfaceTTYNames[panelId] = ttyName
         } else {
             surfaceTTYNames.removeValue(forKey: panelId)
+        }
+
+        if let claudeSessionId = snapshot.claudeSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !claudeSessionId.isEmpty {
+            surfaceClaudeSessionIds[panelId] = claudeSessionId
+        } else {
+            surfaceClaudeSessionIds.removeValue(forKey: panelId)
         }
 
         if let browserSnapshot = snapshot.browser,
@@ -999,6 +1012,8 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
     @Published var listeningPorts: [Int] = []
     var surfaceTTYNames: [UUID: String] = [:]
+    var surfaceClaudeSessionIds: [UUID: String] = [:]
+    var pendingClaudeResumes: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
 
     var focusedSurfaceId: UUID? { focusedPanelId }
@@ -1786,6 +1801,7 @@ final class Workspace: Identifiable, ObservableObject {
         manualUnreadMarkedAt = manualUnreadMarkedAt.filter { validSurfaceIds.contains($0.key) }
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
         surfaceTTYNames = surfaceTTYNames.filter { validSurfaceIds.contains($0.key) }
+        surfaceClaudeSessionIds = surfaceClaudeSessionIds.filter { validSurfaceIds.contains($0.key) }
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
         recomputeListeningPorts()
     }
@@ -4661,6 +4677,7 @@ extension Workspace: BonsplitDelegate {
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         panelSubscriptions.removeValue(forKey: panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
+        surfaceClaudeSessionIds.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
         PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
         terminalInheritanceFontPointsByPanelId.removeValue(forKey: panelId)
@@ -4840,6 +4857,7 @@ extension Workspace: BonsplitDelegate {
                 manualUnreadPanelIds.remove(panelId)
                 panelSubscriptions.removeValue(forKey: panelId)
                 surfaceTTYNames.removeValue(forKey: panelId)
+                surfaceClaudeSessionIds.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
                 PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)


### PR DESCRIPTION
## Summary
- Add **Cmd+Shift+F** shortcut to fork the current Claude Code session into a new tab (runs `claude --continue --fork-session`)
- Persist Claude session IDs in session snapshots so they survive app restarts
- Auto-resume Claude sessions after restore via `claude --resume <id>`
- Add "Fork Claude Session" to the command palette

## Test plan
- [ ] Press Cmd+Shift+F in a terminal with an active Claude Code session — verify a new tab opens and runs `claude --continue --fork-session`
- [ ] Quit and relaunch cmux with active Claude sessions — verify they auto-resume
- [ ] Open command palette and search "Fork Claude" — verify the command appears and works
- [ ] Verify session IDs are cleaned up when panels are closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session fork and restore for Claude Code. Press Cmd+Shift+F or use the command palette to fork into a new tab; Claude sessions now persist and auto-resume after restart.

- New Features
  - Cmd+Shift+F to fork the current Claude Code session into a new tab (`claude --continue --fork-session`).
  - Command palette action: “Fork Claude Session”.
  - Persist `claudeSessionId` in session snapshots; clean up IDs when panels close.
  - On quit, read `~/.cmuxterm/claude-hook-sessions.json` to capture active session IDs before saving.
  - After restore, auto-run `claude --resume <id>` with retries until the surface is ready and sanitized IDs.

<sup>Written for commit 21a5a3dda772df300035a5c62f55ec00482689c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fork Claude sessions directly from within the app using the command palette
  * New keyboard shortcut (Cmd+Shift+F) for quick session forking
  * Automatic Claude session persistence and restoration after app crashes or restarts, ensuring your work is preserved across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->