### PR TITLE
Fix tab and workspace drag reorder on macOS 26+

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7997,7 +7997,7 @@ private struct SidebarExternalDropDelegate: DropDelegate {
     let draggedTabId: UUID?
 
     func validateDrop(info: DropInfo) -> Bool {
-        let hasSidebarPayload = info.hasItemsConforming(to: [SidebarTabDragPayload.typeIdentifier])
+        let hasSidebarPayload = info.hasItemsConforming(to: SidebarTabDragPayload.dropContentTypes)
         let shouldReset = SidebarOutsideDropResetPolicy.shouldResetDrag(
             draggedTabId: draggedTabId,
             hasSidebarDragPayload: hasSidebarPayload
@@ -11329,7 +11329,10 @@ private enum SidebarTabDragPayload {
     static func provider(for tabId: UUID) -> NSItemProvider {
         let provider = NSItemProvider()
         let payload = "\(prefix)\(tabId.uuidString)"
-        provider.registerDataRepresentation(forTypeIdentifier: typeIdentifier, visibility: .ownProcess) { completion in
+        // Use .all visibility for compatibility with macOS 26+ where .ownProcess
+        // can cause drag reorder to fail on fresh installs due to stricter
+        // process-scoped drag session validation.
+        provider.registerDataRepresentation(forTypeIdentifier: typeIdentifier, visibility: .all) { completion in
             completion(payload.data(using: .utf8), nil)
             return nil
         }
@@ -11399,7 +11402,7 @@ private struct SidebarBonsplitTabDropDelegate: DropDelegate {
     @Binding var lastSidebarSelectionIndex: Int?
 
     func validateDrop(info: DropInfo) -> Bool {
-        guard info.hasItemsConforming(to: [BonsplitTabDragPayload.typeIdentifier]) else { return false }
+        guard info.hasItemsConforming(to: BonsplitTabDragPayload.dropContentTypes) else { return false }
         return BonsplitTabDragPayload.currentTransfer() != nil
     }
 
@@ -11455,7 +11458,7 @@ private struct SidebarTabDropDelegate: DropDelegate {
     @Binding var dropIndicator: SidebarDropIndicator?
 
     func validateDrop(info: DropInfo) -> Bool {
-        let hasType = info.hasItemsConforming(to: [SidebarTabDragPayload.typeIdentifier])
+        let hasType = info.hasItemsConforming(to: SidebarTabDragPayload.dropContentTypes)
         let hasDrag = draggedTabId != nil
         #if DEBUG
         dlog("sidebar.validateDrop target=\(targetTabId?.uuidString.prefix(5) ?? "end") hasType=\(hasType) hasDrag=\(hasDrag)")


### PR DESCRIPTION
## Problem
Tab and workspace drag reorder does not work on fresh macOS installs, particularly on macOS 26+. Users report being unable to reorder tabs by dragging even with "Reorder on notification" disabled.

## Root Cause
Two issues in the drag-and-drop implementation:

1. **Type identifier mismatch**: The \"validateDrop\" functions in \"SidebarTabDropDelegate\", \"SidebarBonsplitTabDropDelegate\", and \"SidebarExternalDropDelegate\" were using \"[String]\" type identifiers (\"[SidebarTabDragPayload.typeIdentifier]\") instead of \"[UTType]\" (\"SidebarTabDragPayload.dropContentTypes\") when calling \"info.hasItemsConforming(to:)\". This caused drag validation to fail.

2. **Process visibility restriction**: \"NSItemProvider\" was using \"visibility: .ownProcess\" which on macOS 26+ has stricter process-scoped drag session validation that can cause drag reorder to fail on fresh installs. Changed to \"visibility: .all\" for broader compatibility.

## Change
- Changed \"[SidebarTabDragPayload.typeIdentifier]\" → \"SidebarTabDragPayload.dropContentTypes\" in \"SidebarExternalDropDelegate\" and \"SidebarTabDropDelegate\"
- Changed \"[BonsplitTabDragPayload.typeIdentifier]\" → \"BonsplitTabDragPayload.dropContentTypes\" in \"SidebarBonsplitTabDropDelegate\"
- Changed \"NSItemProvider\" visibility from \".ownProcess\" to \".all\" with explanatory comment

## Verification
- "git diff --check\" passes (no whitespace errors)
- Swift syntax check passed (swiftc -parse)
- 1 file changed, 7 insertions(+), 4 deletions(-)

## Risk/Edge Cases
- The visibility change to \".all\" is the standard approach for intra-app drag operations on macOS 26+ and should not affect security since the type identifier remains app-specific
- UTType-based drag content types are the modern API and should be more reliable than string identifiers

Fixes #1385

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab and workspace drag reordering on macOS 26+. Replaces string-based drag validation with `UTType`s and sets `NSItemProvider` visibility to `.all` so drops are accepted on fresh installs. Fixes #1385.

- **Bug Fixes**
  - `SidebarExternalDropDelegate`, `SidebarTabDropDelegate`, `SidebarBonsplitTabDropDelegate`: use `dropContentTypes` with `info.hasItemsConforming(to:)`.
  - `SidebarTabDragPayload.provider`: change `visibility: .ownProcess` → `.all` with a note for macOS 26+ behavior.

<sup>Written for commit f6577b561bd017ebb3731e9def4c39949b1b5e3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drag and drop reorder failures on fresh macOS installations
  * Resolved drag session validation issues affecting macOS 26+ compatibility

* **Improvements**
  * Enhanced compatibility with broader range of drag payload types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->