### PR TITLE
Exit split zoom when jumping to unread

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9968,7 +9968,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         context.sidebarSelectionState.selection = .tabs
         bringToFront(window)
-        context.tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId)
+        guard context.tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+#if DEBUG
+            recordMultiWindowNotificationOpenFailureIfNeeded(
+                tabId: tabId,
+                surfaceId: surfaceId,
+                notificationId: notificationId,
+                reason: "focus_failed"
+            )
+            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
+                writeJumpUnreadTestData(["jumpUnreadOpenResult": "0"])
+            }
+#endif
+            return false
+        }
 
 #if DEBUG
         // UI test support: Jump-to-unread asserts that the correct workspace/panel is focused.
@@ -10033,7 +10046,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         sidebarSelectionState?.selection = .tabs
         bringToFront(window)
-        tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId)
+        guard tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+#if DEBUG
+            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
+                writeJumpUnreadTestData([
+                    "jumpUnreadFallbackFail": "focus_failed",
+                    "jumpUnreadOpenResult": "0",
+                ])
+            }
+#endif
+            return false
+        }
 
 #if DEBUG
         recordJumpUnreadFocusFromModelIfNeeded(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2203,9 +2203,24 @@ class TabManager: ObservableObject {
         }
     }
 
-    func focusTabFromNotification(_ tabId: UUID, surfaceId: UUID? = nil) {
+    @discardableResult
+    func focusTabFromNotification(_ tabId: UUID, surfaceId: UUID? = nil) -> Bool {
         let wasSelected = selectedTabId == tabId
-        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        guard let tab = tabs.first(where: { $0.id == tabId }) else {
+#if DEBUG
+            dlog("notification.focus.fail tab=\(tabId.uuidString.prefix(5)) reason=missingTab")
+#endif
+            return false
+        }
+        if let surfaceId, tab.panels[surfaceId] == nil {
+#if DEBUG
+            dlog(
+                "notification.focus.fail tab=\(tabId.uuidString.prefix(5)) " +
+                "panel=\(surfaceId.uuidString.prefix(5)) reason=missingPanel"
+            )
+#endif
+            return false
+        }
         let desiredPanelId = surfaceId ?? tab.focusedPanelId
 #if DEBUG
         if let desiredPanelId {
@@ -2232,6 +2247,7 @@ class TabManager: ObservableObject {
             tab.triggerNotificationFocusFlash(panelId: targetPanelId, requiresSplit: false, shouldFocus: true)
             notificationStore.markRead(forTabId: tabId, surfaceId: targetPanelId)
         }
+        return true
     }
 
     func focusSurface(tabId: UUID, surfaceId: UUID) {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -11099,7 +11099,9 @@ class TerminalController {
                 result = "ERROR: Surface not found"
                 return
             }
-            tabManager.focusTabFromNotification(tab.id, surfaceId: surfaceId)
+            if !tabManager.focusTabFromNotification(tab.id, surfaceId: surfaceId) {
+                result = "ERROR: Focus failed"
+            }
         }
         return result
     }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -5505,7 +5505,7 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertTrue(workspace.toggleSplitZoom(panelId: leftPanelId), "Expected split zoom to enable")
         XCTAssertTrue(workspace.bonsplitController.isSplitZoomed, "Expected workspace to start zoomed")
 
-        manager.focusTabFromNotification(workspace.id, surfaceId: rightPanel.id)
+        XCTAssertTrue(manager.focusTabFromNotification(workspace.id, surfaceId: rightPanel.id))
         drainMainQueue()
         drainMainQueue()
 
@@ -5514,6 +5514,16 @@ final class TabManagerNotificationFocusTests: XCTestCase {
             "Expected notification focus to exit split zoom so the target pane becomes visible"
         )
         XCTAssertEqual(workspace.focusedPanelId, rightPanel.id, "Expected notification target panel to be focused")
+    }
+
+    func testFocusTabFromNotificationReturnsFalseForMissingPanel() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected selected workspace")
+            return
+        }
+
+        XCTAssertFalse(manager.focusTabFromNotification(workspace.id, surfaceId: UUID()))
     }
 }
 


### PR DESCRIPTION
## Summary
- add a regression test for jumping to an unread notification while split zoom is active
- clear split zoom before notification focus moves to the unread target panel

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-cmd-shift-u-exit-zoom-unit build`
- `./scripts/reload.sh --tag cmd-shift-u-exit-zoom`

## Task
- Plain-text request: "after cmd shift enter, behavior of cmd shift u is weird. ideally cmd shift u will exit out of cmd shift enter mode"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd-Shift-U (jump to unread) now exits split zoom (Cmd-Shift-Enter) before focusing the target pane so the destination is visible. It also guards focus failures to avoid ending in a bad state.

- **Bug Fixes**
  - Clear split zoom in `TabManager.focusTabFromNotification`, and make it return `Bool`; `AppDelegate` and `TerminalController` now guard and log focus failures.
  - Add regression tests for exiting split zoom and for missing panel returning `false`.

<sup>Written for commit 09a98c911d76fdd3cf060f0659e0ae5b7731d22d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification-driven tab focusing: lingering split/zoom display state is cleared so the correct panel is revealed, and failures to focus are detected and handled (caller shows an error or stops further processing; debug/test failures are recorded).

* **Tests**
  * Added automated tests covering notification-triggered tab focus and missing-target-panel handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->