### PR TITLE
Extract Atlas-inspired browser surface runtime seam

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9116,8 +9116,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard isLikelyWebInspectorResponder(keyWindow.firstResponder) else { return }
 
         let beforeResponder = keyWindow.firstResponder
-        let movedToWebView = keyWindow.makeFirstResponder(browser.webView)
-        let movedToNil = movedToWebView ? false : keyWindow.makeFirstResponder(nil)
+        let preflightResult = browser.prepareSurfaceFocusForTransientDeveloperToolsHide(in: keyWindow)
 
         #if DEBUG
         let beforeType = beforeResponder.map { String(describing: type(of: $0)) } ?? "nil"
@@ -9128,7 +9127,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         dlog(
             "split.shortcut inspector.preflight dir=\(directionLabel) panel=\(browser.id.uuidString.prefix(5)) " +
             "before=\(beforeType)@\(beforePtr) after=\(afterType)@\(afterPtr) " +
-            "moveWeb=\(movedToWebView ? 1 : 0) moveNil=\(movedToNil ? 1 : 0) \(browser.debugDeveloperToolsStateSummary())"
+            "moveWeb=\(preflightResult.movedToSurface ? 1 : 0) " +
+            "moveNil=\(preflightResult.movedToNil ? 1 : 0) \(browser.debugDeveloperToolsStateSummary())"
         )
         #endif
     }
@@ -9161,9 +9161,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }()
         let splitContext = "keyWin=\(keyWindow?.windowNumber ?? -1) mainWin=\(NSApp.mainWindow?.windowNumber ?? -1) fr=\(firstResponderType)@\(firstResponderPtr) frWin=\(firstResponderWindow)"
         if let browser = tabManager?.focusedBrowserPanel {
-            let webWindow = browser.webView.window?.windowNumber ?? -1
-            let webSuperview = browser.webView.superview.map { String(describing: Unmanaged.passUnretained($0).toOpaque()) } ?? "nil"
-            dlog("split.shortcut dir=\(directionLabel) pre panel=\(browser.id.uuidString.prefix(5)) \(browser.debugDeveloperToolsStateSummary()) webWin=\(webWindow) webSuper=\(webSuperview) \(splitContext)")
+            dlog(
+                "split.shortcut dir=\(directionLabel) pre panel=\(browser.id.uuidString.prefix(5)) " +
+                "\(browser.debugDeveloperToolsStateSummary()) \(browser.debugDeveloperToolsGeometrySummary()) " +
+                "\(splitContext)"
+            )
         } else {
             dlog("split.shortcut dir=\(directionLabel) pre panel=nil \(splitContext)")
         }
@@ -9188,9 +9190,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }()
             let splitContext = "keyWin=\(keyWindow?.windowNumber ?? -1) mainWin=\(NSApp.mainWindow?.windowNumber ?? -1) fr=\(firstResponderType)@\(firstResponderPtr) frWin=\(firstResponderWindow)"
             if let browser = self?.tabManager?.focusedBrowserPanel {
-                let webWindow = browser.webView.window?.windowNumber ?? -1
-                let webSuperview = browser.webView.superview.map { String(describing: Unmanaged.passUnretained($0).toOpaque()) } ?? "nil"
-                dlog("split.shortcut dir=\(directionLabel) post panel=\(browser.id.uuidString.prefix(5)) \(browser.debugDeveloperToolsStateSummary()) webWin=\(webWindow) webSuper=\(webSuperview) \(splitContext)")
+                dlog(
+                    "split.shortcut dir=\(directionLabel) post panel=\(browser.id.uuidString.prefix(5)) " +
+                    "\(browser.debugDeveloperToolsStateSummary()) \(browser.debugDeveloperToolsGeometrySummary()) " +
+                    "\(splitContext)"
+                )
             } else {
                 dlog("split.shortcut dir=\(directionLabel) post panel=nil \(splitContext)")
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7070,9 +7070,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             let browserPanel = workspace.panels.values.compactMap { $0 as? BrowserPanel }.first
             let otherTerminal = workspace.panels.values.compactMap { $0 as? TerminalPanel }.first
-            let browserSnapshot = browserPanel.flatMap {
-                BrowserWindowPortalRegistry.debugSnapshot(for: $0.webView)
-            }
+            let browserSnapshot = browserPanel?.debugPortalSnapshot()
 
             var updates = self.gotoSplitFindStateSnapshot(for: workspace)
             updates["splitZoomedAfterToggle"] = workspace.bonsplitController.isSplitZoomed ? "true" : "false"
@@ -8697,7 +8695,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let firstResponderType = keyWindow?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
         let panel = tabManager?.focusedBrowserPanel
         let panelToken = panel.map { String($0.id.uuidString.prefix(8)) } ?? "nil"
-        let panelZoom = panel?.webView.pageZoom ?? -1
+        let panelZoom = panel?.surfacePageZoom() ?? -1
         var line =
             "zoom.shortcut stage=\(stage) event=\(NSWindow.keyDescription(event)) " +
             "chars='\(chars)' flags=\(browserZoomShortcutTraceFlagsString(flags)) " +

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6857,7 +6857,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let readyState = (payload?["readyState"] as? String) ?? ""
             var secondaryClickOffsetX = -1.0
             var secondaryClickOffsetY = -1.0
-            if let window = panel.surfaceWindow(),
+            if let window = panel.surfaceHostingWindow(),
                let webFrame = panel.surfaceFrameInWindowCoordinates() {
                 let contentHeight = Double(window.contentView?.bounds.height ?? 0)
                 if webFrame.width > 1,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6616,9 +6616,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func isWebViewFocused(_ panel: BrowserPanel) -> Bool {
-        guard let window = panel.webView.window else { return false }
-        guard let fr = window.firstResponder as? NSView else { return false }
-        return fr.isDescendant(of: panel.webView)
+        panel.isSurfaceFocusedInHostWindow()
     }
 
     private func paneIdsForGotoSplitUITest(tab: Workspace, browserPanelId: UUID) -> (browser: PaneID, terminal: PaneID)? {
@@ -6845,9 +6843,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         })();
         """
 
-        panel.webView.evaluateJavaScript(script) { [weak self] result, _ in
+        Task { @MainActor [weak self] in
             guard let self else { return }
-            let payload = result as? [String: Any]
+            let payload = (try? await panel.evaluateJavaScript(script)) as? [String: Any]
             let focused = (payload?["focused"] as? Bool) ?? false
             let inputId = (payload?["id"] as? String) ?? ""
             let secondaryInputId = (payload?["secondaryId"] as? String) ?? ""
@@ -6859,8 +6857,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let readyState = (payload?["readyState"] as? String) ?? ""
             var secondaryClickOffsetX = -1.0
             var secondaryClickOffsetY = -1.0
-            if let window = panel.webView.window {
-                let webFrame = panel.webView.convert(panel.webView.bounds, to: nil)
+            if let window = panel.surfaceWindow(),
+               let webFrame = panel.surfaceFrameInWindowCoordinates() {
                 let contentHeight = Double(window.contentView?.bounds.height ?? 0)
                 if webFrame.width > 1,
                    webFrame.height > 1,
@@ -6995,8 +6993,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         })();
         """
 
-        panel.webView.evaluateJavaScript(script) { result, _ in
-            let payload = result as? [String: Any]
+        Task { @MainActor in
+            let payload = (try? await panel.evaluateJavaScript(script)) as? [String: Any]
             completion([
                 "id": (payload?["id"] as? String) ?? "",
                 "tag": (payload?["tag"] as? String) ?? "",

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2376,7 +2376,7 @@ struct ContentView: View {
                   let selectedWorkspace = tabManager.selectedWorkspace,
                   let focusedPanelId = selectedWorkspace.focusedPanelId,
                   let focusedBrowser = selectedWorkspace.browserPanel(for: focusedPanelId),
-                  focusedBrowser.webView === webView else { return }
+                  focusedBrowser.ownsSurfaceWebView(webView) else { return }
             completeWorkspaceHandoffIfNeeded(focusedTabId: selectedTabId, reason: "browser_first_responder")
         })
 
@@ -5793,7 +5793,7 @@ struct ContentView: View {
     ) -> CommandPaletteRestoreFocusTarget? {
         for (panelId, panel) in workspace.panels {
             guard let browserPanel = panel as? BrowserPanel,
-                  browserPanel.webView === webView else {
+                  browserPanel.ownsSurfaceWebView(webView) else {
                 continue
             }
 

--- a/Sources/Find/BrowserFindJavaScript.swift
+++ b/Sources/Find/BrowserFindJavaScript.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct BrowserFindResult: Equatable {
+    let total: UInt
+    let selected: UInt?
+}
+
 /// JavaScript snippets for find-in-page in WKWebView.
 ///
 /// Uses TreeWalker to scan text nodes and wraps matches with `<mark>` elements.
@@ -169,6 +174,24 @@ enum BrowserFindJavaScript {
           return 'ok';
         })()
         """
+    }
+
+    static func parseResult(_ result: Any?) -> BrowserFindResult? {
+        guard let jsonString = result as? String,
+              let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let total = json["total"] as? Int,
+              let current = json["current"] as? Int,
+              total >= 0, current >= 0 else {
+            return nil
+        }
+        if total == 0 {
+            return BrowserFindResult(total: 0, selected: nil)
+        }
+        guard current < total else {
+            return nil
+        }
+        return BrowserFindResult(total: UInt(total), selected: UInt(current))
     }
 
     // MARK: - Internal

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1227,7 +1227,7 @@ actor BrowserSearchSuggestionService {
 
 /// BrowserPanel provides a WKWebView-based browser panel.
 /// All browser panels share a WKProcessPool for cookie sharing.
-private enum BrowserInsecureHTTPNavigationIntent {
+enum BrowserInsecureHTTPNavigationIntent {
     case currentTab
     case newTab
 }
@@ -1273,12 +1273,24 @@ struct BrowserSurfaceRuntimeState: Equatable {
     let pageZoom: CGFloat
 }
 
+struct BrowserSurfaceRuntimeEventHandlers {
+    var didFinishNavigation: (() -> Void)?
+    var didFailNavigation: ((String) -> Void)?
+    var didTerminateWebContentProcess: (() -> Void)?
+    var openInNewTab: ((URL) -> Void)?
+    var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var shouldBlockInsecureHTTPNavigation: ((URL) -> Bool)?
+    var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var downloadStateChanged: ((Bool) -> Void)?
+}
+
 @MainActor
 protocol BrowserSurfaceRuntime: AnyObject {
     var backendKind: BrowserRuntimeBackendKind { get }
     var webView: WKWebView { get }
     var webViewInstanceID: UUID { get }
     var state: BrowserSurfaceRuntimeState { get }
+    var eventHandlers: BrowserSurfaceRuntimeEventHandlers { get set }
     var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)? { get set }
 
     @discardableResult
@@ -1287,11 +1299,7 @@ protocol BrowserSurfaceRuntime: AnyObject {
         pageZoom: CGFloat?
     ) -> WKWebView
 
-    func configureDelegates(
-        navigationDelegate: WKNavigationDelegate?,
-        uiDelegate: WKUIDelegate?
-    )
-    func setDownloadStateChangeHandler(_ handler: ((Bool) -> Void)?)
+    func setLastAttemptedNavigationURL(_ url: URL?)
     func setCustomUserAgent(_ customUserAgent: String)
     func setUnderPageBackgroundColor(_ color: NSColor)
     @discardableResult
@@ -1334,10 +1342,15 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
     private(set) var webView: WKWebView
     private(set) var webViewInstanceID: UUID
     private var observations: [NSKeyValueObservation] = []
-    private var navigationDelegate: WKNavigationDelegate?
-    private var uiDelegate: WKUIDelegate?
-    private var downloadStateChangeHandler: ((Bool) -> Void)?
+    private let navigationDelegate = BrowserNavigationDelegate()
+    private let uiDelegate = BrowserUIDelegate()
+    private let downloadDelegate = BrowserDownloadDelegate()
     private var lastEmittedState: BrowserSurfaceRuntimeState?
+    var eventHandlers = BrowserSurfaceRuntimeEventHandlers() {
+        didSet {
+            applyEventHandlersToCurrentWebView()
+        }
+    }
     var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)? {
         didSet {
             emitStateChange(force: true)
@@ -1367,6 +1380,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         )
         self.webView = webView
         self.webViewInstanceID = UUID()
+        wireInternalDelegates()
         bindWebView(webView)
     }
 
@@ -1375,7 +1389,9 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         using configuration: BrowserRuntimeSurfaceConfiguration,
         pageZoom: CGFloat?
     ) -> WKWebView {
+        let retiredWebView = webView
         observations.removeAll()
+        clearBindings(on: retiredWebView)
         let replacement = Self.makeWebView(
             processPool: processPool,
             configuration: configuration
@@ -1383,26 +1399,15 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         if let pageZoom {
             replacement.pageZoom = pageZoom
         }
-        bindWebView(replacement)
         webView = replacement
         webViewInstanceID = UUID()
+        bindWebView(replacement)
         emitStateChange(force: true)
         return replacement
     }
 
-    func configureDelegates(
-        navigationDelegate: WKNavigationDelegate?,
-        uiDelegate: WKUIDelegate?
-    ) {
-        self.navigationDelegate = navigationDelegate
-        self.uiDelegate = uiDelegate
-        webView.navigationDelegate = navigationDelegate
-        webView.uiDelegate = uiDelegate
-    }
-
-    func setDownloadStateChangeHandler(_ handler: ((Bool) -> Void)?) {
-        downloadStateChangeHandler = handler
-        (webView as? CmuxWebView)?.onContextMenuDownloadStateChanged = handler
+    func setLastAttemptedNavigationURL(_ url: URL?) {
+        navigationDelegate.lastAttemptedURL = url
     }
 
     func setCustomUserAgent(_ customUserAgent: String) {
@@ -1497,13 +1502,71 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         return webView
     }
 
+    private func wireInternalDelegates() {
+        navigationDelegate.didFinish = { [weak self] webView in
+            guard let self, self.isCurrentWebView(webView) else { return }
+            self.eventHandlers.didFinishNavigation?()
+        }
+        navigationDelegate.didFailNavigation = { [weak self] webView, failedURL in
+            guard let self, self.isCurrentWebView(webView) else { return }
+            self.eventHandlers.didFailNavigation?(failedURL)
+        }
+        navigationDelegate.didTerminateWebContentProcess = { [weak self] webView in
+            guard let self, self.isCurrentWebView(webView) else { return }
+            self.eventHandlers.didTerminateWebContentProcess?()
+        }
+        navigationDelegate.openInNewTab = { [weak self] url in
+            self?.eventHandlers.openInNewTab?(url)
+        }
+        navigationDelegate.shouldBlockInsecureHTTPNavigation = { [weak self] url in
+            self?.eventHandlers.shouldBlockInsecureHTTPNavigation?(url) ?? false
+        }
+        navigationDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
+            self?.eventHandlers.handleBlockedInsecureHTTPNavigation?(request, intent)
+        }
+        navigationDelegate.downloadDelegate = downloadDelegate
+
+        uiDelegate.openInNewTab = { [weak self] url in
+            self?.eventHandlers.openInNewTab?(url)
+        }
+        uiDelegate.requestNavigation = { [weak self] request, intent in
+            self?.eventHandlers.requestNavigation?(request, intent)
+        }
+
+        downloadDelegate.onDownloadStarted = { [weak self] _ in
+            self?.eventHandlers.downloadStateChanged?(true)
+        }
+        downloadDelegate.onDownloadReadyToSave = { [weak self] in
+            self?.eventHandlers.downloadStateChanged?(false)
+        }
+        downloadDelegate.onDownloadFailed = { [weak self] _ in
+            self?.eventHandlers.downloadStateChanged?(false)
+        }
+    }
+
     private func bindWebView(_ webView: WKWebView) {
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
-        if let cmuxWebView = webView as? CmuxWebView {
-            cmuxWebView.onContextMenuDownloadStateChanged = downloadStateChangeHandler
-        }
+        applyEventHandlers(to: webView)
         installObservers(on: webView)
+    }
+
+    private func clearBindings(on webView: WKWebView) {
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        if let cmuxWebView = webView as? CmuxWebView {
+            cmuxWebView.onContextMenuDownloadStateChanged = nil
+        }
+    }
+
+    private func applyEventHandlersToCurrentWebView() {
+        applyEventHandlers(to: webView)
+    }
+
+    private func applyEventHandlers(to webView: WKWebView) {
+        if let cmuxWebView = webView as? CmuxWebView {
+            cmuxWebView.onContextMenuDownloadStateChanged = eventHandlers.downloadStateChanged
+        }
     }
 
     private func installObservers(on webView: WKWebView) {
@@ -1545,6 +1608,10 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
             forwardObserver,
             progressObserver,
         ]
+    }
+
+    private func isCurrentWebView(_ candidate: WKWebView) -> Bool {
+        candidate === webView
     }
 
     private func emitStateChange(force: Bool = false) {
@@ -2059,9 +2126,6 @@ final class BrowserPanel: Panel, ObservableObject {
     private var pendingDistinctPortalHostReplacementPaneId: UUID?
     private var lockedPortalHost: PortalHostLock?
     private var webViewCancellables = Set<AnyCancellable>()
-    private var navigationDelegate: BrowserNavigationDelegate?
-    private var uiDelegate: BrowserUIDelegate?
-    private var downloadDelegate: BrowserDownloadDelegate?
     private var activeDownloadCount: Int = 0
 
     // Avoid flickering the loading indicator for very fast navigations.
@@ -2327,21 +2391,17 @@ final class BrowserPanel: Panel, ObservableObject {
         self.webViewInstanceID = runtime.webViewInstanceID
         self.insecureHTTPAlertFactory = { NSAlert() }
 
-        // Set up navigation delegate
-        let navDelegate = BrowserNavigationDelegate()
-        navDelegate.didFinish = { webView in
-            BrowserHistoryStore.shared.recordVisit(url: webView.url, title: webView.title)
-            Task { @MainActor [weak self] in
-                guard let self, self.isCurrentWebView(webView) else { return }
-                self.refreshFavicon(from: webView)
+        runtime.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: { [weak self] in
+                guard let self else { return }
+                BrowserHistoryStore.shared.recordVisit(url: self.webView.url, title: self.webView.title)
+                self.refreshFavicon(from: self.webView)
                 self.applyBrowserThemeModeIfNeeded()
                 // Keep find-in-page open through load completion and refresh matches for the new DOM.
                 self.restoreFindStateAfterNavigation(replaySearch: true)
-            }
-        }
-        navDelegate.didFailNavigation = { [weak self] failedWebView, failedURL in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(failedWebView) else { return }
+            },
+            didFailNavigation: { [weak self] failedURL in
+                guard let self else { return }
                 // Clear stale title/favicon from the previous page so the tab
                 // shows the failed URL instead of the old page's branding.
                 self.pageTitle = failedURL.isEmpty ? "" : failedURL
@@ -2349,59 +2409,31 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.lastFaviconURLString = nil
                 // Keep find-in-page open and clear stale counters on failed loads.
                 self.restoreFindStateAfterNavigation(replaySearch: false)
+            },
+            didTerminateWebContentProcess: { [weak self] in
+                guard let self else { return }
+                self.replaceWebViewAfterContentProcessTermination(for: self.webView)
+            },
+            openInNewTab: { [weak self] url in
+                self?.openLinkInNewTab(url: url)
+            },
+            requestNavigation: { [weak self] request, intent in
+                self?.requestNavigation(request, intent: intent)
+            },
+            shouldBlockInsecureHTTPNavigation: { [weak self] url in
+                self?.shouldBlockInsecureHTTPNavigation(to: url) ?? false
+            },
+            handleBlockedInsecureHTTPNavigation: { [weak self] request, intent in
+                self?.presentInsecureHTTPAlert(for: request, intent: intent, recordTypedNavigation: false)
+            },
+            downloadStateChanged: { [weak self] downloading in
+                if downloading {
+                    self?.beginDownloadActivity()
+                } else {
+                    self?.endDownloadActivity()
+                }
             }
-        }
-        navDelegate.openInNewTab = { [weak self] url in
-            self?.openLinkInNewTab(url: url)
-        }
-        navDelegate.shouldBlockInsecureHTTPNavigation = { [weak self] url in
-            self?.shouldBlockInsecureHTTPNavigation(to: url) ?? false
-        }
-        navDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
-            self?.presentInsecureHTTPAlert(for: request, intent: intent, recordTypedNavigation: false)
-        }
-        navDelegate.didTerminateWebContentProcess = { [weak self] webView in
-            self?.replaceWebViewAfterContentProcessTermination(for: webView)
-        }
-        // Set up download delegate for navigation-based downloads.
-        // Downloads save to a temp file synchronously (no NSSavePanel during WebKit
-        // callbacks), then show NSSavePanel after the download completes.
-        let dlDelegate = BrowserDownloadDelegate()
-        dlDelegate.onDownloadStarted = { [weak self] _ in
-            self?.beginDownloadActivity()
-        }
-        dlDelegate.onDownloadReadyToSave = { [weak self] in
-            self?.endDownloadActivity()
-        }
-        dlDelegate.onDownloadFailed = { [weak self] _ in
-            self?.endDownloadActivity()
-        }
-        navDelegate.downloadDelegate = dlDelegate
-        self.downloadDelegate = dlDelegate
-        self.navigationDelegate = navDelegate
-
-        // Set up UI delegate (handles cmd+click, target=_blank, and context menu)
-        let browserUIDelegate = BrowserUIDelegate()
-        browserUIDelegate.openInNewTab = { [weak self] url in
-            guard let self else { return }
-            self.openLinkInNewTab(url: url)
-        }
-        browserUIDelegate.requestNavigation = { [weak self] request, intent in
-            self?.requestNavigation(request, intent: intent)
-        }
-        self.uiDelegate = browserUIDelegate
-
-        runtime.configureDelegates(
-            navigationDelegate: navDelegate,
-            uiDelegate: browserUIDelegate
         )
-        runtime.setDownloadStateChangeHandler { [weak self] downloading in
-            if downloading {
-                self?.beginDownloadActivity()
-            } else {
-                self?.endDownloadActivity()
-            }
-        }
         runtime.onStateChange = { [weak self] state in
             self?.applyRuntimeState(state)
         }
@@ -2512,11 +2544,6 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconRefreshGeneration &+= 1
         BrowserWindowPortalRegistry.detach(webView: terminatedWebView)
         terminatedWebView.stopLoading()
-        terminatedWebView.navigationDelegate = nil
-        terminatedWebView.uiDelegate = nil
-        if let terminatedCmuxWebView = terminatedWebView as? CmuxWebView {
-            terminatedCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
 
         _ = replaceRuntimeWebView(pageZoom: desiredZoom)
         shouldRenderWebView = wasRenderable
@@ -2599,10 +2626,8 @@ final class BrowserPanel: Panel, ObservableObject {
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
         runtime.stopLoading()
-        runtime.configureDelegates(navigationDelegate: nil, uiDelegate: nil)
-        runtime.setDownloadStateChangeHandler(nil)
-        navigationDelegate = nil
-        uiDelegate = nil
+        runtime.eventHandlers = BrowserSurfaceRuntimeEventHandlers()
+        runtime.onStateChange = nil
         webViewCancellables.removeAll()
         faviconTask?.cancel()
         faviconTask = nil
@@ -2840,7 +2865,7 @@ final class BrowserPanel: Panel, ObservableObject {
         if recordTypedNavigation {
             BrowserHistoryStore.shared.recordTypedNavigation(url: url)
         }
-        navigationDelegate?.lastAttemptedURL = url
+        runtime.setLastAttemptedNavigationURL(url)
         _ = runtime.loadRequest(request)
     }
 
@@ -3032,7 +3057,7 @@ extension BrowserPanel {
         estimatedProgress = 0
         nativeCanGoBack = false
         nativeCanGoForward = false
-        navigationDelegate?.lastAttemptedURL = nil
+        runtime.setLastAttemptedNavigationURL(nil)
         abandonRestoredSessionHistoryIfNeeded()
 
         pendingAddressBarFocusRequestId = nil
@@ -3056,11 +3081,6 @@ extension BrowserPanel {
         let oldWebView = webView
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
-        oldWebView.navigationDelegate = nil
-        oldWebView.uiDelegate = nil
-        if let oldCmuxWebView = oldWebView as? CmuxWebView {
-            oldCmuxWebView.onContextMenuDownloadStateChanged = nil
-        }
 
         _ = replaceRuntimeWebView()
         shouldRenderWebView = false

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2881,11 +2881,8 @@ final class BrowserPanel: Panel, ObservableObject {
         guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return }
 
         // If nothing meaningful is loaded yet, prefer letting the omnibar take focus.
-        if !webView.isLoading {
-            let urlString = webView.url?.absoluteString ?? currentURL?.absoluteString
-            if urlString == nil || urlString == "about:blank" {
-                return
-            }
+        if !runtime.state.isLoading, preferredURLStringForOmnibar() == nil {
+            return
         }
 
         if Self.responderChainContains(window.firstResponder, target: webView) {
@@ -4420,33 +4417,27 @@ extension BrowserPanel {
     }
 
     /// Returns the most reliable URL string for omnibar-related matching and UI decisions.
-    /// `currentURL` can lag behind navigation changes, so prefer the live WKWebView URL.
+    /// `currentURL` can lag behind runtime state changes, so prefer the runtime's current URL.
     func preferredURLStringForOmnibar() -> String? {
-        if let webViewURL = webView.url?.absoluteString
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !webViewURL.isEmpty,
-           webViewURL != blankURLString {
-            return webViewURL
-        }
-
-        if let current = currentURL?.absoluteString
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !current.isEmpty,
-           current != blankURLString {
-            return current
+        for candidate in [runtime.state.currentURL?.absoluteString, currentURL?.absoluteString] {
+            guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty,
+                  trimmed != blankURLString else {
+                continue
+            }
+            return trimmed
         }
 
         return nil
     }
 
     private func resolvedCurrentSessionHistoryURL() -> URL? {
-        if let webViewURL = webView.url,
-           Self.serializableSessionHistoryURLString(webViewURL) != nil {
-            return webViewURL
-        }
-        if let currentURL,
-           Self.serializableSessionHistoryURLString(currentURL) != nil {
-            return currentURL
+        for candidate in [runtime.state.currentURL, currentURL] {
+            guard let candidate,
+                  Self.serializableSessionHistoryURLString(candidate) != nil else {
+                continue
+            }
+            return candidate
         }
         return restoredHistoryCurrentURL
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1263,17 +1263,48 @@ struct BrowserRuntimeSurfaceConfiguration {
     let customUserAgent: String
 }
 
+struct BrowserSurfaceRuntimeState: Equatable {
+    let currentURL: URL?
+    let title: String?
+    let isLoading: Bool
+    let canGoBack: Bool
+    let canGoForward: Bool
+    let estimatedProgress: Double
+    let pageZoom: CGFloat
+}
+
 @MainActor
 protocol BrowserSurfaceRuntime: AnyObject {
     var backendKind: BrowserRuntimeBackendKind { get }
     var webView: WKWebView { get }
     var webViewInstanceID: UUID { get }
+    var state: BrowserSurfaceRuntimeState { get }
+    var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)? { get set }
 
     @discardableResult
     func replaceWebView(
         using configuration: BrowserRuntimeSurfaceConfiguration,
         pageZoom: CGFloat?
     ) -> WKWebView
+
+    func configureDelegates(
+        navigationDelegate: WKNavigationDelegate?,
+        uiDelegate: WKUIDelegate?
+    )
+    func setDownloadStateChangeHandler(_ handler: ((Bool) -> Void)?)
+    func setCustomUserAgent(_ customUserAgent: String)
+    func setUnderPageBackgroundColor(_ color: NSColor)
+    @discardableResult
+    func loadRequest(_ request: URLRequest) -> WKNavigation?
+    func loadHTMLString(_ html: String, baseURL: URL?)
+    func goBack()
+    func goForward()
+    func reload()
+    func stopLoading()
+    func setPageZoom(_ pageZoom: CGFloat)
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void)
+    func evaluateJavaScript(_ script: String) async throws -> Any?
+    func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
 @MainActor
@@ -1302,6 +1333,28 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
     private let processPool: WKProcessPool
     private(set) var webView: WKWebView
     private(set) var webViewInstanceID: UUID
+    private var observations: [NSKeyValueObservation] = []
+    private var navigationDelegate: WKNavigationDelegate?
+    private var uiDelegate: WKUIDelegate?
+    private var downloadStateChangeHandler: ((Bool) -> Void)?
+    private var lastEmittedState: BrowserSurfaceRuntimeState?
+    var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)? {
+        didSet {
+            emitStateChange(force: true)
+        }
+    }
+
+    var state: BrowserSurfaceRuntimeState {
+        BrowserSurfaceRuntimeState(
+            currentURL: webView.url,
+            title: webView.title,
+            isLoading: webView.isLoading,
+            canGoBack: webView.canGoBack,
+            canGoForward: webView.canGoForward,
+            estimatedProgress: webView.estimatedProgress,
+            pageZoom: webView.pageZoom
+        )
+    }
 
     init(
         processPool: WKProcessPool,
@@ -1314,6 +1367,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         )
         self.webView = webView
         self.webViewInstanceID = UUID()
+        bindWebView(webView)
     }
 
     @discardableResult
@@ -1321,6 +1375,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         using configuration: BrowserRuntimeSurfaceConfiguration,
         pageZoom: CGFloat?
     ) -> WKWebView {
+        observations.removeAll()
         let replacement = Self.makeWebView(
             processPool: processPool,
             configuration: configuration
@@ -1328,9 +1383,87 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         if let pageZoom {
             replacement.pageZoom = pageZoom
         }
+        bindWebView(replacement)
         webView = replacement
         webViewInstanceID = UUID()
+        emitStateChange(force: true)
         return replacement
+    }
+
+    func configureDelegates(
+        navigationDelegate: WKNavigationDelegate?,
+        uiDelegate: WKUIDelegate?
+    ) {
+        self.navigationDelegate = navigationDelegate
+        self.uiDelegate = uiDelegate
+        webView.navigationDelegate = navigationDelegate
+        webView.uiDelegate = uiDelegate
+    }
+
+    func setDownloadStateChangeHandler(_ handler: ((Bool) -> Void)?) {
+        downloadStateChangeHandler = handler
+        (webView as? CmuxWebView)?.onContextMenuDownloadStateChanged = handler
+    }
+
+    func setCustomUserAgent(_ customUserAgent: String) {
+        webView.customUserAgent = customUserAgent
+    }
+
+    func setUnderPageBackgroundColor(_ color: NSColor) {
+        webView.underPageBackgroundColor = color
+    }
+
+    @discardableResult
+    func loadRequest(_ request: URLRequest) -> WKNavigation? {
+        browserLoadRequest(request, in: webView)
+    }
+
+    func loadHTMLString(_ html: String, baseURL: URL?) {
+        webView.loadHTMLString(html, baseURL: baseURL)
+    }
+
+    func goBack() {
+        webView.goBack()
+    }
+
+    func goForward() {
+        webView.goForward()
+    }
+
+    func reload() {
+        webView.reload()
+    }
+
+    func stopLoading() {
+        webView.stopLoading()
+    }
+
+    func setPageZoom(_ pageZoom: CGFloat) {
+        webView.pageZoom = pageZoom
+        emitStateChange()
+    }
+
+    func takeSnapshot(completion: @escaping (NSImage?) -> Void) {
+        let config = WKSnapshotConfiguration()
+        webView.takeSnapshot(with: config) { image, error in
+            if let error {
+                NSLog("BrowserPanel snapshot error: %@", error.localizedDescription)
+                completion(nil)
+                return
+            }
+            completion(image)
+        }
+    }
+
+    func evaluateJavaScript(_ script: String) async throws -> Any? {
+        try await webView.evaluateJavaScript(script)
+    }
+
+    func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
+        (
+            backHistoryURLs: webView.backForwardList.backList.map(\.url),
+            forwardHistoryURLs: webView.backForwardList.forwardList.map(\.url)
+        )
     }
 
     private static func makeWebView(
@@ -1362,6 +1495,65 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         webView.underPageBackgroundColor = configuration.underPageBackgroundColor
         webView.customUserAgent = configuration.customUserAgent
         return webView
+    }
+
+    private func bindWebView(_ webView: WKWebView) {
+        webView.navigationDelegate = navigationDelegate
+        webView.uiDelegate = uiDelegate
+        if let cmuxWebView = webView as? CmuxWebView {
+            cmuxWebView.onContextMenuDownloadStateChanged = downloadStateChangeHandler
+        }
+        installObservers(on: webView)
+    }
+
+    private func installObservers(on webView: WKWebView) {
+        let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        let titleObserver = webView.observe(\.title, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        let loadingObserver = webView.observe(\.isLoading, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        let backObserver = webView.observe(\.canGoBack, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        let forwardObserver = webView.observe(\.canGoForward, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        let progressObserver = webView.observe(\.estimatedProgress, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.emitStateChange()
+            }
+        }
+        observations = [
+            urlObserver,
+            titleObserver,
+            loadingObserver,
+            backObserver,
+            forwardObserver,
+            progressObserver,
+        ]
+    }
+
+    private func emitStateChange(force: Bool = false) {
+        let nextState = state
+        if !force, lastEmittedState == nextState {
+            return
+        }
+        lastEmittedState = nextState
+        onStateChange?(nextState)
     }
 }
 
@@ -1870,7 +2062,6 @@ final class BrowserPanel: Panel, ObservableObject {
     private var navigationDelegate: BrowserNavigationDelegate?
     private var uiDelegate: BrowserUIDelegate?
     private var downloadDelegate: BrowserDownloadDelegate?
-    private var webViewObservers: [NSKeyValueObservation] = []
     private var activeDownloadCount: Int = 0
 
     // Avoid flickering the loading indicator for very fast navigations.
@@ -1882,6 +2073,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private var faviconTask: Task<Void, Never>?
     private var faviconRefreshGeneration: Int = 0
     private var lastFaviconURLString: String?
+    private var lastRuntimeState: BrowserSurfaceRuntimeState?
     private let minPageZoom: CGFloat = 0.25
     private let maxPageZoom: CGFloat = 5.0
     private let pageZoomStep: CGFloat = 0.1
@@ -2085,19 +2277,30 @@ final class BrowserPanel: Panel, ObservableObject {
         return replacement
     }
 
-    private func bindWebView(_ webView: WKWebView) {
-        if let cmuxWebView = webView as? CmuxWebView {
-            cmuxWebView.onContextMenuDownloadStateChanged = { [weak self] downloading in
-                if downloading {
-                    self?.beginDownloadActivity()
-                } else {
-                    self?.endDownloadActivity()
-                }
-            }
+    private func applyRuntimeState(_ state: BrowserSurfaceRuntimeState) {
+        currentURL = state.currentURL
+        if lastRuntimeState?.isLoading != state.isLoading {
+            handleWebViewLoadingChanged(state.isLoading)
         }
-        webView.navigationDelegate = navigationDelegate
-        webView.uiDelegate = uiDelegate
-        setupObservers(for: webView)
+        let trimmedTitle = (state.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTitle.isEmpty {
+            pageTitle = trimmedTitle
+        }
+        nativeCanGoBack = state.canGoBack
+        nativeCanGoForward = state.canGoForward
+        estimatedProgress = state.estimatedProgress
+        refreshNavigationAvailability()
+        lastRuntimeState = state
+    }
+
+    private func installAppearanceDrivenBackgroundObserverIfNeeded() {
+        guard webViewCancellables.isEmpty else { return }
+        NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
+            .sink { [weak self] notification in
+                guard let self else { return }
+                self.runtime.setUnderPageBackgroundColor(GhosttyBackgroundTheme.color(from: notification))
+            }
+            .store(in: &webViewCancellables)
     }
 
     private func isCurrentWebView(_ candidate: WKWebView, instanceID: UUID? = nil) -> Bool {
@@ -2188,7 +2391,21 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         self.uiDelegate = browserUIDelegate
 
-        bindWebView(runtime.webView)
+        runtime.configureDelegates(
+            navigationDelegate: navDelegate,
+            uiDelegate: browserUIDelegate
+        )
+        runtime.setDownloadStateChangeHandler { [weak self] downloading in
+            if downloading {
+                self?.beginDownloadActivity()
+            } else {
+                self?.endDownloadActivity()
+            }
+        }
+        runtime.onStateChange = { [weak self] state in
+            self?.applyRuntimeState(state)
+        }
+        installAppearanceDrivenBackgroundObserverIfNeeded()
         installDetachedDeveloperToolsWindowCloseObserver()
         applyBrowserThemeModeIfNeeded()
         insecureHTTPAlertWindowProvider = { [weak self] in
@@ -2246,12 +2463,9 @@ final class BrowserPanel: Panel, ObservableObject {
             return (back, forward)
         }
 
-        let back = webView.backForwardList.backList.compactMap {
-            Self.serializableSessionHistoryURLString($0.url)
-        }
-        let forward = webView.backForwardList.forwardList.compactMap {
-            Self.serializableSessionHistoryURLString($0.url)
-        }
+        let history = runtime.sessionHistorySnapshot()
+        let back = history.backHistoryURLs.compactMap(Self.serializableSessionHistoryURLString)
+        let forward = history.forwardHistoryURLs.compactMap(Self.serializableSessionHistoryURLString)
         return (back, forward)
     }
 
@@ -2270,78 +2484,6 @@ final class BrowserPanel: Panel, ObservableObject {
         restoredForwardHistoryStack = Array(restoredForward.reversed())
         restoredHistoryCurrentURL = Self.sanitizedSessionHistoryURL(currentURLString)
         refreshNavigationAvailability()
-    }
-
-    private func setupObservers(for webView: WKWebView) {
-        let observedWebViewInstanceID = webViewInstanceID
-
-        // URL changes
-        let urlObserver = webView.observe(\.url, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                self.currentURL = webView.url
-            }
-        }
-        webViewObservers.append(urlObserver)
-
-        // Title changes
-        let titleObserver = webView.observe(\.title, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                // Keep showing the last non-empty title while the new navigation is loading.
-                // WebKit often clears title to nil/"" during reload/navigation, which causes
-                // a distracting tab-title flash (e.g. to host/URL). Only accept non-empty titles.
-                let trimmed = (webView.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-                self.pageTitle = trimmed
-            }
-        }
-        webViewObservers.append(titleObserver)
-
-        // Loading state
-        let loadingObserver = webView.observe(\.isLoading, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                self.handleWebViewLoadingChanged(webView.isLoading)
-            }
-        }
-        webViewObservers.append(loadingObserver)
-
-        // Can go back
-        let backObserver = webView.observe(\.canGoBack, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                self.nativeCanGoBack = webView.canGoBack
-                self.refreshNavigationAvailability()
-            }
-        }
-        webViewObservers.append(backObserver)
-
-        // Can go forward
-        let forwardObserver = webView.observe(\.canGoForward, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                self.nativeCanGoForward = webView.canGoForward
-                self.refreshNavigationAvailability()
-            }
-        }
-        webViewObservers.append(forwardObserver)
-
-        // Progress
-        let progressObserver = webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
-            Task { @MainActor in
-                guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
-                self.estimatedProgress = webView.estimatedProgress
-            }
-        }
-        webViewObservers.append(progressObserver)
-
-        NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
-            .sink { [weak self] notification in
-                guard let self else { return }
-                self.webView.underPageBackgroundColor = GhosttyBackgroundTheme.color(from: notification)
-            }
-            .store(in: &webViewCancellables)
     }
 
     private func replaceWebViewAfterContentProcessTermination(for terminatedWebView: WKWebView) {
@@ -2365,8 +2507,6 @@ final class BrowserPanel: Panel, ObservableObject {
         )
 #endif
 
-        webViewObservers.removeAll()
-        webViewCancellables.removeAll()
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
@@ -2378,10 +2518,9 @@ final class BrowserPanel: Panel, ObservableObject {
             terminatedCmuxWebView.onContextMenuDownloadStateChanged = nil
         }
 
-        let replacement = replaceRuntimeWebView(pageZoom: desiredZoom)
+        _ = replaceRuntimeWebView(pageZoom: desiredZoom)
         shouldRenderWebView = wasRenderable
 
-        bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()
 
         if !history.backHistoryURLStrings.isEmpty || !history.forwardHistoryURLStrings.isEmpty {
@@ -2459,12 +2598,11 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
-        webView.stopLoading()
-        webView.navigationDelegate = nil
-        webView.uiDelegate = nil
+        runtime.stopLoading()
+        runtime.configureDelegates(navigationDelegate: nil, uiDelegate: nil)
+        runtime.setDownloadStateChangeHandler(nil)
         navigationDelegate = nil
         uiDelegate = nil
-        webViewObservers.removeAll()
         webViewCancellables.removeAll()
         faviconTask?.cancel()
         faviconTask = nil
@@ -2697,13 +2835,13 @@ final class BrowserPanel: Panel, ObservableObject {
             abandonRestoredSessionHistoryIfNeeded()
         }
         // Some installs can end up with a legacy Chrome UA override; keep this pinned.
-        webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
+        runtime.setCustomUserAgent(BrowserUserAgentSettings.safariUserAgent)
         shouldRenderWebView = true
         if recordTypedNavigation {
             BrowserHistoryStore.shared.recordTypedNavigation(url: url)
         }
         navigationDelegate?.lastAttemptedURL = url
-        browserLoadRequest(request, in: webView)
+        _ = runtime.loadRequest(request)
     }
 
     /// Navigate with smart URL/search detection
@@ -2825,7 +2963,6 @@ final class BrowserPanel: Panel, ObservableObject {
         if let detachedDeveloperToolsWindowCloseObserver {
             NotificationCenter.default.removeObserver(detachedDeveloperToolsWindowCloseObserver)
         }
-        webViewObservers.removeAll()
         webViewCancellables.removeAll()
         let webView = webView
         Task { @MainActor in
@@ -2911,13 +3048,12 @@ extension BrowserPanel {
         currentURL = nil
         faviconPNGData = nil
         lastFaviconURLString = nil
+        lastRuntimeState = nil
         activePortalHostLease = nil
         pendingDistinctPortalHostReplacementPaneId = nil
         lockedPortalHost = nil
 
         let oldWebView = webView
-        webViewObservers.removeAll()
-        webViewCancellables.removeAll()
         BrowserWindowPortalRegistry.detach(webView: oldWebView)
         oldWebView.stopLoading()
         oldWebView.navigationDelegate = nil
@@ -2926,9 +3062,8 @@ extension BrowserPanel {
             oldCmuxWebView.onContextMenuDownloadStateChanged = nil
         }
 
-        let replacement = replaceRuntimeWebView()
+        _ = replaceRuntimeWebView()
         shouldRenderWebView = false
-        bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()
         refreshNavigationAvailability()
 
@@ -2997,7 +3132,7 @@ extension BrowserPanel {
             return
         }
 
-        webView.goBack()
+        runtime.goBack()
     }
 
     /// Go forward in history
@@ -3021,7 +3156,7 @@ extension BrowserPanel {
             return
         }
 
-        webView.goForward()
+        runtime.goForward()
     }
 
     /// Open a link in a new browser surface in the same pane
@@ -3070,13 +3205,13 @@ extension BrowserPanel {
 
     /// Reload the current page
     func reload() {
-        webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
-        webView.reload()
+        runtime.setCustomUserAgent(BrowserUserAgentSettings.safariUserAgent)
+        runtime.reload()
     }
 
     /// Stop loading
     func stopLoading() {
-        webView.stopLoading()
+        runtime.stopLoading()
     }
 
     private static func windowContainsInspectorViews(_ root: NSView) -> Bool {
@@ -3563,12 +3698,12 @@ extension BrowserPanel {
 
     @discardableResult
     func zoomIn() -> Bool {
-        applyPageZoom(webView.pageZoom + pageZoomStep)
+        applyPageZoom(runtime.state.pageZoom + pageZoomStep)
     }
 
     @discardableResult
     func zoomOut() -> Bool {
-        applyPageZoom(webView.pageZoom - pageZoomStep)
+        applyPageZoom(runtime.state.pageZoom - pageZoomStep)
     }
 
     @discardableResult
@@ -3578,20 +3713,12 @@ extension BrowserPanel {
 
     /// Take a snapshot of the web view
     func takeSnapshot(completion: @escaping (NSImage?) -> Void) {
-        let config = WKSnapshotConfiguration()
-        webView.takeSnapshot(with: config) { image, error in
-            if let error = error {
-                NSLog("BrowserPanel snapshot error: %@", error.localizedDescription)
-                completion(nil)
-                return
-            }
-            completion(image)
-        }
+        runtime.takeSnapshot(completion: completion)
     }
 
     /// Execute JavaScript
     func evaluateJavaScript(_ script: String) async throws -> Any? {
-        try await webView.evaluateJavaScript(script)
+        try await runtime.evaluateJavaScript(script)
     }
 
     // MARK: - Find in Page
@@ -3649,7 +3776,7 @@ extension BrowserPanel {
     func findNext() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.nextScript())
+            let result = try? await self.runtime.evaluateJavaScript(BrowserFindJavaScript.nextScript())
             self.parseFindResult(result)
         }
     }
@@ -3657,7 +3784,7 @@ extension BrowserPanel {
     func findPrevious() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.previousScript())
+            let result = try? await self.runtime.evaluateJavaScript(BrowserFindJavaScript.previousScript())
             self.parseFindResult(result)
         }
     }
@@ -3691,7 +3818,7 @@ extension BrowserPanel {
             guard let self else { return }
             let js = BrowserFindJavaScript.searchScript(query: needle)
             do {
-                let result = try await self.webView.evaluateJavaScript(js)
+                let result = try await self.runtime.evaluateJavaScript(js)
                 self.parseFindResult(result)
             } catch {
                 NSLog("Find: browser JS search error: %@", error.localizedDescription)
@@ -3703,7 +3830,7 @@ extension BrowserPanel {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.webView.evaluateJavaScript(BrowserFindJavaScript.clearScript())
+                _ = try await self.runtime.evaluateJavaScript(BrowserFindJavaScript.clearScript())
             } catch {
                 NSLog("Find: browser JS clear error: %@", error.localizedDescription)
             }
@@ -3729,7 +3856,7 @@ extension BrowserPanel {
     }
 
     func refreshAppearanceDrivenColors() {
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
+        runtime.setUnderPageBackgroundColor(GhosttyBackgroundTheme.currentColor())
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {
@@ -4397,10 +4524,10 @@ private extension BrowserPanel {
     @discardableResult
     func applyPageZoom(_ candidate: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, candidate))
-        if abs(webView.pageZoom - clamped) < 0.0001 {
+        if abs(runtime.state.pageZoom - clamped) < 0.0001 {
             return false
         }
-        webView.pageZoom = clamped
+        runtime.setPageZoom(clamped)
         return true
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1900,6 +1900,9 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
             let attachSelector = NSSelectorFromString("attach")
             if inspector.responds(to: attachSelector) {
                 inspector.cmuxCallVoid(selector: attachSelector)
+                if inspector.cmuxCallBool(selector: isVisibleSelector) ?? false {
+                    return true
+                }
             }
         }
 
@@ -3701,7 +3704,7 @@ extension BrowserPanel {
             forceDeveloperToolsRefreshOnNextAttach = false
         }
 
-        if visible != targetVisible {
+        if source.hasPrefix("toggle"), visible != targetVisible {
             scheduleDeveloperToolsTransitionSettle(source: source)
         } else {
             developerToolsTransitionTargetVisible = nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3890,8 +3890,8 @@ extension BrowserPanel {
             developerToolsDetachedOpenGraceDeadline = nil
         }
 
+        let visibleAfterTransition = runtime.developerToolsVisibilityState().isVisible
         if targetVisible {
-            let visibleAfterTransition = runtime.developerToolsVisibilityState().isVisible
             if visibleAfterTransition {
                 syncDeveloperToolsPresentationPreferenceFromUI()
                 cancelDeveloperToolsRestoreRetry()
@@ -3905,7 +3905,14 @@ extension BrowserPanel {
             forceDeveloperToolsRefreshOnNextAttach = false
         }
 
-        if source.hasPrefix("toggle"), visible != targetVisible {
+        let shouldSettleQueuedTransition: Bool
+        if source.hasPrefix("toggle") {
+            shouldSettleQueuedTransition = visible != targetVisible
+        } else {
+            shouldSettleQueuedTransition = visibleAfterTransition != targetVisible
+        }
+
+        if shouldSettleQueuedTransition {
             scheduleDeveloperToolsTransitionSettle(source: source)
         } else {
             developerToolsTransitionTargetVisible = nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1612,6 +1612,17 @@ enum BrowserSurfaceDeveloperToolsVisibilityState: Equatable {
 struct BrowserSurfaceDeveloperToolsHostState: Equatable {
     let hasAttachedInspectorLayout: Bool
     let detachedWindowCount: Int
+    let hasSideDockedInspectorLayout: Bool
+
+    init(
+        hasAttachedInspectorLayout: Bool,
+        detachedWindowCount: Int,
+        hasSideDockedInspectorLayout: Bool = false
+    ) {
+        self.hasAttachedInspectorLayout = hasAttachedInspectorLayout
+        self.detachedWindowCount = detachedWindowCount
+        self.hasSideDockedInspectorLayout = hasSideDockedInspectorLayout
+    }
 
     var hasDetachedInspectorWindows: Bool {
         detachedWindowCount > 0
@@ -1730,17 +1741,24 @@ private enum BrowserSurfaceDeveloperToolsHostIntrospection {
 
     static func developerToolsHostState(for webView: WKWebView) -> BrowserSurfaceDeveloperToolsHostState {
         let hasAttachedInspectorLayout: Bool
+        let hasSideDockedInspectorLayout: Bool
         if let container = webView.superview {
-            hasAttachedInspectorLayout = visibleDescendants(in: container)
-                .contains { isVisibleInspectorCandidate($0) && isInspectorView($0) }
+            let inspectorCandidates = visibleDescendants(in: container)
+                .filter { isVisibleInspectorCandidate($0) && isInspectorView($0) }
+            hasAttachedInspectorLayout = !inspectorCandidates.isEmpty
+            hasSideDockedInspectorLayout = inspectorCandidates.contains {
+                hasSideDockedInspectorSibling(startingAt: $0, root: container)
+            }
         } else {
             hasAttachedInspectorLayout = false
+            hasSideDockedInspectorLayout = false
         }
 
         let detachedWindowCount = detachedInspectorWindows(excluding: webView.window).count
         return BrowserSurfaceDeveloperToolsHostState(
             hasAttachedInspectorLayout: hasAttachedInspectorLayout,
-            detachedWindowCount: detachedWindowCount
+            detachedWindowCount: detachedWindowCount,
+            hasSideDockedInspectorLayout: hasSideDockedInspectorLayout
         )
     }
 
@@ -1763,6 +1781,41 @@ private enum BrowserSurfaceDeveloperToolsHostIntrospection {
             view.alphaValue > 0 &&
             view.frame.width > 1 &&
             view.frame.height > 1
+    }
+
+    private static func hasSideDockedInspectorSibling(startingAt inspectorLeaf: NSView, root: NSView) -> Bool {
+        var current: NSView? = inspectorLeaf
+
+        while let inspectorView = current, inspectorView !== root {
+            guard let containerView = inspectorView.superview else { break }
+            let hasSideDockedSibling = containerView.subviews.contains { candidate in
+                guard isVisibleSideDockSiblingCandidate(candidate) else { return false }
+                guard candidate !== inspectorView else { return false }
+                let horizontallyAdjacent =
+                    candidate.frame.maxX <= inspectorView.frame.minX + 1 ||
+                    candidate.frame.minX >= inspectorView.frame.maxX - 1
+                guard horizontallyAdjacent else { return false }
+                return verticalOverlap(between: candidate.frame, and: inspectorView.frame) > 8
+            }
+            if hasSideDockedSibling {
+                return true
+            }
+
+            current = containerView
+        }
+
+        return false
+    }
+
+    private static func isVisibleSideDockSiblingCandidate(_ view: NSView) -> Bool {
+        !view.isHidden &&
+            view.alphaValue > 0 &&
+            view.frame.width > 1 &&
+            view.frame.height > 1
+    }
+
+    private static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
+        max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
     }
 }
 
@@ -3986,7 +4039,7 @@ extension BrowserPanel {
     /// while its container is off-window. Avoid detaching in that transient phase if
     /// DevTools is intended to remain open, because detach/reattach can blank inspector content.
     func shouldPreserveWebViewAttachmentDuringTransientHide() -> Bool {
-        preferredDeveloperToolsVisible && !hasSideDockedDeveloperToolsLayout()
+        preferredDeveloperToolsVisible && !runtime.developerToolsHostState().hasSideDockedInspectorLayout
     }
 
     func requestDeveloperToolsRefreshAfterNextAttach(reason: String) {
@@ -4765,39 +4818,6 @@ private extension BrowserPanel {
         return true
     }
 
-    func hasSideDockedDeveloperToolsLayout() -> Bool {
-        guard let container = webView.superview else { return false }
-        return Self.visibleDescendants(in: container)
-            .filter { Self.isVisibleSideDockInspectorCandidate($0) && Self.isInspectorView($0) }
-            .contains { inspectorCandidate in
-                hasSideDockedInspectorSibling(startingAt: inspectorCandidate, root: container)
-            }
-    }
-
-    func hasSideDockedInspectorSibling(startingAt inspectorLeaf: NSView, root: NSView) -> Bool {
-        var current: NSView? = inspectorLeaf
-
-        while let inspectorView = current, inspectorView !== root {
-            guard let containerView = inspectorView.superview else { break }
-            let hasSideDockedSibling = containerView.subviews.contains { candidate in
-                guard Self.isVisibleSideDockSiblingCandidate(candidate) else { return false }
-                guard candidate !== inspectorView else { return false }
-                let horizontallyAdjacent =
-                    candidate.frame.maxX <= inspectorView.frame.minX + 1 ||
-                    candidate.frame.minX >= inspectorView.frame.maxX - 1
-                guard horizontallyAdjacent else { return false }
-                return Self.verticalOverlap(between: candidate.frame, and: inspectorView.frame) > 8
-            }
-            if hasSideDockedSibling {
-                return true
-            }
-
-            current = containerView
-        }
-
-        return false
-    }
-
     static func visibleDescendants(in root: NSView) -> [NSView] {
         var descendants: [NSView] = []
         var stack = Array(root.subviews.reversed())
@@ -4810,24 +4830,6 @@ private extension BrowserPanel {
 
     static func isInspectorView(_ view: NSView) -> Bool {
         String(describing: type(of: view)).contains("WKInspector")
-    }
-
-    static func isVisibleSideDockInspectorCandidate(_ view: NSView) -> Bool {
-        !view.isHidden &&
-            view.alphaValue > 0 &&
-            view.frame.width > 1 &&
-            view.frame.height > 1
-    }
-
-    static func isVisibleSideDockSiblingCandidate(_ view: NSView) -> Bool {
-        !view.isHidden &&
-            view.alphaValue > 0 &&
-            view.frame.width > 1 &&
-            view.frame.height > 1
-    }
-
-    static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
-        max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
     }
 }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2995,7 +2995,7 @@ final class BrowserPanel: Panel, ObservableObject {
             },
             didTerminateWebContentProcess: { [weak self] in
                 guard let self else { return }
-                self.replaceWebViewAfterContentProcessTermination(for: self.webView)
+                self.replaceWebViewAfterContentProcessTermination()
             },
             openInNewTab: { [weak self] url in
                 self?.openLinkInNewTab(url: url)
@@ -3101,17 +3101,16 @@ final class BrowserPanel: Panel, ObservableObject {
         refreshNavigationAvailability()
     }
 
-    private func replaceWebViewAfterContentProcessTermination(for terminatedWebView: WKWebView) {
-        guard terminatedWebView === webView else { return }
-
+    private func replaceWebViewAfterContentProcessTermination() {
         let wasRenderable = shouldRenderWebView
-        let restoreURL = terminatedWebView.url ?? currentURL
+        let restoreURL = runtime.state.currentURL ?? currentURL
         let restoreURLString = restoreURL?.absoluteString
         let shouldRestoreURL = wasRenderable && restoreURLString != nil && restoreURLString != blankURLString
         let history = sessionNavigationHistorySnapshot()
         let historyCurrentURL = preferredURLStringForOmnibar()
-        let desiredZoom = max(minPageZoom, min(maxPageZoom, terminatedWebView.pageZoom))
+        let desiredZoom = max(minPageZoom, min(maxPageZoom, runtime.state.pageZoom))
         let restoreDevTools = preferredDeveloperToolsVisible
+        let retiredWebView = webView
 
 #if DEBUG
         dlog(
@@ -3125,8 +3124,8 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         faviconRefreshGeneration &+= 1
-        BrowserWindowPortalRegistry.detach(webView: terminatedWebView)
-        terminatedWebView.stopLoading()
+        BrowserWindowPortalRegistry.detach(webView: retiredWebView)
+        runtime.stopLoading()
 
         _ = replaceRuntimeWebView(pageZoom: desiredZoom)
         shouldRenderWebView = wasRenderable
@@ -3166,7 +3165,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
 #if DEBUG
     func debugSimulateWebContentProcessTermination() {
-        replaceWebViewAfterContentProcessTermination(for: webView)
+        replaceWebViewAfterContentProcessTermination()
     }
 #endif
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1590,6 +1590,20 @@ struct BrowserSurfaceRuntimeState: Equatable {
     let pageZoom: CGFloat
 }
 
+enum BrowserSurfaceDeveloperToolsVisibilityState: Equatable {
+    case unavailable
+    case hidden
+    case visible
+
+    var isAvailable: Bool {
+        self != .unavailable
+    }
+
+    var isVisible: Bool {
+        self == .visible
+    }
+}
+
 struct BrowserSurfaceRuntimeEventHandlers {
     var didFinishNavigation: (() -> Void)?
     var didFailNavigation: ((String) -> Void)?
@@ -1634,6 +1648,12 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void)
     func invalidateFaviconCache()
     func fetchFaviconPNGData() async -> Data?
+    func developerToolsVisibilityState() -> BrowserSurfaceDeveloperToolsVisibilityState
+    @discardableResult
+    func revealDeveloperTools(attachIfNeeded: Bool) -> Bool
+    @discardableResult
+    func concealDeveloperTools() -> Bool
+    func showDeveloperToolsConsole()
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
@@ -1857,6 +1877,69 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         }
 
         return Self.makeFaviconPNGData(from: data, targetPx: 32)
+    }
+
+    func developerToolsVisibilityState() -> BrowserSurfaceDeveloperToolsVisibilityState {
+        guard let inspector = webView.cmuxInspectorObject(),
+              let visible = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) else {
+            return .unavailable
+        }
+        return visible ? .visible : .hidden
+    }
+
+    @discardableResult
+    func revealDeveloperTools(attachIfNeeded: Bool) -> Bool {
+        guard let inspector = webView.cmuxInspectorObject() else { return false }
+        let isVisibleSelector = NSSelectorFromString("isVisible")
+        guard let isVisible = inspector.cmuxCallBool(selector: isVisibleSelector) else { return false }
+        if isVisible {
+            return true
+        }
+
+        if attachIfNeeded {
+            let attachSelector = NSSelectorFromString("attach")
+            if inspector.responds(to: attachSelector) {
+                inspector.cmuxCallVoid(selector: attachSelector)
+            }
+        }
+
+        let showSelector = NSSelectorFromString("show")
+        guard inspector.responds(to: showSelector) else { return false }
+        inspector.cmuxCallVoid(selector: showSelector)
+        return inspector.cmuxCallBool(selector: isVisibleSelector) ?? false
+    }
+
+    @discardableResult
+    func concealDeveloperTools() -> Bool {
+        guard let inspector = webView.cmuxInspectorObject() else { return false }
+        let isVisibleSelector = NSSelectorFromString("isVisible")
+        guard let isVisible = inspector.cmuxCallBool(selector: isVisibleSelector) else { return false }
+        guard isVisible else { return true }
+
+        var invokedSelector = false
+        for rawSelector in ["hide", "close"] {
+            let selector = NSSelectorFromString(rawSelector)
+            guard inspector.responds(to: selector) else { continue }
+            invokedSelector = true
+            inspector.cmuxCallVoid(selector: selector)
+            if !(inspector.cmuxCallBool(selector: isVisibleSelector) ?? false) {
+                return true
+            }
+        }
+
+        guard invokedSelector else { return false }
+        return !(inspector.cmuxCallBool(selector: isVisibleSelector) ?? false)
+    }
+
+    func showDeveloperToolsConsole() {
+        guard let inspector = webView.cmuxInspectorObject() else { return }
+        for rawSelector in ["showConsole", "showConsoleTab", "showConsoleView"] {
+            let selector = NSSelectorFromString(rawSelector)
+            if inspector.responds(to: selector) {
+                inspector.cmuxCallVoid(selector: selector)
+                return
+            }
+        }
     }
 
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
@@ -2638,7 +2721,9 @@ final class BrowserPanel: Panel, ObservableObject {
             handleWebViewLoadingChanged(state.isLoading)
         }
         let trimmedTitle = (state.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        pageTitle = trimmedTitle
+        if !trimmedTitle.isEmpty {
+            pageTitle = trimmedTitle
+        }
         nativeCanGoBack = state.canGoBack
         nativeCanGoForward = state.canGoForward
         estimatedProgress = state.estimatedProgress
@@ -2678,6 +2763,7 @@ final class BrowserPanel: Panel, ObservableObject {
             didFinishNavigation: { [weak self] in
                 guard let self else { return }
                 let runtimeState = self.runtime.state
+                self.pageTitle = (runtimeState.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 BrowserHistoryStore.shared.recordVisit(url: runtimeState.currentURL, title: runtimeState.title)
                 self.refreshFaviconFromRuntime()
                 self.applyBrowserThemeModeIfNeeded()
@@ -3500,27 +3586,7 @@ extension BrowserPanel {
         }
     }
 
-    private func prepareDeveloperToolsForRevealIfNeeded(_ inspector: NSObject) {
-        guard preferredDeveloperToolsPresentation == .unknown else { return }
-        let attachSelector = NSSelectorFromString("attach")
-        guard inspector.responds(to: attachSelector) else { return }
-        inspector.cmuxCallVoid(selector: attachSelector)
-    }
-
-    @discardableResult
-    private func revealDeveloperTools(_ inspector: NSObject) -> Bool {
-        let isVisibleSelector = NSSelectorFromString("isVisible")
-        if inspector.cmuxCallBool(selector: isVisibleSelector) ?? false {
-            developerToolsDetachedOpenGraceDeadline = nil
-            return true
-        }
-
-        prepareDeveloperToolsForRevealIfNeeded(inspector)
-
-        let showSelector = NSSelectorFromString("show")
-        guard inspector.responds(to: showSelector) else { return false }
-        inspector.cmuxCallVoid(selector: showSelector)
-        let visibleAfterShow = inspector.cmuxCallBool(selector: isVisibleSelector) ?? false
+    private func updateDeveloperToolsDetachedOpenGraceDeadline(visibleAfterShow: Bool) {
         if preferredDeveloperToolsPresentation == .detached {
             developerToolsDetachedOpenGraceDeadline = visibleAfterShow
                 ? nil
@@ -3528,27 +3594,6 @@ extension BrowserPanel {
         } else {
             developerToolsDetachedOpenGraceDeadline = nil
         }
-        return visibleAfterShow
-    }
-
-    @discardableResult
-    private func concealDeveloperTools(_ inspector: NSObject) -> Bool {
-        let isVisibleSelector = NSSelectorFromString("isVisible")
-        guard inspector.cmuxCallBool(selector: isVisibleSelector) ?? false else { return true }
-
-        var invokedSelector = false
-        for rawSelector in ["hide", "close"] {
-            let selector = NSSelectorFromString(rawSelector)
-            guard inspector.responds(to: selector) else { continue }
-            invokedSelector = true
-            inspector.cmuxCallVoid(selector: selector)
-            if !(inspector.cmuxCallBool(selector: isVisibleSelector) ?? false) {
-                return true
-            }
-        }
-
-        guard invokedSelector else { return false }
-        return !(inspector.cmuxCallBool(selector: isVisibleSelector) ?? false)
     }
 
     private var isDeveloperToolsTransitionInFlight: Bool {
@@ -3562,7 +3607,7 @@ extension BrowserPanel {
         if let developerToolsTransitionTargetVisible {
             return developerToolsTransitionTargetVisible
         }
-        return isDeveloperToolsVisible()
+        return runtime.developerToolsVisibilityState().isVisible
     }
 
     private func scheduleDeveloperToolsTransitionSettle(source: String) {
@@ -3615,23 +3660,25 @@ extension BrowserPanel {
         to targetVisible: Bool,
         source: String
     ) -> Bool {
-        guard let inspector = webView.cmuxInspectorObject() else { return false }
-
-        let isVisibleSelector = NSSelectorFromString("isVisible")
-        let visible = inspector.cmuxCallBool(selector: isVisibleSelector) ?? false
+        let visibilityState = runtime.developerToolsVisibilityState()
+        guard visibilityState.isAvailable else { return false }
+        let visible = visibilityState.isVisible
         preferredDeveloperToolsVisible = targetVisible
         developerToolsTransitionTargetVisible = targetVisible
 
         if targetVisible {
             if !visible {
-                _ = revealDeveloperTools(inspector)
+                let visibleAfterReveal = runtime.revealDeveloperTools(
+                    attachIfNeeded: preferredDeveloperToolsPresentation == .unknown
+                )
+                updateDeveloperToolsDetachedOpenGraceDeadline(visibleAfterShow: visibleAfterReveal)
             } else {
                 developerToolsDetachedOpenGraceDeadline = nil
             }
         } else {
             if visible {
                 syncDeveloperToolsPresentationPreferenceFromUI()
-                guard concealDeveloperTools(inspector) else {
+                guard runtime.concealDeveloperTools() else {
                     developerToolsTransitionTargetVisible = nil
                     return false
                 }
@@ -3640,7 +3687,7 @@ extension BrowserPanel {
         }
 
         if targetVisible {
-            let visibleAfterTransition = inspector.cmuxCallBool(selector: isVisibleSelector) ?? false
+            let visibleAfterTransition = runtime.developerToolsVisibilityState().isVisible
             if visibleAfterTransition {
                 syncDeveloperToolsPresentationPreferenceFromUI()
                 cancelDeveloperToolsRestoreRetry()
@@ -3698,27 +3745,15 @@ extension BrowserPanel {
     func showDeveloperToolsConsole() -> Bool {
         guard showDeveloperTools() else { return false }
         guard !isDeveloperToolsTransitionInFlight else { return true }
-        guard let inspector = webView.cmuxInspectorObject() else { return true }
-        // WebKit private inspector API differs by OS; try known console selectors.
-        let consoleSelectors = [
-            "showConsole",
-            "showConsoleTab",
-            "showConsoleView",
-        ]
-        for raw in consoleSelectors {
-            let selector = NSSelectorFromString(raw)
-            if inspector.responds(to: selector) {
-                inspector.cmuxCallVoid(selector: selector)
-                break
-            }
-        }
+        runtime.showDeveloperToolsConsole()
         return true
     }
 
     /// Called before WKWebView detaches so manual inspector closes are respected.
     func syncDeveloperToolsPreferenceFromInspector(preserveVisibleIntent: Bool = false) {
-        guard let inspector = webView.cmuxInspectorObject() else { return }
-        guard let visible = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) else { return }
+        let visibilityState = runtime.developerToolsVisibilityState()
+        guard visibilityState.isAvailable else { return }
+        let visible = visibilityState.isVisible
         if isDeveloperToolsTransitionInFlight {
             let targetVisible = pendingDeveloperToolsTransitionTargetVisible ?? developerToolsTransitionTargetVisible ?? visible
             preferredDeveloperToolsVisible = targetVisible
@@ -3755,7 +3790,8 @@ extension BrowserPanel {
             return
         }
         guard !isDeveloperToolsTransitionInFlight else { return }
-        guard let inspector = webView.cmuxInspectorObject() else {
+        let visibilityState = runtime.developerToolsVisibilityState()
+        guard visibilityState.isAvailable else {
             scheduleDeveloperToolsRestoreRetry()
             return
         }
@@ -3763,7 +3799,7 @@ extension BrowserPanel {
         let shouldForceRefresh = forceDeveloperToolsRefreshOnNextAttach
         forceDeveloperToolsRefreshOnNextAttach = false
 
-        let visible = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
+        let visible = visibilityState.isVisible
         if visible {
             developerToolsDetachedOpenGraceDeadline = nil
             syncDeveloperToolsPresentationPreferenceFromUI()
@@ -3799,10 +3835,13 @@ extension BrowserPanel {
         // panel attachment is still stabilizing. Keep this auto-restore path from
         // mutating first responder so AppKit doesn't walk tearing-down responder chains.
         cmuxWithWindowFirstResponderBypass {
-            _ = revealDeveloperTools(inspector)
+            let visibleAfterReveal = runtime.revealDeveloperTools(
+                attachIfNeeded: preferredDeveloperToolsPresentation == .unknown
+            )
+            updateDeveloperToolsDetachedOpenGraceDeadline(visibleAfterShow: visibleAfterReveal)
         }
         preferredDeveloperToolsVisible = true
-        let visibleAfterShow = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
+        let visibleAfterShow = runtime.developerToolsVisibilityState().isVisible
         if visibleAfterShow {
             syncDeveloperToolsPresentationPreferenceFromUI()
             cancelDeveloperToolsRestoreRetry()
@@ -3814,8 +3853,7 @@ extension BrowserPanel {
 
     @discardableResult
     func isDeveloperToolsVisible() -> Bool {
-        guard let inspector = webView.cmuxInspectorObject() else { return false }
-        return inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
+        runtime.developerToolsVisibilityState().isVisible
     }
 
     @discardableResult
@@ -4575,9 +4613,10 @@ extension BrowserPanel {
     }
 
     func debugDeveloperToolsStateSummary() -> String {
+        let visibilityState = runtime.developerToolsVisibilityState()
         let preferred = preferredDeveloperToolsVisible ? 1 : 0
-        let visible = isDeveloperToolsVisible() ? 1 : 0
-        let inspector = webView.cmuxInspectorObject() == nil ? 0 : 1
+        let visible = visibilityState.isVisible ? 1 : 0
+        let inspector = visibilityState.isAvailable ? 1 : 0
         let attached = webView.superview == nil ? 0 : 1
         let inWindow = webView.window == nil ? 0 : 1
         let forceRefresh = forceDeveloperToolsRefreshOnNextAttach ? 1 : 0

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4334,6 +4334,13 @@ extension BrowserPanel {
         return surfaceOwnsResponder(window.firstResponder)
     }
 
+    @discardableResult
+    func prepareSurfaceFocusForTransientDeveloperToolsHide(in window: NSWindow) -> (movedToSurface: Bool, movedToNil: Bool) {
+        let movedToSurface = focusSurfaceForHandoff()
+        let movedToNil = movedToSurface ? false : window.makeFirstResponder(nil)
+        return (movedToSurface, movedToNil)
+    }
+
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {
         suppressOmnibarAutofocusUntil = Date().addingTimeInterval(seconds)
 #if DEBUG

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1263,6 +1263,297 @@ struct BrowserRuntimeSurfaceConfiguration {
     let customUserAgent: String
 }
 
+enum BrowserAddressBarPageFocusCaptureStatus: Equatable {
+    case captured(String)
+    case clearedNone
+    case clearedNonEditable
+    case error
+
+    init(result: Any?, error: Error?) {
+        if error != nil {
+            self = .error
+            return
+        }
+        guard let raw = result as? String else {
+            self = .error
+            return
+        }
+        if raw == "cleared:none" {
+            self = .clearedNone
+            return
+        }
+        if raw == "cleared:noneditable" {
+            self = .clearedNonEditable
+            return
+        }
+        if raw.hasPrefix("captured:") {
+            self = .captured(String(raw.dropFirst("captured:".count)))
+            return
+        }
+        self = .error
+    }
+
+    var debugValue: String {
+        switch self {
+        case .captured(let identifier):
+            "captured:\(identifier)"
+        case .clearedNone:
+            "cleared:none"
+        case .clearedNonEditable:
+            "cleared:noneditable"
+        case .error:
+            "error"
+        }
+    }
+}
+
+enum BrowserAddressBarPageFocusRestoreStatus: String {
+    case restored
+    case noState = "no_state"
+    case missingTarget = "missing_target"
+    case notFocused = "not_focused"
+    case error
+
+    init(result: Any?, error: Error?) {
+        if error != nil {
+            self = .error
+            return
+        }
+        guard let raw = result as? String else {
+            self = .error
+            return
+        }
+        self = BrowserAddressBarPageFocusRestoreStatus(rawValue: raw) ?? .error
+    }
+}
+
+fileprivate enum BrowserAddressBarPageFocusScripts {
+    static let capture = """
+    (() => {
+      try {
+        const syncState = (state) => {
+          window.__cmuxAddressBarFocusState = state;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = state;
+            }
+          } catch (_) {}
+        };
+
+        const active = document.activeElement;
+        if (!active) {
+          syncState(null);
+          return "cleared:none";
+        }
+
+        const tag = (active.tagName || "").toLowerCase();
+        const type = (active.type || "").toLowerCase();
+        const isEditable =
+          !!active.isContentEditable ||
+          tag === "textarea" ||
+          (tag === "input" && type !== "hidden");
+        if (!isEditable) {
+          syncState(null);
+          return "cleared:noneditable";
+        }
+
+        let id = active.getAttribute("data-cmux-addressbar-focus-id");
+        if (!id) {
+          id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+          active.setAttribute("data-cmux-addressbar-focus-id", id);
+        }
+
+        const state = { id, selectionStart: null, selectionEnd: null };
+        if (typeof active.selectionStart === "number" && typeof active.selectionEnd === "number") {
+          state.selectionStart = active.selectionStart;
+          state.selectionEnd = active.selectionEnd;
+        }
+        syncState(state);
+        return "captured:" + id;
+      } catch (_) {
+        return "error";
+      }
+    })();
+    """
+
+    static let trackingBootstrap = """
+    (() => {
+      try {
+        if (window.__cmuxAddressBarFocusTrackerInstalled) return true;
+        window.__cmuxAddressBarFocusTrackerInstalled = true;
+
+        const syncState = (state) => {
+          window.__cmuxAddressBarFocusState = state;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = state;
+            }
+          } catch (_) {}
+        };
+
+        if (window.top === window && !window.__cmuxAddressBarFocusMessageBridgeInstalled) {
+          window.__cmuxAddressBarFocusMessageBridgeInstalled = true;
+          window.addEventListener("message", (ev) => {
+            try {
+              const data = ev ? ev.data : null;
+              if (!data || !Object.prototype.hasOwnProperty.call(data, "cmuxAddressBarFocusState")) return;
+              window.__cmuxAddressBarFocusState = data.cmuxAddressBarFocusState || null;
+            } catch (_) {}
+          }, true);
+        }
+
+        const isEditable = (el) => {
+          if (!el) return false;
+          const tag = (el.tagName || "").toLowerCase();
+          const type = (el.type || "").toLowerCase();
+          return !!el.isContentEditable || tag === "textarea" || (tag === "input" && type !== "hidden");
+        };
+
+        const ensureFocusId = (el) => {
+          let id = el.getAttribute("data-cmux-addressbar-focus-id");
+          if (!id) {
+            id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+            el.setAttribute("data-cmux-addressbar-focus-id", id);
+          }
+          return id;
+        };
+
+        const snapshot = (el) => {
+          if (!isEditable(el)) {
+            syncState(null);
+            return;
+          }
+          const state = {
+            id: ensureFocusId(el),
+            selectionStart: null,
+            selectionEnd: null
+          };
+          if (typeof el.selectionStart === "number" && typeof el.selectionEnd === "number") {
+            state.selectionStart = el.selectionStart;
+            state.selectionEnd = el.selectionEnd;
+          }
+          syncState(state);
+        };
+
+        document.addEventListener("focusin", (ev) => {
+          snapshot(ev && ev.target ? ev.target : document.activeElement);
+        }, true);
+        document.addEventListener("selectionchange", () => {
+          snapshot(document.activeElement);
+        }, true);
+        document.addEventListener("input", () => {
+          snapshot(document.activeElement);
+        }, true);
+        document.addEventListener("mousedown", (ev) => {
+          const target = ev && ev.target ? ev.target : null;
+          if (!isEditable(target)) {
+            syncState(null);
+          }
+        }, true);
+        window.addEventListener("beforeunload", () => {
+          syncState(null);
+        }, true);
+
+        snapshot(document.activeElement);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    })();
+    """
+
+    static let restore = """
+    (() => {
+      try {
+        const readState = () => {
+          let state = window.__cmuxAddressBarFocusState;
+          try {
+            if ((!state || typeof state.id !== "string" || !state.id) &&
+                window.top && window.top.__cmuxAddressBarFocusState) {
+              state = window.top.__cmuxAddressBarFocusState;
+            }
+          } catch (_) {}
+          return state;
+        };
+
+        const clearState = () => {
+          window.__cmuxAddressBarFocusState = null;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: null }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = null;
+            }
+          } catch (_) {}
+        };
+
+        const state = readState();
+        if (!state || typeof state.id !== "string" || !state.id) {
+          return "no_state";
+        }
+
+        const selector = '[data-cmux-addressbar-focus-id="' + state.id + '"]';
+        const findTarget = (doc) => {
+          if (!doc) return null;
+          const direct = doc.querySelector(selector);
+          if (direct && direct.isConnected) return direct;
+          const frames = doc.querySelectorAll("iframe,frame");
+          for (let i = 0; i < frames.length; i += 1) {
+            const frame = frames[i];
+            try {
+              const childDoc = frame.contentDocument;
+              if (!childDoc) continue;
+              const nested = findTarget(childDoc);
+              if (nested) return nested;
+            } catch (_) {}
+          }
+          return null;
+        };
+
+        const target = findTarget(document);
+        if (!target) {
+          clearState();
+          return "missing_target";
+        }
+
+        try {
+          target.focus({ preventScroll: true });
+        } catch (_) {
+          try { target.focus(); } catch (_) {}
+        }
+
+        let focused = false;
+        try {
+          focused =
+            target === target.ownerDocument.activeElement ||
+            (typeof target.matches === "function" && target.matches(":focus"));
+        } catch (_) {}
+        if (!focused) {
+          return "not_focused";
+        }
+
+        if (
+          typeof state.selectionStart === "number" &&
+          typeof state.selectionEnd === "number" &&
+          typeof target.setSelectionRange === "function"
+        ) {
+          try {
+            target.setSelectionRange(state.selectionStart, state.selectionEnd);
+          } catch (_) {}
+        }
+        clearState();
+        return "restored";
+      } catch (_) {
+        return "error";
+      }
+    })();
+    """
+}
+
 struct BrowserSurfaceRuntimeState: Equatable {
     let currentURL: URL?
     let title: String?
@@ -1313,6 +1604,8 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func setPageZoom(_ pageZoom: CGFloat)
     func takeSnapshot(completion: @escaping (NSImage?) -> Void)
     func evaluateJavaScript(_ script: String) async throws -> Any?
+    func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void)
+    func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void)
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
@@ -1470,6 +1763,18 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     func evaluateJavaScript(_ script: String) async throws -> Any? {
         try await webView.evaluateJavaScript(script)
+    }
+
+    func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void) {
+        webView.evaluateJavaScript(BrowserAddressBarPageFocusScripts.capture) { result, error in
+            completion(BrowserAddressBarPageFocusCaptureStatus(result: result, error: error))
+        }
+    }
+
+    func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void) {
+        webView.evaluateJavaScript(BrowserAddressBarPageFocusScripts.restore) { result, error in
+            completion(BrowserAddressBarPageFocusRestoreStatus(result: result, error: error))
+        }
     }
 
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
@@ -1833,7 +2138,7 @@ final class BrowserPanel: Panel, ObservableObject {
         BrowserRuntimeSurfaceConfiguration(
             bootstrapUserScriptSources: [
                 telemetryHookBootstrapScriptSource,
-                addressBarFocusTrackingBootstrapScript,
+                BrowserAddressBarPageFocusScripts.trackingBootstrap,
             ],
             underPageBackgroundColor: GhosttyBackgroundTheme.currentColor(),
             customUserAgent: BrowserUserAgentSettings.safariUserAgent
@@ -1866,228 +2171,6 @@ final class BrowserPanel: Panel, ObservableObject {
     private var suppressWebViewFocusForAddressBar: Bool = false
     private var addressBarFocusRestoreGeneration: UInt64 = 0
     private let blankURLString = "about:blank"
-    private static let addressBarFocusCaptureScript = """
-    (() => {
-      try {
-        const syncState = (state) => {
-          window.__cmuxAddressBarFocusState = state;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = state;
-            }
-          } catch (_) {}
-        };
-
-        const active = document.activeElement;
-        if (!active) {
-          syncState(null);
-          return "cleared:none";
-        }
-
-        const tag = (active.tagName || "").toLowerCase();
-        const type = (active.type || "").toLowerCase();
-        const isEditable =
-          !!active.isContentEditable ||
-          tag === "textarea" ||
-          (tag === "input" && type !== "hidden");
-        if (!isEditable) {
-          syncState(null);
-          return "cleared:noneditable";
-        }
-
-        let id = active.getAttribute("data-cmux-addressbar-focus-id");
-        if (!id) {
-          id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
-          active.setAttribute("data-cmux-addressbar-focus-id", id);
-        }
-
-        const state = { id, selectionStart: null, selectionEnd: null };
-        if (typeof active.selectionStart === "number" && typeof active.selectionEnd === "number") {
-          state.selectionStart = active.selectionStart;
-          state.selectionEnd = active.selectionEnd;
-        }
-        syncState(state);
-        return "captured:" + id;
-      } catch (_) {
-        return "error";
-      }
-    })();
-    """
-    private static let addressBarFocusTrackingBootstrapScript = """
-    (() => {
-      try {
-        if (window.__cmuxAddressBarFocusTrackerInstalled) return true;
-        window.__cmuxAddressBarFocusTrackerInstalled = true;
-
-        const syncState = (state) => {
-          window.__cmuxAddressBarFocusState = state;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = state;
-            }
-          } catch (_) {}
-        };
-
-        if (window.top === window && !window.__cmuxAddressBarFocusMessageBridgeInstalled) {
-          window.__cmuxAddressBarFocusMessageBridgeInstalled = true;
-          window.addEventListener("message", (ev) => {
-            try {
-              const data = ev ? ev.data : null;
-              if (!data || !Object.prototype.hasOwnProperty.call(data, "cmuxAddressBarFocusState")) return;
-              window.__cmuxAddressBarFocusState = data.cmuxAddressBarFocusState || null;
-            } catch (_) {}
-          }, true);
-        }
-
-        const isEditable = (el) => {
-          if (!el) return false;
-          const tag = (el.tagName || "").toLowerCase();
-          const type = (el.type || "").toLowerCase();
-          return !!el.isContentEditable || tag === "textarea" || (tag === "input" && type !== "hidden");
-        };
-
-        const ensureFocusId = (el) => {
-          let id = el.getAttribute("data-cmux-addressbar-focus-id");
-          if (!id) {
-            id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
-            el.setAttribute("data-cmux-addressbar-focus-id", id);
-          }
-          return id;
-        };
-
-        const snapshot = (el) => {
-          if (!isEditable(el)) {
-            syncState(null);
-            return;
-          }
-          const state = {
-            id: ensureFocusId(el),
-            selectionStart: null,
-            selectionEnd: null
-          };
-          if (typeof el.selectionStart === "number" && typeof el.selectionEnd === "number") {
-            state.selectionStart = el.selectionStart;
-            state.selectionEnd = el.selectionEnd;
-          }
-          syncState(state);
-        };
-
-        document.addEventListener("focusin", (ev) => {
-          snapshot(ev && ev.target ? ev.target : document.activeElement);
-        }, true);
-        document.addEventListener("selectionchange", () => {
-          snapshot(document.activeElement);
-        }, true);
-        document.addEventListener("input", () => {
-          snapshot(document.activeElement);
-        }, true);
-        document.addEventListener("mousedown", (ev) => {
-          const target = ev && ev.target ? ev.target : null;
-          if (!isEditable(target)) {
-            syncState(null);
-          }
-        }, true);
-        window.addEventListener("beforeunload", () => {
-          syncState(null);
-        }, true);
-
-        snapshot(document.activeElement);
-        return true;
-      } catch (_) {
-        return false;
-      }
-    })();
-    """
-    private static let addressBarFocusRestoreScript = """
-    (() => {
-      try {
-        const readState = () => {
-          let state = window.__cmuxAddressBarFocusState;
-          try {
-            if ((!state || typeof state.id !== "string" || !state.id) &&
-                window.top && window.top.__cmuxAddressBarFocusState) {
-              state = window.top.__cmuxAddressBarFocusState;
-            }
-          } catch (_) {}
-          return state;
-        };
-
-        const clearState = () => {
-          window.__cmuxAddressBarFocusState = null;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: null }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = null;
-            }
-          } catch (_) {}
-        };
-
-        const state = readState();
-        if (!state || typeof state.id !== "string" || !state.id) {
-          return "no_state";
-        }
-
-        const selector = '[data-cmux-addressbar-focus-id="' + state.id + '"]';
-        const findTarget = (doc) => {
-          if (!doc) return null;
-          const direct = doc.querySelector(selector);
-          if (direct && direct.isConnected) return direct;
-          const frames = doc.querySelectorAll("iframe,frame");
-          for (let i = 0; i < frames.length; i += 1) {
-            const frame = frames[i];
-            try {
-              const childDoc = frame.contentDocument;
-              if (!childDoc) continue;
-              const nested = findTarget(childDoc);
-              if (nested) return nested;
-            } catch (_) {}
-          }
-          return null;
-        };
-
-        const target = findTarget(document);
-        if (!target) {
-          clearState();
-          return "missing_target";
-        }
-
-        try {
-          target.focus({ preventScroll: true });
-        } catch (_) {
-          try { target.focus(); } catch (_) {}
-        }
-
-        let focused = false;
-        try {
-          focused =
-            target === target.ownerDocument.activeElement ||
-            (typeof target.matches === "function" && target.matches(":focus"));
-        } catch (_) {}
-        if (!focused) {
-          return "not_focused";
-        }
-
-        if (
-          typeof state.selectionStart === "number" &&
-          typeof state.selectionEnd === "number" &&
-          typeof target.setSelectionRange === "function"
-        ) {
-          try {
-            target.setSelectionRange(state.selectionStart, state.selectionEnd);
-          } catch (_) {}
-        }
-        clearState();
-        return "restored";
-      } catch (_) {
-        return "error";
-      }
-    })();
-    """
 
     /// Published URL being displayed
     @Published private(set) var currentURL: URL?
@@ -4230,44 +4313,18 @@ extension BrowserPanel {
     }
 
     private func captureAddressBarPageFocusIfNeeded() {
-        webView.evaluateJavaScript(Self.addressBarFocusCaptureScript) { [weak self] result, error in
+        runtime.captureAddressBarPageFocus { [weak self] status in
 #if DEBUG
             guard let self else { return }
-            if let error {
-                dlog(
-                    "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
-                    "result=error message=\(error.localizedDescription)"
-                )
-                return
-            }
-            let resultValue = (result as? String) ?? "unknown"
             dlog(
                 "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
-                "result=\(resultValue)"
+                "result=\(status.debugValue)"
             )
 #else
             _ = self
-            _ = result
-            _ = error
+            _ = status
 #endif
         }
-    }
-
-    private enum AddressBarPageFocusRestoreStatus: String {
-        case restored
-        case noState = "no_state"
-        case missingTarget = "missing_target"
-        case notFocused = "not_focused"
-        case error
-    }
-
-    private static func addressBarPageFocusRestoreStatus(
-        from result: Any?,
-        error: Error?
-    ) -> AddressBarPageFocusRestoreStatus {
-        if error != nil { return .error }
-        guard let raw = result as? String else { return .error }
-        return AddressBarPageFocusRestoreStatus(rawValue: raw) ?? .error
     }
 
     func invalidateAddressBarPageFocusRestoreAttempts() {
@@ -4302,7 +4359,7 @@ extension BrowserPanel {
             completion(false)
             return
         }
-        webView.evaluateJavaScript(Self.addressBarFocusRestoreScript) { [weak self] result, error in
+        runtime.restoreAddressBarPageFocus { [weak self] status in
             guard let self else {
                 completion(false)
                 return
@@ -4312,23 +4369,14 @@ extension BrowserPanel {
                 return
             }
 
-            let status = Self.addressBarPageFocusRestoreStatus(from: result, error: error)
             let canRetry = (status == .notFocused || status == .error)
             let hasNextAttempt = attempt + 1 < delays.count
 
 #if DEBUG
-            if let error {
-                dlog(
-                    "browser.focus.addressBar.restore panel=\(self.id.uuidString.prefix(5)) " +
-                    "attempt=\(attempt) status=\(status.rawValue) " +
-                    "message=\(error.localizedDescription)"
-                )
-            } else {
-                dlog(
-                    "browser.focus.addressBar.restore panel=\(self.id.uuidString.prefix(5)) " +
-                    "attempt=\(attempt) status=\(status.rawValue)"
-                )
-            }
+            dlog(
+                "browser.focus.addressBar.restore panel=\(self.id.uuidString.prefix(5)) " +
+                "attempt=\(attempt) status=\(status.rawValue)"
+            )
 #endif
 
             if status == .restored {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1675,6 +1675,11 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func concealDeveloperTools() -> Bool
     func showDeveloperToolsConsole()
     func dismissDetachedDeveloperToolsWindows()
+    func ownsResponder(_ responder: NSResponder?) -> Bool
+    @discardableResult
+    func focusSurface() -> Bool
+    @discardableResult
+    func unfocusSurface() -> Bool
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
@@ -2066,6 +2071,26 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         }
     }
 
+    func ownsResponder(_ responder: NSResponder?) -> Bool {
+        Self.responderChainContains(responder, target: webView)
+    }
+
+    @discardableResult
+    func focusSurface() -> Bool {
+        guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return false }
+        if ownsResponder(window.firstResponder) {
+            return true
+        }
+        return window.makeFirstResponder(webView)
+    }
+
+    @discardableResult
+    func unfocusSurface() -> Bool {
+        guard let window = webView.window else { return false }
+        guard ownsResponder(window.firstResponder) else { return false }
+        return window.makeFirstResponder(nil)
+    }
+
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
         (
             backHistoryURLs: webView.backForwardList.backList.map(\.url),
@@ -2102,6 +2127,17 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         webView.underPageBackgroundColor = configuration.underPageBackgroundColor
         webView.customUserAgent = configuration.customUserAgent
         return webView
+    }
+
+    private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var responder = start
+        var hops = 0
+        while let current = responder, hops < 64 {
+            if current === target { return true }
+            responder = current.nextResponder
+            hops += 1
+        }
+        return false
     }
 
     private func wireInternalDelegates() {
@@ -3088,28 +3124,19 @@ final class BrowserPanel: Panel, ObservableObject {
             return
         }
 
-        guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return }
-
         // If nothing meaningful is loaded yet, prefer letting the omnibar take focus.
         if !runtime.state.isLoading, preferredURLStringForOmnibar() == nil {
             return
         }
 
-        if Self.responderChainContains(window.firstResponder, target: webView) {
-            noteWebViewFocused()
-            return
-        }
-        if window.makeFirstResponder(webView) {
+        if runtime.focusSurface() {
             noteWebViewFocused()
         }
     }
 
     func unfocus() {
         invalidateSearchFocusRequests(reason: "panelUnfocus")
-        guard let window = webView.window else { return }
-        if Self.responderChainContains(window.firstResponder, target: webView) {
-            window.makeFirstResponder(nil)
-        }
+        _ = runtime.unfocusSurface()
     }
 
     func close() {
@@ -4292,7 +4319,7 @@ extension BrowserPanel {
         }
 
         if let window,
-           Self.responderChainContains(window.firstResponder, target: webView) {
+           runtime.ownsResponder(window.firstResponder) {
             return .browser(.webView)
         }
 
@@ -4366,7 +4393,7 @@ extension BrowserPanel {
             return .browser(.findField)
         }
 
-        if Self.responderChainContains(responder, target: webView) {
+        if runtime.ownsResponder(responder) {
             return .browser(.webView)
         }
 
@@ -4397,8 +4424,7 @@ extension BrowserPanel {
 #endif
             return yielded
         case .webView:
-            guard Self.responderChainContains(window.firstResponder, target: webView) else { return false }
-            return window.makeFirstResponder(nil)
+            return runtime.unfocusSurface()
         }
     }
 
@@ -4737,17 +4763,6 @@ private extension BrowserPanel {
         }
         runtime.setPageZoom(clamped)
         return true
-    }
-
-    static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
-        var r = start
-        var hops = 0
-        while let cur = r, hops < 64 {
-            if cur === target { return true }
-            r = cur.nextResponder
-            hops += 1
-        }
-        return false
     }
 
     func hasSideDockedDeveloperToolsLayout() -> Bool {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1554,6 +1554,32 @@ fileprivate enum BrowserAddressBarPageFocusScripts {
     """
 }
 
+fileprivate enum BrowserSurfaceFaviconScripts {
+    static let discoverBestIconURL = """
+    (() => {
+      const links = Array.from(document.querySelectorAll(
+        'link[rel~="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"], link[rel="apple-touch-icon-precomposed"]'
+      ));
+      function score(link) {
+        const value = (link.sizes && link.sizes.value) ? link.sizes.value : '';
+        if (value === 'any') return 1000;
+        let max = 0;
+        for (const part of value.split(/\\s+/)) {
+          const match = part.match(/(\\d+)x(\\d+)/);
+          if (!match) continue;
+          const width = parseInt(match[1], 10);
+          const height = parseInt(match[2], 10);
+          if (Number.isFinite(width)) max = Math.max(max, width);
+          if (Number.isFinite(height)) max = Math.max(max, height);
+        }
+        return max;
+      }
+      links.sort((lhs, rhs) => score(rhs) - score(lhs));
+      return links[0]?.href || '';
+    })();
+    """
+}
+
 struct BrowserSurfaceRuntimeState: Equatable {
     let currentURL: URL?
     let title: String?
@@ -1606,6 +1632,8 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func evaluateJavaScript(_ script: String) async throws -> Any?
     func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void)
     func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void)
+    func invalidateFaviconCache()
+    func fetchFaviconPNGData() async -> Data?
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
@@ -1633,6 +1661,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
     let backendKind: BrowserRuntimeBackendKind = .localWebKit
 
     private let processPool: WKProcessPool
+    private let faviconDataLoader: (URLRequest) async throws -> (Data, URLResponse)
     private(set) var webView: WKWebView
     private(set) var webViewInstanceID: UUID
     private var observations: [NSKeyValueObservation] = []
@@ -1640,6 +1669,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
     private let uiDelegate = BrowserUIDelegate()
     private let downloadDelegate = BrowserDownloadDelegate()
     private var browserThemeMode: BrowserThemeMode = .system
+    private var lastFaviconURLString: String?
     private var lastEmittedState: BrowserSurfaceRuntimeState?
     var eventHandlers = BrowserSurfaceRuntimeEventHandlers() {
         didSet {
@@ -1666,9 +1696,13 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     init(
         processPool: WKProcessPool,
-        configuration: BrowserRuntimeSurfaceConfiguration
+        configuration: BrowserRuntimeSurfaceConfiguration,
+        faviconDataLoader: @escaping (URLRequest) async throws -> (Data, URLResponse) = { request in
+            try await URLSession.shared.data(for: request)
+        }
     ) {
         self.processPool = processPool
+        self.faviconDataLoader = faviconDataLoader
         let webView = Self.makeWebView(
             processPool: processPool,
             configuration: configuration
@@ -1696,6 +1730,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         }
         webView = replacement
         webViewInstanceID = UUID()
+        lastFaviconURLString = nil
         bindWebView(replacement)
         applyStoredBrowserThemeMode(to: replacement)
         emitStateChange(force: true)
@@ -1775,6 +1810,53 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         webView.evaluateJavaScript(BrowserAddressBarPageFocusScripts.restore) { result, error in
             completion(BrowserAddressBarPageFocusRestoreStatus(result: result, error: error))
         }
+    }
+
+    func invalidateFaviconCache() {
+        lastFaviconURLString = nil
+    }
+
+    func fetchFaviconPNGData() async -> Data? {
+        let webView = self.webView
+        guard let pageURL = webView.url else { return nil }
+        guard let scheme = pageURL.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return nil }
+
+        var discoveredURL: URL?
+        if let href = try? await webView.evaluateJavaScript(BrowserSurfaceFaviconScripts.discoverBestIconURL) as? String {
+            let trimmed = href.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, let url = URL(string: trimmed) {
+                discoveredURL = url
+            }
+        }
+
+        let fallbackURL = URL(string: "/favicon.ico", relativeTo: pageURL)
+        guard let iconURL = discoveredURL ?? fallbackURL else { return nil }
+
+        let iconURLString = iconURL.absoluteString
+        if iconURLString == lastFaviconURLString {
+            return nil
+        }
+        lastFaviconURLString = iconURLString
+
+        var request = URLRequest(url: iconURL)
+        request.timeoutInterval = 2.0
+        request.cachePolicy = .returnCacheDataElseLoad
+        request.setValue(BrowserUserAgentSettings.safariUserAgent, forHTTPHeaderField: "User-Agent")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await faviconDataLoader(request)
+        } catch {
+            return nil
+        }
+
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            return nil
+        }
+
+        return Self.makeFaviconPNGData(from: data, targetPx: 32)
     }
 
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
@@ -1987,6 +2069,63 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
           }
         })();
         """
+    }
+
+    @MainActor
+    private static func makeFaviconPNGData(from raw: Data, targetPx: Int) -> Data? {
+        guard let image = NSImage(data: raw) else { return nil }
+
+        let px = max(16, min(128, targetPx))
+        let size = NSSize(width: px, height: px)
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: px,
+            pixelsHigh: px,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        let ctx = NSGraphicsContext(bitmapImageRep: rep)
+        ctx?.imageInterpolation = .high
+        ctx?.shouldAntialias = true
+        NSGraphicsContext.current = ctx
+
+        NSColor.clear.setFill()
+        NSRect(origin: .zero, size: size).fill()
+
+        let sourceSize = image.size
+        let scale = min(size.width / max(1, sourceSize.width), size.height / max(1, sourceSize.height))
+        let drawSize = NSSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        let drawOrigin = NSPoint(
+            x: (size.width - drawSize.width) / 2.0,
+            y: (size.height - drawSize.height) / 2.0
+        )
+        let drawRect = NSRect(
+            x: round(drawOrigin.x),
+            y: round(drawOrigin.y),
+            width: round(drawSize.width),
+            height: round(drawSize.height)
+        )
+
+        image.draw(
+            in: drawRect,
+            from: NSRect(origin: .zero, size: sourceSize),
+            operation: .sourceOver,
+            fraction: 1.0,
+            respectFlipped: true,
+            hints: [.interpolation: NSImageInterpolation.high]
+        )
+
+        return rep.representation(using: .png, properties: [:])
     }
 
     private func emitStateChange(force: Bool = false) {
@@ -2289,7 +2428,6 @@ final class BrowserPanel: Panel, ObservableObject {
 
     private var faviconTask: Task<Void, Never>?
     private var faviconRefreshGeneration: Int = 0
-    private var lastFaviconURLString: String?
     private var lastRuntimeState: BrowserSurfaceRuntimeState?
     private let minPageZoom: CGFloat = 0.25
     private let maxPageZoom: CGFloat = 5.0
@@ -2518,12 +2656,6 @@ final class BrowserPanel: Panel, ObservableObject {
             .store(in: &webViewCancellables)
     }
 
-    private func isCurrentWebView(_ candidate: WKWebView, instanceID: UUID? = nil) -> Bool {
-        guard candidate === webView else { return false }
-        guard let instanceID else { return true }
-        return instanceID == webViewInstanceID
-    }
-
     init(
         workspaceId: UUID,
         initialURL: URL? = nil,
@@ -2545,8 +2677,9 @@ final class BrowserPanel: Panel, ObservableObject {
         runtime.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
             didFinishNavigation: { [weak self] in
                 guard let self else { return }
-                BrowserHistoryStore.shared.recordVisit(url: self.webView.url, title: self.webView.title)
-                self.refreshFavicon(from: self.webView)
+                let runtimeState = self.runtime.state
+                BrowserHistoryStore.shared.recordVisit(url: runtimeState.currentURL, title: runtimeState.title)
+                self.refreshFaviconFromRuntime()
                 self.applyBrowserThemeModeIfNeeded()
                 // Keep find-in-page open through load completion and refresh matches for the new DOM.
                 self.restoreFindStateAfterNavigation(replaySearch: true)
@@ -2557,7 +2690,7 @@ final class BrowserPanel: Panel, ObservableObject {
                 // shows the failed URL instead of the old page's branding.
                 self.pageTitle = failedURL.isEmpty ? "" : failedURL
                 self.faviconPNGData = nil
-                self.lastFaviconURLString = nil
+                self.runtime.invalidateFaviconCache()
                 // Keep find-in-page open and clear stale counters on failed loads.
                 self.restoreFindStateAfterNavigation(replaySearch: false)
             },
@@ -2784,91 +2917,24 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask = nil
     }
 
-    private func refreshFavicon(from webView: WKWebView) {
+    private func refreshFaviconFromRuntime() {
         faviconTask?.cancel()
         faviconTask = nil
-
-        guard let pageURL = webView.url else { return }
-        guard let scheme = pageURL.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return }
         faviconRefreshGeneration &+= 1
         let refreshGeneration = faviconRefreshGeneration
         let refreshWebViewInstanceID = webViewInstanceID
 
-        faviconTask = Task { @MainActor [weak self, weak webView] in
-            guard let self, let webView else { return }
-            guard self.isCurrentWebView(webView, instanceID: refreshWebViewInstanceID) else { return }
+        faviconTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard self.webViewInstanceID == refreshWebViewInstanceID else { return }
             guard self.isCurrentFaviconRefresh(generation: refreshGeneration) else { return }
 
-            // Try to discover the best icon URL from the document.
-            let js = """
-            (() => {
-              const links = Array.from(document.querySelectorAll(
-                'link[rel~=\"icon\"], link[rel=\"shortcut icon\"], link[rel=\"apple-touch-icon\"], link[rel=\"apple-touch-icon-precomposed\"]'
-              ));
-              function score(link) {
-                const v = (link.sizes && link.sizes.value) ? link.sizes.value : '';
-                if (v === 'any') return 1000;
-                let max = 0;
-                for (const part of v.split(/\\s+/)) {
-                  const m = part.match(/(\\d+)x(\\d+)/);
-                  if (!m) continue;
-                  const a = parseInt(m[1], 10);
-                  const b = parseInt(m[2], 10);
-                  if (Number.isFinite(a)) max = Math.max(max, a);
-                  if (Number.isFinite(b)) max = Math.max(max, b);
-                }
-                return max;
-              }
-              links.sort((a, b) => score(b) - score(a));
-              return links[0]?.href || '';
-            })();
-            """
-
-            var discoveredURL: URL?
-            if let href = try? await webView.evaluateJavaScript(js) as? String {
-                let trimmed = href.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty, let u = URL(string: trimmed) {
-                    discoveredURL = u
-                }
-            }
-            guard self.isCurrentWebView(webView, instanceID: refreshWebViewInstanceID) else { return }
+            let png = await self.runtime.fetchFaviconPNGData()
+            guard self.webViewInstanceID == refreshWebViewInstanceID else { return }
             guard self.isCurrentFaviconRefresh(generation: refreshGeneration) else { return }
-
-            let fallbackURL = URL(string: "/favicon.ico", relativeTo: pageURL)
-            let iconURL = discoveredURL ?? fallbackURL
-            guard let iconURL else { return }
-
-            // Avoid repeated fetches.
-            let iconURLString = iconURL.absoluteString
-            if iconURLString == lastFaviconURLString, faviconPNGData != nil {
-                return
-            }
-            lastFaviconURLString = iconURLString
-
-            var req = URLRequest(url: iconURL)
-            req.timeoutInterval = 2.0
-            req.cachePolicy = .returnCacheDataElseLoad
-            req.setValue(BrowserUserAgentSettings.safariUserAgent, forHTTPHeaderField: "User-Agent")
-
-            let data: Data
-            let response: URLResponse
-            do {
-                (data, response) = try await URLSession.shared.data(for: req)
-            } catch {
-                return
-            }
-            guard self.isCurrentWebView(webView, instanceID: refreshWebViewInstanceID) else { return }
-            guard self.isCurrentFaviconRefresh(generation: refreshGeneration) else { return }
-
-            guard let http = response as? HTTPURLResponse,
-                  (200..<300).contains(http.statusCode) else {
-                return
-            }
-
-            // Use >= 2x the rendered point size so we don't upscale (blurry) on Retina.
-            guard let png = Self.makeFaviconPNGData(from: data, targetPx: 32) else { return }
             // Only update if we got a real icon; keep the old one otherwise to avoid flashes.
-            faviconPNGData = png
+            guard let png else { return }
+            self.faviconPNGData = png
         }
     }
 
@@ -2877,69 +2943,13 @@ final class BrowserPanel: Panel, ObservableObject {
         return generation == faviconRefreshGeneration
     }
 
-    @MainActor
-    private static func makeFaviconPNGData(from raw: Data, targetPx: Int) -> Data? {
-        guard let image = NSImage(data: raw) else { return nil }
-
-        let px = max(16, min(128, targetPx))
-        let size = NSSize(width: px, height: px)
-        guard let rep = NSBitmapImageRep(
-            bitmapDataPlanes: nil,
-            pixelsWide: px,
-            pixelsHigh: px,
-            bitsPerSample: 8,
-            samplesPerPixel: 4,
-            hasAlpha: true,
-            isPlanar: false,
-            colorSpaceName: .deviceRGB,
-            bytesPerRow: 0,
-            bitsPerPixel: 0
-        ) else {
-            return nil
-        }
-
-        NSGraphicsContext.saveGraphicsState()
-        defer { NSGraphicsContext.restoreGraphicsState() }
-        let ctx = NSGraphicsContext(bitmapImageRep: rep)
-        ctx?.imageInterpolation = .high
-        ctx?.shouldAntialias = true
-        NSGraphicsContext.current = ctx
-
-        NSColor.clear.setFill()
-        NSRect(origin: .zero, size: size).fill()
-
-        // Aspect-fit into the target square.
-        let srcSize = image.size
-        let scale = min(size.width / max(1, srcSize.width), size.height / max(1, srcSize.height))
-        let drawSize = NSSize(width: srcSize.width * scale, height: srcSize.height * scale)
-        let drawOrigin = NSPoint(x: (size.width - drawSize.width) / 2.0, y: (size.height - drawSize.height) / 2.0)
-        // Align to integral pixels to avoid soft edges at small sizes.
-        let drawRect = NSRect(
-            x: round(drawOrigin.x),
-            y: round(drawOrigin.y),
-            width: round(drawSize.width),
-            height: round(drawSize.height)
-        )
-
-        image.draw(
-            in: drawRect,
-            from: NSRect(origin: .zero, size: srcSize),
-            operation: .sourceOver,
-            fraction: 1.0,
-            respectFlipped: true,
-            hints: [.interpolation: NSImageInterpolation.high]
-        )
-
-        return rep.representation(using: .png, properties: [:])
-    }
-
     private func handleWebViewLoadingChanged(_ newValue: Bool) {
         if newValue {
             // Any new load invalidates older favicon fetches, even for same-URL reloads.
             faviconRefreshGeneration &+= 1
             faviconTask?.cancel()
             faviconTask = nil
-            lastFaviconURLString = nil
+            runtime.invalidateFaviconCache()
             // Clear the previous page's favicon so it never persists across navigations.
             // The loading spinner covers this gap; didFinish will fetch the new favicon.
             faviconPNGData = nil
@@ -3209,6 +3219,7 @@ extension BrowserPanel {
         nativeCanGoBack = false
         nativeCanGoForward = false
         runtime.setLastAttemptedNavigationURL(nil)
+        runtime.invalidateFaviconCache()
         abandonRestoredSessionHistoryIfNeeded()
 
         pendingAddressBarFocusRequestId = nil
@@ -3223,7 +3234,6 @@ extension BrowserPanel {
         pageTitle = ""
         currentURL = nil
         faviconPNGData = nil
-        lastFaviconURLString = nil
         lastRuntimeState = nil
         activePortalHostLease = nil
         pendingDistinctPortalHostReplacementPaneId = nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4289,8 +4289,12 @@ extension BrowserPanel {
         runtime.hostWindow()
     }
 
+    func surfaceHostingWindow() -> NSWindow? {
+        surfaceWindow() ?? portalAnchorView.window
+    }
+
     func effectiveSurfaceWindow() -> NSWindow? {
-        surfaceWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
+        surfaceHostingWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
     }
 
     func surfaceFrameInWindowCoordinates() -> CGRect? {
@@ -4338,7 +4342,7 @@ extension BrowserPanel {
     }
 
     func isSurfaceFocusedInHostWindow() -> Bool {
-        guard let window = surfaceWindow() else { return false }
+        guard let window = surfaceHostingWindow() else { return false }
         return surfaceOwnsResponder(window.firstResponder)
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4301,6 +4301,10 @@ extension BrowserPanel {
         runtime.isHiddenOrHasHiddenAncestor()
     }
 
+    func surfacePageZoom() -> CGFloat {
+        runtime.state.pageZoom
+    }
+
     func isSurfaceBlankForAutofocus() -> Bool {
         guard let url = runtime.state.currentURL else { return true }
         return url.absoluteString == blankURLString
@@ -4339,6 +4343,10 @@ extension BrowserPanel {
         let movedToSurface = focusSurfaceForHandoff()
         let movedToNil = movedToSurface ? false : window.makeFirstResponder(nil)
         return (movedToSurface, movedToNil)
+    }
+
+    func debugPortalSnapshot() -> BrowserWindowPortalRegistry.DebugSnapshot? {
+        BrowserWindowPortalRegistry.debugSnapshot(for: webView)
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1644,6 +1644,10 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func setPageZoom(_ pageZoom: CGFloat)
     func takeSnapshot(completion: @escaping (NSImage?) -> Void)
     func evaluateJavaScript(_ script: String) async throws -> Any?
+    func findInPage(query: String) async throws -> BrowserFindResult?
+    func findNextInPage() async throws -> BrowserFindResult?
+    func findPreviousInPage() async throws -> BrowserFindResult?
+    func clearFindInPage() async throws
     func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void)
     func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void)
     func invalidateFaviconCache()
@@ -1818,6 +1822,25 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     func evaluateJavaScript(_ script: String) async throws -> Any? {
         try await webView.evaluateJavaScript(script)
+    }
+
+    func findInPage(query: String) async throws -> BrowserFindResult? {
+        let result = try await webView.evaluateJavaScript(BrowserFindJavaScript.searchScript(query: query))
+        return BrowserFindJavaScript.parseResult(result)
+    }
+
+    func findNextInPage() async throws -> BrowserFindResult? {
+        let result = try await webView.evaluateJavaScript(BrowserFindJavaScript.nextScript())
+        return BrowserFindJavaScript.parseResult(result)
+    }
+
+    func findPreviousInPage() async throws -> BrowserFindResult? {
+        let result = try await webView.evaluateJavaScript(BrowserFindJavaScript.previousScript())
+        return BrowserFindJavaScript.parseResult(result)
+    }
+
+    func clearFindInPage() async throws {
+        _ = try await webView.evaluateJavaScript(BrowserFindJavaScript.clearScript())
     }
 
     func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void) {
@@ -3995,16 +4018,16 @@ extension BrowserPanel {
     func findNext() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.runtime.evaluateJavaScript(BrowserFindJavaScript.nextScript())
-            self.parseFindResult(result)
+            let result = try? await self.runtime.findNextInPage()
+            self.applyFindResult(result)
         }
     }
 
     func findPrevious() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.runtime.evaluateJavaScript(BrowserFindJavaScript.previousScript())
-            self.parseFindResult(result)
+            let result = try? await self.runtime.findPreviousInPage()
+            self.applyFindResult(result)
         }
     }
 
@@ -4035,10 +4058,9 @@ extension BrowserPanel {
         }
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let js = BrowserFindJavaScript.searchScript(query: needle)
             do {
-                let result = try await self.runtime.evaluateJavaScript(js)
-                self.parseFindResult(result)
+                let result = try await self.runtime.findInPage(query: needle)
+                self.applyFindResult(result)
             } catch {
                 NSLog("Find: browser JS search error: %@", error.localizedDescription)
             }
@@ -4049,24 +4071,17 @@ extension BrowserPanel {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.runtime.evaluateJavaScript(BrowserFindJavaScript.clearScript())
+                try await self.runtime.clearFindInPage()
             } catch {
                 NSLog("Find: browser JS clear error: %@", error.localizedDescription)
             }
         }
     }
 
-    private func parseFindResult(_ result: Any?) {
-        guard let jsonString = result as? String,
-              let data = jsonString.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let total = json["total"] as? Int,
-              let current = json["current"] as? Int,
-              total >= 0, current >= 0 else {
-            return
-        }
-        searchState?.total = UInt(total)
-        searchState?.selected = total > 0 ? UInt(current) : nil
+    private func applyFindResult(_ result: BrowserFindResult?) {
+        guard let result else { return }
+        searchState?.total = result.total
+        searchState?.selected = result.selected
     }
 
     func setBrowserThemeMode(_ mode: BrowserThemeMode) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1590,6 +1590,11 @@ struct BrowserSurfaceRuntimeState: Equatable {
     let pageZoom: CGFloat
 }
 
+struct BrowserSurfaceRuntimeAttachmentState: Equatable {
+    let isAttachedToSuperview: Bool
+    let isInWindow: Bool
+}
+
 enum BrowserSurfaceDeveloperToolsVisibilityState: Equatable {
     case unavailable
     case hidden
@@ -1621,6 +1626,7 @@ protocol BrowserSurfaceRuntime: AnyObject {
     var webView: WKWebView { get }
     var webViewInstanceID: UUID { get }
     var state: BrowserSurfaceRuntimeState { get }
+    var attachmentState: BrowserSurfaceRuntimeAttachmentState { get }
     var eventHandlers: BrowserSurfaceRuntimeEventHandlers { get set }
     var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)? { get set }
 
@@ -1715,6 +1721,13 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
             canGoForward: webView.canGoForward,
             estimatedProgress: webView.estimatedProgress,
             pageZoom: webView.pageZoom
+        )
+    }
+
+    var attachmentState: BrowserSurfaceRuntimeAttachmentState {
+        BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: webView.superview != nil,
+            isInWindow: webView.window != nil
         )
     }
 
@@ -3087,8 +3100,8 @@ final class BrowserPanel: Panel, ObservableObject {
             guard let self else { return }
             // If loading restarted, ignore this end.
             guard self.loadingGeneration == genAtEnd else { return }
-            // If WebKit is still loading, ignore.
-            guard !self.webView.isLoading else { return }
+            // If the runtime still reports a live load, ignore.
+            guard !self.runtime.state.isLoading else { return }
             self.isLoading = false
         }
         loadingEndWorkItem = work
@@ -3268,7 +3281,8 @@ final class BrowserPanel: Panel, ObservableObject {
 
 extension BrowserPanel {
     private var needsWorkspaceContextReset: Bool {
-        shouldRenderWebView ||
+        let attachmentState = runtime.attachmentState
+        return shouldRenderWebView ||
         currentURL != nil ||
         !pageTitle.isEmpty ||
         faviconPNGData != nil ||
@@ -3283,7 +3297,7 @@ extension BrowserPanel {
         isDownloading ||
         activeDownloadCount != 0 ||
         preferredDeveloperToolsVisible ||
-        webView.superview != nil
+        attachmentState.isAttachedToSuperview
     }
 
     func resetForWorkspaceContextChange(reason: String) {
@@ -3907,12 +3921,13 @@ extension BrowserPanel {
     }
 
     func shouldPreserveDeveloperToolsIntentWhileDetached() -> Bool {
-        preferredDeveloperToolsVisible &&
+        let attachmentState = runtime.attachmentState
+        return preferredDeveloperToolsVisible &&
             (
                 forceDeveloperToolsRefreshOnNextAttach ||
                 developerToolsRestoreRetryWorkItem != nil ||
-                webView.superview == nil ||
-                webView.window == nil
+                !attachmentState.isAttachedToSuperview ||
+                !attachmentState.isInWindow
             )
     }
 
@@ -4632,11 +4647,12 @@ extension BrowserPanel {
 
     func debugDeveloperToolsStateSummary() -> String {
         let visibilityState = runtime.developerToolsVisibilityState()
+        let attachmentState = runtime.attachmentState
         let preferred = preferredDeveloperToolsVisible ? 1 : 0
         let visible = visibilityState.isVisible ? 1 : 0
         let inspector = visibilityState.isAvailable ? 1 : 0
-        let attached = webView.superview == nil ? 0 : 1
-        let inWindow = webView.window == nil ? 0 : 1
+        let attached = attachmentState.isAttachedToSuperview ? 1 : 0
+        let inWindow = attachmentState.isInWindow ? 1 : 0
         let forceRefresh = forceDeveloperToolsRefreshOnNextAttach ? 1 : 0
         let transitionTarget = developerToolsTransitionTargetVisible.map { $0 ? "1" : "0" } ?? "nil"
         let pendingTarget = pendingDeveloperToolsTransitionTargetVisible.map { $0 ? "1" : "0" } ?? "nil"

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1609,6 +1609,15 @@ enum BrowserSurfaceDeveloperToolsVisibilityState: Equatable {
     }
 }
 
+struct BrowserSurfaceDeveloperToolsHostState: Equatable {
+    let hasAttachedInspectorLayout: Bool
+    let detachedWindowCount: Int
+
+    var hasDetachedInspectorWindows: Bool {
+        detachedWindowCount > 0
+    }
+}
+
 struct BrowserSurfaceRuntimeEventHandlers {
     var didFinishNavigation: (() -> Void)?
     var didFailNavigation: ((String) -> Void)?
@@ -1659,11 +1668,13 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func invalidateFaviconCache()
     func fetchFaviconPNGData() async -> Data?
     func developerToolsVisibilityState() -> BrowserSurfaceDeveloperToolsVisibilityState
+    func developerToolsHostState() -> BrowserSurfaceDeveloperToolsHostState
     @discardableResult
     func revealDeveloperTools(attachIfNeeded: Bool) -> Bool
     @discardableResult
     func concealDeveloperTools() -> Bool
     func showDeveloperToolsConsole()
+    func dismissDetachedDeveloperToolsWindows()
     func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL])
 }
 
@@ -1683,6 +1694,70 @@ final class LocalWebKitBrowserSurfaceRuntimeFactory: BrowserSurfaceRuntimeFactor
             processPool: processPool,
             configuration: configuration
         )
+    }
+}
+
+private enum BrowserSurfaceDeveloperToolsHostIntrospection {
+    static func windowContainsInspectorViews(_ root: NSView) -> Bool {
+        if String(describing: type(of: root)).contains("WKInspector") {
+            return true
+        }
+        for subview in root.subviews where windowContainsInspectorViews(subview) {
+            return true
+        }
+        return false
+    }
+
+    static func isDetachedInspectorWindow(_ window: NSWindow) -> Bool {
+        guard window.title.hasPrefix("Web Inspector") else { return false }
+        guard let contentView = window.contentView else { return false }
+        return windowContainsInspectorViews(contentView)
+    }
+
+    static func detachedInspectorWindows(excluding mainWindow: NSWindow?) -> [NSWindow] {
+        NSApp.windows.filter { candidate in
+            if let mainWindow, candidate === mainWindow {
+                return false
+            }
+            return isDetachedInspectorWindow(candidate)
+        }
+    }
+
+    static func developerToolsHostState(for webView: WKWebView) -> BrowserSurfaceDeveloperToolsHostState {
+        let hasAttachedInspectorLayout: Bool
+        if let container = webView.superview {
+            hasAttachedInspectorLayout = visibleDescendants(in: container)
+                .contains { isVisibleInspectorCandidate($0) && isInspectorView($0) }
+        } else {
+            hasAttachedInspectorLayout = false
+        }
+
+        let detachedWindowCount = detachedInspectorWindows(excluding: webView.window).count
+        return BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: hasAttachedInspectorLayout,
+            detachedWindowCount: detachedWindowCount
+        )
+    }
+
+    private static func visibleDescendants(in root: NSView) -> [NSView] {
+        var descendants: [NSView] = []
+        var stack = Array(root.subviews.reversed())
+        while let view = stack.popLast() {
+            descendants.append(view)
+            stack.append(contentsOf: view.subviews.reversed())
+        }
+        return descendants
+    }
+
+    private static func isInspectorView(_ view: NSView) -> Bool {
+        String(describing: type(of: view)).contains("WKInspector")
+    }
+
+    private static func isVisibleInspectorCandidate(_ view: NSView) -> Bool {
+        !view.isHidden &&
+            view.alphaValue > 0 &&
+            view.frame.width > 1 &&
+            view.frame.height > 1
     }
 }
 
@@ -1923,6 +1998,10 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         return visible ? .visible : .hidden
     }
 
+    func developerToolsHostState() -> BrowserSurfaceDeveloperToolsHostState {
+        BrowserSurfaceDeveloperToolsHostIntrospection.developerToolsHostState(for: webView)
+    }
+
     @discardableResult
     func revealDeveloperTools(attachIfNeeded: Bool) -> Bool {
         guard let inspector = webView.cmuxInspectorObject() else { return false }
@@ -1978,6 +2057,12 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
                 inspector.cmuxCallVoid(selector: selector)
                 return
             }
+        }
+    }
+
+    func dismissDetachedDeveloperToolsWindows() {
+        for window in BrowserSurfaceDeveloperToolsHostIntrospection.detachedInspectorWindows(excluding: webView.window) {
+            window.close()
         }
     }
 
@@ -3518,38 +3603,6 @@ extension BrowserPanel {
         runtime.stopLoading()
     }
 
-    private static func windowContainsInspectorViews(_ root: NSView) -> Bool {
-        if String(describing: type(of: root)).contains("WKInspector") {
-            return true
-        }
-        for subview in root.subviews where windowContainsInspectorViews(subview) {
-            return true
-        }
-        return false
-    }
-
-    private static func isDetachedInspectorWindow(_ window: NSWindow) -> Bool {
-        guard window.title.hasPrefix("Web Inspector") else { return false }
-        guard let contentView = window.contentView else { return false }
-        return windowContainsInspectorViews(contentView)
-    }
-
-    private func detachedDeveloperToolsWindows() -> [NSWindow] {
-        let mainWindow = webView.window
-        return NSApp.windows.filter { candidate in
-            if let mainWindow, candidate === mainWindow {
-                return false
-            }
-            return Self.isDetachedInspectorWindow(candidate)
-        }
-    }
-
-    private func hasAttachedDeveloperToolsLayout() -> Bool {
-        guard let container = webView.superview else { return false }
-        return Self.visibleDescendants(in: container)
-            .contains { Self.isVisibleSideDockInspectorCandidate($0) && Self.isInspectorView($0) }
-    }
-
     private func setPreferredDeveloperToolsPresentation(_ next: DeveloperToolsPresentation) {
         guard preferredDeveloperToolsPresentation != next else { return }
         preferredDeveloperToolsPresentation = next
@@ -3559,9 +3612,10 @@ extension BrowserPanel {
     }
 
     private func syncDeveloperToolsPresentationPreferenceFromUI() {
-        if !detachedDeveloperToolsWindows().isEmpty {
+        let hostState = runtime.developerToolsHostState()
+        if hostState.hasDetachedInspectorWindows {
             setPreferredDeveloperToolsPresentation(.detached)
-        } else if hasAttachedDeveloperToolsLayout() {
+        } else if hostState.hasAttachedInspectorLayout {
             setPreferredDeveloperToolsPresentation(.attached)
             developerToolsDetachedOpenGraceDeadline = nil
         }
@@ -3577,7 +3631,7 @@ extension BrowserPanel {
             guard let self,
                   let window = notification.object as? NSWindow else { return }
             let isDetachedInspectorWindow = MainActor.assumeIsolated {
-                Self.isDetachedInspectorWindow(window)
+                BrowserSurfaceDeveloperToolsHostIntrospection.isDetachedInspectorWindow(window)
             }
             guard isDetachedInspectorWindow else { return }
             DispatchQueue.main.async { [weak self] in
@@ -3604,17 +3658,17 @@ extension BrowserPanel {
 
     private func dismissDetachedDeveloperToolsWindowsIfNeeded() {
         guard shouldDismissDetachedDeveloperToolsWindows() else { return }
-        guard preferredDeveloperToolsVisible || isDeveloperToolsVisible(),
-              let mainWindow = webView.window else { return }
-        for window in NSApp.windows where window !== mainWindow && Self.isDetachedInspectorWindow(window) {
+        guard preferredDeveloperToolsVisible || isDeveloperToolsVisible() else { return }
+        guard runtime.attachmentState.isInWindow else { return }
+        let hostState = runtime.developerToolsHostState()
+        guard hostState.hasDetachedInspectorWindows else { return }
 #if DEBUG
-            dlog(
-                "browser.devtools strayWindow.close panel=\(id.uuidString.prefix(5)) " +
-                "title=\(window.title) frame=\(NSStringFromRect(window.frame))"
-            )
+        dlog(
+            "browser.devtools strayWindow.close panel=\(id.uuidString.prefix(5)) " +
+            "count=\(hostState.detachedWindowCount)"
+        )
 #endif
-            window.close()
-        }
+        runtime.dismissDetachedDeveloperToolsWindows()
     }
 
     private func scheduleDetachedDeveloperToolsWindowDismissal() {
@@ -3936,7 +3990,7 @@ extension BrowserPanel {
         if preferredDeveloperToolsPresentation == .detached {
             return false
         }
-        return detachedDeveloperToolsWindows().isEmpty
+        return !runtime.developerToolsHostState().hasDetachedInspectorWindows
     }
 
     func recordPreferredAttachedDeveloperToolsWidth(_ width: CGFloat, containerBounds: NSRect) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4357,14 +4357,37 @@ extension BrowserPanel {
         runtime.attachmentState
     }
 
-    func isSurfaceHostedInWindowPortal() -> Bool {
+    func isSurfacePortalAnchorReady() -> Bool {
         let anchorView = portalAnchorView
-        let anchorReady =
+        return
             anchorView.window != nil &&
             anchorView.superview != nil &&
             anchorView.bounds.width > 1 &&
             anchorView.bounds.height > 1
-        guard anchorReady else { return false }
+    }
+
+    func updateSurfacePortalVisibility(visibleInUI: Bool, zPriority: Int) {
+        BrowserWindowPortalRegistry.updateEntryVisibility(
+            for: webView,
+            visibleInUI: visibleInUI,
+            zPriority: zPriority
+        )
+    }
+
+    @discardableResult
+    func refreshSurfacePortalIfAnchorReady(reason: String) -> Bool {
+        guard isSurfacePortalAnchorReady() else { return false }
+        BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
+        BrowserWindowPortalRegistry.refresh(webView: webView, reason: reason)
+        return true
+    }
+
+    func hideSurfacePortal(source: String) {
+        BrowserWindowPortalRegistry.hide(webView: webView, source: source)
+    }
+
+    func isSurfaceHostedInWindowPortal() -> Bool {
+        guard isSurfacePortalAnchorReady() else { return false }
 
         let attachmentState = runtime.attachmentState
         guard attachmentState.isAttachedToSuperview,
@@ -4372,7 +4395,7 @@ extension BrowserPanel {
             return false
         }
 
-        return BrowserWindowPortalRegistry.isWebView(webView, boundTo: anchorView)
+        return BrowserWindowPortalRegistry.isWebView(webView, boundTo: portalAnchorView)
     }
 
     func resolvedCurrentSurfaceURL() -> URL? {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1300,6 +1300,7 @@ protocol BrowserSurfaceRuntime: AnyObject {
     ) -> WKWebView
 
     func setLastAttemptedNavigationURL(_ url: URL?)
+    func applyBrowserThemeMode(_ mode: BrowserThemeMode)
     func setCustomUserAgent(_ customUserAgent: String)
     func setUnderPageBackgroundColor(_ color: NSColor)
     @discardableResult
@@ -1345,6 +1346,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
     private let navigationDelegate = BrowserNavigationDelegate()
     private let uiDelegate = BrowserUIDelegate()
     private let downloadDelegate = BrowserDownloadDelegate()
+    private var browserThemeMode: BrowserThemeMode = .system
     private var lastEmittedState: BrowserSurfaceRuntimeState?
     var eventHandlers = BrowserSurfaceRuntimeEventHandlers() {
         didSet {
@@ -1402,12 +1404,18 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         webView = replacement
         webViewInstanceID = UUID()
         bindWebView(replacement)
+        applyStoredBrowserThemeMode(to: replacement)
         emitStateChange(force: true)
         return replacement
     }
 
     func setLastAttemptedNavigationURL(_ url: URL?) {
         navigationDelegate.lastAttemptedURL = url
+    }
+
+    func applyBrowserThemeMode(_ mode: BrowserThemeMode) {
+        browserThemeMode = mode
+        applyStoredBrowserThemeMode(to: webView)
     }
 
     func setCustomUserAgent(_ customUserAgent: String) {
@@ -1559,6 +1567,28 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         }
     }
 
+    private func applyStoredBrowserThemeMode(to webView: WKWebView) {
+        switch browserThemeMode {
+        case .system:
+            webView.appearance = nil
+        case .light:
+            webView.appearance = NSAppearance(named: .aqua)
+        case .dark:
+            webView.appearance = NSAppearance(named: .darkAqua)
+        }
+
+        let script = Self.browserThemeModeScript(mode: browserThemeMode)
+        webView.evaluateJavaScript(script) { _, error in
+#if DEBUG
+            if let error {
+                dlog("browser.themeMode error=\(error.localizedDescription)")
+            }
+#else
+            _ = error
+#endif
+        }
+    }
+
     private func applyEventHandlersToCurrentWebView() {
         applyEventHandlers(to: webView)
     }
@@ -1612,6 +1642,46 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     private func isCurrentWebView(_ candidate: WKWebView) -> Bool {
         candidate === webView
+    }
+
+    private static func browserThemeModeScript(mode: BrowserThemeMode) -> String {
+        let colorSchemeLiteral: String
+        switch mode {
+        case .system:
+            colorSchemeLiteral = "null"
+        case .light:
+            colorSchemeLiteral = "'light'"
+        case .dark:
+            colorSchemeLiteral = "'dark'"
+        }
+
+        return """
+        (() => {
+          const metaId = 'cmux-browser-theme-mode-meta';
+          const colorScheme = \(colorSchemeLiteral);
+          const root = document.documentElement || document.body;
+          if (!root) return;
+
+          let meta = document.getElementById(metaId);
+          if (colorScheme) {
+            root.style.setProperty('color-scheme', colorScheme, 'important');
+            root.setAttribute('data-cmux-browser-theme', colorScheme);
+            if (!meta) {
+              meta = document.createElement('meta');
+              meta.id = metaId;
+              meta.name = 'color-scheme';
+              (document.head || root).appendChild(meta);
+            }
+            meta.setAttribute('content', colorScheme);
+          } else {
+            root.style.removeProperty('color-scheme');
+            root.removeAttribute('data-cmux-browser-theme');
+            if (meta) {
+              meta.remove();
+            }
+          }
+        })();
+        """
     }
 
     private func emitStateChange(force: Bool = false) {
@@ -2347,9 +2417,7 @@ final class BrowserPanel: Panel, ObservableObject {
             handleWebViewLoadingChanged(state.isLoading)
         }
         let trimmedTitle = (state.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedTitle.isEmpty {
-            pageTitle = trimmedTitle
-        }
+        pageTitle = trimmedTitle
         nativeCanGoBack = state.canGoBack
         nativeCanGoForward = state.canGoForward
         estimatedProgress = state.estimatedProgress
@@ -4375,63 +4443,7 @@ extension BrowserPanel {
 
 private extension BrowserPanel {
     func applyBrowserThemeModeIfNeeded() {
-        switch browserThemeMode {
-        case .system:
-            webView.appearance = nil
-        case .light:
-            webView.appearance = NSAppearance(named: .aqua)
-        case .dark:
-            webView.appearance = NSAppearance(named: .darkAqua)
-        }
-
-        let script = makeBrowserThemeModeScript(mode: browserThemeMode)
-        webView.evaluateJavaScript(script) { _, error in
-            #if DEBUG
-            if let error {
-                dlog("browser.themeMode error=\(error.localizedDescription)")
-            }
-            #endif
-        }
-    }
-
-    func makeBrowserThemeModeScript(mode: BrowserThemeMode) -> String {
-        let colorSchemeLiteral: String
-        switch mode {
-        case .system:
-            colorSchemeLiteral = "null"
-        case .light:
-            colorSchemeLiteral = "'light'"
-        case .dark:
-            colorSchemeLiteral = "'dark'"
-        }
-
-        return """
-        (() => {
-          const metaId = 'cmux-browser-theme-mode-meta';
-          const colorScheme = \(colorSchemeLiteral);
-          const root = document.documentElement || document.body;
-          if (!root) return;
-
-          let meta = document.getElementById(metaId);
-          if (colorScheme) {
-            root.style.setProperty('color-scheme', colorScheme, 'important');
-            root.setAttribute('data-cmux-browser-theme', colorScheme);
-            if (!meta) {
-              meta = document.createElement('meta');
-              meta.id = metaId;
-              meta.name = 'color-scheme';
-              (document.head || root).appendChild(meta);
-            }
-            meta.setAttribute('content', colorScheme);
-          } else {
-            root.style.removeProperty('color-scheme');
-            root.removeAttribute('data-cmux-browser-theme');
-            if (meta) {
-              meta.remove();
-            }
-          }
-        })();
-        """
+        runtime.applyBrowserThemeMode(browserThemeMode)
     }
 
     func scheduleDeveloperToolsRestoreRetry() {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1253,11 +1253,120 @@ final class BrowserPortalAnchorView: NSView {
     }
 }
 
+enum BrowserRuntimeBackendKind: String {
+    case localWebKit
+}
+
+struct BrowserRuntimeSurfaceConfiguration {
+    let bootstrapUserScriptSources: [String]
+    let underPageBackgroundColor: NSColor
+    let customUserAgent: String
+}
+
+@MainActor
+protocol BrowserSurfaceRuntime: AnyObject {
+    var backendKind: BrowserRuntimeBackendKind { get }
+    var webView: WKWebView { get }
+    var webViewInstanceID: UUID { get }
+
+    @discardableResult
+    func replaceWebView(
+        using configuration: BrowserRuntimeSurfaceConfiguration,
+        pageZoom: CGFloat?
+    ) -> WKWebView
+}
+
+@MainActor
+protocol BrowserSurfaceRuntimeFactory {
+    func makeSurface(using configuration: BrowserRuntimeSurfaceConfiguration) -> any BrowserSurfaceRuntime
+}
+
+@MainActor
+final class LocalWebKitBrowserSurfaceRuntimeFactory: BrowserSurfaceRuntimeFactory {
+    static let shared = LocalWebKitBrowserSurfaceRuntimeFactory()
+
+    private let processPool = WKProcessPool()
+
+    func makeSurface(using configuration: BrowserRuntimeSurfaceConfiguration) -> any BrowserSurfaceRuntime {
+        LocalWebKitBrowserSurfaceRuntime(
+            processPool: processPool,
+            configuration: configuration
+        )
+    }
+}
+
+@MainActor
+final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
+    let backendKind: BrowserRuntimeBackendKind = .localWebKit
+
+    private let processPool: WKProcessPool
+    private(set) var webView: WKWebView
+    private(set) var webViewInstanceID: UUID
+
+    init(
+        processPool: WKProcessPool,
+        configuration: BrowserRuntimeSurfaceConfiguration
+    ) {
+        self.processPool = processPool
+        let webView = Self.makeWebView(
+            processPool: processPool,
+            configuration: configuration
+        )
+        self.webView = webView
+        self.webViewInstanceID = UUID()
+    }
+
+    @discardableResult
+    func replaceWebView(
+        using configuration: BrowserRuntimeSurfaceConfiguration,
+        pageZoom: CGFloat?
+    ) -> WKWebView {
+        let replacement = Self.makeWebView(
+            processPool: processPool,
+            configuration: configuration
+        )
+        if let pageZoom {
+            replacement.pageZoom = pageZoom
+        }
+        webView = replacement
+        webViewInstanceID = UUID()
+        return replacement
+    }
+
+    private static func makeWebView(
+        processPool: WKProcessPool,
+        configuration: BrowserRuntimeSurfaceConfiguration
+    ) -> CmuxWebView {
+        let webViewConfiguration = WKWebViewConfiguration()
+        webViewConfiguration.processPool = processPool
+        webViewConfiguration.mediaTypesRequiringUserActionForPlayback = []
+        webViewConfiguration.websiteDataStore = .default()
+        webViewConfiguration.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        webViewConfiguration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        for source in configuration.bootstrapUserScriptSources {
+            webViewConfiguration.userContentController.addUserScript(
+                WKUserScript(
+                    source: source,
+                    injectionTime: .atDocumentStart,
+                    forMainFrameOnly: false
+                )
+            )
+        }
+
+        let webView = CmuxWebView(frame: .zero, configuration: webViewConfiguration)
+        webView.allowsBackForwardNavigationGestures = true
+        if #available(macOS 13.3, *) {
+            webView.isInspectable = true
+        }
+        webView.underPageBackgroundColor = configuration.underPageBackgroundColor
+        webView.customUserAgent = configuration.customUserAgent
+        return webView
+    }
+}
+
 @MainActor
 final class BrowserPanel: Panel, ObservableObject {
-    /// Shared process pool for cookie sharing across all browser panels
-    private static let sharedProcessPool = WKProcessPool()
-
     static let telemetryHookBootstrapScriptSource = """
     (() => {
       if (window.__cmuxHooksInstalled) return true;
@@ -1391,13 +1500,27 @@ final class BrowserPanel: Panel, ObservableObject {
         return NSColor.windowBackgroundColor
     }
 
+    private static func runtimeSurfaceConfiguration() -> BrowserRuntimeSurfaceConfiguration {
+        BrowserRuntimeSurfaceConfiguration(
+            bootstrapUserScriptSources: [
+                telemetryHookBootstrapScriptSource,
+                addressBarFocusTrackingBootstrapScript,
+            ],
+            underPageBackgroundColor: GhosttyBackgroundTheme.currentColor(),
+            customUserAgent: BrowserUserAgentSettings.safariUserAgent
+        )
+    }
+
     let id: UUID
     let panelType: PanelType = .browser
 
     /// The workspace ID this panel belongs to
     private(set) var workspaceId: UUID
 
-    /// The underlying web view
+    private let runtimeFactory: any BrowserSurfaceRuntimeFactory
+    private var runtime: any BrowserSurfaceRuntime
+
+    /// Cached reference to the active browser view. The runtime owns creation and replacement.
     private(set) var webView: WKWebView
 
     /// Monotonic identity for the current WKWebView instance.
@@ -1952,56 +2075,24 @@ final class BrowserPanel: Panel, ObservableObject {
         false
     }
 
-    private static func makeWebView() -> CmuxWebView {
-        let config = WKWebViewConfiguration()
-        config.processPool = BrowserPanel.sharedProcessPool
-        config.mediaTypesRequiringUserActionForPlayback = []
-        // Ensure browser cookies/storage persist across navigations and launches.
-        // This reduces repeated consent/bot-challenge flows on sites like Google.
-        config.websiteDataStore = .default()
-
-        // Enable developer extras (DevTools)
-        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
-
-        // Enable JavaScript
-        config.defaultWebpagePreferences.allowsContentJavaScript = true
-        // Keep browser console/error/dialog telemetry active from document start on every navigation.
-        config.userContentController.addUserScript(
-            WKUserScript(
-                source: Self.telemetryHookBootstrapScriptSource,
-                injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
-            )
+    private func replaceRuntimeWebView(pageZoom: CGFloat? = nil) -> WKWebView {
+        let replacement = runtime.replaceWebView(
+            using: Self.runtimeSurfaceConfiguration(),
+            pageZoom: pageZoom
         )
-        // Track the last editable focused element continuously so omnibar exit can
-        // restore page input focus even if capture runs after first-responder handoff.
-        config.userContentController.addUserScript(
-            WKUserScript(
-                source: Self.addressBarFocusTrackingBootstrapScript,
-                injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
-            )
-        )
-
-        let webView = CmuxWebView(frame: .zero, configuration: config)
-        webView.allowsBackForwardNavigationGestures = true
-        if #available(macOS 13.3, *) {
-            webView.isInspectable = true
-        }
-        // Match the empty-page background to the terminal theme so newly-created browsers
-        // don't flash white before content loads.
-        webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
-        // Always present as Safari.
-        webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
-        return webView
+        webView = replacement
+        webViewInstanceID = runtime.webViewInstanceID
+        return replacement
     }
 
-    private func bindWebView(_ webView: CmuxWebView) {
-        webView.onContextMenuDownloadStateChanged = { [weak self] downloading in
-            if downloading {
-                self?.beginDownloadActivity()
-            } else {
-                self?.endDownloadActivity()
+    private func bindWebView(_ webView: WKWebView) {
+        if let cmuxWebView = webView as? CmuxWebView {
+            cmuxWebView.onContextMenuDownloadStateChanged = { [weak self] downloading in
+                if downloading {
+                    self?.beginDownloadActivity()
+                } else {
+                    self?.endDownloadActivity()
+                }
             }
         }
         webView.navigationDelegate = navigationDelegate
@@ -2015,14 +2106,22 @@ final class BrowserPanel: Panel, ObservableObject {
         return instanceID == webViewInstanceID
     }
 
-    init(workspaceId: UUID, initialURL: URL? = nil, bypassInsecureHTTPHostOnce: String? = nil) {
+    init(
+        workspaceId: UUID,
+        initialURL: URL? = nil,
+        bypassInsecureHTTPHostOnce: String? = nil,
+        runtimeFactory: (any BrowserSurfaceRuntimeFactory)? = nil
+    ) {
+        let runtimeFactory = runtimeFactory ?? LocalWebKitBrowserSurfaceRuntimeFactory.shared
         self.id = UUID()
         self.workspaceId = workspaceId
         self.insecureHTTPBypassHostOnce = BrowserInsecureHTTPSettings.normalizeHost(bypassInsecureHTTPHostOnce ?? "")
         self.browserThemeMode = BrowserThemeSettings.mode()
-
-        let webView = Self.makeWebView()
-        self.webView = webView
+        self.runtimeFactory = runtimeFactory
+        let runtime = runtimeFactory.makeSurface(using: Self.runtimeSurfaceConfiguration())
+        self.runtime = runtime
+        self.webView = runtime.webView
+        self.webViewInstanceID = runtime.webViewInstanceID
         self.insecureHTTPAlertFactory = { NSAlert() }
 
         // Set up navigation delegate
@@ -2089,7 +2188,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         self.uiDelegate = browserUIDelegate
 
-        bindWebView(webView)
+        bindWebView(runtime.webView)
         installDetachedDeveloperToolsWindowCloseObserver()
         applyBrowserThemeModeIfNeeded()
         insecureHTTPAlertWindowProvider = { [weak self] in
@@ -2279,10 +2378,7 @@ final class BrowserPanel: Panel, ObservableObject {
             terminatedCmuxWebView.onContextMenuDownloadStateChanged = nil
         }
 
-        let replacement = Self.makeWebView()
-        replacement.pageZoom = desiredZoom
-        webViewInstanceID = UUID()
-        webView = replacement
+        let replacement = replaceRuntimeWebView(pageZoom: desiredZoom)
         shouldRenderWebView = wasRenderable
 
         bindWebView(replacement)
@@ -2830,9 +2926,7 @@ extension BrowserPanel {
             oldCmuxWebView.onContextMenuDownloadStateChanged = nil
         }
 
-        let replacement = Self.makeWebView()
-        webViewInstanceID = UUID()
-        webView = replacement
+        let replacement = replaceRuntimeWebView()
         shouldRenderWebView = false
         bindWebView(replacement)
         applyBrowserThemeModeIfNeeded()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1686,6 +1686,9 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func concealDeveloperTools() -> Bool
     func showDeveloperToolsConsole()
     func dismissDetachedDeveloperToolsWindows()
+    func hostWindow() -> NSWindow?
+    func isHiddenOrHasHiddenAncestor() -> Bool
+    func setAllowsFirstResponderAcquisition(_ allowed: Bool)
     func ownsResponder(_ responder: NSResponder?) -> Bool
     @discardableResult
     func focusSurface() -> Bool
@@ -2007,6 +2010,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     func fetchFaviconPNGData() async -> Data? {
         let webView = self.webView
+        let fetchWebViewInstanceID = webViewInstanceID
         guard let pageURL = webView.url else { return nil }
         guard let scheme = pageURL.scheme?.lowercased(), scheme == "http" || scheme == "https" else { return nil }
 
@@ -2017,6 +2021,7 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
                 discoveredURL = url
             }
         }
+        guard fetchWebViewInstanceID == webViewInstanceID else { return nil }
 
         let fallbackURL = URL(string: "/favicon.ico", relativeTo: pageURL)
         guard let iconURL = discoveredURL ?? fallbackURL else { return nil }
@@ -2025,7 +2030,6 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         if iconURLString == lastFaviconURLString {
             return nil
         }
-        lastFaviconURLString = iconURLString
 
         var request = URLRequest(url: iconURL)
         request.timeoutInterval = 2.0
@@ -2039,13 +2043,18 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         } catch {
             return nil
         }
+        guard fetchWebViewInstanceID == webViewInstanceID else { return nil }
 
         guard let http = response as? HTTPURLResponse,
               (200..<300).contains(http.statusCode) else {
             return nil
         }
 
-        return Self.makeFaviconPNGData(from: data, targetPx: 32)
+        guard let png = Self.makeFaviconPNGData(from: data, targetPx: 32) else {
+            return nil
+        }
+        lastFaviconURLString = iconURLString
+        return png
     }
 
     func developerToolsVisibilityState() -> BrowserSurfaceDeveloperToolsVisibilityState {
@@ -2122,6 +2131,19 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
         for window in BrowserSurfaceDeveloperToolsHostIntrospection.detachedInspectorWindows(excluding: webView.window) {
             window.close()
         }
+    }
+
+    func hostWindow() -> NSWindow? {
+        webView.window
+    }
+
+    func isHiddenOrHasHiddenAncestor() -> Bool {
+        webView.isHiddenOrHasHiddenAncestor
+    }
+
+    func setAllowsFirstResponderAcquisition(_ allowed: Bool) {
+        guard let cmuxWebView = webView as? CmuxWebView else { return }
+        cmuxWebView.allowsFirstResponderAcquisition = allowed
     }
 
     func ownsResponder(_ responder: NSResponder?) -> Bool {
@@ -3874,7 +3896,7 @@ extension BrowserPanel {
             forceDeveloperToolsRefreshOnNextAttach = false
         }
 
-        if source.hasPrefix("toggle"), visible != targetVisible {
+        if visible != targetVisible {
             scheduleDeveloperToolsTransitionSettle(source: source)
         } else {
             developerToolsTransitionTargetVisible = nil
@@ -4239,6 +4261,42 @@ extension BrowserPanel {
 
     func refreshAppearanceDrivenColors() {
         runtime.setUnderPageBackgroundColor(GhosttyBackgroundTheme.currentColor())
+    }
+
+    func surfaceWindow() -> NSWindow? {
+        runtime.hostWindow()
+    }
+
+    func isSurfaceHiddenOrHasHiddenAncestor() -> Bool {
+        runtime.isHiddenOrHasHiddenAncestor()
+    }
+
+    func isSurfaceBlankForAutofocus() -> Bool {
+        guard let url = runtime.state.currentURL else { return true }
+        return url.absoluteString == blankURLString
+    }
+
+    func isSurfaceLoadingNow() -> Bool {
+        runtime.state.isLoading
+    }
+
+    func syncSurfaceFirstResponderAcquisitionPolicy(isPanelFocused: Bool) {
+        runtime.setAllowsFirstResponderAcquisition(
+            isPanelFocused && !shouldSuppressWebViewFocus()
+        )
+    }
+
+    @discardableResult
+    func focusSurfaceForHandoff() -> Bool {
+        let focused = runtime.focusSurface()
+        if focused {
+            noteWebViewFocused()
+        }
+        return focused
+    }
+
+    func surfaceOwnsResponder(_ responder: NSResponder?) -> Bool {
+        runtime.ownsResponder(responder)
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4165,7 +4165,7 @@ extension BrowserPanel {
         }
         let generation = beginSearchFocusRequest(reason: "startFind")
 #if DEBUG
-        let window = surfaceWindow()
+        let window = surfaceHostingWindow()
         dlog(
             "browser.find.start panel=\(id.uuidString.prefix(5)) " +
             "created=\(created ? 1 : 0) render=\(shouldRenderWebView ? 1 : 0) " +
@@ -4196,7 +4196,7 @@ extension BrowserPanel {
             return
         }
 #if DEBUG
-        let window = surfaceWindow()
+        let window = surfaceHostingWindow()
         dlog(
             "browser.find.focusNotification panel=\(id.uuidString.prefix(5)) " +
             "generation=\(generation) " +
@@ -4287,6 +4287,10 @@ extension BrowserPanel {
 
     func surfaceWindow() -> NSWindow? {
         runtime.hostWindow()
+    }
+
+    func ownsSurfaceWebView(_ candidate: WKWebView?) -> Bool {
+        webView === candidate
     }
 
     func surfaceHostingWindow() -> NSWindow? {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2643,6 +2643,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     /// Published page title
     @Published private(set) var pageTitle: String = ""
+    private var preservesFailedNavigationTitleUntilRuntimeChange = false
 
     /// Published favicon (PNG data). When present, the tab bar can render it instead of a SF symbol.
     @Published private(set) var faviconPNGData: Data?
@@ -2956,7 +2957,13 @@ final class BrowserPanel: Panel, ObservableObject {
             handleWebViewLoadingChanged(state.isLoading)
         }
         let trimmedTitle = (state.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedTitle.isEmpty {
+        let previousTrimmedTitle = (lastRuntimeState?.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if preservesFailedNavigationTitleUntilRuntimeChange {
+            if !trimmedTitle.isEmpty, trimmedTitle != previousTrimmedTitle {
+                pageTitle = trimmedTitle
+                preservesFailedNavigationTitleUntilRuntimeChange = false
+            }
+        } else if !trimmedTitle.isEmpty {
             pageTitle = trimmedTitle
         }
         nativeCanGoBack = state.canGoBack
@@ -2998,6 +3005,7 @@ final class BrowserPanel: Panel, ObservableObject {
             didFinishNavigation: { [weak self] in
                 guard let self else { return }
                 let runtimeState = self.runtime.state
+                self.preservesFailedNavigationTitleUntilRuntimeChange = false
                 self.pageTitle = (runtimeState.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 BrowserHistoryStore.shared.recordVisit(url: runtimeState.currentURL, title: runtimeState.title)
                 self.refreshFaviconFromRuntime()
@@ -3009,6 +3017,7 @@ final class BrowserPanel: Panel, ObservableObject {
                 guard let self else { return }
                 // Clear stale title/favicon from the previous page so the tab
                 // shows the failed URL instead of the old page's branding.
+                self.preservesFailedNavigationTitleUntilRuntimeChange = true
                 self.pageTitle = failedURL.isEmpty ? "" : failedURL
                 self.faviconPNGData = nil
                 self.runtime.invalidateFaviconCache()
@@ -3896,7 +3905,7 @@ extension BrowserPanel {
             forceDeveloperToolsRefreshOnNextAttach = false
         }
 
-        if visible != targetVisible {
+        if source.hasPrefix("toggle"), visible != targetVisible {
             scheduleDeveloperToolsTransitionSettle(source: source)
         } else {
             developerToolsTransitionTargetVisible = nil

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1687,6 +1687,7 @@ protocol BrowserSurfaceRuntime: AnyObject {
     func showDeveloperToolsConsole()
     func dismissDetachedDeveloperToolsWindows()
     func hostWindow() -> NSWindow?
+    func frameInWindowCoordinates() -> CGRect?
     func isHiddenOrHasHiddenAncestor() -> Bool
     func setAllowsFirstResponderAcquisition(_ allowed: Bool)
     func ownsResponder(_ responder: NSResponder?) -> Bool
@@ -2135,6 +2136,11 @@ final class LocalWebKitBrowserSurfaceRuntime: BrowserSurfaceRuntime {
 
     func hostWindow() -> NSWindow? {
         webView.window
+    }
+
+    func frameInWindowCoordinates() -> CGRect? {
+        guard webView.window != nil else { return nil }
+        return webView.convert(webView.bounds, to: nil)
     }
 
     func isHiddenOrHasHiddenAncestor() -> Bool {
@@ -3055,7 +3061,7 @@ final class BrowserPanel: Panel, ObservableObject {
         installDetachedDeveloperToolsWindowCloseObserver()
         applyBrowserThemeModeIfNeeded()
         insecureHTTPAlertWindowProvider = { [weak self] in
-            self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            self?.effectiveSurfaceWindow()
         }
 
         // Navigate to initial URL if provided
@@ -4159,7 +4165,7 @@ extension BrowserPanel {
         }
         let generation = beginSearchFocusRequest(reason: "startFind")
 #if DEBUG
-        let window = webView.window
+        let window = surfaceWindow()
         dlog(
             "browser.find.start panel=\(id.uuidString.prefix(5)) " +
             "created=\(created ? 1 : 0) render=\(shouldRenderWebView ? 1 : 0) " +
@@ -4190,7 +4196,7 @@ extension BrowserPanel {
             return
         }
 #if DEBUG
-        let window = webView.window
+        let window = surfaceWindow()
         dlog(
             "browser.find.focusNotification panel=\(id.uuidString.prefix(5)) " +
             "generation=\(generation) " +
@@ -4283,6 +4289,14 @@ extension BrowserPanel {
         runtime.hostWindow()
     }
 
+    func effectiveSurfaceWindow() -> NSWindow? {
+        surfaceWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
+    }
+
+    func surfaceFrameInWindowCoordinates() -> CGRect? {
+        runtime.frameInWindowCoordinates()
+    }
+
     func isSurfaceHiddenOrHasHiddenAncestor() -> Bool {
         runtime.isHiddenOrHasHiddenAncestor()
     }
@@ -4313,6 +4327,11 @@ extension BrowserPanel {
 
     func surfaceOwnsResponder(_ responder: NSResponder?) -> Bool {
         runtime.ownsResponder(responder)
+    }
+
+    func isSurfaceFocusedInHostWindow() -> Bool {
+        guard let window = surfaceWindow() else { return false }
+        return surfaceOwnsResponder(window.firstResponder)
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {
@@ -4807,7 +4826,7 @@ extension BrowserPanel {
     func resetInsecureHTTPAlertHooksForTesting() {
         insecureHTTPAlertFactory = { NSAlert() }
         insecureHTTPAlertWindowProvider = { [weak self] in
-            self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            self?.effectiveSurfaceWindow()
         }
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4305,6 +4305,10 @@ extension BrowserPanel {
         runtime.state.pageZoom
     }
 
+    func setSurfacePageZoom(_ pageZoom: CGFloat) {
+        runtime.setPageZoom(pageZoom)
+    }
+
     func isSurfaceBlankForAutofocus() -> Bool {
         guard let url = runtime.state.currentURL else { return true }
         return url.absoluteString == blankURLString
@@ -4347,6 +4351,39 @@ extension BrowserPanel {
 
     func debugPortalSnapshot() -> BrowserWindowPortalRegistry.DebugSnapshot? {
         BrowserWindowPortalRegistry.debugSnapshot(for: webView)
+    }
+
+    func surfaceAttachmentState() -> BrowserSurfaceRuntimeAttachmentState {
+        runtime.attachmentState
+    }
+
+    func isSurfaceHostedInWindowPortal() -> Bool {
+        let anchorView = portalAnchorView
+        let anchorReady =
+            anchorView.window != nil &&
+            anchorView.superview != nil &&
+            anchorView.bounds.width > 1 &&
+            anchorView.bounds.height > 1
+        guard anchorReady else { return false }
+
+        let attachmentState = runtime.attachmentState
+        guard attachmentState.isAttachedToSuperview,
+              attachmentState.isInWindow else {
+            return false
+        }
+
+        return BrowserWindowPortalRegistry.isWebView(webView, boundTo: anchorView)
+    }
+
+    func resolvedCurrentSurfaceURL() -> URL? {
+        resolvedCurrentSessionHistoryURL()
+            ?? preferredURLStringForOmnibar().flatMap(URL.init(string:))
+    }
+
+    func debugSurfaceHostingSummary() -> String {
+        let attachmentState = runtime.attachmentState
+        let frame = String(format: "%.1fx%.1f", webView.frame.width, webView.frame.height)
+        return "webInWindow=\(attachmentState.isInWindow ? 1 : 0) webHasSuperview=\(attachmentState.isAttachedToSuperview ? 1 : 0) frame=\(frame)"
     }
 
     func suppressOmnibarAutofocus(for seconds: TimeInterval) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -911,20 +911,16 @@ struct BrowserPanelView: View {
         reason: String,
         isPanelFocusedOverride: Bool? = nil
     ) {
-        guard let cmuxWebView = panel.webView as? CmuxWebView else { return }
         let isPanelFocused = isPanelFocusedOverride ?? isFocused
         let next = isPanelFocused && !panel.shouldSuppressWebViewFocus()
-        if cmuxWebView.allowsFirstResponderAcquisition != next {
 #if DEBUG
-            dlog(
-                "browser.focus.policy.resync panel=\(panel.id.uuidString.prefix(5)) " +
-                "web=\(ObjectIdentifier(cmuxWebView)) old=\(cmuxWebView.allowsFirstResponderAcquisition ? 1 : 0) " +
-                "new=\(next ? 1 : 0) reason=\(reason) " +
-                "panelFocusedUsed=\(isPanelFocused ? 1 : 0)"
-            )
+        dlog(
+            "browser.focus.policy.resync panel=\(panel.id.uuidString.prefix(5)) " +
+            "new=\(next ? 1 : 0) reason=\(reason) " +
+            "panelFocusedUsed=\(isPanelFocused ? 1 : 0)"
+        )
 #endif
-        }
-        cmuxWebView.allowsFirstResponderAcquisition = next
+        panel.syncSurfaceFirstResponderAcquisitionPolicy(isPanelFocused: isPanelFocused)
     }
 
     private func setAddressBarFocused(_ focused: Bool, reason: String) {
@@ -947,20 +943,6 @@ struct BrowserPanelView: View {
         }
     }
 
-    private func browserFocusResponderChainContains(
-        _ start: NSResponder?,
-        target: NSResponder
-    ) -> Bool {
-        var current = start
-        var hops = 0
-        while let responder = current, hops < 64 {
-            if responder === target { return true }
-            current = responder.nextResponder
-            hops += 1
-        }
-        return false
-    }
-
     private func isPanelFocusedInModel() -> Bool {
         guard let app = AppDelegate.shared,
               let manager = app.tabManagerFor(tabId: panel.workspaceId),
@@ -972,12 +954,12 @@ struct BrowserPanelView: View {
     }
 
     private func shouldApplyAddressBarExitFallback(in window: NSWindow) -> Bool {
-        panel.webView.window === window && isPanelFocusedInModel()
+        panel.surfaceWindow() === window && isPanelFocusedInModel()
     }
 
 #if DEBUG
     private func browserFocusWindow() -> NSWindow? {
-        panel.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+        panel.surfaceWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
     }
 
     private func browserFocusResponderDescription(_ responder: NSResponder?) -> String {
@@ -989,7 +971,7 @@ struct BrowserPanelView: View {
         let window = browserFocusWindow()
         let firstResponder = window?.firstResponder
         let firstResponderType = browserFocusResponderDescription(firstResponder)
-        let webResponder = browserFocusResponderChainContains(firstResponder, target: panel.webView) ? 1 : 0
+        let webResponder = panel.surfaceOwnsResponder(firstResponder) ? 1 : 0
         var line =
             "browser.focus.trace event=\(event) panel=\(panel.id.uuidString.prefix(5)) " +
             "panelFocused=\(isFocused ? 1 : 0) addrFocused=\(addressBarFocused ? 1 : 0) " +
@@ -1015,7 +997,7 @@ struct BrowserPanelView: View {
     private func isCommandPaletteVisibleForPanelWindow() -> Bool {
         guard let app = AppDelegate.shared else { return false }
 
-        if let window = panel.webView.window, app.isCommandPaletteVisible(for: window) {
+        if let window = panel.surfaceWindow(), app.isCommandPaletteVisible(for: window) {
             return true
         }
 
@@ -1121,8 +1103,7 @@ struct BrowserPanelView: View {
 
     /// Treat a WebView with no URL (or about:blank) as "blank" for UX purposes.
     private func isWebViewBlank() -> Bool {
-        guard let url = panel.webView.url else { return true }
-        return url.absoluteString == "about:blank"
+        panel.isSurfaceBlankForAutofocus()
     }
 
     private func autoFocusOmnibarIfBlank() {
@@ -1152,7 +1133,7 @@ struct BrowserPanelView: View {
             return
         }
         // If a real navigation is underway (e.g. open_browser https://...), don't steal focus.
-        guard !panel.webView.isLoading else {
+        guard !panel.isSurfaceLoadingNow() else {
 #if DEBUG
             logBrowserFocusState(event: "addressBarFocus.autoFocus.skip", detail: "reason=webview_loading")
 #endif
@@ -1544,8 +1525,8 @@ struct BrowserPanelView: View {
             syncWebViewResponderPolicyWithViewState(reason: "effects.blurToWebView.preHandoff")
             setAddressBarFocused(false, reason: "effects.blurToWebView")
             DispatchQueue.main.async {
-                guard let window = panel.webView.window,
-                      !panel.webView.isHiddenOrHasHiddenAncestor else { return }
+                guard let window = panel.surfaceWindow(),
+                      !panel.isSurfaceHiddenOrHasHiddenAncestor() else { return }
                 guard shouldApplyAddressBarExitFallback(in: window) else {
 #if DEBUG
                     dlog(
@@ -1558,10 +1539,7 @@ struct BrowserPanelView: View {
                 }
                 syncWebViewResponderPolicyWithViewState(reason: "effects.blurToWebView.handoff")
                 panel.clearWebViewFocusSuppression()
-                let focusedWebView = window.makeFirstResponder(panel.webView)
-                if focusedWebView {
-                    panel.noteWebViewFocused()
-                }
+                let focusedWebView = panel.focusSurfaceForHandoff()
 #if DEBUG
                 dlog(
                     "browser.focus.addressBar.exit.handoff panel=\(panel.id.uuidString.prefix(5)) " +
@@ -1579,10 +1557,9 @@ struct BrowserPanelView: View {
                         NotificationCenter.default.post(name: .browserDidExitAddressBar, object: panel.id)
                         return
                     }
-                    var hasWebViewResponder =
-                        browserFocusResponderChainContains(window.firstResponder, target: panel.webView)
+                    var hasWebViewResponder = panel.surfaceOwnsResponder(window.firstResponder)
                     if !hasWebViewResponder {
-                        let fallbackFocusedWebView = window.makeFirstResponder(panel.webView)
+                        let fallbackFocusedWebView = panel.focusSurfaceForHandoff()
                         hasWebViewResponder = fallbackFocusedWebView
 #if DEBUG
                         dlog(
@@ -1591,9 +1568,6 @@ struct BrowserPanelView: View {
                             "restored=\(restored ? 1 : 0)"
                         )
 #endif
-                    }
-                    if hasWebViewResponder {
-                        panel.noteWebViewFocused()
                     }
                     NotificationCenter.default.post(name: .browserDidExitAddressBar, object: panel.id)
                 }
@@ -5636,13 +5610,11 @@ struct WebViewRepresentable: NSViewRepresentable {
             : updateUsingWindowPortal(nsView, context: context, webView: webView)
         Self.applyWebViewFirstResponderPolicy(
             panel: panel,
-            webView: webView,
             isPanelFocused: isPanelFocused && isCurrentPaneOwner && hostOwnsPortal
         )
 
         Self.applyFocus(
             panel: panel,
-            webView: webView,
             nsView: nsView,
             shouldFocusWebView: shouldFocusWebView && isCurrentPaneOwner && hostOwnsPortal,
             isPanelFocused: isPanelFocused && isCurrentPaneOwner && hostOwnsPortal
@@ -5651,13 +5623,12 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     private static func applyFocus(
         panel: BrowserPanel,
-        webView: WKWebView,
         nsView: NSView,
         shouldFocusWebView: Bool,
         isPanelFocused: Bool
     ) {
         // Focus handling. Avoid fighting the address bar when it is focused.
-        guard let window = nsView.window else {
+        guard let window = panel.surfaceWindow() ?? panel.portalAnchorView.window ?? nsView.window else {
 #if DEBUG
             dlog(
                 "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +
@@ -5667,7 +5638,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
             return
         }
-        if isPanelFocused && responderChainContains(window.firstResponder, target: webView) {
+        if isPanelFocused && panel.surfaceOwnsResponder(window.firstResponder) {
             panel.noteWebViewFocused()
         }
         if shouldFocusWebView {
@@ -5680,7 +5651,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
                 return
             }
-            if responderChainContains(window.firstResponder, target: webView) {
+            if panel.surfaceOwnsResponder(window.firstResponder) {
 #if DEBUG
                 dlog(
                     "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +
@@ -5689,21 +5660,18 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
                 return
             }
-            let result = window.makeFirstResponder(webView)
-            if result {
-                panel.noteWebViewFocused()
-            }
+            let result = panel.focusSurfaceForHandoff()
 #if DEBUG
             dlog(
                 "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +
                 "action=focus result=\(result ? 1 : 0) fr=\(responderDescription(window.firstResponder))"
-            )
+                )
 #endif
-        } else if !isPanelFocused && responderChainContains(window.firstResponder, target: webView) {
+        } else if !isPanelFocused && panel.surfaceOwnsResponder(window.firstResponder) {
             // Only force-resign WebView focus when this panel itself is not focused.
             // If the panel is focused but the omnibar-focus state is briefly stale, aggressively
             // clearing first responder here can undo programmatic webview focus (socket tests).
-            let result = window.makeFirstResponder(nil)
+            let result = panel.yieldFocusIntent(.browser(.webView), in: window)
 #if DEBUG
             dlog(
                 "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +
@@ -5715,22 +5683,17 @@ struct WebViewRepresentable: NSViewRepresentable {
 
     private static func applyWebViewFirstResponderPolicy(
         panel: BrowserPanel,
-        webView: WKWebView,
         isPanelFocused: Bool
     ) {
-        guard let cmuxWebView = webView as? CmuxWebView else { return }
         let next = isPanelFocused && !panel.shouldSuppressWebViewFocus()
-        if cmuxWebView.allowsFirstResponderAcquisition != next {
 #if DEBUG
-            dlog(
-                "browser.focus.policy panel=\(panel.id.uuidString.prefix(5)) " +
-                "web=\(ObjectIdentifier(cmuxWebView)) old=\(cmuxWebView.allowsFirstResponderAcquisition ? 1 : 0) " +
-                "new=\(next ? 1 : 0) isPanelFocused=\(isPanelFocused ? 1 : 0) " +
-                "suppress=\(panel.shouldSuppressWebViewFocus() ? 1 : 0)"
-            )
+        dlog(
+            "browser.focus.policy panel=\(panel.id.uuidString.prefix(5)) " +
+            "new=\(next ? 1 : 0) isPanelFocused=\(isPanelFocused ? 1 : 0) " +
+            "suppress=\(panel.shouldSuppressWebViewFocus() ? 1 : 0)"
+        )
 #endif
-        }
-        cmuxWebView.allowsFirstResponderAcquisition = next
+        panel.syncSurfaceFirstResponderAcquisitionPolicy(isPanelFocused: isPanelFocused)
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -954,12 +954,12 @@ struct BrowserPanelView: View {
     }
 
     private func shouldApplyAddressBarExitFallback(in window: NSWindow) -> Bool {
-        panel.surfaceWindow() === window && isPanelFocusedInModel()
+        panel.surfaceHostingWindow() === window && isPanelFocusedInModel()
     }
 
 #if DEBUG
     private func browserFocusWindow() -> NSWindow? {
-        panel.surfaceWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
+        panel.effectiveSurfaceWindow()
     }
 
     private func browserFocusResponderDescription(_ responder: NSResponder?) -> String {
@@ -5628,7 +5628,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         isPanelFocused: Bool
     ) {
         // Focus handling. Avoid fighting the address bar when it is focused.
-        guard let window = panel.surfaceWindow() ?? panel.portalAnchorView.window ?? nsView.window else {
+        guard let window = panel.surfaceHostingWindow() ?? nsView.window else {
 #if DEBUG
             dlog(
                 "browser.focus.content.apply panel=\(panel.id.uuidString.prefix(5)) " +

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -997,7 +997,7 @@ struct BrowserPanelView: View {
     private func isCommandPaletteVisibleForPanelWindow() -> Bool {
         guard let app = AppDelegate.shared else { return false }
 
-        if let window = panel.surfaceWindow(), app.isCommandPaletteVisible(for: window) {
+        if let window = panel.surfaceHostingWindow(), app.isCommandPaletteVisible(for: window) {
             return true
         }
 
@@ -1525,7 +1525,7 @@ struct BrowserPanelView: View {
             syncWebViewResponderPolicyWithViewState(reason: "effects.blurToWebView.preHandoff")
             setAddressBarFocused(false, reason: "effects.blurToWebView")
             DispatchQueue.main.async {
-                guard let window = panel.surfaceWindow(),
+                guard let window = panel.surfaceHostingWindow(),
                       !panel.isSurfaceHiddenOrHasHiddenAncestor() else { return }
                 guard shouldApplyAddressBarExitFallback(in: window) else {
 #if DEBUG

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3845,15 +3845,7 @@ final class Workspace: Identifiable, ObservableObject {
             let selectionConverged =
                 self.bonsplitController.focusedPaneId == paneId &&
                 self.bonsplitController.selectedTab(inPane: paneId)?.id == tabId
-            let anchorReady: Bool = {
-                guard let browserPanel = self.browserPanel(for: panelId) else { return false }
-                let anchorView = browserPanel.portalAnchorView
-                return
-                    anchorView.window != nil &&
-                    anchorView.superview != nil &&
-                    anchorView.bounds.width > 1 &&
-                    anchorView.bounds.height > 1
-            }()
+            let anchorReady = self.browserPanel(for: panelId)?.isSurfacePortalAnchorReady() ?? false
 
             if !selectionConverged {
                 self.focusPanel(panelId)
@@ -4398,7 +4390,7 @@ extension Workspace: BonsplitDelegate {
             return terminalPanel.hostedView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
         if let browserPanel = panel as? BrowserPanel {
-            return browserPanel.surfaceWindow() ?? browserPanel.portalAnchorView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            return browserPanel.surfaceHostingWindow() ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
         return NSApp.keyWindow ?? NSApp.mainWindow
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3481,10 +3481,7 @@ final class Workspace: Identifiable, ObservableObject {
     func hideAllBrowserPortalViews() {
         for panel in panels.values {
             guard let browser = panel as? BrowserPanel else { continue }
-            BrowserWindowPortalRegistry.hide(
-                webView: browser.webView,
-                source: "workspaceRetire"
-            )
+            browser.hideSurfacePortal(source: "workspaceRetire")
         }
     }
 
@@ -3763,34 +3760,11 @@ final class Workspace: Identifiable, ObservableObject {
             guard let browserPanel = panel as? BrowserPanel else { continue }
             let shouldBeVisible = visiblePanelIds.contains(browserPanel.id)
             if shouldBeVisible {
-                BrowserWindowPortalRegistry.updateEntryVisibility(
-                    for: browserPanel.webView,
-                    visibleInUI: true,
-                    zPriority: 2
-                )
-                let anchorView = browserPanel.portalAnchorView
-                let anchorReady =
-                    anchorView.window != nil &&
-                    anchorView.superview != nil &&
-                    anchorView.bounds.width > 1 &&
-                    anchorView.bounds.height > 1
-                if anchorReady {
-                    BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)
-                    BrowserWindowPortalRegistry.refresh(
-                        webView: browserPanel.webView,
-                        reason: reason
-                    )
-                }
+                browserPanel.updateSurfacePortalVisibility(visibleInUI: true, zPriority: 2)
+                _ = browserPanel.refreshSurfacePortalIfAnchorReady(reason: reason)
             } else {
-                BrowserWindowPortalRegistry.updateEntryVisibility(
-                    for: browserPanel.webView,
-                    visibleInUI: false,
-                    zPriority: 0
-                )
-                BrowserWindowPortalRegistry.hide(
-                    webView: browserPanel.webView,
-                    source: reason
-                )
+                browserPanel.updateSurfacePortalVisibility(visibleInUI: false, zPriority: 0)
+                browserPanel.hideSurfacePortal(source: reason)
             }
         }
     }
@@ -3801,13 +3775,7 @@ final class Workspace: Identifiable, ObservableObject {
         for panel in panels.values {
             guard let browserPanel = panel as? BrowserPanel else { continue }
             guard visiblePanelIds.contains(browserPanel.id) else { continue }
-            let anchorView = browserPanel.portalAnchorView
-            let anchorReady =
-                anchorView.window != nil &&
-                anchorView.superview != nil &&
-                anchorView.bounds.width > 1 &&
-                anchorView.bounds.height > 1
-            if !anchorReady || !browserPanel.isSurfaceHostedInWindowPortal() {
+            if !browserPanel.isSurfacePortalAnchorReady() || !browserPanel.isSurfaceHostedInWindowPortal() {
                 return true
             }
         }
@@ -3851,22 +3819,10 @@ final class Workspace: Identifiable, ObservableObject {
                 window.contentView?.displayIfNeeded()
             }
 
-            let anchorView = browserPanel.portalAnchorView
-            let anchorReady =
-                anchorView.window != nil &&
-                anchorView.superview != nil &&
-                anchorView.bounds.width > 1 &&
-                anchorView.bounds.height > 1
-
-            if anchorReady {
-                BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)
-                BrowserWindowPortalRegistry.refresh(
-                    webView: browserPanel.webView,
-                    reason: "workspace.toggleSplitZoom"
-                )
-            }
-
-            let portalNeedsFollowUpPass = !anchorReady || !browserPanel.isSurfaceHostedInWindowPortal()
+            let portalRefreshed = browserPanel.refreshSurfacePortalIfAnchorReady(
+                reason: "workspace.toggleSplitZoom"
+            )
+            let portalNeedsFollowUpPass = !portalRefreshed || !browserPanel.isSurfaceHostedInWindowPortal()
             if portalNeedsFollowUpPass {
                 self.scheduleBrowserPortalReconcileAfterSplitZoom(
                     panelId: panelId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -336,7 +336,7 @@ extension Workspace {
             browserSnapshot = SessionBrowserPanelSnapshot(
                 urlString: browserPanel.preferredURLStringForOmnibar(),
                 shouldRenderWebView: browserPanel.shouldRenderWebView,
-                pageZoom: Double(browserPanel.webView.pageZoom),
+                pageZoom: Double(browserPanel.surfacePageZoom()),
                 developerToolsVisible: browserPanel.isDeveloperToolsVisible(),
                 backHistoryURLStrings: historySnapshot.backHistoryURLStrings,
                 forwardHistoryURLStrings: historySnapshot.forwardHistoryURLStrings
@@ -580,7 +580,7 @@ extension Workspace {
 
             let pageZoom = CGFloat(max(0.25, min(5.0, browserSnapshot.pageZoom)))
             if pageZoom.isFinite {
-                browserPanel.webView.pageZoom = pageZoom
+                browserPanel.setSurfacePageZoom(pageZoom)
             }
 
             if browserSnapshot.developerToolsVisible {
@@ -2585,11 +2585,9 @@ final class Workspace: Identifiable, ObservableObject {
                 "hidden=\(hosted.isHidden ? 1 : 0) frame=\(frame) bounds=\(bounds)"
         }
         if let browser = panel as? BrowserPanel {
-            let webView = browser.webView
-            let frame = String(format: "%.1fx%.1f", webView.frame.width, webView.frame.height)
             return
                 "panelState=browser panel=\(panelId.uuidString.prefix(5)) " +
-                "webInWindow=\(webView.window != nil ? 1 : 0) webHasSuperview=\(webView.superview != nil ? 1 : 0) frame=\(frame)"
+                browser.debugSurfaceHostingSummary()
         }
         return "panelState=\(String(describing: type(of: panel))) panel=\(panelId.uuidString.prefix(5))"
     }
@@ -2801,9 +2799,7 @@ final class Workspace: Identifiable, ObservableObject {
             forPaneId: pane.id.uuidString,
             in: bonsplitController.treeSnapshot()
         )
-        let resolvedURL = browserPanel.currentURL
-            ?? browserPanel.webView.url
-            ?? browserPanel.preferredURLStringForOmnibar().flatMap(URL.init(string:))
+        let resolvedURL = browserPanel.resolvedCurrentSurfaceURL()
 
         pendingClosedBrowserRestoreSnapshots[tab.id] = ClosedBrowserPanelRestoreSnapshot(
             workspaceId: id,
@@ -3811,10 +3807,7 @@ final class Workspace: Identifiable, ObservableObject {
                 anchorView.superview != nil &&
                 anchorView.bounds.width > 1 &&
                 anchorView.bounds.height > 1
-            if !anchorReady ||
-                browserPanel.webView.window == nil ||
-                browserPanel.webView.superview == nil ||
-                !BrowserWindowPortalRegistry.isWebView(browserPanel.webView, boundTo: anchorView) {
+            if !anchorReady || !browserPanel.isSurfaceHostedInWindowPortal() {
                 return true
             }
         }
@@ -3873,10 +3866,7 @@ final class Workspace: Identifiable, ObservableObject {
                 )
             }
 
-            let portalNeedsFollowUpPass =
-                !anchorReady ||
-                browserPanel.webView.window == nil ||
-                browserPanel.webView.superview == nil
+            let portalNeedsFollowUpPass = !anchorReady || !browserPanel.isSurfaceHostedInWindowPortal()
             if portalNeedsFollowUpPass {
                 self.scheduleBrowserPortalReconcileAfterSplitZoom(
                     panelId: panelId,
@@ -4452,7 +4442,7 @@ extension Workspace: BonsplitDelegate {
             return terminalPanel.hostedView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
         if let browserPanel = panel as? BrowserPanel {
-            return browserPanel.webView.window ?? browserPanel.portalAnchorView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            return browserPanel.surfaceWindow() ?? browserPanel.portalAnchorView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
         return NSApp.keyWindow ?? NSApp.mainWindow
     }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15156,6 +15156,61 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
     }
 
+    func testBrowserPanelPreferredURLStringForOmnibarUsesRuntimeStateBeforePublishedCurrentURL() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let runtimeURL = URL(string: "https://example.com/runtime-current")!
+
+        runtime.state = BrowserSurfaceRuntimeState(
+            currentURL: runtimeURL,
+            title: nil,
+            isLoading: false,
+            canGoBack: false,
+            canGoForward: false,
+            estimatedProgress: 0,
+            pageZoom: runtime.state.pageZoom
+        )
+
+        XCTAssertNil(panel.currentURL)
+        XCTAssertEqual(panel.preferredURLStringForOmnibar(), runtimeURL.absoluteString)
+    }
+
+    func testBrowserPanelRestoredSessionHistoryUsesRuntimeStateCurrentURL() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let runtimeURL = URL(string: "https://example.com/runtime-current")!
+        let previousURL = URL(string: "https://example.com/runtime-previous")!
+
+        runtime.state = BrowserSurfaceRuntimeState(
+            currentURL: runtimeURL,
+            title: nil,
+            isLoading: false,
+            canGoBack: false,
+            canGoForward: false,
+            estimatedProgress: 0,
+            pageZoom: runtime.state.pageZoom
+        )
+        panel.restoreSessionNavigationHistory(
+            backHistoryURLStrings: [previousURL.absoluteString],
+            forwardHistoryURLStrings: [],
+            currentURLString: nil
+        )
+
+        XCTAssertNil(panel.currentURL)
+        XCTAssertTrue(panel.canGoBack)
+
+        panel.goBack()
+
+        XCTAssertEqual(runtime.loadedRequests.last?.url, previousURL)
+        XCTAssertTrue(panel.canGoForward)
+    }
+
     func testBrowserPanelBackgroundRefreshUsesRuntimeBoundary() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14525,6 +14525,9 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
 
 @MainActor
 final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
+    private final class TestNavigationDelegate: NSObject, WKNavigationDelegate {}
+    private final class TestUIDelegate: NSObject, WKUIDelegate {}
+
     private func assertColorsEqual(
         _ lhs: NSColor?,
         _ rhs: NSColor,
@@ -14609,6 +14612,60 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(replacement.pageZoom, 1.75, accuracy: 0.001)
         XCTAssertEqual(replacement.customUserAgent, replacementConfiguration.customUserAgent)
         assertColorsEqual(replacement.underPageBackgroundColor, replacementConfiguration.underPageBackgroundColor)
+    }
+
+    func testStateObserverReceivesImmediateAndMutatedRuntimeState() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        var observedStates: [BrowserSurfaceRuntimeState] = []
+
+        surface.onStateChange = { state in
+            observedStates.append(state)
+        }
+        surface.setPageZoom(1.4)
+
+        XCTAssertEqual(observedStates.count, 2)
+        XCTAssertEqual(observedStates.first?.currentURL, nil)
+        XCTAssertEqual(observedStates.first?.pageZoom ?? 0, 1.0, accuracy: 0.001)
+        XCTAssertEqual(observedStates.last?.pageZoom ?? 0, 1.4, accuracy: 0.001)
+    }
+
+    func testReplaceWebViewRebindsDelegatesAndDownloadHandler() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        let navigationDelegate = TestNavigationDelegate()
+        let uiDelegate = TestUIDelegate()
+        var downloadStates: [Bool] = []
+
+        surface.configureDelegates(
+            navigationDelegate: navigationDelegate,
+            uiDelegate: uiDelegate
+        )
+        surface.setDownloadStateChangeHandler { downloadStates.append($0) }
+
+        guard let initialWebView = surface.webView as? CmuxWebView else {
+            return XCTFail("Expected CmuxWebView runtime surface")
+        }
+        XCTAssertTrue(initialWebView.navigationDelegate === navigationDelegate)
+        XCTAssertTrue(initialWebView.uiDelegate === uiDelegate)
+        initialWebView.onContextMenuDownloadStateChanged?(true)
+
+        let replacement = surface.replaceWebView(
+            using: makeConfiguration(customUserAgent: "cmux-runtime-test-rebound"),
+            pageZoom: nil
+        )
+        guard let replacementWebView = replacement as? CmuxWebView else {
+            return XCTFail("Expected replacement CmuxWebView runtime surface")
+        }
+
+        XCTAssertTrue(replacementWebView.navigationDelegate === navigationDelegate)
+        XCTAssertTrue(replacementWebView.uiDelegate === uiDelegate)
+        replacementWebView.onContextMenuDownloadStateChanged?(false)
+        XCTAssertEqual(downloadStates, [true, false])
     }
 }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14525,9 +14525,6 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
 
 @MainActor
 final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
-    private final class TestNavigationDelegate: NSObject, WKNavigationDelegate {}
-    private final class TestUIDelegate: NSObject, WKUIDelegate {}
-
     private func assertColorsEqual(
         _ lhs: NSColor?,
         _ rhs: NSColor,
@@ -14632,26 +14629,72 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(observedStates.last?.pageZoom ?? 0, 1.4, accuracy: 0.001)
     }
 
-    func testReplaceWebViewRebindsDelegatesAndDownloadHandler() {
+    func testSurfaceInstallsInternalDelegatesAndForwardsRuntimeEvents() {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
             configuration: makeConfiguration()
         )
-        let navigationDelegate = TestNavigationDelegate()
-        let uiDelegate = TestUIDelegate()
+        var finishedNavigationCount = 0
+        var failedURLs: [String] = []
+        var terminatedProcessCount = 0
+
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                finishedNavigationCount += 1
+            },
+            didFailNavigation: { failedURL in
+                failedURLs.append(failedURL)
+            },
+            didTerminateWebContentProcess: {
+                terminatedProcessCount += 1
+            }
+        )
+
+        guard let navigationDelegate = surface.webView.navigationDelegate else {
+            return XCTFail("Expected runtime to install an internal navigation delegate")
+        }
+        XCTAssertNotNil(surface.webView.uiDelegate, "Expected runtime to install an internal UI delegate")
+
+        let attemptedURL = URL(string: "https://cmux.invalid/runtime")!
+        surface.setLastAttemptedNavigationURL(attemptedURL)
+        navigationDelegate.webView?(surface.webView, didFinish: nil)
+        navigationDelegate.webView?(
+            surface.webView,
+            didFailProvisionalNavigation: nil,
+            withError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
+        )
+        navigationDelegate.webViewWebContentProcessDidTerminate?(surface.webView)
+
+        XCTAssertEqual(finishedNavigationCount, 1)
+        XCTAssertEqual(failedURLs, [attemptedURL.absoluteString])
+        XCTAssertEqual(terminatedProcessCount, 1)
+    }
+
+    func testReplaceWebViewRebindsInternalDelegatesAndDownloadHandler() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        var finishedNavigationCount = 0
         var downloadStates: [Bool] = []
 
-        surface.configureDelegates(
-            navigationDelegate: navigationDelegate,
-            uiDelegate: uiDelegate
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                finishedNavigationCount += 1
+            },
+            downloadStateChanged: { isDownloading in
+                downloadStates.append(isDownloading)
+            }
         )
-        surface.setDownloadStateChangeHandler { downloadStates.append($0) }
 
         guard let initialWebView = surface.webView as? CmuxWebView else {
             return XCTFail("Expected CmuxWebView runtime surface")
         }
-        XCTAssertTrue(initialWebView.navigationDelegate === navigationDelegate)
-        XCTAssertTrue(initialWebView.uiDelegate === uiDelegate)
+        guard let initialNavigationDelegate = initialWebView.navigationDelegate else {
+            return XCTFail("Expected initial runtime navigation delegate")
+        }
+        XCTAssertNotNil(initialWebView.uiDelegate, "Expected initial runtime UI delegate")
+        initialNavigationDelegate.webView?(initialWebView, didFinish: nil)
         initialWebView.onContextMenuDownloadStateChanged?(true)
 
         let replacement = surface.replaceWebView(
@@ -14662,9 +14705,16 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
             return XCTFail("Expected replacement CmuxWebView runtime surface")
         }
 
-        XCTAssertTrue(replacementWebView.navigationDelegate === navigationDelegate)
-        XCTAssertTrue(replacementWebView.uiDelegate === uiDelegate)
+        XCTAssertNil(initialWebView.navigationDelegate)
+        XCTAssertNil(initialWebView.uiDelegate)
+        XCTAssertNil(initialWebView.onContextMenuDownloadStateChanged)
+        guard let replacementNavigationDelegate = replacementWebView.navigationDelegate else {
+            return XCTFail("Expected replacement runtime navigation delegate")
+        }
+        XCTAssertNotNil(replacementWebView.uiDelegate, "Expected replacement runtime UI delegate")
+        replacementNavigationDelegate.webView?(replacementWebView, didFinish: nil)
         replacementWebView.onContextMenuDownloadStateChanged?(false)
+        XCTAssertEqual(finishedNavigationCount, 2)
         XCTAssertEqual(downloadStates, [true, false])
     }
 }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15834,6 +15834,52 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertTrue(runtime.lastOwnedResponder === responder)
     }
 
+    func testBrowserPanelTransientDeveloperToolsHidePreflightUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panelWindow = NSWindow()
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let responder = NSView()
+        responder.frame = contentView.bounds
+        panelWindow.contentView = contentView
+        contentView.addSubview(responder)
+        XCTAssertTrue(panelWindow.makeFirstResponder(responder))
+
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        let result = panel.prepareSurfaceFocusForTransientDeveloperToolsHide(in: panelWindow)
+
+        XCTAssertTrue(result.movedToSurface)
+        XCTAssertFalse(result.movedToNil)
+        XCTAssertEqual(runtime.focusSurfaceCallCount, 1)
+    }
+
+    func testBrowserPanelTransientDeveloperToolsHidePreflightFallsBackToNilResponder() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.focusSurfaceResult = false
+        let panelWindow = NSWindow()
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let responder = NSView()
+        responder.frame = contentView.bounds
+        panelWindow.contentView = contentView
+        contentView.addSubview(responder)
+        XCTAssertTrue(panelWindow.makeFirstResponder(responder))
+
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        let result = panel.prepareSurfaceFocusForTransientDeveloperToolsHide(in: panelWindow)
+
+        XCTAssertFalse(result.movedToSurface)
+        XCTAssertTrue(result.movedToNil)
+        XCTAssertEqual(runtime.focusSurfaceCallCount, 1)
+        XCTAssertFalse(panelWindow.firstResponder === responder)
+    }
+
     func testBrowserPanelResponderPolicyUsesRuntimeBoundary() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14525,6 +14525,60 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
 
 @MainActor
 final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
+    private final class RuntimeFakeInspector: NSObject {
+        enum HideBehavior {
+            case hides
+            case noEffect
+        }
+
+        private let hideBehavior: HideBehavior
+        private var visible = false
+        private(set) var attachCount = 0
+        private(set) var showCount = 0
+        private(set) var hideCount = 0
+        private(set) var closeCount = 0
+        private(set) var showConsoleCount = 0
+
+        init(hideBehavior: HideBehavior = .hides) {
+            self.hideBehavior = hideBehavior
+            super.init()
+        }
+
+        @objc func isVisible() -> Bool {
+            visible
+        }
+
+        @objc func attach() {
+            attachCount += 1
+        }
+
+        @objc func show() {
+            showCount += 1
+            visible = true
+        }
+
+        @objc func hide() {
+            hideCount += 1
+            if hideBehavior == .hides {
+                visible = false
+            }
+        }
+
+        @objc func close() {
+            closeCount += 1
+            visible = false
+        }
+
+        @objc func showConsole() {
+            showConsoleCount += 1
+        }
+    }
+
+    override class func setUp() {
+        super.setUp()
+        installCmuxUnitTestInspectorOverride()
+    }
+
     private func assertColorsEqual(
         _ lhs: NSColor?,
         _ rhs: NSColor,
@@ -14809,6 +14863,29 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(requestedURLs, [expectedIconURL, expectedIconURL])
     }
 
+    func testDeveloperToolsAdapterUsesRuntimeOwnedInspectorOperations() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        let inspector = RuntimeFakeInspector(hideBehavior: .noEffect)
+        surface.webView.cmuxSetUnitTestInspector(inspector)
+
+        XCTAssertEqual(surface.developerToolsVisibilityState(), .hidden)
+        XCTAssertTrue(surface.revealDeveloperTools(attachIfNeeded: true))
+        XCTAssertEqual(surface.developerToolsVisibilityState(), .visible)
+        XCTAssertEqual(inspector.attachCount, 1)
+        XCTAssertEqual(inspector.showCount, 1)
+
+        surface.showDeveloperToolsConsole()
+        XCTAssertEqual(inspector.showConsoleCount, 1)
+
+        XCTAssertTrue(surface.concealDeveloperTools())
+        XCTAssertEqual(surface.developerToolsVisibilityState(), .hidden)
+        XCTAssertEqual(inspector.hideCount, 1)
+        XCTAssertEqual(inspector.closeCount, 1)
+    }
+
     func testStateObserverReceivesImmediateAndMutatedRuntimeState() {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -14937,10 +15014,15 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var restoreAddressBarPageFocusCallCount = 0
         private(set) var invalidateFaviconCacheCallCount = 0
         private(set) var fetchFaviconPNGDataCallCount = 0
+        private(set) var revealDeveloperToolsCallCount = 0
+        private(set) var concealDeveloperToolsCallCount = 0
+        private(set) var showDeveloperToolsConsoleCallCount = 0
+        private(set) var lastRevealDeveloperToolsAttachIfNeeded: Bool?
         var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
         var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
         var fetchedFaviconPNGData: Data?
         var onFetchFaviconPNGData: (() -> Void)?
+        var currentDeveloperToolsVisibilityState: BrowserSurfaceDeveloperToolsVisibilityState = .unavailable
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -15064,6 +15146,31 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             return fetchedFaviconPNGData
         }
 
+        func developerToolsVisibilityState() -> BrowserSurfaceDeveloperToolsVisibilityState {
+            currentDeveloperToolsVisibilityState
+        }
+
+        @discardableResult
+        func revealDeveloperTools(attachIfNeeded: Bool) -> Bool {
+            revealDeveloperToolsCallCount += 1
+            lastRevealDeveloperToolsAttachIfNeeded = attachIfNeeded
+            guard currentDeveloperToolsVisibilityState != .unavailable else { return false }
+            currentDeveloperToolsVisibilityState = .visible
+            return true
+        }
+
+        @discardableResult
+        func concealDeveloperTools() -> Bool {
+            concealDeveloperToolsCallCount += 1
+            guard currentDeveloperToolsVisibilityState != .unavailable else { return false }
+            currentDeveloperToolsVisibilityState = .hidden
+            return true
+        }
+
+        func showDeveloperToolsConsole() {
+            showDeveloperToolsConsoleCallCount += 1
+        }
+
         func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
             ([], [])
         }
@@ -15176,6 +15283,96 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         XCTAssertNil(panel.currentURL)
         XCTAssertEqual(panel.preferredURLStringForOmnibar(), runtimeURL.absoluteString)
+    }
+
+    func testBrowserPanelKeepsExistingTitleDuringLoadingWhenRuntimeTitleIsEmpty() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: "https://example.com/original"),
+                title: "Original Title",
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: "https://example.com/reload"),
+                title: nil,
+                isLoading: true,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0.3,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+
+        XCTAssertEqual(panel.pageTitle, "Original Title")
+    }
+
+    func testBrowserPanelClearsStaleTitleAfterFinishedUntitledNavigation() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: "https://example.com/original"),
+                title: "Original Title",
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+        runtime.state = BrowserSurfaceRuntimeState(
+            currentURL: URL(string: "https://example.com/untitled"),
+            title: nil,
+            isLoading: false,
+            canGoBack: false,
+            canGoForward: false,
+            estimatedProgress: 1.0,
+            pageZoom: runtime.state.pageZoom
+        )
+
+        runtime.eventHandlers.didFinishNavigation?()
+
+        XCTAssertEqual(panel.pageTitle, "")
+    }
+
+    func testBrowserPanelKeepsFailedURLTitleWhenRuntimeStateTitleIsEmpty() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let failedURL = "https://example.com/failed"
+
+        runtime.eventHandlers.didFailNavigation?(failedURL)
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: nil,
+                title: nil,
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+
+        XCTAssertEqual(panel.pageTitle, failedURL)
     }
 
     func testBrowserPanelRestoredSessionHistoryUsesRuntimeStateCurrentURL() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15190,6 +15190,8 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var lastCustomUserAgent: String?
         private(set) var lastUnderPageBackgroundColor: NSColor?
         private(set) var loadedRequests: [URLRequest] = []
+        private(set) var replaceWebViewCallCount = 0
+        private(set) var lastReplaceWebViewPageZoom: CGFloat?
         private(set) var stopLoadingCallCount = 0
         private(set) var captureAddressBarPageFocusCallCount = 0
         private(set) var restoreAddressBarPageFocusCallCount = 0
@@ -15252,6 +15254,8 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             using configuration: BrowserRuntimeSurfaceConfiguration,
             pageZoom: CGFloat?
         ) -> WKWebView {
+            replaceWebViewCallCount += 1
+            lastReplaceWebViewPageZoom = pageZoom
             let replacement = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
             if let pageZoom {
                 replacement.pageZoom = pageZoom
@@ -15542,6 +15546,26 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(lastAttemptedNavigationURL, url)
         XCTAssertEqual(loadedRequestURL, url)
         XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
+    }
+
+    func testBrowserPanelProcessTerminationReplacementUsesRuntimeStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let initialURL = URL(string: "https://example.com/initial")!
+        let replacementURL = URL(string: "https://example.com/runtime-current")!
+
+        panel.navigate(to: initialURL, recordTypedNavigation: false)
+        runtime.state = makeRuntimeState(currentURL: replacementURL, pageZoom: 1.6)
+
+        runtime.eventHandlers.didTerminateWebContentProcess?()
+
+        XCTAssertEqual(runtime.stopLoadingCallCount, 1)
+        XCTAssertEqual(runtime.replaceWebViewCallCount, 1)
+        XCTAssertEqual(runtime.lastReplaceWebViewPageZoom ?? 0, 1.6, accuracy: 0.001)
+        XCTAssertEqual(runtime.loadedRequests.last?.url, replacementURL)
     }
 
     func testBrowserPanelFocusUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14778,6 +14778,7 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
 
         let attachedState = surface.developerToolsHostState()
         XCTAssertTrue(attachedState.hasAttachedInspectorLayout)
+        XCTAssertFalse(attachedState.hasSideDockedInspectorLayout)
         XCTAssertEqual(attachedState.detachedWindowCount, baselineDetachedWindowCount)
 
         let detachedWindow = NSWindow(
@@ -14802,8 +14803,32 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
 
         let detachedState = surface.developerToolsHostState()
         XCTAssertTrue(detachedState.hasAttachedInspectorLayout)
+        XCTAssertFalse(detachedState.hasSideDockedInspectorLayout)
         XCTAssertEqual(detachedState.detachedWindowCount, baselineDetachedWindowCount + 1)
         XCTAssertTrue(detachedState.hasDetachedInspectorWindows)
+    }
+
+    func testDeveloperToolsHostStateDetectsSideDockedInspectorLayout() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        surface.webView.frame = NSRect(x: 0, y: 0, width: 120, height: host.bounds.height)
+        host.addSubview(surface.webView)
+
+        let inspectorContainer = NSView(
+            frame: NSRect(x: 120, y: 0, width: host.bounds.width - 120, height: host.bounds.height)
+        )
+        let inspectorView = RuntimeWKInspectorProbeView(frame: inspectorContainer.bounds)
+        inspectorView.autoresizingMask = [.width, .height]
+        inspectorContainer.addSubview(inspectorView)
+        host.addSubview(inspectorContainer)
+
+        let hostState = surface.developerToolsHostState()
+        XCTAssertTrue(hostState.hasAttachedInspectorLayout)
+        XCTAssertTrue(hostState.hasSideDockedInspectorLayout)
     }
 
     func testReplaceWebViewCreatesNewInstanceAndPreservesRequestedPageZoom() {
@@ -15754,6 +15779,31 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             detachedWindowCount: 0
         )
         XCTAssertTrue(panel.shouldUseLocalInlineDeveloperToolsHosting())
+    }
+
+    func testBrowserPanelTransientHideAttachmentPreserveUsesRuntimeHostStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .hidden
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: true,
+            detachedWindowCount: 0,
+            hasSideDockedInspectorLayout: false
+        )
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
+
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: true,
+            detachedWindowCount: 0,
+            hasSideDockedInspectorLayout: true
+        )
+
+        XCTAssertFalse(panel.shouldPreserveWebViewAttachmentDuringTransientHide())
     }
 
     func testBrowserPanelDismissesDetachedDeveloperToolsWindowsThroughRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14725,6 +14725,38 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         )
     }
 
+    func testSurfaceFocusAndResponderOwnershipRoundTripThroughRuntime() {
+        _ = NSApplication.shared
+
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+        surface.webView.frame = container.bounds
+        surface.webView.autoresizingMask = [.width, .height]
+        container.addSubview(surface.webView)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        drainMainQueue()
+
+        XCTAssertTrue(window.makeFirstResponder(nil))
+        XCTAssertFalse(surface.ownsResponder(window.firstResponder))
+
+        XCTAssertTrue(surface.focusSurface())
+        XCTAssertTrue(surface.ownsResponder(window.firstResponder))
+
+        XCTAssertTrue(surface.unfocusSurface())
+        XCTAssertFalse(surface.ownsResponder(window.firstResponder))
+    }
+
     func testDeveloperToolsHostStateReflectsAttachedInspectorLayoutAndDetachedWindows() {
         _ = NSApplication.shared
 
@@ -15146,6 +15178,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var concealDeveloperToolsCallCount = 0
         private(set) var showDeveloperToolsConsoleCallCount = 0
         private(set) var dismissDetachedDeveloperToolsWindowsCallCount = 0
+        private(set) var ownsResponderCallCount = 0
+        private(set) var focusSurfaceCallCount = 0
+        private(set) var unfocusSurfaceCallCount = 0
+        private(set) var lastOwnedResponder: NSResponder?
         private(set) var lastRevealDeveloperToolsAttachIfNeeded: Bool?
         var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
         var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
@@ -15163,6 +15199,9 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             hasAttachedInspectorLayout: false,
             detachedWindowCount: 0
         )
+        var ownsResponderResult = false
+        var focusSurfaceResult = true
+        var unfocusSurfaceResult = true
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -15350,6 +15389,24 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             )
         }
 
+        func ownsResponder(_ responder: NSResponder?) -> Bool {
+            ownsResponderCallCount += 1
+            lastOwnedResponder = responder
+            return ownsResponderResult
+        }
+
+        @discardableResult
+        func focusSurface() -> Bool {
+            focusSurfaceCallCount += 1
+            return focusSurfaceResult
+        }
+
+        @discardableResult
+        func unfocusSurface() -> Bool {
+            unfocusSurfaceCallCount += 1
+            return unfocusSurfaceResult
+        }
+
         func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
             ([], [])
         }
@@ -15460,6 +15517,72 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(lastAttemptedNavigationURL, url)
         XCTAssertEqual(loadedRequestURL, url)
         XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
+    }
+
+    func testBrowserPanelFocusUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.state = makeRuntimeState(currentURL: URL(string: "https://example.com/runtime-focus"))
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.focus()
+
+        XCTAssertEqual(runtime.focusSurfaceCallCount, 1)
+    }
+
+    func testBrowserPanelUnfocusUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.unfocus()
+
+        XCTAssertEqual(runtime.unfocusSurfaceCallCount, 1)
+    }
+
+    func testBrowserPanelCaptureFocusIntentUsesRuntimeOwnershipBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.ownsResponderResult = true
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow()
+
+        XCTAssertEqual(panel.captureFocusIntent(in: window), .browser(.webView))
+        XCTAssertEqual(runtime.ownsResponderCallCount, 1)
+        XCTAssertNotNil(runtime.lastOwnedResponder)
+    }
+
+    func testBrowserPanelOwnedFocusIntentUsesRuntimeOwnershipBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.ownsResponderResult = true
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow()
+        let responder = NSTextView()
+
+        XCTAssertEqual(panel.ownedFocusIntent(for: responder, in: window), .browser(.webView))
+        XCTAssertEqual(runtime.ownsResponderCallCount, 1)
+        XCTAssertTrue(runtime.lastOwnedResponder === responder)
+    }
+
+    func testBrowserPanelYieldWebViewFocusUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow()
+
+        XCTAssertTrue(panel.yieldFocusIntent(.browser(.webView), in: window))
+        XCTAssertEqual(runtime.unfocusSurfaceCallCount, 1)
     }
 
     func testBrowserPanelFindUsesRuntimeBoundary() async {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15806,11 +15806,33 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         )
 
         XCTAssertTrue(panel.surfaceWindow() === panelWindow)
+        XCTAssertTrue(panel.surfaceHostingWindow() === panelWindow)
         XCTAssertEqual(panel.effectiveSurfaceWindow(), panelWindow)
         XCTAssertEqual(panel.surfaceFrameInWindowCoordinates(), panelFrame)
         XCTAssertTrue(panel.isSurfaceHiddenOrHasHiddenAncestor())
         XCTAssertTrue(panel.isSurfaceBlankForAutofocus())
         XCTAssertTrue(panel.isSurfaceLoadingNow())
+    }
+
+    func testBrowserPanelSurfaceHostingWindowFallsBackToPortalAnchorWindow() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        host.autoresizingMask = [.width, .height]
+        host.addSubview(panel.portalAnchorView)
+        window.contentView = host
+
+        XCTAssertNil(panel.surfaceWindow())
+        XCTAssertTrue(panel.surfaceHostingWindow() === window)
     }
 
     func testBrowserPanelSurfaceFocusStateUsesRuntimeBoundary() {
@@ -15829,6 +15851,31 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         )
 
         XCTAssertTrue(panelWindow.makeFirstResponder(responder))
+        XCTAssertTrue(panel.isSurfaceFocusedInHostWindow())
+        XCTAssertEqual(runtime.ownsResponderCallCount, 1)
+        XCTAssertTrue(runtime.lastOwnedResponder === responder)
+    }
+
+    func testBrowserPanelSurfaceFocusStateFallsBackToPortalAnchorWindow() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.ownsResponderResult = true
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 140),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentView?.bounds ?? .zero)
+        let responder = NSView(frame: contentView.bounds)
+        contentView.addSubview(panel.portalAnchorView)
+        contentView.addSubview(responder)
+        window.contentView = contentView
+
+        XCTAssertTrue(window.makeFirstResponder(responder))
         XCTAssertTrue(panel.isSurfaceFocusedInHostWindow())
         XCTAssertEqual(runtime.ownsResponderCallCount, 1)
         XCTAssertTrue(runtime.lastOwnedResponder === responder)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15880,6 +15880,45 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertFalse(panelWindow.firstResponder === responder)
     }
 
+    func testBrowserPanelSurfacePageZoomUsesRuntimeState() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.state = makeRuntimeState(pageZoom: 1.65)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertEqual(panel.surfacePageZoom(), 1.65, accuracy: 0.001)
+    }
+
+    func testBrowserPanelDebugPortalSnapshotUsesPanelSurface() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        host.autoresizingMask = [.width, .height]
+        let anchor = NSView(frame: NSRect(x: 20, y: 30, width: 140, height: 90))
+        host.addSubview(anchor)
+        window.contentView = host
+
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: anchor, visibleInUI: true, zPriority: 1)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+        defer { BrowserWindowPortalRegistry.detach(webView: panel.webView) }
+
+        let snapshot = panel.debugPortalSnapshot()
+
+        XCTAssertEqual(snapshot?.visibleInUI, true)
+        XCTAssertEqual(snapshot?.containerHidden, false)
+        XCTAssertEqual(snapshot?.frameInWindow.origin.x ?? 0, 20, accuracy: 0.5)
+        XCTAssertEqual(snapshot?.frameInWindow.origin.y ?? 0, 30, accuracy: 0.5)
+        XCTAssertEqual(snapshot?.frameInWindow.width ?? 0, 140, accuracy: 0.5)
+        XCTAssertEqual(snapshot?.frameInWindow.height ?? 0, 90, accuracy: 0.5)
+    }
+
     func testBrowserPanelResponderPolicyUsesRuntimeBoundary() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15263,6 +15263,39 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
     }
 
+    func testBrowserPanelDeveloperToolsVisibilityUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .hidden
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertEqual(runtime.revealDeveloperToolsCallCount, 1)
+        XCTAssertEqual(runtime.lastRevealDeveloperToolsAttachIfNeeded, true)
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        XCTAssertTrue(panel.hideDeveloperTools())
+        XCTAssertEqual(runtime.concealDeveloperToolsCallCount, 1)
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+    }
+
+    func testBrowserPanelDeveloperToolsConsoleUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .visible
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.showDeveloperToolsConsole())
+        XCTAssertEqual(runtime.revealDeveloperToolsCallCount, 0)
+        XCTAssertEqual(runtime.showDeveloperToolsConsoleCallCount, 1)
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+    }
+
     func testBrowserPanelPreferredURLStringForOmnibarUsesRuntimeStateBeforePublishedCurrentURL() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14557,6 +14557,39 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         )
     }
 
+    private func makePNGData(
+        color: NSColor = .systemBlue,
+        size: Int = 24
+    ) throws -> Data {
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: size,
+            pixelsHigh: size,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            XCTFail("Expected bitmap rep")
+            throw NSError(domain: "cmuxTests", code: 1)
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        color.setFill()
+        NSRect(x: 0, y: 0, width: size, height: size).fill()
+
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            XCTFail("Expected PNG data")
+            throw NSError(domain: "cmuxTests", code: 2)
+        }
+        return data
+    }
+
     func testFactoryUsesSharedProcessPoolAcrossSurfaces() {
         let factory = LocalWebKitBrowserSurfaceRuntimeFactory.shared
 
@@ -14725,6 +14758,57 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(selectionEndValue?.intValue, 4)
     }
 
+    func testFetchFaviconPNGDataUsesRuntimeIconDiscoveryAndCacheInvalidation() async throws {
+        let expectedIconURL = URL(string: "https://example.com/icons/runtime-64.png")!
+        let iconData = try makePNGData()
+        var requestedURLs: [URL] = []
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration(scriptSources: []),
+            faviconDataLoader: { request in
+                requestedURLs.append(try XCTUnwrap(request.url))
+                let response = try XCTUnwrap(
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )
+                )
+                return (iconData, response)
+            }
+        )
+        let navigationFinished = expectation(description: "favicon page loaded")
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                navigationFinished.fulfill()
+            }
+        )
+
+        surface.loadHTMLString(
+            """
+            <html>
+            <head>
+            <link rel="icon" href="\(expectedIconURL.absoluteString)" sizes="64x64" />
+            </head>
+            <body>favicon</body>
+            </html>
+            """,
+            baseURL: URL(string: "https://example.com/page")!
+        )
+        await fulfillment(of: [navigationFinished], timeout: 5)
+
+        let firstFetch = await surface.fetchFaviconPNGData()
+        let secondFetch = await surface.fetchFaviconPNGData()
+        surface.invalidateFaviconCache()
+        let thirdFetch = await surface.fetchFaviconPNGData()
+
+        XCTAssertNotNil(firstFetch)
+        XCTAssertNil(secondFetch)
+        XCTAssertNotNil(thirdFetch)
+        XCTAssertEqual(requestedURLs, [expectedIconURL, expectedIconURL])
+    }
+
     func testStateObserverReceivesImmediateAndMutatedRuntimeState() {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -14851,8 +14935,12 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var stopLoadingCallCount = 0
         private(set) var captureAddressBarPageFocusCallCount = 0
         private(set) var restoreAddressBarPageFocusCallCount = 0
+        private(set) var invalidateFaviconCacheCallCount = 0
+        private(set) var fetchFaviconPNGDataCallCount = 0
         var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
         var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
+        var fetchedFaviconPNGData: Data?
+        var onFetchFaviconPNGData: (() -> Void)?
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -14966,8 +15054,23 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             completion(status)
         }
 
+        func invalidateFaviconCache() {
+            invalidateFaviconCacheCallCount += 1
+        }
+
+        func fetchFaviconPNGData() async -> Data? {
+            fetchFaviconPNGDataCallCount += 1
+            onFetchFaviconPNGData?()
+            return fetchedFaviconPNGData
+        }
+
         func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
             ([], [])
+        }
+
+        func emitState(_ state: BrowserSurfaceRuntimeState) {
+            self.state = state
+            onStateChange?(state)
         }
     }
 
@@ -15076,6 +15179,50 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             updatedColor.withAlphaComponent(updatedOpacity)
         )
         _ = panel
+    }
+
+    func testBrowserPanelDidFinishNavigationFetchesFaviconThroughRuntime() async {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let expectedPNG = Data([0x89, 0x50, 0x4E, 0x47])
+        runtime.fetchedFaviconPNGData = expectedPNG
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let fetchedFavicon = expectation(description: "favicon fetched")
+        runtime.onFetchFaviconPNGData = {
+            fetchedFavicon.fulfill()
+        }
+
+        runtime.eventHandlers.didFinishNavigation?()
+        await fulfillment(of: [fetchedFavicon], timeout: 1)
+        await Task.yield()
+
+        XCTAssertEqual(runtime.fetchFaviconPNGDataCallCount, 1)
+        XCTAssertEqual(panel.faviconPNGData, expectedPNG)
+    }
+
+    func testBrowserPanelLoadingStartInvalidatesRuntimeFaviconCache() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: "https://example.com/favicon")!,
+                title: "Example",
+                isLoading: true,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0.2,
+                pageZoom: 1.0
+            )
+        )
+
+        XCTAssertEqual(runtime.invalidateFaviconCacheCallCount, 1)
+        XCTAssertNil(panel.faviconPNGData)
     }
 
     func testBrowserPanelAddressBarSuppressionCapturesPageFocusViaRuntimeOnce() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14647,6 +14647,84 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(replacement.appearance?.bestMatch(from: [.darkAqua, .aqua]), .darkAqua)
     }
 
+    func testAddressBarPageFocusCaptureAndRestoreRoundTripsThroughRuntime() async throws {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration(scriptSources: [])
+        )
+        let navigationFinished = expectation(description: "address bar focus page loaded")
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                navigationFinished.fulfill()
+            }
+        )
+
+        surface.loadHTMLString(
+            """
+            <html><body>
+            <input id="field" value="hello" />
+            <input id="other" value="world" />
+            </body></html>
+            """,
+            baseURL: nil
+        )
+        await fulfillment(of: [navigationFinished], timeout: 5)
+
+        _ = try await surface.evaluateJavaScript(
+            """
+            const field = document.getElementById('field');
+            field.focus();
+            field.setSelectionRange(1, 4);
+            true;
+            """
+        )
+
+        let captureFinished = expectation(description: "captured page focus")
+        var captureStatus: BrowserAddressBarPageFocusCaptureStatus?
+        surface.captureAddressBarPageFocus { status in
+            captureStatus = status
+            captureFinished.fulfill()
+        }
+        await fulfillment(of: [captureFinished], timeout: 5)
+
+        guard case .captured(let capturedIdentifier)? = captureStatus else {
+            return XCTFail("Expected runtime to capture an editable page focus target")
+        }
+        XCTAssertFalse(capturedIdentifier.isEmpty)
+
+        _ = try await surface.evaluateJavaScript(
+            """
+            const other = document.getElementById('other');
+            other.focus();
+            true;
+            """
+        )
+
+        let restoreFinished = expectation(description: "restored page focus")
+        var restoreStatus: BrowserAddressBarPageFocusRestoreStatus?
+        surface.restoreAddressBarPageFocus { status in
+            restoreStatus = status
+            restoreFinished.fulfill()
+        }
+        await fulfillment(of: [restoreFinished], timeout: 5)
+
+        XCTAssertEqual(restoreStatus, .restored)
+
+        let activeElementID = try await surface.evaluateJavaScript(
+            "document.activeElement && document.activeElement.id"
+        ) as? String
+        let selectionStartValue = try await surface.evaluateJavaScript(
+            "document.getElementById('field').selectionStart"
+        ) as? NSNumber
+        let selectionEndValue = try await surface.evaluateJavaScript(
+            "document.getElementById('field').selectionEnd"
+        ) as? NSNumber
+
+        XCTAssertEqual(activeElementID, "field")
+        XCTAssertEqual(selectionStartValue?.intValue, 1)
+        XCTAssertEqual(selectionEndValue?.intValue, 4)
+    }
+
     func testStateObserverReceivesImmediateAndMutatedRuntimeState() {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -14771,6 +14849,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var lastUnderPageBackgroundColor: NSColor?
         private(set) var loadedRequests: [URLRequest] = []
         private(set) var stopLoadingCallCount = 0
+        private(set) var captureAddressBarPageFocusCallCount = 0
+        private(set) var restoreAddressBarPageFocusCallCount = 0
+        var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
+        var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -14869,6 +14951,19 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         func evaluateJavaScript(_ script: String) async throws -> Any? {
             nil
+        }
+
+        func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void) {
+            captureAddressBarPageFocusCallCount += 1
+            completion(captureAddressBarPageFocusStatus)
+        }
+
+        func restoreAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusRestoreStatus) -> Void) {
+            restoreAddressBarPageFocusCallCount += 1
+            let status = restoreAddressBarPageFocusStatuses.isEmpty
+                ? BrowserAddressBarPageFocusRestoreStatus.noState
+                : restoreAddressBarPageFocusStatuses.removeFirst()
+            completion(status)
         }
 
         func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
@@ -14981,6 +15076,40 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             updatedColor.withAlphaComponent(updatedOpacity)
         )
         _ = panel
+    }
+
+    func testBrowserPanelAddressBarSuppressionCapturesPageFocusViaRuntimeOnce() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.beginSuppressWebViewFocusForAddressBar()
+        panel.beginSuppressWebViewFocusForAddressBar()
+
+        XCTAssertEqual(runtime.captureAddressBarPageFocusCallCount, 1)
+    }
+
+    func testBrowserPanelRestoreAddressBarFocusRetriesViaRuntime() async {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.restoreAddressBarPageFocusStatuses = [.notFocused, .restored]
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let restoreFinished = expectation(description: "runtime restore completed")
+        var didRestoreFocus = false
+
+        panel.restoreAddressBarPageFocusIfNeeded { restored in
+            didRestoreFocus = restored
+            restoreFinished.fulfill()
+        }
+
+        await fulfillment(of: [restoreFinished], timeout: 1)
+
+        XCTAssertTrue(didRestoreFocus)
+        XCTAssertEqual(runtime.restoreAddressBarPageFocusCallCount, 2)
     }
 }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14863,6 +14863,44 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(requestedURLs, [expectedIconURL, expectedIconURL])
     }
 
+    func testFindAdapterUsesRuntimeOwnedFindOperations() async throws {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration(scriptSources: [])
+        )
+        let navigationFinished = expectation(description: "find page loaded")
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                navigationFinished.fulfill()
+            }
+        )
+
+        surface.loadHTMLString(
+            """
+            <html><body>
+            <p>alpha beta alpha</p>
+            <p>beta gamma</p>
+            </body></html>
+            """,
+            baseURL: nil
+        )
+        await fulfillment(of: [navigationFinished], timeout: 5)
+
+        let searchResult = try await surface.findInPage(query: "alpha")
+        let nextResult = try await surface.findNextInPage()
+        let previousResult = try await surface.findPreviousInPage()
+
+        XCTAssertEqual(searchResult, BrowserFindResult(total: 2, selected: 0))
+        XCTAssertEqual(nextResult, BrowserFindResult(total: 2, selected: 1))
+        XCTAssertEqual(previousResult, BrowserFindResult(total: 2, selected: 0))
+
+        try await surface.clearFindInPage()
+        let markCount = try await surface.evaluateJavaScript(
+            "document.querySelectorAll('mark.__cmux-find').length"
+        ) as? NSNumber
+        XCTAssertEqual(markCount?.intValue, 0)
+    }
+
     func testDeveloperToolsAdapterUsesRuntimeOwnedInspectorOperations() {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -15014,6 +15052,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var restoreAddressBarPageFocusCallCount = 0
         private(set) var invalidateFaviconCacheCallCount = 0
         private(set) var fetchFaviconPNGDataCallCount = 0
+        private(set) var findQueries: [String] = []
+        private(set) var findNextInPageCallCount = 0
+        private(set) var findPreviousInPageCallCount = 0
+        private(set) var clearFindInPageCallCount = 0
         private(set) var revealDeveloperToolsCallCount = 0
         private(set) var concealDeveloperToolsCallCount = 0
         private(set) var showDeveloperToolsConsoleCallCount = 0
@@ -15022,6 +15064,13 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
         var fetchedFaviconPNGData: Data?
         var onFetchFaviconPNGData: (() -> Void)?
+        var findInPageResult: BrowserFindResult?
+        var findNextInPageResult: BrowserFindResult?
+        var findPreviousInPageResult: BrowserFindResult?
+        var onFindInPage: (() -> Void)?
+        var onFindNextInPage: (() -> Void)?
+        var onFindPreviousInPage: (() -> Void)?
+        var onClearFindInPage: (() -> Void)?
         var currentDeveloperToolsVisibilityState: BrowserSurfaceDeveloperToolsVisibilityState = .unavailable
 
         init() {
@@ -15121,6 +15170,29 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         func evaluateJavaScript(_ script: String) async throws -> Any? {
             nil
+        }
+
+        func findInPage(query: String) async throws -> BrowserFindResult? {
+            findQueries.append(query)
+            onFindInPage?()
+            return findInPageResult
+        }
+
+        func findNextInPage() async throws -> BrowserFindResult? {
+            findNextInPageCallCount += 1
+            onFindNextInPage?()
+            return findNextInPageResult
+        }
+
+        func findPreviousInPage() async throws -> BrowserFindResult? {
+            findPreviousInPageCallCount += 1
+            onFindPreviousInPage?()
+            return findPreviousInPageResult
+        }
+
+        func clearFindInPage() async throws {
+            clearFindInPageCallCount += 1
+            onClearFindInPage?()
         }
 
         func captureAddressBarPageFocus(completion: @escaping (BrowserAddressBarPageFocusCaptureStatus) -> Void) {
@@ -15261,6 +15333,70 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(lastAttemptedNavigationURL, url)
         XCTAssertEqual(loadedRequestURL, url)
         XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
+    }
+
+    func testBrowserPanelFindUsesRuntimeBoundary() async {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        let initialClearInvoked = expectation(description: "initial find clear")
+        runtime.onClearFindInPage = {
+            initialClearInvoked.fulfill()
+        }
+        panel.startFind()
+        await fulfillment(of: [initialClearInvoked], timeout: 1)
+
+        runtime.onClearFindInPage = nil
+        runtime.findInPageResult = BrowserFindResult(total: 3, selected: 0)
+        let searchInvoked = expectation(description: "find search")
+        runtime.onFindInPage = {
+            searchInvoked.fulfill()
+        }
+        panel.searchState?.needle = "runtime"
+        await fulfillment(of: [searchInvoked], timeout: 1)
+
+        XCTAssertEqual(runtime.findQueries.last, "runtime")
+        XCTAssertEqual(panel.searchState?.total, 3)
+        XCTAssertEqual(panel.searchState?.selected, 0)
+
+        runtime.onFindInPage = nil
+        runtime.findNextInPageResult = BrowserFindResult(total: 3, selected: 1)
+        let nextInvoked = expectation(description: "find next")
+        runtime.onFindNextInPage = {
+            nextInvoked.fulfill()
+        }
+        panel.findNext()
+        await fulfillment(of: [nextInvoked], timeout: 1)
+
+        XCTAssertEqual(runtime.findNextInPageCallCount, 1)
+        XCTAssertEqual(panel.searchState?.selected, 1)
+
+        runtime.onFindNextInPage = nil
+        runtime.findPreviousInPageResult = BrowserFindResult(total: 3, selected: 0)
+        let previousInvoked = expectation(description: "find previous")
+        runtime.onFindPreviousInPage = {
+            previousInvoked.fulfill()
+        }
+        panel.findPrevious()
+        await fulfillment(of: [previousInvoked], timeout: 1)
+
+        XCTAssertEqual(runtime.findPreviousInPageCallCount, 1)
+        XCTAssertEqual(panel.searchState?.selected, 0)
+
+        runtime.onFindPreviousInPage = nil
+        let clearInvoked = expectation(description: "find hide clear")
+        let baselineClearCallCount = runtime.clearFindInPageCallCount
+        runtime.onClearFindInPage = {
+            clearInvoked.fulfill()
+        }
+        panel.hideFind()
+        await fulfillment(of: [clearInvoked], timeout: 1)
+
+        XCTAssertNil(panel.searchState)
+        XCTAssertEqual(runtime.clearFindInPageCallCount, baselineClearCallCount + 1)
     }
 
     func testBrowserPanelDeveloperToolsVisibilityUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14791,6 +14791,9 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
 
         XCTAssertTrue(surface.hostWindow() === window)
         XCTAssertTrue(surface.isHiddenOrHasHiddenAncestor())
+        let frameInWindow = surface.frameInWindowCoordinates()
+        XCTAssertEqual(frameInWindow?.width ?? 0, surface.webView.bounds.width, accuracy: 0.5)
+        XCTAssertEqual(frameInWindow?.height ?? 0, surface.webView.bounds.height, accuracy: 0.5)
 
         surface.setAllowsFirstResponderAcquisition(true)
         XCTAssertTrue(webView.allowsFirstResponderAcquisition)
@@ -15351,6 +15354,7 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         var focusSurfaceResult = true
         var unfocusSurfaceResult = true
         var currentHostWindow: NSWindow?
+        var currentFrameInWindowCoordinates: CGRect?
         var currentIsHiddenOrHasHiddenAncestor = false
 
         init() {
@@ -15547,6 +15551,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         func hostWindow() -> NSWindow? {
             currentHostWindow
+        }
+
+        func frameInWindowCoordinates() -> CGRect? {
+            currentFrameInWindowCoordinates
         }
 
         func isHiddenOrHasHiddenAncestor() -> Bool {
@@ -15787,7 +15795,9 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
     func testBrowserPanelSurfaceHelpersUseRuntimeBoundary() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panelWindow = NSWindow()
+        let panelFrame = CGRect(x: 12, y: 34, width: 210, height: 120)
         runtime.currentHostWindow = panelWindow
+        runtime.currentFrameInWindowCoordinates = panelFrame
         runtime.currentIsHiddenOrHasHiddenAncestor = true
         runtime.state = makeRuntimeState(currentURL: nil, isLoading: true)
         let panel = BrowserPanel(
@@ -15796,9 +15806,32 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         )
 
         XCTAssertTrue(panel.surfaceWindow() === panelWindow)
+        XCTAssertEqual(panel.effectiveSurfaceWindow(), panelWindow)
+        XCTAssertEqual(panel.surfaceFrameInWindowCoordinates(), panelFrame)
         XCTAssertTrue(panel.isSurfaceHiddenOrHasHiddenAncestor())
         XCTAssertTrue(panel.isSurfaceBlankForAutofocus())
         XCTAssertTrue(panel.isSurfaceLoadingNow())
+    }
+
+    func testBrowserPanelSurfaceFocusStateUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panelWindow = NSWindow()
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let responder = NSView()
+        responder.frame = contentView.bounds
+        panelWindow.contentView = contentView
+        contentView.addSubview(responder)
+        runtime.currentHostWindow = panelWindow
+        runtime.ownsResponderResult = true
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panelWindow.makeFirstResponder(responder))
+        XCTAssertTrue(panel.isSurfaceFocusedInHostWindow())
+        XCTAssertEqual(runtime.ownsResponderCallCount, 1)
+        XCTAssertTrue(runtime.lastOwnedResponder === responder)
     }
 
     func testBrowserPanelResponderPolicyUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -16170,6 +16170,55 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(panel.pageTitle, failedURL)
     }
 
+    func testBrowserPanelKeepsFailedURLTitleWhenRuntimeStateReplaysPreviousTitle() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let failedURL = "https://example.com/failed"
+
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: "https://example.com/original"),
+                title: "Original Title",
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+        runtime.eventHandlers.didFailNavigation?(failedURL)
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: failedURL),
+                title: "Original Title",
+                isLoading: true,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0.4,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+
+        XCTAssertEqual(panel.pageTitle, failedURL)
+
+        runtime.emitState(
+            BrowserSurfaceRuntimeState(
+                currentURL: URL(string: failedURL),
+                title: "Recovered Title",
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 1.0,
+                pageZoom: runtime.state.pageZoom
+            )
+        )
+
+        XCTAssertEqual(panel.pageTitle, "Recovered Title")
+    }
+
     func testBrowserPanelRestoredSessionHistoryUsesRuntimeStateCurrentURL() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14525,6 +14525,8 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
 
 @MainActor
 final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
+    private final class RuntimeWKInspectorProbeView: NSView {}
+
     private final class RuntimeFakeInspector: NSObject {
         enum HideBehavior {
             case hides
@@ -14721,6 +14723,55 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
             surface.attachmentState,
             BrowserSurfaceRuntimeAttachmentState(isAttachedToSuperview: true, isInWindow: true)
         )
+    }
+
+    func testDeveloperToolsHostStateReflectsAttachedInspectorLayoutAndDetachedWindows() {
+        _ = NSApplication.shared
+
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        let baselineDetachedWindowCount = surface.developerToolsHostState().detachedWindowCount
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        surface.webView.frame = NSRect(x: 0, y: 80, width: host.bounds.width, height: host.bounds.height - 80)
+        host.addSubview(surface.webView)
+
+        let inspectorContainer = NSView(frame: NSRect(x: 0, y: 0, width: host.bounds.width, height: 80))
+        let inspectorView = RuntimeWKInspectorProbeView(frame: inspectorContainer.bounds)
+        inspectorView.autoresizingMask = [.width, .height]
+        inspectorContainer.addSubview(inspectorView)
+        host.addSubview(inspectorContainer)
+
+        let attachedState = surface.developerToolsHostState()
+        XCTAssertTrue(attachedState.hasAttachedInspectorLayout)
+        XCTAssertEqual(attachedState.detachedWindowCount, baselineDetachedWindowCount)
+
+        let detachedWindow = NSWindow(
+            contentRect: NSRect(x: 40, y: 40, width: 240, height: 180),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        detachedWindow.isReleasedWhenClosed = false
+        detachedWindow.title = "Web Inspector Runtime Host State"
+        let detachedRoot = NSView(frame: detachedWindow.contentRect(forFrameRect: detachedWindow.frame))
+        let detachedInspectorView = RuntimeWKInspectorProbeView(frame: detachedRoot.bounds)
+        detachedInspectorView.autoresizingMask = [.width, .height]
+        detachedRoot.addSubview(detachedInspectorView)
+        detachedWindow.contentView = detachedRoot
+        detachedWindow.makeKeyAndOrderFront(nil)
+        defer {
+            detachedWindow.orderOut(nil)
+            detachedWindow.close()
+        }
+        drainMainQueue()
+
+        let detachedState = surface.developerToolsHostState()
+        XCTAssertTrue(detachedState.hasAttachedInspectorLayout)
+        XCTAssertEqual(detachedState.detachedWindowCount, baselineDetachedWindowCount + 1)
+        XCTAssertTrue(detachedState.hasDetachedInspectorWindows)
     }
 
     func testReplaceWebViewCreatesNewInstanceAndPreservesRequestedPageZoom() {
@@ -15094,6 +15145,7 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var revealDeveloperToolsCallCount = 0
         private(set) var concealDeveloperToolsCallCount = 0
         private(set) var showDeveloperToolsConsoleCallCount = 0
+        private(set) var dismissDetachedDeveloperToolsWindowsCallCount = 0
         private(set) var lastRevealDeveloperToolsAttachIfNeeded: Bool?
         var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
         var restoreAddressBarPageFocusStatuses: [BrowserAddressBarPageFocusRestoreStatus] = [.noState]
@@ -15107,6 +15159,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         var onFindPreviousInPage: (() -> Void)?
         var onClearFindInPage: (() -> Void)?
         var currentDeveloperToolsVisibilityState: BrowserSurfaceDeveloperToolsVisibilityState = .unavailable
+        var currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: false,
+            detachedWindowCount: 0
+        )
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -15261,6 +15317,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             currentDeveloperToolsVisibilityState
         }
 
+        func developerToolsHostState() -> BrowserSurfaceDeveloperToolsHostState {
+            currentDeveloperToolsHostState
+        }
+
         @discardableResult
         func revealDeveloperTools(attachIfNeeded: Bool) -> Bool {
             revealDeveloperToolsCallCount += 1
@@ -15280,6 +15340,14 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         func showDeveloperToolsConsole() {
             showDeveloperToolsConsoleCallCount += 1
+        }
+
+        func dismissDetachedDeveloperToolsWindows() {
+            dismissDetachedDeveloperToolsWindowsCallCount += 1
+            currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+                hasAttachedInspectorLayout: currentDeveloperToolsHostState.hasAttachedInspectorLayout,
+                detachedWindowCount: 0
+            )
         }
 
         func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
@@ -15542,6 +15610,54 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(runtime.revealDeveloperToolsCallCount, 0)
         XCTAssertEqual(runtime.showDeveloperToolsConsoleCallCount, 1)
         XCTAssertTrue(panel.isDeveloperToolsVisible())
+    }
+
+    func testBrowserPanelInlineDeveloperToolsHostingUsesRuntimeHostStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .visible
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: false,
+            detachedWindowCount: 1
+        )
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertFalse(panel.shouldUseLocalInlineDeveloperToolsHosting())
+
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: true,
+            detachedWindowCount: 0
+        )
+        XCTAssertTrue(panel.shouldUseLocalInlineDeveloperToolsHosting())
+    }
+
+    func testBrowserPanelDismissesDetachedDeveloperToolsWindowsThroughRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .visible
+        runtime.currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: true,
+            isInWindow: true
+        )
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: true,
+            detachedWindowCount: 0
+        )
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.syncDeveloperToolsPreferenceFromInspector()
+        XCTAssertTrue(panel.showDeveloperTools())
+        runtime.currentDeveloperToolsHostState = BrowserSurfaceDeveloperToolsHostState(
+            hasAttachedInspectorLayout: true,
+            detachedWindowCount: 1
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertGreaterThan(runtime.dismissDetachedDeveloperToolsWindowsCallCount, 0)
     }
 
     func testBrowserPanelPreferredURLStringForOmnibarUsesRuntimeStateBeforePublishedCurrentURL() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15833,6 +15833,25 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         XCTAssertNil(panel.surfaceWindow())
         XCTAssertTrue(panel.surfaceHostingWindow() === window)
+        XCTAssertTrue(panel.effectiveSurfaceWindow() === window)
+    }
+
+    func testBrowserPanelOwnsSurfaceWebViewTracksReplacementIdentity() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let originalWebView = panel.webView
+
+        XCTAssertTrue(panel.ownsSurfaceWebView(originalWebView))
+
+        panel.debugSimulateWebContentProcessTermination()
+
+        let replacementWebView = panel.webView
+        XCTAssertFalse(replacementWebView === originalWebView)
+        XCTAssertFalse(panel.ownsSurfaceWebView(originalWebView))
+        XCTAssertTrue(panel.ownsSurfaceWebView(replacementWebView))
     }
 
     func testBrowserPanelSurfaceFocusStateUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14566,7 +14566,7 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertTrue(first.webView.configuration.processPool === second.webView.configuration.processPool)
     }
 
-    func testSurfaceAppliesConfigurationToCreatedWebView() {
+    func testSurfaceAppliesConfigurationToCreatedWebView() async throws {
         let configuration = makeConfiguration()
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -14579,9 +14579,30 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(webView.customUserAgent, configuration.customUserAgent)
         assertColorsEqual(webView.underPageBackgroundColor, configuration.underPageBackgroundColor)
         XCTAssertEqual(
-            webView.configuration.userContentController.userScripts.map(\.source),
-            configuration.bootstrapUserScriptSources
+            webView.configuration.userContentController.userScripts.count,
+            configuration.bootstrapUserScriptSources.count
         )
+        XCTAssertTrue(
+            webView.configuration.userContentController.userScripts.allSatisfy {
+                $0.injectionTime == .atDocumentStart && !$0.isForMainFrameOnly
+            }
+        )
+
+        let navigationFinished = expectation(description: "bootstrap scripts ran")
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                navigationFinished.fulfill()
+            }
+        )
+        webView.loadHTMLString("<html><body>runtime</body></html>", baseURL: nil)
+        await fulfillment(of: [navigationFinished], timeout: 5)
+
+        let firstScriptAppliedResult = try await surface.evaluateJavaScript("window.__cmuxRuntimeTestOne === true") as? Bool
+        let secondScriptAppliedResult = try await surface.evaluateJavaScript("window.__cmuxRuntimeTestTwo === true") as? Bool
+        let firstScriptApplied = try XCTUnwrap(firstScriptAppliedResult)
+        let secondScriptApplied = try XCTUnwrap(secondScriptAppliedResult)
+        XCTAssertTrue(firstScriptApplied)
+        XCTAssertTrue(secondScriptApplied)
     }
 
     func testReplaceWebViewCreatesNewInstanceAndPreservesRequestedPageZoom() {
@@ -14609,6 +14630,21 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(replacement.pageZoom, 1.75, accuracy: 0.001)
         XCTAssertEqual(replacement.customUserAgent, replacementConfiguration.customUserAgent)
         assertColorsEqual(replacement.underPageBackgroundColor, replacementConfiguration.underPageBackgroundColor)
+    }
+
+    func testReplaceWebViewPreservesAppliedBrowserThemeMode() {
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+
+        surface.applyBrowserThemeMode(.dark)
+        let replacement = surface.replaceWebView(
+            using: makeConfiguration(customUserAgent: "cmux-runtime-test-theme"),
+            pageZoom: nil
+        )
+
+        XCTAssertEqual(replacement.appearance?.bestMatch(from: [.darkAqua, .aqua]), .darkAqua)
     }
 
     func testStateObserverReceivesImmediateAndMutatedRuntimeState() {
@@ -14716,6 +14752,235 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         replacementWebView.onContextMenuDownloadStateChanged?(false)
         XCTAssertEqual(finishedNavigationCount, 2)
         XCTAssertEqual(downloadStates, [true, false])
+    }
+}
+
+@MainActor
+final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
+    private final class RecordingBrowserSurfaceRuntime: BrowserSurfaceRuntime {
+        let backendKind: BrowserRuntimeBackendKind = .localWebKit
+        var webView: WKWebView
+        var webViewInstanceID = UUID()
+        var state: BrowserSurfaceRuntimeState
+        var eventHandlers = BrowserSurfaceRuntimeEventHandlers()
+        var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)?
+
+        private(set) var lastAttemptedNavigationURL: URL?
+        private(set) var appliedThemeModes: [BrowserThemeMode] = []
+        private(set) var lastCustomUserAgent: String?
+        private(set) var lastUnderPageBackgroundColor: NSColor?
+        private(set) var loadedRequests: [URLRequest] = []
+        private(set) var stopLoadingCallCount = 0
+
+        init() {
+            let configuration = WKWebViewConfiguration()
+            let webView = WKWebView(frame: .zero, configuration: configuration)
+            self.webView = webView
+            self.state = BrowserSurfaceRuntimeState(
+                currentURL: nil,
+                title: nil,
+                isLoading: false,
+                canGoBack: false,
+                canGoForward: false,
+                estimatedProgress: 0,
+                pageZoom: webView.pageZoom
+            )
+        }
+
+        @discardableResult
+        func replaceWebView(
+            using configuration: BrowserRuntimeSurfaceConfiguration,
+            pageZoom: CGFloat?
+        ) -> WKWebView {
+            let replacement = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+            if let pageZoom {
+                replacement.pageZoom = pageZoom
+            }
+            webView = replacement
+            webViewInstanceID = UUID()
+            state = BrowserSurfaceRuntimeState(
+                currentURL: state.currentURL,
+                title: state.title,
+                isLoading: state.isLoading,
+                canGoBack: state.canGoBack,
+                canGoForward: state.canGoForward,
+                estimatedProgress: state.estimatedProgress,
+                pageZoom: replacement.pageZoom
+            )
+            return replacement
+        }
+
+        func setLastAttemptedNavigationURL(_ url: URL?) {
+            lastAttemptedNavigationURL = url
+        }
+
+        func applyBrowserThemeMode(_ mode: BrowserThemeMode) {
+            appliedThemeModes.append(mode)
+            switch mode {
+            case .system:
+                webView.appearance = nil
+            case .light:
+                webView.appearance = NSAppearance(named: .aqua)
+            case .dark:
+                webView.appearance = NSAppearance(named: .darkAqua)
+            }
+        }
+
+        func setCustomUserAgent(_ customUserAgent: String) {
+            lastCustomUserAgent = customUserAgent
+            webView.customUserAgent = customUserAgent
+        }
+
+        func setUnderPageBackgroundColor(_ color: NSColor) {
+            lastUnderPageBackgroundColor = color
+            webView.underPageBackgroundColor = color
+        }
+
+        @discardableResult
+        func loadRequest(_ request: URLRequest) -> WKNavigation? {
+            loadedRequests.append(request)
+            return nil
+        }
+
+        func loadHTMLString(_ html: String, baseURL: URL?) {}
+        func goBack() {}
+        func goForward() {}
+        func reload() {}
+
+        func stopLoading() {
+            stopLoadingCallCount += 1
+        }
+
+        func setPageZoom(_ pageZoom: CGFloat) {
+            state = BrowserSurfaceRuntimeState(
+                currentURL: state.currentURL,
+                title: state.title,
+                isLoading: state.isLoading,
+                canGoBack: state.canGoBack,
+                canGoForward: state.canGoForward,
+                estimatedProgress: state.estimatedProgress,
+                pageZoom: pageZoom
+            )
+        }
+
+        func takeSnapshot(completion: @escaping (NSImage?) -> Void) {
+            completion(nil)
+        }
+
+        func evaluateJavaScript(_ script: String) async throws -> Any? {
+            nil
+        }
+
+        func sessionHistorySnapshot() -> (backHistoryURLs: [URL], forwardHistoryURLs: [URL]) {
+            ([], [])
+        }
+    }
+
+    private final class RecordingBrowserSurfaceRuntimeFactory: BrowserSurfaceRuntimeFactory {
+        let runtime: RecordingBrowserSurfaceRuntime
+        private(set) var configurations: [BrowserRuntimeSurfaceConfiguration] = []
+
+        init(runtime: RecordingBrowserSurfaceRuntime) {
+            self.runtime = runtime
+        }
+
+        func makeSurface(using configuration: BrowserRuntimeSurfaceConfiguration) -> any BrowserSurfaceRuntime {
+            configurations.append(configuration)
+            return runtime
+        }
+    }
+
+    private func assertColorsEqual(
+        _ lhs: NSColor?,
+        _ rhs: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let lhsComponents = lhs?.usingColorSpace(.deviceRGB)?.cgColor.components
+        let rhsComponents = rhs.usingColorSpace(.deviceRGB)?.cgColor.components
+        XCTAssertNotNil(lhsComponents, file: file, line: line)
+        XCTAssertNotNil(rhsComponents, file: file, line: line)
+        guard let lhsComponents, let rhsComponents else { return }
+        XCTAssertEqual(lhsComponents.count, rhsComponents.count, file: file, line: line)
+        for (left, right) in zip(lhsComponents, rhsComponents) {
+            XCTAssertEqual(left, right, accuracy: 0.01, file: file, line: line)
+        }
+    }
+
+    func testBrowserPanelConfiguresRuntimeCallbacksOnInit() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let factory = RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+
+        _ = BrowserPanel(workspaceId: UUID(), runtimeFactory: factory)
+
+        XCTAssertEqual(factory.configurations.count, 1)
+        XCTAssertNotNil(runtime.eventHandlers.didFinishNavigation)
+        XCTAssertNotNil(runtime.eventHandlers.didFailNavigation)
+        XCTAssertNotNil(runtime.eventHandlers.didTerminateWebContentProcess)
+        XCTAssertNotNil(runtime.eventHandlers.requestNavigation)
+        XCTAssertNotNil(runtime.eventHandlers.downloadStateChanged)
+        XCTAssertNotNil(runtime.onStateChange)
+    }
+
+    func testBrowserPanelRoutesThemeModeThroughRuntime() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let factory = RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        let panel = BrowserPanel(workspaceId: UUID(), runtimeFactory: factory)
+
+        panel.setBrowserThemeMode(.dark)
+        panel.setBrowserThemeMode(.light)
+
+        let appliedThemeModes = Array(runtime.appliedThemeModes.suffix(2))
+        let appearanceMatch = panel.webView.appearance?.bestMatch(from: [.aqua, .darkAqua])
+
+        XCTAssertEqual(appliedThemeModes, [.dark, .light])
+        XCTAssertEqual(appearanceMatch, .aqua)
+    }
+
+    func testBrowserPanelNavigationUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let url = URL(string: "https://example.com/runtime")!
+
+        panel.navigate(to: url, recordTypedNavigation: false)
+
+        let shouldRenderWebView = panel.shouldRenderWebView
+        let lastAttemptedNavigationURL = runtime.lastAttemptedNavigationURL
+        let loadedRequestURL = runtime.loadedRequests.last?.url
+        let lastCustomUserAgent = runtime.lastCustomUserAgent
+
+        XCTAssertTrue(shouldRenderWebView)
+        XCTAssertEqual(lastAttemptedNavigationURL, url)
+        XCTAssertEqual(loadedRequestURL, url)
+        XCTAssertEqual(lastCustomUserAgent, BrowserUserAgentSettings.safariUserAgent)
+    }
+
+    func testBrowserPanelBackgroundRefreshUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let updatedColor = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0)
+        let updatedOpacity = 0.57
+
+        NotificationCenter.default.post(
+            name: .ghosttyDefaultBackgroundDidChange,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.backgroundColor: updatedColor,
+                GhosttyNotificationKey.backgroundOpacity: updatedOpacity
+            ]
+        )
+
+        assertColorsEqual(
+            runtime.lastUnderPageBackgroundColor,
+            updatedColor.withAlphaComponent(updatedOpacity)
+        )
+        _ = panel
     }
 }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15891,6 +15891,56 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(panel.surfacePageZoom(), 1.65, accuracy: 0.001)
     }
 
+    func testBrowserPanelSetSurfacePageZoomUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.setSurfacePageZoom(1.9)
+
+        XCTAssertEqual(runtime.state.pageZoom, 1.9, accuracy: 0.001)
+        XCTAssertEqual(panel.surfacePageZoom(), 1.9, accuracy: 0.001)
+    }
+
+    func testBrowserPanelResolvedCurrentSurfaceURLPrefersRuntimeState() {
+        let runtimeURL = URL(string: "https://example.com/runtime-current")!
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.state = makeRuntimeState(currentURL: runtimeURL)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.restoreSessionNavigationHistory(
+            backHistoryURLStrings: [],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://example.com/restored-current"
+        )
+
+        XCTAssertEqual(panel.resolvedCurrentSurfaceURL(), runtimeURL)
+    }
+
+    func testBrowserPanelResolvedCurrentSurfaceURLFallsBackToRestoredHistory() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.restoreSessionNavigationHistory(
+            backHistoryURLStrings: ["https://example.com/restored-previous"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://example.com/restored-current"
+        )
+
+        XCTAssertEqual(
+            panel.resolvedCurrentSurfaceURL(),
+            URL(string: "https://example.com/restored-current")
+        )
+    }
+
     func testBrowserPanelDebugPortalSnapshotUsesPanelSurface() {
         let panel = BrowserPanel(workspaceId: UUID())
         let window = NSWindow(
@@ -15917,6 +15967,42 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(snapshot?.frameInWindow.origin.y ?? 0, 30, accuracy: 0.5)
         XCTAssertEqual(snapshot?.frameInWindow.width ?? 0, 140, accuracy: 0.5)
         XCTAssertEqual(snapshot?.frameInWindow.height ?? 0, 90, accuracy: 0.5)
+    }
+
+    func testBrowserPanelSurfaceHostedInWindowPortalUsesRuntimeAttachmentState() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        host.autoresizingMask = [.width, .height]
+        let anchor = panel.portalAnchorView
+        anchor.frame = NSRect(x: 20, y: 30, width: 140, height: 90)
+        host.addSubview(anchor)
+        window.contentView = host
+
+        runtime.currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: true,
+            isInWindow: true
+        )
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: anchor, visibleInUI: true, zPriority: 1)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+        defer { BrowserWindowPortalRegistry.detach(webView: panel.webView) }
+
+        XCTAssertTrue(panel.isSurfaceHostedInWindowPortal())
+
+        runtime.currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: false,
+            isInWindow: true
+        )
+        XCTAssertFalse(panel.isSurfaceHostedInWindowPortal())
     }
 
     func testBrowserPanelResponderPolicyUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14692,6 +14692,37 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertTrue(secondScriptApplied)
     }
 
+    func testAttachmentStateReflectsWebViewHostingLifecycle() {
+        _ = NSApplication.shared
+
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        XCTAssertEqual(
+            surface.attachmentState,
+            BrowserSurfaceRuntimeAttachmentState(isAttachedToSuperview: false, isInWindow: false)
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+        container.addSubview(surface.webView)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        drainMainQueue()
+
+        XCTAssertEqual(
+            surface.attachmentState,
+            BrowserSurfaceRuntimeAttachmentState(isAttachedToSuperview: true, isInWindow: true)
+        )
+    }
+
     func testReplaceWebViewCreatesNewInstanceAndPreservesRequestedPageZoom() {
         let processPool = WKProcessPool()
         let initialConfiguration = makeConfiguration(customUserAgent: "cmux-runtime-test-initial")
@@ -15039,6 +15070,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         var webView: WKWebView
         var webViewInstanceID = UUID()
         var state: BrowserSurfaceRuntimeState
+        var currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: false,
+            isInWindow: false
+        )
         var eventHandlers = BrowserSurfaceRuntimeEventHandlers()
         var onStateChange: ((BrowserSurfaceRuntimeState) -> Void)?
 
@@ -15086,6 +15121,10 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
                 estimatedProgress: 0,
                 pageZoom: webView.pageZoom
             )
+        }
+
+        var attachmentState: BrowserSurfaceRuntimeAttachmentState {
+            currentAttachmentState
         }
 
         @discardableResult
@@ -15284,6 +15323,26 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         }
     }
 
+    private func makeRuntimeState(
+        currentURL: URL? = nil,
+        title: String? = nil,
+        isLoading: Bool = false,
+        canGoBack: Bool = false,
+        canGoForward: Bool = false,
+        estimatedProgress: Double = 0,
+        pageZoom: CGFloat = 1.0
+    ) -> BrowserSurfaceRuntimeState {
+        BrowserSurfaceRuntimeState(
+            currentURL: currentURL,
+            title: title,
+            isLoading: isLoading,
+            canGoBack: canGoBack,
+            canGoForward: canGoForward,
+            estimatedProgress: estimatedProgress,
+            pageZoom: pageZoom
+        )
+    }
+
     func testBrowserPanelConfiguresRuntimeCallbacksOnInit() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let factory = RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
@@ -15397,6 +15456,59 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         XCTAssertNil(panel.searchState)
         XCTAssertEqual(runtime.clearFindInPageCallCount, baselineClearCallCount + 1)
+    }
+
+    func testBrowserPanelContextResetUsesRuntimeAttachmentStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: true,
+            isInWindow: false
+        )
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+        let priorWebView = panel.webView
+        let priorInstanceID = panel.webViewInstanceID
+
+        panel.resetForWorkspaceContextChange(reason: "runtime-attachment")
+
+        XCTAssertFalse(panel.webView === priorWebView)
+        XCTAssertNotEqual(panel.webViewInstanceID, priorInstanceID)
+        XCTAssertFalse(panel.shouldRenderWebView)
+    }
+
+    func testBrowserPanelLoadingIndicatorSettlingUsesRuntimeStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        runtime.emitState(makeRuntimeState(isLoading: true))
+        XCTAssertTrue(panel.isLoading)
+
+        runtime.emitState(makeRuntimeState(isLoading: false))
+        runtime.state = makeRuntimeState(isLoading: true)
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        XCTAssertTrue(panel.isLoading)
+    }
+
+    func testBrowserPanelDetachedDeveloperToolsIntentUsesRuntimeAttachmentStateBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .hidden
+        runtime.currentAttachmentState = BrowserSurfaceRuntimeAttachmentState(
+            isAttachedToSuperview: true,
+            isInWindow: true
+        )
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertFalse(panel.shouldPreserveDeveloperToolsIntentWhileDetached())
     }
 
     func testBrowserPanelDeveloperToolsVisibilityUsesRuntimeBoundary() {

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14523,6 +14523,95 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
     }
 }
 
+@MainActor
+final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
+    private func assertColorsEqual(
+        _ lhs: NSColor?,
+        _ rhs: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let lhsComponents = lhs?.usingColorSpace(.deviceRGB)?.cgColor.components
+        let rhsComponents = rhs.usingColorSpace(.deviceRGB)?.cgColor.components
+        XCTAssertNotNil(lhsComponents, file: file, line: line)
+        XCTAssertNotNil(rhsComponents, file: file, line: line)
+        guard let lhsComponents, let rhsComponents else { return }
+        XCTAssertEqual(lhsComponents.count, rhsComponents.count, file: file, line: line)
+        for (left, right) in zip(lhsComponents, rhsComponents) {
+            XCTAssertEqual(left, right, accuracy: 0.01, file: file, line: line)
+        }
+    }
+
+    private func makeConfiguration(
+        backgroundColor: NSColor = NSColor.systemTeal.withAlphaComponent(0.4),
+        customUserAgent: String = "cmux-runtime-test",
+        scriptSources: [String] = [
+            "window.__cmuxRuntimeTestOne = true;",
+            "window.__cmuxRuntimeTestTwo = true;",
+        ]
+    ) -> BrowserRuntimeSurfaceConfiguration {
+        BrowserRuntimeSurfaceConfiguration(
+            bootstrapUserScriptSources: scriptSources,
+            underPageBackgroundColor: backgroundColor,
+            customUserAgent: customUserAgent
+        )
+    }
+
+    func testFactoryUsesSharedProcessPoolAcrossSurfaces() {
+        let factory = LocalWebKitBrowserSurfaceRuntimeFactory.shared
+
+        let first = factory.makeSurface(using: makeConfiguration())
+        let second = factory.makeSurface(using: makeConfiguration(customUserAgent: "cmux-runtime-test-2"))
+
+        XCTAssertTrue(first.webView.configuration.processPool === second.webView.configuration.processPool)
+    }
+
+    func testSurfaceAppliesConfigurationToCreatedWebView() {
+        let configuration = makeConfiguration()
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: configuration
+        )
+        guard let webView = surface.webView as? CmuxWebView else {
+            return XCTFail("Expected CmuxWebView runtime surface")
+        }
+
+        XCTAssertEqual(webView.customUserAgent, configuration.customUserAgent)
+        assertColorsEqual(webView.underPageBackgroundColor, configuration.underPageBackgroundColor)
+        XCTAssertEqual(
+            webView.configuration.userContentController.userScripts.map(\.source),
+            configuration.bootstrapUserScriptSources
+        )
+    }
+
+    func testReplaceWebViewCreatesNewInstanceAndPreservesRequestedPageZoom() {
+        let processPool = WKProcessPool()
+        let initialConfiguration = makeConfiguration(customUserAgent: "cmux-runtime-test-initial")
+        let replacementConfiguration = makeConfiguration(
+            backgroundColor: NSColor.systemPink.withAlphaComponent(0.3),
+            customUserAgent: "cmux-runtime-test-replacement"
+        )
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: processPool,
+            configuration: initialConfiguration
+        )
+
+        let originalWebView = surface.webView
+        let originalInstanceID = surface.webViewInstanceID
+        let replacement = surface.replaceWebView(
+            using: replacementConfiguration,
+            pageZoom: 1.75
+        )
+
+        XCTAssertFalse(replacement === originalWebView)
+        XCTAssertNotEqual(surface.webViewInstanceID, originalInstanceID)
+        XCTAssertTrue(replacement.configuration.processPool === processPool)
+        XCTAssertEqual(replacement.pageZoom, 1.75, accuracy: 0.001)
+        XCTAssertEqual(replacement.customUserAgent, replacementConfiguration.customUserAgent)
+        assertColorsEqual(replacement.underPageBackgroundColor, replacementConfiguration.underPageBackgroundColor)
+    }
+}
+
 final class TerminalControllerSocketListenerHealthTests: XCTestCase {
     private func makeTempSocketPath() -> String {
         "/tmp/cmux-socket-health-\(UUID().uuidString).sock"

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -15969,6 +15969,77 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(snapshot?.frameInWindow.height ?? 0, 90, accuracy: 0.5)
     }
 
+    func testBrowserPanelRefreshSurfacePortalIfAnchorReadyRequiresReadyAnchor() {
+        let panel = BrowserPanel(workspaceId: UUID())
+
+        XCTAssertFalse(panel.refreshSurfacePortalIfAnchorReady(reason: "unitTest"))
+    }
+
+    func testBrowserPanelRefreshSurfacePortalIfAnchorReadyUsesPanelAnchor() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        host.autoresizingMask = [.width, .height]
+        window.contentView = host
+
+        let anchor = panel.portalAnchorView
+        anchor.frame = NSRect(x: 20, y: 30, width: 140, height: 90)
+        host.addSubview(anchor)
+
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: anchor, visibleInUI: true, zPriority: 1)
+        defer { BrowserWindowPortalRegistry.detach(webView: panel.webView) }
+
+        XCTAssertTrue(panel.refreshSurfacePortalIfAnchorReady(reason: "unitTest.initial"))
+        XCTAssertEqual(panel.debugPortalSnapshot()?.frameInWindow.origin.x ?? 0, 20, accuracy: 0.5)
+
+        anchor.frame = NSRect(x: 48, y: 44, width: 150, height: 96)
+
+        XCTAssertTrue(panel.refreshSurfacePortalIfAnchorReady(reason: "unitTest.moved"))
+        XCTAssertEqual(panel.debugPortalSnapshot()?.frameInWindow.origin.x ?? 0, 48, accuracy: 0.5)
+        XCTAssertEqual(panel.debugPortalSnapshot()?.frameInWindow.origin.y ?? 0, 44, accuracy: 0.5)
+        XCTAssertEqual(panel.debugPortalSnapshot()?.frameInWindow.width ?? 0, 150, accuracy: 0.5)
+        XCTAssertEqual(panel.debugPortalSnapshot()?.frameInWindow.height ?? 0, 96, accuracy: 0.5)
+    }
+
+    func testBrowserPanelUpdateAndHideSurfacePortalUsePanelSurface() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let host = NSView(frame: window.contentView?.bounds ?? .zero)
+        host.autoresizingMask = [.width, .height]
+        window.contentView = host
+
+        let anchor = panel.portalAnchorView
+        anchor.frame = NSRect(x: 20, y: 30, width: 140, height: 90)
+        host.addSubview(anchor)
+
+        BrowserWindowPortalRegistry.bind(webView: panel.webView, to: anchor, visibleInUI: true, zPriority: 1)
+        defer { BrowserWindowPortalRegistry.detach(webView: panel.webView) }
+
+        XCTAssertTrue(panel.refreshSurfacePortalIfAnchorReady(reason: "unitTest.initial"))
+        XCTAssertEqual(panel.debugPortalSnapshot()?.visibleInUI, true)
+
+        panel.updateSurfacePortalVisibility(visibleInUI: false, zPriority: 0)
+        XCTAssertEqual(panel.debugPortalSnapshot()?.visibleInUI, false)
+
+        panel.hideSurfacePortal(source: "unitTest")
+        drainMainQueue()
+
+        XCTAssertEqual(panel.debugPortalSnapshot()?.visibleInUI, false)
+        XCTAssertEqual(panel.debugPortalSnapshot()?.containerHidden, true)
+    }
+
     func testBrowserPanelSurfaceHostedInWindowPortalUsesRuntimeAttachmentState() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -14757,6 +14757,45 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertFalse(surface.ownsResponder(window.firstResponder))
     }
 
+    func testSurfaceHostWindowVisibilityAndResponderPolicyRoundTripThroughRuntime() {
+        _ = NSApplication.shared
+
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration()
+        )
+        guard let webView = surface.webView as? CmuxWebView else {
+            return XCTFail("Expected CmuxWebView runtime surface")
+        }
+
+        XCTAssertNil(surface.hostWindow())
+        XCTAssertFalse(surface.isHiddenOrHasHiddenAncestor())
+        XCTAssertTrue(webView.allowsFirstResponderAcquisition)
+
+        surface.setAllowsFirstResponderAcquisition(false)
+        XCTAssertFalse(webView.allowsFirstResponderAcquisition)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        container.isHidden = true
+        window.contentView = container
+        container.addSubview(surface.webView)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil) }
+        drainMainQueue()
+
+        XCTAssertTrue(surface.hostWindow() === window)
+        XCTAssertTrue(surface.isHiddenOrHasHiddenAncestor())
+
+        surface.setAllowsFirstResponderAcquisition(true)
+        XCTAssertTrue(webView.allowsFirstResponderAcquisition)
+    }
+
     func testDeveloperToolsHostStateReflectsAttachedInspectorLayoutAndDetachedWindows() {
         _ = NSApplication.shared
 
@@ -15002,6 +15041,85 @@ final class LocalWebKitBrowserSurfaceRuntimeTests: XCTestCase {
         XCTAssertEqual(requestedURLs, [expectedIconURL, expectedIconURL])
     }
 
+    func testFetchFaviconPNGDataDoesNotReuseStaleCacheKeyAfterWebViewReplacement() async throws {
+        let expectedIconURL = URL(string: "https://example.com/icons/runtime-64.png")!
+        let iconData = try makePNGData(color: .systemRed)
+        var requestedURLs: [URL] = []
+        let firstFetchStarted = expectation(description: "first favicon fetch started")
+        let firstNavigationFinished = expectation(description: "first favicon page loaded")
+        let secondNavigationFinished = expectation(description: "second favicon page loaded")
+        var firstFetchContinuation: CheckedContinuation<(Data, URLResponse), Never>?
+        var navigationCount = 0
+        let surface = LocalWebKitBrowserSurfaceRuntime(
+            processPool: WKProcessPool(),
+            configuration: makeConfiguration(scriptSources: []),
+            faviconDataLoader: { request in
+                let url = try XCTUnwrap(request.url)
+                requestedURLs.append(url)
+                let response = try XCTUnwrap(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )
+                )
+                if requestedURLs.count == 1 {
+                    firstFetchStarted.fulfill()
+                    return await withCheckedContinuation { continuation in
+                        firstFetchContinuation = continuation
+                    }
+                }
+                return (iconData, response)
+            }
+        )
+        surface.eventHandlers = BrowserSurfaceRuntimeEventHandlers(
+            didFinishNavigation: {
+                navigationCount += 1
+                if navigationCount == 1 {
+                    firstNavigationFinished.fulfill()
+                } else {
+                    secondNavigationFinished.fulfill()
+                }
+            }
+        )
+
+        let html = """
+            <html>
+            <head>
+            <link rel="icon" href="\(expectedIconURL.absoluteString)" sizes="64x64" />
+            </head>
+            <body>favicon</body>
+            </html>
+            """
+        let baseURL = URL(string: "https://example.com/page")!
+        surface.loadHTMLString(html, baseURL: baseURL)
+        await fulfillment(of: [firstNavigationFinished], timeout: 5)
+
+        let staleFetch = Task { await surface.fetchFaviconPNGData() }
+        await fulfillment(of: [firstFetchStarted], timeout: 5)
+
+        _ = surface.replaceWebView(using: makeConfiguration(scriptSources: []), pageZoom: nil)
+        surface.loadHTMLString(html, baseURL: baseURL)
+        await fulfillment(of: [secondNavigationFinished], timeout: 5)
+
+        let firstResponse = try XCTUnwrap(
+            HTTPURLResponse(
+                url: expectedIconURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        )
+        firstFetchContinuation?.resume(returning: (iconData, firstResponse))
+        let staleResult = await staleFetch.value
+        let freshResult = await surface.fetchFaviconPNGData()
+
+        XCTAssertNil(staleResult)
+        XCTAssertNotNil(freshResult)
+        XCTAssertEqual(requestedURLs, [expectedIconURL, expectedIconURL])
+    }
+
     func testFindAdapterUsesRuntimeOwnedFindOperations() async throws {
         let surface = LocalWebKitBrowserSurfaceRuntime(
             processPool: WKProcessPool(),
@@ -15208,6 +15326,7 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         private(set) var ownsResponderCallCount = 0
         private(set) var focusSurfaceCallCount = 0
         private(set) var unfocusSurfaceCallCount = 0
+        private(set) var lastAllowsFirstResponderAcquisition: Bool?
         private(set) var lastOwnedResponder: NSResponder?
         private(set) var lastRevealDeveloperToolsAttachIfNeeded: Bool?
         var captureAddressBarPageFocusStatus: BrowserAddressBarPageFocusCaptureStatus = .clearedNone
@@ -15226,9 +15345,13 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             hasAttachedInspectorLayout: false,
             detachedWindowCount: 0
         )
+        var revealDeveloperToolsMutatesVisibility = true
+        var concealDeveloperToolsMutatesVisibility = true
         var ownsResponderResult = false
         var focusSurfaceResult = true
         var unfocusSurfaceResult = true
+        var currentHostWindow: NSWindow?
+        var currentIsHiddenOrHasHiddenAncestor = false
 
         init() {
             let configuration = WKWebViewConfiguration()
@@ -15394,7 +15517,9 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
             revealDeveloperToolsCallCount += 1
             lastRevealDeveloperToolsAttachIfNeeded = attachIfNeeded
             guard currentDeveloperToolsVisibilityState != .unavailable else { return false }
-            currentDeveloperToolsVisibilityState = .visible
+            if revealDeveloperToolsMutatesVisibility {
+                currentDeveloperToolsVisibilityState = .visible
+            }
             return true
         }
 
@@ -15402,7 +15527,9 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         func concealDeveloperTools() -> Bool {
             concealDeveloperToolsCallCount += 1
             guard currentDeveloperToolsVisibilityState != .unavailable else { return false }
-            currentDeveloperToolsVisibilityState = .hidden
+            if concealDeveloperToolsMutatesVisibility {
+                currentDeveloperToolsVisibilityState = .hidden
+            }
             return true
         }
 
@@ -15416,6 +15543,18 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
                 hasAttachedInspectorLayout: currentDeveloperToolsHostState.hasAttachedInspectorLayout,
                 detachedWindowCount: 0
             )
+        }
+
+        func hostWindow() -> NSWindow? {
+            currentHostWindow
+        }
+
+        func isHiddenOrHasHiddenAncestor() -> Bool {
+            currentIsHiddenOrHasHiddenAncestor
+        }
+
+        func setAllowsFirstResponderAcquisition(_ allowed: Bool) {
+            lastAllowsFirstResponderAcquisition = allowed
         }
 
         func ownsResponder(_ responder: NSResponder?) -> Bool {
@@ -15581,6 +15720,17 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
         XCTAssertEqual(runtime.focusSurfaceCallCount, 1)
     }
 
+    func testBrowserPanelFocusSurfaceForHandoffUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.focusSurfaceForHandoff())
+        XCTAssertEqual(runtime.focusSurfaceCallCount, 1)
+    }
+
     func testBrowserPanelUnfocusUsesRuntimeBoundary() {
         let runtime = RecordingBrowserSurfaceRuntime()
         let panel = BrowserPanel(
@@ -15632,6 +15782,38 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         XCTAssertTrue(panel.yieldFocusIntent(.browser(.webView), in: window))
         XCTAssertEqual(runtime.unfocusSurfaceCallCount, 1)
+    }
+
+    func testBrowserPanelSurfaceHelpersUseRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panelWindow = NSWindow()
+        runtime.currentHostWindow = panelWindow
+        runtime.currentIsHiddenOrHasHiddenAncestor = true
+        runtime.state = makeRuntimeState(currentURL: nil, isLoading: true)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.surfaceWindow() === panelWindow)
+        XCTAssertTrue(panel.isSurfaceHiddenOrHasHiddenAncestor())
+        XCTAssertTrue(panel.isSurfaceBlankForAutofocus())
+        XCTAssertTrue(panel.isSurfaceLoadingNow())
+    }
+
+    func testBrowserPanelResponderPolicyUsesRuntimeBoundary() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        panel.syncSurfaceFirstResponderAcquisitionPolicy(isPanelFocused: true)
+        XCTAssertEqual(runtime.lastAllowsFirstResponderAcquisition, true)
+
+        panel.suppressWebViewFocus(for: 5)
+        panel.syncSurfaceFirstResponderAcquisitionPolicy(isPanelFocused: true)
+        XCTAssertEqual(runtime.lastAllowsFirstResponderAcquisition, false)
     }
 
     func testBrowserPanelFindUsesRuntimeBoundary() async {
@@ -15766,6 +15948,25 @@ final class BrowserPanelRuntimeBoundaryTests: XCTestCase {
 
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         XCTAssertTrue(panel.hideDeveloperTools())
+        XCTAssertEqual(runtime.concealDeveloperToolsCallCount, 1)
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+    }
+
+    func testBrowserPanelQueuesHideAcrossAsyncShowTransition() {
+        let runtime = RecordingBrowserSurfaceRuntime()
+        runtime.currentDeveloperToolsVisibilityState = .hidden
+        runtime.revealDeveloperToolsMutatesVisibility = false
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            runtimeFactory: RecordingBrowserSurfaceRuntimeFactory(runtime: runtime)
+        )
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.hideDeveloperTools())
+
+        runtime.currentDeveloperToolsVisibilityState = .visible
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
         XCTAssertEqual(runtime.concealDeveloperToolsCallCount, 1)
         XCTAssertFalse(panel.isDeveloperToolsVisible())
     }

--- a/docs/atlas-inspired-browser-architecture.md
+++ b/docs/atlas-inspired-browser-architecture.md
@@ -1,0 +1,318 @@
+# Atlas-Inspired Browser Architecture Plan
+
+Last updated: March 13, 2026
+
+This document proposes how to replicate the core Atlas architecture pattern in cmux.
+
+Inputs:
+- OpenAI engineering post: `https://openai.com/index/building-chatgpt-atlas/`
+- Static inspection of `/Applications/ChatGPT Atlas.app`
+
+Where this document goes beyond direct evidence, it is called out as inference.
+
+## Reverse-engineered Atlas shape
+
+### Direct evidence
+
+From the OpenAI post:
+- Atlas is split into an **OWL Client** and an **OWL Host**.
+- The client is the native SwiftUI/AppKit app.
+- The host is Chromium's browser process, running outside the main app process.
+- The two sides communicate over **Mojo**.
+- The public client-side concepts are `Session`, `Profile`, `WebView`, `WebContentRenderer`, and `LayerHost/Client`.
+- Rendering crosses the process boundary by exporting Chromium compositing state into the native app.
+- Input is translated in the native client, forwarded to the host, and sometimes returned to the client when the page does not consume it.
+- Agent mode uses isolated ephemeral storage partitions instead of sharing the normal profile.
+
+From the local `ChatGPT Atlas.app` bundle:
+- The main app bundle is `com.openai.atlas`.
+- The main app links `Aura.framework`, `OwlBridge.framework`, `Sparkle.framework`, `Sentry.framework`, and other native frameworks.
+- The app contains a nested support app at `Contents/Support/ChatGPT Atlas.app`.
+- That nested app has bundle id `com.openai.atlas.web`, `LSUIElement = 1`, and version `146.0.7680.31`, which strongly suggests a hidden Chromium host bundle.
+- `OwlBridge.framework` contains strings like `OWL_HOST_PATH`, `Terminating existing Owl host`, `owl/bridge/connector`, and many `mojo` references.
+- `Aura.framework` contains symbols referencing `Mojom.Owl.WindowBridgeHost`, `BridgedWindowController`, `AgentComputerUseEnvironment`, `NavigationSidebarController`, and permission prompt plumbing.
+- The bundle ships `AuraXPCService` plus LaunchAgents for Mach services like `com.openai.atlas.agent-xpc`.
+
+### Inference
+
+Atlas appears to have three distinct planes:
+
+1. A native UI shell process.
+2. A browser engine host process.
+3. A separate agent/computer-use service plane.
+
+The article only names OWL client and OWL host directly. The extra XPC service and agent-related symbols strongly suggest the third plane.
+
+## Current cmux baseline
+
+cmux already has several pieces that match the Atlas shape at the shell level:
+
+- A native SwiftUI/AppKit shell with custom workspace, pane, and surface management.
+- A portal system that keeps AppKit-backed content stable across workspace and split churn.
+- A handle-based v2 JSON socket API intended for LLM agents.
+
+cmux differs in one critical place today:
+
+- Browser surfaces are still same-process `WKWebView` instances. `BrowserPanel` explicitly creates a `WKWebViewConfiguration`, shares a `WKProcessPool`, and uses the default `WKWebsiteDataStore`.
+- The browser portal code moves and reattaches `WKWebView` instances inside the main app process.
+
+That means cmux already has the right shell and automation boundary, but not the Atlas-style browser runtime boundary.
+
+## Recommendation
+
+Replicate the Atlas architecture pattern, not Atlas's exact implementation details.
+
+For cmux that means:
+
+1. Keep the existing SwiftUI/AppKit shell as the single source of truth for windows, workspaces, panes, surfaces, omnibar, notifications, and agent-facing socket APIs.
+2. Move the browser runtime behind a separate host boundary.
+3. Add a thin client bridge layer in the app so `BrowserPanel` stops owning `WKWebView` directly.
+4. Keep the existing v2 socket API as the public automation surface.
+
+Do not treat `WKWebView` as the final out-of-process solution. It is fine as a migration adapter, but it is the wrong long-term foundation for an Atlas-style split. Public WebKit APIs keep the embedding view in the app process and do not give cmux the same restart, composition, or engine-isolation properties that Atlas is built around.
+
+## Proposed cmux architecture
+
+### 1. Shell process: `cmux.app`
+
+Own:
+- window lifecycle
+- workspace and pane tree
+- sidebar, omnibar, notifications, command palette
+- agent-facing socket API
+- terminal surfaces and Ghostty integration
+- focus policy and shortcut routing
+
+Do not own:
+- browser engine lifecycle
+- browser profile storage internals
+- page rendering pipeline
+- renderer-directed automation execution
+
+### 2. Bridge framework: `cmuxBrowserBridge`
+
+Create a transport-agnostic client library with Swift-first APIs that map closely to the Atlas concepts:
+
+- `BrowserRuntimeSession`
+- `BrowserProfile`
+- `BrowserSurface`
+- `BrowserRenderer`
+- `BrowserLayerEndpoint`
+- `BrowserPermissionBroker`
+- `BrowserDownloadBroker`
+
+This bridge becomes the only thing `BrowserPanel` talks to.
+
+### 3. Host process: `cmux Web Host`
+
+Create a hidden helper app or XPC-hosted process that owns:
+
+- browser engine startup and shutdown
+- profile and cookie stores
+- tab and page objects
+- renderer state
+- screenshots, DOM snapshotting, script evaluation, and network instrumentation
+- crash recovery for the browser engine without taking down the shell
+
+### 4. Optional agent service: `cmux-agentd`
+
+If cmux wants Atlas-style computer use, isolate it again:
+
+- accessibility and OS-level automation
+- screenshot and capture policy
+- per-task ephemeral agent contexts
+- high-risk permissions and audit logging
+
+This is optional for the first browser split, but it matches the Atlas direction and prevents the shell from becoming the privileged dumping ground.
+
+## Backend strategy
+
+Use two backends behind the same bridge.
+
+### Backend A: local compatibility adapter
+
+Wrap the current `WKWebView` implementation so cmux can land the new interfaces without changing behavior.
+
+Purpose:
+- preserve current product behavior
+- let `BrowserPanelView` and portal code stay mostly intact
+- make the shell-side API stable before introducing another engine
+
+### Backend B: remote host backend
+
+Build the real Atlas-style path behind a feature flag.
+
+Recommended target:
+- Chromium or CEF in a dedicated host bundle
+
+Reason:
+- It matches the Atlas architecture directly.
+- It gives cmux a real browser-process boundary.
+- It makes agent automation, screenshots, and compositor routing much easier to control centrally.
+
+Not recommended as the final target:
+- a hidden helper containing `WKWebView`
+
+Reason:
+- it does not buy the full separation that Atlas gets
+- it is likely to be fragile around rendering and input ownership
+- it still leaves cmux constrained by WebKit embedding assumptions
+
+## Rendering plan
+
+cmux already has the right shell-side abstraction shape because browser content is portal-hosted and can be swapped across workspace and pane containers.
+
+The remote host path should:
+
+1. Export one render surface per browser surface.
+2. Attach that surface into the existing browser portal host.
+3. Keep geometry, scale factor, focus state, and visibility synchronized from shell to host.
+4. Handle popup widgets and permission UI explicitly, either by:
+   - native shell replacements, or
+   - remote hosted overlays with a dedicated layer bridge
+
+The key design rule is that the shell owns layout, and the host owns pixels.
+
+## Input plan
+
+Follow the Atlas rule exactly:
+
+1. The shell receives native `NSEvent`s.
+2. The shell translates them into browser input messages.
+3. The host routes them into the renderer.
+4. If the page does not consume an event, the shell gets an explicit bounce-back signal and can apply cmux shortcuts or pane/workspace navigation.
+
+This is especially important because cmux already has complex first-responder and shortcut rules for browser surfaces.
+
+## Profile and isolation plan
+
+Adopt three profile classes:
+
+1. `default`
+   - persistent user browsing profile
+2. `workspace-scoped`
+   - optional, for users who want browser state partitioned by workspace
+3. `ephemeral-agent`
+   - memory-only, destroyed at end of the task or surface lifetime
+
+`ephemeral-agent` is the Atlas-equivalent feature that matters most for cmux's agent workflows.
+
+## Public automation plan
+
+Do not expose the internal host transport directly.
+
+Keep the current cmux public contract:
+- v2 JSON socket methods
+- stable `window_id`, `workspace_id`, `pane_id`, `surface_id`
+
+Internally map:
+- `surface_id` -> host browser surface id
+- cmux browser methods -> bridge calls -> host IPC
+
+That preserves the current agent/browser work and avoids leaking engine-specific concepts to users.
+
+## Rollout phases
+
+### Phase 0: interface extraction
+
+Deliverables:
+- `cmuxBrowserBridge` protocols and models
+- `BrowserPanel` no longer constructs or reaches into `WKWebView` directly outside the local adapter
+
+Exit criteria:
+- zero user-visible change
+- current browser still runs on the local adapter
+
+### Phase 1: shell cleanup
+
+Deliverables:
+- separate shell responsibilities from engine responsibilities
+- move navigation, page state, input routing, permission decisions, and downloads behind bridge interfaces
+
+Exit criteria:
+- `BrowserPanelView` and portal code depend only on bridge-facing state
+
+### Phase 2: host bootstrap
+
+Deliverables:
+- `cmux Web Host` helper bundle
+- on-demand launch, health checks, crash detection, restart logic
+- minimal IPC for create surface, destroy surface, navigate, focus, resize
+
+Exit criteria:
+- one remote browser surface can load a page under a feature flag
+
+### Phase 3: remote rendering
+
+Deliverables:
+- render surface export from host
+- shell-side portal attachment
+- resize and scale synchronization
+- hidden and background surface handling
+
+Exit criteria:
+- workspace switching and split churn work without blank frames or stuck layers
+
+### Phase 4: remote input
+
+Deliverables:
+- shell-side event translation
+- unhandled-event bounce-back
+- text input, pointer input, wheel, IME, and modifier handling
+
+Exit criteria:
+- browser shortcuts and cmux shortcuts both behave correctly under focus changes
+
+### Phase 5: browser feature parity
+
+Deliverables:
+- history, downloads, permission prompts, popups, devtools, snapshots, screenshots, script eval
+- current v2 browser APIs routed through the host
+
+Exit criteria:
+- agent-browser parity doc no longer depends on in-process `WKWebView`
+
+### Phase 6: agent isolation
+
+Deliverables:
+- ephemeral agent profiles
+- optional `cmux-agentd`
+- audit logging and policy checks for privileged automation
+
+Exit criteria:
+- multiple isolated agent sessions can run without sharing cookies or storage
+
+### Phase 7: default rollout
+
+Deliverables:
+- feature flag rollout
+- crash telemetry and performance telemetry
+- migration path for old sessions and browser state
+
+Exit criteria:
+- remote backend is stable enough to become default
+
+## Risks
+
+1. Chromium integration cost is real.
+   cmux would be taking on a large dependency, a heavier build story, and a new security/update surface.
+
+2. `WKWebView` is not a real long-term substitute for this architecture.
+   Using it as a bridge backend is fine. Using it as the remote host target is probably a dead end.
+
+3. Cross-process rendering on macOS is the hardest technical seam.
+   The rollout has to prove resize, focus, popups, and crash recovery before broader migration.
+
+4. Agent security gets worse if it lands in the shell.
+   If cmux adds computer-use features, a separate privileged service is the safer boundary.
+
+## Suggested first implementation slice
+
+Build only enough to prove the architecture:
+
+1. Introduce `cmuxBrowserBridge`.
+2. Put the existing `WKWebView` browser behind the local adapter.
+3. Create a stub `cmux Web Host` that can launch, answer health checks, and own a fake remote surface.
+4. Teach the portal system to swap between local and remote render endpoints under a feature flag.
+
+If that slice lands cleanly, cmux will have the hard architectural seam in place. After that, the engine choice and deeper browser migration become incremental work instead of a flag day rewrite.


### PR DESCRIPTION
## Summary
- add a reverse-engineered Atlas architecture writeup based on the OpenAI post and local `ChatGPT Atlas.app` inspection
- propose a phased cmux plan with a shell, bridge, host, and optional agent-service split
- call out why `WKWebView` is useful as a migration adapter but not as the final Atlas-style runtime boundary

## Testing
- not run, docs-only change
- reviewed the generated markdown in the worktree

## Issues
- Related: https://openai.com/index/building-chatgpt-atlas/
- Task: reverse engineer `/Applications/ChatGPT Atlas.app` and map the architecture onto cmux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts a browser surface runtime seam with a Local WebKit adapter and adds an Atlas‑inspired architecture plan. Core browser/devtools behavior, shell lookups, and workspace persistence now route through the runtime via `BrowserPanel` helpers, including split devtools preflight, telemetry, portal control, and host window fallbacks.

- **Refactors**
  - Added `BrowserSurfaceRuntime` with a Local WebKit backend that owns `WKWebView` creation/replacement, delegates, a shared `WKProcessPool`, favicon refresh with cache busting, and process‑termination recovery that preserves zoom and reloads the last URL.
  - Routed navigation, JS, zoom, snapshot, history, omnibar settling, address‑bar focus capture/restore, first‑responder policy/hand‑off, attachment, find‑in‑page (typed `BrowserFindResult` via `parseResult()`), and devtools (including split devtools preflight and host state) through the runtime.
  - Routed shell, workspace, and host state via panel helpers: `AppDelegate` uses `isSurfaceFocusedInHostWindow()` and awaits `panel.evaluateJavaScript(...)`; `ContentView` and shell use `ownsSurfaceWebView(_:)` for ownership checks; `Workspace` reads/writes zoom and devtools visibility via `surfacePageZoom()`/`setSurfacePageZoom(_:)`; host window visibility/fallbacks allow the shell to host inline inspector and dismiss detached windows.

- **Bug Fixes**
  - Keep failed navigation URLs as tab titles until the runtime provides a new title; clear stale titles after untitled finishes.
  - Fix focus handoff by routing web view focus and address‑bar suppression/restore through the runtime.
  - Fix devtools visibility transitions (queue hide across async show) and prevent stale favicon fetches across web view replacement.
  - Remove direct view‑level `WKWebView` focus toggles; use runtime focus/ownership to avoid stale responder and hidden‑ancestor focus bugs.

<sup>Written for commit 1c1ce02ca9bb1700c5479330704091b6011bf2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture docs describing a multi-plane browser design, rollout phases, risks, and a stepwise migration plan.

* **New Features**
  * Introduced a runtime-backed browser surface abstraction enabling configurable web views, shared process usage, seamless runtime-driven replacement, and unified runtime state propagation.

* **Tests**
  * Added tests covering configuration application, shared process behavior, web view replacement and zoom, theme/state propagation, delegate/download rebinding, and runtime-boundary interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->