### PR TITLE
Fix macOS dictation NSTextInputClient conformance

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8229,7 +8229,6 @@ extension GhosttyNSView: NSTextInputClient {
         if range.length == 0, w > 0 {
             // Dictation expects a caret rect for insertion points rather than a box.
             w = 0
-            x += cellSize.width * Double(range.location + range.length)
         }
 
         // Ghostty coordinates are top-left origin; AppKit expects bottom-left.

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -695,7 +695,7 @@ final class CJKIMEFirstRectTests: XCTestCase {
         XCTAssertEqual(rect.height, 18, accuracy: 0.001)
     }
 
-    func testFirstRectUsesZeroWidthForInsertionPoint() {
+    func testFirstRectUsesZeroWidthForInsertionPointWithoutOffsettingCaretAnchor() {
         let frame = NSRect(x: 0, y: 0, width: 640, height: 480)
         let view = GhosttyNSView(frame: frame)
         view.cellSize = CGSize(width: 9, height: 18)
@@ -717,7 +717,12 @@ final class CJKIMEFirstRectTests: XCTestCase {
             window.orderOut(nil)
         }
 
-        let rect = view.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        let rect = view.firstRect(forCharacterRange: NSRange(location: 5, length: 0), actualRange: nil)
+        let expectedViewRect = NSRect(x: 80, y: frame.height - 120, width: 0, height: 24)
+        let expectedScreenRect = window.convertToScreen(view.convert(expectedViewRect, to: nil))
+
+        XCTAssertEqual(rect.origin.x, expectedScreenRect.origin.x, accuracy: 0.001)
+        XCTAssertEqual(rect.origin.y, expectedScreenRect.origin.y, accuracy: 0.001)
         XCTAssertEqual(rect.width, 0, accuracy: 0.001)
         XCTAssertEqual(rect.height, 24, accuracy: 0.001)
     }


### PR DESCRIPTION
## Summary
- tighten `GhosttyNSView` NSTextInputClient behavior so dictation and Voice Control get a stable selection range, selection substring, caret-style rect, and macOS 14 selection geometry hooks
- add regression coverage for the empty selection range, caret insertion rect, and screen-coordinate visible rect path

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-955-dictation-unit build` (succeeded)
- `./scripts/reload.sh --tag issue-955-dictation` (succeeded)

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/955
- Related: https://github.com/manaflow-ai/cmux/issues/722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS dictation and Voice Control in the terminal by tightening `NSTextInputClient` conformance and stabilizing selection/caret geometry. Adds regression tests. Closes #955.

- **Bug Fixes**
  - Return accurate selectedRange (empty = {0,0}) and selection text via attributedSubstring/attributedString.
  - Stable geometry: non-empty selection uses its top-left; insertion caret is zero-width and anchored at the IME point (no offset).
  - Implement documentVisibleRect and unionRectInVisibleSelectedRange (macOS 14+) and windowLevel.
  - characterIndex(for:) now returns the caret location.
  - Invalidate text-input coordinates on window attach, resize, and layout; notify on selection changes (macOS 15.4+).
  - Add tests for empty selection range, zero-width insertion caret anchoring, and screen-based visible rect.

<sup>Written for commit 497a654fc2a6c2e8d325acf546d2461a3f064b68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection reporting for IME (Input Method Editor) users by returning actual selection ranges instead of empty values.
  * Fixed accessibility to accurately report selected text content.
  * Enhanced text input coordinate synchronization with layout and window changes.

* **Tests**
  * Added coverage for IME coordinate geometry and selection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->