### PR TITLE
Throttle repeated socket listener start failures

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -60,6 +60,9 @@ class TerminalController {
     private nonisolated static let socketProbePollTimeoutMs: Int32 = 100
     private nonisolated static let socketProbePollAttempts = 3
     private nonisolated static let socketProbePollRetryBackoffUs: useconds_t = 50_000
+    private nonisolated static let socketListenerFailureCaptureCooldown: TimeInterval = 60
+    private nonisolated static let socketListenerFailureCaptureLock = NSLock()
+    private nonisolated(unsafe) static var socketListenerFailureLastCapturedAt: [String: Date] = [:]
     private nonisolated static let unixSocketPathMaxLength: Int = {
         var addr = sockaddr_un()
         // Reserve one byte for the null terminator.
@@ -505,7 +508,33 @@ class TerminalController {
     ) {
         let data = socketListenerEventData(stage: stage, errnoCode: errnoCode, extra: extra)
         sentryBreadcrumb(message, category: "socket", data: data)
+        guard Self.shouldCaptureSocketListenerFailure(
+            message: message,
+            stage: stage,
+            path: data["path"] as? String ?? "",
+            errnoCode: errnoCode
+        ) else {
+            return
+        }
         sentryCaptureError(message, category: "socket", data: data, contextKey: "socket_listener")
+    }
+
+    private nonisolated static func shouldCaptureSocketListenerFailure(
+        message: String,
+        stage: String,
+        path: String,
+        errnoCode: Int32?
+    ) -> Bool {
+        let key = "\(message)|\(stage)|\(path)|\(errnoCode.map(String.init) ?? "none")"
+        let now = Date()
+        socketListenerFailureCaptureLock.lock()
+        defer { socketListenerFailureCaptureLock.unlock() }
+        if let lastCapturedAt = socketListenerFailureLastCapturedAt[key],
+           now.timeIntervalSince(lastCapturedAt) < socketListenerFailureCaptureCooldown {
+            return false
+        }
+        socketListenerFailureLastCapturedAt[key] = now
+        return true
     }
 
     nonisolated static func acceptErrorClassification(errnoCode: Int32) -> String {


### PR DESCRIPTION
## Summary
- keep socket listener failure breadcrumbs, but rate-limit repeated `socket.listener.start.failed` captures
- key the cooldown by failure signature so repeated bind loops stop flooding Sentry while distinct failures still report

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-throttle-socket-listener-start-failures`

## Task
- Internal task: reduce socket listener start failure Sentry spam

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle repeated socket listener start failures to cut Sentry noise while keeping breadcrumbs. Adds a 60s per-signature cooldown so unique failures still get captured.

- **Bug Fixes**
  - Added a cooldown in `TerminalController` keyed by message, stage, path, and errno.
  - All failures add a breadcrumb; Sentry captures are rate-limited per key for 60s.
  - Uses `NSLock` with an in-memory map to ensure thread-safe checks.

<sup>Written for commit 2a8d4475a3c847d5206d8c97241366ddce71a8b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented rate-limiting for socket listener failure telemetry to prevent repeated identical errors from overwhelming system logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->