### PR TITLE
Localize notification fallback title and validate --pid input

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -73580,6 +73580,23 @@
           }
         }
       }
+    },
+    "notification.fallback.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1931,7 +1931,7 @@ class GhosttyApp {
                        workspace.agentPIDs["claude_code"] != nil {
                         return true
                     }
-                    let tabTitle = owningManager.titleForTab(tabId) ?? "Terminal"
+                    let tabTitle = owningManager.titleForTab(tabId) ?? String(localized: "notification.fallback.title", defaultValue: "Terminal")
                     let command = actionTitle.isEmpty ? tabTitle : actionTitle
                     let body = actionBody
                     let surfaceId = tabManager.focusedSurfaceId(for: tabId)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2209,7 +2209,7 @@ class GhosttyApp {
                    workspace.agentPIDs["claude_code"] != nil {
                     return
                 }
-                let tabTitle = owningManager?.titleForTab(tabId) ?? "Terminal"
+                let tabTitle = owningManager?.titleForTab(tabId) ?? String(localized: "notification.fallback.title", defaultValue: "Terminal")
                 let command = actionTitle.isEmpty ? tabTitle : actionTitle
                 let body = actionBody
                 TerminalNotificationStore.shared.addNotification(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13067,13 +13067,15 @@ class TerminalController {
             return tabResolution.error ?? "ERROR: No tab selected"
         }
 
-        let pidValue: pid_t? = {
-            if let rawPid = normalizedOptionValue(parsed.options["pid"]),
-               let p = Int32(rawPid), p > 0 {
-                return p
+        let pidValue: pid_t?
+        if let rawPid = normalizedOptionValue(parsed.options["pid"]) {
+            guard let p = Int32(rawPid), p > 0 else {
+                return "ERROR: Invalid pid '\(rawPid)' — must be a positive integer"
             }
-            return nil
-        }()
+            pidValue = p
+        } else {
+            pidValue = nil
+        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13068,8 +13068,11 @@ class TerminalController {
         }
 
         let pidValue: pid_t?
-        if let rawPid = normalizedOptionValue(parsed.options["pid"]) {
-            guard let p = Int32(rawPid), p > 0 else {
+        if parsed.options.keys.contains("pid") {
+            let rawPid = parsed.options["pid"] ?? ""
+            guard let normalized = normalizedOptionValue(rawPid),
+                  let p = Int32(normalized),
+                  p > 0 else {
                 return "ERROR: Invalid pid '\(rawPid)' — must be a positive integer"
             }
             pidValue = p

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -310,52 +310,6 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testReleaseAppSupportFallbackLoadsForDebugWhenOnlyReleaseConfigExists() {
-        XCTAssertTrue(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-    }
-
-    func testReleaseAppSupportFallbackSkipsWhenDebugConfigAlreadyExists() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-829",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: 64,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-    }
-
-    func testReleaseAppSupportFallbackSkipsForNonDebugBundleOrMissingReleaseConfig() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: nil,
-                releaseLegacyConfigFileSize: 0
-            )
-        )
-    }
-
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
         XCTAssertTrue(
             GhosttyApp.shouldApplyDefaultBackgroundUpdate(


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/1306 addressing remaining review comments.

- Localize bare `"Terminal"` fallback in OSC notification paths (lines [1934](https://github.com/manaflow-ai/cmux/blob/fix-hook-review-followups/Sources/GhosttyTerminalView.swift#L1934), [2212](https://github.com/manaflow-ai/cmux/blob/fix-hook-review-followups/Sources/GhosttyTerminalView.swift#L2212)) with `String(localized:defaultValue:)`
- Reject invalid `--pid` values in `set_agent_pid` with an error instead of silently falling through as nil

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the fallback notification title and validates `--pid` input to improve notification UX and error messages. Removes obsolete tests for a deleted function to restore CI.

- **Bug Fixes**
  - Replaced hardcoded "Terminal" fallbacks in notification paths with `String(localized: "notification.fallback.title", defaultValue: "Terminal")`; added `en` and `ja` translations.
  - If `--pid` is present, require a positive integer; return an error for empty or non-numeric values instead of silently ignoring.
  - Removed tests for deleted `shouldLoadReleaseAppSupportGhosttyConfig` to fix CI.

<sup>Written for commit f8a2e4d5d455d22751d575ddfea82653bad63b46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized fallback titles for desktop notifications in multiple languages.

* **Bug Fixes**
  * Improved PID input validation with clearer error messages on invalid values.
  * Notifications now use the localized fallback title instead of a generic label.

* **Tests**
  * Removed obsolete unit tests related to legacy config fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->