### PR TITLE
feat: Add session save/open feature for exporting and importing current session

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1926,6 +1926,10 @@ struct CMUXCLI {
         case "markdown":
             try runMarkdownCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        // Session export/import
+        case "session":
+            try runSessionCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+
         default:
             print(usage())
             throw CLIError(message: "Unknown command: \(command)")
@@ -2065,6 +2069,52 @@ struct CMUXCLI {
             let paneText = formatHandle(payload, kind: "pane", idFormat: idFormat) ?? "unknown"
             let filePath = (payload["path"] as? String) ?? absolutePath
             print("OK surface=\(surfaceText) pane=\(paneText) path=\(filePath)")
+        }
+    }
+
+    // MARK: - Session Commands
+
+    private func runSessionCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        guard let subcommand = commandArgs.first?.lowercased() else {
+            throw CLIError(message: "session requires save|open <path>. Usage: cmux session save <path> | cmux session open <path>")
+        }
+        let subArgs = Array(commandArgs.dropFirst())
+
+        switch subcommand {
+        case "save":
+            guard let rawPath = subArgs.first, !rawPath.isEmpty else {
+                throw CLIError(message: "session save requires a file path. Usage: cmux session save <path>")
+            }
+            let absolutePath = resolvePath(rawPath)
+            let payload = try client.sendV2(method: "session.save", params: ["path": absolutePath])
+            if jsonOutput {
+                print(jsonString(formatIDs(payload, mode: idFormat)))
+            } else {
+                let savedPath = (payload["path"] as? String) ?? absolutePath
+                print("OK path=\(savedPath)")
+            }
+
+        case "open":
+            guard let rawPath = subArgs.first, !rawPath.isEmpty else {
+                throw CLIError(message: "session open requires a file path. Usage: cmux session open <path>")
+            }
+            let absolutePath = resolvePath(rawPath)
+            let payload = try client.sendV2(method: "session.open", params: ["path": absolutePath])
+            if jsonOutput {
+                print(jsonString(formatIDs(payload, mode: idFormat)))
+            } else {
+                let windowCount = (payload["windows_created"] as? Int) ?? 0
+                let savedPath = (payload["path"] as? String) ?? absolutePath
+                print("OK windows_created=\(windowCount) path=\(savedPath)")
+            }
+
+        default:
+            throw CLIError(message: "Unknown session subcommand: \(subcommand). Usage: cmux session save <path> | cmux session open <path>")
         }
     }
 
@@ -5502,6 +5552,23 @@ struct CMUXCLI {
               cmux markdown open plan.md
               cmux markdown ~/project/CHANGELOG.md
               cmux markdown open ./docs/design.md --workspace 0
+            """
+        case "session":
+            return """
+            Usage: cmux session save <path>
+                   cmux session open <path>
+
+            Save or restore a cmux session to/from a .cmux-session JSON file.
+
+            Subcommands:
+              save <path>   Save the current session (all windows, workspaces, tabs, splits)
+                            to a .cmux-session file. Does not include scrollback history.
+              open <path>   Open a .cmux-session file, restoring each saved window as a
+                            new window. Existing windows are not affected.
+
+            Examples:
+              cmux session save ~/my-project.cmux-session
+              cmux session open ~/my-project.cmux-session
             """
         default:
             return nil
@@ -9589,6 +9656,9 @@ struct CMUXCLI {
           display-message [-p|--print] <text>
 
           markdown [open] <path>             (open markdown file in formatted viewer panel with live reload)
+
+          session save <path>                  (save current session to a .cmux-session file)
+          session open <path>                  (open a .cmux-session file, restoring windows as new windows)
 
           browser [--surface <id|ref|index> | <surface>] <subcommand> ...
           browser open [url]                   (create browser split in caller's workspace; if surface supplied, behaves like navigate)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -32758,6 +32758,345 @@
         }
       }
     },
+    "menu.file.openSession": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Session…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションを開く…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开会话..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟工作階段..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션 열기…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung öffnen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir sesión…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir une session..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri sessione…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn session…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz sesję…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть сессию..."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori sesiju…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح جلسة…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne økt …"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Sessão…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดเซสชัน..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oturumu Aç…"
+          }
+        }
+      }
+    },
+    "menu.file.openSession.panelPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aç"
+          }
+        }
+      }
+    },
+    "menu.file.openSession.panelTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションを開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开会话"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟工作階段"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션 열기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir une session"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri sessione"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn session"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz sesję"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть сессию"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori sesiju"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح جلسة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne økt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Sessão"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดเซสชัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oturumu Aç"
+          }
+        }
+      }
+    },
     "menu.file.reopenClosedBrowserPanel": {
       "extractionState": "manual",
       "localizations": {
@@ -32867,6 +33206,345 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kapatılan Tarayıcı Panelini Yeniden Aç"
+          }
+        }
+      }
+    },
+    "menu.file.saveSession": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Session…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションを保存…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存会话..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存工作階段..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션 저장…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung sichern …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar sesión…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer la session..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva sessione…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gem session…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz sesję…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить сессию..."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremi sesiju…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ الجلسة…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagre økt …"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar Sessão…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกเซสชัน..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oturumu Kaydet…"
+          }
+        }
+      }
+    },
+    "menu.file.saveSession.panelPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gem"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremi"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagre"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaydet"
+          }
+        }
+      }
+    },
+    "menu.file.saveSession.panelTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッションを保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存会话"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存工作階段"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션 저장"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitzung sichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar sesión"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer la session"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva sessione"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gem session"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz sesję"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить сессию"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremi sesiju"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ الجلسة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagre økt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar Sessão"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึกเซสชัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oturumu Kaydet"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import Bonsplit
 import CoreServices
+import UniformTypeIdentifiers
 import UserNotifications
 import Sentry
 import WebKit
@@ -5024,6 +5025,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @objc func openNewMainWindow(_ sender: Any?) {
         _ = createMainWindow()
+    }
+
+    // MARK: - Session file save / open
+
+    @objc func saveSessionToFile(_ sender: Any?) {
+        guard let snapshot = buildSessionSnapshot(includeScrollback: false) else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [
+            UTType(filenameExtension: SessionExportStore.fileExtension) ?? .json,
+        ]
+        panel.nameFieldStringValue = "session.\(SessionExportStore.fileExtension)"
+        panel.canCreateDirectories = true
+        panel.title = String(localized: "menu.file.saveSession.panelTitle", defaultValue: "Save Session")
+        panel.prompt = String(localized: "menu.file.saveSession.panelPrompt", defaultValue: "Save")
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        SessionExportStore.save(snapshot, to: url)
+    }
+
+    @objc func openSessionFromFile(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [
+            UTType(filenameExtension: SessionExportStore.fileExtension) ?? .json,
+        ]
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.title = String(localized: "menu.file.openSession.panelTitle", defaultValue: "Open Session")
+        panel.prompt = String(localized: "menu.file.openSession.panelPrompt", defaultValue: "Open")
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let snapshot = SessionExportStore.load(from: url) else { return }
+        for windowSnapshot in snapshot.windows.prefix(SessionPersistencePolicy.maxWindowsPerSnapshot) {
+            createMainWindow(sessionWindowSnapshot: windowSnapshot)
+        }
+    }
+
+    /// Build session snapshot for export (without scrollback). Accessible from TerminalController for socket commands.
+    func buildSessionSnapshotForExport() -> AppSessionSnapshot? {
+        return buildSessionSnapshot(includeScrollback: false)
     }
 
     @objc func openWindow(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2526,6 +2526,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private let configTemplate: ghostty_surface_config_s?
     private let workingDirectory: String?
     var requestedWorkingDirectory: String? { workingDirectory }
+    private let command: String?
     private var additionalEnvironment: [String: String]
     let hostedView: GhosttySurfaceScrollView
     private let surfaceView: GhosttyNSView
@@ -2597,6 +2598,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         context: ghostty_surface_context_e,
         configTemplate: ghostty_surface_config_s?,
         workingDirectory: String? = nil,
+        command: String? = nil,
         additionalEnvironment: [String: String] = [:]
     ) {
         self.id = UUID()
@@ -2604,6 +2606,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         self.surfaceContext = context
         self.configTemplate = configTemplate
         self.workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.command = command?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.additionalEnvironment = additionalEnvironment
         // Match Ghostty's own SurfaceView: ensure a non-zero initial frame so the backing layer
         // has non-zero bounds and the renderer can initialize without presenting a blank/stretched
@@ -3098,13 +3101,24 @@ final class TerminalSurface: Identifiable, ObservableObject {
             }
         }
 
+        let applyCommandAndCreate = {
+            if let command = self.command, !command.isEmpty {
+                command.withCString { cCommand in
+                    surfaceConfig.command = cCommand
+                    createSurface()
+                }
+            } else {
+                createSurface()
+            }
+        }
+
         if let workingDirectory, !workingDirectory.isEmpty {
             workingDirectory.withCString { cWorkingDir in
                 surfaceConfig.working_directory = cWorkingDir
-                createSurface()
+                applyCommandAndCreate()
             }
         } else {
-            createSurface()
+            applyCommandAndCreate()
         }
 
         if surface == nil {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -88,6 +88,7 @@ final class TerminalPanel: Panel, ObservableObject {
         context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_SPLIT,
         configTemplate: ghostty_surface_config_s? = nil,
         workingDirectory: String? = nil,
+        command: String? = nil,
         additionalEnvironment: [String: String] = [:],
         portOrdinal: Int = 0
     ) {
@@ -96,6 +97,7 @@ final class TerminalPanel: Panel, ObservableObject {
             context: context,
             configTemplate: configTemplate,
             workingDirectory: workingDirectory,
+            command: command,
             additionalEnvironment: additionalEnvironment
         )
         surface.portOrdinal = portOrdinal

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -224,6 +224,7 @@ struct SessionGitBranchSnapshot: Codable, Sendable {
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var scrollback: String?
+    var command: String?
 }
 
 struct SessionBrowserPanelSnapshot: Codable, Sendable {
@@ -414,6 +415,38 @@ enum SessionPersistenceStore {
         return resolvedAppSupport
             .appendingPathComponent("cmux", isDirectory: true)
             .appendingPathComponent("session-\(safeBundleId).json", isDirectory: false)
+    }
+}
+
+enum SessionExportStore {
+    static let fileExtension = "cmux-session"
+
+    @discardableResult
+    static func save(_ snapshot: AppSessionSnapshot, to fileURL: URL) -> Bool {
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(snapshot)
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func load(from fileURL: URL) -> AppSessionSnapshot? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        guard let snapshot = try? decoder.decode(AppSessionSnapshot.self, from: data) else { return nil }
+        guard snapshot.version == SessionSnapshotSchema.currentVersion else { return nil }
+        guard !snapshot.windows.isEmpty else { return nil }
+        return snapshot
     }
 }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2174,6 +2174,11 @@ class TerminalController {
         case "surface.read_text":
             return v2Result(id: id, self.v2SurfaceReadText(params: params))
 
+        // Session export/import
+        case "session.save":
+            return v2Result(id: id, self.v2SessionSave(params: params))
+        case "session.open":
+            return v2Result(id: id, self.v2SessionOpen(params: params))
 
 #if DEBUG
         // Debug / test-only
@@ -6208,6 +6213,87 @@ class TerminalController {
             ])
         }
         return result
+    }
+
+    // MARK: - Session export/import
+
+    private func v2SessionSave(params: [String: Any]) -> V2CallResult {
+        guard let rawPath = v2String(params, "path") else {
+            return .err(code: "invalid_params", message: "Missing 'path' parameter", data: nil)
+        }
+
+        let expandedPath = NSString(string: rawPath).expandingTildeInPath
+        let filePath = NSString(string: expandedPath).standardizingPath
+
+        guard filePath.hasPrefix("/") else {
+            return .err(code: "invalid_params", message: "Path must be absolute: \(filePath)", data: ["path": filePath])
+        }
+
+        // Ensure the parent directory exists and is writable
+        let parentDir = (filePath as NSString).deletingLastPathComponent
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: parentDir, isDirectory: &isDir), isDir.boolValue else {
+            return .err(code: "not_found", message: "Parent directory not found: \(parentDir)", data: ["path": filePath])
+        }
+        guard FileManager.default.isWritableFile(atPath: parentDir) else {
+            return .err(code: "permission_denied", message: "Parent directory not writable: \(parentDir)", data: ["path": filePath])
+        }
+
+        // Build snapshot on main thread
+        guard let snapshot = v2MainSync({ AppDelegate.shared?.buildSessionSnapshotForExport() }) else {
+            return .err(code: "internal_error", message: "Failed to build session snapshot", data: nil)
+        }
+
+        let url = URL(fileURLWithPath: filePath)
+        guard SessionExportStore.save(snapshot, to: url) else {
+            return .err(code: "internal_error", message: "Failed to write session file", data: ["path": filePath])
+        }
+
+        return .ok(["path": filePath])
+    }
+
+    private func v2SessionOpen(params: [String: Any]) -> V2CallResult {
+        guard let rawPath = v2String(params, "path") else {
+            return .err(code: "invalid_params", message: "Missing 'path' parameter", data: nil)
+        }
+
+        let expandedPath = NSString(string: rawPath).expandingTildeInPath
+        let filePath = NSString(string: expandedPath).standardizingPath
+
+        guard filePath.hasPrefix("/") else {
+            return .err(code: "invalid_params", message: "Path must be absolute: \(filePath)", data: ["path": filePath])
+        }
+
+        var isDirCheck: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: filePath, isDirectory: &isDirCheck) else {
+            return .err(code: "not_found", message: "File not found: \(filePath)", data: ["path": filePath])
+        }
+        guard !isDirCheck.boolValue else {
+            return .err(code: "invalid_params", message: "Path is a directory, not a file: \(filePath)", data: ["path": filePath])
+        }
+        guard FileManager.default.isReadableFile(atPath: filePath) else {
+            return .err(code: "permission_denied", message: "File not readable: \(filePath)", data: ["path": filePath])
+        }
+
+        let url = URL(fileURLWithPath: filePath)
+        guard let snapshot = SessionExportStore.load(from: url) else {
+            return .err(code: "invalid_data", message: "Failed to parse session file", data: ["path": filePath])
+        }
+
+        var windowIds: [String] = []
+        v2MainSync {
+            for windowSnapshot in snapshot.windows.prefix(SessionPersistencePolicy.maxWindowsPerSnapshot) {
+                if let windowId = AppDelegate.shared?.createMainWindow(sessionWindowSnapshot: windowSnapshot) {
+                    windowIds.append(windowId.uuidString)
+                }
+            }
+        }
+
+        return .ok([
+            "path": filePath,
+            "windows_created": windowIds.count,
+            "window_ids": windowIds
+        ])
     }
 
     // MARK: - Browser

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -316,9 +316,20 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback
             )
+            let snapshotCommand: String? = {
+                let title = panelTitles[panelId] ?? ""
+                let shellNames: Set<String> = [
+                    "bash", "zsh", "fish", "sh", "dash", "tcsh", "csh", "ksh",
+                    "nu", "nushell", "pwsh", "elvish", "login",
+                ]
+                let processName = title.components(separatedBy: " ").first ?? title
+                if shellNames.contains(processName.lowercased()) { return nil }
+                return title.isEmpty ? nil : title
+            }()
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: panelDirectories[panelId],
-                scrollback: resolvedScrollback
+                scrollback: resolvedScrollback,
+                command: snapshotCommand
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -489,6 +500,7 @@ extension Workspace {
         switch snapshot.type {
         case .terminal:
             let workingDirectory = snapshot.terminal?.workingDirectory ?? snapshot.directory ?? currentDirectory
+            let command = snapshot.terminal?.command
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: snapshot.terminal?.scrollback
             )
@@ -496,6 +508,7 @@ extension Workspace {
                 inPane: paneId,
                 focus: false,
                 workingDirectory: workingDirectory,
+                command: command,
                 startupEnvironment: replayEnvironment
             ) else {
                 return nil
@@ -2211,6 +2224,7 @@ final class Workspace: Identifiable, ObservableObject {
         inPane paneId: PaneID,
         focus: Bool? = nil,
         workingDirectory: String? = nil,
+        command: String? = nil,
         startupEnvironment: [String: String] = [:]
     ) -> TerminalPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
@@ -2223,6 +2237,7 @@ final class Workspace: Identifiable, ObservableObject {
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
             workingDirectory: workingDirectory,
+            command: command,
             additionalEnvironment: startupEnvironment,
             portOrdinal: portOrdinal
         )

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -433,6 +433,18 @@ struct cmuxApp: App {
                         }
                     }
                 }
+
+                Divider()
+
+                Button(String(localized: "menu.file.saveSession", defaultValue: "Save Session…")) {
+                    appDelegate.saveSessionToFile(nil)
+                }
+                .keyboardShortcut("s", modifiers: [.command, .shift])
+
+                Button(String(localized: "menu.file.openSession", defaultValue: "Open Session…")) {
+                    appDelegate.openSessionFromFile(nil)
+                }
+                .keyboardShortcut("o", modifiers: [.command, .shift])
             }
 
             // Close tab/workspace


### PR DESCRIPTION
## Summary
- add "Save Session…" (⇧⌘S) and "Open Session…" (⇧⌘O) menu items under File for exporting/importing the full app session as a `.cmux-session` JSON file
- leverage the existing `SessionPersistence` snapshot infrastructure (`AppSessionSnapshot`, `Workspace.sessionSnapshot()`, `TabManager.restoreSessionSnapshot()`) — no new persistence model needed
- capture foreground process commands (ssh, tmux, etc.) in snapshots so restored sessions re-launch non-shell commands via Ghostty's `command` config field
- opening a session file creates new windows alongside existing ones (non-destructive); scrollback is excluded to keep files small
- add `session.save` and `session.open` v2 socket commands and `cmux session save/open` CLI subcommands
- localize all 6 new menu/dialog strings across 18 languages
- register the `.cmux-session` UTType in Info.plist

 ## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag session-save-open`
- Manually verified: save a multi-window session with splits and workspaces, quit, re-open, import the file — all windows/workspaces/splits restored with correct working directories and foreground commands
 

## Context
- Motivated by losing a complex session layout after closing cmux — the built-in autosave only restores the last session on relaunch, not arbitrary saved snapshots
- Exported `.cmux-session` files can also serve as reusable workspace templates (e.g. save a "backend dev" layout and import it whenever needed, similar to vscode "Open Workspace from file")

## Issues
- Relates to #480 (persistence of tab information and pane layouts — this adds manual save/open; auto-restore on launch not yet covered)
- Relates to #1337 (restore live SSH/tmux sessions — foreground commands are now captured and re-launched on import)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add session export/import to save the full app state to a `.cmux-session` JSON file and reopen it later as new windows. Restores windows, workspaces, tabs, splits, and non-shell foreground commands; scrollback is excluded.

- **New Features**
  - File menu: “Save Session…” (Shift+Cmd+S) and “Open Session…” (Shift+Cmd+O).
  - Uses existing snapshot pipeline; imports create new windows without touching the current ones.
  - Captures foreground commands (e.g., ssh/tmux) and restores them via Ghostty’s `command`.
  - CLI: `cmux session save <path>` and `cmux session open <path>`; Socket: `session.save`, `session.open`.
  - Localized strings for menu items and dialog titles/prompts across 18 languages.

<sup>Written for commit 39df922a7e912a394f5efc29f708593e2b0980e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Save and restore workspace sessions: Export your current workspace configuration to a file and restore it later using the new "Save Session…" and "Open Session…" menu items with keyboard shortcuts Cmd+Shift+S and Cmd+Shift+O.
  * CLI session management: Introduced `cmux session save <path>` and `cmux session open <path>` commands for managing sessions from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->