### PR TITLE
Fix inconsistent theme chrome on non-mounted workspaces

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2442,6 +2442,23 @@ struct ContentView: View {
 #endif
         })
 
+        // When the system appearance changes or Ghostty reloads its config, the default
+        // background color updates. Only the currently-mounted WorkspaceContentView
+        // receives this notification — non-mounted workspaces keep stale bonsplit
+        // chrome until they mount. Push the updated chrome to ALL workspaces here
+        // so every tab's split bar reflects the current appearance immediately.
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
+            let backgroundColor = GhosttyApp.shared.defaultBackgroundColor
+            let backgroundOpacity = GhosttyApp.shared.defaultBackgroundOpacity
+            for workspace in tabManager.tabs {
+                workspace.applyGhosttyChrome(
+                    backgroundColor: backgroundColor,
+                    backgroundOpacity: backgroundOpacity,
+                    reason: "contentView.ghosttyDefaultBackgroundDidChange"
+                )
+            }
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteToggleRequested)) { notification in
             let requestedWindow = notification.object as? NSWindow
             guard Self.shouldHandleCommandPaletteRequest(


### PR DESCRIPTION
## Problem

When the system appearance changes (light/dark mode toggle) or Ghostty reloads its config, the default background color updates and a `ghosttyDefaultBackgroundDidChange` notification fires. However, only the currently-mounted `WorkspaceContentView` (one workspace at a time, per `WorkspaceMountPolicy.maxMountedWorkspaces=1`) observes this notification and calls `workspace.applyGhosttyChrome()`. Non-mounted workspaces retain stale bonsplit chrome until the user switches to them and their view fires `onAppear`.

This causes inconsistent tab bar/split bar colors after:
- System appearance toggles with multiple workspaces
- Session restore creating workspaces before the first surface triggers a config reload

## Fix

Observe `ghosttyDefaultBackgroundDidChange` in `ContentView` (which owns the full `tabManager.tabs` list) and push `applyGhosttyChrome` to every workspace. The existing `isNoOp` guard inside `applyGhosttyChrome` ensures workspaces already at the correct color are skipped.

## Why this is safe

- `applyGhosttyChrome` has a built-in no-op check: if the workspace's chrome hex already matches, it returns immediately
- The notification is global, and each `ContentView` (one per window) iterates only its own `tabManager.tabs`
- No new allocations, no new state — just pushing an existing value to workspaces that missed it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent tab/split chrome across workspaces by updating all tabs when the default background changes. When system appearance or config reload updates the background, every workspace now refreshes immediately.

- **Bug Fixes**
  - Listen for `ghosttyDefaultBackgroundDidChange` in `ContentView` and call `applyGhosttyChrome` for each workspace with the current background color/opacity.
  - Safe and cheap: no-op if chrome already matches, and each window only updates its own tabs.

<sup>Written for commit 0646798347c83b287ebb1eef55b48d52a83a5276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed appearance theme changes to propagate consistently across all UI elements, ensuring the app's visual styling updates immediately when the system theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->