### PR TITLE
Persist split pane sizes across app restarts

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -425,7 +425,8 @@ extension Workspace {
                     from: anchorPanelId,
                     orientation: split.orientation.splitOrientation,
                     insertFirst: false,
-                    focus: false
+                    focus: false,
+                    animate: false
                   ),
                   let secondPaneId = self.paneId(forPanelId: newSplitPanel.id) else {
                 leaves.append(
@@ -2100,7 +2101,8 @@ final class Workspace: Identifiable, ObservableObject {
         from panelId: UUID,
         orientation: SplitOrientation,
         insertFirst: Bool = false,
-        focus: Bool = true
+        focus: Bool = true,
+        animate: Bool = true
     ) -> TerminalPanel? {
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
@@ -2170,7 +2172,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Create the split with the new tab already present in the new pane.
         isProgrammaticSplit = true
         defer { isProgrammaticSplit = false }
-        guard bonsplitController.splitPane(paneId, orientation: orientation, withTab: newTab, insertFirst: insertFirst) != nil else {
+        guard bonsplitController.splitPane(paneId, orientation: orientation, withTab: newTab, insertFirst: insertFirst, animate: animate) != nil else {
             panels.removeValue(forKey: newPanel.id)
             panelTitles.removeValue(forKey: newPanel.id)
             surfaceIdToPanelId.removeValue(forKey: newTab.id)


### PR DESCRIPTION
Fixes #1376

## Summary
- split pane sizes were resetting to 50/50 on restart because the entry animation code overwrites `dividerPosition` back to 0.5 after `applySessionDividerPositions` has already set the saved values
- add `animate` parameter to bonsplit's `splitPane` (default `true`, no behavior change for existing callers)
- pass `animate: false` during session restore so splits are created without entry animation and saved divider positions stick

Companion bonsplit PR: manaflow-ai/bonsplit#25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal panels now restore without animation during session recovery, delivering faster restoration times and a smoother visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->