### PR TITLE
Fix tab bar and titlebar not updating on system appearance change

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1580,10 +1580,13 @@ class GhosttyApp {
         }
         loadDefaultConfigFilesWithLegacyFallback(newConfig)
         ghostty_app_update_config(app, newConfig)
+        // Must use .surface scope: ghostty_app_update_config fires surface-scoped
+        // CONFIG_CHANGE callbacks synchronously, and the last surface may carry a
+        // stale color from the previous appearance. This write comes after and must win.
         updateDefaultBackground(
             from: newConfig,
             source: "reloadConfiguration(source=\(source))",
-            scope: .unscoped
+            scope: .surface
         )
         DispatchQueue.main.async {
             self.applyBackgroundToKeyWindow()
@@ -3812,11 +3815,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         layoutSubtreeIfNeeded()
         updateSurfaceSize()
         applySurfaceBackground()
-        applySurfaceColorScheme(force: true)
+        // Synchronize theme before applySurfaceColorScheme, which triggers a soft
+        // reload that updates lastAppearanceColorScheme as a side effect.
         GhosttyApp.shared.synchronizeThemeWithAppearance(
             effectiveAppearance,
             source: "surface.viewDidMoveToWindow"
         )
+        applySurfaceColorScheme(force: true)
         applyWindowBackgroundIfActive()
         invalidateTextInputCoordinates()
     }
@@ -3829,11 +3834,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 "surface appearance changed tab=\(tabId?.uuidString ?? "nil") surface=\(terminalSurface?.id.uuidString ?? "nil") bestMatch=\(bestMatch?.rawValue ?? "nil")"
             )
         }
-        applySurfaceColorScheme()
+        // Synchronize theme before applySurfaceColorScheme, which triggers a soft
+        // reload that updates lastAppearanceColorScheme as a side effect.
         GhosttyApp.shared.synchronizeThemeWithAppearance(
             effectiveAppearance,
             source: "surface.viewDidChangeEffectiveAppearance"
         )
+        applySurfaceColorScheme()
     }
 
     fileprivate func updateOcclusionState() {


### PR DESCRIPTION
## Problem

When toggling macOS system appearance (light/dark mode), the bonsplit tab bar and window titlebar stayed stuck at the old appearance color. Terminal content and the sidebar updated correctly, but the tab bar and titlebar required switching workspaces to refresh.

## Root Cause

Two issues in `SurfaceView_AppKit`:

**1. Call order in `viewDidChangeEffectiveAppearance` / `viewDidMoveToWindow`**

`applySurfaceColorScheme()` was called before `synchronizeThemeWithAppearance()`. The former triggers a Ghostty soft reload whose `CONFIG_CHANGE` callback updates `lastAppearanceColorScheme` as a side effect. By the time `synchronizeThemeWithAppearance` ran, it saw `previous == current` and skipped the full config reload needed to update `defaultBackgroundColor`.

**2. Scope priority in `reloadConfiguration`**

Even after fixing the call order, the full config reload set `defaultBackgroundColor` with `.unscoped` scope (priority 0). But `ghostty_app_update_config` fires surface-scoped `CONFIG_CHANGE` callbacks synchronously (priority 2), and with multiple workspaces, the last surface to report could carry a stale color from the previous appearance — overwriting the correct value.

## Fix

1. Swap the call order: `synchronizeThemeWithAppearance` now runs before `applySurfaceColorScheme` so the light/dark transition is detected and triggers a full config reload.

2. Change the full reload's `updateDefaultBackground` scope from `.unscoped` to `.surface` so its write (which reads the correct appearance-conditional config) is not rejected by stale surface callbacks.

## Testing

Verified with screenshot-based testing across multiple scenarios:
- Light \u2192 dark toggle with restored session (multiple workspaces)
- Dark \u2192 light toggle
- New workspace creation after toggle
- App restart with session restore followed by toggle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab bar and titlebar staying on the old theme when macOS switches light/dark mode. Updates call order and config scope so the correct background color applies immediately across workspaces.

- **Bug Fixes**
  - Call `synchronizeThemeWithAppearance` before `applySurfaceColorScheme` in `viewDidMoveToWindow` and `viewDidChangeEffectiveAppearance` to detect the appearance change and trigger the full reload.
  - Set `updateDefaultBackground` to `.surface` scope during full reload so it wins over stale surface-scoped callbacks and correctly updates `defaultBackgroundColor`.

<sup>Written for commit 0795d6a5b7380027ccfae9eec1e665f2936defed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme and color scheme synchronization to ensure the terminal appearance updates correctly when the system theme changes or configuration is reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->