### PR TITLE
Fix Option+Delete not deleting previous word

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5248,6 +5248,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
                 return nil
             }
+
+            // When Option transforms a control/special key into a printable
+            // Unicode character (e.g. Option+Delete → "∂"), suppress the text
+            // so Ghostty's key encoder handles Alt+key instead.
+            if let unmodified = event.charactersIgnoringModifiers?.unicodeScalars.first,
+               (unmodified.value < 0x20 || unmodified.value == 0x7F),
+               scalar.value != unmodified.value {
+                return nil
+            }
         }
 
         return chars

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5249,11 +5249,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 return nil
             }
 
-            // When Option transforms a control/special key into a printable
+            // When Option transforms Delete/Backspace into a printable
             // Unicode character (e.g. Option+Delete → "∂"), suppress the text
-            // so Ghostty's key encoder handles Alt+key instead.
+            // so Ghostty's key encoder handles Alt+Backspace instead.
             if let unmodified = event.charactersIgnoringModifiers?.unicodeScalars.first,
-               (unmodified.value < 0x20 || unmodified.value == 0x7F),
+               unmodified.value == 0x7F,
                scalar.value != unmodified.value {
                 return nil
             }


### PR DESCRIPTION
Fixes #1424

## Summary
- macOS maps Option+Delete to "∂" (U+2202), which was sent to Ghostty as literal text instead of letting the key encoder handle Alt+Backspace
- Option+Arrow works because arrow keys produce PUA characters (0xF700-0xF8FF) that `textForKeyEvent` already filters out — "∂" wasn't caught by any filter
- suppress text in `textForKeyEvent` when the unmodified key produces a control character (< 0x20 or DEL/0x7F) but Option transforms it into a different printable character

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Option+Delete on macOS so it deletes the previous word instead of inserting "∂". Suppresses printable text for Option+Backspace only so the key encoder handles Alt+Backspace.

- **Bug Fixes**
  - In `textForKeyEvent`, ignore text only when the unmodified key is Delete/Backspace (0x7F) and Option produces a different printable character (e.g., Option+Delete → "∂").
  - Keeps existing PUA filtering for arrow keys; Option+Arrow behavior is unchanged.

<sup>Written for commit cab1d9fcdc3cb79e0a20cf3560fa992f8aecb3ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for Option/Alt combinations that produce printable characters (e.g., Option+Delete → "∂"), preventing those characters from being sent as text so Alt+key sequences are correctly processed by the terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->