### PR TITLE
Fix accessibility role on GhosttyScrollView for voice input tools

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5828,6 +5828,19 @@ private final class GhosttyScrollView: NSScrollView {
     // Keep keyboard routing on the terminal surface; this wrapper is viewport plumbing.
     override var acceptsFirstResponder: Bool { false }
 
+    // MARK: - Accessibility
+
+    /// Report this scroll view as a text area so that AX clients (e.g. Typeless
+    /// voice input) recognize it as an editable input target rather than a plain
+    /// scroll area.
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        .textArea
+    }
+
+    override func isAccessibilityElement() -> Bool {
+        true
+    }
+
     override func scrollWheel(with event: NSEvent) {
         guard let surfaceView else {
             super.scrollWheel(with: event)


### PR DESCRIPTION
## Summary

- `GhosttyScrollView` (`NSScrollView`) reports `AXScrollArea` by default, which causes voice input tools (e.g. [Typeless](https://www.typeless.com)) to fail to detect an editable text target
- When this happens, Typeless shows a fallback "Copy last transcript" dialog instead of inserting text directly into the terminal
- This PR overrides `accessibilityRole()` to return `.textArea`, consistent with the child `GhosttyNSView` which already reports `.textArea` at line 4361

## Reproduction

1. Install a voice input tool that uses macOS Accessibility API (e.g. Typeless)
2. Focus a terminal pane in cmux
3. Dictate text → fallback copy dialog appears instead of direct text insertion

Verified with:
```bash
osascript -e 'tell application "System Events" to get value of attribute "AXRole" of (value of attribute "AXFocusedUIElement" of first application process whose frontmost is true)'
```
- Before: `AXScrollArea`
- After: `AXTextArea`

## Risk

- Low. `accessibilityRole` only affects how the view identifies itself to AX clients (voice input, screen readers). It does not change rendering, event handling, or keyboard focus routing.
- `GhosttyScrollView` has `acceptsFirstResponder = false`, so keyboard focus always goes to the child `GhosttyNSView`.

## Test plan

- [x] Typeless voice input inserts text directly without fallback dialog
- [ ] VoiceOver navigation still works correctly
- [ ] Standard keyboard/mouse input unaffected