### PR TITLE
Fix arrow key glyph matching in customizable shortcuts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9504,6 +9504,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case ".": return 47  // kVK_ANSI_Period
         case "`": return 50  // kVK_ANSI_Grave
         case "\r": return 36 // kVK_Return
+        case "←": return 123 // kVK_LeftArrow
+        case "→": return 124 // kVK_RightArrow
+        case "↓": return 125 // kVK_DownArrow
+        case "↑": return 126 // kVK_UpArrow
         default:
             return nil
         }


### PR DESCRIPTION
## Summary
- `keyCodeForShortcutKey()` was missing mappings for arrow glyphs (←→↑↓) to macOS key codes (123-126)
- The shortcut recorder stored arrow keys as glyphs via `storedKey()`, but `matchShortcut()` couldn't resolve them back for ANSI keyCode fallback matching
- This affected any non-directional action bound to arrow keys (e.g. Next/Previous Surface with Cmd+Arrow), since pane focus shortcuts use a separate `matchDirectionalShortcut()` path

## Test plan
- Set "Next Surface" to Cmd+Right and "Previous Surface" to Cmd+Left in Settings → Keyboard Shortcuts
- Open 2+ surfaces in a workspace
- Verify Cmd+Right/Left switches between surfaces
- Verify existing pane focus shortcuts (Cmd+Option+Arrow) still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix arrow key shortcut matching by mapping arrow glyphs (← → ↑ ↓) to their macOS key codes (123–126). Non-directional actions bound to Cmd+Arrow (e.g., Next/Previous Surface) now work; existing pane focus shortcuts are unaffected.

<sup>Written for commit 80dc663b3fa0a97b6b43b1141ca9f09fb8178339. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arrow keys (↑, ↓, ←, →) are now supported as keyboard shortcuts for navigation and control functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->