### PR TITLE
fix: remove blocking sleep from preexec hook causing command lag

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -263,11 +263,9 @@ _cmux_run_pr_probe_with_timeout() {
 
 _cmux_stop_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" TERM
-        sleep 0.1
-        if kill -0 "$_CMUX_PR_POLL_PID" >/dev/null 2>&1; then
-            _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" KILL
-        fi
+        # Use SIGKILL directly to avoid blocking sleep in preexec.
+        # The poll loop is lightweight and safe to kill abruptly.
+        _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" KILL
         _CMUX_PR_POLL_PID=""
     fi
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -288,11 +288,9 @@ _cmux_run_pr_probe_with_timeout() {
 
 _cmux_stop_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" TERM
-        sleep 0.1
-        if kill -0 "$_CMUX_PR_POLL_PID" >/dev/null 2>&1; then
-            _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" KILL
-        fi
+        # Use SIGKILL directly to avoid blocking sleep in preexec.
+        # The poll loop is lightweight and safe to kill abruptly.
+        _cmux_kill_process_tree "$_CMUX_PR_POLL_PID" KILL
         _CMUX_PR_POLL_PID=""
     fi
 }


### PR DESCRIPTION
## Problem

When socket connection mode is set to anything other than "off", running any command introduces noticeable lag (~100ms+ per command). Commands like `ls` and `clear` feel sluggish compared to when socket mode is "off" or other terminals.

Fixes #1436

## Root Cause

The `_cmux_stop_pr_poll_loop` function in both zsh and bash shell integration scripts had a blocking `sleep 0.1` call. This function is invoked in the `preexec` hook (before every command) when socket mode is not "off", causing at least 100ms of blocking delay on every single command execution.

When socket mode is "off", the PR poll loop is never started (due to socket path checks), so `_CMUX_PR_POLL_PID` is never set, and the blocking sleep is never executed.

## Change Summary

- Modified `_cmux_stop_pr_poll_loop` in `cmux-zsh-integration.zsh`
- Modified `_cmux_stop_pr_poll_loop` in `cmux-bash-integration.bash`
- Replaced the `TERM → sleep 0.1 → conditional KILL` pattern with direct `SIGKILL`
- Added clear comments explaining the change

The PR poll loop is a lightweight background process that just runs `gh pr view` periodically. It is safe to kill abruptly with SIGKILL without waiting for graceful termination.

## Verification

```bash
# Syntax validation
zsh -n Resources/shell-integration/cmux-zsh-integration.zsh
bash -n Resources/shell-integration/cmux-bash-integration.bash

# No trailing whitespace or other issues
git diff --check
```

All checks passed.

## Risk

**None.** The PR poll loop is a stateless periodic `gh pr view` query. Killing it abruptly does not corrupt any state or lose any data. The next command will simply start a fresh poll loop if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes ~100ms command lag in socket mode by eliminating a blocking sleep in the preexec hook. Replaces the TERM→sleep→KILL sequence with a direct SIGKILL to stop the PR poll loop in both zsh and bash integrations, fixing #1436.

<sup>Written for commit eb7c7d0e61054c330645ce69156cbefbc01719a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of internal poll process termination by using a more direct approach, eliminating intermediate delays and simplifying the shutdown sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->