### PR TITLE
fix: close About/Licenses windows with Cmd+W

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1034,7 +1034,7 @@ struct cmuxApp: App {
 
     private func closePanelOrWindow() {
         if let window = NSApp.keyWindow,
-           window.identifier?.rawValue == "cmux.settings" {
+           ["cmux.settings", "cmux.about", "cmux.licenses"].contains(window.identifier?.rawValue ?? "") {
             window.performClose(nil)
             return
         }


### PR DESCRIPTION
## Problem

When the user opens the About cmux window (cmux > About cmux menu) and presses Cmd+W, instead of closing the About dialog, it closes the terminal session/panel in the main window. The same issue occurs with the Licenses window.

**Issue**: Fixes #1439

## Root Cause

The `closePanelOrWindow()` function (bound to Cmd+W) only checked for `cmux.settings` window identifier to call `performClose`. When the About window (`cmux.about`) or Licenses window (`cmux.licenses`) was key, the check failed and it fell through to `activeTabManager.closeCurrentPanelWithConfirmation()` which closes the terminal panel.

## Change

Extended the window identifier check in `closePanelOrWindow()` to include `cmux.about` and `cmux.licenses`:

```swift
// Before
if let window = NSApp.keyWindow,
   window.identifier?.rawValue == "cmux.settings" {

// After
if let window = NSApp.keyWindow,
   ["cmux.settings", "cmux.about", "cmux.licenses"].contains(window.identifier?.rawValue ?? "") {
```

Cmd+W now correctly closes the About window and Licenses window when they are the key window, matching expected macOS behavior for closing auxiliary windows.

## Verification

- `git diff --check` passes (no whitespace issues)
- Minimal change: 1 line modified, 1 insertion, 1 deletion
- Change follows existing pattern for Settings window handling

## Risk

Low risk - minimal change that extends an existing pattern. The change is additive and doesn't modify any existing behavior for the Settings window or terminal panels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+W now closes the About and Licenses windows when focused, instead of closing the terminal panel. Adds their window identifiers to the `closePanelOrWindow()` check to match macOS behavior (fixes #1439).

<sup>Written for commit 5c435293180cb2a9b8ff02e3dcac905bc32035b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window closing behavior to properly handle About and Licenses windows in addition to the Settings window, ensuring consistent window management across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->