### PR TITLE
Let users scale sidebar font size with keyboard shortcuts

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10135,6 +10135,12 @@ private struct TabItemView: View, Equatable {
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var activeTabIndicatorStyleRaw = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage(SidebarFontSizeSettings.scaleKey)
+    private var sidebarFontSizeScale = SidebarFontSizeSettings.defaultScale
+
+    private func scaledFont(size: CGFloat, weight: Font.Weight = .regular, design: Font.Design = .default) -> Font {
+        .system(size: size * CGFloat(sidebarFontSizeScale), weight: weight, design: design)
+    }
 
     var isMultiSelected: Bool {
         selectedTabIds.contains(tab.id)
@@ -10291,7 +10297,7 @@ private struct TabItemView: View, Equatable {
                         Circle()
                             .fill(activeUnreadBadgeFillColor)
                         Text("\(unreadCount)")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(scaledFont(size: 9, weight: .semibold))
                             .foregroundColor(.white)
                     }
                     .frame(width: 16, height: 16)
@@ -10299,12 +10305,12 @@ private struct TabItemView: View, Equatable {
 
                 if tab.isPinned {
                     Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(scaledFont(size: 9, weight: .semibold))
                         .foregroundColor(activeSecondaryColor(0.8))
                 }
 
                 Text(tab.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(scaledFont(size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -10319,7 +10325,7 @@ private struct TabItemView: View, Equatable {
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
                         Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .medium))
+                            .font(scaledFont(size: 9, weight: .medium))
                             .foregroundColor(activeSecondaryColor(0.7))
                     }
                     .buttonStyle(.plain)
@@ -10332,7 +10338,7 @@ private struct TabItemView: View, Equatable {
                         Text(workspaceShortcutLabel)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(scaledFont(size: 10, weight: .semibold, design: .rounded))
                             .monospacedDigit()
                             .foregroundColor(activePrimaryTextColor)
                             .padding(.horizontal, 6)
@@ -10351,7 +10357,7 @@ private struct TabItemView: View, Equatable {
 
             if let subtitle = latestNotificationSubtitle {
                 Text(subtitle)
-                    .font(.system(size: 10))
+                    .font(scaledFont(size: 10))
                     .foregroundColor(activeSecondaryColor(0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -10383,10 +10389,10 @@ private struct TabItemView: View, Equatable {
             if detailVisibility.showsLog, let latestLog = tab.logEntries.last {
                 HStack(spacing: 4) {
                     Image(systemName: logLevelIcon(latestLog.level))
-                        .font(.system(size: 8))
+                        .font(scaledFont(size: 8))
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
-                        .font(.system(size: 10))
+                        .font(scaledFont(size: 10))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -10410,7 +10416,7 @@ private struct TabItemView: View, Equatable {
 
                     if let label = progress.label {
                         Text(label)
-                            .font(.system(size: 9))
+                            .font(scaledFont(size: 9))
                             .foregroundColor(activeSecondaryColor(0.6))
                             .lineLimit(1)
                     }
@@ -10425,7 +10431,7 @@ private struct TabItemView: View, Equatable {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, branchLinesContainBranch {
                                 Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: 9))
+                                    .font(scaledFont(size: 9))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
@@ -10433,20 +10439,20 @@ private struct TabItemView: View, Equatable {
                                     HStack(spacing: 3) {
                                         if let branch = line.branch {
                                             Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(scaledFont(size: 10, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
                                         }
                                         if line.branch != nil, line.directory != nil {
                                             Image(systemName: "circle.fill")
-                                                .font(.system(size: 3))
+                                                .font(scaledFont(size: 3))
                                                 .foregroundColor(activeSecondaryColor(0.6))
                                                 .padding(.horizontal, 1)
                                         }
                                         if let directory = line.directory {
                                             Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(scaledFont(size: 10, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -10460,11 +10466,11 @@ private struct TabItemView: View, Equatable {
                     HStack(spacing: 3) {
                         if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
                             Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
+                                .font(scaledFont(size: 9))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(scaledFont(size: 10, design: .monospaced))
                             .foregroundColor(activeSecondaryColor(0.75))
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -10492,7 +10498,7 @@ private struct TabItemView: View, Equatable {
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(scaledFont(size: 10, weight: .semibold))
                             .foregroundColor(pullRequestForegroundColor)
                         }
                         .buttonStyle(.plain)
@@ -10504,7 +10510,7 @@ private struct TabItemView: View, Equatable {
             // Ports row
             if detailVisibility.showsPorts, !tab.listeningPorts.isEmpty {
                 Text(tab.listeningPorts.map { ":\($0)" }.joined(separator: ", "))
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(scaledFont(size: 10, design: .monospaced))
                     .foregroundColor(activeSecondaryColor(0.75))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -11335,6 +11341,8 @@ private struct SidebarMetadataRows: View {
     let entries: [SidebarStatusEntry]
     let isActive: Bool
     let onFocus: () -> Void
+    @AppStorage(SidebarFontSizeSettings.scaleKey)
+    private var sidebarFontSizeScale = SidebarFontSizeSettings.defaultScale
 
     @State private var isExpanded: Bool = false
     private let collapsedEntryLimit = 3
@@ -11353,7 +11361,7 @@ private struct SidebarMetadataRows: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: 10 * CGFloat(sidebarFontSizeScale), weight: .semibold))
                 .foregroundColor(isActive ? activeSecondaryTextColor : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -11387,6 +11395,8 @@ private struct SidebarMetadataEntryRow: View {
     let entry: SidebarStatusEntry
     let isActive: Bool
     let onFocus: () -> Void
+    @AppStorage(SidebarFontSizeSettings.scaleKey)
+    private var sidebarFontSizeScale = SidebarFontSizeSettings.defaultScale
 
     var body: some View {
         Group {
@@ -11419,7 +11429,7 @@ private struct SidebarMetadataEntryRow: View {
                 .truncationMode(.tail)
             Spacer(minLength: 0)
         }
-        .font(.system(size: 10))
+        .font(.system(size: 10 * CGFloat(sidebarFontSizeScale)))
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -11443,12 +11453,12 @@ private struct SidebarMetadataEntryRow: View {
         if iconRaw.hasPrefix("emoji:") {
             let value = String(iconRaw.dropFirst("emoji:".count))
             guard !value.isEmpty else { return nil }
-            return AnyView(Text(value).font(.system(size: 9)))
+            return AnyView(Text(value).font(.system(size: 9 * CGFloat(sidebarFontSizeScale))))
         }
         if iconRaw.hasPrefix("text:") {
             let value = String(iconRaw.dropFirst("text:".count))
             guard !value.isEmpty else { return nil }
-            return AnyView(Text(value).font(.system(size: 8, weight: .semibold)))
+            return AnyView(Text(value).font(.system(size: 8 * CGFloat(sidebarFontSizeScale), weight: .semibold)))
         }
         let symbolName: String
         if iconRaw.hasPrefix("sf:") {
@@ -11457,7 +11467,7 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(Image(systemName: symbolName).font(.system(size: 8, weight: .medium)))
+        return AnyView(Image(systemName: symbolName).font(.system(size: 8 * CGFloat(sidebarFontSizeScale), weight: .medium)))
     }
 
     @ViewBuilder
@@ -11485,6 +11495,8 @@ private struct SidebarMetadataMarkdownBlocks: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @AppStorage(SidebarFontSizeSettings.scaleKey)
+    private var sidebarFontSizeScale = SidebarFontSizeSettings.defaultScale
     @State private var isExpanded: Bool = false
     private let collapsedBlockLimit = 1
 
@@ -11506,7 +11518,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: 10 * CGFloat(sidebarFontSizeScale), weight: .semibold))
                 .foregroundColor(isActive ? .white.opacity(0.65) : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -11528,6 +11540,8 @@ private struct SidebarMetadataMarkdownBlockRow: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @AppStorage(SidebarFontSizeSettings.scaleKey)
+    private var sidebarFontSizeScale = SidebarFontSizeSettings.defaultScale
     @State private var renderedMarkdown: AttributedString?
 
     var body: some View {
@@ -11540,7 +11554,7 @@ private struct SidebarMetadataMarkdownBlockRow: View {
                     .foregroundColor(foregroundColor)
             }
         }
-        .font(.system(size: 10))
+        .font(.system(size: 10 * CGFloat(sidebarFontSizeScale)))
         .multilineTextAlignment(.leading)
         .fixedSize(horizontal: false, vertical: true)
         .contentShape(Rectangle())

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -51,6 +51,36 @@ enum WorkspaceAutoReorderSettings {
     }
 }
 
+enum SidebarFontSizeSettings {
+    static let scaleKey = "sidebarFontSizeScale"
+    static let defaultScale: Double = 1.0
+    static let minimumScale: Double = 0.75
+    static let maximumScale: Double = 1.5
+    static let scaleStep: Double = 0.05
+
+    static func currentScale(defaults: UserDefaults = .standard) -> Double {
+        let stored = defaults.double(forKey: scaleKey)
+        guard stored > 0 else { return defaultScale }
+        return min(max(stored, minimumScale), maximumScale)
+    }
+
+    static func increase(defaults: UserDefaults = .standard) {
+        let current = currentScale(defaults: defaults)
+        let newScale = min(current + scaleStep, maximumScale)
+        defaults.set(newScale, forKey: scaleKey)
+    }
+
+    static func decrease(defaults: UserDefaults = .standard) {
+        let current = currentScale(defaults: defaults)
+        let newScale = max(current - scaleStep, minimumScale)
+        defaults.set(newScale, forKey: scaleKey)
+    }
+
+    static func reset(defaults: UserDefaults = .standard) {
+        defaults.set(defaultScale, forKey: scaleKey)
+    }
+}
+
 enum SidebarBranchLayoutSettings {
     static let key = "sidebarBranchVerticalLayout"
     static let defaultVerticalLayout = true

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -587,6 +587,23 @@ struct cmuxApp: App {
                     BrowserHistoryStore.shared.clearHistory()
                 }
 
+                Divider()
+
+                Button(String(localized: "menu.view.sidebarZoomIn", defaultValue: "Sidebar Zoom In")) {
+                    SidebarFontSizeSettings.increase()
+                }
+                .keyboardShortcut("=", modifiers: [.command, .shift])
+
+                Button(String(localized: "menu.view.sidebarZoomOut", defaultValue: "Sidebar Zoom Out")) {
+                    SidebarFontSizeSettings.decrease()
+                }
+                .keyboardShortcut("-", modifiers: [.command, .shift])
+
+                Button(String(localized: "menu.view.sidebarZoomReset", defaultValue: "Sidebar Actual Size")) {
+                    SidebarFontSizeSettings.reset()
+                }
+                .keyboardShortcut("0", modifiers: [.command, .shift])
+
                 splitCommandButton(title: String(localized: "menu.view.nextWorkspace", defaultValue: "Next Workspace"), shortcut: nextWorkspaceMenuShortcut) {
                     activeTabManager.selectNextTab()
                 }


### PR DESCRIPTION
## Summary

- Adds the ability to zoom sidebar text in and out (Cmd+Shift+= / Cmd+Shift+-), similar to how browser zoom already works
- Font sizes across all sidebar tab content (titles, branches, ports, metadata, etc.) scale proportionally from 0.75x to 1.5x
- Cmd+Shift+0 resets back to the default size
- Spacing and layout stay untouched — only font sizes change
- Persisted via UserDefaults so it sticks across sessions

## How it works

A new `SidebarFontSizeSettings` enum in `TabManager.swift` manages the scale factor. Each sidebar view reads it through `@AppStorage` and multiplies its base font size by the scale. Three new menu items under View make it discoverable.

## Test plan

- [ ] Open cmux, press Cmd+Shift+= a few times — sidebar text should get larger
- [ ] Press Cmd+Shift+- — sidebar text should shrink
- [ ] Press Cmd+Shift+0 — sidebar text should reset to default
- [ ] Verify spacing/padding doesn't change, only font sizes
- [ ] Restart cmux — the chosen scale should persist
- [ ] Confirm existing Cmd+=/- browser zoom still works independently

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard shortcuts to scale sidebar text. Improves readability without changing spacing or layout.

- **New Features**
  - Cmd+Shift+= to zoom in, Cmd+Shift+- to zoom out, Cmd+Shift+0 to reset. Also in View > Sidebar Zoom In/Out/Actual Size.
  - All sidebar text, badges, and SF Symbols scale from 0.75x to 1.5x in 0.05 steps.
  - Persists via `UserDefaults` and works independently of browser zoom.
  - Implemented `SidebarFontSizeSettings` with increase/decrease/reset and used `@AppStorage` to apply across sidebar views.

<sup>Written for commit c2540014ad1995099b4b5805b5b325c90af41a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar text-size controls added to the View menu with keyboard shortcuts (increase, decrease, reset).
  * Global sidebar font scaling now applies consistently to titles, badges, pins, subtitles, metadata, icons and markdown blocks.
  * Per-view scaling state persists so adjustments are remembered across views and sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->