### PR TITLE
Fix main CI regressions

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4441,9 +4441,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func invalidateTextInputCoordinates(selectionChanged: Bool = false) {
         guard let inputContext else { return }
         inputContext.invalidateCharacterCoordinates()
-        if #available(macOS 15.4, *), selectionChanged {
-            inputContext.textInputClientDidUpdateSelection()
-        }
+        guard selectionChanged else { return }
+
+        // `textInputClientDidUpdateSelection` is absent from the Xcode 16.2 AppKit SDK
+        // used by the macOS 14 compatibility lane, so call it dynamically when present.
+        let updateSelectionSelector = NSSelectorFromString("textInputClientDidUpdateSelection")
+        guard inputContext.responds(to: updateSelectionSelector) else { return }
+        _ = inputContext.perform(updateSelectionSelector)
     }
 
     override var acceptsFirstResponder: Bool { true }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -310,50 +310,84 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testReleaseAppSupportFallbackLoadsForDebugWhenOnlyReleaseConfigExists() {
-        XCTAssertTrue(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
+    func testCmuxAppSupportConfigURLsUseReleaseConfigForDebugBundleWithoutCurrentConfig() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let releaseConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config",
+                contents: "font-size = 13\n"
             )
-        )
+
+            XCTAssertEqual(
+                GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug",
+                    appSupportDirectory: appSupportDirectory
+                ),
+                [releaseConfigURL]
+            )
+        }
     }
 
-    func testReleaseAppSupportFallbackSkipsWhenDebugConfigAlreadyExists() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-829",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: 64,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
+    func testCmuxAppSupportConfigURLsPreferCurrentBundleConfigWhenPresent() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config",
+                contents: "font-size = 13\n"
             )
-        )
+            let currentConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app.debug.issue-829",
+                filename: "config.ghostty",
+                contents: "font-size = 14\n"
+            )
+
+            XCTAssertEqual(
+                GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug.issue-829",
+                    appSupportDirectory: appSupportDirectory
+                ),
+                [currentConfigURL]
+            )
+        }
     }
 
-    func testReleaseAppSupportFallbackSkipsForNonDebugBundleOrMissingReleaseConfig() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
+    func testCmuxAppSupportConfigURLsSkipReleaseFallbackForNonDebugBundle() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config",
+                contents: "font-size = 13\n"
             )
-        )
 
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: nil,
-                releaseLegacyConfigFileSize: 0
+            XCTAssertTrue(
+                GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.example.other-app",
+                    appSupportDirectory: appSupportDirectory
+                ).isEmpty
             )
-        )
+        }
+    }
+
+    func testCmuxAppSupportConfigURLsIgnoreMissingOrEmptyFiles() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: ""
+            )
+
+            XCTAssertTrue(
+                GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug",
+                    appSupportDirectory: appSupportDirectory
+                ).isEmpty
+            )
+        }
     }
 
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
@@ -561,6 +595,33 @@ final class GhosttyConfigTests: XCTestCase {
             green: Int(round(green * 255)),
             blue: Int(round(blue * 255))
         )
+    }
+
+    private func withTemporaryAppSupportDirectory(
+        _ body: (URL) throws -> Void
+    ) throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-app-support-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        try body(directory)
+    }
+
+    private func writeAppSupportConfig(
+        appSupportDirectory: URL,
+        bundleIdentifier: String,
+        filename: String,
+        contents: String
+    ) throws -> URL {
+        let fileManager = FileManager.default
+        let bundleDirectory = appSupportDirectory
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+        try fileManager.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+
+        let configURL = bundleDirectory.appendingPathComponent(filename, isDirectory: false)
+        try contents.write(to: configURL, atomically: true, encoding: .utf8)
+        return configURL
     }
 }
 


### PR DESCRIPTION
## Summary
- call `textInputClientDidUpdateSelection` dynamically so the macOS 14 compatibility lane still builds with Xcode 16.2
- replace stale release-app-support tests with file-backed coverage for `GhosttyApp.cmuxAppSupportConfigURLs`

## Testing
- `./scripts/download-prebuilt-ghosttykit.sh`
- `./scripts/reload.sh --tag task-fix-main-cicd` (build succeeded)

## Issues
- Related: https://github.com/manaflow-ai/cmux/actions/runs/23086348082
- Related: https://github.com/manaflow-ai/cmux/actions/runs/23086348083


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI build failures on the macOS 14 compatibility lane and refresh app support config tests. Build now succeeds with Xcode 16.2, and tests validate `GhosttyApp.cmuxAppSupportConfigURLs` using real files.

- **Bug Fixes**
  - Call the text input selection update via a dynamic selector when available, avoiding missing AppKit symbols in Xcode 16.2.

- **Refactors**
  - Replace stale release-app-support tests with file-backed coverage for `GhosttyApp.cmuxAppSupportConfigURLs`, including fallback, preference, non-debug skip, and ignoring empty/missing files.

<sup>Written for commit 545c5ac9a91ff8ac73801b35b762dff66f4ad97e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input handling to prevent potential crashes on certain system configurations while maintaining selection update functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->