### PR TITLE
feat: Spatial Project Workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ tests/visual_output/
 tests/visual_report.html
 
 # Local scratch (screenshots, etc.)
+.a5c/
 tmp/
 tmp-*/

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
+		A5001408 /* WorkspaceGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001422 /* WorkspaceGroup.swift */; };
 			A5001093 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001090 /* AppDelegate.swift */; };
 			A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 			A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
@@ -217,6 +218,7 @@
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
+		A5001422 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		A5001092 /* TerminalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationStore.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 					A5001520 /* PostHogAnalytics.swift */,
 					A5001416 /* Workspace.swift */,
 				A5001417 /* WorkspaceContentView.swift */,
+				A5001422 /* WorkspaceGroup.swift */,
 				A5001014 /* GhosttyConfig.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
 				A5001531 /* TerminalWindowPortal.swift */,
@@ -724,6 +727,7 @@
 						A5001521 /* PostHogAnalytics.swift in Sources */,
 						A5001406 /* Workspace.swift in Sources */,
 				A5001407 /* WorkspaceContentView.swift in Sources */,
+				A5001408 /* WorkspaceGroup.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
 				A5001005 /* GhosttyTerminalView.swift in Sources */,
 				A5001532 /* TerminalWindowPortal.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -664,7 +664,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A Ghostty-based terminal with vertical tabs\nand a notification panel for macOS."
+            "value": "A Ghostty-based terminal with vertical tabs\\nand a notification panel for macOS."
           }
         },
         "ja": {
@@ -676,43 +676,43 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "基于 Ghostty 的 macOS 终端，\n支持垂直标签页和通知面板。"
+            "value": "基于 Ghostty 的 macOS 终端，\\n支持垂直标签页和通知面板。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "基於 Ghostty 的 macOS 終端機，\n具備垂直標籤頁與通知面板。"
+            "value": "基於 Ghostty 的 macOS 終端機，\\n具備垂直標籤頁與通知面板。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "세로 탭과 알림 패널을 갖춘\nGhostty 기반 macOS 터미널."
+            "value": "세로 탭과 알림 패널을 갖춘\\nGhostty 기반 macOS 터미널."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ein Ghostty-basiertes Terminal mit vertikalen Tabs\nund einem Benachrichtigungsfeld für macOS."
+            "value": "Ein Ghostty-basiertes Terminal mit vertikalen Tabs\\nund einem Benachrichtigungsfeld für macOS."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminal basado en Ghostty con pestañas verticales\ny un panel de notificaciones para macOS."
+            "value": "Un terminal basado en Ghostty con pestañas verticales\\ny un panel de notificaciones para macOS."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminal basé sur Ghostty avec des onglets verticaux\net un panneau de notifications pour macOS."
+            "value": "Un terminal basé sur Ghostty avec des onglets verticaux\\net un panneau de notifications pour macOS."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Un terminale basato su Ghostty con schede verticali\ne un pannello notifiche per macOS."
+            "value": "Un terminale basato su Ghostty con schede verticali\\ne un pannello notifiche per macOS."
           }
         },
         "da": {
@@ -730,49 +730,43 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Терминал на базе Ghostty с вертикальными вкладками\nи панелью уведомлений для macOS."
+            "value": "Терминал на базе Ghostty с вертикальными вкладками\\nи панелью уведомлений для macOS."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Terminal zasnovan na Ghostty sa vertikalnim tabovima\ni panelom za obavještenja za macOS."
+            "value": "Terminal zasnovan na Ghostty sa vertikalnim tabovima\\ni panelom za obavještenja za macOS."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "طرفية مبنية على Ghostty مع ألسنة عمودية\nولوحة إشعارات لنظام macOS."
+            "value": "طرفية مبنية على Ghostty مع ألسنة عمودية\\nولوحة إشعارات لنظام macOS."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "En Ghostty-basert terminal med vertikale faner\nog et varselpanel for macOS."
+            "value": "En Ghostty-basert terminal med vertikale faner\\nog et varselpanel for macOS."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Um terminal baseado no Ghostty com abas verticais\ne um painel de notificações para macOS."
+            "value": "Um terminal baseado no Ghostty com abas verticais\\ne um painel de notificações para macOS."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เทอร์มินัลบน Ghostty พร้อมแท็บแนวตั้ง\nและแผงการแจ้งเตือนสำหรับ macOS"
+            "value": "เทอร์มินัลบน Ghostty พร้อมแท็บแนวตั้ง\\nและแผงการแจ้งเตือนสำหรับ macOS"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS için dikey sekmeli ve bildirim panelli\nGhostty tabanlı terminal."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Термінал на основі Ghostty з вертикальними вкладками\nта панеллю сповіщень для macOS."
+            "value": "macOS için dikey sekmeli ve bildirim panelli\\nGhostty tabanlı terminal."
           }
         }
       }
@@ -47752,19 +47746,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep Workspace Open When Closing Last Surface"
+            "value": "Closing Last Surface Closes Workspace"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "最後のサーフェスを閉じてもワークスペースを残す"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Залишати робочу область відкритою при закритті останньої поверхні"
+            "value": "最後のサーフェスを閉じるとワークスペースも閉じる"
           }
         }
       }
@@ -47775,19 +47763,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut also closes the workspace."
+            "value": "Closing the last surface keeps the workspace open. Use Cmd+Shift+W to close a workspace explicitly."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つなら、サーフェスを閉じるショートカットはワークスペースも閉じます。"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Коли активна поверхня є останньою у робочій області, комбінація закриття поверхні також закриває робочу область."
+            "value": "最後のサーフェスを閉じてもワークスペースは残ります。ワークスペースを明示的に閉じるにはCmd+Shift+Wを使います。"
           }
         }
       }
@@ -47798,19 +47780,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut closes only the surface and keeps the workspace open. Use the close-workspace shortcut to close the workspace explicitly."
+            "value": "Closing the last surface also closes its workspace."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つでも、サーフェスを閉じるショートカットはサーフェスだけを閉じ、ワークスペースは残します。ワークスペースを閉じるショートカットを使うと明示的に閉じられます。"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Коли активна поверхня є останньою у робочій області, комбінація закриття поверхні закриває лише поверхню, залишаючи робочу область відкритою. Використовуйте комбінацію закриття робочої області для явного закриття."
+            "value": "最後のサーフェスを閉じると、そのワークスペースも閉じます。"
           }
         }
       }
@@ -58756,13 +58732,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Intercept open http(s) in Terminal"
+            "value": "Route `open http(s)` commands in Terminal to the cmux browser"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルでopen http(s)をインターセプト"
+            "value": "ターミナルの`open http(s)`コマンドをcmuxブラウザで開く"
           }
         },
         "zh-Hans": {
@@ -58860,12 +58836,6 @@
             "state": "translated",
             "value": "Terminalde open http(s) Komutlarını Yakala"
           }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перехоплювати open http(s) у терміналі"
-          }
         }
       }
     },
@@ -58875,13 +58845,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When off, `open https://...` and `open http://...` always use your default browser."
+            "value": "When on, `open https://...` and `open http://...` commands open in the cmux embedded browser. Off by default — these commands use your system browser."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "オフの場合、`open https://...`および`open http://...`は常にデフォルトブラウザを使用します。"
+            "value": "オンの場合、`open https://...`および`open http://...`コマンドはcmux内蔵ブラウザで開きます。デフォルトはオフ — これらのコマンドはシステムブラウザを使用します。"
           }
         },
         "zh-Hans": {
@@ -58978,12 +58948,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kapalıyken, `open https://...` ve `open http://...` her zaman varsayılan tarayıcınızı kullanır."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Якщо вимкнено, `open https://...` та `open http://...` завжди використовують стандартний браузер."
           }
         }
       }
@@ -59113,13 +59077,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When off, links clicked in terminal output open in your default browser."
+            "value": "When on, links clicked in terminal output open in the cmux embedded browser. Off by default — links open in your system browser."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "オフの場合、ターミナル出力のリンクはデフォルトブラウザで開きます。"
+            "value": "オンの場合、ターミナル出力のリンクはcmux内蔵ブラウザで開きます。デフォルトはオフ — リンクはシステムブラウザで開きます。"
           }
         },
         "zh-Hans": {
@@ -59216,12 +59180,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kapalıyken, terminal çıktısında tıklanan bağlantılar varsayılan tarayıcınızda açılır."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Якщо вимкнено, посилання у виводі терміналу відкриваються у стандартному браузері."
           }
         }
       }
@@ -74561,6 +74519,23 @@
         }
       }
     },
+    "toolbar.focusedWorkspace.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        }
+      }
+    },
     "update.available.short": {
       "extractionState": "manual",
       "localizations": {
@@ -84844,6 +84819,312 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не вдалося завантажити перетягнутий файл: %@"
+          }
+        }
+      }
+    },
+    "command.focusPaneDown.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Pane Down"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下のペインにフォーカス"
+          }
+        }
+      }
+    },
+    "command.focusPaneLeft.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Pane Left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左のペインにフォーカス"
+          }
+        }
+      }
+    },
+    "command.focusPaneRight.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Pane Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右のペインにフォーカス"
+          }
+        }
+      }
+    },
+    "command.focusPaneUp.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Pane Up"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上のペインにフォーカス"
+          }
+        }
+      }
+    },
+    "command.group.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループ"
+          }
+        }
+      }
+    },
+    "command.markBackground.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark Pane as Background"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインをバックグラウンドとしてマーク"
+          }
+        }
+      }
+    },
+    "command.markForeground.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmark Pane as Background"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインのバックグラウンドマークを解除"
+          }
+        }
+      }
+    },
+    "command.newGroup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規グループ"
+          }
+        }
+      }
+    },
+    "command.splitLayout.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Navigation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分割ナビゲーション"
+          }
+        }
+      }
+    },
+    "command.toggleGroupCollapse.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Group Collapse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループの折りたたみを切替"
+          }
+        }
+      }
+    },
+    "group.contextMenu.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループを削除"
+          }
+        }
+      }
+    },
+    "group.contextMenu.rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループ名を変更"
+          }
+        }
+      }
+    },
+    "group.default.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規グループ"
+          }
+        }
+      }
+    },
+    "panel.background.indicator.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンドプロセス"
+          }
+        }
+      }
+    },
+    "shortcut.markBackground.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark Pane as Background"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインをバックグラウンドとしてマーク"
+          }
+        }
+      }
+    },
+    "shortcut.markForeground.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmark Pane as Background"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインのバックグラウンドマークを解除"
+          }
+        }
+      }
+    },
+    "shortcut.newGroup.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規グループ"
+          }
+        }
+      }
+    },
+    "shortcut.toggleGroupCollapse.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Group Collapse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループの折りたたみを切替"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9614,6 +9614,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Workspace Group shortcuts (FR3)
+        // newGroup (Cmd+Shift+G): create a new named group containing the currently selected workspace.
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .newGroup)) {
+            if let manager = tabManager, let selectedId = manager.selectedTabId {
+#if DEBUG
+                dlog("shortcut.action name=newGroup selected=\(String(selectedId.uuidString.prefix(5))) \(debugShortcutRouteSnapshot(event: event))")
+#endif
+                manager.createGroup(title: String(localized: "group.default.title", defaultValue: "New Group"), workspaceIds: [selectedId])
+            }
+            return true
+        }
+
+        // toggleGroupCollapse (Cmd+Opt+G): collapse/expand the group that owns the currently selected workspace.
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleGroupCollapse)) {
+            if let manager = tabManager, let selectedId = manager.selectedTabId,
+               let group = manager.group(forWorkspaceId: selectedId) {
+#if DEBUG
+                dlog("shortcut.action name=toggleGroupCollapse group=\(String(group.id.uuidString.prefix(5))) collapsed=\(group.isCollapsed) \(debugShortcutRouteSnapshot(event: event))")
+#endif
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    manager.toggleGroupCollapse(id: group.id)
+                }
+            }
+            return true
+        }
+
+        // markBackground (Cmd+Opt+Shift+B): mark the focused pane as a background/long-running process.
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .markBackground)) {
+            if let manager = tabManager,
+               let workspace = manager.selectedWorkspace,
+               let panelId = workspace.focusedPanelId {
+#if DEBUG
+                dlog("shortcut.action name=markBackground panel=\(panelId.uuidString.prefix(5)) \(debugShortcutRouteSnapshot(event: event))")
+#endif
+                workspace.markBackground(panelId: panelId)
+            }
+            return true
+        }
+
+        // markForeground (Cmd+Opt+B): remove background mark from the focused pane.
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .markForeground)) {
+            if let manager = tabManager,
+               let workspace = manager.selectedWorkspace,
+               let panelId = workspace.focusedPanelId {
+#if DEBUG
+                dlog("shortcut.action name=markForeground panel=\(panelId.uuidString.prefix(5)) \(debugShortcutRouteSnapshot(event: event))")
+#endif
+                workspace.markForeground(panelId: panelId)
+            }
+            return true
+        }
+
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .renameWorkspace)) {
             return requestRenameWorkspaceViaCommandPalette(
                 preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5170,6 +5170,22 @@ struct ContentView: View {
             return .toggleSplitZoom
         case "palette.triggerFlash":
             return .triggerFlash
+        case "palette.focusPaneLeft":
+            return .focusLeft
+        case "palette.focusPaneRight":
+            return .focusRight
+        case "palette.focusPaneUp":
+            return .focusUp
+        case "palette.focusPaneDown":
+            return .focusDown
+        case "palette.newGroup":
+            return .newGroup
+        case "palette.toggleGroupCollapse":
+            return .toggleGroupCollapse
+        case "palette.markBackground":
+            return .markBackground
+        case "palette.markForeground":
+            return .markForeground
         default:
             return nil
         }
@@ -6009,6 +6025,85 @@ struct ContentView: View {
             )
         }
 
+        // --- Spatial navigation: focus pane movement ---
+        let splitLayoutSubtitle = constant(String(localized: "command.splitLayout.subtitle", defaultValue: "Split Navigation"))
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.focusPaneLeft",
+                title: constant(String(localized: "command.focusPaneLeft.title", defaultValue: "Focus Pane Left")),
+                subtitle: splitLayoutSubtitle,
+                keywords: ["focus", "pane", "left", "split", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.focusPaneRight",
+                title: constant(String(localized: "command.focusPaneRight.title", defaultValue: "Focus Pane Right")),
+                subtitle: splitLayoutSubtitle,
+                keywords: ["focus", "pane", "right", "split", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.focusPaneUp",
+                title: constant(String(localized: "command.focusPaneUp.title", defaultValue: "Focus Pane Up")),
+                subtitle: splitLayoutSubtitle,
+                keywords: ["focus", "pane", "up", "split", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.focusPaneDown",
+                title: constant(String(localized: "command.focusPaneDown.title", defaultValue: "Focus Pane Down")),
+                subtitle: splitLayoutSubtitle,
+                keywords: ["focus", "pane", "down", "split", "navigate"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
+            )
+        )
+
+        // --- Workspace Groups ---
+        let groupSubtitle = constant(String(localized: "command.group.subtitle", defaultValue: "Workspace Group"))
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.newGroup",
+                title: constant(String(localized: "command.newGroup.title", defaultValue: "New Group")),
+                subtitle: groupSubtitle,
+                keywords: ["new", "group", "workspace", "organize", "folder"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.toggleGroupCollapse",
+                title: constant(String(localized: "command.toggleGroupCollapse.title", defaultValue: "Toggle Group Collapse")),
+                subtitle: groupSubtitle,
+                keywords: ["group", "collapse", "expand", "toggle"],
+                when: { _ in true }
+            )
+        )
+
+        // --- Background pane (FR6) ---
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.markBackground",
+                title: constant(String(localized: "command.markBackground.title", defaultValue: "Mark Pane as Background")),
+                subtitle: panelSubtitle,
+                keywords: ["background", "pane", "mark", "process", "server"],
+                when: { $0.bool(CommandPaletteContextKeys.hasFocusedPanel) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.markForeground",
+                title: constant(String(localized: "command.markForeground.title", defaultValue: "Unmark Pane as Background")),
+                subtitle: panelSubtitle,
+                keywords: ["background", "pane", "unmark", "foreground", "clear"],
+                when: { $0.bool(CommandPaletteContextKeys.hasFocusedPanel) }
+            )
+        )
+
         return contributions
     }
 
@@ -6368,6 +6463,56 @@ struct ContentView: View {
                     globalConfigPath: globalPath
                 )
             }
+        }
+
+        // Focus pane navigation via command palette
+        registry.register(commandId: "palette.focusPaneLeft") {
+            tabManager.movePaneFocus(direction: .left)
+        }
+        registry.register(commandId: "palette.focusPaneRight") {
+            tabManager.movePaneFocus(direction: .right)
+        }
+        registry.register(commandId: "palette.focusPaneUp") {
+            tabManager.movePaneFocus(direction: .up)
+        }
+        registry.register(commandId: "palette.focusPaneDown") {
+            tabManager.movePaneFocus(direction: .down)
+        }
+
+        // Workspace group management via command palette
+        registry.register(commandId: "palette.newGroup") {
+            guard let selectedId = tabManager.selectedTabId else {
+                NSSound.beep()
+                return
+            }
+            tabManager.createGroup(
+                title: String(localized: "group.default.title", defaultValue: "New Group"),
+                workspaceIds: [selectedId]
+            )
+        }
+        registry.register(commandId: "palette.toggleGroupCollapse") {
+            guard let selectedId = tabManager.selectedTabId,
+                  let group = tabManager.group(forWorkspaceId: selectedId) else {
+                NSSound.beep()
+                return
+            }
+            tabManager.toggleGroupCollapse(id: group.id)
+        }
+
+        // Background pane (FR6) via command palette
+        registry.register(commandId: "palette.markBackground") {
+            guard let panelContext = focusedPanelContext else {
+                NSSound.beep()
+                return
+            }
+            panelContext.workspace.markBackground(panelId: panelContext.panelId)
+        }
+        registry.register(commandId: "palette.markForeground") {
+            guard let panelContext = focusedPanelContext else {
+                NSSound.beep()
+                return
+            }
+            panelContext.workspace.markForeground(panelId: panelContext.panelId)
         }
     }
 
@@ -8559,50 +8704,122 @@ struct VerticalTabsSidebar: View {
                             .frame(height: trafficLightPadding)
 
                         LazyVStack(spacing: tabRowSpacing) {
-                            ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
-                                let selectedContextIds: Set<UUID> = selectedTabIds.contains(tab.id) ? selectedTabIds : [tab.id]
-                                let contextTargetIds = tabManager.tabs.compactMap { workspace in
-                                    selectedContextIds.contains(workspace.id) ? workspace.id : nil
-                                }
-                                let remoteContextMenuTargets = tabManager.tabs.filter { workspace in
-                                    contextTargetIds.contains(workspace.id) && workspace.isRemoteWorkspace
-                                }
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
-                                    index: index,
-                                    isActive: tabManager.selectedTabId == tab.id,
-                                    workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                                        at: index,
-                                        workspaceCount: workspaceCount
-                                    ),
-                                    workspaceShortcutModifierSymbol: workspaceNumberShortcut.modifierDisplayString,
-                                    canCloseWorkspace: canCloseWorkspace,
-                                    accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: notificationStore.unreadCount(forTabId: tab.id),
-                                    latestNotificationText: {
-                                        guard showsSidebarNotificationMessage,
-                                              let notification = notificationStore.latestNotification(forTabId: tab.id) else {
-                                            return nil
-                                        }
-                                        let text = notification.body.isEmpty ? notification.title : notification.body
-                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        return trimmed.isEmpty ? nil : trimmed
-                                    }(),
-                                    rowSpacing: tabRowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                                    showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
-                                    remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
-                                    allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
-                                    allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
+                            // Precompute lookup maps once per render pass to avoid O(n) scans.
+                            let tabById: [_ : _] = Dictionary(
+                                tabManager.tabs.map { ($0.id, $0) },
+                                uniquingKeysWith: { first, _ in first }
+                            )
+                            let indexById: [_ : Int] = Dictionary(
+                                tabManager.tabs.enumerated().map { ($0.element.id, $0.offset) },
+                                uniquingKeysWith: { first, _ in first }
+                            )
+
+                            // --- FR3: Grouped workspaces ---
+                            ForEach(tabManager.groups) { group in
+                                WorkspaceGroupHeaderView(
+                                    group: group,
+                                    tabManager: tabManager
                                 )
-                                .equatable()
+
+                                if !group.isCollapsed {
+                                    ForEach(group.memberIds, id: \.self) { memberId in
+                                        if let tab = tabById[memberId],
+                                           let index = indexById[memberId] {
+                                            let selectedContextIds: Set<UUID> = selectedTabIds.contains(tab.id) ? selectedTabIds : [tab.id]
+                                            let contextTargetIds = tabManager.tabs.compactMap { workspace in
+                                                selectedContextIds.contains(workspace.id) ? workspace.id : nil
+                                            }
+                                            let remoteContextMenuTargets = tabManager.tabs.filter { workspace in
+                                                contextTargetIds.contains(workspace.id) && workspace.isRemoteWorkspace
+                                            }
+                                            TabItemView(
+                                                tabManager: tabManager,
+                                                notificationStore: notificationStore,
+                                                tab: tab,
+                                                index: index,
+                                                isActive: tabManager.selectedTabId == tab.id,
+                                                workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                                                    at: index,
+                                                    workspaceCount: workspaceCount
+                                                ),
+                                                workspaceShortcutModifierSymbol: workspaceNumberShortcut.modifierDisplayString,
+                                                canCloseWorkspace: canCloseWorkspace,
+                                                accessibilityWorkspaceCount: workspaceCount,
+                                                unreadCount: notificationStore.unreadCount(forTabId: tab.id),
+                                                latestNotificationText: {
+                                                    guard showsSidebarNotificationMessage,
+                                                          let notification = notificationStore.latestNotification(forTabId: tab.id) else { return nil }
+                                                    let text = notification.body.isEmpty ? notification.title : notification.body
+                                                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                                    return trimmed.isEmpty ? nil : trimmed
+                                                }(),
+                                                rowSpacing: tabRowSpacing,
+                                                setSelectionToTabs: { selection = .tabs },
+                                                selectedTabIds: $selectedTabIds,
+                                                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                                showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
+                                                dragAutoScrollController: dragAutoScrollController,
+                                                draggedTabId: $draggedTabId,
+                                                dropIndicator: $dropIndicator,
+                                                remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
+                                                allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
+                                                allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected },
+                                                isGrouped: true
+                                            )
+                                            .equatable()
+                                            .transition(.opacity.combined(with: .move(edge: .top)))
+                                        }
+                                    }
+                                }
+                            }
+
+                            // --- Ungrouped workspaces (rendered flat, as before) ---
+                            let ungroupedIds = Set(tabManager.ungroupedWorkspaceIds)
+                            ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
+                                if ungroupedIds.contains(tab.id) {
+                                    let selectedContextIds: Set<UUID> = selectedTabIds.contains(tab.id) ? selectedTabIds : [tab.id]
+                                    let contextTargetIds = tabManager.tabs.compactMap { workspace in
+                                        selectedContextIds.contains(workspace.id) ? workspace.id : nil
+                                    }
+                                    let remoteContextMenuTargets = tabManager.tabs.filter { workspace in
+                                        contextTargetIds.contains(workspace.id) && workspace.isRemoteWorkspace
+                                    }
+                                    TabItemView(
+                                        tabManager: tabManager,
+                                        notificationStore: notificationStore,
+                                        tab: tab,
+                                        index: index,
+                                        isActive: tabManager.selectedTabId == tab.id,
+                                        workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                                            at: index,
+                                            workspaceCount: workspaceCount
+                                        ),
+                                        workspaceShortcutModifierSymbol: workspaceNumberShortcut.modifierDisplayString,
+                                        canCloseWorkspace: canCloseWorkspace,
+                                        accessibilityWorkspaceCount: workspaceCount,
+                                        unreadCount: notificationStore.unreadCount(forTabId: tab.id),
+                                        latestNotificationText: {
+                                            guard showsSidebarNotificationMessage,
+                                                  let notification = notificationStore.latestNotification(forTabId: tab.id) else { return nil }
+                                            let text = notification.body.isEmpty ? notification.title : notification.body
+                                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                            return trimmed.isEmpty ? nil : trimmed
+                                        }(),
+                                        rowSpacing: tabRowSpacing,
+                                        setSelectionToTabs: { selection = .tabs },
+                                        selectedTabIds: $selectedTabIds,
+                                        lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                        showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
+                                        dragAutoScrollController: dragAutoScrollController,
+                                        draggedTabId: $draggedTabId,
+                                        dropIndicator: $dropIndicator,
+                                        remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
+                                        allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
+                                        allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected },
+                                        isGrouped: false
+                                    )
+                                    .equatable()
+                                }
                             }
                         }
                         .padding(.vertical, 8)
@@ -10951,23 +11168,45 @@ enum SidebarWorkspaceShortcutHintMetrics {
     #endif
 }
 
-enum SidebarTrailingAccessoryWidthPolicy {
-    static let closeButtonWidth: CGFloat = 16
+// MARK: - FR3: Workspace Group Header View
 
-    static func width(
-        canCloseWorkspace: Bool,
-        showsWorkspaceShortcutHint: Bool,
-        workspaceShortcutLabel: String?,
-        debugXOffset: Double
-    ) -> CGFloat {
-        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-            return SidebarWorkspaceShortcutHintMetrics.slotWidth(
-                label: workspaceShortcutLabel,
-                debugXOffset: debugXOffset
-            )
+/// Renders a collapsible group header row in the sidebar.
+/// Tapping the row or chevron toggles collapse; only group-level state is observed.
+private struct WorkspaceGroupHeaderView: View {
+    @ObservedObject var group: WorkspaceGroup
+    let tabManager: TabManager
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                tabManager.toggleGroupCollapse(id: group.id)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: group.isCollapsed ? "chevron.right" : "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 14)
+                Text(group.title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
         }
-
-        return canCloseWorkspace ? closeButtonWidth : 0
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button(
+                role: .destructive,
+                action: { tabManager.deleteGroup(id: group.id) }
+            ) {
+                Text(String(localized: "group.contextMenu.delete", defaultValue: "Delete Group"))
+            }
+        }
     }
 }
 
@@ -11000,7 +11239,8 @@ private struct TabItemView: View, Equatable {
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
-        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected
+        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
+        lhs.isGrouped == rhs.isGrouped
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing
@@ -11029,6 +11269,9 @@ private struct TabItemView: View, Equatable {
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
+    /// Whether this workspace is rendered inside a group section (FR3).
+    /// Included in == so SwiftUI correctly re-evaluates when grouping state changes.
+    let isGrouped: Bool
     @State private var workspaceObservationGeneration: UInt64 = 0
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3623,6 +3623,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
             protectedStartupEnvironmentKeys.insert(key)
         }
 
+        // Terminal type detection: lets agents (e.g. Claude Code) detect they are inside cmux.
+        setManagedEnvironmentValue("CMUX_TERM", "1")
         setManagedEnvironmentValue("CMUX_SURFACE_ID", id.uuidString)
         setManagedEnvironmentValue("CMUX_WORKSPACE_ID", tabId.uuidString)
         // Backward-compatible shell integration keys used by existing scripts/tests.
@@ -3652,16 +3654,20 @@ final class TerminalSurface: Identifiable, ObservableObject {
         if !claudeHooksEnabled {
             setManagedEnvironmentValue("CMUX_CLAUDE_HOOKS_DISABLED", "1")
         }
-
-        if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+        // Inject the bundled bin/ directory: PATH-independent fallback for agents (CMUX_CLAUDE_HOOKS_PATH)
+        // and prepend to PATH so the cmux CLI wrapper is always resolvable without shell config changes.
+        if let binPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+            env["CMUX_CLAUDE_HOOKS_PATH"] = binPath
             let currentPath = env["PATH"]
                 ?? getenv("PATH").map { String(cString: $0) }
                 ?? ProcessInfo.processInfo.environment["PATH"]
                 ?? ""
-            if !currentPath.split(separator: ":").contains(Substring(cliBinPath)) {
-                let separator = currentPath.isEmpty ? "" : ":"
-                setManagedEnvironmentValue("PATH", "\(cliBinPath)\(separator)\(currentPath)")
-            }
+            let strippedPath = currentPath
+                .split(separator: ":", omittingEmptySubsequences: false)
+                .filter { $0 != Substring(binPath) }
+                .joined(separator: ":")
+            let separator = strippedPath.isEmpty ? "" : ":"
+            setManagedEnvironmentValue("PATH", "\(binPath)\(separator)\(strippedPath)")
         }
 
         // Shell integration: inject ZDOTDIR wrapper for zsh shells.

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -47,6 +47,14 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
+        // Workspace Groups (FR3)
+        case newGroup
+        case toggleGroupCollapse
+
+        // Background pane (FR6)
+        case markBackground
+        case markForeground
+
         var id: String { rawValue }
 
         var label: String {
@@ -83,6 +91,10 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
+            case .newGroup: return String(localized: "shortcut.newGroup.label", defaultValue: "New Group")
+            case .toggleGroupCollapse: return String(localized: "shortcut.toggleGroupCollapse.label", defaultValue: "Toggle Group Collapse")
+            case .markBackground: return String(localized: "shortcut.markBackground.label", defaultValue: "Mark Pane as Background")
+            case .markForeground: return String(localized: "shortcut.markForeground.label", defaultValue: "Unmark Pane as Background")
             }
         }
 
@@ -120,6 +132,10 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
+            case .newGroup: return "shortcut.newGroup"
+            case .toggleGroupCollapse: return "shortcut.toggleGroupCollapse"
+            case .markBackground: return "shortcut.markBackground"
+            case .markForeground: return "shortcut.markForeground"
             }
         }
 
@@ -191,6 +207,15 @@ enum KeyboardShortcutSettings {
             case .showBrowserJavaScriptConsole:
                 // Safari default: Show JavaScript Console.
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
+            case .newGroup:
+                return StoredShortcut(key: "g", command: true, shift: true, option: false, control: false)
+            case .toggleGroupCollapse:
+                // Cmd+Opt+G avoids conflicting with the system Cmd+G "Find Next" shortcut.
+                return StoredShortcut(key: "g", command: true, shift: false, option: true, control: false)
+            case .markBackground:
+                return StoredShortcut(key: "b", command: true, shift: true, option: true, control: false)
+            case .markForeground:
+                return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
             }
         }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -522,7 +522,7 @@ final class BrowserProfileStore: ObservableObject {
 
 enum BrowserLinkOpenSettings {
     static let openTerminalLinksInCmuxBrowserKey = "browserOpenTerminalLinksInCmuxBrowser"
-    static let defaultOpenTerminalLinksInCmuxBrowser: Bool = true
+    static let defaultOpenTerminalLinksInCmuxBrowser: Bool = false
 
     static let openSidebarPullRequestLinksInCmuxBrowserKey = "browserOpenSidebarPullRequestLinksInCmuxBrowser"
     static let defaultOpenSidebarPullRequestLinksInCmuxBrowser: Bool = true
@@ -531,7 +531,7 @@ enum BrowserLinkOpenSettings {
     static let defaultOpenSidebarPortLinksInCmuxBrowser: Bool = true
 
     static let interceptTerminalOpenCommandInCmuxBrowserKey = "browserInterceptTerminalOpenCommandInCmuxBrowser"
-    static let defaultInterceptTerminalOpenCommandInCmuxBrowser: Bool = true
+    static let defaultInterceptTerminalOpenCommandInCmuxBrowser: Bool = false
 
     static let browserHostWhitelistKey = "browserHostWhitelist"
     static let defaultBrowserHostWhitelist: String = ""

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -18,6 +18,29 @@ struct PanelContentView: View {
     let onTriggerFlash: () -> Void
 
     var body: some View {
+        panelContent
+            .overlay {
+                // Focus ring: thin accent-colored border shown only when this pane is focused
+                // and there are multiple panes. SwiftUI-only — never touches AppKit layers.
+                // allowsHitTesting(false) ensures the ring never intercepts pointer events.
+                FocusRingView(isVisible: isFocused && isSplit)
+            }
+    }
+
+    private struct FocusRingView: View {
+        let isVisible: Bool
+
+        var body: some View {
+            Rectangle()
+                .strokeBorder(Color.accentColor, lineWidth: 2)
+                .opacity(isVisible ? 1 : 0)
+                .animation(.easeInOut(duration: 0.15), value: isVisible)
+                .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private var panelContent: some View {
         switch panel.panelType {
         case .terminal:
             if let terminalPanel = panel as? TerminalPanel {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -254,6 +254,8 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?
+    /// Optional so existing session files without background data decode successfully (backward compat, FR6).
+    var isBackground: Bool?
 }
 
 enum SessionSplitOrientation: String, Codable, Sendable {
@@ -345,6 +347,9 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
 struct SessionTabManagerSnapshot: Codable, Sendable {
     var selectedWorkspaceIndex: Int?
     var workspaces: [SessionWorkspaceSnapshot]
+    /// Optional so existing session files without group data decode successfully (backward compat).
+    /// Defaults to nil so call sites that only pass selectedWorkspaceIndex/workspaces keep compiling.
+    var groups: [WorkspaceGroupSnapshot]? = nil
 }
 
 struct SessionWindowSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -690,6 +690,14 @@ class TabManager: ObservableObject {
     weak var window: NSWindow?
 
     @Published var tabs: [Workspace] = []
+
+    // MARK: - Workspace Groups (FR3)
+    /// Ordered list of workspace groups for the two-level sidebar hierarchy.
+    @Published var groups: [WorkspaceGroup] = []
+    /// Forwards each group's objectWillChange into TabManager so sidebar views re-render
+    /// when a group's title, isCollapsed, or memberIds change (groups are reference types).
+    private var groupCancellables: [UUID: AnyCancellable] = [:]
+
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
@@ -2597,6 +2605,9 @@ class TabManager: ObservableObject {
         unwireClosedBrowserTracking(for: workspace)
         workspace.owningTabManager = nil
 
+        // Purge from any groups before removing from tabs so group member lists stay clean.
+        removeWorkspaceFromAllGroups(workspace.id)
+
         if let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
             tabs.remove(at: index)
 
@@ -2617,6 +2628,9 @@ class TabManager: ObservableObject {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return nil }
         clearWorkspaceGitProbes(workspaceId: tabId)
         sidebarSelectedWorkspaceIds.remove(tabId)
+
+        // Purge from any groups before removing so group member lists stay clean.
+        removeWorkspaceFromAllGroups(tabId)
 
         let removed = tabs.remove(at: index)
         unwireClosedBrowserTracking(for: removed)
@@ -2771,6 +2785,92 @@ class TabManager: ObservableObject {
 
     // Keep selectTab as convenience alias
     func selectTab(_ tab: Workspace) { selectWorkspace(tab) }
+
+    // MARK: - Workspace Group Management (FR3)
+
+    @discardableResult
+    func createGroup(title: String, workspaceIds: [UUID]) -> WorkspaceGroup {
+        // 1. Keep only IDs that exist in the workspace store.
+        let existingIds = Set(tabs.map(\.id))
+        // 2. Deduplicate while preserving order.
+        var seen = Set<UUID>()
+        let validIds = workspaceIds.filter { existingIds.contains($0) && seen.insert($0).inserted }
+        // 3. Move workspaces out of any existing group (enforces single-group membership).
+        for id in validIds { removeWorkspaceFromAllGroups(id) }
+
+        let group = WorkspaceGroup(title: title, memberIds: validIds)
+        groups.append(group)
+        wireGroupObservation(group)
+        return group
+    }
+
+    func deleteGroup(id: UUID) {
+        groupCancellables.removeValue(forKey: id)
+        groups.removeAll { $0.id == id }
+        // Workspaces are kept; they become ungrouped automatically because
+        // the sidebar renders ungrouped workspaces below all group headers.
+    }
+
+    private func wireGroupObservation(_ group: WorkspaceGroup) {
+        groupCancellables[group.id] = group.objectWillChange
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+    }
+
+    func renameGroup(id: UUID, title: String) {
+        guard let group = groups.first(where: { $0.id == id }) else { return }
+        group.title = title
+    }
+
+    func collapseGroup(id: UUID) {
+        guard let group = groups.first(where: { $0.id == id }) else { return }
+        group.isCollapsed = true
+    }
+
+    func expandGroup(id: UUID) {
+        guard let group = groups.first(where: { $0.id == id }) else { return }
+        group.isCollapsed = false
+    }
+
+    func toggleGroupCollapse(id: UUID) {
+        guard let group = groups.first(where: { $0.id == id }) else { return }
+        group.isCollapsed.toggle()
+    }
+
+    func addWorkspace(_ workspaceId: UUID, toGroup groupId: UUID) {
+        guard tabs.contains(where: { $0.id == workspaceId }) else { return }
+        guard let group = groups.first(where: { $0.id == groupId }) else { return }
+        // Remove from any existing group first to avoid duplicate membership.
+        for g in groups where g.id != groupId {
+            g.memberIds.removeAll { $0 == workspaceId }
+        }
+        if !group.memberIds.contains(workspaceId) {
+            group.memberIds.append(workspaceId)
+        }
+    }
+
+    func removeWorkspace(_ workspaceId: UUID, fromGroup groupId: UUID) {
+        guard let group = groups.first(where: { $0.id == groupId }) else { return }
+        group.memberIds.removeAll { $0 == workspaceId }
+    }
+
+    /// Removes a workspace ID from every group it belongs to.
+    /// Called from `closeWorkspace` and `detachWorkspace` to keep group member lists clean.
+    private func removeWorkspaceFromAllGroups(_ workspaceId: UUID) {
+        for group in groups {
+            group.memberIds.removeAll { $0 == workspaceId }
+        }
+    }
+
+    /// Returns the group that contains the given workspace ID, if any.
+    func group(forWorkspaceId workspaceId: UUID) -> WorkspaceGroup? {
+        groups.first { $0.memberIds.contains(workspaceId) }
+    }
+
+    /// Returns workspace IDs that are not a member of any group.
+    var ungroupedWorkspaceIds: [UUID] {
+        let allGroupedIds = Set(groups.flatMap { $0.memberIds })
+        return tabs.map { $0.id }.filter { !allGroupedIds.contains($0) }
+    }
 
     private func confirmClose(title: String, message: String, acceptCmdD: Bool) -> Bool {
         if let confirmCloseHandler {
@@ -3760,12 +3860,15 @@ class TabManager: ObservableObject {
 
     /// Create a new split in the specified direction
     /// Returns the new panel's ID (which is also the surface ID for terminals)
-    func newSplit(tabId: UUID, surfaceId: UUID, direction: SplitDirection, focus: Bool = true) -> UUID? {
+    func newSplit(tabId: UUID, surfaceId: UUID, direction: SplitDirection, initialDividerRatio: CGFloat = 0.6, focus: Bool = true) -> UUID? {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return nil }
-        return tab.newTerminalSplit(
+        // Clamp to (0, 1) exclusive — ratios at the extremes produce a fully-collapsed pane.
+        let clampedRatio = max(0.01, min(0.99, initialDividerRatio))
+        let createdPanel = tab.newTerminalSplit(
             from: surfaceId,
             orientation: direction.orientation,
             insertFirst: direction.insertFirst,
+            initialDividerRatio: clampedRatio,
             focus: focus
         )?.id
     }
@@ -5491,6 +5594,17 @@ extension TabManager {
             }
         }
 
+        hasher.combine(groups.count)
+        for group in groups {
+            hasher.combine(group.id)
+            hasher.combine(group.title)
+            hasher.combine(group.isCollapsed)
+            hasher.combine(group.memberIds.count)
+            for memberId in group.memberIds {
+                hasher.combine(memberId)
+            }
+        }
+
         return hasher.finalize()
     }
 
@@ -5503,9 +5617,11 @@ extension TabManager {
         let selectedWorkspaceIndex = selectedTabId.flatMap { selectedTabId in
             restorableTabs.firstIndex(where: { $0.id == selectedTabId })
         }
+        let groupSnapshots = groups.isEmpty ? nil : groups.map { WorkspaceGroupSnapshot(group: $0) }
         return SessionTabManagerSnapshot(
             selectedWorkspaceIndex: selectedWorkspaceIndex,
-            workspaces: workspaceSnapshots
+            workspaces: workspaceSnapshots,
+            groups: groupSnapshots
         )
     }
 
@@ -5581,9 +5697,37 @@ extension TabManager {
             newSelectedId = newTabs.first?.id
         }
 
+        // Reconstruct workspace groups from snapshot if present (FR3).
+        var newGroups: [WorkspaceGroup] = []
+        let restoredTabIds = Set(newTabs.map { $0.id })
+        var assignedWorkspaceIds = Set<UUID>()
+        if let groupSnapshots = snapshot.groups {
+            for snap in groupSnapshots {
+                // Only keep member IDs that exist in the restored workspace list and haven't
+                // been claimed by a prior group (enforces single-group membership on restore).
+                // First-group-in-snapshot wins when a workspace appears in multiple groups.
+                let validMemberIds = snap.memberIds.filter {
+                    restoredTabIds.contains($0) && assignedWorkspaceIds.insert($0).inserted
+                }
+                // Skip groups that lost all members to deduplication — an empty group
+                // has no valid state in the sidebar and would appear as a ghost row.
+                guard !validMemberIds.isEmpty else { continue }
+                let group = WorkspaceGroup(
+                    id: snap.id,
+                    title: snap.title,
+                    isCollapsed: snap.isCollapsed,
+                    memberIds: validMemberIds
+                )
+                newGroups.append(group)
+            }
+        }
+
         // Single atomic assignment of @Published properties so SwiftUI observers
         // never see an intermediate state with empty tabs or nil selection.
         tabs = newTabs
+        groups = newGroups
+        groupCancellables = [:]
+        for group in newGroups { wireGroupObservation(group) }
         selectedTabId = newSelectedId
         let existingIds = Set(newTabs.map(\.id))
         pruneBackgroundWorkspaceLoads(existingIds: existingIds)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2104,6 +2104,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceFocus(params: params))
         case "surface.split":
             return v2Result(id: id, self.v2SurfaceSplit(params: params))
+        case "surface.split_sized":
+            return v2Result(id: id, self.v2SurfaceSplitSized(params: params))
         case "surface.create":
             return v2Result(id: id, self.v2SurfaceCreate(params: params))
         case "surface.close":
@@ -2152,6 +2154,12 @@ class TerminalController {
             return v2Result(id: id, self.v2PaneJoin(params: params))
         case "pane.last":
             return v2Result(id: id, self.v2PaneLast(params: params))
+
+        // Panel background state (FR6)
+        case "panel.mark_background":
+            return v2Result(id: id, self.v2PanelMarkBackground(params: params))
+        case "panel.mark_foreground":
+            return v2Result(id: id, self.v2PanelMarkForeground(params: params))
 
         // Notifications
         case "notification.create":
@@ -2458,6 +2466,7 @@ class TerminalController {
             "surface.current",
             "surface.focus",
             "surface.split",
+            "surface.split_sized",
             "surface.create",
             "surface.close",
             "surface.drag_to_split",
@@ -2482,6 +2491,8 @@ class TerminalController {
             "pane.break",
             "pane.join",
             "pane.last",
+            "panel.mark_background",
+            "panel.mark_foreground",
             "notification.create",
             "notification.create_for_surface",
             "notification.create_for_target",
@@ -4653,6 +4664,79 @@ class TerminalController {
         }
         return result
     }
+
+    /// Like `surface.split` but accepts a `ratio` parameter (0.0–1.0) that sets the divider
+    /// position after the split. The existing pane receives `ratio` of the available space
+    /// and the new pane receives `1 - ratio`. Defaults to 0.6 (existing pane keeps 60%).
+    private func v2SurfaceSplitSized(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let directionStr = v2String(params, "direction"),
+              let direction = parseSplitDirection(directionStr) else {
+            return .err(code: "invalid_params", message: "Missing or invalid direction (left|right|up|down)", data: nil)
+        }
+
+        let ratio: CGFloat
+        if params["ratio"] != nil {
+            guard let rawRatio = params["ratio"] as? Double else {
+                return .err(code: "invalid_params", message: "ratio must be a number between 0 and 1", data: nil)
+            }
+            guard rawRatio > 0.0 && rawRatio < 1.0 else {
+                return .err(code: "invalid_params", message: "ratio must be between 0 and 1 exclusive", data: nil)
+            }
+            ratio = CGFloat(rawRatio)
+        } else {
+            ratio = 0.6
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to create split", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            v2MaybeFocusWindow(for: tabManager)
+            v2MaybeSelectWorkspace(tabManager, workspace: ws)
+
+            let targetSurfaceId: UUID? = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let targetSurfaceId else {
+                result = .err(code: "not_found", message: "No focused surface", data: nil)
+                return
+            }
+            guard ws.panels[targetSurfaceId] != nil else {
+                result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": targetSurfaceId.uuidString])
+                return
+            }
+
+            if let newId = tabManager.newSplit(
+                tabId: ws.id,
+                surfaceId: targetSurfaceId,
+                direction: direction,
+                focus: v2FocusAllowed(),
+                initialDividerRatio: ratio
+            ) {
+                let paneUUID = ws.paneId(forPanelId: newId)?.id
+                let windowId = v2ResolveWindowId(tabManager: tabManager)
+                result = .ok([
+                    "window_id": v2OrNull(windowId?.uuidString),
+                    "window_ref": v2Ref(kind: .window, uuid: windowId),
+                    "workspace_id": ws.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                    "pane_id": v2OrNull(paneUUID?.uuidString),
+                    "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
+                    "surface_id": newId.uuidString,
+                    "surface_ref": v2Ref(kind: .surface, uuid: newId),
+                    "type": v2OrNull(ws.panels[newId]?.panelType.rawValue),
+                    "ratio": Double(max(0.01, min(0.99, ratio)))
+                ])
+            } else {
+                result = .err(code: "internal_error", message: "Failed to create split", data: nil)
+            }
+        }
+        return result
+    }
+
     private func v2SurfaceCreate(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -6464,6 +6548,100 @@ class TerminalController {
                 "surface_id": v2OrNull(selectedSurfaceId?.uuidString),
                 "surface_ref": v2Ref(kind: .surface, uuid: selectedSurfaceId)
             ])
+        }
+        return result
+    }
+
+    // MARK: - V2 Panel Background State Methods (FR6)
+
+    /// `panel.mark_background` — marks a panel as a long-running/background process.
+    /// The entire body (workspace scan + badge mutation) executes on the main thread via `v2MainSync`.
+    private func v2PanelMarkBackground(params: [String: Any]) -> V2CallResult {
+        guard let panelId = v2UUID(params, "surface_id") ?? v2UUID(params, "panel_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id / panel_id", data: nil)
+        }
+        // Resolve the tab manager that owns this panel. v2ResolveTabManager routes by
+        // window_id/workspace_id/surface_id/tab_id; if only panel_id is supplied it may
+        // return the active window's manager even when the panel lives in another window.
+        // Fall back to a cross-window lookup via locateSurface so non-active windows are
+        // correctly handled.
+        let tabManager: TabManager?
+        if let resolved = v2ResolveTabManager(params: params),
+           resolved.tabs.contains(where: { $0.panels[panelId] != nil }) {
+            tabManager = resolved
+        } else {
+            tabManager = v2MainSync { AppDelegate.shared?.locateSurface(surfaceId: panelId)?.tabManager }
+        }
+        guard let tabManager else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "not_found", message: "Panel not found", data: nil)
+        v2MainSync {
+            for workspace in tabManager.tabs {
+                if workspace.panels[panelId] != nil {
+                    workspace.markBackground(panelId: panelId)
+                    let windowId = v2ResolveWindowId(tabManager: tabManager)
+                    result = .ok([
+                        "window_id": v2OrNull(windowId?.uuidString),
+                        "window_ref": v2Ref(kind: .window, uuid: windowId),
+                        "workspace_id": workspace.id.uuidString,
+                        "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id),
+                        "surface_id": panelId.uuidString,
+                        "surface_ref": v2Ref(kind: .surface, uuid: panelId),
+                        "panel_id": panelId.uuidString,
+                        "panel_ref": v2Ref(kind: .surface, uuid: panelId),
+                        "is_background": true
+                    ])
+                    return
+                }
+            }
+        }
+        return result
+    }
+
+    /// `panel.mark_foreground` — removes the background mark from a panel.
+    /// The entire body (workspace scan + badge mutation) executes on the main thread via `v2MainSync`.
+    private func v2PanelMarkForeground(params: [String: Any]) -> V2CallResult {
+        guard let panelId = v2UUID(params, "surface_id") ?? v2UUID(params, "panel_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id / panel_id", data: nil)
+        }
+        // Resolve the tab manager that owns this panel. v2ResolveTabManager routes by
+        // window_id/workspace_id/surface_id/tab_id; if only panel_id is supplied it may
+        // return the active window's manager even when the panel lives in another window.
+        // Fall back to a cross-window lookup via locateSurface so non-active windows are
+        // correctly handled.
+        let tabManager: TabManager?
+        if let resolved = v2ResolveTabManager(params: params),
+           resolved.tabs.contains(where: { $0.panels[panelId] != nil }) {
+            tabManager = resolved
+        } else {
+            tabManager = v2MainSync { AppDelegate.shared?.locateSurface(surfaceId: panelId)?.tabManager }
+        }
+        guard let tabManager else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "not_found", message: "Panel not found", data: nil)
+        v2MainSync {
+            for workspace in tabManager.tabs {
+                if workspace.panels[panelId] != nil {
+                    workspace.markForeground(panelId: panelId)
+                    let windowId = v2ResolveWindowId(tabManager: tabManager)
+                    result = .ok([
+                        "window_id": v2OrNull(windowId?.uuidString),
+                        "window_ref": v2Ref(kind: .window, uuid: windowId),
+                        "workspace_id": workspace.id.uuidString,
+                        "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id),
+                        "surface_id": panelId.uuidString,
+                        "surface_ref": v2Ref(kind: .surface, uuid: panelId),
+                        "panel_id": panelId.uuidString,
+                        "panel_ref": v2Ref(kind: .surface, uuid: panelId),
+                        "is_background": false
+                    ])
+                    return
+                }
+            }
         }
         return result
     }

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -10,6 +10,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
 
     private var commandLabels: [ObjectIdentifier: NSTextField] = [:]
     private var observers: [NSObjectProtocol] = []
+    private var cancellables: Set<AnyCancellable> = []
     private let focusedCommandUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
     private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
 
@@ -62,6 +63,15 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
                 self?.attach(to: window)
             }
         })
+
+        tabManager?.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.scheduleFocusedCommandTextUpdate()
+                }
+            }
+            .store(in: &cancellables)
 
         observers.append(center.addObserver(
             forName: UserDefaults.didChangeNotification,
@@ -138,10 +148,17 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
         let text: String
         if let selectedId = tabManager.selectedTabId,
            let tab = tabManager.tabs.first(where: { $0.id == selectedId }) {
-            let title = tab.title.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-            text = title.isEmpty ? "Cmd: —" : "Cmd: \(title)"
+            let title = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let workspaceName = title.isEmpty ? String(localized: "toolbar.focusedWorkspace.empty", defaultValue: "—") : title
+            // Show group breadcrumb when the workspace belongs to a group (UX3: "where am I?")
+            if let group = tabManager.group(forWorkspaceId: selectedId) {
+                let groupName = group.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                text = groupName.isEmpty ? workspaceName : "\(groupName)  ›  \(workspaceName)"
+            } else {
+                text = workspaceName
+            }
         } else {
-            text = "Cmd: —"
+            text = String(localized: "toolbar.focusedWorkspace.empty", defaultValue: "—")
         }
 
         for label in commandLabels.values {
@@ -164,7 +181,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
     func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         if itemIdentifier == commandItemIdentifier {
             let item = NSToolbarItem(itemIdentifier: itemIdentifier)
-            let label = NSTextField(labelWithString: "Cmd: —")
+            let label = NSTextField(labelWithString: String(localized: "toolbar.focusedWorkspace.empty", defaultValue: "—"))
             label.font = NSFont.systemFont(ofSize: 12, weight: .medium)
             label.textColor = .secondaryLabelColor
             label.lineBreakMode = .byTruncatingMiddle

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -317,6 +317,17 @@ extension Workspace {
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
 
+        // Restore FR6 background panel state (optional field; ignored on old session files).
+        backgroundPanelIds = Set(
+            snapshot.panels
+                .filter { $0.isBackground == true }
+                .compactMap { oldToNewPanelIds[$0.id] }
+                .filter { panels[$0] != nil }
+        )
+        for panelId in backgroundPanelIds {
+            syncBackgroundBadgeForPanel(panelId)
+        }
+
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
@@ -483,7 +494,8 @@ extension Workspace {
             ttyName: ttyName,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
-            markdown: markdownSnapshot
+            markdown: markdownSnapshot,
+            isBackground: backgroundPanelIds.contains(panelId) ? true : nil
         )
     }
 
@@ -5507,6 +5519,8 @@ final class Workspace: Identifiable, ObservableObject {
     @Published private(set) var tmuxWorkspaceFlashPanelId: UUID?
     @Published private(set) var tmuxWorkspaceFlashReason: WorkspaceAttentionFlashReason?
     @Published private(set) var tmuxWorkspaceFlashToken: UInt64 = 0
+    /// FR6: Panel IDs marked as background / long-running processes.
+    @Published private(set) var backgroundPanelIds: Set<UUID> = []
     private var manualUnreadMarkedAt: [UUID: Date] = [:]
     nonisolated private static let manualUnreadFocusGraceInterval: TimeInterval = 0.2
     nonisolated private static let manualUnreadClearDelayAfterFocusFlash: TimeInterval = 0.2
@@ -5775,10 +5789,6 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitController.onExternalTabDrop = { [weak self] request in
             self?.handleExternalTabDrop(request) ?? false
         }
-        bonsplitController.onTabCloseRequest = { [weak self] tabId, _ in
-            self?.markExplicitClose(surfaceId: tabId)
-        }
-
         // Set ourselves as delegate
         bonsplitController.delegate = self
 
@@ -5890,6 +5900,7 @@ final class Workspace: Identifiable, ObservableObject {
         let kind: String?
         let isLoading: Bool
         let isPinned: Bool
+        let isBackground: Bool
         let directory: String?
         let ttyName: String?
         let cachedTitle: String?
@@ -6294,6 +6305,41 @@ final class Workspace: Identifiable, ObservableObject {
         normalizePinnedTabs(in: paneId)
     }
 
+    // MARK: - FR6: Background Panel Management
+
+    /// Marks a panel as a long-running / background process.
+    /// The panel remains fully accessible; a visual badge is added to its bonsplit tab.
+    func markBackground(panelId: UUID) {
+        guard panels[panelId] != nil else { return }
+        guard backgroundPanelIds.insert(panelId).inserted else { return }
+        syncBackgroundBadgeForPanel(panelId)
+    }
+
+    /// Removes the background mark from a panel, restoring normal appearance.
+    func markForeground(panelId: UUID) {
+        guard panels[panelId] != nil else { return }
+        guard backgroundPanelIds.remove(panelId) != nil else { return }
+        syncBackgroundBadgeForPanel(panelId)
+    }
+
+    func isPanelBackground(_ panelId: UUID) -> Bool {
+        backgroundPanelIds.contains(panelId)
+    }
+
+    private func syncBackgroundBadgeForPanel(_ panelId: UUID) {
+        guard let tabId = surfaceIdFromPanelId(panelId),
+              let panel = panels[panelId] else { return }
+        let isBackground = backgroundPanelIds.contains(panelId)
+        bonsplitController.updateTab(
+            tabId,
+            title: .some(resolvedPanelTitle(panelId: panelId, fallback: panelTitles[panelId] ?? panel.displayTitle)),
+            icon: isBackground ? .some("server.rack") : .some(panel.displayIcon),
+            kind: .some(surfaceKind(for: panel)),
+            hasCustomTitle: panelCustomTitles[panelId] != nil,
+            isPinned: pinnedPanelIds.contains(panelId)
+        )
+    }
+
     func markPanelUnread(_ panelId: UUID) {
         guard panels[panelId] != nil else { return }
         guard manualUnreadPanelIds.insert(panelId).inserted else { return }
@@ -6588,6 +6634,7 @@ final class Workspace: Identifiable, ObservableObject {
         panelTitles = panelTitles.filter { validSurfaceIds.contains($0.key) }
         panelCustomTitles = panelCustomTitles.filter { validSurfaceIds.contains($0.key) }
         pinnedPanelIds = pinnedPanelIds.filter { validSurfaceIds.contains($0) }
+        backgroundPanelIds = backgroundPanelIds.filter { validSurfaceIds.contains($0) }
         manualUnreadPanelIds = manualUnreadPanelIds.filter { validSurfaceIds.contains($0) }
         panelGitBranches = panelGitBranches.filter { validSurfaceIds.contains($0.key) }
         manualUnreadMarkedAt = manualUnreadMarkedAt.filter { validSurfaceIds.contains($0.key) }
@@ -7425,12 +7472,27 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
+    /// Walk the bonsplit tree to find the UUID of the split node whose direct children contain `paneId`.
+    private func parentSplitId(of paneId: PaneID, in node: ExternalTreeNode) -> UUID? {
+        guard case .split(let split) = node else { return nil }
+        // Check if either direct child is a pane node matching paneId.
+        func isTargetPane(_ child: ExternalTreeNode) -> Bool {
+            guard case .pane(let p) = child else { return false }
+            return UUID(uuidString: p.id) == paneId.id
+        }
+        if isTargetPane(split.first) || isTargetPane(split.second) {
+            return UUID(uuidString: split.id)
+        }
+        return parentSplitId(of: paneId, in: split.first) ?? parentSplitId(of: paneId, in: split.second)
+    }
+
     /// Create a new split with a terminal panel
     @discardableResult
     func newTerminalSplit(
         from panelId: UUID,
         orientation: SplitOrientation,
         insertFirst: Bool = false,
+        initialDividerRatio: CGFloat = 0.6,
         focus: Bool = true
     ) -> TerminalPanel? {
         // Find the pane containing the source panel
@@ -7518,8 +7580,16 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
 
+        // Apply non-default divider ratio so the existing pane keeps its proportional space.
+        if initialDividerRatio != 0.5 {
+            let ratio = insertFirst ? (1.0 - initialDividerRatio) : initialDividerRatio
+            if let splitId = parentSplitId(of: paneId, in: bonsplitController.treeSnapshot()) {
+                _ = bonsplitController.setDividerPosition(ratio, forSplit: splitId, fromExternal: true)
+            }
+        }
+
 #if DEBUG
-        dlog("split.created pane=\(paneId.id.uuidString.prefix(5)) orientation=\(orientation)")
+        dlog("split.created pane=\(paneId.id.uuidString.prefix(5)) orientation=\(orientation) ratio=\(initialDividerRatio)")
 #endif
 
         // Suppress the old view's becomeFirstResponder side-effects during SwiftUI reparenting.
@@ -7633,6 +7703,7 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         url: URL? = nil,
         preferredProfileID: UUID? = nil,
+        initialDividerRatio: CGFloat = 0.6,
         focus: Bool = true
     ) -> BrowserPanel? {
         // Find the pane containing the source panel
@@ -7686,6 +7757,14 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
         setPreferredBrowserProfileID(browserPanel.profileID)
+
+        // Apply non-default divider ratio so the existing pane keeps its proportional space.
+        if initialDividerRatio != 0.5 {
+            let ratio = insertFirst ? (1.0 - initialDividerRatio) : initialDividerRatio
+            if let splitId = parentSplitId(of: paneId, in: bonsplitController.treeSnapshot()) {
+                _ = bonsplitController.setDividerPosition(ratio, forSplit: splitId, fromExternal: true)
+            }
+        }
 
         // See newTerminalSplit: suppress old view's becomeFirstResponder during reparenting.
         let previousHostedView = focusedTerminalPanel?.hostedView
@@ -7790,6 +7869,7 @@ final class Workspace: Identifiable, ObservableObject {
         orientation: SplitOrientation,
         insertFirst: Bool = false,
         filePath: String,
+        initialDividerRatio: CGFloat = 0.6,
         focus: Bool = true
     ) -> MarkdownPanel? {
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
@@ -7828,6 +7908,15 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
 
+        // Apply non-default divider ratio so the existing pane keeps its proportional space.
+        if initialDividerRatio != 0.5 {
+            let ratio = insertFirst ? (1.0 - initialDividerRatio) : initialDividerRatio
+            if let splitId = parentSplitId(of: paneId, in: bonsplitController.treeSnapshot()) {
+                _ = bonsplitController.setDividerPosition(ratio, forSplit: splitId, fromExternal: true)
+            }
+        }
+
+        // Suppress old view's becomeFirstResponder during reparenting.
         let previousHostedView = focusedTerminalPanel?.hostedView
         if focus {
             previousHostedView?.suppressReparentFocus()
@@ -8428,6 +8517,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelTitles.removeValue(forKey: detached.panelId)
             panelCustomTitles.removeValue(forKey: detached.panelId)
             pinnedPanelIds.remove(detached.panelId)
+            backgroundPanelIds.remove(detached.panelId)
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
             panelSubscriptions.removeValue(forKey: detached.panelId)
@@ -8461,6 +8551,10 @@ final class Workspace: Identifiable, ObservableObject {
         }
         syncPinnedStateForTab(newTabId, panelId: detached.panelId)
         syncUnreadBadgeStateForPanel(detached.panelId)
+        if detached.isBackground {
+            backgroundPanelIds.insert(detached.panelId)
+            syncBackgroundBadgeForPanel(detached.panelId)
+        }
         normalizePinnedTabs(in: paneId)
 
         if focus {
@@ -10324,6 +10418,7 @@ extension Workspace: BonsplitDelegate {
                 kind: surfaceKind(for: panel),
                 isLoading: browserPanel?.isLoading ?? false,
                 isPinned: pinnedPanelIds.contains(panelId),
+                isBackground: backgroundPanelIds.contains(panelId),
                 directory: panelDirectories[panelId],
                 ttyName: surfaceTTYNames[panelId],
                 cachedTitle: cachedTitle,
@@ -10352,6 +10447,7 @@ extension Workspace: BonsplitDelegate {
         panelTitles.removeValue(forKey: panelId)
         panelCustomTitles.removeValue(forKey: panelId)
         pinnedPanelIds.remove(panelId)
+        backgroundPanelIds.remove(panelId)
         manualUnreadPanelIds.remove(panelId)
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         panelSubscriptions.removeValue(forKey: panelId)
@@ -10505,6 +10601,7 @@ extension Workspace: BonsplitDelegate {
                 panelTitles.removeValue(forKey: panelId)
                 panelCustomTitles.removeValue(forKey: panelId)
                 pinnedPanelIds.remove(panelId)
+                backgroundPanelIds.remove(panelId)
                 manualUnreadPanelIds.remove(panelId)
                 panelSubscriptions.removeValue(forKey: panelId)
                 panelShellActivityStates.removeValue(forKey: panelId)

--- a/Sources/WorkspaceGroup.swift
+++ b/Sources/WorkspaceGroup.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - WorkspaceGroup Model
+
+/// A named group that contains an ordered list of Workspace IDs.
+/// Groups are owned by TabManager and provide a two-level sidebar hierarchy (FR3).
+@MainActor
+final class WorkspaceGroup: ObservableObject, Identifiable {
+    let id: UUID
+    @Published var title: String
+    @Published var isCollapsed: Bool
+    @Published var memberIds: [UUID]  // ordered list of Workspace IDs
+
+    init(id: UUID = UUID(), title: String, isCollapsed: Bool = false, memberIds: [UUID] = []) {
+        self.id = id
+        self.title = title
+        self.isCollapsed = isCollapsed
+        self.memberIds = memberIds
+    }
+}
+
+// MARK: - Codable Snapshot for Session Persistence
+
+/// Lightweight, Codable representation of a WorkspaceGroup for session save/restore.
+/// All fields are non-optional here because the containing field on
+/// SessionTabManagerSnapshot is already declared optional for backward compatibility.
+struct WorkspaceGroupSnapshot: Codable, Sendable {
+    let id: UUID
+    let title: String
+    let isCollapsed: Bool
+    let memberIds: [UUID]
+
+    @MainActor
+    init(group: WorkspaceGroup) {
+        self.id = group.id
+        self.title = group.title
+        self.isCollapsed = group.isCollapsed
+        self.memberIds = group.memberIds
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5296,7 +5296,7 @@ struct SettingsView: View {
 
                         SettingsCardRow(
                             String(localized: "settings.browser.openTerminalLinks", defaultValue: "Open Terminal Links in cmux Browser"),
-                            subtitle: String(localized: "settings.browser.openTerminalLinks.subtitle", defaultValue: "When off, links clicked in terminal output open in your default browser.")
+                            subtitle: String(localized: "settings.browser.openTerminalLinks.subtitle", defaultValue: "When on, links clicked in terminal output open in the cmux embedded browser. Off by default — links open in your system browser.")
                         ) {
                             Toggle("", isOn: $openTerminalLinksInCmuxBrowser)
                                 .labelsHidden()
@@ -5306,8 +5306,8 @@ struct SettingsView: View {
                         SettingsCardDivider()
 
                         SettingsCardRow(
-                            String(localized: "settings.browser.interceptOpen", defaultValue: "Intercept open http(s) in Terminal"),
-                            subtitle: String(localized: "settings.browser.interceptOpen.subtitle", defaultValue: "When off, `open https://...` and `open http://...` always use your default browser.")
+                            String(localized: "settings.browser.interceptOpen", defaultValue: "Route open http(s) in Terminal to cmux Browser"),
+                            subtitle: String(localized: "settings.browser.interceptOpen.subtitle", defaultValue: "When on, `open https://...` and `open http://...` commands open in the cmux embedded browser. Off by default — these commands use your system browser.")
                         ) {
                             Toggle("", isOn: $interceptTerminalOpenCommandInCmuxBrowser)
                                 .labelsHidden()


### PR DESCRIPTION
## Summary

Implements the Spatial Project Workspaces PRD — a set of features designed to make cmux a better environment for parallel development with AI agents running in separate panes.

- **FR1 — 60/40 split ratio**: New splits open at 0.6/0.4 instead of 0.5/0.5, giving the primary pane more space
- **FR2 — Focus ring**: Thin accent-colored border appears on the active pane when multiple panes are open (`allowsHitTesting(false)`, SwiftUI overlay only, never touches AppKit layers)
- **FR3 — Workspace groups**: Two-level sidebar hierarchy — named folders that contain workspaces. Collapse/expand (`Cmd+Opt+G`), create (`Cmd+Shift+G`), delete via context menu. Toolbar shows `Group › Workspace` breadcrumb. Session-persisted with backward-compat optional fields.
- **FR6 — Background pane marking**: Mark any pane as "background" (`Cmd+Opt+Shift+B`) to badge it with a `server.rack` icon in the tab strip. Restore with `Cmd+Opt+B`. Useful for long-running agent processes.
- **SR1 — External links → system browser**: `defaultOpenTerminalLinksInCmuxBrowser` and `defaultInterceptTerminalOpenCommandInCmuxBrowser` both default to `false`
- **SR2 — Agent env vars**: Every terminal gets `CMUX_TERM=1` and `CMUX_CLAUDE_HOOKS_PATH` pointing to the bundled `bin/` directory. Also prepends `bin/` to `PATH`.
- **9 new command palette actions** for all group and background pane operations
- **Full EN + JA localization** for all new strings

## Implementation notes

- `WorkspaceGroup` is `@MainActor final class ObservableObject`. Changes are forwarded to `TabManager.objectWillChange` via Combine sinks so `VerticalTabsSidebar` re-renders on collapse/expand and membership changes.
- `TabItemView` `Equatable` conformance extended for `isGrouped` — `.equatable()` call sites preserved, no typing-latency regression.
- `FocusRingView` uses `allowsHitTesting(false)` and is a SwiftUI-only overlay — never participates in `hitTest()`.
- All new session persistence fields are `Optional` with `= nil` defaults for backward compatibility.
- `backgroundPanelIds` included in `pruneSurfaceMetadata` alongside `pinnedPanelIds`.
- Socket commands `panel.mark_background` / `panel.mark_foreground` use `v2MainSync` per the socket threading policy.

## Test plan

- [ ] Create a workspace group via `Cmd+Shift+G` or command palette — verify it appears in the sidebar
- [ ] Collapse/expand group via `Cmd+Opt+G` — verify member workspaces appear/disappear with animation
- [ ] Close a grouped workspace — verify it is removed from the group member list
- [ ] Mark a pane as background (`Cmd+Opt+Shift+B`) — verify `server.rack` badge appears in tab strip
- [ ] Open a new split — verify it opens at ~60/40 ratio
- [ ] Focus different panes in a split — verify blue focus ring appears/disappears with 0.15s fade
- [ ] Click a terminal link — verify it opens in the system browser (not in-app)
- [ ] Open a new terminal, run `echo $CMUX_TERM` — verify output is `1`
- [ ] Quit and relaunch — verify groups and background pane state are restored from session
- [ ] Verify no extra `→ ~` prompt lines appear on terminal open (geometry reconcile regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Spatial Project Workspaces for faster multi‑pane work: 60/40 splits with a new sized split API, a focus ring, grouped workspaces with a live Group › Workspace breadcrumb, background pane badges, safer browser defaults, and agent env vars. State is persisted and de‑duped; groups and background marks survive session restore and pane moves across windows.

- **New Features**
  - Splits default to 60/40; `surface.split_sized` accepts a ratio (0–1), rejects non‑numeric/out‑of‑range, clamps to avoid collapsed panes, and returns the applied clamped ratio. Matches `surface.split` focus policy.
  - Pane UX: focus ring on the active pane in split layouts.
  - Background panes: mark/unmark with a `server.rack` badge (shortcuts + command palette). APIs `panel.mark_background` / `panel.mark_foreground` resolve across windows, are advertised via capabilities, persist, survive detach/attach, and clean up on close.
  - Workspace groups: two‑level sidebar with collapse/expand and a live Group › Workspace toolbar breadcrumb (localized empty state). Session restore de‑dups to single‑group membership; autosave fingerprints include groups. Shortcuts and command palette actions added. Grouped rendering is faster.
  - Navigation: command palette adds Focus Pane Left/Right/Up/Down plus group/background actions.
  - Browser and env: external links and `open http(s)` default to the system browser (clearer settings copy). Terminals get `CMUX_TERM=1`, `CMUX_CLAUDE_HOOKS_PATH`, and `bin/` is prepended to `PATH` and kept first after env merges. EN + JA localization for new strings. Adopted upstream keys for the dev build banner and “search all surfaces”. Reverted terminal geometry reconcile delay to avoid extra prompts.

- **Migration**
  - To use the embedded browser, enable “Open Terminal Links in cmux Browser” and “Route `open http(s)` in Terminal to cmux Browser” in Settings. Old session files load unchanged; new group/background fields are optional.

<sup>Written for commit 0a8c0d8a6dde05a756329989c0b4724c41135544. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace grouping with collapsible groups and breadcrumb toolbar display.
  * New shortcuts and command-palette actions for group creation/collapse, pane navigation, and marking panels background/foreground.
  * Persisted background panel state with UI badge and restore support.
  * Split sizing control (initial divider ratio) and a visual focus ring for split panes.
  * Expanded localization for many UI labels, menus, and shortcuts.

* **Bug Fixes**
  * Terminal link defaults adjusted for improved browser integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->