### PR TITLE
Preserve scroll position across workspace switches

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5901,6 +5901,8 @@ final class GhosttySurfaceScrollView: NSView {
     private var windowObservers: [NSObjectProtocol] = []
     private var isLiveScrolling = false
     private var lastSentRow: Int?
+    /// Scroll row saved when the view is hidden (workspace switch). Restored on next layout.
+    private var savedScrollRow: Int?
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
     private var activeDropZone: DropZone?
@@ -6935,6 +6937,26 @@ final class GhosttySurfaceScrollView: NSView {
     func setVisibleInUI(_ visible: Bool) {
         let wasVisible = surfaceView.isVisibleInUI
         surfaceView.setVisibleInUI(visible)
+
+        if !visible {
+            // Save scroll position before hiding so it survives workspace switches.
+            // Only save when the user is scrolled up; if they were following output at
+            // the bottom, let the default synchronizeScrollView() behavior keep them there.
+            if let scrollbar = surfaceView.scrollbar, scrollbar.offset > 0 {
+                savedScrollRow = currentScrollRow()
+            } else {
+                savedScrollRow = nil
+            }
+        } else {
+            // Restore scroll position: tell Ghostty to scroll to the saved row *before*
+            // isHidden = false, so synchronizeScrollView() picks up the correct offset
+            // when layout() fires.
+            if let row = savedScrollRow {
+                savedScrollRow = nil
+                _ = surfaceView.performBindingAction("scroll_to_row:\(row)")
+            }
+        }
+
         isHidden = !visible
 #if DEBUG
         if wasVisible != visible {
@@ -8027,15 +8049,19 @@ final class GhosttySurfaceScrollView: NSView {
         synchronizeSurfaceView()
     }
 
-    private func handleLiveScroll() {
+    /// Returns the current scroll row derived from the NSScrollView visible rect,
+    /// using the same calculation as handleLiveScroll. Returns nil if cell height is unavailable.
+    private func currentScrollRow() -> Int? {
         let cellHeight = surfaceView.cellSize.height
-        guard cellHeight > 0 else { return }
-
+        guard cellHeight > 0 else { return nil }
         let visibleRect = scrollView.contentView.documentVisibleRect
         let documentHeight = documentView.frame.height
         let scrollOffset = documentHeight - visibleRect.origin.y - visibleRect.height
-        let row = Int(scrollOffset / cellHeight)
+        return Int(scrollOffset / cellHeight)
+    }
 
+    private func handleLiveScroll() {
+        guard let row = currentScrollRow() else { return }
         guard row != lastSentRow else { return }
         lastSentRow = row
         _ = surfaceView.performBindingAction("scroll_to_row:\(row)")


### PR DESCRIPTION
## Summary

- Fixes scroll position resetting to bottom when switching away from a workspace and back
- Saves the current scroll row (from the NSScrollView visible rect) in `setVisibleInUI(false)` before the view is hidden
- Restores it via `scroll_to_row:` in `setVisibleInUI(true)` before layout runs, so `synchronizeScrollView()` picks up the correct offset

Fixes #945

## Test plan

- [ ] Open cmux with multiple workspaces
- [ ] In one workspace, run a command that produces lots of output (e.g. `seq 10000`)
- [ ] Scroll up to a specific position in the middle of the output
- [ ] Switch to a different workspace
- [ ] Switch back to the original workspace
- [ ] Verify the scroll position is preserved (not reset to bottom)
- [ ] Verify normal scrolling still works after restoring
- [ ] Verify new output still auto-scrolls to bottom when at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves scroll position when switching workspaces so the view no longer jumps to the bottom. Only persists when scrolled up; following the bottom remains unchanged (fixes #945).

- **Bug Fixes**
  - Save current scroll row in `setVisibleInUI(false)` from the `NSScrollView` visible rect when `scrollbar.offset > 0`; restore via `scroll_to_row` in `setVisibleInUI(true)` before layout so `synchronizeScrollView()` uses the right offset.
  - Added `currentScrollRow()` and used it in live scroll with a guard when cell height is unavailable.

<sup>Written for commit c54573f205a59cb3800f73450715d7715ad7cedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persist and restore terminal scroll position when the surface is hidden and shown again.
  * Prevent crashes and improve reliability during layout/resize by skipping scroll actions when the current row cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->