### PR TITLE
feat: add path-based workspace color rules

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10813,7 +10813,8 @@ private struct TabItemView: View, Equatable {
     }
 
     private var resolvedCustomTabColor: Color? {
-        guard let hex = tab.customColor else { return nil }
+        let hex = tab.customColor ?? WorkspaceColorRules.colorForDirectory(tab.currentDirectory)
+        guard let hex else { return nil }
         return WorkspaceTabColorSettings.displayColor(
             hex: hex,
             colorScheme: colorScheme,

--- a/Sources/WorkspaceColorRules.swift
+++ b/Sources/WorkspaceColorRules.swift
@@ -9,8 +9,15 @@ struct WorkspaceColorRulesConfig: Codable {
     let workspaceColorRules: [WorkspaceColorRule]
 }
 
+private struct CompiledColorRule {
+    let expandedPath: String
+    let compiledRegex: NSRegularExpression?
+    let normalizedColor: String
+}
+
+@MainActor
 enum WorkspaceColorRules {
-    private static var rules: [WorkspaceColorRule] = []
+    private static var compiledRules: [CompiledColorRule] = []
     private static var loaded = false
 
     static var configURL: URL {
@@ -19,48 +26,51 @@ enum WorkspaceColorRules {
     }
 
     static func reloadRules() {
-        guard FileManager.default.fileExists(atPath: configURL.path),
-              let data = try? Data(contentsOf: configURL),
+        guard let data = try? Data(contentsOf: configURL),
               let config = try? JSONDecoder().decode(WorkspaceColorRulesConfig.self, from: data)
         else {
-            rules = []
+            compiledRules = []
             loaded = true
             return
         }
 
-        rules = config.workspaceColorRules
+        compiledRules = config.workspaceColorRules.compactMap { rule in
+            let expanded = (rule.path as NSString).expandingTildeInPath
+            guard let color = WorkspaceTabColorSettings.normalizedHex(rule.color) else {
+                return nil
+            }
+            let regex: NSRegularExpression?
+            if expanded.contains("*") || expanded.contains("?") {
+                let pattern = convertGlobToRegex(expanded)
+                regex = try? NSRegularExpression(pattern: pattern)
+            } else {
+                regex = nil
+            }
+            return CompiledColorRule(expandedPath: expanded, compiledRegex: regex, normalizedColor: color)
+        }
         loaded = true
     }
 
     static func colorForDirectory(_ directory: String) -> String? {
         if !loaded { reloadRules() }
 
-        let expandedDir = expandTilde(directory)
+        let expandedDir = (directory as NSString).expandingTildeInPath
 
-        for rule in rules {
-            let expandedPattern = expandTilde(rule.path)
-            if matchesPattern(directory: expandedDir, pattern: expandedPattern) {
-                return WorkspaceTabColorSettings.normalizedHex(rule.color)
+        for rule in compiledRules {
+            if matches(directory: expandedDir, rule: rule) {
+                return rule.normalizedColor
             }
         }
 
         return nil
     }
 
-    private static func expandTilde(_ path: String) -> String {
-        if path.hasPrefix("~/") {
-            return FileManager.default.homeDirectoryForCurrentUser.path
-                + String(path.dropFirst(1))
-        }
-        return path
-    }
-
-    private static func matchesPattern(directory: String, pattern: String) -> Bool {
-        if pattern.contains("*") {
-            let regexPattern = convertGlobToRegex(pattern)
-            return directory.range(of: regexPattern, options: .regularExpression) != nil
+    private static func matches(directory: String, rule: CompiledColorRule) -> Bool {
+        if let regex = rule.compiledRegex {
+            let range = NSRange(directory.startIndex..., in: directory)
+            return regex.firstMatch(in: directory, range: range) != nil
         } else {
-            return directory == pattern || directory.hasPrefix(pattern + "/")
+            return directory == rule.expandedPath || directory.hasPrefix(rule.expandedPath + "/")
         }
     }
 
@@ -73,16 +83,13 @@ enum WorkspaceColorRules {
             if c == "*" {
                 let next = glob.index(after: i)
                 if next < glob.endIndex && glob[next] == "*" {
-                    // ** matches any path including separators
                     result += ".*"
                     i = glob.index(after: next)
-                    // Skip trailing / after **
                     if i < glob.endIndex && glob[i] == "/" {
                         i = glob.index(after: i)
                     }
                     continue
                 } else {
-                    // * matches anything except /
                     result += "[^/]*"
                 }
             } else if c == "?" {

--- a/Sources/WorkspaceColorRules.swift
+++ b/Sources/WorkspaceColorRules.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+struct WorkspaceColorRule: Codable {
+    let path: String
+    let color: String
+}
+
+struct WorkspaceColorRulesConfig: Codable {
+    let workspaceColorRules: [WorkspaceColorRule]
+}
+
+enum WorkspaceColorRules {
+    private static var rules: [WorkspaceColorRule] = []
+    private static var loaded = false
+
+    static var configURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux/color-rules.json")
+    }
+
+    static func reloadRules() {
+        guard FileManager.default.fileExists(atPath: configURL.path),
+              let data = try? Data(contentsOf: configURL),
+              let config = try? JSONDecoder().decode(WorkspaceColorRulesConfig.self, from: data)
+        else {
+            rules = []
+            loaded = true
+            return
+        }
+
+        rules = config.workspaceColorRules
+        loaded = true
+    }
+
+    static func colorForDirectory(_ directory: String) -> String? {
+        if !loaded { reloadRules() }
+
+        let expandedDir = expandTilde(directory)
+
+        for rule in rules {
+            let expandedPattern = expandTilde(rule.path)
+            if matchesPattern(directory: expandedDir, pattern: expandedPattern) {
+                return WorkspaceTabColorSettings.normalizedHex(rule.color)
+            }
+        }
+
+        return nil
+    }
+
+    private static func expandTilde(_ path: String) -> String {
+        if path.hasPrefix("~/") {
+            return FileManager.default.homeDirectoryForCurrentUser.path
+                + String(path.dropFirst(1))
+        }
+        return path
+    }
+
+    private static func matchesPattern(directory: String, pattern: String) -> Bool {
+        if pattern.contains("*") {
+            let regexPattern = convertGlobToRegex(pattern)
+            return directory.range(of: regexPattern, options: .regularExpression) != nil
+        } else {
+            return directory == pattern || directory.hasPrefix(pattern + "/")
+        }
+    }
+
+    private static func convertGlobToRegex(_ glob: String) -> String {
+        var result = "^"
+        var i = glob.startIndex
+
+        while i < glob.endIndex {
+            let c = glob[i]
+            if c == "*" {
+                let next = glob.index(after: i)
+                if next < glob.endIndex && glob[next] == "*" {
+                    // ** matches any path including separators
+                    result += ".*"
+                    i = glob.index(after: next)
+                    // Skip trailing / after **
+                    if i < glob.endIndex && glob[i] == "/" {
+                        i = glob.index(after: i)
+                    }
+                    continue
+                } else {
+                    // * matches anything except /
+                    result += "[^/]*"
+                }
+            } else if c == "?" {
+                result += "[^/]"
+            } else if ".+^${}()|[]\\".contains(c) {
+                result += "\\\(c)"
+            } else {
+                result.append(c)
+            }
+            i = glob.index(after: i)
+        }
+
+        result += "(/.*)?$"
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

- Add automatic workspace color assignment based on configurable path-matching rules
- Rules are loaded from `~/.config/cmux/color-rules.json`
- Manual color overrides (via right-click context menu) take priority over rule-based colors

## Configuration

Create `~/.config/cmux/color-rules.json`:

```json
{
  "workspaceColorRules": [
    { "path": "~/Developments/faceless-fm", "color": "#1565C0" },
    { "path": "~/Developments/podcast-*", "color": "#196F3D" },
    { "path": "~/work/**", "color": "#C0392B" },
    { "path": "~/personal/**", "color": "#6A1B9A" }
  ]
}
```

### Matching behavior

| Pattern | Matches |
|---------|---------|
| `~/projects/foo` | Exact path + any subdirectory |
| `~/work/*` | Direct children of `~/work/` |
| `~/work/**` | All descendants of `~/work/` |
| `~/dev/app-*` | Directories starting with `app-` in `~/dev/` |

- Rules are evaluated top-to-bottom; **first match wins**
- Manually set colors (via context menu) always take priority
- Clearing a manual color reverts to the rule-based color

## Changes

- **New**: `Sources/WorkspaceColorRules.swift` — Rule engine with glob pattern matching, tilde expansion, and lazy config loading
- **Modified**: `Sources/ContentView.swift` — `resolvedCustomTabColor` falls back to `WorkspaceColorRules.colorForDirectory()` when no manual color is set

## Test plan

- [ ] Create `~/.config/cmux/color-rules.json` with sample rules
- [ ] Open workspaces in matching directories → verify colors appear
- [ ] Open workspace in non-matching directory → verify no color applied
- [ ] Manually set color on a rule-matched workspace → verify manual color takes priority
- [ ] Clear manual color → verify rule-based color returns
- [ ] Test glob patterns (`*`, `**`, `?`)
- [ ] Verify app launches normally without config file present

Closes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds path-based workspace color rules to auto-assign tab colors; manual overrides still win. Loads from ~/.config/cmux/color-rules.json and precompiles rules on the main actor for thread safety and lower overhead.

- **New Features**
  - Auto-assigns workspace colors from rules in ~/.config/cmux/color-rules.json.
  - Supports glob patterns (*, **, ?) and prefix matching; first match wins.
  - Manual colors (context menu) override rule-based colors; clearing restores the rule color.
  - Works without a config file; no color is applied if no rule matches.

<sup>Written for commit 793835d063d005b607bf31dd8f9857ecbcf6c323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs now automatically display colors based on workspace directory rules via JSON configuration
  * Added support for configurable workspace color rules at ~/.config/cmux/color-rules.json with wildcard pattern matching for directory paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->