### PR TITLE
Add configurable sidebar font families

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43896,97 +43896,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "侧边栏标题字体"
+            "value": "侧边栏文本字体"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "側邊欄標題字體"
+            "value": "側邊欄文字字體"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사이드바 제목 글꼴"
+            "value": "사이드바 텍스트 글꼴"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Seitenleisten-Titelschrift"
+            "value": "Seitenleisten-Textschrift"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fuente del título de la barra lateral"
+            "value": "Fuente de texto de la barra lateral"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Police du titre de la barre latérale"
+            "value": "Police du texte de la barre latérale"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Font del titolo nella barra laterale"
+            "value": "Font del testo nella barra laterale"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidebjælkens titelskrifttype"
+            "value": "Sidebjælkens tekstskrifttype"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Czcionka tytułu paska bocznego"
+            "value": "Czcionka tekstu paska bocznego"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Шрифт заголовка боковой панели"
+            "value": "Шрифт текста боковой панели"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Font naslova bočne trake"
+            "value": "Font teksta bočne trake"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "خط عنوان الشريط الجانبي"
+            "value": "خط نص الشريط الجانبي"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tittelskrifttype i sidepanelet"
+            "value": "Tekstskrifttype i sidepanelet"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte do Título na Barra Lateral"
+            "value": "Fonte do Texto na Barra Lateral"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แบบอักษรชื่อในแถบด้านข้าง"
+            "value": "แบบอักษรข้อความในแถบด้านข้าง"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kenar Çubuğu Başlık Yazı Tipi"
+            "value": "Kenar Çubuğu Metin Yazı Tipi"
           }
         }
       }
@@ -44009,97 +44009,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "工作区标题的字体样式。"
+            "value": "用于工作区标题、通知、日志、元数据和其他常规侧边栏文本的字体。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "工作區標題的字體樣式。"
+            "value": "用於工作區標題、通知、日誌、中繼資料和其他一般側邊欄文字的字體。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "워크스페이스 제목의 글꼴 스타일입니다."
+            "value": "워크스페이스 제목, 알림, 로그, 메타데이터 및 기타 일반적인 사이드바 텍스트에 사용하는 글꼴입니다."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Schriftstil für Workspace-Titel."
+            "value": "Die Schrift für Workspace-Titel, Benachrichtigungen, Logs, Metadaten und anderen regulären Seitenleisten-Text."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El estilo de fuente para los títulos de espacios de trabajo."
+            "value": "La fuente para los títulos de espacios de trabajo, notificaciones, registros, metadatos y otro texto normal de la barra lateral."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Le style de police pour les titres d'espaces de travail."
+            "value": "La police pour les titres d'espaces de travail, les notifications, les journaux, les métadonnées et les autres textes ordinaires de la barre latérale."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lo stile del font per i titoli dei workspace."
+            "value": "Il font per i titoli dei workspace, le notifiche, i log, i metadati e gli altri testi normali della barra laterale."
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skrifttypestilen for arbejdsområdetitler."
+            "value": "Skrifttypen til arbejdsområdetitler, notifikationer, logfiler, metadata og anden almindelig tekst i sidebjælken."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Styl czcionki dla tytułów przestrzeni roboczych."
+            "value": "Czcionka dla tytułów obszarów roboczych, powiadomień, logów, metadanych i innego zwykłego tekstu paska bocznego."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Стиль шрифта для заголовков рабочих пространств."
+            "value": "Шрифт для заголовков рабочих пространств, уведомлений, журналов, метаданных и другого обычного текста боковой панели."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stil fonta za naslove radnih prostora."
+            "value": "Font za naslove radnih prostora, obavijesti, logove, metapodatke i ostali obični tekst bočne trake."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمط الخط لعناوين مساحات العمل."
+            "value": "الخط المستخدم لعناوين مساحات العمل والإشعارات والسجلات والبيانات الوصفية ونص الشريط الجانبي العادي الآخر."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skrifttypestilen for arbeidsområdetitler."
+            "value": "Skrifttypen for arbeidsområdetitler, varsler, logger, metadata og annen vanlig tekst i sidepanelet."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "O estilo de fonte para títulos de espaço de trabalho."
+            "value": "A fonte para títulos de espaço de trabalho, notificações, logs, metadados e outros textos normais da barra lateral."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "รูปแบบแบบอักษรสำหรับชื่อพื้นที่ทำงาน"
+            "value": "แบบอักษรสำหรับชื่อพื้นที่ทำงาน การแจ้งเตือน บันทึก เมทาดาทา และข้อความทั่วไปอื่น ๆ ในแถบด้านข้าง"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Çalışma alanı başlıkları için yazı tipi stili."
+            "value": "Çalışma alanı başlıkları, bildirimler, günlükler, meta veriler ve diğer normal kenar çubuğu metinleri için yazı tipi."
           }
         }
       }
@@ -44348,97 +44348,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "侧边栏详细信息字体"
+            "value": "侧边栏分支/路径字体"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "側邊欄詳細資訊字體"
+            "value": "側邊欄分支/路徑字體"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사이드바 세부 정보 글꼴"
+            "value": "사이드바 브랜치/경로 글꼴"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Seitenleisten-Detailschrift"
+            "value": "Seitenleisten-Schrift für Branches/Pfade"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fuente de detalles de la barra lateral"
+            "value": "Fuente de ramas/rutas de la barra lateral"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Police des détails de la barre latérale"
+            "value": "Police des branches/chemins de la barre latérale"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Font dettagli nella barra laterale"
+            "value": "Font dei branch/percorsi nella barra laterale"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidebjælkens detalje-skrifttype"
+            "value": "Sidebjælkens gren-/stiskrifttype"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Czcionka szczegółów paska bocznego"
+            "value": "Czcionka gałęzi/ścieżek paska bocznego"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Шрифт деталей боковой панели"
+            "value": "Шрифт веток/путей боковой панели"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Font detalja bočne trake"
+            "value": "Font grana/putanja bočne trake"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "خط تفاصيل الشريط الجانبي"
+            "value": "خط الفروع/المسارات في الشريط الجانبي"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Detaljskrifttype i sidepanelet"
+            "value": "Gren-/stiskrifttype i sidepanelet"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fonte de Detalhes na Barra Lateral"
+            "value": "Fonte de Branches/Caminhos na Barra Lateral"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แบบอักษรรายละเอียดในแถบด้านข้าง"
+            "value": "แบบอักษรสาขา/พาธในแถบด้านข้าง"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kenar Çubuğu Detay Yazı Tipi"
+            "value": "Kenar Çubuğu Dal/Yol Yazı Tipi"
           }
         }
       }
@@ -44461,97 +44461,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "分支、端口、元数据等详细信息的字体样式。"
+            "value": "用于分支、目录和端口的字体。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "分支、連接埠、中繼資料等詳細資訊的字體樣式。"
+            "value": "用於分支、目錄和連接埠的字體。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "브랜치, 포트, 메타데이터 등 세부 정보의 글꼴 스타일입니다."
+            "value": "브랜치, 디렉터리, 포트에 사용하는 글꼴입니다."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Der Schriftstil für Branches, Ports, Metadaten und andere Details."
+            "value": "Die Schrift für Branches, Verzeichnisse und Ports."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "El estilo de fuente para ramas, puertos, metadatos y otros detalles."
+            "value": "La fuente para ramas, directorios y puertos."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Le style de police pour les branches, ports, métadonnées et autres détails."
+            "value": "La police pour les branches, répertoires et ports."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lo stile del font per branch, porte, metadati e altri dettagli."
+            "value": "Il font per branch, directory e porte."
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skrifttypestilen for grene, porte, metadata og andre detaljer."
+            "value": "Skrifttypen til grene, mapper og porte."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Styl czcionki dla gałęzi, portów, metadanych i innych szczegółów."
+            "value": "Czcionka dla gałęzi, katalogów i portów."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Стиль шрифта для веток, портов, метаданных и других деталей."
+            "value": "Шрифт для веток, каталогов и портов."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stil fonta za grane, portove, metapodatke i ostale detalje."
+            "value": "Font za grane, direktorije i portove."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمط الخط للفروع والمنافذ والبيانات الوصفية والتفاصيل الأخرى."
+            "value": "الخط المستخدم للفروع والدلائل والمنافذ."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skrifttypestilen for grener, porter, metadata og andre detaljer."
+            "value": "Skrifttypen for grener, kataloger og porter."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "O estilo de fonte para branches, portas, metadados e outros detalhes."
+            "value": "A fonte para branches, diretórios e portas."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "รูปแบบแบบอักษรสำหรับสาขา พอร์ต ข้อมูลเมตา และรายละเอียดอื่น ๆ"
+            "value": "แบบอักษรสำหรับสาขา ไดเรกทอรี และพอร์ต"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dallar, portlar, meta veriler ve diğer detaylar için yazı tipi stili."
+            "value": "Dallar, dizinler ve portlar için yazı tipi."
           }
         }
       }
@@ -44574,97 +44574,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "标题字体设计"
+            "value": "文本字体"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "標題字體設計"
+            "value": "文字字體"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "제목 글꼴 디자인"
+            "value": "텍스트 글꼴"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Titelschriftdesign"
+            "value": "Textschrift"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diseño de fuente del título"
+            "value": "Fuente de texto"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design de police du titre"
+            "value": "Police du texte"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design del font del titolo"
+            "value": "Font del testo"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Titel-skrifttypedesign"
+            "value": "Tekstskrifttype"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Styl czcionki tytułu"
+            "value": "Czcionka tekstu"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Дизайн шрифта заголовка"
+            "value": "Шрифт текста"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dizajn fonta naslova"
+            "value": "Font teksta"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تصميم خط العنوان"
+            "value": "خط النص"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tittelskrifttypedesign"
+            "value": "Tekstskrifttype"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design da Fonte do Título"
+            "value": "Fonte do Texto"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การออกแบบแบบอักษรชื่อ"
+            "value": "แบบอักษรข้อความ"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Başlık Yazı Tipi Tasarımı"
+            "value": "Metin Yazı Tipi"
           }
         }
       }
@@ -44687,97 +44687,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷键提示字体设计"
+            "value": "快捷键提示字体"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷鍵提示字體設計"
+            "value": "快捷鍵提示字體"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "단축키 힌트 글꼴 디자인"
+            "value": "단축키 힌트 글꼴"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tastenkürzelhinweis-Schriftdesign"
+            "value": "Tastenkürzelhinweis-Schrift"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diseño de fuente de atajos"
+            "value": "Fuente de atajos"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design de police des raccourcis"
+            "value": "Police des raccourcis"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design del font scorciatoie"
+            "value": "Font scorciatoie"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Genvejstip-skrifttypedesign"
+            "value": "Genvejstip-skrifttype"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Styl czcionki skrótów"
+            "value": "Czcionka skrótów"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Дизайн шрифта подсказок клавиш"
+            "value": "Шрифт подсказок клавиш"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dizajn fonta prečica"
+            "value": "Font prečica"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تصميم خط تلميحات الاختصارات"
+            "value": "خط تلميحات الاختصارات"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hurtigtasttips-skrifttypedesign"
+            "value": "Hurtigtasttips-skrifttype"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design da Fonte de Dicas de Atalho"
+            "value": "Fonte de Dicas de Atalho"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การออกแบบแบบอักษรคำแนะนำทางลัด"
+            "value": "แบบอักษรคำแนะนำทางลัด"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kısayol İpucu Yazı Tipi Tasarımı"
+            "value": "Kısayol İpucu Yazı Tipi"
           }
         }
       }
@@ -44800,97 +44800,97 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "详细信息字体设计"
+            "value": "分支/路径字体"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "詳細資訊字體設計"
+            "value": "分支/路徑字體"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "세부 정보 글꼴 디자인"
+            "value": "브랜치/경로 글꼴"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Detail-Schriftdesign"
+            "value": "Branch-/Pfadschrift"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Diseño de fuente de detalles"
+            "value": "Fuente de ramas/rutas"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design de police des détails"
+            "value": "Police des branches/chemins"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design del font dettagli"
+            "value": "Font branch/percorsi"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Detalje-skrifttypedesign"
+            "value": "Gren-/stiskrifttype"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Styl czcionki szczegółów"
+            "value": "Czcionka gałęzi/ścieżek"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Дизайн шрифта деталей"
+            "value": "Шрифт веток/путей"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dizajn fonta detalja"
+            "value": "Font grana/putanja"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تصميم خط التفاصيل"
+            "value": "خط الفروع/المسارات"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Detaljskrifttypedesign"
+            "value": "Gren-/stiskrifttype"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Design da Fonte de Detalhes"
+            "value": "Fonte de Branches/Caminhos"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การออกแบบแบบอักษรรายละเอียด"
+            "value": "แบบอักษรสาขา/พาธ"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Detay Yazı Tipi Tasarımı"
+            "value": "Dal/Yol Yazı Tipi"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7282,13 +7282,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Loading\u2026"
+            "value": "Loading…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\u8aad\u307f\u8fbc\u307f\u4e2d\u2026"
+            "value": "読み込み中…"
           }
         }
       }
@@ -76193,6 +76193,345 @@
           "stringUnit": {
             "state": "translated",
             "value": "Varsayılan"
+          }
+        }
+      }
+    },
+    "sidebar.font.default.text": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default (San Francisco)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト (San Francisco)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认 (San Francisco)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設 (San Francisco)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값 (San Francisco)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (San Francisco)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminada (San Francisco)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut (San Francisco)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinito (San Francisco)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (San Francisco)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślna (San Francisco)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию (San Francisco)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadani (San Francisco)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الافتراضي (San Francisco)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (San Francisco)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrão (San Francisco)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น (San Francisco)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan (San Francisco)"
+          }
+        }
+      }
+    },
+    "sidebar.font.default.shortcutHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default (SF Rounded)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト (SF Rounded)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认 (SF Rounded)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設 (SF Rounded)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값 (SF Rounded)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Rounded)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminada (SF Rounded)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut (SF Rounded)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinito (SF Rounded)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Rounded)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślna (SF Rounded)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию (SF Rounded)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadani (SF Rounded)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الافتراضي (SF Rounded)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Rounded)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrão (SF Rounded)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น (SF Rounded)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan (SF Rounded)"
+          }
+        }
+      }
+    },
+    "sidebar.font.default.codeDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default (SF Mono)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト (SF Mono)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认 (SF Mono)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設 (SF Mono)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값 (SF Mono)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Mono)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminada (SF Mono)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut (SF Mono)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinito (SF Mono)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Mono)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślna (SF Mono)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию (SF Mono)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadani (SF Mono)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الافتراضي (SF Mono)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard (SF Mono)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrão (SF Mono)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น (SF Mono)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan (SF Mono)"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -43878,6 +43878,1136 @@
         }
       }
     },
+    "settings.app.sidebarTitleFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Text Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのテキストフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧边栏标题字体"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "側邊欄標題字體"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 제목 글꼴"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Titelschrift"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente del título de la barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police du titre de la barre latérale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font del titolo nella barra laterale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkens titelskrifttype"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czcionka tytułu paska bocznego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт заголовка боковой панели"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font naslova bočne trake"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خط عنوان الشريط الجانبي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tittelskrifttype i sidepanelet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonte do Título na Barra Lateral"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แบบอักษรชื่อในแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar Çubuğu Başlık Yazı Tipi"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarTitleFont.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The font for workspace titles, notifications, logs, metadata, and other regular sidebar text."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタイトル、通知、ログ、メタデータなど、通常のサイドバーテキストに使用するフォント。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区标题的字体样式。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作區標題的字體樣式。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 제목의 글꼴 스타일입니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schriftstil für Workspace-Titel."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de fuente para los títulos de espacios de trabajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le style de police pour les titres d'espaces de travail."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stile del font per i titoli dei workspace."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for arbejdsområdetitler."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki dla tytułów przestrzeni roboczych."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль шрифта для заголовков рабочих пространств."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil fonta za naslove radnih prostora."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمط الخط لعناوين مساحات العمل."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for arbeidsområdetitler."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O estilo de fonte para títulos de espaço de trabalho."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปแบบแบบอักษรสำหรับชื่อพื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma alanı başlıkları için yazı tipi stili."
+          }
+        }
+      }
+    },
+    "settings.app.sidebarShortcutHintFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Shortcut Hint Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのショートカットヒントフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧边栏快捷键提示字体"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "側邊欄快捷鍵提示字體"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 단축키 힌트 글꼴"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Tastenkürzelschrift"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente de atajos de la barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police des raccourcis de la barre latérale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font scorciatoie nella barra laterale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkens genvejstip-skrifttype"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czcionka skrótów paska bocznego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт подсказок горячих клавиш"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font prečica bočne trake"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خط تلميحات الاختصارات في الشريط الجانبي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hurtigtast-tipsskrifttype i sidepanelet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonte de Dicas de Atalho na Barra Lateral"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แบบอักษรคำแนะนำทางลัดในแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar Çubuğu Kısayol İpucu Yazı Tipi"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarShortcutHintFont.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The font for keyboard shortcut hints (⌘1, ⌘2, …)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードショートカットヒント（⌘1、⌘2、…）に使用するフォント。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键盘快捷键提示（⌘1、⌘2、…）的字体样式。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤快捷鍵提示（⌘1、⌘2、…）的字體樣式。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 단축키 힌트(⌘1, ⌘2, …)의 글꼴 스타일입니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schriftstil für Tastenkürzelhinweise (⌘1, ⌘2, …)."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de fuente para las indicaciones de atajos de teclado (⌘1, ⌘2, …)."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le style de police pour les indications de raccourcis clavier (⌘1, ⌘2, …)."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stile del font per le indicazioni delle scorciatoie da tastiera (⌘1, ⌘2, …)."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for tastaturgenvejstip (⌘1, ⌘2, …)."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki dla podpowiedzi skrótów klawiszowych (⌘1, ⌘2, …)."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль шрифта для подсказок горячих клавиш (⌘1, ⌘2, …)."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil fonta za savjete o prečicama na tipkovnici (⌘1, ⌘2, …)."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمط الخط لتلميحات اختصارات لوحة المفاتيح (⌘1، ⌘2، …)."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for hurtigtasttips (⌘1, ⌘2, …)."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O estilo de fonte para dicas de atalhos de teclado (⌘1, ⌘2, …)."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปแบบแบบอักษรสำหรับคำแนะนำทางลัดคีย์บอร์ด (⌘1, ⌘2, …)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klavye kısayol ipuçları (⌘1, ⌘2, …) için yazı tipi stili."
+          }
+        }
+      }
+    },
+    "settings.app.sidebarDetailFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Branch/Path Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのブランチ/パスフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧边栏详细信息字体"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "側邊欄詳細資訊字體"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 세부 정보 글꼴"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Detailschrift"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuente de detalles de la barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Police des détails de la barre latérale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font dettagli nella barra laterale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkens detalje-skrifttype"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czcionka szczegółów paska bocznego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт деталей боковой панели"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font detalja bočne trake"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خط تفاصيل الشريط الجانبي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detaljskrifttype i sidepanelet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonte de Detalhes na Barra Lateral"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แบบอักษรรายละเอียดในแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar Çubuğu Detay Yazı Tipi"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarDetailFont.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The font for branches, directories, and ports."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチ、ディレクトリ、ポートに使用するフォント。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分支、端口、元数据等详细信息的字体样式。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分支、連接埠、中繼資料等詳細資訊的字體樣式。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "브랜치, 포트, 메타데이터 등 세부 정보의 글꼴 스타일입니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schriftstil für Branches, Ports, Metadaten und andere Details."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El estilo de fuente para ramas, puertos, metadatos y otros detalles."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le style de police pour les branches, ports, métadonnées et autres détails."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo stile del font per branch, porte, metadati e altri dettagli."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for grene, porte, metadata og andre detaljer."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki dla gałęzi, portów, metadanych i innych szczegółów."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль шрифта для веток, портов, метаданных и других деталей."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil fonta za grane, portove, metapodatke i ostale detalje."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمط الخط للفروع والمنافذ والبيانات الوصفية والتفاصيل الأخرى."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrifttypestilen for grener, porter, metadata og andre detaljer."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O estilo de fonte para branches, portas, metadados e outros detalhes."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปแบบแบบอักษรสำหรับสาขา พอร์ต ข้อมูลเมตา และรายละเอียดอื่น ๆ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dallar, portlar, meta veriler ve diğer detaylar için yazı tipi stili."
+          }
+        }
+      }
+    },
+    "settings.debug.sidebarTitleFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标题字体设计"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標題字體設計"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제목 글꼴 디자인"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titelschriftdesign"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño de fuente del título"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design de police du titre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design del font del titolo"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titel-skrifttypedesign"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki tytułu"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дизайн шрифта заголовка"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dizajn fonta naslova"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصميم خط العنوان"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tittelskrifttypedesign"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design da Fonte do Título"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การออกแบบแบบอักษรชื่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başlık Yazı Tipi Tasarımı"
+          }
+        }
+      }
+    },
+    "settings.debug.sidebarShortcutHintFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut Hint Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットヒントフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键提示字体设计"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷鍵提示字體設計"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키 힌트 글꼴 디자인"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenkürzelhinweis-Schriftdesign"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño de fuente de atajos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design de police des raccourcis"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design del font scorciatoie"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genvejstip-skrifttypedesign"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki skrótów"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дизайн шрифта подсказок клавиш"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dizajn fonta prečica"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصميم خط تلميحات الاختصارات"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hurtigtasttips-skrifttypedesign"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design da Fonte de Dicas de Atalho"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การออกแบบแบบอักษรคำแนะนำทางลัด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kısayol İpucu Yazı Tipi Tasarımı"
+          }
+        }
+      }
+    },
+    "settings.debug.sidebarDetailFont": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch/Path Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチ/パスフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "详细信息字体设计"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細資訊字體設計"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세부 정보 글꼴 디자인"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail-Schriftdesign"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño de fuente de detalles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design de police des détails"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design del font dettagli"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalje-skrifttypedesign"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl czcionki szczegółów"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дизайн шрифта деталей"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dizajn fonta detalja"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصميم خط التفاصيل"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detaljskrifttypedesign"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design da Fonte de Detalhes"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การออกแบบแบบอักษรรายละเอียด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detay Yazı Tipi Tasarımı"
+          }
+        }
+      }
+    },
+    "sidebar.font.systemDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinito"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślne"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadano"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتراضي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrão"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan"
+          }
+        }
+      }
+    },
     "settings.app.sidebarBranchLayout": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10135,6 +10135,12 @@ private struct TabItemView: View, Equatable {
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var activeTabIndicatorStyleRaw = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var textFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.shortcutHintFamilyKey)
+    private var shortcutHintFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.codeDetailFamilyKey)
+    private var codeDetailFontFamily = SidebarFontSettings.defaultFamily
 
     var isMultiSelected: Bool {
         selectedTabIds.contains(tab.id)
@@ -10304,7 +10310,7 @@ private struct TabItemView: View, Equatable {
                 }
 
                 Text(tab.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -10332,7 +10338,7 @@ private struct TabItemView: View, Equatable {
                         Text(workspaceShortcutLabel)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(SidebarFontSettings.font(family: shortcutHintFontFamily, role: .shortcutHint, size: 10, weight: .semibold))
                             .monospacedDigit()
                             .foregroundColor(activePrimaryTextColor)
                             .padding(.horizontal, 6)
@@ -10351,7 +10357,7 @@ private struct TabItemView: View, Equatable {
 
             if let subtitle = latestNotificationSubtitle {
                 Text(subtitle)
-                    .font(.system(size: 10))
+                    .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10))
                     .foregroundColor(activeSecondaryColor(0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -10386,7 +10392,7 @@ private struct TabItemView: View, Equatable {
                         .font(.system(size: 8))
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
-                        .font(.system(size: 10))
+                        .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -10410,7 +10416,7 @@ private struct TabItemView: View, Equatable {
 
                     if let label = progress.label {
                         Text(label)
-                            .font(.system(size: 9))
+                            .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 9))
                             .foregroundColor(activeSecondaryColor(0.6))
                             .lineLimit(1)
                     }
@@ -10433,7 +10439,7 @@ private struct TabItemView: View, Equatable {
                                     HStack(spacing: 3) {
                                         if let branch = line.branch {
                                             Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(SidebarFontSettings.font(family: codeDetailFontFamily, role: .codeDetail, size: 10))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -10446,7 +10452,7 @@ private struct TabItemView: View, Equatable {
                                         }
                                         if let directory = line.directory {
                                             Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(SidebarFontSettings.font(family: codeDetailFontFamily, role: .codeDetail, size: 10))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -10464,7 +10470,7 @@ private struct TabItemView: View, Equatable {
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(SidebarFontSettings.font(family: codeDetailFontFamily, role: .codeDetail, size: 10))
                             .foregroundColor(activeSecondaryColor(0.75))
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -10492,7 +10498,7 @@ private struct TabItemView: View, Equatable {
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10, weight: .semibold))
                             .foregroundColor(pullRequestForegroundColor)
                         }
                         .buttonStyle(.plain)
@@ -10504,7 +10510,7 @@ private struct TabItemView: View, Equatable {
             // Ports row
             if detailVisibility.showsPorts, !tab.listeningPorts.isEmpty {
                 Text(tab.listeningPorts.map { ":\($0)" }.joined(separator: ", "))
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(SidebarFontSettings.font(family: codeDetailFontFamily, role: .codeDetail, size: 10))
                     .foregroundColor(activeSecondaryColor(0.75))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -11337,6 +11343,8 @@ private struct SidebarMetadataRows: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var textFontFamily = SidebarFontSettings.defaultFamily
     private let collapsedEntryLimit = 3
 
     var body: some View {
@@ -11353,7 +11361,7 @@ private struct SidebarMetadataRows: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10, weight: .semibold))
                 .foregroundColor(isActive ? activeSecondaryTextColor : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -11386,6 +11394,8 @@ private struct SidebarMetadataRows: View {
 private struct SidebarMetadataEntryRow: View {
     let entry: SidebarStatusEntry
     let isActive: Bool
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var textFontFamily = SidebarFontSettings.defaultFamily
     let onFocus: () -> Void
 
     var body: some View {
@@ -11419,7 +11429,7 @@ private struct SidebarMetadataEntryRow: View {
                 .truncationMode(.tail)
             Spacer(minLength: 0)
         }
-        .font(.system(size: 10))
+        .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10))
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -11486,6 +11496,8 @@ private struct SidebarMetadataMarkdownBlocks: View {
     let onFocus: () -> Void
 
     @State private var isExpanded: Bool = false
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var textFontFamily = SidebarFontSettings.defaultFamily
     private let collapsedBlockLimit = 1
 
     var body: some View {
@@ -11506,7 +11518,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10, weight: .semibold))
                 .foregroundColor(isActive ? .white.opacity(0.65) : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -11529,6 +11541,8 @@ private struct SidebarMetadataMarkdownBlockRow: View {
     let onFocus: () -> Void
 
     @State private var renderedMarkdown: AttributedString?
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var textFontFamily = SidebarFontSettings.defaultFamily
 
     var body: some View {
         Group {
@@ -11540,7 +11554,7 @@ private struct SidebarMetadataMarkdownBlockRow: View {
                     .foregroundColor(foregroundColor)
             }
         }
-        .font(.system(size: 10))
+        .font(SidebarFontSettings.font(family: textFontFamily, role: .text, size: 10))
         .multilineTextAlignment(.leading)
         .fixedSize(horizontal: false, vertical: true)
         .contentShape(Rectangle())

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -70,6 +70,18 @@ enum SidebarFontSettings {
     static let availableFamilies = NSFontManager.shared.availableFontFamilies.sorted()
     private static let availableFamilySet = Set(availableFamilies)
 
+    /// Cache mapping family name → PostScript face name for the regular member.
+    private static let familyToFaceName: [String: String] = {
+        var map = [String: String]()
+        for family in availableFamilies {
+            guard let members = NSFontManager.shared.availableMembers(ofFontFamily: family),
+                  let first = members.first,
+                  let faceName = first[0] as? String else { continue }
+            map[family] = faceName
+        }
+        return map
+    }()
+
     static func legacyFont(
         role: SidebarFontRole,
         size: CGFloat,
@@ -98,10 +110,10 @@ enum SidebarFontSettings {
         guard !trimmed.isEmpty else {
             return legacyFont(role: role, size: size, weight: weight)
         }
-        guard availableFamilySet.contains(trimmed) else {
+        guard let faceName = familyToFaceName[trimmed] else {
             return legacyFont(role: role, size: size, weight: weight)
         }
-        return .custom(trimmed, size: size).weight(weight)
+        return .custom(faceName, size: size).weight(weight)
     }
 }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -51,6 +51,60 @@ enum WorkspaceAutoReorderSettings {
     }
 }
 
+enum SidebarFontRole {
+    case text
+    case shortcutHint
+    case codeDetail
+}
+
+enum SidebarFontSettings {
+    // Keep the original storage keys so existing selections continue to apply.
+    static let textFamilyKey = "sidebarFontFamilyTitle"
+    static let shortcutHintFamilyKey = "sidebarFontFamilyShortcutHint"
+    static let codeDetailFamilyKey = "sidebarFontFamilyDetail"
+
+    /// Empty string means "use the legacy built-in default for this role".
+    static let defaultFamily = ""
+
+    /// All font families available on the system, sorted alphabetically.
+    static let availableFamilies = NSFontManager.shared.availableFontFamilies.sorted()
+    private static let availableFamilySet = Set(availableFamilies)
+
+    static func legacyFont(
+        role: SidebarFontRole,
+        size: CGFloat,
+        weight: Font.Weight = .regular
+    ) -> Font {
+        switch role {
+        case .text:
+            return .system(size: size, weight: weight)
+        case .shortcutHint:
+            return .system(size: size, weight: weight, design: .rounded)
+        case .codeDetail:
+            return .system(size: size, weight: weight, design: .monospaced)
+        }
+    }
+
+    /// Returns a SwiftUI `Font` for the given stored family name.
+    /// An empty or invalid family falls back to the role's legacy built-in
+    /// font so resets preserve the pre-settings sidebar styling.
+    static func font(
+        family: String,
+        role: SidebarFontRole,
+        size: CGFloat,
+        weight: Font.Weight = .regular
+    ) -> Font {
+        let trimmed = family.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return legacyFont(role: role, size: size, weight: weight)
+        }
+        guard availableFamilySet.contains(trimmed) else {
+            return legacyFont(role: role, size: size, weight: weight)
+        }
+        return .custom(trimmed, size: size).weight(weight)
+    }
+}
+
 enum SidebarBranchLayoutSettings {
     static let key = "sidebarBranchVerticalLayout"
     static let defaultVerticalLayout = true

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1550,6 +1550,9 @@ private enum DebugWindowConfigSnapshot {
         sidebarTintOpacity=\(String(format: "%.2f", doubleValue(defaults, key: "sidebarTintOpacity", fallback: 0.18)))
         sidebarCornerRadius=\(String(format: "%.1f", doubleValue(defaults, key: "sidebarCornerRadius", fallback: 0.0)))
         sidebarBranchVerticalLayout=\(boolValue(defaults, key: SidebarBranchLayoutSettings.key, fallback: SidebarBranchLayoutSettings.defaultVerticalLayout))
+        sidebarTextFontFamily=\(stringValue(defaults, key: SidebarFontSettings.textFamilyKey, fallback: SidebarFontSettings.defaultFamily))
+        sidebarShortcutHintFontFamily=\(stringValue(defaults, key: SidebarFontSettings.shortcutHintFamilyKey, fallback: SidebarFontSettings.defaultFamily))
+        sidebarCodeDetailFontFamily=\(stringValue(defaults, key: SidebarFontSettings.codeDetailFamilyKey, fallback: SidebarFontSettings.defaultFamily))
         sidebarActiveTabIndicatorStyle=\(stringValue(defaults, key: SidebarActiveTabIndicatorSettings.styleKey, fallback: SidebarActiveTabIndicatorSettings.defaultStyle.rawValue))
         sidebarDevBuildBannerVisible=\(boolValue(defaults, key: DevBuildBannerDebugSettings.sidebarBannerVisibleKey, fallback: DevBuildBannerDebugSettings.defaultShowSidebarBanner))
         shortcutHintSidebarXOffset=\(String(format: "%.1f", doubleValue(defaults, key: ShortcutHintDebugSettings.sidebarHintXKey, fallback: ShortcutHintDebugSettings.defaultSidebarHintX)))
@@ -2184,6 +2187,9 @@ private struct SidebarDebugView: View {
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
+    @AppStorage(SidebarFontSettings.textFamilyKey) private var sidebarTextFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.shortcutHintFamilyKey) private var sidebarShortcutHintFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.codeDetailFamilyKey) private var sidebarCodeDetailFontFamily = SidebarFontSettings.defaultFamily
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
@@ -2324,6 +2330,25 @@ private struct SidebarDebugView: View {
                         Text("When enabled, each branch appears on its own line in the sidebar.")
                             .font(.caption)
                             .foregroundColor(.secondary)
+
+                        Picker(String(localized: "settings.debug.sidebarTitleFont", defaultValue: "Text Font"), selection: $sidebarTextFontFamily) {
+                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
+                                Text(family).tag(family)
+                            }
+                        }
+                        Picker(String(localized: "settings.debug.sidebarShortcutHintFont", defaultValue: "Shortcut Hint Font"), selection: $sidebarShortcutHintFontFamily) {
+                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
+                                Text(family).tag(family)
+                            }
+                        }
+                        Picker(String(localized: "settings.debug.sidebarDetailFont", defaultValue: "Branch/Path Font"), selection: $sidebarCodeDetailFontFamily) {
+                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
+                                Text(family).tag(family)
+                            }
+                        }
                     }
                     .padding(.top, 2)
                 }
@@ -2419,6 +2444,9 @@ private struct SidebarDebugView: View {
         sidebarTintOpacity=\(String(format: "%.2f", sidebarTintOpacity))
         sidebarCornerRadius=\(String(format: "%.1f", sidebarCornerRadius))
         sidebarBranchVerticalLayout=\(sidebarBranchVerticalLayout)
+        sidebarTextFontFamily=\(sidebarTextFontFamily)
+        sidebarShortcutHintFontFamily=\(sidebarShortcutHintFontFamily)
+        sidebarCodeDetailFontFamily=\(sidebarCodeDetailFontFamily)
         sidebarActiveTabIndicatorStyle=\(sidebarActiveTabIndicatorStyle)
         sidebarDevBuildBannerVisible=\(showSidebarDevBuildBanner)
         shortcutHintSidebarXOffset=\(String(format: "%.1f", ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset)))
@@ -3127,6 +3155,12 @@ struct SettingsView: View {
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage(SidebarFontSettings.textFamilyKey)
+    private var sidebarTextFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.shortcutHintFamilyKey)
+    private var sidebarShortcutHintFontFamily = SidebarFontSettings.defaultFamily
+    @AppStorage(SidebarFontSettings.codeDetailFamilyKey)
+    private var sidebarCodeDetailFontFamily = SidebarFontSettings.defaultFamily
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
     @AppStorage("sidebarShowPullRequest") private var sidebarShowPullRequest = true
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
@@ -3793,6 +3827,33 @@ struct SettingsView: View {
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
+
+                        SettingsCardDivider()
+
+                        SidebarFontFamilyPickerRow(
+                            title: String(localized: "settings.app.sidebarTitleFont", defaultValue: "Sidebar Text Font"),
+                            subtitle: String(localized: "settings.app.sidebarTitleFont.subtitle", defaultValue: "The font for workspace titles, notifications, logs, metadata, and other regular sidebar text."),
+                            selection: $sidebarTextFontFamily,
+                            controlWidth: pickerColumnWidth
+                        )
+
+                        SettingsCardDivider()
+
+                        SidebarFontFamilyPickerRow(
+                            title: String(localized: "settings.app.sidebarShortcutHintFont", defaultValue: "Sidebar Shortcut Hint Font"),
+                            subtitle: String(localized: "settings.app.sidebarShortcutHintFont.subtitle", defaultValue: "The font for keyboard shortcut hints (⌘1, ⌘2, …)."),
+                            selection: $sidebarShortcutHintFontFamily,
+                            controlWidth: pickerColumnWidth
+                        )
+
+                        SettingsCardDivider()
+
+                        SidebarFontFamilyPickerRow(
+                            title: String(localized: "settings.app.sidebarDetailFont", defaultValue: "Sidebar Branch/Path Font"),
+                            subtitle: String(localized: "settings.app.sidebarDetailFont.subtitle", defaultValue: "The font for branches, directories, and ports."),
+                            selection: $sidebarCodeDetailFontFamily,
+                            controlWidth: pickerColumnWidth
+                        )
 
                         SettingsCardDivider()
 
@@ -4629,6 +4690,9 @@ struct SettingsView: View {
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+        sidebarTextFontFamily = SidebarFontSettings.defaultFamily
+        sidebarShortcutHintFontFamily = SidebarFontSettings.defaultFamily
+        sidebarCodeDetailFontFamily = SidebarFontSettings.defaultFamily
         sidebarShowBranchDirectory = true
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
@@ -4879,6 +4943,32 @@ private struct SettingsCardDivider: View {
         Rectangle()
             .fill(Color(nsColor: NSColor.separatorColor).opacity(0.5))
             .frame(height: 1)
+    }
+}
+
+/// A font-family picker row that lists all installed system fonts plus a
+/// role-specific built-in default entry (stored as empty string). The picker uses the
+/// standard macOS `.menu` style so it scrolls through the full font list.
+private struct SidebarFontFamilyPickerRow: View {
+    let title: String
+    let subtitle: String
+    @Binding var selection: String
+    let controlWidth: CGFloat
+
+    var body: some View {
+        SettingsCardRow(title, subtitle: subtitle, controlWidth: controlWidth) {
+            Picker("", selection: $selection) {
+                Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default"))
+                    .tag("")
+                ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
+                    Text(family)
+                        .font(.custom(family, size: 13))
+                        .tag(family)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        }
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2332,21 +2332,21 @@ private struct SidebarDebugView: View {
                             .foregroundColor(.secondary)
 
                         Picker(String(localized: "settings.debug.sidebarTitleFont", defaultValue: "Text Font"), selection: $sidebarTextFontFamily) {
-                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            Text(String(localized: "sidebar.font.default.text", defaultValue: "Default (San Francisco)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).tag(family)
+                                Text(family).font(.custom(family, size: 13)).tag(family)
                             }
                         }
                         Picker(String(localized: "settings.debug.sidebarShortcutHintFont", defaultValue: "Shortcut Hint Font"), selection: $sidebarShortcutHintFontFamily) {
-                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            Text(String(localized: "sidebar.font.default.shortcutHint", defaultValue: "Default (SF Rounded)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).tag(family)
+                                Text(family).font(.custom(family, size: 13)).tag(family)
                             }
                         }
                         Picker(String(localized: "settings.debug.sidebarDetailFont", defaultValue: "Branch/Path Font"), selection: $sidebarCodeDetailFontFamily) {
-                            Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default")).tag("")
+                            Text(String(localized: "sidebar.font.default.codeDetail", defaultValue: "Default (SF Mono)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).tag(family)
+                                Text(family).font(.custom(family, size: 13)).tag(family)
                             }
                         }
                     }
@@ -3833,6 +3833,7 @@ struct SettingsView: View {
                         SidebarFontFamilyPickerRow(
                             title: String(localized: "settings.app.sidebarTitleFont", defaultValue: "Sidebar Text Font"),
                             subtitle: String(localized: "settings.app.sidebarTitleFont.subtitle", defaultValue: "The font for workspace titles, notifications, logs, metadata, and other regular sidebar text."),
+                            defaultLabel: String(localized: "sidebar.font.default.text", defaultValue: "Default (San Francisco)"),
                             selection: $sidebarTextFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -3842,6 +3843,7 @@ struct SettingsView: View {
                         SidebarFontFamilyPickerRow(
                             title: String(localized: "settings.app.sidebarShortcutHintFont", defaultValue: "Sidebar Shortcut Hint Font"),
                             subtitle: String(localized: "settings.app.sidebarShortcutHintFont.subtitle", defaultValue: "The font for keyboard shortcut hints (⌘1, ⌘2, …)."),
+                            defaultLabel: String(localized: "sidebar.font.default.shortcutHint", defaultValue: "Default (SF Rounded)"),
                             selection: $sidebarShortcutHintFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -3851,6 +3853,7 @@ struct SettingsView: View {
                         SidebarFontFamilyPickerRow(
                             title: String(localized: "settings.app.sidebarDetailFont", defaultValue: "Sidebar Branch/Path Font"),
                             subtitle: String(localized: "settings.app.sidebarDetailFont.subtitle", defaultValue: "The font for branches, directories, and ports."),
+                            defaultLabel: String(localized: "sidebar.font.default.codeDetail", defaultValue: "Default (SF Mono)"),
                             selection: $sidebarCodeDetailFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -4952,14 +4955,15 @@ private struct SettingsCardDivider: View {
 private struct SidebarFontFamilyPickerRow: View {
     let title: String
     let subtitle: String
+    let defaultLabel: String
     @Binding var selection: String
     let controlWidth: CGFloat
 
     var body: some View {
         SettingsCardRow(title, subtitle: subtitle, controlWidth: controlWidth) {
             Picker("", selection: $selection) {
-                Text(String(localized: "sidebar.font.systemDefault", defaultValue: "Default"))
-                    .tag("")
+                Text(defaultLabel)
+                    .tag(SidebarFontSettings.defaultFamily)
                 ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
                     Text(family)
                         .font(.custom(family, size: 13))

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2334,19 +2334,19 @@ private struct SidebarDebugView: View {
                         Picker(String(localized: "settings.debug.sidebarTitleFont", defaultValue: "Text Font"), selection: $sidebarTextFontFamily) {
                             Text(String(localized: "sidebar.font.default.text", defaultValue: "Default (San Francisco)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).font(.custom(family, size: 13)).tag(family)
+                                Text(family).font(SidebarFontSettings.font(family: family, role: .text, size: 13)).tag(family)
                             }
                         }
                         Picker(String(localized: "settings.debug.sidebarShortcutHintFont", defaultValue: "Shortcut Hint Font"), selection: $sidebarShortcutHintFontFamily) {
                             Text(String(localized: "sidebar.font.default.shortcutHint", defaultValue: "Default (SF Rounded)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).font(.custom(family, size: 13)).tag(family)
+                                Text(family).font(SidebarFontSettings.font(family: family, role: .shortcutHint, size: 13)).tag(family)
                             }
                         }
                         Picker(String(localized: "settings.debug.sidebarDetailFont", defaultValue: "Branch/Path Font"), selection: $sidebarCodeDetailFontFamily) {
                             Text(String(localized: "sidebar.font.default.codeDetail", defaultValue: "Default (SF Mono)")).tag(SidebarFontSettings.defaultFamily)
                             ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
-                                Text(family).font(.custom(family, size: 13)).tag(family)
+                                Text(family).font(SidebarFontSettings.font(family: family, role: .codeDetail, size: 13)).tag(family)
                             }
                         }
                     }
@@ -3834,6 +3834,7 @@ struct SettingsView: View {
                             title: String(localized: "settings.app.sidebarTitleFont", defaultValue: "Sidebar Text Font"),
                             subtitle: String(localized: "settings.app.sidebarTitleFont.subtitle", defaultValue: "The font for workspace titles, notifications, logs, metadata, and other regular sidebar text."),
                             defaultLabel: String(localized: "sidebar.font.default.text", defaultValue: "Default (San Francisco)"),
+                            previewRole: .text,
                             selection: $sidebarTextFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -3844,6 +3845,7 @@ struct SettingsView: View {
                             title: String(localized: "settings.app.sidebarShortcutHintFont", defaultValue: "Sidebar Shortcut Hint Font"),
                             subtitle: String(localized: "settings.app.sidebarShortcutHintFont.subtitle", defaultValue: "The font for keyboard shortcut hints (⌘1, ⌘2, …)."),
                             defaultLabel: String(localized: "sidebar.font.default.shortcutHint", defaultValue: "Default (SF Rounded)"),
+                            previewRole: .shortcutHint,
                             selection: $sidebarShortcutHintFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -3854,6 +3856,7 @@ struct SettingsView: View {
                             title: String(localized: "settings.app.sidebarDetailFont", defaultValue: "Sidebar Branch/Path Font"),
                             subtitle: String(localized: "settings.app.sidebarDetailFont.subtitle", defaultValue: "The font for branches, directories, and ports."),
                             defaultLabel: String(localized: "sidebar.font.default.codeDetail", defaultValue: "Default (SF Mono)"),
+                            previewRole: .codeDetail,
                             selection: $sidebarCodeDetailFontFamily,
                             controlWidth: pickerColumnWidth
                         )
@@ -4956,6 +4959,7 @@ private struct SidebarFontFamilyPickerRow: View {
     let title: String
     let subtitle: String
     let defaultLabel: String
+    let previewRole: SidebarFontRole
     @Binding var selection: String
     let controlWidth: CGFloat
 
@@ -4966,7 +4970,7 @@ private struct SidebarFontFamilyPickerRow: View {
                     .tag(SidebarFontSettings.defaultFamily)
                 ForEach(SidebarFontSettings.availableFamilies, id: \.self) { family in
                     Text(family)
-                        .font(.custom(family, size: 13))
+                        .font(SidebarFontSettings.font(family: family, role: previewRole, size: 13))
                         .tag(family)
                 }
             }


### PR DESCRIPTION
## Summary
- add three font-family pickers to Settings for sidebar text, shortcut hints, and branch/path details
- each picker lists all installed system fonts with a role-specific "Default" option that preserves the original built-in style (San Francisco, SF Rounded, SF Mono)
- font names are previewed in their own typeface inside the picker menu
- include the same pickers in the Sidebar Appearance debug view and config export
- localized for all 17 supported languages

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag sidebar-font-design
- open Settings → scroll to sidebar section → verify three font pickers appear below "Hide All Sidebar Details"
- select different fonts for each role and confirm the sidebar updates live
- reset to defaults and verify original styling is restored

## Related
- Closes #1468

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable font families for the sidebar (text, shortcut hints, branch/path). Defaults preserve the original look; selections preview in menus and apply live across the UI and debug view.

- **New Features**
  - Settings: three font pickers with all installed fonts and role‑specific defaults (“Default (San Francisco)”, “Default (SF Rounded)”, “Default (SF Mono)”); menu previews; reset restores legacy styles.
  - Debug/Export: same pickers in the Sidebar Appearance debug view with previews; values included in the debug snapshot and export.
  - Localization: updated copy and translations for new settings in 17 languages.

- **Bug Fixes**
  - Resolve selected families to PostScript face names via NSFontManager.availableMembers before using Font.custom, and route picker previews through the same resolver to avoid silent fallbacks and mismatched previews.
  - Invalid or empty selections safely fall back to the legacy font per role.

<sup>Written for commit 7b09f60248d2d4ad08d933e6be8731f19ffe2878. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar font customization: choose separate fonts for sidebar text, shortcut hints, and code/details via Settings and Debug pickers; applied across titles, subtitles, hints, metadata, and code snippets.
* **Localization**
  * Expanded translations for many UI labels, tooltips, prompts, settings, notifications, and themes across multiple languages for a more complete multilingual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->