### PR TITLE
fix(Workspace): fix EXC_BAD_ACCESS caused by over-releasing ghostty font

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -23,7 +23,7 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
-    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeRetainedValue()
+    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
     return points


### PR DESCRIPTION
Fixes #1452.

### Root Cause Analysis
According to issue #1452, cmux consistently crashes with `EXC_BAD_ACCESS (SIGSEGV)` on Intel Macs when creating a new tab (Cmd + T) or splitting a pane (Cmd + D).

The issue stems from the `cmuxCurrentSurfaceFontSizePoints` function:
```swift
let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeRetainedValue()
```

The `ghostty_surface_quicklook_font()` C API returns an unretained inner pointer (Get semantics). Forcing `.takeRetainedValue()` incorrectly transfers ownership of this pointer to Swift's ARC. When the variable goes out of scope, ARC attempts to release it, causing an over-release of the underlying font object, which leads to a segmentation fault on certain architectures (like Intel).

### Fix
Replaced `takeRetainedValue()` with `takeUnretainedValue()` to prevent ARC from consuming the memory reference, fixing the over-release crash

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent EXC_BAD_ACCESS on Intel Macs when creating a tab (Cmd+T) or splitting a pane (Cmd+D) by fixing CoreText font ownership in `cmux`. Fixes #1452.

- **Bug Fixes**
  - Replace `.takeRetainedValue()` with `.takeUnretainedValue()` when converting the pointer from `ghostty_surface_quicklook_font()` to `CTFont` (Get semantics) to avoid ARC over-release and the crash.

<sup>Written for commit b3bac4f0e11a044823ff8f0664eadbc8c2170912. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update includes internal optimizations to memory management that improve code reliability without affecting application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->