### PR TITLE
Migrate CI/CD to WarpBuild runners

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -11,6 +11,7 @@ jobs:
     # Never run WarpBuild jobs for fork pull requests (avoid billing on external PRs).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         os: [warp-macos-14-arm64-6x, warp-macos-15-arm64-6x]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
 
   tests:
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -193,10 +194,11 @@ jobs:
 
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_version_memory_guard.py
 
-  tests-depot:
+  tests-ui:
     # Never run WarpBuild jobs for fork pull requests (avoid billing on external PRs).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,7 @@ jobs:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout build ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-sign-notarize:
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   tests:
     runs-on: warp-macos-15-arm64-6x
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   e2e:
     runs-on: ${{ inputs.runner || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 20
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
     steps:

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -16,14 +16,14 @@ if ! grep -Fq "$EXPECTED_IF" "$WORKFLOW_FILE"; then
 fi
 
 if ! awk '
-  /^  tests-depot:/ { in_tests=1; next }
+  /^  tests-ui:/ { in_tests=1; next }
   in_tests && /^  [^[:space:]]/ { in_tests=0 }
   in_tests && /runs-on: warp-macos-15-arm64-6x/ { saw_warp=1 }
   in_tests && /github.event.pull_request.head.repo.full_name == github.repository/ { saw_guard=1 }
   END { exit !(saw_warp && saw_guard) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: tests-depot block must keep both warp-macos-15-arm64-6x runner and fork guard"
+  echo "FAIL: tests-ui block must keep both warp-macos-15-arm64-6x runner and fork guard"
   exit 1
 fi
 
-echo "PASS: tests-depot WarpBuild runner fork guard is present"
+echo "PASS: tests-ui WarpBuild runner fork guard is present"


### PR DESCRIPTION
## Summary

Swaps all macOS runner labels from Depot and GitHub-hosted to WarpBuild. Job structure is unchanged.

- `depot-macos-latest` → `warp-macos-15-arm64-6x`
- `macos-15` → `warp-macos-15-arm64-6x`  
- `macos-14` → `warp-macos-14-arm64-6x`
- `ubuntu-latest` unchanged for lightweight jobs
- Updated CI guard test and comments

Affected workflows: ci.yml, build-ghosttykit.yml, ci-macos-compat.yml, nightly.yml, release.yml, test-depot.yml, test-e2e.yml

Compare with https://github.com/manaflow-ai/cmux/pull/new/task-migrate-warpcloud-consolidated (consolidated version that merges tests + tests-depot into one job).

## Testing

- Guard test passes locally: `bash tests/test_ci_self_hosted_guard.sh` → PASS
- No old runner labels remain: `grep -rn 'depot-macos-latest\|runs-on: macos-1[45]' .github/workflows/` → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all macOS CI/CD workflows to WarpBuild runners and pins `zig` 0.15.2 via tarballs for consistent builds. Adds 20‑minute timeouts to macOS jobs; Ubuntu jobs remain on `ubuntu-latest`.

- **Migration**
  - Runner label swaps: `depot-macos-latest` → `warp-macos-15-arm64-6x`, `macos-15` → `warp-macos-15-arm64-6x`, `macos-14` → `warp-macos-14-arm64-6x`.
  - Job updates: add 20‑min timeouts; rename `tests-depot` → `tests-ui`; update guard script/test for WarpBuild-only internal runs; update `test-e2e.yml` runner inputs/defaults and cache keys to WarpBuild labels.
  - Pin `zig` to 0.15.2 by downloading from ziglang.org; auto-upgrade if outdated; fix tarball to `zig-aarch64-macos-0.15.2.tar.xz`; create `/usr/local/bin` and `/usr/local/lib` before install.
  - Workflows touched: `ci.yml`, `ci-macos-compat.yml`, `test-e2e.yml`, `test-depot.yml`, `release.yml`, `nightly.yml`, `build-ghosttykit.yml`.

<sup>Written for commit 0b1b591f2ae6110f2bbfdc9468f1a45462c2db6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI to new WarpBuild macOS runners across workflows for consistent builds and releases.
  * Introduced a guarded, versioned Zig install requiring Zig 0.15.2; missing or mismatched installs are downloaded, installed, and verified before continuing.
  * Updated workflow references and platform-related cache keys to reflect the new runner platform.

* **Tests**
  * Updated CI self-hosted guard checks and success/error messaging to align with the new runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->