### PR TITLE
Migrate all CI to Depot runners

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [depot-macos-14, depot-macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -24,9 +24,8 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          # Pick the latest Xcode installed on the runner. GitHub-hosted macos-14
-          # defaults to Xcode 15.4, but the project needs Xcode 16+ (Swift tools
-          # version 6.0 required by sentry-cocoa).
+          # Pick the latest Xcode installed on the runner. The project needs
+          # Xcode 16+ (Swift tools version 6.0 required by sentry-cocoa).
           XCODE_APP="$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort | tail -n 1)"
           if [ -z "$XCODE_APP" ]; then
             XCODE_APP="/Applications/Xcode.app"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         run: bun tsc --noEmit
 
   tests:
-    runs-on: macos-15
+    # Never run Depot jobs for fork pull requests (avoid billing on external PRs).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,17 +20,16 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS (macos-15 or macos-26)"
+        description: "Runner (Depot)"
         required: false
-        default: "macos-15"
+        default: "depot-macos-latest"
         type: choice
         options:
-          - macos-15
-          - macos-26
+          - depot-macos-latest
 
 jobs:
   e2e:
-    runs-on: ${{ inputs.runner || 'macos-15' }}
+    runs-on: ${{ inputs.runner || 'depot-macos-latest' }}
     env:
       TEST_REF: ${{ inputs.ref || github.ref }}
     steps:
@@ -161,8 +160,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: .ci-source-packages
-          key: spm-${{ inputs.runner || 'macos-15' }}-${{ hashFiles('GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ inputs.runner || 'macos-15' }}-
+          key: spm-${{ inputs.runner || 'depot-macos-latest' }}-${{ hashFiles('GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ inputs.runner || 'depot-macos-latest' }}-
 
       - name: Resolve Swift packages
         run: |

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -16,6 +16,19 @@ if ! grep -Fq "$EXPECTED_IF" "$WORKFLOW_FILE"; then
 fi
 
 if ! awk '
+  /^  tests:$/ { in_tests=1; next }
+  in_tests && /^  [^[:space:]]/ { in_tests=0 }
+  in_tests && /runs-on: depot-macos-latest/ { saw_depot=1 }
+  in_tests && /github.event.pull_request.head.repo.full_name == github.repository/ { saw_guard=1 }
+  END { exit !(saw_depot && saw_guard) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: tests block must have both depot-macos-latest runner and fork guard"
+  exit 1
+fi
+
+echo "PASS: tests Depot runner fork guard is present"
+
+if ! awk '
   /^  tests-depot:/ { in_tests=1; next }
   in_tests && /^  [^[:space:]]/ { in_tests=0 }
   in_tests && /runs-on: depot-macos-latest/ { saw_depot=1 }


### PR DESCRIPTION
## Summary

Standardizes all macOS CI on Depot runners (eliminates GitHub-hosted macOS runners).

- `macos-15` → `depot-macos-latest`
- `macos-14` → `depot-macos-14`
- Added fork guard to the `tests` job (was missing since it previously ran on free GitHub-hosted runners)
- Updated CI guard test to verify both `tests` and `tests-depot` have Depot runner + fork guard
- `ubuntu-latest` unchanged for lightweight jobs

Affected workflows: ci.yml, ci-macos-compat.yml, test-e2e.yml (others already on Depot)

Fallback option while WarpBuild runners are being configured. Compare with:
- https://github.com/manaflow-ai/cmux/pull/1500 (WarpBuild, separate jobs)
- https://github.com/manaflow-ai/cmux/pull/1501 (WarpBuild, consolidated)

## Testing

- Guard test passes: `bash tests/test_ci_self_hosted_guard.sh` → PASS (both jobs)
- No GitHub-hosted macOS runners remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate all macOS CI to Depot runners and add a fork guard to avoid billing on external PRs. Removes GitHub-hosted macOS runners and updates the CI guard script.

- **Refactors**
  - `macos-15` → `depot-macos-latest`; `macos-14` → `depot-macos-14`
  - Add fork guard to the `tests` job (skip on forked PRs)
  - Update guard script to verify both `tests` and `tests-depot` use Depot + guard
  - E2E: default runner and cache keys now use `depot-macos-latest`
  - Keep `ubuntu-latest` for lightweight jobs

<sup>Written for commit 19fd6ca12c459316b380125b0e9ace1fc69cc194. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to standardize test runner configurations and improve fork pull request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->