### PR TITLE
Require pinned IDs in the sidebar drop planner

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11578,7 +11578,7 @@ enum SidebarDropPlanner {
         draggedTabId: UUID?,
         targetTabId: UUID?,
         tabIds: [UUID],
-        pinnedTabIds: Set<UUID> = [],
+        pinnedTabIds: Set<UUID>,
         pointerY: CGFloat? = nil,
         targetHeight: CGFloat? = nil
     ) -> SidebarDropIndicator? {
@@ -11619,7 +11619,7 @@ enum SidebarDropPlanner {
         targetTabId: UUID?,
         indicator: SidebarDropIndicator?,
         tabIds: [UUID],
-        pinnedTabIds: Set<UUID> = []
+        pinnedTabIds: Set<UUID>
     ) -> Int? {
         guard let fromIndex = tabIds.firstIndex(of: draggedTabId) else { return nil }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7166,14 +7166,16 @@ final class SidebarDropPlannerTests: XCTestCase {
             SidebarDropPlanner.indicator(
                 draggedTabId: first,
                 targetTabId: first,
-                tabIds: tabIds
+                tabIds: tabIds,
+                pinnedTabIds: []
             )
         )
         XCTAssertNil(
             SidebarDropPlanner.indicator(
                 draggedTabId: third,
                 targetTabId: nil,
-                tabIds: tabIds
+                tabIds: tabIds,
+                pinnedTabIds: []
             )
         )
     }
@@ -7184,14 +7186,16 @@ final class SidebarDropPlannerTests: XCTestCase {
             SidebarDropPlanner.indicator(
                 draggedTabId: only,
                 targetTabId: nil,
-                tabIds: [only]
+                tabIds: [only],
+                pinnedTabIds: []
             )
         )
         XCTAssertNil(
             SidebarDropPlanner.indicator(
                 draggedTabId: only,
                 targetTabId: only,
-                tabIds: [only]
+                tabIds: [only],
+                pinnedTabIds: []
             )
         )
     }
@@ -7205,7 +7209,8 @@ final class SidebarDropPlannerTests: XCTestCase {
         let indicator = SidebarDropPlanner.indicator(
             draggedTabId: second,
             targetTabId: nil,
-            tabIds: tabIds
+            tabIds: tabIds,
+            pinnedTabIds: []
         )
         XCTAssertEqual(indicator?.tabId, nil)
         XCTAssertEqual(indicator?.edge, .bottom)
@@ -7221,7 +7226,8 @@ final class SidebarDropPlannerTests: XCTestCase {
             draggedTabId: second,
             targetTabId: nil,
             indicator: SidebarDropIndicator(tabId: nil, edge: .bottom),
-            tabIds: tabIds
+            tabIds: tabIds,
+            pinnedTabIds: []
         )
         XCTAssertEqual(index, 2)
     }
@@ -7236,7 +7242,8 @@ final class SidebarDropPlannerTests: XCTestCase {
             SidebarDropPlanner.indicator(
                 draggedTabId: second,
                 targetTabId: second,
-                tabIds: tabIds
+                tabIds: tabIds,
+                pinnedTabIds: []
             )
         )
     }
@@ -7252,6 +7259,7 @@ final class SidebarDropPlannerTests: XCTestCase {
                 draggedTabId: first,
                 targetTabId: second,
                 tabIds: tabIds,
+                pinnedTabIds: [],
                 pointerY: 2,
                 targetHeight: 40
             )
@@ -7268,6 +7276,7 @@ final class SidebarDropPlannerTests: XCTestCase {
             draggedTabId: first,
             targetTabId: second,
             tabIds: tabIds,
+            pinnedTabIds: [],
             pointerY: 38,
             targetHeight: 40
         )
@@ -7278,7 +7287,8 @@ final class SidebarDropPlannerTests: XCTestCase {
                 draggedTabId: first,
                 targetTabId: second,
                 indicator: indicator,
-                tabIds: tabIds
+                tabIds: tabIds,
+                pinnedTabIds: []
             ),
             1
         )
@@ -7294,6 +7304,7 @@ final class SidebarDropPlannerTests: XCTestCase {
             draggedTabId: third,
             targetTabId: first,
             tabIds: tabIds,
+            pinnedTabIds: [],
             pointerY: 38,
             targetHeight: 40
         )
@@ -7301,6 +7312,7 @@ final class SidebarDropPlannerTests: XCTestCase {
             draggedTabId: third,
             targetTabId: second,
             tabIds: tabIds,
+            pinnedTabIds: [],
             pointerY: 2,
             targetHeight: 40
         )
@@ -7322,6 +7334,7 @@ final class SidebarDropPlannerTests: XCTestCase {
                 draggedTabId: third,
                 targetTabId: second,
                 tabIds: tabIds,
+                pinnedTabIds: [],
                 pointerY: 38,
                 targetHeight: 40
             )


### PR DESCRIPTION
## Summary
Follow-up to the CodeRabbit nit on https://github.com/manaflow-ai/cmux/pull/1503#pullrequestreview-3951364965.

- make `SidebarDropPlanner.indicator` require `pinnedTabIds`
- make `SidebarDropPlanner.targetIndex` require `pinnedTabIds`
- update tests and helper call sites to pass explicit pinned ID sets

## Testing
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination "platform=macOS" -derivedDataPath /tmp/cmux-task-pinned-tabs-require-pinned-ids-tests -only-testing:cmuxTests/WorkspaceReorderTests -only-testing:cmuxTests/SidebarDropPlannerTests test
- ./scripts/reload.sh --tag task-pinned-tabs-require-pinned-ids

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit `pinnedTabIds` in the sidebar drop planner to ensure pinned tabs are respected during drag-and-drop. Removes the implicit empty default for better correctness.

- **Refactors**
  - `SidebarDropPlanner.indicator` now requires `pinnedTabIds: Set<UUID>`.
  - `SidebarDropPlanner.targetIndex` now requires `pinnedTabIds: Set<UUID>`.
  - Updated tests to pass pinned IDs explicitly.

- **Migration**
  - Pass the current pinned tab ID set to both methods; there is no default.

<sup>Written for commit 848ddcfe86f2d3707322f519c9f057a3f693f921. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal method signatures to enforce explicit parameter handling for tab pinning functionality.
  
* **Tests**
  * Updated test cases to align with modified method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->