### PR TITLE
Fix dark mode app icon not applied in automatic mode

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9649,14 +9649,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func ensureApplicationIcon() {
         let mode = AppIconSettings.resolvedMode()
-        if mode == .automatic {
-            // Let the asset catalog handle appearance-based icon selection.
-            if let icon = NSImage(named: NSImage.applicationIconName) {
-                NSApplication.shared.applicationIconImage = icon
-            }
-        } else {
-            AppIconSettings.applyIcon(mode)
-        }
+        AppIconSettings.applyIcon(mode)
     }
 
     private func scheduleLaunchServicesBundleRegistration(


### PR DESCRIPTION
## Summary

- Fixes `ensureApplicationIcon()` in `AppDelegate.swift` which was overriding the asset catalog's appearance-based icon selection in automatic mode
- The method was explicitly loading the light icon via `NSImage(named: NSImage.applicationIconName)` and setting it, preventing macOS 15+ from automatically selecting the dark variant
- Now delegates to `AppIconSettings.applyIcon()` which correctly sets `applicationIconImage = nil` for automatic mode

## Root cause

`ensureApplicationIcon()` had a code path for `.automatic` that contradicted `AppIconSettings.applyIcon(.automatic)`:

```swift
// Before (broken): explicitly sets light icon
if mode == .automatic {
    if let icon = NSImage(named: NSImage.applicationIconName) {
        NSApplication.shared.applicationIconImage = icon  // always light
    }
}

// After (fixed): delegates to applyIcon which sets nil for automatic
AppIconSettings.applyIcon(mode)  // nil lets asset catalog handle dark/light
```

## Test plan

- [ ] Launch cmux in macOS dark mode with icon setting on "Automatic"
- [ ] Verify dock icon shows dark variant while running
- [ ] Quit cmux and verify dock icon / Launchpad shows dark variant
- [ ] Switch to light mode and verify light icon is shown
- [ ] Test "Light" and "Dark" manual icon settings still work

## Related

- Fixes #1509
- Related: #688, #702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the app icon not switching to the dark variant in Automatic mode. We now delegate icon handling to `AppIconSettings.applyIcon()` so macOS uses the asset catalog to pick light/dark correctly.

- **Bug Fixes**
  - Removed explicit light icon assignment in `ensureApplicationIcon()` for `.automatic`.
  - Delegate to `AppIconSettings.applyIcon(mode)`, which sets `applicationIconImage = nil` in Automatic mode so the system selects the correct variant.

<sup>Written for commit 0b02736a1efe8674ec3a7226c6f4a1483702ad63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal icon application handling for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->