### PR TITLE
Fix Ghostty Settings config file selection

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -161,20 +161,12 @@ struct GhosttyConfig {
             return hasNonEmptyRegularFileAttributes(at: url.path) ? url : nil
         }
 
-        guard type == .typeSymbolicLink,
-              let linkDestination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+        guard type == .typeSymbolicLink else {
             return nil
         }
-
-        let resolvedPath: String
-        if (linkDestination as NSString).isAbsolutePath {
-            resolvedPath = linkDestination
-        } else {
-            resolvedPath = url.deletingLastPathComponent()
-                .appendingPathComponent(linkDestination, isDirectory: false)
-                .path
+        guard let resolvedPath = canonicalConfigPath(for: url, fileManager: fileManager) else {
+            return nil
         }
-
         return hasNonEmptyRegularFileAttributes(at: resolvedPath) ? url : nil
     }
 

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -103,27 +103,11 @@ struct GhosttyConfig {
             return []
         }
 
-        func paths(for bundleIdentifier: String) -> [String] {
-            let directory = appSupport.appendingPathComponent(bundleIdentifier, isDirectory: true)
-            return [
-                directory.appendingPathComponent("config", isDirectory: false).path,
-                directory.appendingPathComponent("config.ghostty", isDirectory: false).path,
-            ]
-        }
-
-        func hasConfig(_ paths: [String]) -> Bool {
-            paths.contains { path in
-                guard let attributes = try? fileManager.attributesOfItem(atPath: path),
-                      let type = attributes[.type] as? FileAttributeType,
-                      type == .typeRegular,
-                      let size = attributes[.size] as? NSNumber else {
-                    return false
-                }
-                return size.intValue > 0
-            }
-        }
-
-        let releasePaths = paths(for: cmuxReleaseBundleIdentifier)
+        let releasePaths = cmuxAppSupportConfigURLs(
+            currentBundleIdentifier: cmuxReleaseBundleIdentifier,
+            appSupportDirectory: appSupport,
+            fileManager: fileManager
+        ).map(\.path)
         guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else {
             return releasePaths
         }
@@ -131,8 +115,12 @@ struct GhosttyConfig {
             return releasePaths
         }
 
-        let currentPaths = paths(for: currentBundleIdentifier)
-        if hasConfig(currentPaths) {
+        let currentPaths = cmuxAppSupportConfigURLs(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupport,
+            fileManager: fileManager
+        ).map(\.path)
+        if !currentPaths.isEmpty {
             return currentPaths
         }
         if SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
@@ -141,53 +129,59 @@ struct GhosttyConfig {
         return []
     }
 
-    static func editorConfigURLs(
-        fileManager: FileManager = .default,
-        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
-        appSupportDirectory: URL? = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first,
-        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> [URL] {
-        func existingNonEmptyFileURL(for url: URL) -> URL? {
-            func hasNonEmptyRegularFileAttributes(at path: String) -> Bool {
-                guard let attributes = try? fileManager.attributesOfItem(atPath: path),
-                      let type = attributes[.type] as? FileAttributeType,
-                      type == .typeRegular,
-                      let size = attributes[.size] as? NSNumber else {
-                    return false
-                }
-                return size.intValue > 0
-            }
+    private static func canonicalConfigPath(
+        for url: URL,
+        fileManager: FileManager = .default
+    ) -> String? {
+        let path = url.standardizedFileURL.path
+        guard fileManager.fileExists(atPath: path) else { return nil }
+        return URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+    }
 
-            guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
-                  let type = attributes[.type] as? FileAttributeType else {
-                return nil
+    private static func existingNonEmptyConfigURL(
+        for url: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        func hasNonEmptyRegularFileAttributes(at path: String) -> Bool {
+            guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+                  let type = attributes[.type] as? FileAttributeType,
+                  type == .typeRegular,
+                  let size = attributes[.size] as? NSNumber else {
+                return false
             }
-
-            if type == .typeRegular {
-                return hasNonEmptyRegularFileAttributes(at: url.path) ? url : nil
-            }
-
-            guard type == .typeSymbolicLink,
-                  let linkDestination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
-                return nil
-            }
-
-            let resolvedPath: String
-            if (linkDestination as NSString).isAbsolutePath {
-                resolvedPath = linkDestination
-            } else {
-                resolvedPath = url.deletingLastPathComponent()
-                    .appendingPathComponent(linkDestination, isDirectory: false)
-                    .path
-            }
-
-            return hasNonEmptyRegularFileAttributes(at: resolvedPath) ? url : nil
+            return size.intValue > 0
         }
 
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let type = attributes[.type] as? FileAttributeType else {
+            return nil
+        }
+
+        if type == .typeRegular {
+            return hasNonEmptyRegularFileAttributes(at: url.path) ? url : nil
+        }
+
+        guard type == .typeSymbolicLink,
+              let linkDestination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+            return nil
+        }
+
+        let resolvedPath: String
+        if (linkDestination as NSString).isAbsolutePath {
+            resolvedPath = linkDestination
+        } else {
+            resolvedPath = url.deletingLastPathComponent()
+                .appendingPathComponent(linkDestination, isDirectory: false)
+                .path
+        }
+
+        return hasNonEmptyRegularFileAttributes(at: resolvedPath) ? url : nil
+    }
+
+    private static func defaultConfigURLs(
+        homeDirectory: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [URL] {
         let xdgConfigRoot: URL = {
             if let raw = environment["XDG_CONFIG_HOME"], !raw.isEmpty {
                 let expanded = NSString(string: raw).expandingTildeInPath
@@ -199,7 +193,7 @@ struct GhosttyConfig {
             return homeDirectory.appendingPathComponent(".config", isDirectory: true)
         }()
 
-        var urls = [
+        return [
             xdgConfigRoot.appendingPathComponent("ghostty/config", isDirectory: false),
             xdgConfigRoot.appendingPathComponent("ghostty/config.ghostty", isDirectory: false),
             homeDirectory.appendingPathComponent(
@@ -210,13 +204,61 @@ struct GhosttyConfig {
                 "Library/Application Support/com.mitchellh.ghostty/config.ghostty",
                 isDirectory: false
             ),
-        ].compactMap(existingNonEmptyFileURL(for:))
+        ]
+    }
 
-        if let appSupportDirectory {
+    static func cmuxAppSupportConfigURLs(
+        currentBundleIdentifier: String?,
+        appSupportDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else { return [] }
+
+        func existingConfigURLs(for bundleIdentifier: String) -> [URL] {
+            let directory = appSupportDirectory.appendingPathComponent(bundleIdentifier, isDirectory: true)
+            return [
+                directory.appendingPathComponent("config", isDirectory: false),
+                directory.appendingPathComponent("config.ghostty", isDirectory: false),
+            ].compactMap { existingNonEmptyConfigURL(for: $0, fileManager: fileManager) }
+        }
+
+        let currentURLs = existingConfigURLs(for: currentBundleIdentifier)
+        if !currentURLs.isEmpty {
+            return currentURLs
+        }
+        if SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
+            let releaseURLs = existingConfigURLs(for: cmuxReleaseBundleIdentifier)
+            if !releaseURLs.isEmpty {
+                return releaseURLs
+            }
+        }
+        return []
+    }
+
+    static func editorConfigURLs(
+        fileManager: FileManager = .default,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil,
+        homeDirectory: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [URL] {
+        let resolvedHomeDirectory = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
+        let resolvedAppSupportDirectory = appSupportDirectory ?? fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+        let defaultURLs = defaultConfigURLs(
+            homeDirectory: resolvedHomeDirectory,
+            environment: environment
+        )
+
+        var urls = defaultURLs.compactMap { existingNonEmptyConfigURL(for: $0, fileManager: fileManager) }
+
+        if let resolvedAppSupportDirectory {
             urls.append(
-                contentsOf: GhosttyApp.cmuxAppSupportConfigURLs(
+                contentsOf: Self.cmuxAppSupportConfigURLs(
                     currentBundleIdentifier: currentBundleIdentifier,
-                    appSupportDirectory: appSupportDirectory,
+                    appSupportDirectory: resolvedAppSupportDirectory,
                     fileManager: fileManager
                 )
             )
@@ -226,7 +268,7 @@ struct GhosttyConfig {
             return urls
         }
 
-        return [xdgConfigRoot.appendingPathComponent("ghostty/config", isDirectory: false)]
+        return [defaultURLs[0]]
     }
 
     mutating func resolveSidebarBackground(preferredColorScheme: ColorSchemePreference) {
@@ -277,16 +319,34 @@ struct GhosttyConfig {
         }
     }
 
-    private static func loadFromDisk(preferredColorScheme: ColorSchemePreference) -> GhosttyConfig {
+    static func loadFromDiskForTests(
+        preferredColorScheme: ColorSchemePreference,
+        fileManager: FileManager = .default,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL? = nil,
+        appSupportDirectory: URL? = nil,
+        bundleResourceURL: URL? = Bundle.main.resourceURL
+    ) -> GhosttyConfig {
         var config = GhosttyConfig()
+        let resolvedHomeDirectory = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
+        let resolvedAppSupportDirectory = appSupportDirectory ?? fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
 
-        // Match Ghostty's default load order on macOS.
-        let configPaths = [
-            "~/.config/ghostty/config",
-            "~/.config/ghostty/config.ghostty",
-            "~/Library/Application Support/com.mitchellh.ghostty/config",
-            "~/Library/Application Support/com.mitchellh.ghostty/config.ghostty",
-        ].map { NSString(string: $0).expandingTildeInPath } + cmuxConfigPaths()
+        let configPaths = defaultConfigURLs(
+            homeDirectory: resolvedHomeDirectory,
+            environment: environment
+        ).map(\.path) + (
+            resolvedAppSupportDirectory.map {
+                cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: currentBundleIdentifier,
+                    appSupportDirectory: $0,
+                    fileManager: fileManager
+                ).map(\.path)
+            } ?? []
+        )
 
         for path in configPaths {
             if let contents = readConfigFile(at: path) {
@@ -298,8 +358,8 @@ struct GhosttyConfig {
         if let themeName = config.theme {
             config.loadTheme(
                 themeName,
-                environment: ProcessInfo.processInfo.environment,
-                bundleResourceURL: Bundle.main.resourceURL,
+                environment: environment,
+                bundleResourceURL: bundleResourceURL,
                 preferredColorScheme: preferredColorScheme
             )
         }
@@ -308,6 +368,10 @@ struct GhosttyConfig {
         config.applySidebarAppearanceToUserDefaults()
 
         return config
+    }
+
+    private static func loadFromDisk(preferredColorScheme: ColorSchemePreference) -> GhosttyConfig {
+        loadFromDiskForTests(preferredColorScheme: preferredColorScheme)
     }
 
     mutating func parse(_ contents: String) {
@@ -612,18 +676,12 @@ struct GhosttyConfig {
 
     private static func readConfigFile(at path: String) -> String? {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: path) else { return nil }
-
-        if let attributes = try? fileManager.attributesOfItem(atPath: path) {
-            if let type = attributes[.type] as? FileAttributeType, type != .typeRegular {
-                return nil
-            }
-            if let size = attributes[.size] as? NSNumber, size.intValue == 0 {
-                return nil
-            }
-        }
-
-        return try? String(contentsOfFile: path, encoding: .utf8)
+        guard let url = existingNonEmptyConfigURL(
+            for: URL(fileURLWithPath: path),
+            fileManager: fileManager
+        ) else { return nil }
+        let resolvedPath = canonicalConfigPath(for: url, fileManager: fileManager) ?? url.path
+        return try? String(contentsOfFile: resolvedPath, encoding: .utf8)
     }
 }
 

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -176,11 +176,19 @@ struct GhosttyConfig {
     ) -> [URL] {
         let xdgConfigRoot: URL = {
             if let raw = environment["XDG_CONFIG_HOME"], !raw.isEmpty {
-                let expanded = NSString(string: raw).expandingTildeInPath
-                if (expanded as NSString).isAbsolutePath {
-                    return URL(fileURLWithPath: expanded, isDirectory: true)
+                let normalized: String
+                if raw == "~" {
+                    normalized = homeDirectory.path
+                } else if raw.hasPrefix("~/") {
+                    normalized = homeDirectory
+                        .appendingPathComponent(String(raw.dropFirst(2)), isDirectory: true)
+                        .path
+                } else {
+                    normalized = raw
                 }
-                return homeDirectory.appendingPathComponent(expanded, isDirectory: true)
+                if (normalized as NSString).isAbsolutePath {
+                    return URL(fileURLWithPath: normalized, isDirectory: true)
+                }
             }
             return homeDirectory.appendingPathComponent(".config", isDirectory: true)
         }()

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -152,14 +152,40 @@ struct GhosttyConfig {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> [URL] {
         func existingNonEmptyFileURL(for url: URL) -> URL? {
+            func hasNonEmptyRegularFileAttributes(at path: String) -> Bool {
+                guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+                      let type = attributes[.type] as? FileAttributeType,
+                      type == .typeRegular,
+                      let size = attributes[.size] as? NSNumber else {
+                    return false
+                }
+                return size.intValue > 0
+            }
+
             guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
-                  let type = attributes[.type] as? FileAttributeType,
-                  type == .typeRegular,
-                  let size = attributes[.size] as? NSNumber,
-                  size.intValue > 0 else {
+                  let type = attributes[.type] as? FileAttributeType else {
                 return nil
             }
-            return url
+
+            if type == .typeRegular {
+                return hasNonEmptyRegularFileAttributes(at: url.path) ? url : nil
+            }
+
+            guard type == .typeSymbolicLink,
+                  let linkDestination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+                return nil
+            }
+
+            let resolvedPath: String
+            if (linkDestination as NSString).isAbsolutePath {
+                resolvedPath = linkDestination
+            } else {
+                resolvedPath = url.deletingLastPathComponent()
+                    .appendingPathComponent(linkDestination, isDirectory: false)
+                    .path
+            }
+
+            return hasNonEmptyRegularFileAttributes(at: resolvedPath) ? url : nil
         }
 
         let xdgConfigRoot: URL = {

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -158,7 +158,10 @@ struct GhosttyConfig {
         }
 
         if type == .typeRegular {
-            return hasNonEmptyRegularFileAttributes(at: url.path) ? url : nil
+            guard let size = attributes[.size] as? NSNumber, size.intValue > 0 else {
+                return nil
+            }
+            return url
         }
 
         guard type == .typeSymbolicLink else {
@@ -349,7 +352,7 @@ struct GhosttyConfig {
         )
 
         for path in configPaths {
-            if let contents = readConfigFile(at: path) {
+            if let contents = readConfigFile(at: path, using: fileManager) {
                 config.parse(contents)
             }
         }
@@ -674,8 +677,7 @@ struct GhosttyConfig {
         return paths
     }
 
-    private static func readConfigFile(at path: String) -> String? {
-        let fileManager = FileManager.default
+    private static func readConfigFile(at path: String, using fileManager: FileManager = .default) -> String? {
         guard let url = existingNonEmptyConfigURL(
             for: URL(fileURLWithPath: path),
             fileManager: fileManager

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -141,6 +141,68 @@ struct GhosttyConfig {
         return []
     }
 
+    static func editorConfigURLs(
+        fileManager: FileManager = .default,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [URL] {
+        func existingNonEmptyFileURL(for url: URL) -> URL? {
+            guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+                  let type = attributes[.type] as? FileAttributeType,
+                  type == .typeRegular,
+                  let size = attributes[.size] as? NSNumber,
+                  size.intValue > 0 else {
+                return nil
+            }
+            return url
+        }
+
+        let xdgConfigRoot: URL = {
+            if let raw = environment["XDG_CONFIG_HOME"], !raw.isEmpty {
+                let expanded = NSString(string: raw).expandingTildeInPath
+                if (expanded as NSString).isAbsolutePath {
+                    return URL(fileURLWithPath: expanded, isDirectory: true)
+                }
+                return homeDirectory.appendingPathComponent(expanded, isDirectory: true)
+            }
+            return homeDirectory.appendingPathComponent(".config", isDirectory: true)
+        }()
+
+        var urls = [
+            xdgConfigRoot.appendingPathComponent("ghostty/config", isDirectory: false),
+            xdgConfigRoot.appendingPathComponent("ghostty/config.ghostty", isDirectory: false),
+            homeDirectory.appendingPathComponent(
+                "Library/Application Support/com.mitchellh.ghostty/config",
+                isDirectory: false
+            ),
+            homeDirectory.appendingPathComponent(
+                "Library/Application Support/com.mitchellh.ghostty/config.ghostty",
+                isDirectory: false
+            ),
+        ].compactMap(existingNonEmptyFileURL(for:))
+
+        if let appSupportDirectory {
+            urls.append(
+                contentsOf: GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: currentBundleIdentifier,
+                    appSupportDirectory: appSupportDirectory,
+                    fileManager: fileManager
+                )
+            )
+        }
+
+        if !urls.isEmpty {
+            return urls
+        }
+
+        return [xdgConfigRoot.appendingPathComponent("ghostty/config", isDirectory: false)]
+    }
+
     mutating func resolveSidebarBackground(preferredColorScheme: ColorSchemePreference) {
         guard let raw = rawSidebarBackground else { return }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1411,42 +1411,6 @@ class GhosttyApp {
         return true
     }
 
-    static func cmuxAppSupportConfigURLs(
-        currentBundleIdentifier: String?,
-        appSupportDirectory: URL,
-        fileManager: FileManager = .default
-    ) -> [URL] {
-        guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else { return [] }
-
-        func existingConfigURLs(for bundleIdentifier: String) -> [URL] {
-            let directory = appSupportDirectory.appendingPathComponent(bundleIdentifier, isDirectory: true)
-            return [
-                directory.appendingPathComponent("config", isDirectory: false),
-                directory.appendingPathComponent("config.ghostty", isDirectory: false)
-            ].filter { url in
-                guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
-                      let type = attrs[.type] as? FileAttributeType,
-                      type == .typeRegular,
-                      let size = attrs[.size] as? NSNumber else {
-                    return false
-                }
-                return size.intValue > 0
-            }
-        }
-
-        let currentURLs = existingConfigURLs(for: currentBundleIdentifier)
-        if !currentURLs.isEmpty {
-            return currentURLs
-        }
-        if SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
-            let releaseURLs = existingConfigURLs(for: releaseBundleIdentifier)
-            if !releaseURLs.isEmpty {
-                return releaseURLs
-            }
-        }
-        return []
-    }
-
     static func shouldApplyDefaultBackgroundUpdate(
         currentScope: GhosttyDefaultBackgroundUpdateScope,
         incomingScope: GhosttyDefaultBackgroundUpdateScope
@@ -1490,14 +1454,30 @@ class GhosttyApp {
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
         guard let currentBundleIdentifier = Bundle.main.bundleIdentifier,
               !currentBundleIdentifier.isEmpty else { return }
-        let urls = Self.cmuxAppSupportConfigURLs(
+        let urls = GhosttyConfig.cmuxAppSupportConfigURLs(
             currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupport,
             fileManager: fm
         )
         guard !urls.isEmpty else { return }
 
+        let loadedCanonicalPathList = GhosttyConfig.editorConfigURLs(
+            fileManager: fm,
+            currentBundleIdentifier: nil,
+            appSupportDirectory: nil,
+            homeDirectory: fm.homeDirectoryForCurrentUser
+        ).compactMap { url -> String? in
+            let path = url.standardizedFileURL.path
+            guard fm.fileExists(atPath: path) else { return nil }
+            return URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+        }
+        let loadedCanonicalPaths = Set<String>(loadedCanonicalPathList)
+
         for url in urls {
+            let canonicalPath = url.standardizedFileURL.resolvingSymlinksInPath().path
+            if loadedCanonicalPaths.contains(canonicalPath) {
+                continue
+            }
             url.path.withCString { path in
                 ghostty_config_load_file(config, path)
             }
@@ -1642,11 +1622,24 @@ class GhosttyApp {
             let fallbackPath = fallbackURL.path
             if fileURLs.count == 1,
                !fileManager.fileExists(atPath: fallbackPath) {
-                try? fileManager.createDirectory(
-                    at: fallbackURL.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                fileManager.createFile(atPath: fallbackPath, contents: Data())
+                do {
+                    try fileManager.createDirectory(
+                        at: fallbackURL.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    let created = fileManager.createFile(atPath: fallbackPath, contents: Data())
+                    guard created || fileManager.fileExists(atPath: fallbackPath) else {
+                        #if DEBUG
+                        dlog("settings.open failed to create fallback config at \(fallbackPath)")
+                        #endif
+                        return
+                    }
+                } catch {
+                    #if DEBUG
+                    dlog("settings.open failed to prepare fallback config path error=\(error.localizedDescription)")
+                    #endif
+                    return
+                }
             }
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1634,21 +1634,26 @@ class GhosttyApp {
 
     func openConfigurationInTextEdit() {
         #if os(macOS)
-        let path = ghosttyStringValue(ghostty_config_open_path())
-        guard !path.isEmpty else { return }
-        let fileURL = URL(fileURLWithPath: path)
+        let fileManager = FileManager.default
+        let fileURLs = GhosttyConfig.editorConfigURLs(fileManager: fileManager)
+        guard !fileURLs.isEmpty else { return }
+
+        if let fallbackURL = fileURLs.first {
+            let fallbackPath = fallbackURL.path
+            if fileURLs.count == 1,
+               !fileManager.fileExists(atPath: fallbackPath) {
+                try? fileManager.createDirectory(
+                    at: fallbackURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                fileManager.createFile(atPath: fallbackPath, contents: Data())
+            }
+        }
+
         let editorURL = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
         let configuration = NSWorkspace.OpenConfiguration()
-        NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: configuration)
+        NSWorkspace.shared.open(fileURLs, withApplicationAt: editorURL, configuration: configuration)
         #endif
-    }
-
-    private func ghosttyStringValue(_ value: ghostty_string_s) -> String {
-        defer { ghostty_string_free(value) }
-        guard let ptr = value.ptr, value.len > 0 else { return "" }
-        let rawPtr = UnsafeRawPointer(ptr).assumingMemoryBound(to: UInt8.self)
-        let buffer = UnsafeBufferPointer(start: rawPtr, count: Int(value.len))
-        return String(decoding: buffer, as: UTF8.self)
     }
 
     private func resetDefaultBackgroundUpdateScope(source: String) {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -390,6 +390,191 @@ final class GhosttyConfigTests: XCTestCase {
         }
     }
 
+    func testEditorConfigURLsIncludeExistingNonEmptyFilesInLoadOrder() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-order-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let xdgConfig = homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(at: xdgConfig.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "font-size = 13\n".write(to: xdgConfig, atomically: true, encoding: .utf8)
+
+        let ghosttyLegacy = homeDirectory
+            .appendingPathComponent("Library/Application Support/com.mitchellh.ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: ghosttyLegacy.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "theme = dark\n".write(to: ghosttyLegacy, atomically: true, encoding: .utf8)
+
+        let cmuxConfig = try writeAppSupportConfig(
+            appSupportDirectory: appSupportDirectory,
+            bundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+            filename: "config.ghostty",
+            contents: "working-directory = /tmp\n"
+        )
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: [:]
+            ),
+            [xdgConfig, ghosttyLegacy, cmuxConfig]
+        )
+    }
+
+    func testEditorConfigURLsFallsBackToXDGConfigWhenNoExistingFiles() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-fallback-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: [:]
+            ),
+            [homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)]
+        )
+    }
+
+    func testEditorConfigURLsIgnoresEmptyFiles() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-empty-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let emptyXDGConfig = homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: emptyXDGConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: emptyXDGConfig, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: [:]
+            ),
+            [homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)]
+        )
+    }
+
+    func testEditorConfigURLsUsesInjectedHomeDirectoryInsteadOfAnotherCandidateHome() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-injected-home-\(UUID().uuidString)", isDirectory: true)
+        let injectedHomeDirectory = root.appendingPathComponent("home-injected", isDirectory: true)
+        let otherHomeDirectory = root.appendingPathComponent("home-other", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: injectedHomeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: otherHomeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let injectedConfig = injectedHomeDirectory
+            .appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: injectedConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(to: injectedConfig, atomically: true, encoding: .utf8)
+
+        let otherConfig = otherHomeDirectory
+            .appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: otherConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 99\n".write(to: otherConfig, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: injectedHomeDirectory,
+                environment: [:]
+            ),
+            [injectedConfig]
+        )
+        XCTAssertNotEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: injectedHomeDirectory,
+                environment: [:]
+            ),
+            [otherConfig]
+        )
+    }
+
+    func testEditorConfigURLsUsesCustomXDGConfigHomeWhenProvided() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-custom-xdg-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let xdgConfigHome = root.appendingPathComponent("xdg-config", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: xdgConfigHome, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let xdgConfig = xdgConfigHome.appendingPathComponent("ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: xdgConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(to: xdgConfig, atomically: true, encoding: .utf8)
+
+        let defaultConfig = homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: defaultConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 99\n".write(to: defaultConfig, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: ["XDG_CONFIG_HOME": xdgConfigHome.path]
+            ),
+            [xdgConfig]
+        )
+    }
+
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
         XCTAssertTrue(
             GhosttyApp.shouldApplyDefaultBackgroundUpdate(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -644,6 +644,36 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
+    func testEditorConfigURLsExpandsTildeXDGConfigHomeAgainstInjectedHomeDirectory() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-tilde-xdg-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let xdgConfig = homeDirectory.appendingPathComponent("xdg/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: xdgConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(to: xdgConfig, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: ["XDG_CONFIG_HOME": "~/xdg"]
+            ),
+            [xdgConfig]
+        )
+    }
+
     func testEditorConfigURLsIncludesSymlinkedConfigWhenTargetIsNonEmpty() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -544,6 +544,14 @@ final class GhosttyConfigTests: XCTestCase {
         )
         try "".write(to: emptyXDGConfig, atomically: true, encoding: .utf8)
 
+        let ghosttyLegacy = homeDirectory
+            .appendingPathComponent("Library/Application Support/com.mitchellh.ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: ghosttyLegacy.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "theme = dark\n".write(to: ghosttyLegacy, atomically: true, encoding: .utf8)
+
         XCTAssertEqual(
             GhosttyConfig.editorConfigURLs(
                 fileManager: fileManager,
@@ -552,7 +560,7 @@ final class GhosttyConfigTests: XCTestCase {
                 homeDirectory: homeDirectory,
                 environment: [:]
             ),
-            [homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)]
+            [ghosttyLegacy]
         )
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -709,7 +709,7 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testEditorConfigURLsDeduplicatesCanonicalPathWhenCmuxConfigSymlinksToDefaultGhosttyConfig() throws {
+    func testEditorConfigURLsPreservesBothEntrypointsWhenSymlinkedToSameCanonicalTarget() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("cmux-editor-config-dedupe-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -575,6 +575,41 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
+    func testEditorConfigURLsIncludesSymlinkedConfigWhenTargetIsNonEmpty() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-symlink-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+        let dotfilesDirectory = root.appendingPathComponent("dotfiles", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: dotfilesDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let targetConfig = dotfilesDirectory.appendingPathComponent("ghostty-config", isDirectory: false)
+        try "font-size = 13\n".write(to: targetConfig, atomically: true, encoding: .utf8)
+
+        let symlinkConfig = homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: symlinkConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.createSymbolicLink(atPath: symlinkConfig.path, withDestinationPath: targetConfig.path)
+
+        XCTAssertEqual(
+            GhosttyConfig.editorConfigURLs(
+                fileManager: fileManager,
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                appSupportDirectory: appSupportDirectory,
+                homeDirectory: homeDirectory,
+                environment: [:]
+            ),
+            [symlinkConfig]
+        )
+    }
+
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
         XCTAssertTrue(
             GhosttyApp.shouldApplyDefaultBackgroundUpdate(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -320,7 +320,7 @@ final class GhosttyConfigTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                GhosttyApp.cmuxAppSupportConfigURLs(
+                GhosttyConfig.cmuxAppSupportConfigURLs(
                     currentBundleIdentifier: "com.cmuxterm.app.debug",
                     appSupportDirectory: appSupportDirectory
                 ),
@@ -345,7 +345,7 @@ final class GhosttyConfigTests: XCTestCase {
             )
 
             XCTAssertEqual(
-                GhosttyApp.cmuxAppSupportConfigURLs(
+                GhosttyConfig.cmuxAppSupportConfigURLs(
                     currentBundleIdentifier: "com.cmuxterm.app.debug.issue-829",
                     appSupportDirectory: appSupportDirectory
                 ),
@@ -364,7 +364,7 @@ final class GhosttyConfigTests: XCTestCase {
             )
 
             XCTAssertTrue(
-                GhosttyApp.cmuxAppSupportConfigURLs(
+                GhosttyConfig.cmuxAppSupportConfigURLs(
                     currentBundleIdentifier: "com.example.other-app",
                     appSupportDirectory: appSupportDirectory
                 ).isEmpty
@@ -382,12 +382,83 @@ final class GhosttyConfigTests: XCTestCase {
             )
 
             XCTAssertTrue(
-                GhosttyApp.cmuxAppSupportConfigURLs(
+                GhosttyConfig.cmuxAppSupportConfigURLs(
                     currentBundleIdentifier: "com.cmuxterm.app.debug",
                     appSupportDirectory: appSupportDirectory
                 ).isEmpty
             )
         }
+    }
+
+    func testCmuxAppSupportConfigURLsIncludesSymlinkedConfigWhenTargetIsNonEmpty() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let dotfilesDirectory = appSupportDirectory.appendingPathComponent("dotfiles", isDirectory: true)
+            try FileManager.default.createDirectory(at: dotfilesDirectory, withIntermediateDirectories: true)
+
+            let targetConfigURL = dotfilesDirectory.appendingPathComponent("cmux-config", isDirectory: false)
+            try "font-size = 15\n".write(to: targetConfigURL, atomically: true, encoding: .utf8)
+
+            let bundleDirectory = appSupportDirectory
+                .appendingPathComponent("com.cmuxterm.app.debug.issue-1476", isDirectory: true)
+            try FileManager.default.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+
+            let symlinkConfigURL = bundleDirectory.appendingPathComponent("config", isDirectory: false)
+            try FileManager.default.createSymbolicLink(
+                atPath: symlinkConfigURL.path,
+                withDestinationPath: targetConfigURL.path
+            )
+
+            XCTAssertEqual(
+                GhosttyConfig.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+                    appSupportDirectory: appSupportDirectory
+                ),
+                [symlinkConfigURL]
+            )
+        }
+    }
+
+    func testLoadFromDiskForTestsParsesSymlinkedCmuxAppSupportConfig() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-load-symlinked-config-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+        let dotfilesDirectory = root.appendingPathComponent("dotfiles", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: dotfilesDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let targetConfigURL = dotfilesDirectory.appendingPathComponent("cmux-config", isDirectory: false)
+        try """
+        background = #112233
+        background-opacity = 0.42
+        """.write(to: targetConfigURL, atomically: true, encoding: .utf8)
+
+        let bundleDirectory = appSupportDirectory
+            .appendingPathComponent("com.cmuxterm.app.debug.issue-1476", isDirectory: true)
+        try fileManager.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+
+        let symlinkConfigURL = bundleDirectory.appendingPathComponent("config", isDirectory: false)
+        try fileManager.createSymbolicLink(
+            atPath: symlinkConfigURL.path,
+            withDestinationPath: targetConfigURL.path
+        )
+
+        let loaded = GhosttyConfig.loadFromDiskForTests(
+            preferredColorScheme: .dark,
+            fileManager: fileManager,
+            currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+            environment: [:],
+            homeDirectory: homeDirectory,
+            appSupportDirectory: appSupportDirectory,
+            bundleResourceURL: nil
+        )
+
+        XCTAssertEqual(rgb255(loaded.backgroundColor), RGB(red: 17, green: 34, blue: 51))
+        XCTAssertEqual(loaded.backgroundOpacity, 0.42, accuracy: 0.0001)
     }
 
     func testEditorConfigURLsIncludeExistingNonEmptyFilesInLoadOrder() throws {
@@ -524,16 +595,6 @@ final class GhosttyConfigTests: XCTestCase {
             ),
             [injectedConfig]
         )
-        XCTAssertNotEqual(
-            GhosttyConfig.editorConfigURLs(
-                fileManager: fileManager,
-                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
-                appSupportDirectory: appSupportDirectory,
-                homeDirectory: injectedHomeDirectory,
-                environment: [:]
-            ),
-            [otherConfig]
-        )
     }
 
     func testEditorConfigURLsUsesCustomXDGConfigHomeWhenProvided() throws {
@@ -608,6 +669,47 @@ final class GhosttyConfigTests: XCTestCase {
             ),
             [symlinkConfig]
         )
+    }
+
+    func testEditorConfigURLsDeduplicatesCanonicalPathWhenCmuxConfigSymlinksToDefaultGhosttyConfig() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-editor-config-dedupe-\(UUID().uuidString)", isDirectory: true)
+        let homeDirectory = root.appendingPathComponent("home", isDirectory: true)
+        let appSupportDirectory = root.appendingPathComponent("app-support", isDirectory: true)
+
+        try fileManager.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let defaultConfigURL = homeDirectory.appendingPathComponent(".config/ghostty/config", isDirectory: false)
+        try fileManager.createDirectory(
+            at: defaultConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "font-size = 13\n".write(to: defaultConfigURL, atomically: true, encoding: .utf8)
+
+        let bundleDirectory = appSupportDirectory
+            .appendingPathComponent("com.cmuxterm.app.debug.issue-1476", isDirectory: true)
+        try fileManager.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+
+        let symlinkConfigURL = bundleDirectory.appendingPathComponent("config", isDirectory: false)
+        try fileManager.createSymbolicLink(
+            atPath: symlinkConfigURL.path,
+            withDestinationPath: defaultConfigURL.path
+        )
+
+        let urls = GhosttyConfig.editorConfigURLs(
+            fileManager: fileManager,
+            currentBundleIdentifier: "com.cmuxterm.app.debug.issue-1476",
+            appSupportDirectory: appSupportDirectory,
+            homeDirectory: homeDirectory,
+            environment: [:]
+        )
+
+        XCTAssertEqual(urls.map(\.path), [defaultConfigURL.path, symlinkConfigURL.path])
+        let canonicalPaths = Set(urls.map { $0.standardizedFileURL.resolvingSymlinksInPath().path })
+        XCTAssertEqual(canonicalPaths.count, 1)
     }
 
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {


### PR DESCRIPTION
## Summary

  - Replaced the single-path `ghostty_config_open_path()` behavior behind `Ghostty Settings…` with cmux-side resolution that walks the expected top-level Ghostty config load order and opens all
  existing non-empty config files in TextEdit.
  - Added support for `XDG_CONFIG_HOME` so the settings action follows the same XDG root users expect when their Ghostty config is not under `~/.config`.
  - Preserved symlinked config entrypoints so users with dotfiles-managed Ghostty configs do not get redirected to a different fallback file.

  Why:
  - `Ghostty Settings…` was opening the wrong file for users whose real config lived in XDG locations such as `~/.config/ghostty/config`.
  - In practice that meant the menu could open a nearly empty app-support config while the user’s actual active config lived elsewhere.
  - This change makes the settings action open the config files users are actually editing in the standard load-order locations used by cmux.

  Closes #1476

  ## Testing

  - Built and launched a tagged debug app with:
    - `./scripts/reload.sh --tag issue-1476`
  - Added unit coverage for:
    - load-order resolution
    - fallback path selection
    - empty-file filtering
    - injected home-directory handling
    - custom `XDG_CONFIG_HOME`
    - symlinked config entrypoints
  - Verified the tagged app build succeeds locally.

  Manual verification:
  - Verified the settings action behavior against the original issue scenario by checking that XDG-path config resolution is used instead of only opening the app-support Ghostty config path.

  Note:
  - I did not complete a full local unit-test run because the local SwiftPM test invocation hit a pre-existing binary artifact cache issue unrelated to this patch. The tagged app build completed
  successfully.

  ## Demo Video

  - Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)
```
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist
- [x] tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved editor config discovery across XDG, home, and Application Support with canonical-path resolution, symlink handling, and deduplication.
  * Opens all discovered config files at once and auto-creates parent directories/files when editing a single, non-existent config.
  * More reliable disk loading that respects environment and bundle resource contexts and avoids reloading duplicate paths.

* **Tests**
  * Added extensive tests for resolution order, symlink handling, deduplication, empty-file ignoring, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->