### PR TITLE
feat: add web-browser entitlement for iCloud Passwords autofill

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add the `com.apple.developer.web-browser` entitlement to `cmux.entitlements`
- This enables native password autofill from iCloud Passwords and third-party Credential Provider Extensions (e.g. 1Password) in the browser panel's WKWebView
- The entitlement tells macOS that cmux functions as a web browser, allowing the system to provide credential autofill suggestions on password fields for any domain — the same mechanism Safari uses

## What this does

WKWebView supports password autofill from iCloud Keychain and third-party credential providers, but only when the app has the [`com.apple.developer.web-browser`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_web-browser) entitlement. Without it, autofill is limited to domains registered via Associated Domains (`webcredentials:`), which isn't practical for a general-purpose browser.

With this entitlement active, clicking on a username or password field in the browser panel will show the system autofill popover (same as Safari), offering credentials from iCloud Passwords and any installed Credential Provider Extensions.

## What still needs to be done

1. **Request the entitlement from Apple.** This is a [restricted entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_web-browser) — Apple must explicitly approve it. Until approved, the entitlement will be present in the binary but inactive at runtime. The request can be submitted at [developer.apple.com/contact/request/web-browser](https://developer.apple.com/contact/request/web-browser).

2. **Update `CODE_SIGN_ENTITLEMENTS` in the Xcode project.** The project currently sets `CODE_SIGN_ENTITLEMENTS = ""` for the main target (entitlements are applied at the post-build signing step). Once the provisioning profile includes this entitlement, `CODE_SIGN_ENTITLEMENTS` should be set to `cmux.entitlements` in the Debug build configuration so Xcode can generate a matching provisioning profile automatically.

3. **Optional: add a settings toggle.** A "Password AutoFill" toggle in Settings > Browser could let users disable autofill if desired. A `BrowserPasswordAutofillSettings` enum (following the existing `BrowserSearchSettings` / `BrowserThemeSettings` pattern) and a `SettingsCardRow` toggle would be the right approach.

4. **Optional: add an explicit trigger button.** A key icon in the browser address bar could use `ASAuthorizationController` with `ASAuthorizationPasswordProvider` to present the system credential picker on demand. This requires the app to be signed with a team identifier and a provisioning profile that includes the application identifier.

## Test plan

- [ ] Verify the entitlement is present in the signed binary: `codesign -d --entitlements - <path-to-app>`
- [ ] Once Apple approves the entitlement: navigate to a login page in the browser panel, click on a password field, and verify the iCloud Passwords autofill popover appears
- [ ] Verify existing browser functionality is not affected (navigation, cookies, DevTools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated app permissions to add a new web-browser entitlement enabling web-related capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `com.apple.developer.web-browser` entitlement to enable iCloud Passwords and third‑party autofill in the browser panel’s `WKWebView`. This restricted entitlement requires Apple approval before autofill appears.

- **Migration**
  - Request the web‑browser entitlement from Apple: https://developer.apple.com/contact/request/web-browser
  - After approval, update the provisioning profile and set `CODE_SIGN_ENTITLEMENTS` to `cmux.entitlements` so Xcode matches the profile automatically.

<sup>Written for commit a1e4ce8408041ffc4f56aa0e0c5e757b16024e9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

