### PR TITLE
fix: create offscreen NSWindow for background workspace PTY initialization

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3412,6 +3412,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var pendingSocketInputBytes: Int = 0
     private let maxPendingSocketInputBytes = 1_048_576
     private var backgroundSurfaceStartQueued = false
+    /// Offscreen window used to host the view hierarchy during background surface creation.
+    /// Ghostty requires a live NSWindow for Metal layer setup and backing context.
+    /// Released when the view moves to a real window or on teardown.
+    private var offscreenHostWindow: NSWindow?
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
     /// The desired focus state for the Ghostty C surface. May be set before the
     /// C surface exists (e.g. during layout restoration); `createSurface`
@@ -3844,6 +3848,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     func teardownSurface() {
         recordTeardownRequest(reason: "surface.teardown")
         markPortalLifecycleClosed(reason: "teardown")
+        offscreenHostWindow = nil
 
         let callbackContext = surfaceCallbackContext
         surfaceCallbackContext = nil
@@ -3960,6 +3965,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
             dlog("surface.attach.reuse surface=\(id.uuidString.prefix(5)) view=\(Unmanaged.passUnretained(view).toOpaque())")
 #endif
+            // Release the offscreen host window once the view has moved to a real window.
+            if let offscreen = offscreenHostWindow, view.window !== offscreen {
+                offscreenHostWindow = nil
+            }
             if let screen = view.window?.screen ?? NSScreen.main,
                let displayID = screen.displayID,
                displayID != 0,
@@ -4610,7 +4619,37 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         guard allowsRuntimeSurfaceCreation() else { return }
-        guard surface == nil, attachedView != nil else { return }
+        guard surface == nil else { return }
+
+        // Background workspaces may not be in any NSWindow yet — ghostty requires
+        // a live window for Metal layer setup and backing context. Provide an offscreen
+        // host window so the standard viewDidMoveToWindow → attachToView → createSurface
+        // chain fires with a valid window.
+        if surfaceView.window == nil && offscreenHostWindow == nil {
+            let window = NSWindow(
+                contentRect: NSRect(x: -10000, y: -10000, width: 800, height: 600),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.orderOut(nil)
+            offscreenHostWindow = window
+            if let contentView = window.contentView {
+                hostedView.frame = contentView.bounds
+                hostedView.autoresizingMask = [.width, .height]
+                contentView.addSubview(hostedView)
+            }
+            // viewDidMoveToWindow fires on surfaceView → attachToView → createSurface
+            if surface != nil {
+#if DEBUG
+                dlog("surface.background_start.offscreen surface=\(id.uuidString.prefix(8)) ready=1")
+#endif
+                return
+            }
+        }
+
+        guard attachedView != nil else { return }
         guard !backgroundSurfaceStartQueued else { return }
         backgroundSurfaceStartQueued = true
 


### PR DESCRIPTION
Fixes #1472

## Summary

- Fix background workspaces created via the socket API (`workspace.create` with `select: false`) having dead PTY surfaces that reject `send`, `read-screen`, and `send-key` commands.
- Add an offscreen `NSWindow` host so `ghostty_surface_new()` gets a valid Metal-backed window context even when the workspace has never been displayed.
- The offscreen window is released automatically when the view migrates to a real window or on teardown.

## Why

We built an [MCP server](https://github.com/EtanHey/cmuxlayer) on top of cmux for multi-agent AI orchestration — spawning Claude Code, Codex, and Gemini CLI sessions in separate workspaces programmatically. When creating workspaces via the socket API without selecting them, the surfaces are listed correctly but all commands fail with "Surface is not a terminal."

Root cause: `requestBackgroundSurfaceStartIfNeeded()` calls `attachToView`, which requires `surfaceView.window != nil`. Background workspaces have no `NSWindow`, so `createSurface` silently defers and the PTY is never forked.

## Testing

1. Create a background workspace: `cmux new-workspace` (without `--focus`)
2. Immediately run `cmux read-screen --surface <new-surface>`
3. **Before fix:** "Surface is not a terminal"
4. **After fix:** Returns terminal content (shell prompt)

Could not verify local build — `zig` is required for `GhosttyKit.xcframework`. CI should handle build verification.
