### PR TITLE
Improve Help menu actions and shortcut

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -250,6 +250,67 @@ struct cmuxApp: App {
                 InstallUpdateMenuItem(model: appDelegate.updateViewModel)
             }
 
+            CommandGroup(replacing: .help) {
+                Button(String(localized: "sidebar.help.welcome", defaultValue: "Welcome to cmux!")) {
+                    AppDelegate.shared?.openWelcomeWorkspace()
+                }
+
+                Button(String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback")) {
+                    FeedbackComposerBridge.openComposer()
+                }
+
+                Divider()
+
+                Button(String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts")) {
+                    if let appDelegate = AppDelegate.shared {
+                        appDelegate.openPreferencesWindow(
+                            debugSource: "menu.help.keyboardShortcuts",
+                            navigationTarget: .keyboardShortcuts
+                        )
+                    } else {
+                        AppDelegate.presentPreferencesWindow(navigationTarget: .keyboardShortcuts)
+                    }
+                }
+
+                Divider()
+
+                if let docsURL = URL(string: "https://cmux.dev/docs") {
+                    Button(String(localized: "about.docs", defaultValue: "Docs")) {
+                        NSWorkspace.shared.open(docsURL)
+                    }
+                }
+
+                if let changelogURL = URL(string: "https://cmux.dev/docs/changelog") {
+                    Button(String(localized: "sidebar.help.changelog", defaultValue: "Changelog")) {
+                        NSWorkspace.shared.open(changelogURL)
+                    }
+                }
+
+                if let githubURL = URL(string: "https://github.com/manaflow-ai/cmux") {
+                    Button(String(localized: "about.github", defaultValue: "GitHub")) {
+                        NSWorkspace.shared.open(githubURL)
+                    }
+                }
+
+                if let githubIssuesURL = URL(string: "https://github.com/manaflow-ai/cmux/issues") {
+                    Button(String(localized: "sidebar.help.githubIssues", defaultValue: "GitHub Issues")) {
+                        NSWorkspace.shared.open(githubIssuesURL)
+                    }
+                }
+
+                if let discordURL = URL(string: "https://discord.gg/xsgFEVrWCZ") {
+                    Button(String(localized: "sidebar.help.discord", defaultValue: "Discord")) {
+                        NSWorkspace.shared.open(discordURL)
+                    }
+                }
+
+                Divider()
+
+                Button(String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates")) {
+                    AppDelegate.shared?.checkForUpdates(nil)
+                }
+            }
+
 #if DEBUG
             CommandMenu("Update Pill") {
                 Button("Show Update Pill") {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -37,6 +37,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.sendFeedback.defaultsKey) private var sendFeedbackShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     init() {
@@ -255,7 +256,10 @@ struct cmuxApp: App {
                     AppDelegate.shared?.openWelcomeWorkspace()
                 }
 
-                Button(String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback")) {
+                splitCommandButton(
+                    title: String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback"),
+                    shortcut: sendFeedbackMenuShortcut
+                ) {
                     FeedbackComposerBridge.openComposer()
                 }
 
@@ -845,6 +849,13 @@ struct cmuxApp: App {
         decodeShortcut(
             from: closeWorkspaceShortcutData,
             fallback: KeyboardShortcutSettings.Action.closeWorkspace.defaultShortcut
+        )
+    }
+
+    private var sendFeedbackMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: sendFeedbackShortcutData,
+            fallback: KeyboardShortcutSettings.Action.sendFeedback.defaultShortcut
         )
     }
 


### PR DESCRIPTION
## Summary

- Replace the default Help menu with a custom cmux Help menu that matches the sidebar options
- Add the Send Feedback shortcut in the Help menu
- Keep Help menu strings localized by reusing existing keys

## Testing

- Not run (per project policy)

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved