### PR TITLE
Add keyboard shortcut to pin current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ For more info on how to configure cmux, [head over to our docs](https://cmux.dev
 | ⌃ ⌘ [ | Previous workspace |
 | ⌘ ⇧ W | Close workspace |
 | ⌘ ⇧ R | Rename workspace |
+| ⌥ ⌘ P | Pin or unpin workspace |
 | ⌘ B | Toggle sidebar |
 
 ### Surfaces

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8348,6 +8348,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
 
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleWorkspacePin)) {
+#if DEBUG
+            dlog("shortcut.action name=toggleWorkspacePin \(debugShortcutRouteSnapshot(event: event))")
+#endif
+            return toggleWorkspacePinInActiveMainWindow(
+                preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            )
+        }
+
         if matchShortcut(
             event: event,
             shortcut: StoredShortcut(key: "t", command: true, shift: false, option: true, control: false)
@@ -9309,6 +9318,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             preferredWindow: targetWindow,
             source: "shortcut.renameWorkspace"
         )
+        return true
+    }
+
+    @discardableResult
+    func toggleWorkspacePinInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        if let preferredWindow,
+           contextForMainWindow(preferredWindow) == nil {
+            NSSound.beep()
+            return false
+        }
+
+        let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        guard let manager = synchronizeActiveMainWindowContext(preferredWindow: targetWindow) else {
+            NSSound.beep()
+            return false
+        }
+        guard let workspace = manager.selectedWorkspace else {
+            NSSound.beep()
+            return false
+        }
+
+        manager.setPinned(workspace, pinned: !workspace.isPinned)
         return true
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4851,12 +4851,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return contextForMainTerminalWindow(window)
     }
 
-    private func resolvedWorkspacePinTarget(
+    private func resolvedWorkspacePinTargetForMainWindow(
         for window: NSWindow?
     ) -> (context: MainWindowContext, workspace: Workspace)? {
         if let context = contextForMainWindow(window),
            let workspace = context.tabManager.selectedWorkspace {
             return (context, workspace)
+        }
+        return nil
+    }
+
+    private func resolvedWorkspacePinTargetIncludingPopups(
+        for window: NSWindow?
+    ) -> (context: MainWindowContext, workspace: Workspace)? {
+        if let target = resolvedWorkspacePinTargetForMainWindow(for: window) {
+            return target
         }
         guard let workspaceId = BrowserPopupWindowController.openerWorkspaceId(for: window),
               let context = contextContainingTabId(workspaceId),
@@ -4867,16 +4876,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func canPinWorkspace(from window: NSWindow?) -> Bool {
-        resolvedWorkspacePinTarget(for: window) != nil
+        resolvedWorkspacePinTargetForMainWindow(for: window) != nil
     }
 
     func workspaceForWorkspacePin(from window: NSWindow?) -> Workspace? {
-        resolvedWorkspacePinTarget(for: window)?.workspace
+        resolvedWorkspacePinTargetForMainWindow(for: window)?.workspace
+    }
+
+    private func canToggleWorkspacePin(from window: NSWindow?) -> Bool {
+        resolvedWorkspacePinTargetIncludingPopups(for: window) != nil
     }
 
     private func isVisibleUnsupportedWorkspacePinWindow(_ window: NSWindow?) -> Bool {
         guard let window else { return false }
-        guard !canPinWorkspace(from: window) else { return false }
+        guard !canToggleWorkspacePin(from: window) else { return false }
         return window.isVisible
     }
 
@@ -5483,7 +5496,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleWorkspacePin)) else {
             return false
         }
-        return canPinWorkspace(from: eventWindowForWorkspacePinShortcut(event))
+        return canToggleWorkspacePin(from: eventWindowForWorkspacePinShortcut(event))
     }
 
     private func preferredWindowForWorkspacePinShortcut(
@@ -5492,7 +5505,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) -> NSWindow? {
         let eventWindow = eventWindowForWorkspacePinShortcut(event)
         if let eventWindow,
-           canPinWorkspace(from: eventWindow) {
+           canToggleWorkspacePin(from: eventWindow) {
             return eventWindow
         }
         return commandPaletteTargetWindow ?? eventWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
@@ -9392,23 +9405,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func toggleWorkspacePinInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        if isVisibleUnsupportedWorkspacePinWindow(preferredWindow) {
+        let requestedWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        let targetWindow: NSWindow?
+        if preferredWindow == nil,
+           isVisibleUnsupportedWorkspacePinWindow(requestedWindow) {
+            targetWindow = NSApp.mainWindow
+        } else {
+            targetWindow = requestedWindow
+        }
+        if isVisibleUnsupportedWorkspacePinWindow(targetWindow) {
             NSSound.beep()
             return false
         }
 
         let manager: TabManager
         let workspace: Workspace
-        if let preferredWindow,
-           preferredWindow.isVisible {
-            guard let target = resolvedWorkspacePinTarget(for: preferredWindow) else {
+        if let targetWindow,
+           targetWindow.isVisible {
+            guard let target = resolvedWorkspacePinTargetIncludingPopups(for: targetWindow) else {
                 NSSound.beep()
                 return false
             }
             manager = activateMainWindowContext(target.context)
             workspace = target.workspace
         } else {
-            let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
             guard let synchronizedManager = synchronizeActiveMainWindowContext(
                 preferredWindow: targetWindow
             ) else {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4847,8 +4847,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func contextForMainWindow(_ window: NSWindow?) -> MainWindowContext? {
-        guard let window, isMainTerminalWindow(window) else { return nil }
-        return mainWindowContexts[ObjectIdentifier(window)]
+        guard let window else { return nil }
+        return contextForMainTerminalWindow(window)
+    }
+
+    private func isVisibleNonMainWindow(_ window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        guard contextForMainWindow(window) == nil else { return false }
+        return window.isVisible
     }
 
 #if DEBUG
@@ -9321,10 +9327,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    func isMainTerminalWindowForCommands(_ window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        return isMainTerminalWindow(window)
+    }
+
     @discardableResult
     func toggleWorkspacePinInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        if let preferredWindow,
-           contextForMainWindow(preferredWindow) == nil {
+        if isVisibleNonMainWindow(preferredWindow) {
             NSSound.beep()
             return false
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9410,15 +9410,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if preferredWindow == nil,
            let candidate = requestedWindow,
            candidate.isVisible,
-           !canPinWorkspace(from: candidate, includingPopups: true) {
+           resolvedWorkspacePinTargetIncludingPopups(for: candidate) == nil {
             targetWindow = NSApp.mainWindow
         } else {
             targetWindow = requestedWindow
-        }
-        if let targetWindow,
-           targetWindow.isVisible,
-           !canPinWorkspace(from: targetWindow, includingPopups: true) {
-            return nil
         }
 
         if let targetWindow, targetWindow.isVisible {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4851,10 +4851,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return contextForMainTerminalWindow(window)
     }
 
-    private func isVisibleNonMainWindow(_ window: NSWindow?) -> Bool {
+    private func resolvedWorkspacePinTarget(
+        for window: NSWindow?
+    ) -> (context: MainWindowContext, workspace: Workspace)? {
+        if let context = contextForMainWindow(window),
+           let workspace = context.tabManager.selectedWorkspace {
+            return (context, workspace)
+        }
+        guard let workspaceId = BrowserPopupWindowController.openerWorkspaceId(for: window),
+              let context = contextContainingTabId(workspaceId),
+              let workspace = context.tabManager.tabs.first(where: { $0.id == workspaceId }) else {
+            return nil
+        }
+        return (context, workspace)
+    }
+
+    func canPinWorkspace(from window: NSWindow?) -> Bool {
+        resolvedWorkspacePinTarget(for: window) != nil
+    }
+
+    func workspaceForWorkspacePin(from window: NSWindow?) -> Workspace? {
+        resolvedWorkspacePinTarget(for: window)?.workspace
+    }
+
+    private func isVisibleUnsupportedWorkspacePinWindow(_ window: NSWindow?) -> Bool {
         guard let window else { return false }
-        guard contextForMainWindow(window) == nil else { return false }
+        guard !canPinWorkspace(from: window) else { return false }
         return window.isVisible
+    }
+
+    private func activateMainWindowContext(_ context: MainWindowContext) -> TabManager {
+        if let window = context.window ?? windowForMainWindowId(context.windowId) {
+            setActiveMainWindow(window)
+        } else {
+            tabManager = context.tabManager
+            sidebarState = context.sidebarState
+            sidebarSelectionState = context.sidebarSelectionState
+            TerminalController.shared.setActiveTabManager(context.tabManager)
+        }
+        return context.tabManager
     }
 
 #if DEBUG
@@ -9327,26 +9362,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    func isMainTerminalWindowForCommands(_ window: NSWindow?) -> Bool {
-        guard let window else { return false }
-        return isMainTerminalWindow(window)
-    }
-
     @discardableResult
     func toggleWorkspacePinInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        if isVisibleNonMainWindow(preferredWindow) {
+        if isVisibleUnsupportedWorkspacePinWindow(preferredWindow) {
             NSSound.beep()
             return false
         }
 
-        let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
-        guard let manager = synchronizeActiveMainWindowContext(preferredWindow: targetWindow) else {
-            NSSound.beep()
-            return false
-        }
-        guard let workspace = manager.selectedWorkspace else {
-            NSSound.beep()
-            return false
+        let manager: TabManager
+        let workspace: Workspace
+        if let preferredWindow,
+           preferredWindow.isVisible {
+            guard let target = resolvedWorkspacePinTarget(for: preferredWindow) else {
+                NSSound.beep()
+                return false
+            }
+            manager = activateMainWindowContext(target.context)
+            workspace = target.workspace
+        } else {
+            let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+            guard let synchronizedManager = synchronizeActiveMainWindowContext(
+                preferredWindow: targetWindow
+            ) else {
+                NSSound.beep()
+                return false
+            }
+            manager = synchronizedManager
+            guard let selectedWorkspace = manager.selectedWorkspace else {
+                NSSound.beep()
+                return false
+            }
+            workspace = selectedWorkspace
         }
 
         manager.setPinned(workspace, pinned: !workspace.isPinned)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8353,7 +8353,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             dlog("shortcut.action name=toggleWorkspacePin \(debugShortcutRouteSnapshot(event: event))")
 #endif
             return toggleWorkspacePinInActiveMainWindow(
-                preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+                preferredWindow: event.window ?? commandPaletteTargetWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
             )
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4875,22 +4875,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return (context, workspace)
     }
 
-    func canPinWorkspace(from window: NSWindow?) -> Bool {
-        resolvedWorkspacePinTargetForMainWindow(for: window) != nil
-    }
-
-    func workspaceForWorkspacePin(from window: NSWindow?) -> Workspace? {
-        resolvedWorkspacePinTargetForMainWindow(for: window)?.workspace
-    }
-
-    private func canToggleWorkspacePin(from window: NSWindow?) -> Bool {
-        resolvedWorkspacePinTargetIncludingPopups(for: window) != nil
-    }
-
-    private func isVisibleUnsupportedWorkspacePinWindow(_ window: NSWindow?) -> Bool {
-        guard let window else { return false }
-        guard !canToggleWorkspacePin(from: window) else { return false }
-        return window.isVisible
+    func canPinWorkspace(from window: NSWindow?, includingPopups: Bool = false) -> Bool {
+        if includingPopups {
+            return resolvedWorkspacePinTargetIncludingPopups(for: window) != nil
+        }
+        return resolvedWorkspacePinTargetForMainWindow(for: window) != nil
     }
 
     private func activateMainWindowContext(_ context: MainWindowContext) -> TabManager {
@@ -5496,7 +5485,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleWorkspacePin)) else {
             return false
         }
-        return canToggleWorkspacePin(from: eventWindowForWorkspacePinShortcut(event))
+        return canPinWorkspace(from: eventWindowForWorkspacePinShortcut(event), includingPopups: true)
     }
 
     private func preferredWindowForWorkspacePinShortcut(
@@ -5505,7 +5494,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) -> NSWindow? {
         let eventWindow = eventWindowForWorkspacePinShortcut(event)
         if let eventWindow,
-           canToggleWorkspacePin(from: eventWindow) {
+           canPinWorkspace(from: eventWindow, includingPopups: true) {
             return eventWindow
         }
         return commandPaletteTargetWindow ?? eventWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
@@ -9405,46 +9394,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func toggleWorkspacePinInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        guard let target = resolveWorkspacePinTarget(preferredWindow: preferredWindow) else {
+            NSSound.beep()
+            return false
+        }
+        target.manager.togglePin(tabId: target.workspace.id)
+        return true
+    }
+
+    private func resolveWorkspacePinTarget(
+        preferredWindow: NSWindow?
+    ) -> (manager: TabManager, workspace: Workspace)? {
         let requestedWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
         let targetWindow: NSWindow?
         if preferredWindow == nil,
-           isVisibleUnsupportedWorkspacePinWindow(requestedWindow) {
+           let candidate = requestedWindow,
+           candidate.isVisible,
+           !canPinWorkspace(from: candidate, includingPopups: true) {
             targetWindow = NSApp.mainWindow
         } else {
             targetWindow = requestedWindow
         }
-        if isVisibleUnsupportedWorkspacePinWindow(targetWindow) {
-            NSSound.beep()
-            return false
-        }
-
-        let manager: TabManager
-        let workspace: Workspace
         if let targetWindow,
-           targetWindow.isVisible {
-            guard let target = resolvedWorkspacePinTargetIncludingPopups(for: targetWindow) else {
-                NSSound.beep()
-                return false
-            }
-            manager = activateMainWindowContext(target.context)
-            workspace = target.workspace
-        } else {
-            guard let synchronizedManager = synchronizeActiveMainWindowContext(
-                preferredWindow: targetWindow
-            ) else {
-                NSSound.beep()
-                return false
-            }
-            manager = synchronizedManager
-            guard let selectedWorkspace = manager.selectedWorkspace else {
-                NSSound.beep()
-                return false
-            }
-            workspace = selectedWorkspace
+           targetWindow.isVisible,
+           !canPinWorkspace(from: targetWindow, includingPopups: true) {
+            return nil
         }
 
-        manager.setPinned(workspace, pinned: !workspace.isPinned)
-        return true
+        if let targetWindow, targetWindow.isVisible {
+            guard let resolved = resolvedWorkspacePinTargetIncludingPopups(for: targetWindow) else {
+                return nil
+            }
+            let manager = activateMainWindowContext(resolved.context)
+            return (manager, resolved.workspace)
+        }
+
+        guard let manager = synchronizeActiveMainWindowContext(preferredWindow: targetWindow),
+              let workspace = manager.selectedWorkspace else {
+            return nil
+        }
+        return (manager, workspace)
     }
 
 #if DEBUG

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5475,6 +5475,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    private func eventWindowForWorkspacePinShortcut(_ event: NSEvent) -> NSWindow? {
+        event.window ?? NSApp.window(withWindowNumber: event.windowNumber)
+    }
+
+    private func canHandleWorkspacePinWithoutSynchronizedContext(event: NSEvent) -> Bool {
+        guard matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleWorkspacePin)) else {
+            return false
+        }
+        return canPinWorkspace(from: eventWindowForWorkspacePinShortcut(event))
+    }
+
+    private func preferredWindowForWorkspacePinShortcut(
+        event: NSEvent,
+        commandPaletteTargetWindow: NSWindow?
+    ) -> NSWindow? {
+        let eventWindow = eventWindowForWorkspacePinShortcut(event)
+        if let eventWindow,
+           canPinWorkspace(from: eventWindow) {
+            return eventWindow
+        }
+        return commandPaletteTargetWindow ?? eventWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+    }
+
     @discardableResult
     func createMainWindow(
         initialWorkingDirectory: String? = nil,
@@ -8200,7 +8223,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let hasEventWindowContext = shortcutEventHasAddressableWindow(event)
         let didSynchronizeShortcutContext = synchronizeShortcutRoutingContext(event: event)
-        if hasEventWindowContext && !didSynchronizeShortcutContext {
+        if hasEventWindowContext
+            && !didSynchronizeShortcutContext
+            && !canHandleWorkspacePinWithoutSynchronizedContext(event: event) {
 #if DEBUG
             dlog("handleCustomShortcut: unresolved event window context; bypassing app shortcut handling")
 #endif
@@ -8394,7 +8419,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             dlog("shortcut.action name=toggleWorkspacePin \(debugShortcutRouteSnapshot(event: event))")
 #endif
             return toggleWorkspacePinInActiveMainWindow(
-                preferredWindow: event.window ?? commandPaletteTargetWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+                preferredWindow: preferredWindowForWorkspacePinShortcut(
+                    event: event,
+                    commandPaletteTargetWindow: commandPaletteTargetWindow
+                )
             )
         }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4524,6 +4524,8 @@ struct ContentView: View {
             return .renameTab
         case "palette.renameWorkspace":
             return .renameWorkspace
+        case "palette.toggleWorkspacePin":
+            return .toggleWorkspacePin
         case "palette.nextWorkspace":
             return .nextSidebarTab
         case "palette.previousWorkspace":

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5472,7 +5472,7 @@ struct ContentView: View {
                 NSSound.beep()
                 return
             }
-            tabManager.setPinned(workspace, pinned: !workspace.isPinned)
+            tabManager.togglePin(tabId: workspace.id)
         }
         registry.register(commandId: "palette.nextWorkspace") {
             tabManager.selectNextTab()

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -22,6 +22,7 @@ enum KeyboardShortcutSettings {
         case prevSidebarTab
         case renameTab
         case renameWorkspace
+        case toggleWorkspacePin
         case closeWorkspace
         case newSurface
         case toggleTerminalCopyMode
@@ -61,6 +62,7 @@ enum KeyboardShortcutSettings {
             case .prevSidebarTab: return String(localized: "shortcut.previousWorkspace.label", defaultValue: "Previous Workspace")
             case .renameTab: return String(localized: "shortcut.renameTab.label", defaultValue: "Rename Tab")
             case .renameWorkspace: return String(localized: "shortcut.renameWorkspace.label", defaultValue: "Rename Workspace")
+            case .toggleWorkspacePin: return String(localized: "command.pinWorkspace.title", defaultValue: "Pin Workspace")
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
@@ -94,6 +96,7 @@ enum KeyboardShortcutSettings {
             case .prevSidebarTab: return "shortcut.prevSidebarTab"
             case .renameTab: return "shortcut.renameTab"
             case .renameWorkspace: return "shortcut.renameWorkspace"
+            case .toggleWorkspacePin: return "shortcut.toggleWorkspacePin"
             case .closeWorkspace: return "shortcut.closeWorkspace"
             case .focusLeft: return "shortcut.focusLeft"
             case .focusRight: return "shortcut.focusRight"
@@ -142,6 +145,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
             case .renameWorkspace:
                 return StoredShortcut(key: "r", command: true, shift: true, option: false, control: false)
+            case .toggleWorkspacePin:
+                return StoredShortcut(key: "p", command: true, shift: false, option: true, control: false)
             case .closeWorkspace:
                 return StoredShortcut(key: "w", command: true, shift: true, option: false, control: false)
             case .focusLeft:

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -81,6 +81,15 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
 
     private static var associatedObjectKey: UInt8 = 0
 
+    static func openerWorkspaceId(for window: NSWindow?) -> UUID? {
+        guard let window,
+              let controller = objc_getAssociatedObject(window, &Self.associatedObjectKey)
+                as? BrowserPopupWindowController else {
+            return nil
+        }
+        return controller.openerPanel?.workspaceId
+    }
+
     init(
         configuration: WKWebViewConfiguration,
         windowFeatures: WKWindowFeatures,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -600,15 +600,15 @@ struct cmuxApp: App {
                     _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
                 }
 
-                let isNonMainWindowFocused: Bool = {
+                let canPin: Bool = {
                     guard let keyWindow = NSApp.keyWindow else { return false }
-                    return AppDelegate.shared?.canPinWorkspace(from: keyWindow) != true
+                    return AppDelegate.shared?.canPinWorkspace(from: keyWindow) == true
                 }()
-                let workspacePinTarget = NSApp.keyWindow.flatMap {
-                    AppDelegate.shared?.workspaceForWorkspacePin(from: $0)
-                } ?? activeTabManager.selectedWorkspace
+                let workspacePinTarget = canPin
+                    ? activeTabManager.selectedWorkspace
+                    : nil
                 splitCommandButton(
-                    title: !isNonMainWindowFocused && workspacePinTarget?.isPinned == true
+                    title: canPin && workspacePinTarget?.isPinned == true
                         ? String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
                         : String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
                     shortcut: toggleWorkspacePinMenuShortcut
@@ -617,7 +617,7 @@ struct cmuxApp: App {
                         preferredWindow: NSApp.keyWindow
                     )
                 }
-                .disabled(isNonMainWindowFocused)
+                .disabled(!canPin)
 
                 Divider()
 
@@ -870,7 +870,7 @@ struct cmuxApp: App {
 
     private func toggleSelectedWorkspacePinned(in manager: TabManager) {
         guard let workspace = manager.selectedWorkspace else { return }
-        manager.setPinned(workspace, pinned: !workspace.isPinned)
+        manager.togglePin(tabId: workspace.id)
     }
 
     private func clearSelectedWorkspaceCustomName(in manager: TabManager) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -602,10 +602,13 @@ struct cmuxApp: App {
 
                 let isNonMainWindowFocused: Bool = {
                     guard let keyWindow = NSApp.keyWindow else { return false }
-                    return AppDelegate.shared?.isMainTerminalWindowForCommands(keyWindow) != true
+                    return AppDelegate.shared?.canPinWorkspace(from: keyWindow) != true
                 }()
+                let workspacePinTarget = NSApp.keyWindow.flatMap {
+                    AppDelegate.shared?.workspaceForWorkspacePin(from: $0)
+                } ?? activeTabManager.selectedWorkspace
                 splitCommandButton(
-                    title: !isNonMainWindowFocused && activeTabManager.selectedWorkspace?.isPinned == true
+                    title: !isNonMainWindowFocused && workspacePinTarget?.isPinned == true
                         ? String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
                         : String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
                     shortcut: toggleWorkspacePinMenuShortcut

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -36,6 +36,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.splitBrowserDown.defaultsKey) private var splitBrowserDownShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultsKey) private var toggleWorkspacePinShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
@@ -599,6 +600,15 @@ struct cmuxApp: App {
                     _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
                 }
 
+                splitCommandButton(
+                    title: activeTabManager.selectedWorkspace?.isPinned == true
+                        ? String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
+                        : String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
+                    shortcut: toggleWorkspacePinMenuShortcut
+                ) {
+                    _ = AppDelegate.shared?.toggleWorkspacePinInActiveMainWindow()
+                }
+
                 Divider()
 
                 splitCommandButton(title: String(localized: "menu.view.splitRight", defaultValue: "Split Right"), shortcut: splitRightMenuShortcut) {
@@ -777,6 +787,13 @@ struct cmuxApp: App {
         decodeShortcut(
             from: renameWorkspaceShortcutData,
             fallback: KeyboardShortcutSettings.Action.renameWorkspace.defaultShortcut
+        )
+    }
+
+    private var toggleWorkspacePinMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: toggleWorkspacePinShortcutData,
+            fallback: KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultShortcut
         )
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -600,14 +600,21 @@ struct cmuxApp: App {
                     _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
                 }
 
+                let isNonMainWindowFocused: Bool = {
+                    guard let keyWindow = NSApp.keyWindow else { return false }
+                    return AppDelegate.shared?.isMainTerminalWindowForCommands(keyWindow) != true
+                }()
                 splitCommandButton(
-                    title: activeTabManager.selectedWorkspace?.isPinned == true
+                    title: !isNonMainWindowFocused && activeTabManager.selectedWorkspace?.isPinned == true
                         ? String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
                         : String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
                     shortcut: toggleWorkspacePinMenuShortcut
                 ) {
-                    _ = AppDelegate.shared?.toggleWorkspacePinInActiveMainWindow()
+                    _ = AppDelegate.shared?.toggleWorkspacePinInActiveMainWindow(
+                        preferredWindow: NSApp.keyWindow
+                    )
                 }
+                .disabled(isNonMainWindowFocused)
 
                 Divider()
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1653,6 +1653,125 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(observedWorkspaceWindow?.windowNumber, window.windowNumber)
     }
 
+    func testCmdOptionPTogglesWorkspacePinForEventWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId),
+              let firstWorkspace = firstManager.selectedWorkspace,
+              let secondWorkspace = secondManager.selectedWorkspace else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+
+        XCTAssertFalse(firstWorkspace.isPinned)
+        XCTAssertFalse(secondWorkspace.isPinned)
+
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        guard let event = makeKeyDownEvent(
+            key: "p",
+            modifiers: [.command, .option],
+            keyCode: 35, // kVK_ANSI_P
+            windowNumber: secondWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Option+P event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertFalse(firstWorkspace.isPinned)
+        XCTAssertTrue(secondWorkspace.isPinned)
+    }
+
+    func testCmdOptionPDoesNotToggleWorkspacePinFromSettingsWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+        appDelegate.tabManager = manager
+
+        let settingsWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        settingsWindow.identifier = NSUserInterfaceItemIdentifier("cmux.settings")
+        XCTAssertFalse(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: settingsWindow))
+
+        XCTAssertFalse(workspace.isPinned)
+    }
+
+    func testToggleWorkspacePinFallsBackToMainWindowWhenKeyWindowIsAuxiliary() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let window = window(withId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let settingsWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        settingsWindow.identifier = NSUserInterfaceItemIdentifier("cmux.settings")
+        settingsWindow.makeKeyAndOrderFront(nil)
+        defer {
+            settingsWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow())
+        XCTAssertTrue(workspace.isPinned)
+    }
+
     func testEscapeDismissesVisibleCommandPaletteAndIsConsumed() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WebKit
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -1931,9 +1932,68 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTFail("debugInjectWindowContextKeyMismatch is only available in DEBUG")
 #endif
 
-        XCTAssertTrue(appDelegate.isMainTerminalWindowForCommands(window))
+        XCTAssertTrue(appDelegate.canPinWorkspace(from: window))
         XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: window))
         XCTAssertTrue(workspace.isPinned)
+    }
+
+    func testToggleWorkspacePinUsesPopupOpenerWorkspaceContext() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let firstWindow = window(withId: firstWindowId),
+              let firstWorkspace = firstManager.selectedWorkspace,
+              let secondWorkspace = secondManager.selectedWorkspace else {
+            XCTFail("Expected both main window workspaces")
+            return
+        }
+
+        let alternateWorkspace = firstManager.addWorkspace()
+        firstManager.selectWorkspace(firstWorkspace)
+        XCTAssertFalse(firstWorkspace.isPinned)
+        XCTAssertFalse(alternateWorkspace.isPinned)
+        XCTAssertFalse(secondWorkspace.isPinned)
+        firstWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let openerPanel = BrowserPanel(workspaceId: firstWorkspace.id)
+        let popupController = BrowserPopupWindowController(
+            configuration: WKWebViewConfiguration(),
+            windowFeatures: WKWindowFeatures(),
+            openerPanel: openerPanel
+        )
+        guard let popupWindow = popupController.webView.window else {
+            XCTFail("Expected popup window")
+            return
+        }
+        popupWindow.makeKeyAndOrderFront(nil)
+        defer {
+            popupController.closePopup()
+            openerPanel.close()
+            popupWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        firstManager.selectWorkspace(alternateWorkspace)
+        appDelegate.tabManager = secondManager
+        XCTAssertTrue(appDelegate.tabManager === secondManager)
+        XCTAssertTrue(appDelegate.workspaceForWorkspacePin(from: popupWindow) === firstWorkspace)
+        XCTAssertTrue(appDelegate.canPinWorkspace(from: popupWindow))
+        XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: popupWindow))
+        XCTAssertTrue(firstWorkspace.isPinned)
+        XCTAssertFalse(alternateWorkspace.isPinned)
+        XCTAssertFalse(secondWorkspace.isPinned)
     }
 
     func testEscapeDismissesVisibleCommandPaletteAndIsConsumed() {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2052,8 +2052,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         firstManager.selectWorkspace(alternateWorkspace)
         appDelegate.tabManager = secondManager
         XCTAssertTrue(appDelegate.tabManager === secondManager)
-        XCTAssertNil(appDelegate.workspaceForWorkspacePin(from: popupWindow))
         XCTAssertFalse(appDelegate.canPinWorkspace(from: popupWindow))
+        XCTAssertTrue(appDelegate.canPinWorkspace(from: popupWindow, includingPopups: true))
         XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: popupWindow))
         XCTAssertTrue(firstWorkspace.isPinned)
         XCTAssertFalse(alternateWorkspace.isPinned)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2052,8 +2052,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         firstManager.selectWorkspace(alternateWorkspace)
         appDelegate.tabManager = secondManager
         XCTAssertTrue(appDelegate.tabManager === secondManager)
-        XCTAssertTrue(appDelegate.workspaceForWorkspacePin(from: popupWindow) === firstWorkspace)
-        XCTAssertTrue(appDelegate.canPinWorkspace(from: popupWindow))
+        XCTAssertNil(appDelegate.workspaceForWorkspacePin(from: popupWindow))
+        XCTAssertFalse(appDelegate.canPinWorkspace(from: popupWindow))
         XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: popupWindow))
         XCTAssertTrue(firstWorkspace.isPinned)
         XCTAssertFalse(alternateWorkspace.isPinned)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1755,6 +1755,65 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(workspace.isPinned)
     }
 
+    func testCmdOptionPUsesPopupWindowNumberWhenEventWindowIsNil() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let window = window(withId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+        let openerPanel = BrowserPanel(workspaceId: workspace.id)
+        let popupController = BrowserPopupWindowController(
+            configuration: WKWebViewConfiguration(),
+            windowFeatures: WKWindowFeatures(),
+            openerPanel: openerPanel
+        )
+        guard let popupWindow = popupController.webView.window else {
+            XCTFail("Expected popup window")
+            return
+        }
+        popupWindow.makeKeyAndOrderFront(nil)
+        defer {
+            popupController.closePopup()
+            openerPanel.close()
+            popupWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "p",
+            modifiers: [.command, .option],
+            keyCode: 35, // kVK_ANSI_P
+            windowNumber: popupWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Option+P event for popup window")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertTrue(workspace.isPinned)
+    }
+
     func testToggleWorkspacePinFallsBackToMainWindowWhenKeyWindowIsAuxiliary() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -1783,6 +1842,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        settingsWindow.isReleasedWhenClosed = false
         settingsWindow.identifier = NSUserInterfaceItemIdentifier("cmux.settings")
         settingsWindow.makeKeyAndOrderFront(nil)
         defer {
@@ -1897,6 +1957,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        auxiliaryWindow.isReleasedWhenClosed = false
+        defer {
+            auxiliaryWindow.orderOut(nil)
+        }
 
         XCTAssertTrue(
             appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: auxiliaryWindow)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1793,6 +1793,149 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertTrue(workspace.isPinned)
     }
 
+    func testToggleWorkspacePinRejectsSettingsPreferredWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+
+        let settingsWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        settingsWindow.isReleasedWhenClosed = false
+        settingsWindow.identifier = NSUserInterfaceItemIdentifier("cmux.settings")
+        settingsWindow.makeKeyAndOrderFront(nil)
+        defer {
+            settingsWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertFalse(
+            appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: settingsWindow)
+        )
+        XCTAssertFalse(workspace.isPinned)
+    }
+
+    func testToggleWorkspacePinRejectsCmuxAuxiliaryPreferredWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+
+        let auxiliaryWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        auxiliaryWindow.isReleasedWhenClosed = false
+        auxiliaryWindow.identifier = NSUserInterfaceItemIdentifier("cmux.about")
+        auxiliaryWindow.makeKeyAndOrderFront(nil)
+        defer {
+            auxiliaryWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertFalse(
+            appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: auxiliaryWindow)
+        )
+        XCTAssertFalse(workspace.isPinned)
+    }
+
+    func testToggleWorkspacePinFallsBackToMainWindowWhenPreferredWindowIsAuxiliary() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+
+        let auxiliaryWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        XCTAssertTrue(
+            appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: auxiliaryWindow)
+        )
+        XCTAssertTrue(workspace.isPinned)
+    }
+
+    func testToggleWorkspacePinUsesResolvedMainWindowContextWhenObjectKeyLookupMisses() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let window = window(withId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected main window workspace")
+            return
+        }
+
+        XCTAssertFalse(workspace.isPinned)
+        window.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugInjectWindowContextKeyMismatch(windowId: windowId))
+#else
+        XCTFail("debugInjectWindowContextKeyMismatch is only available in DEBUG")
+#endif
+
+        XCTAssertTrue(appDelegate.isMainTerminalWindowForCommands(window))
+        XCTAssertTrue(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: window))
+        XCTAssertTrue(workspace.isPinned)
+    }
+
     func testEscapeDismissesVisibleCommandPaletteAndIsConsumed() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1727,8 +1727,29 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        settingsWindow.isReleasedWhenClosed = false
         settingsWindow.identifier = NSUserInterfaceItemIdentifier("cmux.settings")
-        XCTAssertFalse(appDelegate.toggleWorkspacePinInActiveMainWindow(preferredWindow: settingsWindow))
+        settingsWindow.makeKeyAndOrderFront(nil)
+        defer {
+            settingsWindow.orderOut(nil)
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = makeKeyDownEvent(
+            key: "p",
+            modifiers: [.command, .option],
+            keyCode: 35, // kVK_ANSI_P
+            windowNumber: settingsWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Option+P event for settings window")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
 
         XCTAssertFalse(workspace.isPinned)
     }

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1689,7 +1689,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
 
     func testToggleWorkspacePinShortcutConvertsToMenuShortcut() {
         let shortcut = KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultShortcut
-        XCTAssertNotNil(shortcut.keyEquivalent)
+        XCTAssertEqual(shortcut.menuItemKeyEquivalent, "p")
         XCTAssertTrue(shortcut.eventModifiers.contains(.command))
         XCTAssertFalse(shortcut.eventModifiers.contains(.shift))
         XCTAssertTrue(shortcut.eventModifiers.contains(.option))

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1675,6 +1675,27 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         XCTAssertFalse(shortcut.eventModifiers.contains(.control))
     }
 
+    func testToggleWorkspacePinShortcutDefaultsAndMetadata() {
+        XCTAssertEqual(KeyboardShortcutSettings.Action.toggleWorkspacePin.label, "Pin Workspace")
+        XCTAssertEqual(KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultsKey, "shortcut.toggleWorkspacePin")
+
+        let shortcut = KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultShortcut
+        XCTAssertEqual(shortcut.key, "p")
+        XCTAssertTrue(shortcut.command)
+        XCTAssertFalse(shortcut.shift)
+        XCTAssertTrue(shortcut.option)
+        XCTAssertFalse(shortcut.control)
+    }
+
+    func testToggleWorkspacePinShortcutConvertsToMenuShortcut() {
+        let shortcut = KeyboardShortcutSettings.Action.toggleWorkspacePin.defaultShortcut
+        XCTAssertNotNil(shortcut.keyEquivalent)
+        XCTAssertTrue(shortcut.eventModifiers.contains(.command))
+        XCTAssertFalse(shortcut.eventModifiers.contains(.shift))
+        XCTAssertTrue(shortcut.eventModifiers.contains(.option))
+        XCTAssertFalse(shortcut.eventModifiers.contains(.control))
+    }
+
     func testCloseWorkspaceShortcutDefaultsAndMetadata() {
         XCTAssertEqual(KeyboardShortcutSettings.Action.closeWorkspace.label, "Close Workspace")
         XCTAssertEqual(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey, "shortcut.closeWorkspace")


### PR DESCRIPTION
## Summary

- add a customizable Cmd+Option+P shortcut to pin or unpin the selected workspace
- show the shortcut in the README, command palette hinting, and menu wiring
- route the shortcut through the event window first so it does not mutate a background workspace while Settings is focused
- add focused regression coverage for event-window routing and the settings-window guard

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a customizable Cmd+Option+P shortcut to pin or unpin the current workspace. Wired into the View menu, command palette, and README, with event‑window routing so popup shortcuts target their opener, ignore Settings/auxiliary windows, and fall back to the active main window; popup context is only considered when performing the action.

- **Bug Fixes**
  - Route popup shortcuts by their event window to the opener workspace; reject visible non‑main windows and fall back cleanly to the active main window.
  - Keep popup-aware context resolution limited to the action (menus/hints use the main window). Show Pin/Unpin dynamically and disable when a non‑main window is focused.

- **Refactors**
  - Centralized pin-target resolution (`canPinWorkspace(...)`, `toggleWorkspacePinInActiveMainWindow(...)`) and window selection; removed a redundant capability recheck.
  - Reused `TabManager.togglePin(tabId:)` across the app and command palette to simplify pin/unpin behavior.

<sup>Written for commit bc1a6894f92afc143c24083bef156cc9f53147cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (⌥ ⌘ P) to pin or unpin the active workspace.
  * Added a dynamic Workspace menu item that shows "Pin Workspace" or "Unpin Workspace" and invokes the shortcut.
  * Command Palette now supports the Pin Workspace command and the shortcut is persisted and customizable.

* **Bug Fixes / Improvements**
  * Improved shortcut routing to handle various window contexts when toggling pin state.

* **Tests**
  * Expanded tests covering shortcut defaults, routing, and pin/unpin behavior across window edge cases.

* **Documentation**
  * Updated Workspaces shortcuts table (README) with the new shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
