### PR TITLE
Reclaim sidebar tab title space with dynamic trailing slot width

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10020,7 +10020,7 @@ enum SidebarPathFormatter {
 
 enum SidebarWorkspaceShortcutHintMetrics {
     private static let measurementFont = NSFont.systemFont(ofSize: 10, weight: .semibold)
-    private static let minimumSlotWidth: CGFloat = 28
+    private static let minimumSlotWidth: CGFloat = 16
     private static let horizontalPadding: CGFloat = 12
     private static let lock = NSLock()
     private static var cachedHintWidths: [String: CGFloat] = [:]
@@ -10221,10 +10221,16 @@ private struct TabItemView: View, Equatable {
     }
 
     private var workspaceHintSlotWidth: CGFloat {
-        SidebarWorkspaceShortcutHintMetrics.slotWidth(
-            label: workspaceShortcutLabel,
-            debugXOffset: sidebarShortcutHintXOffset
-        )
+        if showsWorkspaceShortcutHint {
+            return SidebarWorkspaceShortcutHintMetrics.slotWidth(
+                label: workspaceShortcutLabel,
+                debugXOffset: sidebarShortcutHintXOffset
+            )
+        } else if showCloseButton {
+            return 16
+        } else {
+            return 0
+        }
     }
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {
@@ -10285,7 +10291,7 @@ private struct TabItemView: View, Equatable {
         }()
 
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
+            HStack(spacing: 4) {
                 if unreadCount > 0 {
                     ZStack {
                         Circle()
@@ -10308,8 +10314,7 @@ private struct TabItemView: View, Equatable {
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
-
-                Spacer()
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 ZStack(alignment: .trailing) {
                     Button(action: {
@@ -10345,8 +10350,8 @@ private struct TabItemView: View, Equatable {
                             .transition(.opacity)
                     }
                 }
-                .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
                 .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
+                .animation(.easeInOut(duration: 0.14), value: workspaceHintSlotWidth)
             }
 
             if let subtitle = latestNotificationSubtitle {
@@ -10513,7 +10518,7 @@ private struct TabItemView: View, Equatable {
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
-        .padding(.horizontal, 10)
+        .padding(.horizontal, 8)
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 6)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10069,6 +10069,22 @@ enum SidebarWorkspaceShortcutHintMetrics {
         return count
     }
     #endif
+
+    static func resolvedSlotWidth(
+        showsHint: Bool,
+        showsCloseButton: Bool,
+        hintLabel: String?,
+        debugXOffset: Double,
+        closeButtonSize: CGFloat
+    ) -> CGFloat {
+        if showsHint {
+            return slotWidth(label: hintLabel, debugXOffset: debugXOffset)
+        } else if showsCloseButton {
+            return closeButtonSize
+        } else {
+            return 0
+        }
+    }
 }
 
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
@@ -10223,16 +10239,13 @@ private struct TabItemView: View, Equatable {
     }
 
     private var workspaceHintSlotWidth: CGFloat {
-        if showsWorkspaceShortcutHint {
-            return SidebarWorkspaceShortcutHintMetrics.slotWidth(
-                label: workspaceShortcutLabel,
-                debugXOffset: sidebarShortcutHintXOffset
-            )
-        } else if showCloseButton {
-            return Self.closeButtonSize
-        } else {
-            return 0
-        }
+        SidebarWorkspaceShortcutHintMetrics.resolvedSlotWidth(
+            showsHint: showsWorkspaceShortcutHint,
+            showsCloseButton: showCloseButton,
+            hintLabel: workspaceShortcutLabel,
+            debugXOffset: sidebarShortcutHintXOffset,
+            closeButtonSize: Self.closeButtonSize
+        )
     }
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10148,6 +10148,8 @@ private struct TabItemView: View, Equatable {
         SidebarActiveTabIndicatorSettings.resolvedStyle(rawValue: activeTabIndicatorStyleRaw)
     }
 
+    private static let closeButtonSize: CGFloat = 16
+
     private var titleFontWeight: Font.Weight {
         .semibold
     }
@@ -10227,7 +10229,7 @@ private struct TabItemView: View, Equatable {
                 debugXOffset: sidebarShortcutHintXOffset
             )
         } else if showCloseButton {
-            return 16
+            return Self.closeButtonSize
         } else {
             return 0
         }
@@ -10329,7 +10331,7 @@ private struct TabItemView: View, Equatable {
                     }
                     .buttonStyle(.plain)
                     .safeHelp(KeyboardShortcutSettings.Action.closeWorkspace.tooltip(closeWorkspaceTooltip))
-                    .frame(width: 16, height: 16, alignment: .center)
+                    .frame(width: Self.closeButtonSize, height: Self.closeButtonSize, alignment: .center)
                     .opacity(showCloseButton && !showsWorkspaceShortcutHint ? 1 : 0)
                     .allowsHitTesting(showCloseButton && !showsWorkspaceShortcutHint)
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10365,7 +10365,7 @@ private struct TabItemView: View, Equatable {
                             .transition(.opacity)
                     }
                 }
-                .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
+                .frame(width: workspaceHintSlotWidth, height: Self.closeButtonSize, alignment: .trailing)
                 .animation(.easeInOut(duration: 0.14), value: workspaceHintSlotWidth)
             }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -11846,7 +11846,7 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
 
     func testSlotWidthAppliesMinimumAndDebugInset() {
         let nilLabelWidth = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: nil, debugXOffset: 999)
-        XCTAssertEqual(nilLabelWidth, 28)
+        XCTAssertEqual(nilLabelWidth, 16)
 
         let base = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
         let widened = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 10)

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -11852,6 +11852,53 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
         let widened = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 10)
         XCTAssertGreaterThan(widened, base)
     }
+
+    func testResolvedSlotWidthReturnsZeroWhenNothingVisible() {
+        let width = SidebarWorkspaceShortcutHintMetrics.resolvedSlotWidth(
+            showsHint: false,
+            showsCloseButton: false,
+            hintLabel: "⌘1",
+            debugXOffset: 0,
+            closeButtonSize: 16
+        )
+        XCTAssertEqual(width, 0)
+    }
+
+    func testResolvedSlotWidthReturnsCloseButtonSizeOnHover() {
+        let width = SidebarWorkspaceShortcutHintMetrics.resolvedSlotWidth(
+            showsHint: false,
+            showsCloseButton: true,
+            hintLabel: "⌘1",
+            debugXOffset: 0,
+            closeButtonSize: 16
+        )
+        XCTAssertEqual(width, 16)
+    }
+
+    func testResolvedSlotWidthReturnsHintWidthWhenHintVisible() {
+        let width = SidebarWorkspaceShortcutHintMetrics.resolvedSlotWidth(
+            showsHint: true,
+            showsCloseButton: false,
+            hintLabel: "⌘1",
+            debugXOffset: 0,
+            closeButtonSize: 16
+        )
+        let expectedHintWidth = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
+        XCTAssertEqual(width, expectedHintWidth)
+        XCTAssertGreaterThan(width, 16)
+    }
+
+    func testResolvedSlotWidthHintTakesPrecedenceOverCloseButton() {
+        let width = SidebarWorkspaceShortcutHintMetrics.resolvedSlotWidth(
+            showsHint: true,
+            showsCloseButton: true,
+            hintLabel: "⌘1",
+            debugXOffset: 0,
+            closeButtonSize: 16
+        )
+        let expectedHintWidth = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
+        XCTAssertEqual(width, expectedHintWidth)
+    }
 }
 #endif
 


### PR DESCRIPTION
> **Note:** This is a stylistic change that I think improves the sidebar tab readability, but it's entirely up to the maintainers whether to move forward with it. Happy to adjust or close if this doesn't align with the design direction.

<img width="272" height="144" alt="Screenshot 2026-03-16 at 2 11 56 PM" src="https://github.com/user-attachments/assets/8fe8bf84-76b0-494d-a2da-391074041868" />
<img width="272" height="144" alt="Screenshot 2026-03-16 at 2 12 13 PM" src="https://github.com/user-attachments/assets/7a500a20-1f4c-4785-b3c5-91cd28b56552" />



## Summary
- Make the trailing hint/close-button slot fully dynamic: **0pt normally**,
  **16pt on hover** (close button), and **full hint width only when the user
  holds Cmd** (or has "Always Show Shortcut Hints" enabled)
- Previously the slot permanently reserved ~34pt for the keyboard shortcut
  hint pill even when invisible, causing titles to truncate early
- Remove `Spacer` child from the title HStack; replace with
  `.frame(maxWidth: .infinity)` on the title Text (eliminates an 8pt
  spacing gap)
- Reduce HStack spacing 8→4pt and inner horizontal padding 10→8pt
- Animate on `workspaceHintSlotWidth` value directly — when the user
  holds Cmd for 300ms, the trailing slot smoothly expands to show the
  hint pill (e.g. ⌘1), the title shortens with an animated transition,
  and both reverse smoothly on release
- Reduce `minimumSlotWidth` 28→16pt (close-button size floor)

Total space reclaimed for the title: ~58pt at default sidebar width.

### Before / After

| State | Trailing slot | Title overhead |
|-------|-------------|----------------|
| **Before** (always) | ~34pt | ~82pt |
| **After** normal | 0pt | ~24pt |
| **After** hover | 16pt | ~40pt |
| **After** Cmd held | ~34pt | ~58pt |

## Testing
- `./scripts/reload.sh --tag fix-tab-truncation`
- Verified titles show significantly more text at default 200pt sidebar
- Hold Cmd 300ms → hint pills animate in smoothly, titles shorten with transition
- Release Cmd → titles expand back, pills fade out
- Hover tab row → close button appears within 16pt animated slot
- Enable "Always Show Shortcut Hints" → pills show with full slot width
- Resize sidebar to minimum → titles truncate gracefully, no layout breaks
- Unit test updated: `testSlotWidthAppliesMinimumAndDebugInset`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclaims ~58pt of sidebar tab title space by making the trailing slot dynamic and animating it on hover/Cmd. Improves readability while keeping the close button and shortcut hints without a permanent layout cost.

- **Refactors**
  - Dynamic trailing slot: 0pt normally, 16pt on hover (close), full hint width only on Cmd/always-show.
  - Extract `resolvedSlotWidth()` in `SidebarWorkspaceShortcutHintMetrics`; `TabItemView` delegates.
  - Extract `closeButtonSize` (16pt) so slot width, ZStack height, and close button stay in sync.
  - Add unit tests for width resolution: none, hover, hint, and precedence.
  - Reduce minimum slot width 28→16; update assertion.
  - Remove Spacer; title uses `.frame(maxWidth: .infinity)`.
  - Tighten layout: HStack spacing 8→4; horizontal padding 10→8.

<sup>Written for commit e5508646ad41f1a71ad64a8e41430a6c8fa01c6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed minimum slot width regression for workspace shortcut hints (now displays smaller close-button-only slots).

* **Style**
  * Refined spacing and layout in sidebar workspace hint areas for improved visual alignment and consistent sizing.
  * Adjusted top-level padding and header spacing for tighter layout.

* **Tests**
  * Updated/added tests to validate dynamic sizing and visibility behaviors of workspace hint and close-button slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->