### PR TITLE
Add 'rc' and 'remote-control' to command passthrough

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -57,7 +57,7 @@ REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&
 
 # Pass through subcommands that don't support session/hook flags.
 case "${1:-}" in
-    mcp|config|api-key) exec "$REAL_CLAUDE" "$@" ;;
+    mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
 esac
 
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are


### PR DESCRIPTION
## Summary

- What changed? Added 'rc' and 'remote-control' as passthrough commands
- Why? The session_id injection gives an "Error: Unknown argument" when trying to run claude rc

## Testing

- How did you test this change? I updated "/Applications/cmux.app/Contents/Resources/bin/claude" locally and ran `claude remote-control` and `claude rc`
- What did you verify manually? Above

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added rc and remote-control to the wrapper’s passthrough list so these commands bypass session/hook flags. This fixes the "Error: Unknown argument" when running `claude rc` or `claude remote-control`.

<sup>Written for commit c6e894f8278e8f5e33862b0d32365fb5e9f7a7c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated handling for 'rc' and 'remote-control' subcommands to behave consistently with other pass-through commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->