### PR TITLE
fix(socket): prevent main thread starvation from report_pr/clear_pr commands

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13611,39 +13611,25 @@ class TerminalController {
         }
         let label = String(labelRaw.prefix(16))
 
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
-                return
-            }
+        // Use async dispatch to avoid blocking socket threads during expensive main thread work
+        // (e.g., SwiftUI render passes). Telemetry commands should not block.
+        DispatchQueue.main.async {
+            guard let tab = self.resolveTabForReport(args) else { return }
             let validSurfaceIds = Set(tab.panels.keys)
             tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
 
             let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
             let surfaceId: UUID
             if let panelArg {
-                if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--tab=X] [--panel=Y]"
-                    return
-                }
-                guard let parsedId = UUID(uuidString: panelArg) else {
-                    result = "ERROR: Invalid panel id '\(panelArg)'"
-                    return
-                }
+                if panelArg.isEmpty { return }
+                guard let parsedId = UUID(uuidString: panelArg) else { return }
                 surfaceId = parsedId
             } else {
-                guard let focused = tab.focusedPanelId else {
-                    result = "ERROR: Missing panel id (no focused surface)"
-                    return
-                }
+                guard let focused = tab.focusedPanelId else { return }
                 surfaceId = focused
             }
 
-            guard validSurfaceIds.contains(surfaceId) else {
-                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
-                return
-            }
+            guard validSurfaceIds.contains(surfaceId) else { return }
 
             guard Self.shouldReplacePullRequest(
                 current: tab.panelPullRequests[surfaceId],
@@ -13651,9 +13637,7 @@ class TerminalController {
                 label: label,
                 url: url,
                 status: status
-            ) else {
-                return
-            }
+            ) else { return }
 
             tab.updatePanelPullRequest(
                 panelId: surfaceId,
@@ -13663,48 +13647,33 @@ class TerminalController {
                 status: status
             )
         }
-        return result
+        return "OK"
     }
 
     private func clearPullRequest(_ args: String) -> String {
         let parsed = parseOptions(args)
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
-                return
-            }
+        // Use async dispatch to avoid blocking socket threads during expensive main thread work
+        // (e.g., SwiftUI render passes). Telemetry commands should not block.
+        DispatchQueue.main.async {
+            guard let tab = self.resolveTabForReport(args) else { return }
             let validSurfaceIds = Set(tab.panels.keys)
             tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
 
             let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
             let surfaceId: UUID
             if let panelArg {
-                if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: clear_pr [--tab=X] [--panel=Y]"
-                    return
-                }
-                guard let parsedId = UUID(uuidString: panelArg) else {
-                    result = "ERROR: Invalid panel id '\(panelArg)'"
-                    return
-                }
+                if panelArg.isEmpty { return }
+                guard let parsedId = UUID(uuidString: panelArg) else { return }
                 surfaceId = parsedId
             } else {
-                guard let focused = tab.focusedPanelId else {
-                    result = "ERROR: Missing panel id (no focused surface)"
-                    return
-                }
+                guard let focused = tab.focusedPanelId else { return }
                 surfaceId = focused
             }
 
-            guard validSurfaceIds.contains(surfaceId) else {
-                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
-                return
-            }
-
+            guard validSurfaceIds.contains(surfaceId) else { return }
             tab.clearPanelPullRequest(panelId: surfaceId)
         }
-        return result
+        return "OK"
     }
 
     private func reportPorts(_ args: String) -> String {


### PR DESCRIPTION
## Summary

Fixes #1550

Change `reportPullRequest` and `clearPullRequest` to use `DispatchQueue.main.async` instead of `DispatchQueue.main.sync`. This prevents socket handler threads from blocking when the main thread is busy with expensive SwiftUI render passes (e.g., `BrowserPanelView.body`).

## Problem

The app periodically enters "Not Responding" state due to a deadlock between:
- Main thread: stuck in SwiftUI render pass for `BrowserPanelView.body`
- Socket threads: calling `DispatchQueue.main.sync` from `reportPullRequest` and `clearPullRequest`

The socket threads can never complete because the main thread is occupied, and the main thread can't finish because the event loop is starved.

## Solution

Per the CLAUDE.md socket command threading policy: telemetry commands should not use `DispatchQueue.main.sync`. These commands are high-frequency telemetry updates that don't require synchronous confirmation.

Changed both functions to:
1. Return "OK" immediately after validation
2. Use `DispatchQueue.main.async` for the actual state update
3. Silently skip updates when tab/panel is not found (fire-and-forget semantics)

## Testing

- [ ] Socket commands `report_pr` and `clear_pr` still function correctly
- [ ] No more main thread blocking from socket threads during BrowserPanelView renders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent UI hangs by dispatching `reportPullRequest` and `clearPullRequest` updates with `DispatchQueue.main.async` instead of `DispatchQueue.main.sync`. Fixes #1550.

- **Bug Fixes**
  - `report_pr` and `clear_pr` now return "OK" immediately; state updates run async.
  - Invalid or missing tab/panel are ignored (fire-and-forget) to keep the UI responsive.
  - Matches the socket threading policy: telemetry should not use synchronous main-queue dispatch.

<sup>Written for commit aa3e3afc3a0a1cc04c594a6b57a6a1926a00cb8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized terminal command execution to prevent blocking operations, resulting in improved responsiveness when running commands and interacting with panels and surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->