### PR TITLE
fix: skip shortcut processing when external tool changes keyboard input source

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7870,11 +7870,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // reaches our local monitor. If the input source changed since the last keyDown,
         // skip shortcut processing so the layout switch takes effect instead of triggering
         // a bound cmux command.
+        //
+        // Do not update lastKeyboardInputSourceId in the skip branch: the same event
+        // can re-enter via handleBrowserSurfaceKeyEquivalent → handleCustomShortcut,
+        // and updating here would let the second pass process shortcuts normally.
+        // The baseline is only updated when we proceed with normal shortcut handling.
         let currentInputSourceId = KeyboardLayout.id
         if let previousId = lastKeyboardInputSourceId,
            let currentId = currentInputSourceId,
            previousId != currentId {
-            lastKeyboardInputSourceId = currentId
 #if DEBUG
             dlog("shortcut.inputSourceChanged previous=\(previousId) current=\(currentId) — skipping shortcut")
 #endif

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1946,6 +1946,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var windowKeyObserver: NSObjectProtocol?
     private var shortcutMonitor: Any?
     private var shortcutDefaultsObserver: NSObjectProtocol?
+    /// Tracks the keyboard input source ID at the time of the last keyDown event
+    /// processed by the shortcut monitor. When an external tool (e.g. a keyboard
+    /// layout switcher like Mr. Borat) changes the input source via a CGEvent tap
+    /// before the local monitor fires, the ID will differ and we skip shortcut
+    /// processing for that event to let the layout switch take effect.
+    private var lastKeyboardInputSourceId: String?
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var splitButtonTooltipRefreshScheduled = false
     private var ghosttyConfigObserver: NSObjectProtocol?
@@ -7628,6 +7634,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if self.clearEscapeSuppressionForKeyUp(event: event, consumeIfSuppressed: true) {
                 return nil
             }
+            // Keep input source tracking fresh on flagsChanged so the next
+            // keyDown can detect if an external tool changed the layout.
+            // Many layout switchers fire on modifier-only sequences (e.g.
+            // Caps Lock, double-press Shift) which only produce flagsChanged
+            // events. Only refresh when all modifiers are released to avoid
+            // unnecessary TIS calls on every Cmd/Shift press during normal use.
+            if event.type == .flagsChanged {
+                let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                    .subtracting([.numericPad, .function, .capsLock])
+                if modifiers.isEmpty {
+                    self.lastKeyboardInputSourceId = KeyboardLayout.id
+                }
+            }
             return event
         }
     }
@@ -7846,6 +7865,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func handleCustomShortcut(event: NSEvent) -> Bool {
+        // Detect external keyboard layout switches (e.g. Mr. Borat, Input Source Pro).
+        // These tools change the macOS input source via CGEvent taps before the event
+        // reaches our local monitor. If the input source changed since the last keyDown,
+        // skip shortcut processing so the layout switch takes effect instead of triggering
+        // a bound cmux command.
+        let currentInputSourceId = KeyboardLayout.id
+        if let previousId = lastKeyboardInputSourceId,
+           let currentId = currentInputSourceId,
+           previousId != currentId {
+            lastKeyboardInputSourceId = currentId
+#if DEBUG
+            dlog("shortcut.inputSourceChanged previous=\(previousId) current=\(currentId) — skipping shortcut")
+#endif
+            return false
+        }
+        lastKeyboardInputSourceId = currentInputSourceId
+
         // `charactersIgnoringModifiers` can be nil for some synthetic NSEvents and certain special keys.
         // Treat nil as "" and rely on keyCode/layout-aware fallback logic where needed.
         let chars = (event.charactersIgnoringModifiers ?? "").lowercased()


### PR DESCRIPTION
## Problem

When using external keyboard layout switching tools (e.g. [Mr. Borat](https://apps.apple.com/app/id6741402869), [Input Source Pro](https://inputsource.pro), Caramba Switcher), pressing the tool's hotkey while cmux is focused triggers a cmux shortcut instead of switching the keyboard layout.

These tools work by installing a CGEvent tap that intercepts the key event and changes the macOS input source before the event reaches the application. However, cmux's local shortcut monitor (`NSEvent.addLocalMonitorForEvents`) still receives the original key event and matches it against the shortcut table, consuming it before the layout switch can take effect.

**Steps to reproduce:**
1. Install a keyboard layout switching tool (e.g. Mr. Borat)
2. Bind a hotkey in the tool (e.g. Cmd+Space, Ctrl+Shift, etc.)
3. Focus a cmux terminal window
4. Press the hotkey — cmux fires a bound shortcut instead of switching layouts

## Solution

Track the keyboard input source ID between events using `KeyboardLayout.id` (which calls `TISCopyCurrentKeyboardInputSource`). At the start of `handleCustomShortcut`, compare the current input source against the last known value. If they differ, an external tool changed the layout — skip shortcut processing and let the event pass through.

Additionally, refresh the tracked ID on `flagsChanged` events when all modifiers are released, so layout switches triggered by modifier-only sequences (Caps Lock, double-Shift, etc.) are correctly detected on the next keyDown.

### Why this approach

This follows the same pattern already used in `GhosttyTerminalView.keyDown` (around line 4956) for IME composition detection, where a `KeyboardLayout.id` change between before/after `interpretKeyEvents` causes the event to be absorbed rather than forwarded to Ghostty. The approach is proven in the codebase and has no typing latency impact — `TISCopyCurrentKeyboardInputSource` is already called multiple times per shortcut evaluation via `KeyboardLayout.character(forKeyCode:)`.

### Typing latency

The fix adds one `TISCopyCurrentKeyboardInputSource` call at the top of `handleCustomShortcut`. This function is already called multiple times deeper in the shortcut matching path (via `KeyboardLayout.character(forKeyCode:modifierFlags:)` in `matchShortcut`), so the additional call has negligible impact. The `flagsChanged` tracking only fires when all modifiers are released (not on every modifier press/release), avoiding unnecessary TIS calls during normal Cmd+key shortcuts.

### Edge cases considered

- **First keyDown after manual layout switch** (e.g. via macOS globe key): The shortcut is skipped once, then the tracked ID updates and subsequent shortcuts work normally. This matches the existing IME detection behavior in GhosttyTerminalView.
- **`KeyboardLayout.id` returns nil**: Both the previous and current values must be non-nil for the comparison to trigger, so nil results are safely ignored.
- **Layout switchers using modifier-only sequences**: The `flagsChanged` handler refreshes the tracked ID when modifiers return to empty, catching Caps Lock toggles and double-Shift patterns.

## Changes

Single file change: `Sources/AppDelegate.swift` (+36 lines)

1. **New property** `lastKeyboardInputSourceId: String?` — tracks the input source ID between events
2. **Guard in `handleCustomShortcut`** — compares current vs tracked ID, skips shortcuts on mismatch
3. **`flagsChanged` handler** — refreshes tracked ID when all modifiers are released
4. **Debug logging** — `shortcut.inputSourceChanged` entry in debug builds for diagnostics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip shortcut handling when the keyboard input source changes (e.g., via external switchers) so layout switches work while cmux is focused. Prevents accidental shortcut firing on hotkeys and modifier-only sequences.

- **Bug Fixes**
  - Track and compare `KeyboardLayout.id` in `handleCustomShortcut` via `lastKeyboardInputSourceId`; skip shortcuts on change and log a debug line.
  - On `.flagsChanged`, when all modifiers are cleared, refresh the tracked ID to catch Caps Lock/double-Shift switchers.
  - Do not update `lastKeyboardInputSourceId` in the skip path to prevent re-entry bypass via `handleBrowserSurfaceKeyEquivalent` → `handleCustomShortcut`.

<sup>Written for commit 1279b68ab275d7d420f9110e1ba27c46d33b10d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

Fixes #1557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unintended keyboard shortcuts from firing when the system keyboard/input source or layout changes (e.g., when switching to an external tool or different layout), improving reliability of shortcut handling and reducing accidental actions during layout switches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->