### PR TITLE
fix: avoid main thread starvation from synchronous socket telemetry commands

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13687,17 +13687,27 @@ class TerminalController {
         reportArgs: String,
         options: [String: String]
     ) -> (tabId: UUID?, error: String?) {
-        var tabId: UUID?
+        // Off-main fast-path: honor explicit --tab UUID without touching the main thread.
+        // High-frequency agent/shell flows typically provide explicit IDs.
+        if let rawTab = options["tab"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawTab.isEmpty {
+            guard let explicitId = UUID(uuidString: rawTab) else {
+                return (nil, "ERROR: Invalid tab id '\(rawTab)'")
+            }
+            return (explicitId, nil)
+        }
+
+        // Fallback: resolve the currently-selected tab on main as a short, bounded hop.
+        var selectedId: UUID?
         DispatchQueue.main.sync {
             if let tab = resolveTabForReport(reportArgs) {
-                tabId = tab.id
+                selectedId = tab.id
             }
         }
-        if let tabId {
-            return (tabId, nil)
+        if let selectedId {
+            return (selectedId, nil)
         }
-        let error = options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
-        return (nil, error)
+        return (nil, "ERROR: No tab selected")
     }
 
     private func tabForSidebarMutation(id: UUID) -> Tab? {
@@ -14356,46 +14366,21 @@ class TerminalController {
             }
             ports.append(port)
         }
+        let normalizedPorts = Array(Set(ports)).sorted()
 
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+        // Use the shared helper to parse/resolve off-main and schedule mutation async,
+        // avoiding main thread starvation from synchronous socket telemetry (see #1550).
+        return schedulePanelMetadataMutation(
+            args: args,
+            options: parsed.options,
+            missingPanelUsage: "report_ports <port1> [port2...] [--tab=X] [--panel=Y]"
+        ) { tab, surfaceId in
+            guard Self.shouldReplacePorts(current: tab.surfaceListeningPorts[surfaceId], next: normalizedPorts) else {
                 return
             }
-
-            let validSurfaceIds = Set(tab.panels.keys)
-            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
-
-            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
-            let surfaceId: UUID
-            if let panelArg {
-                if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_ports <port1> [port2...] [--tab=X] [--panel=Y]"
-                    return
-                }
-                guard let parsedId = UUID(uuidString: panelArg) else {
-                    result = "ERROR: Invalid panel id '\(panelArg)'"
-                    return
-                }
-                surfaceId = parsedId
-            } else {
-                guard let focused = tab.focusedPanelId else {
-                    result = "ERROR: Missing panel id (no focused surface)"
-                    return
-                }
-                surfaceId = focused
-            }
-
-            guard validSurfaceIds.contains(surfaceId) else {
-                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
-                return
-            }
-
-            tab.surfaceListeningPorts[surfaceId] = ports
+            tab.surfaceListeningPorts[surfaceId] = normalizedPorts
             tab.recomputeListeningPorts()
         }
-        return result
     }
 
     private func reportPwd(_ args: String) -> String {


### PR DESCRIPTION
## Summary

- Convert `reportPullRequest`, `clearPullRequest`, `reportPorts`, and `clearSidebarMetadata` from `DispatchQueue.main.sync` to `main.async`, matching the pattern already used by `upsertSidebarMetadata` (`reportMeta`)
- Parse and validate arguments off-main, resolve tab ID via `resolveTabIdForSidebarMutation` (short sync), then schedule model mutation with `main.async` and return `"OK"` immediately
- Eliminates the deadlock described in #1550 where 8-10 socket threads calling `main.sync` block indefinitely while the main thread is stuck in a SwiftUI render pass (especially `BrowserPanelView.body`)

## Root Cause

`reportPullRequest` and `clearPullRequest` (and `reportPorts`, `clearSidebarMetadata`) used `DispatchQueue.main.sync` for their entire body — tab resolution + validation + mutation — all in one synchronous block. When external tools like Claude Code fire these commands rapidly on multiple socket threads, and the main thread is occupied by a SwiftUI render, all socket threads convoy-block, starving the event loop and causing "Not Responding" hangs.

`reportMeta` (via `upsertSidebarMetadata`) was already fixed to use `main.async`. This PR applies the same pattern to the remaining telemetry commands.

## Behavioral Change

These commands now return `"OK"` optimistically instead of reporting tab/panel resolution errors synchronously. This is acceptable because they are fire-and-forget telemetry — callers do not retry on error, and the panel/tab validation still happens in the async block (silently dropping invalid mutations).

Fixes #1550

## Test plan

- [ ] Open cmux with a browser panel and active Claude Code integration
- [ ] Verify sidebar PR badges still appear after `report_pr` commands
- [ ] Verify `clear_pr` still clears badges
- [ ] Verify `report_ports` still updates port indicators
- [ ] Verify `clear_status` / `clear_meta` still work
- [ ] Confirm the app no longer enters "Not Responding" state during heavy SwiftUI rendering + socket traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make socket telemetry updates async and add a fast-path for tab resolution to prevent main-thread starvation and “Not Responding” hangs during heavy SwiftUI renders. Fixes #1550.

- **Bug Fixes**
  - Switched `reportPullRequest`, `clearPullRequest`, `reportPorts`, and `clearSidebarMetadata` to `main.async` via `schedulePanelMetadataMutation`; commands return "OK" immediately instead of blocking.
  - Added off-main fast-path in `resolveTabIdForSidebarMutation` for explicit `--tab` UUIDs; fallback is a short main-thread hop when no tab is provided.
  - `reportPorts` now dedupes and sorts port lists and uses `shouldReplacePorts` to coalesce updates and reduce redundant model work.

<sup>Written for commit d9e5ac215cb1e2b9f39556cf2ad82273634c686f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for tab/panel identifiers to avoid processing invalid commands.
  * Preserved clear error responses when no or invalid tab/panel is selected.

* **Refactor**
  * Reduced main-thread blocking for command and socket handling by deferring state mutations asynchronously, improving terminal responsiveness and throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->