### PR TITLE
Add IntelliJ IDEA to command palette Open Directory targets

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7282,13 +7282,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Loading\u2026"
+            "value": "Loading…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\u8aad\u307f\u8fbc\u307f\u4e2d\u2026"
+            "value": "読み込み中…"
           }
         }
       }
@@ -75063,6 +75063,119 @@
           "stringUnit": {
             "state": "translated",
             "value": "Varsayılan"
+          }
+        }
+      }
+    },
+    "menu.openInIntelliJ": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Current Directory in IntelliJ IDEA"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のディレクトリを IntelliJ IDEA で開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 IntelliJ IDEA 中打开当前目录"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 IntelliJ IDEA 中開啟目前目錄"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 디렉토리를 IntelliJ IDEA에서 열기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuelles Verzeichnis in IntelliJ IDEA öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir directorio actual en IntelliJ IDEA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le répertoire courant dans IntelliJ IDEA"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri la directory corrente in IntelliJ IDEA"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn nuværende mappe i IntelliJ IDEA"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz bieżący katalog w IntelliJ IDEA"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть текущий каталог в IntelliJ IDEA"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori trenutni direktorij u IntelliJ IDEA"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الدليل الحالي في IntelliJ IDEA"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne gjeldende katalog i IntelliJ IDEA"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Diretório Atual no IntelliJ IDEA"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดไดเรกทอรีปัจจุบันใน IntelliJ IDEA"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçerli Dizini IntelliJ IDEA'da Aç"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -403,6 +403,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case cursor
     case finder
     case ghostty
+    case intellij
     case iterm2
     case terminal
     case tower
@@ -451,6 +452,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return String(localized: "menu.openInFinder", defaultValue: "Open Current Directory in Finder")
         case .ghostty:
             return String(localized: "menu.openInGhostty", defaultValue: "Open Current Directory in Ghostty")
+        case .intellij:
+            return String(localized: "menu.openInIntelliJ", defaultValue: "Open Current Directory in IntelliJ IDEA")
         case .iterm2:
             return String(localized: "menu.openInITerm2", defaultValue: "Open Current Directory in iTerm2")
         case .terminal:
@@ -485,6 +488,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["finder", "file", "manager", "reveal"]
         case .ghostty:
             return common + ["ghostty", "terminal", "shell"]
+        case .intellij:
+            return common + ["intellij", "idea", "jetbrains"]
         case .iterm2:
             return common + ["iterm", "iterm2", "terminal", "shell"]
         case .terminal:
@@ -559,6 +564,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return ["/System/Library/CoreServices/Finder.app"]
         case .ghostty:
             return ["/Applications/Ghostty.app"]
+        case .intellij:
+            return ["/Applications/IntelliJ IDEA.app"]
         case .iterm2:
             return [
                 "/Applications/iTerm.app",

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -7567,6 +7567,11 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertTrue(TerminalDirectoryOpenTarget.tower.isAvailable(in: env))
     }
 
+    func testIntelliJDetected() {
+        let env = environment(existingPaths: ["/Applications/IntelliJ IDEA.app"])
+        XCTAssertTrue(TerminalDirectoryOpenTarget.intellij.isAvailable(in: env))
+    }
+
     func testCommandPaletteShortcutsExcludeGenericIDEEntry() {
         let targets = TerminalDirectoryOpenTarget.commandPaletteShortcutTargets
         XCTAssertFalse(targets.contains(where: { $0.commandPaletteTitle == "Open Current Directory in IDE" }))


### PR DESCRIPTION
## Summary

  - Adds IntelliJ IDEA as an "Open Directory" target in the command palette
  - Follows the same pattern as #627 (Tower)
  - Detects `/Applications/IntelliJ IDEA.app` with `~/Applications` fallback
  - Keywords: `intellij`, `idea`, `jetbrains`
  - Localized for all 18 supported languages

  ## Testing

  - Added `testIntelliJDetected()` unit test following the same pattern as
  `testTowerDetected()`
  - Verified `/Applications/IntelliJ IDEA.app` is detected via mock
  `DetectionEnvironment`

  ## Demo Video

  N/A — command palette item appears automatically when IntelliJ IDEA is installed,
   consistent with existing Open Directory targets behavior.

  ## Review Trigger (Copy/Paste as PR comment)

  \```text
  @codex review
  @coderabbitai review
  @greptile-apps review
  @cubic-dev-ai review
  \```

  ## Checklist

  - [ ] I tested the change locally
  - [x] I added or updated tests for behavior changes
  - [ ] I updated docs/changelog if needed
  - [ ] I requested bot reviews after my latest commit (copy/paste block above or
  equivalent)
  - [ ] All code review bot comments are resolved
  - [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add IntelliJ IDEA to the command palette “Open Current Directory” targets so users can open the current folder in IntelliJ with one action. The item shows up automatically when IntelliJ is installed.

- **New Features**
  - New target: IntelliJ IDEA for “Open Current Directory”.
  - Detects `/Applications/IntelliJ IDEA.app`.
  - Keywords: `intellij`, `idea`, `jetbrains`.
  - Localized label in 18 languages.
  - Unit test added: `testIntelliJDetected()`.

- **Bug Fixes**
  - Use the correct ellipsis character in “Loading…” for en and ja.

<sup>Written for commit 05179ae3b3032bdf85105954aec58e04953ae9ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening the current directory in IntelliJ IDEA via the command palette.
  * Expanded localization support for 15+ languages including Japanese, Chinese, Korean, German, Spanish, French, Italian, and others.

* **Chores**
  * Updated UI text localizations for workspace management, appearance settings, and IDE integration across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->