### PR TITLE
fix(terminal): prevent redundant focus events causing Powerlevel10k redraws

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2538,6 +2538,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private let maxPendingTextBytes = 1_048_576
     private var backgroundSurfaceStartQueued = false
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
+    /// Tracks the last focus state to avoid sending redundant focus events.
+    /// This prevents prompt redraw issues with zsh themes like Powerlevel10k.
+    private var lastFocusState: Bool = false
 #if DEBUG
     private var needsConfirmCloseOverrideForTesting: Bool?
 #endif
@@ -3291,6 +3294,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func setFocus(_ focused: Bool) {
         guard let surface = surface else { return }
+        // Only send focus events when the state changes to avoid redundant
+        // prompt redraws with zsh themes like Powerlevel10k.
+        guard focused != lastFocusState else { return }
+        lastFocusState = focused
         ghostty_surface_set_focus(surface, focused)
 
         // If we focus a surface while it is being rapidly reparented (closing splits, etc),


### PR DESCRIPTION
Fixes #1566

## Problem
When using zsh with Powerlevel10k in cmux, there was a double prompt / extra redraw issue when switching workspaces or using right-aligned elements on the prompt.

## Root Cause
The `setFocus` method in TerminalSurface unconditionally called `ghostty_surface_set_focus` even when the focus state hadn't changed. This caused focus events (CSI I/O sequences) to be sent to the terminal on every workspace switch, triggering Powerlevel10k to redraw its prompt unnecessarily.

## Solution
Add `lastFocusState` tracking to TerminalSurface to avoid sending duplicate focus events to the terminal surface.

### Changes
- Added `private var lastFocusState: Bool = false` to track focus state
- Modified `setFocus(_ focused: Bool)` to only send focus events when the state actually changes

## Testing
- Build completed successfully with `swift build`
- Diff: 7 lines added to Sources/GhosttyTerminalView.swift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent redundant focus events in TerminalSurface that triggered zsh/Powerlevel10k prompt redraws and double prompts on workspace switches. Track the last focus state and only call `ghostty_surface_set_focus` when it changes (fixes #1566).

<sup>Written for commit 7ee57c3650af15e2665494a1e14b093e66896ba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant focus state changes that caused unnecessary terminal prompt redraws with certain terminal themes (e.g., Powerlevel10k).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->