### PR TITLE
fix(browser): ensure webView is in window before DevTools restore

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3824,6 +3824,12 @@ extension BrowserPanel {
             return
         }
         guard !isDeveloperToolsTransitionInFlight else { return }
+        // Ensure webView is in a window before attempting restoration. Inspector
+        // may not be immediately available after workspace switch; retry later.
+        guard webView.window != nil else {
+            scheduleDeveloperToolsRestoreRetry()
+            return
+        }
         guard let inspector = webView.cmuxInspectorObject() else {
             scheduleDeveloperToolsRestoreRetry()
             return


### PR DESCRIPTION
## Problem

When switching workspaces with DevTools open, returning to the workspace shows a blank DevTools UI (Issue #1494).

## Root Cause

During workspace switch, `restoreDeveloperToolsAfterAttachIfNeeded()` is called after the webView is rebound to the portal, but before it is fully attached to the window hierarchy (`webView.window == nil`). In this transient state, the inspector object may not be immediately available or functional, causing the restoration to fail silently.

## Fix

Add a guard to check `webView.window != nil` before attempting DevTools restoration. If the window is not yet available, schedule a retry using the existing `scheduleDeveloperToolsRestoreRetry()` mechanism. This ensures the restoration happens after the webView is fully attached to the window.

## Changes

- Added window availability check in `restoreDeveloperToolsAfterAttachIfNeeded()`
- Falls back to retry mechanism if window is not ready

## Testing

- Built successfully with `swift build`
- The fix follows the existing retry pattern already used for inspector unavailability

Fixes #1494


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents blank DevTools after switching workspaces by restoring DevTools only once the web view is attached to a window, retrying if not. Adds a `webView.window != nil` guard in `restoreDeveloperToolsAfterAttachIfNeeded()` and falls back to `scheduleDeveloperToolsRestoreRetry()` to wait for the inspector (fixes #1494).

<sup>Written for commit c3305d01bf75f77534e0f5c3004b80d388f68c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when switching workspaces by ensuring developer tools are properly restored only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->