### PR TITLE
fix(workspace): restore DevTools UI when returning to workspace

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3846,6 +3846,9 @@ final class Workspace: Identifiable, ObservableObject {
                         reason: reason
                     )
                 }
+                // Restore DevTools when workspace becomes visible again after being hidden
+                // (e.g., after workspace switch). This fixes blank DevTools UI issue.
+                browserPanel.restoreDeveloperToolsAfterAttachIfNeeded()
             } else {
                 BrowserWindowPortalRegistry.updateEntryVisibility(
                     for: browserPanel.webView,


### PR DESCRIPTION
## Summary

Fixed an issue where the DevTools panel would display blank after switching workspaces and returning to a workspace with DevTools open.

**What changed:**
- Added a call to `restoreDeveloperToolsAfterAttachIfNeeded()` in `reconcileBrowserPortalVisibilityForCurrentRenderedLayout()` when a browser panel becomes visible

**Why:**
When switching workspaces, the browser portal is hidden via `hideAllBrowserPortalViews()`. When returning to the workspace, `reconcileBrowserPortalVisibilityForCurrentRenderedLayout()` makes the portal visible again, but DevTools was not being restored, causing a blank panel.

## Testing

- Verified the fix compiles successfully with `swift build`
- The change is minimal (3 lines) and targeted to the specific issue
- The fix follows the existing pattern used elsewhere in the codebase (e.g., `BrowserPanelView` calls the same method during view updates)

## Checklist

- [x] I tested the change locally (build verification)
- [ ] I added or updated tests for behavior changes (N/A - UI state restoration)
- [ ] I updated docs/changelog if needed (N/A - minor bug fix)

Fixes #1494

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix blank DevTools panel when returning to a workspace after switching. DevTools are restored when the browser portal becomes visible again.

- **Bug Fixes**
  - Call `restoreDeveloperToolsAfterAttachIfNeeded()` in `reconcileBrowserPortalVisibilityForCurrentRenderedLayout()` when a browser panel becomes visible.

<sup>Written for commit 529f7dc3c6f4e2ad3e51d8d819ee8812c8b18ad9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where developer tools state was not properly restored when switching workspace visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->