### PR TITLE
feat: add "Classic Light" appearance mode with terminal surface light theme

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 					F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 					F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */; };
+				FB000000A1B2C3D4E5F60718 /* AppearanceModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000001A1B2C3D4E5F60718 /* AppearanceModeTests.swift */; };
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 					FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
@@ -302,6 +303,7 @@
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
+				FB000001A1B2C3D4E5F60718 /* AppearanceModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceModeTests.swift; sourceTree = "<group>"; };
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportMappingTests.swift; sourceTree = "<group>"; };
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
@@ -585,6 +587,7 @@
 					F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 					F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 					F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
+					FB000001A1B2C3D4E5F60718 /* AppearanceModeTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
@@ -911,6 +914,7 @@
 					CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
+					FB000000A1B2C3D4E5F60718 /* AppearanceModeTests.swift in Sources */,
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;

--- a/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
+++ b/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
@@ -1,32 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion="1500" version="1.7">
-  <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
-        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
-    <Testables>
-      <TestableReference skipped="NO">
-        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="CB450DF0F0B3839599082C4D" BuildableName="cmuxUITests.xctest" BlueprintName="cmuxUITests" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-      </TestableReference>
-    </Testables>
-    <MacroExpansion>
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </MacroExpansion>
-  </TestAction>
-  <LaunchAction buildConfiguration="Release" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" allowLocationSimulation="YES">
-    <BuildableProductRunnable runnableDebuggingMode="0">
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </BuildableProductRunnable>
-  </LaunchAction>
-  <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
-    <BuildableProductRunnable runnableDebuggingMode="0">
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </BuildableProductRunnable>
-  </ProfileAction>
-  <AnalyzeAction buildConfiguration="Release"/>
-  <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"/>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5001050"
+               BuildableName = "cmux.app"
+               BlueprintName = "GhosttyTabs"
+               ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB450DF0F0B3839599082C4D"
+               BuildableName = "cmuxUITests.xctest"
+               BlueprintName = "cmuxUITests"
+               ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4975,6 +4975,119 @@
         }
       }
     },
+    "appearance.classicLight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classic Light"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシックライト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "经典浅色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "經典淺色"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식 라이트"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch Hell"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro clásico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clair classique"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiaro classico"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk lys"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny jasny"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классическое светлое"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasična svijetla"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فاتح كلاسيكي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk lys"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro clássico"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สว่างคลาสสิก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasik Açık"
+          }
+        }
+      }
+    },
     "appearance.system": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1618,6 +1618,7 @@ class GhosttyApp {
                 return
             }
 
+            loadClassicLightThemeIfNeeded(fallbackConfig)
             loadInlineGhosttyConfig(
                 "macos-background-from-layer = true",
                 into: fallbackConfig,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1775,7 +1775,7 @@ class GhosttyApp {
             }
         } catch {
             #if DEBUG
-            Self.initLog("failed to write classic light theme config: \(error)")
+            dlog("classicLight theme injection write failed error=\(error)")
             #endif
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1713,6 +1713,7 @@ class GhosttyApp {
         ghostty_config_load_recursive_files(config)
         loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         loadCJKFontFallbackIfNeeded(config)
+        loadClassicLightThemeIfNeeded(config)
         let useHostLayerBackground = !hasConfiguredBackgroundImage(config)
         usesHostLayerBackground = useHostLayerBackground
         if !useHostLayerBackground {
@@ -1753,6 +1754,39 @@ class GhosttyApp {
     /// default based on the system's preferred languages without overriding
     /// user-managed fallback chains or configured fonts that already cover
     /// the affected CJK ranges.
+    private func loadClassicLightThemeIfNeeded(_ config: ghostty_config_t) {
+        let mode = AppearanceSettings.resolvedMode()
+        #if DEBUG
+        dlog("classicLight check mode=\(mode.rawValue)")
+        #endif
+        guard mode == .classicLight else { return }
+        let line = "theme = light:Builtin Light,dark:Ghostty Default Style Dark"
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-classic-light-theme-\(UUID().uuidString).conf")
+        do {
+            try line.write(to: tmpURL, atomically: true, encoding: .utf8)
+            defer { try? FileManager.default.removeItem(at: tmpURL) }
+            #if DEBUG
+            let contents = try? String(contentsOf: tmpURL, encoding: .utf8)
+            dlog("classicLight injecting theme file: \(tmpURL.path) contents=[\(contents ?? "nil")]")
+            #endif
+            tmpURL.path.withCString { path in
+                ghostty_config_load_file(config, path)
+            }
+        } catch {
+            #if DEBUG
+            Self.initLog("failed to write classic light theme config: \(error)")
+            #endif
+        }
+    }
+
+    /// When the user has not configured `font-codepoint-map` for CJK ranges,
+    /// Ghostty's `CTFontCollection` scoring may pick an inappropriate fallback
+    /// font for Hiragana, Katakana, and CJK symbols. The scoring prioritizes
+    /// monospace fonts, so decorative fonts with monospace attributes (e.g.
+    /// AB_appare from Adobe CC, or LingWai) can be selected depending on what
+    /// is installed. This injects a sensible default based on the system's
+    /// preferred languages.
     ///
     /// See: https://github.com/manaflow-ai/cmux/pull/1017
     private func loadCJKFontFallbackIfNeeded(_ config: ghostty_config_t) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1708,6 +1708,7 @@ class GhosttyApp {
     }
 
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
+        loadClassicLightThemeIfNeeded(config)
         ghostty_config_load_default_files(config)
         loadLegacyGhosttyConfigIfNeeded(config)
         ghostty_config_load_recursive_files(config)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1994,6 +1994,9 @@ class TerminalController {
         case "reload_config":
             return reloadConfig(args)
 
+        case "set_appearance_mode":
+            return setAppearanceMode(args)
+
         case "refresh_surfaces":
             return refreshSurfaces()
 
@@ -11385,6 +11388,7 @@ class TerminalController {
           focus_surface_by_panel <panel_id> - Focus surface by panel ID
           close_surface [id|idx]          - Close surface (collapse split)
           reload_config                   - Reload Ghostty config, cmux settings, and refresh terminals
+          set_appearance_mode [mode]      - Get/set appearance (system, light, classicLight, dark)
           refresh_surfaces                - Force refresh all terminals
           surface_health [workspace]      - Check view health of all surfaces
 
@@ -15658,6 +15662,23 @@ class TerminalController {
             GhosttyApp.shared.reloadConfiguration(source: "socket.reload_config")
         }
         return "OK Reloaded config"
+    }
+
+    private func setAppearanceMode(_ args: String) -> String {
+        let mode = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !mode.isEmpty else {
+            let current = AppearanceSettings.resolvedMode()
+            return "OK \(current.rawValue)"
+        }
+        guard let newMode = AppearanceMode(rawValue: mode) else {
+            let valid = AppearanceMode.allCases.map(\.rawValue).joined(separator: ", ")
+            return "ERROR: Invalid mode '\(mode)'. Valid: \(valid)"
+        }
+        v2MainSync {
+            UserDefaults.standard.set(newMode.rawValue, forKey: AppearanceSettings.appearanceModeKey)
+            GhosttyApp.shared.reloadConfiguration(source: "socket.set_appearance_mode")
+        }
+        return "OK \(newMode.rawValue)"
     }
 
     private func refreshSurfaces() -> String {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -344,7 +344,6 @@ struct cmuxApp: App {
                 }
                 .onChange(of: appearanceMode) { _ in
                     applyAppearance()
-                    GhosttyApp.shared.reloadConfiguration(source: "appearanceModeChanged")
                 }
                 .onChange(of: socketControlMode) { _ in
                     updateSocketController()
@@ -836,6 +835,7 @@ struct cmuxApp: App {
             NSApplication.shared.appearance = nil
         case .light, .classicLight:
             NSApplication.shared.appearance = NSAppearance(named: .aqua)
+            GhosttyApp.shared.reloadConfiguration(source: "appearanceModeChanged")
         case .dark:
             NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
         case .auto:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -835,12 +835,12 @@ struct cmuxApp: App {
             NSApplication.shared.appearance = nil
         case .light, .classicLight:
             NSApplication.shared.appearance = NSAppearance(named: .aqua)
-            GhosttyApp.shared.reloadConfiguration(source: "appearanceModeChanged")
         case .dark:
             NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
         case .auto:
             NSApplication.shared.appearance = nil
         }
+        GhosttyApp.shared.reloadConfiguration(source: "appearanceModeChanged")
     }
 
     private func updateSocketController() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -344,6 +344,7 @@ struct cmuxApp: App {
                 }
                 .onChange(of: appearanceMode) { _ in
                     applyAppearance()
+                    GhosttyApp.shared.reloadConfiguration(source: "appearanceModeChanged")
                 }
                 .onChange(of: socketControlMode) { _ in
                     updateSocketController()
@@ -833,7 +834,7 @@ struct cmuxApp: App {
         switch mode {
         case .system:
             NSApplication.shared.appearance = nil
-        case .light:
+        case .light, .classicLight:
             NSApplication.shared.appearance = NSAppearance(named: .aqua)
         case .dark:
             NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
@@ -3523,13 +3524,14 @@ private struct AboutVisualEffectBackground: NSViewRepresentable {
 enum AppearanceMode: String, CaseIterable, Identifiable {
     case system
     case light
+    case classicLight
     case dark
     case auto
 
     var id: String { rawValue }
 
     static var visibleCases: [AppearanceMode] {
-        [.system, .light, .dark]
+        [.system, .light, .classicLight, .dark]
     }
 
     var displayName: String {
@@ -3538,6 +3540,8 @@ enum AppearanceMode: String, CaseIterable, Identifiable {
             return String(localized: "appearance.system", defaultValue: "System")
         case .light:
             return String(localized: "appearance.light", defaultValue: "Light")
+        case .classicLight:
+            return String(localized: "appearance.classicLight", defaultValue: "Classic Light")
         case .dark:
             return String(localized: "appearance.dark", defaultValue: "Dark")
         case .auto:

--- a/cmuxTests/AppearanceModeTests.swift
+++ b/cmuxTests/AppearanceModeTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class AppearanceModeTests: XCTestCase {
+
+    // MARK: - AppearanceMode enum
+
+    func testClassicLightRawValueRoundTrips() {
+        let mode = AppearanceMode(rawValue: "classicLight")
+        XCTAssertEqual(mode, .classicLight)
+        XCTAssertEqual(AppearanceMode.classicLight.rawValue, "classicLight")
+    }
+
+    func testVisibleCasesIncludesClassicLight() {
+        XCTAssertTrue(AppearanceMode.visibleCases.contains(.classicLight))
+    }
+
+    func testVisibleCasesOrderIsSystemLightClassicLightDark() {
+        XCTAssertEqual(
+            AppearanceMode.visibleCases,
+            [.system, .light, .classicLight, .dark]
+        )
+    }
+
+    func testClassicLightDisplayNameIsNotEmpty() {
+        XCTAssertFalse(AppearanceMode.classicLight.displayName.isEmpty)
+    }
+
+    // MARK: - AppearanceSettings.mode(for:)
+
+    func testModeForClassicLightRawValue() {
+        XCTAssertEqual(AppearanceSettings.mode(for: "classicLight"), .classicLight)
+    }
+
+    func testModeForNilDefaultsToSystem() {
+        XCTAssertEqual(AppearanceSettings.mode(for: nil), .system)
+    }
+
+    func testModeForInvalidStringDefaultsToSystem() {
+        XCTAssertEqual(AppearanceSettings.mode(for: "invalid"), .system)
+    }
+
+    func testModeForAutoMigratesToSystem() {
+        XCTAssertEqual(AppearanceSettings.mode(for: "auto"), .system)
+    }
+
+    func testModeForLightReturnsLight() {
+        XCTAssertEqual(AppearanceSettings.mode(for: "light"), .light)
+    }
+
+    func testModeForDarkReturnsDark() {
+        XCTAssertEqual(AppearanceSettings.mode(for: "dark"), .dark)
+    }
+
+    // MARK: - AppearanceSettings.resolvedMode(defaults:)
+
+    func testResolvedModeReadsClassicLightFromDefaults() {
+        let suite = "com.cmux.test.appearance.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        defaults.set("classicLight", forKey: AppearanceSettings.appearanceModeKey)
+
+        let mode = AppearanceSettings.resolvedMode(defaults: defaults)
+        XCTAssertEqual(mode, .classicLight)
+    }
+
+    func testResolvedModeDefaultsToSystemWhenEmpty() {
+        let suite = "com.cmux.test.appearance.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+
+        let mode = AppearanceSettings.resolvedMode(defaults: defaults)
+        XCTAssertEqual(mode, .system)
+    }
+
+    func testResolvedModeMigratesAutoToSystem() {
+        let suite = "com.cmux.test.appearance.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        defaults.set("auto", forKey: AppearanceSettings.appearanceModeKey)
+
+        let mode = AppearanceSettings.resolvedMode(defaults: defaults)
+        XCTAssertEqual(mode, .system)
+        XCTAssertEqual(defaults.string(forKey: AppearanceSettings.appearanceModeKey), "system")
+    }
+}

--- a/tests_v2/test_classic_light_appearance.py
+++ b/tests_v2/test_classic_light_appearance.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""E2E: Classic Light appearance mode renders a light terminal background.
+
+Activates Classic Light mode via `defaults write`, triggers a config reload,
+captures a screenshot, and verifies the terminal background pixels are bright
+(RGB average >= 200).  Restores the original appearance mode on exit.
+
+Usage:
+    CMUX_SOCKET=/tmp/cmux-debug-<tag>.sock python3 tests_v2/test_classic_light_appearance.py
+"""
+
+import os
+import select
+import socket
+import struct
+import sys
+import time
+import zlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+# Pixel brightness threshold: RGB average must be >= this value for "light".
+LIGHT_THRESHOLD = 200
+
+# How many pixels to sample from the center region of the screenshot.
+SAMPLE_SIZE = 100
+
+# Percentage of sampled pixels that must be light.
+LIGHT_PIXEL_RATIO = 0.7
+
+
+def _send_v1_command(socket_path: str, command: str, timeout_s: float = 5.0) -> str:
+    """Send a v1 (plain text) command to the cmux socket and return the response."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(socket_path)
+    sock.setblocking(False)
+    sock.sendall((command + "\n").encode())
+
+    data = b""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        ready, _, _ = select.select([sock], [], [], 0.5)
+        if ready:
+            try:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                if b"\n" in data:
+                    break
+            except BlockingIOError:
+                continue
+        elif data:
+            break
+    sock.close()
+    return data.decode().strip()
+
+
+def _parse_png_pixels(image_path: str) -> tuple[list[tuple[int, int, int]], int, int]:
+    """Parse a PNG file using only stdlib (struct + zlib). Returns (pixels, width, height).
+
+    Supports 8-bit RGB and RGBA color types (the format macOS screenshots use).
+    Each pixel is an (R, G, B) tuple.
+    """
+    with open(image_path, "rb") as f:
+        data = f.read()
+
+    # Validate PNG signature.
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise RuntimeError(f"Not a valid PNG file: {image_path}")
+
+    pos = 8
+    width = height = bit_depth = color_type = 0
+    idat_chunks: list[bytes] = []
+
+    while pos < len(data):
+        chunk_len = struct.unpack(">I", data[pos:pos + 4])[0]
+        chunk_type = data[pos + 4:pos + 8]
+        chunk_data = data[pos + 8:pos + 8 + chunk_len]
+        pos += 12 + chunk_len  # 4 (len) + 4 (type) + data + 4 (crc)
+
+        if chunk_type == b"IHDR":
+            width, height, bit_depth, color_type = struct.unpack(">IIBB", chunk_data[:10])
+            interlace = chunk_data[12]
+            if interlace != 0:
+                raise RuntimeError("Interlaced PNGs are not supported")
+        elif chunk_type == b"IDAT":
+            idat_chunks.append(chunk_data)
+        elif chunk_type == b"IEND":
+            break
+
+    if width == 0 or height == 0:
+        raise RuntimeError("PNG IHDR chunk not found or invalid")
+    if bit_depth != 8:
+        raise RuntimeError(f"Unsupported PNG bit depth: {bit_depth} (only 8-bit supported)")
+    if color_type not in (2, 6):  # 2 = RGB, 6 = RGBA
+        raise RuntimeError(f"Unsupported PNG color type: {color_type} (only RGB/RGBA supported)")
+
+    bpp = 3 if color_type == 2 else 4
+    raw = zlib.decompress(b"".join(idat_chunks))
+
+    # Reconstruct scanlines with PNG filtering.
+    stride = width * bpp
+    pixels: list[tuple[int, int, int]] = []
+    prev_row = bytes(stride)
+
+    for y in range(height):
+        row_start = y * (stride + 1)
+        filter_type = raw[row_start]
+        scanline = bytearray(raw[row_start + 1:row_start + 1 + stride])
+
+        if filter_type == 1:  # Sub
+            for i in range(bpp, stride):
+                scanline[i] = (scanline[i] + scanline[i - bpp]) & 0xFF
+        elif filter_type == 2:  # Up
+            for i in range(stride):
+                scanline[i] = (scanline[i] + prev_row[i]) & 0xFF
+        elif filter_type == 3:  # Average
+            for i in range(stride):
+                left = scanline[i - bpp] if i >= bpp else 0
+                scanline[i] = (scanline[i] + (left + prev_row[i]) // 2) & 0xFF
+        elif filter_type == 4:  # Paeth
+            for i in range(stride):
+                a = scanline[i - bpp] if i >= bpp else 0
+                b = prev_row[i]
+                c = prev_row[i - bpp] if i >= bpp else 0
+                p = a + b - c
+                pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+                pr = a if pa <= pb and pa <= pc else (b if pb <= pc else c)
+                scanline[i] = (scanline[i] + pr) & 0xFF
+
+        prev_row = bytes(scanline)
+        for x in range(width):
+            offset = x * bpp
+            pixels.append((scanline[offset], scanline[offset + 1], scanline[offset + 2]))
+
+    return pixels, width, height
+
+
+def _sample_background_brightness(image_path: str) -> tuple[float, float]:
+    """Sample pixels from the center of a screenshot and return (avg_brightness, light_ratio)."""
+    pixels, width, height = _parse_png_pixels(image_path)
+
+    cx, cy = width // 2, height // 2
+    radius = min(width, height) // 6
+    total_brightness = 0.0
+    light_count = 0
+    sampled = 0
+    step = max(1, (2 * radius) // SAMPLE_SIZE)
+
+    for dy in range(-radius, radius, step):
+        for dx in range(-radius, radius, step):
+            px, py = cx + dx, cy + dy
+            if 0 <= px < width and 0 <= py < height:
+                r, g, b = pixels[py * width + px]
+                avg = (r + g + b) / 3.0
+                total_brightness += avg
+                if avg >= LIGHT_THRESHOLD:
+                    light_count += 1
+                sampled += 1
+                if sampled >= SAMPLE_SIZE:
+                    break
+        if sampled >= SAMPLE_SIZE:
+            break
+
+    if sampled == 0:
+        raise RuntimeError("No pixels sampled")
+
+    return total_brightness / sampled, light_count / sampled
+
+
+def main() -> int:
+    # 1. Query current appearance mode via socket, then set classicLight.
+    print("Querying current appearance mode via socket...")
+    original_mode = _send_v1_command(SOCKET_PATH, "set_appearance_mode").removeprefix("OK ")
+    print(f"Original appearance mode: {original_mode or '(not set)'}")
+
+    try:
+        # 2. Set Classic Light mode via socket (sets UserDefaults in-process + reloads config).
+        print("Setting appearance mode to classicLight via socket...")
+        result = _send_v1_command(SOCKET_PATH, "set_appearance_mode classicLight")
+        if not result.startswith("OK"):
+            print(f"FAIL: set_appearance_mode returned: {result}", file=sys.stderr)
+            return 1
+        time.sleep(2.0)  # Wait for theme application and re-render.
+
+        with cmux(SOCKET_PATH) as c:
+
+            # 3. Capture screenshot.
+            print("Taking screenshot...")
+            result = c.screenshot(label="classic_light_verify")
+            screenshot_path = result.get("path")
+            if not screenshot_path:
+                print(f"FAIL: screenshot returned no path: {result}", file=sys.stderr)
+                return 1
+
+            if not Path(screenshot_path).exists():
+                print(f"FAIL: screenshot file not found: {screenshot_path}", file=sys.stderr)
+                return 1
+
+            print(f"Screenshot saved: {screenshot_path}")
+
+            # 4. Analyze pixel brightness.
+            avg_brightness, light_ratio = _sample_background_brightness(screenshot_path)
+            print(f"Average brightness: {avg_brightness:.1f} / 255")
+            print(f"Light pixel ratio:  {light_ratio:.1%} (threshold: {LIGHT_PIXEL_RATIO:.0%})")
+
+            if light_ratio >= LIGHT_PIXEL_RATIO:
+                print("PASS: Terminal background is light in Classic Light mode.")
+                return 0
+            else:
+                print(
+                    f"FAIL: Only {light_ratio:.1%} of sampled pixels are light "
+                    f"(need {LIGHT_PIXEL_RATIO:.0%}). "
+                    f"Average brightness: {avg_brightness:.1f}.",
+                    file=sys.stderr,
+                )
+                return 1
+
+    finally:
+        # Restore original appearance mode via socket.
+        _send_v1_command(SOCKET_PATH, f"set_appearance_mode {original_mode}")
+        print(f"Restored appearance mode to: {original_mode}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

  - Added a new "Classic Light" appearance mode that switches both the app chrome AND the terminal surface
  to a light color scheme. The existing "Light" mode remains unchanged (chrome only).
  - When "Classic Light" is selected, a Ghostty theme pair (Builtin Light / Ghostty Default Style Dark) is
  injected into the config so the terminal renderer follows the appearance mode.
  - Added full localizations (16 languages) for the new option.
  - Added unit tests for AppearanceMode and AppearanceSettings covering the new classicLight case.

## Testing

  - Ran AppearanceModeTests (13 tests, 0 failures) via xcodebuild -scheme cmux-unit.
  - Manually verified: System → Light → Classic Light → Dark transitions.
  - Verified new tabs/workspaces created in Classic Light mode render with white background and dark text.
  - Verified switching back to Light/Dark restores expected terminal colors for new surfaces.

## Demo Video

  - Video URL or attachment: https://youtu.be/Lq1VfQUUXrc

  Review Trigger (Copy/Paste as PR comment)

  @codex review
  @coderabbitai review
  @greptile-apps review
  @cubic-dev-ai review

## Checklist

  - I tested the change locally
  - I added or updated tests for behavior changes
  - I updated docs/changelog if needed
  - I requested bot reviews after my latest commit (copy/paste block above or equivalent)
  - All code review bot comments are resolved
  - All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Classic Light” appearance mode that makes both the app chrome and the terminal surface use a light theme. Adds a `set_appearance_mode` socket command to switch modes in-process with an immediate config reload.

- **New Features**
  - Added `classicLight` to `AppearanceMode` with full localization and order: System → Light → Classic Light → Dark.
  - Injects `theme = light:Builtin Light,dark:Ghostty Default Style Dark` before default/user config and during fallback init; an explicit `theme` still wins. Applies `.aqua` for `.light`/`.classicLight`.
  - Added `set_appearance_mode` socket command to get/set the current mode and trigger a reload; added E2E screenshot test and unit tests for parsing, order, and resolved mode.

- **Bug Fixes**
  - Reload configuration after every appearance change to correctly apply or clear Classic Light themes.
  - Use `dlog` for theme-injection write errors for consistent logging.

<sup>Written for commit f64f7be92844b1bbaba404ae2bd8e0e57aba7d06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Classic Light" appearance option; selecting it applies a compatible default theme early in startup and triggers an immediate UI configuration reload.

* **Localization**
  * Added localized display name for "Classic Light" across many languages.

* **Tests**
  * Added unit tests covering appearance modes, display names, parsing/migration, resolution, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->