### PR TITLE
Fix unread jump fallback and title sync after SSH stack merge

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10580,7 +10580,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         context.sidebarSelectionState.selection = .tabs
         bringToFront(window)
-        guard context.tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+        let resolvedSurfaceId = resolvedNotificationSurfaceId(
+            tabManager: context.tabManager,
+            tabId: tabId,
+            requestedSurfaceId: surfaceId
+        )
+        guard context.tabManager.focusTabFromNotification(tabId, surfaceId: resolvedSurfaceId) else {
 #if DEBUG
             recordMultiWindowNotificationOpenFailureIfNeeded(
                 tabId: tabId,
@@ -10601,7 +10606,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         recordJumpUnreadFocusFromModelIfNeeded(
             tabManager: context.tabManager,
             tabId: tabId,
-            expectedSurfaceId: surfaceId
+            expectedSurfaceId: resolvedSurfaceId
         )
 #endif
 
@@ -10609,7 +10614,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             markReadIfFocused(
                 notificationId: notificationId,
                 tabId: tabId,
-                surfaceId: surfaceId,
+                surfaceId: resolvedSurfaceId,
                 tabManager: context.tabManager,
                 notificationStore: store
             )
@@ -10619,7 +10624,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         recordMultiWindowNotificationFocusIfNeeded(
             windowId: context.windowId,
             tabId: tabId,
-            surfaceId: surfaceId,
+            surfaceId: resolvedSurfaceId,
             sidebarSelection: context.sidebarSelectionState.selection
         )
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
@@ -10658,7 +10663,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         sidebarSelectionState?.selection = .tabs
         bringToFront(window)
-        guard tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+        let resolvedSurfaceId = resolvedNotificationSurfaceId(
+            tabManager: tabManager,
+            tabId: tabId,
+            requestedSurfaceId: surfaceId
+        )
+        guard tabManager.focusTabFromNotification(tabId, surfaceId: resolvedSurfaceId) else {
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
                 writeJumpUnreadTestData([
@@ -10674,7 +10684,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         recordJumpUnreadFocusFromModelIfNeeded(
             tabManager: tabManager,
             tabId: tabId,
-            expectedSurfaceId: surfaceId
+            expectedSurfaceId: resolvedSurfaceId
         )
 #endif
 
@@ -10682,7 +10692,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             markReadIfFocused(
                 notificationId: notificationId,
                 tabId: tabId,
-                surfaceId: surfaceId,
+                surfaceId: resolvedSurfaceId,
                 tabManager: tabManager,
                 notificationStore: store
             )
@@ -10693,6 +10703,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 #endif
         return true
+    }
+
+    private func resolvedNotificationSurfaceId(
+        tabManager: TabManager,
+        tabId: UUID,
+        requestedSurfaceId: UUID?
+    ) -> UUID? {
+        guard let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
+            return requestedSurfaceId
+        }
+
+        guard let requestedSurfaceId else { return nil }
+        if tab.panels[requestedSurfaceId] != nil {
+            return requestedSurfaceId
+        }
+
+        if let latestUnreadSurfaceId = notificationStore?.latestNotification(forTabId: tabId)?.surfaceId,
+           tab.panels[latestUnreadSurfaceId] != nil {
+            return latestUnreadSurfaceId
+        }
+
+        if let focusedPanelId = tab.focusedPanelId,
+           tab.panels[focusedPanelId] != nil {
+            return focusedPanelId
+        }
+
+        return tab.panels.keys.sorted { $0.uuidString < $1.uuidString }.first
     }
 
 #if DEBUG

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5707,8 +5707,11 @@ final class Workspace: Identifiable, ObservableObject {
             )
         }
 
-        // If this is the only panel and no custom title, update workspace title
-        if panels.count == 1, customTitle == nil {
+        let shouldRefreshWorkspaceTitle = customTitle == nil &&
+            (panels.count == 1 || panelId == focusedPanelId)
+
+        // Keep the workspace title in sync with the focused panel without touching unrelated tabs.
+        if shouldRefreshWorkspaceTitle {
             if self.title != trimmed {
                 self.title = trimmed
                 didMutate = true

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1246,6 +1246,75 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         XCTAssertNotNil(createdWorkspace)
         XCTAssertEqual(createdWorkspace?.currentDirectory, droppedDirectory.path)
     }
+
+    func testOpenNotificationFallsBackToFocusedPanelWhenTargetSurfaceIsMissing() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+
+        let windowId = UUID()
+        let window = makeMainWindow(id: windowId)
+        defer { window.orderOut(nil) }
+
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = app.notificationStore
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        app.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+            app.notificationStore = originalNotificationStore
+        }
+
+        app.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+
+        window.makeKeyAndOrderFront(nil)
+        _ = app.synchronizeActiveMainWindowContext(preferredWindow: window)
+
+        guard let workspace = manager.selectedWorkspace,
+              let focusedPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with a focused panel")
+            return
+        }
+
+        let staleSurfaceId = UUID()
+        store.addNotification(
+            tabId: workspace.id,
+            surfaceId: staleSurfaceId,
+            title: "Unread",
+            subtitle: "",
+            body: ""
+        )
+
+        guard let notification = store.notifications.first else {
+            XCTFail("Expected unread notification")
+            return
+        }
+
+        XCTAssertTrue(
+            app.openNotification(
+                tabId: workspace.id,
+                surfaceId: staleSurfaceId,
+                notificationId: notification.id
+            ),
+            "Expected jump-to-unread to recover from stale surface ids instead of returning a no-op"
+        )
+
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(manager.selectedTabId, workspace.id)
+        XCTAssertEqual(manager.focusedSurfaceId(for: workspace.id), focusedPanelId)
+        XCTAssertTrue(store.notifications.first?.isRead == true)
+    }
 }
 
 @MainActor
@@ -1274,6 +1343,27 @@ final class AppDelegateLaunchServicesRegistrationTests: XCTestCase {
         scheduledWork?()
 
         XCTAssertEqual(registerCallCount, 1)
+    }
+}
+
+@MainActor
+final class WorkspaceTitleSyncTests: XCTestCase {
+    func testFocusedSplitWorkspaceUpdatesWorkspaceTitleWhenPanelTitleChanges() {
+        let workspace = Workspace()
+        guard let leftPanelId = workspace.focusedPanelId,
+              let rightPanel = workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        XCTAssertEqual(workspace.focusedPanelId, rightPanel.id)
+
+        workspace.applyProcessTitle("cmux-macmini: claude --dangerously-skip-permissions")
+        XCTAssertEqual(workspace.title, "cmux-macmini: claude --dangerously-skip-permissions")
+
+        XCTAssertTrue(workspace.updatePanelTitle(panelId: rightPanel.id, title: "cmux-macmini: codex"))
+        XCTAssertEqual(workspace.panelTitle(panelId: rightPanel.id), "cmux-macmini: codex")
+        XCTAssertEqual(workspace.title, "cmux-macmini: codex")
     }
 }
 


### PR DESCRIPTION
## Summary
- restore `Cmd+Shift+U` when an unread notification points at a stale surface by falling back to a live panel in the same workspace
- keep the workspace title in sync when the focused split panel changes titles after the merged SSH workspace stack
- keep the red/green regression history proving both regressions on top of current `main`

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1581-mainline-red test -only-testing:cmuxTests/AppDelegateWindowContextRoutingTests/testOpenNotificationFallsBackToFocusedPanelWhenTargetSurfaceIsMissing -only-testing:cmuxTests/WorkspaceTitleSyncTests/testFocusedSplitWorkspaceUpdatesWorkspaceTitleWhenPanelTitleChanges` (fails before fix)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1581-mainline-green test -only-testing:cmuxTests/AppDelegateWindowContextRoutingTests -only-testing:cmuxTests/WorkspaceTitleSyncTests` (passes)
- `./scripts/reload.sh --tag issue-1581-ssh-host-waiting-mainline`

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/1581
- Supersedes https://github.com/manaflow-ai/cmux/pull/1585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes jump-to-unread when a notification points to a missing surface by falling back to a valid panel, and restores workspace title sync after the SSH stack merge. Closes #1581.

- **Bug Fixes**
  - Jump-to-unread fallback: use the requested surface if it exists; else latest unread in the tab; else the focused panel; else the first panel. Applies to Cmd+Shift+U and notification clicks, and marks the notification read.
  - Workspace title sync: update the workspace title when the focused split panel’s title changes (or when there’s only one panel), but only if no custom title is set.

<sup>Written for commit 5edc405566d149c8579df99a5c0891b8a2247c39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification routing to gracefully fall back to the correct workspace and panel when the target surface is unavailable.
  * Fixed workspace title synchronization in split workspaces to properly reflect panel title updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->