### PR TITLE
Fix nightly release browser portal compile

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5172,13 +5172,6 @@ extension BrowserPanel {
         return "webFrame=\(Self.debugRectDescription(webFrame)) webBounds=\(Self.debugRectDescription(webView.bounds)) webWin=\(webView.window?.windowNumber ?? -1) super=\(Self.debugObjectToken(container)) superType=\(containerType) superBounds=\(Self.debugRectDescription(containerBounds)) inspectorHApprox=\(String(format: "%.1f", inspectorHeightApprox)) inspectorInsets=\(String(format: "%.1f", inspectorInsets)) inspectorOverflow=\(String(format: "%.1f", inspectorOverflow)) inspectorSubviews=\(inspectorSubviews)"
     }
 
-    func hideBrowserPortalView(source: String) {
-        BrowserWindowPortalRegistry.hide(
-            webView: webView,
-            source: source
-        )
-    }
-
 }
 #endif
 
@@ -5267,6 +5260,15 @@ private extension BrowserPanel {
 
     static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
         max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    }
+}
+
+extension BrowserPanel {
+    func hideBrowserPortalView(source: String) {
+        BrowserWindowPortalRegistry.hide(
+            webView: webView,
+            source: source
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- move `BrowserPanel.hideBrowserPortalView` out of the `#if DEBUG` block so Release builds still compile
- keep the debug-only inspector helpers gated, but leave the runtime portal hide API available in all configs
- unblock the nightly universal Release build that was failing in `GhosttyTabs` x86_64 compilation

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -destination "generic/platform=macOS" -derivedDataPath /tmp/cmux-task-fix-nightly-build-failure-release ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build`
- `./scripts/reload.sh --tag task-fix-nightly-build-failure`
- failing nightly run reference: https://github.com/manaflow-ai/cmux/actions/runs/23184741706/job/66760869584

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nightly universal Release build by exposing the browser portal hide API in Release builds. Moved `BrowserPanel.hideBrowserPortalView` out of `#if DEBUG` (debug-only inspector helpers remain gated), unblocking the `GhosttyTabs` x86_64 compile.

<sup>Written for commit 66174ceb2650a0a6ecd57ed263b4864c6fb97a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal API adjustments made to the browser panel component for improved extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->