### PR TITLE
fix(scroll): prevent doomscroll bug in terminal panes

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5996,8 +5996,11 @@ final class GhosttySurfaceScrollView: NSView {
     private var observers: [NSObjectProtocol] = []
     private var windowObservers: [NSObjectProtocol] = []
     private var isLiveScrolling = false
+    private var lastLiveScrollEndTime: CFTimeInterval = 0
+    private let scrollGracePeriod: TimeInterval = 0.25
     private var lastSentRow: Int?
     private var isActive = true
+    private var scrollbarUpdateDebounceTimer: Timer?
     private var lastFocusRefreshAt: CFTimeInterval = 0
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
@@ -6324,6 +6327,7 @@ final class GhosttySurfaceScrollView: NSView {
             queue: .main
         ) { [weak self] _ in
             self?.isLiveScrolling = false
+            self?.lastLiveScrollEndTime = CACurrentMediaTime()
         })
 
         observers.append(NotificationCenter.default.addObserver(
@@ -6380,6 +6384,7 @@ final class GhosttySurfaceScrollView: NSView {
         observers.forEach { NotificationCenter.default.removeObserver($0) }
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         deferredSearchOverlayMutationWorkItem?.cancel()
+        scrollbarUpdateDebounceTimer?.invalidate()
         dropZoneOverlayView.removeFromSuperview()
         cancelFocusRequest()
     }
@@ -8231,6 +8236,12 @@ final class GhosttySurfaceScrollView: NSView {
         }
 
         if !isLiveScrolling {
+            // Prevent scroll position sync immediately after user interaction ends.
+            // This grace period stops "doomscroll" jumps caused by racing scrollbar
+            // updates from Ghostty while the trackpad/mouse momentum is settling.
+            let timeSinceLastScroll = CACurrentMediaTime() - lastLiveScrollEndTime
+            guard timeSinceLastScroll >= scrollGracePeriod else { return }
+
             let cellHeight = surfaceView.cellSize.height
             if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
                 let offsetY =
@@ -8279,7 +8290,15 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
         surfaceView.scrollbar = scrollbar
-        synchronizeScrollView()
+
+        // Debounce scrollbar updates to prevent "doomscroll" behavior during
+        // high-volume terminal output. Rapid-fire updates can race with user
+        // scroll gestures and cause erratic scroll position jumps.
+        scrollbarUpdateDebounceTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: false) { [weak self] _ in
+            self?.synchronizeScrollView()
+        }
+        scrollbarUpdateDebounceTimer = timer
     }
 
     private func documentHeight() -> CGFloat {


### PR DESCRIPTION
## Problem

Terminal panes spontaneously jump to the top of scrollback, then rapidly scroll back to the bottom. This "doomscroll" bug happens at random, increasingly frequent intervals, especially with many workspaces/panes/agent sessions.

Fixes #1577

## Root Cause Analysis

The bug was caused by a race condition in the scrollbar synchronization mechanism:

1. When users scroll, `isLiveScrolling = true` during active scrolling
2. Ghostty sends scrollbar update notifications during terminal output
3. `handleScrollbarUpdate()` immediately calls `synchronizeScrollView()`
4. When the user stops scrolling, `isLiveScrolling = false`
5. `synchronizeScrollView()` then forces the scroll position to match Ghostty's reported scrollbar state
6. If there's a timing mismatch between AppKit's scroll state and Ghostty's internal state, the view jumps to the wrong position

## Solution

This fix adds two protective mechanisms:

1. **Scroll Grace Period (250ms)**: After the user stops scrolling, wait 250ms before allowing `synchronizeScrollView()` to adjust the scroll position. This prevents the scroll position from snapping while trackpad/mouse momentum is settling.

2. **Debounced Scrollbar Updates (50ms)**: Debounce rapid scrollbar update notifications from Ghostty during high-volume terminal output. This batches rapid updates and prevents them from fighting with user scroll gestures.

## Changes

- Added `lastLiveScrollEndTime` tracking and `scrollGracePeriod` constant
- Added `scrollbarUpdateDebounceTimer` for debouncing updates
- Modified `synchronizeScrollView()` to respect the grace period
- Modified `handleScrollbarUpdate()` to debounce rapid updates
- Added timer cleanup in `deinit`

## Testing

- Verified scroll behavior remains smooth during normal use
- Grace period is short enough to not interfere with intended scroll-to-bottom behavior
- Debouncing is tight enough to not cause perceptible lag

---

ClawOSS is an autonomous codebase helper.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent “doomscroll” in terminal panes by guarding scroll sync with a short post-gesture grace period and debouncing scrollbar updates (fixes #1577).

- **Bug Fixes**
  - Add 250ms grace period after live scroll ends before allowing `synchronizeScrollView()` to adjust position.
  - Debounce scrollbar updates by 50ms to batch rapid notifications during heavy output.
  - Track `lastLiveScrollEndTime`, respect grace in `synchronizeScrollView()`, and clean up the debounce timer in `deinit`.

<sup>Written for commit 370ba1634bd7b2ec9eb2dab10d21d2804091d0d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll handling to prevent jumpy or erratic scrollbar movements during rapid updates.
  * Enhanced scrollbar synchronization to provide smoother, more responsive scrolling behavior.
  * Improved scroll responsiveness by adding intelligent delays between user interactions and scrollbar position updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->