### PR TITLE
Fix remote daemon build output path

### DIFF
--- a/scripts/build_remote_daemon_release_assets.sh
+++ b/scripts/build_remote_daemon_release_assets.sh
@@ -66,6 +66,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DAEMON_ROOT="${REPO_ROOT}/daemon/remote"
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 rm -f "$OUTPUT_DIR"/cmuxd-remote-* "$OUTPUT_DIR"/cmuxd-remote-checksums.txt "$OUTPUT_DIR"/cmuxd-remote-manifest.json
 
 DAEMON_GO_LDFLAGS="-s -w -X main.version=${VERSION}"


### PR DESCRIPTION
## Summary
- `build_remote_daemon_release_assets.sh` runs `go build -o` with a relative output path after `cd daemon/remote/`, writing binaries to the wrong directory
- Resolve `OUTPUT_DIR` to absolute path after `mkdir` so the Go build outputs land in the correct location
- Fixes nightly build failure: `chmod: remote-daemon-assets/cmuxd-remote-darwin-arm64: No such file or directory`

## Test plan
- [ ] Nightly build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the remote daemon release build by resolving `OUTPUT_DIR` to an absolute path in `scripts/build_remote_daemon_release_assets.sh`, so `go build -o` writes to the correct directory after `cd daemon/remote/`. This prevents the nightly failure: `chmod: remote-daemon-assets/cmuxd-remote-darwin-arm64: No such file or directory`.

<sup>Written for commit 361ff9dc313ff05fac5ae13b393095712736d6ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability for artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->