### PR TITLE
fix: crash on launch from Auto Layout constraint cycle

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -746,7 +746,15 @@ final class TerminalNotificationStore: ObservableObject {
             self?.refreshDockBadge()
         }
         refreshDockBadge()
-        refreshAuthorizationStatus()
+        // Defer initial authorization check past the window constraint setup
+        // phase. When getNotificationSettings completes quickly (cached result),
+        // setting @Published authorizationState during an active Auto Layout
+        // pass triggers an infinite constraint-update cycle (NSGenericException).
+        // A real delay (not just async) is needed because the constraint pass
+        // can span multiple main-queue drain cycles.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.refreshAuthorizationStatus()
+        }
     }
 
     deinit {
@@ -804,9 +812,24 @@ final class TerminalNotificationStore: ObservableObject {
 
     func refreshAuthorizationStatus() {
         center.getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
+            // Use asyncAfter to ensure the @Published update lands outside
+            // any active Auto Layout constraint pass. A plain main.async can
+            // still fire during the same display cycle that triggered the
+            // settings query, causing an infinite constraint-update loop.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 guard let self else { return }
-                self.authorizationState = Self.authorizationState(from: settings.authorizationStatus)
+                let newState = Self.authorizationState(from: settings.authorizationStatus)
+                // Skip no-op updates to avoid triggering @Published / SwiftUI
+                // invalidation during Auto Layout constraint passes. When this
+                // fires during window setup the constraint-update cycle can
+                // exceed AppKit's limit and throw NSGenericException.
+                guard newState != self.authorizationState else {
+                    self.logAuthorization(
+                        "refresh status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(newState.statusLabel) (no change)"
+                    )
+                    return
+                }
+                self.authorizationState = newState
                 self.logAuthorization(
                     "refresh status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(self.authorizationState.statusLabel)"
                 )

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -705,6 +705,12 @@ final class TerminalNotificationStore: ObservableObject {
     private var hasDeferredAuthorizationRequest = false
     private var hasPromptedForSettings = false
     private var userDefaultsObserver: NSObjectProtocol?
+    /// Delay before the initial authorization check from init, allowing the
+    /// window constraint setup phase to complete before any @Published update.
+    private static let initialAuthCheckDelay: TimeInterval = 0.2
+    /// Delay before applying authorizationState mutations from async callbacks,
+    /// ensuring the update lands outside any active Auto Layout constraint pass.
+    private static let authStateUpdateDelay: TimeInterval = 0.05
     private let settingsPromptWindowRetryDelay: TimeInterval = 0.5
     private let settingsPromptWindowRetryLimit = 20
     private var notificationSettingsWindowProvider: () -> NSWindow? = {
@@ -752,7 +758,7 @@ final class TerminalNotificationStore: ObservableObject {
         // pass triggers an infinite constraint-update cycle (NSGenericException).
         // A real delay (not just async) is needed because the constraint pass
         // can span multiple main-queue drain cycles.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.initialAuthCheckDelay) { [weak self] in
             self?.refreshAuthorizationStatus()
         }
     }
@@ -816,7 +822,7 @@ final class TerminalNotificationStore: ObservableObject {
             // any active Auto Layout constraint pass. A plain main.async can
             // still fire during the same display cycle that triggered the
             // settings query, causing an infinite constraint-update loop.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.authStateUpdateDelay) {
                 guard let self else { return }
                 let newState = Self.authorizationState(from: settings.authorizationStatus)
                 // Skip no-op updates to avoid triggering @Published / SwiftUI
@@ -1203,6 +1209,9 @@ final class TerminalNotificationStore: ObservableObject {
     ) {
         logAuthorization("ensure start origin=\(origin.rawValue)")
         center.getNotificationSettings { [weak self] settings in
+            // Safe to use plain main.async here: ensureAuthorization is only
+            // called from user-initiated actions (settings button, notification
+            // delivery) well after window constraints have converged.
             DispatchQueue.main.async {
                 guard let self else {
                     completion(false)
@@ -1263,6 +1272,9 @@ final class TerminalNotificationStore: ObservableObject {
             "request starting origin=\(origin.rawValue) automatic=\(isAutomaticRequest) hasRequestedAutomatic=\(hasRequestedAutomaticAuthorization)"
         )
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            // Safe to use plain main.async: requestAuthorization is triggered
+            // by explicit user action or automatic first-request, both after
+            // window constraint setup has completed.
             DispatchQueue.main.async {
                 if granted {
                     self.authorizationState = .authorized

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10531,6 +10531,11 @@ final class Workspace: Identifiable, ObservableObject {
         return min(0.25, baseDelay * pow(2.0, Double(exponent)))
     }
 
+    /// Windows positioned below this Y coordinate are treated as off-screen
+    /// SwiftUI system windows (settings, about, etc.) and skipped during layout
+    /// flushes to avoid triggering Auto Layout constraint cycles.
+    private static let offscreenLayoutSkipYThreshold: CGFloat = -2000
+
     private func flushWorkspaceWindowLayouts() {
         for window in NSApp.windows {
             // Skip windows that are not visible or are off-screen SwiftUI
@@ -10538,7 +10543,7 @@ final class Workspace: Identifiable, ObservableObject {
             // layoutSubtreeIfNeeded on those can trigger an infinite
             // constraint-update cycle (NSGenericException) when their
             // SwiftUI layout has not converged.
-            guard window.isVisible, window.frame.origin.y >= -2000 else { continue }
+            guard window.isVisible, window.frame.origin.y >= Self.offscreenLayoutSkipYThreshold else { continue }
             window.contentView?.layoutSubtreeIfNeeded()
             window.contentView?.displayIfNeeded()
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10533,6 +10533,12 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func flushWorkspaceWindowLayouts() {
         for window in NSApp.windows {
+            // Skip windows that are not visible or are off-screen SwiftUI
+            // system windows (settings, about, etc.). Calling
+            // layoutSubtreeIfNeeded on those can trigger an infinite
+            // constraint-update cycle (NSGenericException) when their
+            // SwiftUI layout has not converged.
+            guard window.isVisible, window.frame.origin.y >= -2000 else { continue }
             window.contentView?.layoutSubtreeIfNeeded()
             window.contentView?.displayIfNeeded()
         }


### PR DESCRIPTION
## Summary
Fixes crash on launch from Auto Layout constraint cycle in TerminalNotificationStore.

## Relationship with PR #2305
PR #2305 (merged Mar 28) addressed a related crash path by deferring flushWorkspaceWindowLayouts in Workspace.swift. This PR addresses the remaining trigger: TerminalNotificationStore auth state updates that fire before the window hierarchy is established.

These fixes are complementary — #2305 prevents re-entrant layout at the flush site, while this PR prevents the trigger from firing prematurely.

## Changes
- Add delay constants for auth state checks (initialAuthCheckDelay, authStateUpdateDelay)
- Guard against layout updates on offscreen/unattached windows
- Add safety comments on mutation sites in TerminalNotificationStore

## Test Plan
- Launch app repeatedly (20+ times) — no crash
- Verify auth state updates still fire correctly after window is established
- Verify background workspace creation doesn't trigger constraint cycle

Closes #2757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of permission handling by smoothing timing of authorization checks and avoiding redundant state updates.
  * Reduced UI glitches and crashes by skipping layout/display work for hidden or far off-screen windows, preventing unnecessary rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->