### PR TITLE
fix(terminal): prevent doomscroll when reviewing scrollback

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6089,6 +6089,12 @@ final class GhosttySurfaceScrollView: NSView {
     private var windowObservers: [NSObjectProtocol] = []
     private var isLiveScrolling = false
     private var lastSentRow: Int?
+    /// Tracks whether the user has scrolled away from the bottom to review scrollback.
+    /// When true, auto-scroll should be suspended to prevent the "doomscroll" bug
+    /// where the terminal fights the user's scroll position.
+    private var userScrolledAwayFromBottom = false
+    /// Threshold in points from bottom to consider "at bottom" (allows for minor float drift)
+    private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
     private var activeDropZone: DropZone?
@@ -6416,6 +6422,8 @@ final class GhosttySurfaceScrollView: NSView {
             queue: .main
         ) { [weak self] _ in
             self?.isLiveScrolling = false
+            // Final scroll position check to update userScrolledAwayFromBottom state
+            self?.handleLiveScroll()
         })
 
         observers.append(NotificationCenter.default.addObserver(
@@ -8328,11 +8336,29 @@ final class GhosttySurfaceScrollView: NSView {
                 let offsetY =
                     CGFloat(scrollbar.total - scrollbar.offset - scrollbar.len) * cellHeight
                 let targetOrigin = CGPoint(x: 0, y: offsetY)
-                if !pointApproximatelyEqual(scrollView.contentView.bounds.origin, targetOrigin) {
+
+                // Check if we're currently at the bottom (with threshold for float drift)
+                let currentOrigin = scrollView.contentView.bounds.origin
+                let documentHeight = documentView.frame.height
+                let viewportHeight = scrollView.contentView.bounds.height
+                let distanceFromBottom = documentHeight - currentOrigin.y - viewportHeight
+                let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
+
+                // Update userScrolledAwayFromBottom based on current position
+                if isAtBottom {
+                    userScrolledAwayFromBottom = false
+                }
+
+                // Only auto-scroll if user hasn't manually scrolled away from bottom
+                // or if we're following terminal output (scrollbar shows we're at bottom)
+                let shouldAutoScroll = !userScrolledAwayFromBottom ||
+                    (scrollbar.offset + scrollbar.len >= scrollbar.total)
+
+                if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
 #if DEBUG
                     logDragGeometryChange(
                         event: "scrollOrigin",
-                        old: scrollView.contentView.bounds.origin,
+                        old: currentOrigin,
                         new: targetOrigin
                     )
 #endif
@@ -8359,6 +8385,14 @@ final class GhosttySurfaceScrollView: NSView {
         let visibleRect = scrollView.contentView.documentVisibleRect
         let documentHeight = documentView.frame.height
         let scrollOffset = documentHeight - visibleRect.origin.y - visibleRect.height
+
+        // Track if user has scrolled away from bottom to review scrollback
+        if scrollOffset > Self.scrollToBottomThreshold {
+            userScrolledAwayFromBottom = true
+        } else if scrollOffset <= 0 {
+            userScrolledAwayFromBottom = false
+        }
+
         let row = Int(scrollOffset / cellHeight)
 
         guard row != lastSentRow else { return }


### PR DESCRIPTION
The synchronizeScrollView() method was constantly resetting the scroll position to match the terminal's scrollbar state, even when the user had manually scrolled up to review scrollback. This caused the 'doomscroll' bug where panes would spontaneously jump to the top and rapidly scroll back to the bottom.

Added userScrolledAwayFromBottom flag to track when the user has scrolled away from the bottom. Auto-scroll is now only performed when the user is already at the bottom or when the scrollbar indicates we're following terminal output. A 5-point threshold is used to tolerate minor float drift.

Fixes #1577

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent “doomscroll” by suspending auto-scroll when the user scrolls up; auto-scroll only resumes at the bottom or when following output (fixes #1577).

- **Bug Fixes**
  - Track scroll intent with a userScrolledAwayFromBottom flag and a 5pt “at bottom” threshold to handle float drift.
  - Update scroll sync and live-scroll handlers to set/reset the flag and avoid adjusting the origin while the user reviews scrollback.

<sup>Written for commit 1616f2df474fd82ffbad8563c6baef9106b9e6ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll behavior to respect user scrolling. The terminal now maintains your scroll position when manually scrolling up to view earlier content, while still auto-scrolling when at the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->