### PR TITLE
fix: suppress socat stdout in _cmux_send to prevent OK leak

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -5,7 +5,7 @@ _cmux_send() {
     if command -v ncat >/dev/null 2>&1; then
         printf '%s\n' "$payload" | ncat -w 1 -U "$CMUX_SOCKET_PATH" --send-only
     elif command -v socat >/dev/null 2>&1; then
-        printf '%s\n' "$payload" | socat -T 1 - "UNIX-CONNECT:$CMUX_SOCKET_PATH"
+        printf '%s\n' "$payload" | socat -T 1 - "UNIX-CONNECT:$CMUX_SOCKET_PATH" >/dev/null 2>&1
     elif command -v nc >/dev/null 2>&1; then
         # Some nc builds don't support unix sockets, but keep as a last-ditch fallback.
         #

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -6,7 +6,7 @@ _cmux_send() {
     if command -v ncat >/dev/null 2>&1; then
         print -r -- "$payload" | ncat -w 1 -U "$CMUX_SOCKET_PATH" --send-only
     elif command -v socat >/dev/null 2>&1; then
-        print -r -- "$payload" | socat -T 1 - "UNIX-CONNECT:$CMUX_SOCKET_PATH"
+        print -r -- "$payload" | socat -T 1 - "UNIX-CONNECT:$CMUX_SOCKET_PATH" >/dev/null 2>&1
     elif command -v nc >/dev/null 2>&1; then
         # Some nc builds don't support unix sockets, but keep as a last-ditch fallback.
         #


### PR DESCRIPTION
## Summary

- Redirect socat stdout/stderr to `/dev/null` in `_cmux_send` for both zsh and bash shell integrations
- The `ncat` path uses `--send-only` and the `nc` path already redirects — the `socat` path was the only one leaking the socket response to the terminal

## Root cause

The cmux socket responds with `OK` to every message. `socat` reads bidirectionally by default, so without output suppression it prints that response to stdout. On systems where `ncat` is absent but `socat` is installed (common on macOS via Homebrew), this causes a spurious `OK` to appear on every new tab, directory change, and shell prompt.

Fixes #1618

## Test plan

- [ ] On a system with `socat` but no `ncat`, open a new terminal tab — no `OK` should appear
- [ ] Run `cd /tmp && cd -` — no `OK` should appear
- [ ] Verify sidebar still updates (pwd, git branch, PR badge) since the socket send itself is unaffected

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the cmux socket `OK` from appearing in the terminal by redirecting `socat` stdout/stderr to `/dev/null` in `_cmux_send` for both `bash` and `zsh`. This aligns the `socat` path with `ncat --send-only`/`nc` and prevents stray `OK` on new tabs, `cd`, and prompts when `ncat` is missing.

<sup>Written for commit aae07c24c65a92099c8c9517c3940243dc49d2cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed extraneous output from shell integration commands for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->