### PR TITLE
fix(web): exclude PostHog proxy from i18n middleware

### DIFF
--- a/web/app/[locale]/posthog.tsx
+++ b/web/app/[locale]/posthog.tsx
@@ -7,7 +7,7 @@ import { useEffect, Suspense } from "react";
 
 if (typeof window !== "undefined") {
   posthog.init("phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP", {
-    api_host: "/cmuxterm",
+    api_host: "https://r.cmux.dev",
     ui_host: "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -15,18 +15,6 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  async rewrites() {
-    return [
-      {
-        source: "/cmuxterm/static/:path*",
-        destination: "https://us-assets.i.posthog.com/static/:path*",
-      },
-      {
-        source: "/cmuxterm/:path*",
-        destination: "https://us.i.posthog.com/:path*",
-      },
-    ];
-  },
 };
 
 export default withNextIntl(nextConfig);

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -4,5 +4,5 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|cmuxterm|.*\\..*).*)"],
+  matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
 };


### PR DESCRIPTION
## Summary
- The i18n middleware added in https://github.com/manaflow-ai/cmux/commit/cf75da8f intercepts `/cmuxterm/*` requests (PostHog reverse proxy), breaking all analytics since March 12.
- Add `cmuxterm` to the middleware matcher's negative lookahead so PostHog proxy requests bypass i18n routing.

## Testing
- Verify pageviews resume on PostHog dashboard after deploy.
- Confirm i18n locale detection still works for all other routes.

## Related
- Regression introduced by https://github.com/manaflow-ai/cmux/pull/1216

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PostHog to the managed reverse proxy at https://r.cmux.dev and remove the `/cmuxterm` rewrites, eliminating the i18n matcher conflict and restoring analytics. Rename the middleware to `web/proxy.ts` for Next.js 16; locale detection for other routes is unchanged.

<sup>Written for commit 4e6a0b81159b9d72c4a10ee68a66aeb17f555883. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened route-matching exclusions to omit additional paths from standard processing, refining request handling.
* **Bug Fixes / Maintenance**
  * Removed legacy proxy rewrite rules that routed certain paths through external rewrite mappings.
* **Telemetry**
  * Switched analytics initialization to use an absolute analytics endpoint URL to ensure consistent event delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->