### PR TITLE
Fix browser devtools X-close persistence

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4221,11 +4221,18 @@ extension BrowserPanel {
     func noteDeveloperToolsHostAttached() {
         cancelPendingDeveloperToolsVisibilityLossCheck()
         developerToolsLastAttachedHostAt = Date()
-        developerToolsLastKnownVisibleAt = isDeveloperToolsVisible() ? Date() : nil
+        if isDeveloperToolsVisible() {
+            developerToolsLastKnownVisibleAt = Date()
+        }
     }
 
     func scheduleDeveloperToolsVisibilityLossCheck() {
         developerToolsVisibilityLossCheckWorkItem?.cancel()
+        let attachedAge = developerToolsLastAttachedHostAt.map { Date().timeIntervalSince($0) } ?? 0
+        let delay = max(
+            developerToolsTransitionSettleDelay,
+            developerToolsAttachedManualCloseDetectionDelay - attachedAge
+        )
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.developerToolsVisibilityLossCheckWorkItem = nil
@@ -4233,7 +4240,7 @@ extension BrowserPanel {
         }
         developerToolsVisibilityLossCheckWorkItem = workItem
         DispatchQueue.main.asyncAfter(
-            deadline: .now() + developerToolsTransitionSettleDelay,
+            deadline: .now() + max(0, delay),
             execute: workItem
         )
     }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -542,7 +542,7 @@ struct BrowserPanelView: View {
                 // `isVisibleInUI` never flips to false. Check for an attached-inspector
                 // X-close when focus leaves as well so the persisted intent stays in sync.
                 DispatchQueue.main.async {
-                    _ = panel.consumeAttachedDeveloperToolsManualCloseIfNeeded()
+                    panel.scheduleDeveloperToolsVisibilityLossCheck()
                 }
             }
             syncWebViewResponderPolicyWithViewState(


### PR DESCRIPTION
## Summary
- persist attached browser devtools X-button closes before surface detach so switching away and back does not reopen them
- consume stable attached-inspector manual closes in the local inline host path instead of treating them like transient attach churn
- add debug logging for the attached close consumption path to make future regressions easier to confirm from logs

## Verification
- `./scripts/reload.sh --tag fix-1623-devtools-close`
- inspected `/tmp/cmux-debug-fix-1623-devtools-close.log` and confirmed the failing path was `pref=1 vis=0` on the stable local host before auto-restore retries re-opened devtools

## Notes
- local tests were not run per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DevTools X-button close persistence in the browser panel and debounces visibility-loss detection so manually closed attached inspectors stay closed across layout, focus, and view changes. Tightens timing by anchoring detection to host-attach and last-visible state. Addresses Linear issue 1623.

- **Bug Fixes**
  - Detect and persist manual closes for attached inspectors after 0.35s from host attach; require last-seen-visible before consuming; stop auto-restore.
  - Debounce visibility-loss sync by 0.15s; schedule on UI hide and focus loss, cancel on show; delay dynamically based on attach age; also check on host updates.
  - Track last-known visibility and host-attach times and sync preference from the real inspector on attach/detach; add debug logs for the close path.

<sup>Written for commit 48426bf1ec1eb797550c1bc031e0f87f1a6f38d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of DevTools attach/detach, visibility and focus changes to prevent stale or out-of-sync UI state; cancels and schedules visibility-loss checks to keep UI consistent.
* **New Features**
  * Panel now tracks DevTools host-attach and visibility timings and can detect and consume manual-close events automatically for smoother UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->