### PR TITLE
fix(portal): GC orphaned terminal subviews in pruneDeadEntries

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1523,6 +1523,28 @@ final class WindowTerminalPortal: NSObject {
             entry.anchorView.map { ObjectIdentifier($0) }
         })
         hostedByAnchorId = hostedByAnchorId.filter { validAnchorIds.contains($0.key) }
+
+        // GC orphan subviews: terminal views that are still subviews of the host
+        // but have no corresponding entry in entriesByHostedId. This can happen when
+        // a workspace is removed while an entry has visibleInUI=true and its anchor
+        // is deallocated before visibleInUI is set to false — the entry gets stuck
+        // (pruneDeadEntries skips visible entries with nil anchors to avoid flicker
+        // during tab drag churn) and eventually removed by another path without
+        // calling removeFromSuperview.
+        let validHostedIds = Set(entriesByHostedId.keys)
+        for subview in hostView.subviews {
+            guard let hostedView = subview as? GhosttySurfaceScrollView else { continue }
+            let hostedId = ObjectIdentifier(hostedView)
+            if !validHostedIds.contains(hostedId) {
+#if DEBUG
+                dlog(
+                    "portal.orphan.gc hosted=\(portalDebugToken(hostedView)) " +
+                    "hidden=\(hostedView.isHidden ? 1 : 0) frame=\(portalDebugFrame(hostedView.frame))"
+                )
+#endif
+                hostedView.removeFromSuperview()
+            }
+        }
     }
 
     func hostedIds() -> Set<ObjectIdentifier> {


### PR DESCRIPTION
## Summary

- Adds orphan subview garbage collection to `pruneDeadEntries()` in `WindowTerminalPortal`
- After dictionary-based entry cleanup, scans `hostView.subviews` for `GhosttySurfaceScrollView` instances with no corresponding entry in `entriesByHostedId` and removes them
- Fixes the floating orphan terminal visible in the bottom-left corner on NIGHTLY

Root cause: when a workspace is removed while a portal entry has `visibleInUI=true` and its SwiftUI anchor is deallocated, `pruneDeadEntries` skips it (to prevent flicker during tab drag churn). If the entry is later removed by another code path that doesn't call `removeFromSuperview`, the surface stays as a visible orphan in the `WindowTerminalHostView`.

## Test plan

- [ ] Open cmux NIGHTLY, verify no floating terminal appears in bottom-left
- [ ] Create/close workspaces rapidly, verify no orphan surfaces appear
- [ ] Tab drag/reorder still works without flicker (the `visibleInUI` skip is preserved for entries, GC only targets subviews with zero entries)

Fixes https://github.com/manaflow-ai/cmux/issues/1630

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Garbage-collect orphaned terminal subviews in `WindowTerminalPortal.pruneDeadEntries()` to stop the floating terminal in the bottom-left on NIGHTLY. Fixes #1630.

- **Bug Fixes**
  - After entry cleanup, scan `hostView.subviews` for `GhosttySurfaceScrollView` without a matching ID in `entriesByHostedId` and remove them.
  - Preserve the `visibleInUI` skip to avoid tab-drag flicker; GC only targets subviews with no entries.

<sup>Written for commit c0526e9988488d3251e5fdac0267a40f5f14b9b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced view cleanup to ensure orphaned UI elements are properly removed from the display hierarchy, improving application stability and preventing potential memory-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->