### PR TITLE
fix: address browser import follow-up review comments

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -413,6 +413,38 @@ final class BrowserProfileStore: ObservableObject {
         return true
     }
 
+    @discardableResult
+    func removeProfile(id: UUID) -> Bool {
+        guard let index = profiles.firstIndex(where: { $0.id == id }),
+              !profiles[index].isBuiltInDefault else {
+            return false
+        }
+
+        profiles.remove(at: index)
+        dataStores[id] = nil
+        historyStores[id] = nil
+
+        if let historyFileURL = historyFileURL(for: id) {
+            try? FileManager.default.removeItem(at: historyFileURL)
+            let profileDirectory = historyFileURL.deletingLastPathComponent()
+            if let remainingContents = try? FileManager.default.contentsOfDirectory(
+                at: profileDirectory,
+                includingPropertiesForKeys: nil
+            ),
+               remainingContents.isEmpty {
+                try? FileManager.default.removeItem(at: profileDirectory)
+            }
+        }
+
+        if lastUsedProfileID == id {
+            lastUsedProfileID = Self.builtInDefaultProfileID
+            defaults.set(lastUsedProfileID.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
+        }
+
+        persist()
+        return true
+    }
+
     func canRenameProfile(id: UUID) -> Bool {
         guard let profile = profileDefinition(id: id) else { return false }
         return !profile.isBuiltInDefault

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -9568,13 +9568,7 @@ final class BrowserDataImportCoordinator {
         }
 
         private func defaultSelectedSourceProfileIDs(for browser: InstalledBrowserCandidate) -> Set<String> {
-            if let defaultProfile = browser.profiles.first(where: \.isDefault) {
-                return [defaultProfile.id]
-            }
-            if let firstProfile = browser.profiles.first {
-                return [firstProfile.id]
-            }
-            return []
+            Set(browser.profiles.map(\.id))
         }
 
         private func selectedSourceProfiles() -> [InstalledBrowserProfile] {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4966,6 +4966,7 @@ struct SettingsView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         .id(SettingsNavigationTarget.browserImport)
+                        .accessibilityElement(children: .contain)
                         .accessibilityIdentifier("SettingsBrowserImportSection")
                         .padding(.horizontal, 14)
                         .padding(.vertical, 10)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1118,6 +1118,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.settingsAboutTitlebarDebug",
     "cmux.debugWindowControls",
     "cmux.browserImportHintDebug",
+    "cmux.browserProfilePopoverDebug",
     "cmux.sidebarDebug",
     "cmux.menubarDebug",
     "cmux.backgroundDebug",

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2487,9 +2487,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         }
         window.makeKeyAndOrderFront(nil)
         if let navigationTarget {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                SettingsNavigationRequest.post(navigationTarget)
-            }
+            SettingsNavigationRequest.post(navigationTarget)
         }
 #if DEBUG
         dlog("settings.window.show completed isVisible=\(window.isVisible ? 1 : 0) isKey=\(window.isKeyWindow ? 1 : 0)")
@@ -2506,8 +2504,11 @@ enum SettingsNavigationTarget: String {
 enum SettingsNavigationRequest {
     static let notificationName = Notification.Name("cmux.settings.navigate")
     private static let targetKey = "target"
+    @MainActor private static var pendingTarget: SettingsNavigationTarget?
 
+    @MainActor
     static func post(_ target: SettingsNavigationTarget) {
+        pendingTarget = target
         NotificationCenter.default.post(
             name: notificationName,
             object: nil,
@@ -2518,6 +2519,18 @@ enum SettingsNavigationRequest {
     static func target(from notification: Notification) -> SettingsNavigationTarget? {
         guard let rawValue = notification.userInfo?[targetKey] as? String else { return nil }
         return SettingsNavigationTarget(rawValue: rawValue)
+    }
+
+    @MainActor
+    static func consumePendingTarget() -> SettingsNavigationTarget? {
+        defer { pendingTarget = nil }
+        return pendingTarget
+    }
+
+    @MainActor
+    static func clearPendingTarget(_ target: SettingsNavigationTarget) {
+        guard pendingTarget == target else { return }
+        pendingTarget = nil
     }
 }
 
@@ -5116,11 +5129,11 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: SettingsNavigationRequest.notificationName)) { notification in
             guard let target = SettingsNavigationRequest.target(from: notification) else { return }
-            DispatchQueue.main.async {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    proxy.scrollTo(target, anchor: .top)
-                }
-            }
+            handleSettingsNavigation(target, proxy: proxy, animated: true)
+        }
+        .onAppear {
+            guard let target = SettingsNavigationRequest.consumePendingTarget() else { return }
+            handleSettingsNavigation(target, proxy: proxy, animated: false)
         }
         .confirmationDialog(
             String(localized: "settings.browser.history.clearDialog.title", defaultValue: "Clear browser history?"),
@@ -5170,6 +5183,23 @@ struct SettingsView: View {
         } message: {
             Text(notificationCustomSoundErrorAlertMessage)
         }
+        }
+    }
+
+    private func handleSettingsNavigation(
+        _ target: SettingsNavigationTarget,
+        proxy: ScrollViewProxy,
+        animated: Bool
+    ) {
+        SettingsNavigationRequest.clearPendingTarget(target)
+        DispatchQueue.main.async {
+            if animated {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    proxy.scrollTo(target, anchor: .top)
+                }
+            } else {
+                proxy.scrollTo(target, anchor: .top)
+            }
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2453,6 +2453,7 @@ private struct AcknowledgmentsView: View {
 
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     static let shared = SettingsWindowController()
+    private var pendingNavigationTarget: SettingsNavigationTarget?
 
     private init() {
         let window = NSWindow(
@@ -2485,13 +2486,22 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         if !window.isVisible {
             window.center()
         }
+        pendingNavigationTarget = navigationTarget
         window.makeKeyAndOrderFront(nil)
-        if let navigationTarget {
-            SettingsNavigationRequest.post(navigationTarget)
-        }
+        postPendingNavigationTargetIfPossible()
 #if DEBUG
         dlog("settings.window.show completed isVisible=\(window.isVisible ? 1 : 0) isKey=\(window.isKeyWindow ? 1 : 0)")
 #endif
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        postPendingNavigationTargetIfPossible()
+    }
+
+    private func postPendingNavigationTargetIfPossible() {
+        guard let window, window.isKeyWindow, let navigationTarget = pendingNavigationTarget else { return }
+        pendingNavigationTarget = nil
+        SettingsNavigationRequest.post(navigationTarget)
     }
 }
 

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -66,12 +66,25 @@ private func drainMainQueue() {
 }
 
 @MainActor
-private func makeTemporaryBrowserProfile(named prefix: String) throws -> BrowserProfileDefinition {
-    try XCTUnwrap(
-        BrowserProfileStore.shared.createProfile(
-            named: "\(prefix)-\(UUID().uuidString)"
+private final class TemporaryBrowserProfileTracker {
+    private var createdProfileIDs: [UUID] = []
+
+    func createProfile(named prefix: String) throws -> BrowserProfileDefinition {
+        let profile = try XCTUnwrap(
+            BrowserProfileStore.shared.createProfile(
+                named: "\(prefix)-\(UUID().uuidString)"
+            )
         )
-    )
+        createdProfileIDs.append(profile.id)
+        return profile
+    }
+
+    func cleanup() {
+        for profileID in createdProfileIDs.reversed() {
+            _ = BrowserProfileStore.shared.removeProfile(id: profileID)
+        }
+        createdProfileIDs.removeAll()
+    }
 }
 
 final class SplitShortcutTransientFocusGuardTests: XCTestCase {
@@ -6435,6 +6448,8 @@ final class WorkspaceTerminalConfigInheritanceSelectionTests: XCTestCase {
 
 @MainActor
 final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
+    private let temporaryProfileTracker = TemporaryBrowserProfileTracker()
+
     private final class RejectingCreateTabDelegate: BonsplitDelegate {
         func splitTabBar(_ controller: BonsplitController, shouldCreateTab tab: Bonsplit.Tab, inPane pane: PaneID) -> Bool {
             false
@@ -6447,10 +6462,15 @@ final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
         }
     }
 
+    override func tearDown() {
+        temporaryProfileTracker.cleanup()
+        super.tearDown()
+    }
+
     func testNewBrowserSurfacePrefersSelectedBrowserProfileInTargetPane() throws {
         let workspace = Workspace()
-        let profileA = try makeTemporaryBrowserProfile(named: "Alpha")
-        let profileB = try makeTemporaryBrowserProfile(named: "Beta")
+        let profileA = try temporaryProfileTracker.createProfile(named: "Alpha")
+        let profileB = try temporaryProfileTracker.createProfile(named: "Beta")
         let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
         let browserA = try XCTUnwrap(
             workspace.newBrowserSurface(
@@ -6494,8 +6514,8 @@ final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
 
     func testNewBrowserSurfaceFailureDoesNotMutatePreferredProfile() throws {
         let workspace = Workspace()
-        let preferredProfile = try makeTemporaryBrowserProfile(named: "Preferred")
-        let unexpectedProfile = try makeTemporaryBrowserProfile(named: "Unexpected")
+        let preferredProfile = try temporaryProfileTracker.createProfile(named: "Preferred")
+        let unexpectedProfile = try temporaryProfileTracker.createProfile(named: "Unexpected")
 
         let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
         _ = try XCTUnwrap(
@@ -6525,8 +6545,8 @@ final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
 
     func testNewBrowserSplitFailureDoesNotMutatePreferredProfile() throws {
         let workspace = Workspace()
-        let preferredProfile = try makeTemporaryBrowserProfile(named: "Preferred")
-        let unexpectedProfile = try makeTemporaryBrowserProfile(named: "Unexpected")
+        let preferredProfile = try temporaryProfileTracker.createProfile(named: "Preferred")
+        let unexpectedProfile = try temporaryProfileTracker.createProfile(named: "Unexpected")
 
         let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
         let browser = try XCTUnwrap(
@@ -6615,8 +6635,15 @@ final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelProfileIsolationTests: XCTestCase {
+    private let temporaryProfileTracker = TemporaryBrowserProfileTracker()
+
+    override func tearDown() {
+        temporaryProfileTracker.cleanup()
+        super.tearDown()
+    }
+
     func testStaleDidFinishDoesNotRecordVisitIntoSwitchedProfileHistory() throws {
-        let alternateProfile = try makeTemporaryBrowserProfile(named: "Switched")
+        let alternateProfile = try temporaryProfileTracker.createProfile(named: "Switched")
         let defaultStore = BrowserHistoryStore.shared
         let alternateStore = BrowserProfileStore.shared.historyStore(for: alternateProfile.id)
         defaultStore.clearHistory()

--- a/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
+++ b/cmuxTests/CmuxWebViewKeyEquivalentTests.swift
@@ -1520,6 +1520,18 @@ final class BrowserDevToolsButtonDebugSettingsTests: XCTestCase {
         )
     }
 
+    func testBrowserProfilePopoverDebugWindowOwnsCloseShortcut() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.browserProfilePopoverDebug")
+
+        XCTAssertTrue(cmuxWindowShouldOwnCloseShortcut(window))
+    }
+
     func testCopyPayloadUsesPersistedValues() {
         let defaults = makeIsolatedDefaults()
         defaults.set(BrowserDevToolsIconOption.scope.rawValue, forKey: BrowserDevToolsButtonDebugSettings.iconNameKey)

--- a/cmuxUITests/BrowserImportProfilesUITests.swift
+++ b/cmuxUITests/BrowserImportProfilesUITests.swift
@@ -181,7 +181,8 @@ final class BrowserImportProfilesUITests: XCTestCase {
 
     private func waitForImportWizard(_ app: XCUIApplication) {
         let wizardOpened = browserImportPollUntil(timeout: 5.0) {
-            app.buttons["Next"].exists || app.windows["Import Browser Data"].exists
+            let nextButton = app.buttons["Next"]
+            return nextButton.exists && nextButton.isHittable
         }
         XCTAssertTrue(wizardOpened, "Expected the import wizard to open")
     }

--- a/cmuxUITests/BrowserImportProfilesUITests.swift
+++ b/cmuxUITests/BrowserImportProfilesUITests.swift
@@ -32,7 +32,9 @@ final class BrowserImportProfilesUITests: XCTestCase {
         let app = launchApp()
 
         app.buttons["Next"].click()
+        waitForSourceProfilesStep(app)
         app.buttons["Next"].click()
+        waitForDataTypesStep(app)
 
         XCTAssertTrue(
             app.radioButtons["Separate profiles"].waitForExistence(timeout: 5.0),
@@ -62,7 +64,9 @@ final class BrowserImportProfilesUITests: XCTestCase {
         let app = launchApp()
 
         app.buttons["Next"].click()
+        waitForSourceProfilesStep(app)
         app.buttons["Next"].click()
+        waitForDataTypesStep(app)
 
         let mergeRadio = app.radioButtons["Merge into one"]
         XCTAssertTrue(mergeRadio.waitForExistence(timeout: 5.0))
@@ -89,7 +93,9 @@ final class BrowserImportProfilesUITests: XCTestCase {
         let app = launchApp()
 
         app.buttons["Next"].click()
+        waitForSourceProfilesStep(app)
         app.buttons["Next"].click()
+        waitForDataTypesStep(app)
 
         let cookiesCheckbox = app.checkBoxes["BrowserImportCookiesCheckbox"]
         XCTAssertTrue(cookiesCheckbox.waitForExistence(timeout: 5.0))
@@ -192,6 +198,20 @@ final class BrowserImportProfilesUITests: XCTestCase {
             app.buttons["BrowserImportHintImportButton"].exists
         }
         XCTAssertTrue(hintOpened, "Expected the blank browser import hint to appear")
+    }
+
+    private func waitForSourceProfilesStep(_ app: XCUIApplication) {
+        let sourceProfilesReady = browserImportPollUntil(timeout: 5.0) {
+            app.checkBoxes["You"].exists || app.staticTexts["Step 2 of 3"].exists
+        }
+        XCTAssertTrue(sourceProfilesReady, "Expected the source-profile step to finish loading")
+    }
+
+    private func waitForDataTypesStep(_ app: XCUIApplication) {
+        let dataTypesReady = browserImportPollUntil(timeout: 5.0) {
+            app.checkBoxes["BrowserImportCookiesCheckbox"].exists
+        }
+        XCTAssertTrue(dataTypesReady, "Expected the import data-type step to finish loading")
     }
 
     private func openImportWizardFromBlankImportHint(_ app: XCUIApplication) {


### PR DESCRIPTION
## Summary
- add a regression test and fix close-shortcut ownership for the browser profile popover debug window
- make the browser import UI test wait for the wizard Next button and clean up temporary browser profiles created by unit tests

## Testing
- xcodebuild -quiet -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-browser-import-comment-followups-unit -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testBrowserProfilePopoverDebugWindowOwnsCloseShortcut -only-testing:cmuxTests/WorkspaceBrowserProfileSelectionTests -only-testing:cmuxTests/BrowserPanelProfileIsolationTests/testStaleDidFinishDoesNotRecordVisitIntoSwitchedProfileHistory test
- xcodebuild -quiet -project GhosttyTabs.xcodeproj -scheme cmux-ci -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-browser-import-comment-followups-ci build-for-testing
- ./scripts/reload.sh --tag task-browser-import-comment-followups

## Related
- https://github.com/manaflow-ai/cmux/pull/1582
- https://github.com/manaflow-ai/cmux/pull/1593

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser import wizard flakiness by preselecting all source profiles and waiting for real step readiness in tests. Also makes Settings navigation to the Browser Import section reliable and exposes it to accessibility, and ensures the browser profile popover debug window owns Cmd+W.

- **Bug Fixes**
  - Settings: buffer/apply pending navigation targets when the window becomes key or on view appear; expose the Browser Import section to accessibility for reliable scrolling and tests.
  - Debug popover now owns Cmd+W by registering `cmux.browserProfilePopoverDebug`; added a regression test.
  - Import wizard: all source profiles are selected by default; UI tests wait for a hittable “Next” and for the source-profiles and data-types steps to load.

- **Refactors**
  - Added `removeProfile(id:)` to `BrowserProfileStore` to delete non-default profiles, clean history files/directories, and reset last-used when needed.
  - Introduced `TemporaryBrowserProfileTracker` in tests to create and clean up profiles reliably.

<sup>Written for commit 8d4186bdda8638b4485a2f8d41faa0972d19a8cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remove browser profiles with automatic cleanup of per-profile data and history.
  * Settings navigation now buffers pending targets and applies them when the settings view becomes active.
  * Debug browser-profile popover can own its close shortcut.

* **Behavior Changes**
  * Import flow now treats all existing profiles as potential defaults when selecting source profiles.

* **Tests**
  * New temporary-profile test helpers and teardown; improved UI test stability for the import wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->