### PR TITLE
Fix AZERTY Option+Delete word delete in Claude Code

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4817,7 +4817,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Check if this event matches a Ghostty keybinding.
         let bindingFlags: ghostty_binding_flags_e? = {
             var keyEvent = ghosttyKeyEvent(for: event, surface: surface)
-            let text = event.characters ?? ""
+            let text = textForKeyEvent(event).flatMap { shouldSendText($0) ? $0 : nil } ?? ""
             var flags = ghostty_binding_flags_e(0)
             let isBinding = text.withCString { ptr in
                 keyEvent.text = ptr
@@ -5204,6 +5204,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     )
 #endif
                 } else {
+                    keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                     keyEvent.text = nil
                     #if DEBUG
                     let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -5249,6 +5250,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     )
 #endif
                 } else {
+                    keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                     keyEvent.text = nil
                     #if DEBUG
                     let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -5264,6 +5266,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     #endif
                 }
             } else {
+                keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                 keyEvent.text = nil
                 #if DEBUG
                 let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -5417,7 +5420,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
             // If we have a single control character, return the character without
             // the control modifier so Ghostty's KeyEncoder can handle it.
-            if scalar.value < 0x20 {
+            if isControlCharacterScalar(scalar) {
                 if flags.contains(.control) {
                     return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
                 }
@@ -5454,9 +5457,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return scalar.value
     }
 
+    private func isControlCharacterScalar(_ scalar: UnicodeScalar) -> Bool {
+        scalar.value < 0x20 || scalar.value == 0x7F
+    }
+
     private func shouldSendText(_ text: String) -> Bool {
-        guard let first = text.utf8.first else { return false }
-        return first >= 0x20
+        guard !text.isEmpty else { return false }
+        if text.count == 1, let scalar = text.unicodeScalars.first {
+            return !isControlCharacterScalar(scalar)
+        }
+        return true
     }
 
     /// If AppKit consumed Shift+Space for IME/input-source switching, interpretKeyEvents

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -993,3 +993,77 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
         XCTAssertEqual(pressUnshiftedCodepoint, "`".unicodeScalars.first?.value)
     }
 }
+
+@MainActor
+final class GhosttyOptionDeleteRegressionTests: XCTestCase {
+    func testOptionDeletePreservesAltAsModifierForWordDelete() {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            window.orderOut(nil)
+        }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        var pressEvent: ghostty_input_key_s?
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 51 else { return }
+            pressEvent = keyEvent
+        }
+
+        let sent = hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
+            characters: "\u{7F}",
+            charactersIgnoringModifiers: "\u{7F}",
+            keyCode: 51,
+            modifierFlags: [.option]
+        )
+        XCTAssertTrue(sent, "Expected synthetic Option+Delete event to be dispatched")
+
+        guard let pressEvent else {
+            XCTFail("Expected to capture Option+Delete key event")
+            return
+        }
+
+        XCTAssertEqual(pressEvent.action, GHOSTTY_ACTION_PRESS)
+        XCTAssertEqual(pressEvent.keycode, 51)
+        XCTAssertEqual(
+            pressEvent.mods.rawValue & GHOSTTY_MODS_ALT.rawValue,
+            GHOSTTY_MODS_ALT.rawValue,
+            "Option+Delete should preserve Alt on the raw key event"
+        )
+        XCTAssertEqual(
+            pressEvent.consumed_mods.rawValue,
+            GHOSTTY_MODS_NONE.rawValue,
+            "Non-printing delete should not consume Option as text input"
+        )
+        XCTAssertNil(pressEvent.text, "Delete should be encoded as a key event, not forwarded as DEL text")
+    }
+}


### PR DESCRIPTION
## Summary
- treat DEL (`Option+Delete`) as a non-text control key in the terminal key bridge
- clear consumed text modifiers when a key event is forwarded without text so Option remains available as Meta for word-delete
- add a regression test covering synthetic `Option+Delete` through the real `keyDown` path

Closes #1635.

## Verification
- built and launched with `./scripts/reload.sh --tag fix-1635-azerty-delete`
- did not run local tests per repo policy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Option+Delete on AZERTY by treating Delete (DEL) as a non-text key and not consuming Option, so Alt+Delete deletes a word again in the terminal. Adds a regression test that drives a synthetic Option+Delete through keyDown to ensure Alt is preserved and no DEL text is sent.

<sup>Written for commit e9db155943c1230e7314e84acde88070e381b6fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard event text extraction for improved input reliability and consistency
  * Improved control character detection to prevent accidental text transmission
  * Added defensive modifier state reset to ensure correct behavior in edge cases

* **Tests**
  * Added regression tests verifying Option+Delete correctly preserves the Alt modifier during word deletion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->