### PR TITLE
Address command palette follow-up review comments

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1569,7 +1569,6 @@ struct ContentView: View {
 
     private struct CommandPaletteCommandsContext {
         let snapshot: CommandPaletteContextSnapshot
-        let cliInstalledInPATH: Bool
     }
 
     private enum CommandPaletteContextKeys {
@@ -1594,6 +1593,7 @@ struct ContentView: View {
         static let panelHasUnread = "panel.hasUnread"
 
         static let updateHasAvailable = "update.hasAvailable"
+        static let cliInstalledInPATH = "cli.installedInPATH"
 
         static func terminalOpenTargetAvailable(_ target: TerminalDirectoryOpenTarget) -> String {
             "terminal.openTarget.\(target.rawValue).available"
@@ -4298,10 +4298,7 @@ struct ContentView: View {
     }
 
     private func commandPaletteCommandsFingerprint(commandsContext: CommandPaletteCommandsContext) -> Int {
-        var hasher = Hasher()
-        hasher.combine(commandsContext.snapshot.fingerprint())
-        hasher.combine(commandsContext.cliInstalledInPATH)
-        return hasher.finalize()
+        commandsContext.snapshot.fingerprint()
     }
 
     private func commandPaletteSwitcherEntriesFingerprint(includeSurfaces: Bool) -> Int {
@@ -4672,9 +4669,11 @@ struct ContentView: View {
     private func commandPaletteCommandsContext(
         terminalOpenTargets: Set<TerminalDirectoryOpenTarget>
     ) -> CommandPaletteCommandsContext {
-        CommandPaletteCommandsContext(
-            snapshot: commandPaletteContextSnapshot(terminalOpenTargets: terminalOpenTargets),
-            cliInstalledInPATH: AppDelegate.shared?.isCmuxCLIInstalledInPATH() ?? false
+        let cliInstalledInPATH = AppDelegate.shared?.isCmuxCLIInstalledInPATH() ?? false
+        var snapshot = commandPaletteContextSnapshot(terminalOpenTargets: terminalOpenTargets)
+        snapshot.setBool(CommandPaletteContextKeys.cliInstalledInPATH, cliInstalledInPATH)
+        return CommandPaletteCommandsContext(
+            snapshot: snapshot
         )
     }
 
@@ -4946,7 +4945,7 @@ struct ContentView: View {
                 title: constant(String(localized: "command.installCLI.title", defaultValue: "Shell Command: Install 'cmux' in PATH")),
                 subtitle: constant(String(localized: "command.installCLI.subtitle", defaultValue: "CLI")),
                 keywords: ["install", "cli", "path", "shell", "command", "symlink"],
-                when: { _ in !(AppDelegate.shared?.isCmuxCLIInstalledInPATH() ?? false) }
+                when: { !$0.bool(CommandPaletteContextKeys.cliInstalledInPATH) }
             )
         )
         contributions.append(
@@ -4955,7 +4954,7 @@ struct ContentView: View {
                 title: constant(String(localized: "command.uninstallCLI.title", defaultValue: "Shell Command: Uninstall 'cmux' from PATH")),
                 subtitle: constant(String(localized: "command.uninstallCLI.subtitle", defaultValue: "CLI")),
                 keywords: ["uninstall", "remove", "cli", "path", "shell", "command", "symlink"],
-                when: { _ in AppDelegate.shared?.isCmuxCLIInstalledInPATH() ?? false }
+                when: { $0.bool(CommandPaletteContextKeys.cliInstalledInPATH) }
             )
         )
         contributions.append(

--- a/cmuxUITests/SidebarHelpMenuUITests.swift
+++ b/cmuxUITests/SidebarHelpMenuUITests.swift
@@ -313,14 +313,24 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
         super.tearDown()
     }
 
-    func testCmdShiftPBackspaceReturnsToWorkspaceResults() throws {
-        let app = XCUIApplication()
+    private func configureSocketControlledLaunch(
+        _ app: XCUIApplication,
+        showSettingsWindow: Bool = false
+    ) {
         app.launchArguments += ["-socketControlMode", "allowAll"]
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
         app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        if showSettingsWindow {
+            app.launchEnvironment["CMUX_UI_TEST_SHOW_SETTINGS"] = "1"
+        }
+    }
+
+    func testCmdShiftPBackspaceReturnsToWorkspaceResults() throws {
+        let app = XCUIApplication()
+        configureSocketControlledLaunch(app)
         launchAndActivate(app)
 
         XCTAssertTrue(
@@ -402,13 +412,7 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
 
     func testCmdPSearchCanIncludeSurfacesFromOtherWorkspacesWhenEnabled() throws {
         let app = XCUIApplication()
-        app.launchArguments += ["-socketControlMode", "allowAll"]
-        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_SHOW_SETTINGS"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        configureSocketControlledLaunch(app, showSettingsWindow: true)
         launchAndActivate(app)
 
         XCTAssertTrue(
@@ -484,12 +488,7 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
 
     func testSwitcherEmptyStateDoesNotBlinkWhileRefiningNoMatchQuery() throws {
         let app = XCUIApplication()
-        app.launchArguments += ["-socketControlMode", "allowAll"]
-        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        configureSocketControlledLaunch(app)
         launchAndActivate(app)
 
         XCTAssertTrue(
@@ -510,20 +509,20 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
         XCTAssertTrue(searchField.waitForExistence(timeout: 5.0), "Expected command palette search field")
         searchField.click()
 
-        let seededWorkspaceTitle = seededWorkspaceTitle(index: 1)
+        let seededWorkspaceTitlePrefix = "\(noMatchWorkspaceQuery)-"
         try debugTypeText(noMatchWorkspaceQuery)
 
         let seededSnapshot = try XCTUnwrap(
             waitForCommandPaletteSnapshot(windowId: mainWindowId, query: noMatchWorkspaceQuery, timeout: 5.0) { snapshot in
                 self.commandPaletteResultRows(from: snapshot).contains { row in
-                    (row["title"] as? String) == seededWorkspaceTitle
+                    ((row["title"] as? String) ?? "").hasPrefix(seededWorkspaceTitlePrefix)
                 }
             },
             "Expected seeded workspace titles to be indexed before exercising the no-match path"
         )
         XCTAssertTrue(
             commandPaletteResultRows(from: seededSnapshot).contains { row in
-                (row["title"] as? String) == seededWorkspaceTitle
+                ((row["title"] as? String) ?? "").hasPrefix(seededWorkspaceTitlePrefix)
             },
             "Expected the seeded workspace corpus to be searchable before the no-match assertion. snapshot=\(seededSnapshot)"
         )
@@ -709,8 +708,13 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
         searchField.click()
         app.typeKey("a", modifierFlags: [.command])
         app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
-        _ = try XCTUnwrap(
+        let clearedSnapshot = try XCTUnwrap(
             waitForCommandPaletteSnapshot(windowId: windowId, query: "", timeout: 5.0),
+            "Expected the command palette query to clear"
+        )
+        XCTAssertEqual(
+            clearedSnapshot["query"] as? String,
+            "",
             "Expected the command palette query to clear"
         )
     }
@@ -772,7 +776,7 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
             guard (snapshot["query"] as? String) == query else { return false }
             return predicate?(snapshot) ?? true
         }
-        return matched ? latest : latest
+        return matched ? latest : nil
     }
 
     private func commandPaletteSnapshot(windowId: String) -> [String: Any]? {


### PR DESCRIPTION
Addresses the technically valid follow-up comments from https://github.com/manaflow-ai/cmux/pull/1621.

Changes:
- tighten the sidebar no-blink UI regression so it first proves the seeded workspace corpus is indexed
- keep the empty-state visibility assertion alive until the refined query snapshot resolves
- stop re-running terminal open-target discovery from the command-palette context snapshot hot path by resolving availability once per refresh and reusing it

Verification:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-1621-review-followups-unit test -only-testing:cmuxTests/CommandPaletteSearchEngineTests -only-testing:cmuxTests/TerminalDirectoryOpenTargetAvailabilityTests`
- GitHub Actions XCUITest run: https://github.com/manaflow-ai/cmux/actions/runs/23223057140
- `./scripts/reload.sh --tag task-1621-review-followups`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves command palette stability and performance: fixes sidebar no-blink/empty-state behavior, caches terminal open-target availability (and resets it on dismiss), and hardens UI tests by forcing raw socket control.

- **Bug Fixes**
  - Ensure the seeded workspace corpus is indexed before asserting the switcher’s no-match state.
  - Keep the empty-state label visible while a refined no-match query resolves.
  - Force raw socket control in command palette UI tests (`allowAll` via launch args/env) and add helpers (search clear + launch config) for deterministic, compiling tests.

- **Performance**
  - Resolve terminal directory open-target availability once per refresh and reuse it.
  - Thread a cached commands context into entries/fingerprinting to avoid recomputing availability during search.

<sup>Written for commit 868d362dff4dde7f7708dad39bef56b8a6761ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command Palette gains contextual awareness of terminal targets and CLI-in-PATH state, plus a snapshot-based commands context to surface and cache relevant commands.

* **Bug Fixes**
  * Palette now resets terminal-target availability on dismiss; search fingerprints and entry generation consistently reflect current context to avoid stale results.

* **Tests**
  * UI tests expanded and hardened: socket-controlled launch setup, seeded workspace indexing, refined no-match flows, and search-clear helpers for more reliable coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->