### PR TITLE
Avoid menu resync on window activation

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4912,6 +4912,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
+    /// Resolve the best current `TabManager` for menu/UI reads without mutating
+    /// the app-wide active window pointers.
+    func preferredTabManager(preferredWindow: NSWindow? = nil) -> TabManager? {
+        if let preferredWindow,
+           let context = contextForMainWindow(preferredWindow) {
+            return context.tabManager
+        }
+        if let context = contextForMainWindow(NSApp.keyWindow) {
+            return context.tabManager
+        }
+        if let context = contextForMainWindow(NSApp.mainWindow) {
+            return context.tabManager
+        }
+        if let activeManager = tabManager {
+            return activeManager
+        }
+        return mainWindowContexts.values.first?.tabManager
+    }
+
     /// Re-sync app-level active window pointers from the currently focused main terminal window.
     /// This keeps menu/shortcut actions window-scoped even if the cached `tabManager` drifts.
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10451,7 +10451,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             queue: .main
         ) { [weak self] note in
             guard let self, let window = note.object as? NSWindow else { return }
-            self.setActiveMainWindow(window)
+            guard let context = self.setActiveMainWindow(window) else { return }
+            self.restoreFocusedTerminalOnWindowActivation(window: window, context: context)
         }
     }
 
@@ -10495,8 +10496,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return tabManager?.selectedWorkspace?.browserPanel(for: panelId)
     }
 
-    private func setActiveMainWindow(_ window: NSWindow) {
-        guard let context = contextForMainTerminalWindow(window) else { return }
+    private func restoreFocusedTerminalOnWindowActivation(
+        window: NSWindow,
+        context: MainWindowContext
+    ) {
+        guard window.isKeyWindow,
+              let workspace = context.tabManager.selectedWorkspace,
+              let focusedPanelId = workspace.focusedPanelId,
+              let terminalPanel = workspace.terminalPanel(for: focusedPanelId) else {
+            return
+        }
+#if DEBUG
+        dlog(
+            "mainWindow.focusRestore window={\(debugWindowToken(window))} " +
+            "workspace=\(workspace.id.uuidString.prefix(5)) panel=\(focusedPanelId.uuidString.prefix(5))"
+        )
+#endif
+        terminalPanel.hostedView.ensureFocus(for: workspace.id, surfaceId: focusedPanelId)
+    }
+
+    @discardableResult
+    private func setActiveMainWindow(_ window: NSWindow) -> MainWindowContext? {
+        guard let context = contextForMainTerminalWindow(window) else { return nil }
+        let sameTabManager = tabManager === context.tabManager
+        let sameSidebarState = sidebarState === context.sidebarState
+        let sameSidebarSelectionState = sidebarSelectionState === context.sidebarSelectionState
+        if sameTabManager {
+            let repairedSidebarState = !sameSidebarState && sidebarState == nil
+            let repairedSidebarSelectionState =
+                !sameSidebarSelectionState && sidebarSelectionState == nil
+            if repairedSidebarState {
+                sidebarState = context.sidebarState
+            }
+            if repairedSidebarSelectionState {
+                sidebarSelectionState = context.sidebarSelectionState
+            }
+            TerminalController.shared.setActiveTabManager(context.tabManager)
+#if DEBUG
+            dlog(
+                "mainWindow.active window={\(debugWindowToken(window))} context={\(debugContextToken(context))} " +
+                "nochange=1 repairSidebar=\(repairedSidebarState ? 1 : 0) " +
+                "repairSelection=\(repairedSidebarSelectionState ? 1 : 0) " +
+                "\(debugShortcutRouteSnapshot())"
+            )
+#endif
+            return context
+        }
 #if DEBUG
         let beforeManagerToken = debugManagerToken(tabManager)
 #endif
@@ -10509,6 +10554,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             "mainWindow.active window={\(debugWindowToken(window))} context={\(debugContextToken(context))} beforeMgr=\(beforeManagerToken) afterMgr=\(debugManagerToken(tabManager)) \(debugShortcutRouteSnapshot())"
         )
 #endif
+        return context
     }
 
     private func unregisterMainWindow(_ window: NSWindow) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6697,18 +6697,6 @@ final class GhosttySurfaceScrollView: NSView {
         windowObservers.removeAll()
         guard let window else { return }
         windowObservers.append(NotificationCenter.default.addObserver(
-            forName: NSWindow.didBecomeKeyNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            guard let self else { return }
-            let searchActive = self.surfaceView.terminalSurface?.searchState != nil
-#if DEBUG
-            dlog("find.window.didBecomeKey surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") searchActive=\(searchActive) focusTarget=\(self.searchFocusTarget) firstResponder=\(String(describing: self.window?.firstResponder))")
-#endif
-            self.scheduleAutomaticFirstResponderApply(reason: "didBecomeKey")
-        })
-        windowObservers.append(NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,
             object: window,
             queue: .main

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -840,7 +840,7 @@ struct cmuxApp: App {
     }
 
     private var activeTabManager: TabManager {
-        AppDelegate.shared?.synchronizeActiveMainWindowContext(
+        appDelegate.preferredTabManager(
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
     }


### PR DESCRIPTION
## Summary
- stop menu state reads from calling `synchronizeActiveMainWindowContext` on every window activation
- add a non-mutating `preferredTabManager` lookup for menu/UI reads so focus changes reuse the already-updated active window context

## Testing
- `./scripts/reload.sh --tag task-1641-window-focus-lag` ✅
- switched Finder -> `cmux DEV task-1641-window-focus-lag` via AppleScript and confirmed `/tmp/cmux-debug-task-1641-window-focus-lag.log` contains `0` `shortcut.sync` entries on the activation path

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/1641

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop resyncing menu state on window activation by using a non‑mutating tab manager lookup and centralizing focus restore. This removes focus lag, stops redundant shortcut syncs, and reliably restores terminal focus (closes #1641).

- **Refactors**
  - Added `AppDelegate.preferredTabManager(...)` and switched `activeTabManager` to use it with key/main window fallback, replacing `synchronizeActiveMainWindowContext` for menu/UI reads.
  - Centralized window activation focus restore in `AppDelegate` (invoked on `didBecomeKey`), removed the per-view observer in `GhosttyTerminalView`, and updated `setActiveMainWindow` to return context, avoid pointer churn when unchanged, and repair missing sidebar state only when nil.

<sup>Written for commit 17c5ea62c1d84417ed7804eb47517e8463906506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced window and tab context selection logic for improved reliability.
  * Optimized active context synchronization with better state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->