### PR TITLE
Fix keyboard shortcuts with CJK input sources

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9975,8 +9975,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // For command-based shortcuts, trust AppKit's layout-aware characters when present.
         // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
         // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
+        // When a non-Latin input source is active (Korean, Chinese, Japanese, etc.),
+        // charactersIgnoringModifiers returns non-ASCII characters that can never match
+        // a Latin shortcut key — skip this guard and fall through to layout-based matching.
         let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
+        let eventCharsAreASCII = eventCharsIgnoringModifiers?.allSatisfy(\.isASCII) ?? true
         if hasEventChars,
+           eventCharsAreASCII,
            flags.contains(.command),
            !flags.contains(.control),
            shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
@@ -9999,12 +10004,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // so keep ANSI keyCode fallback for control-modified shortcuts. Also allow fallback for
         // command punctuation shortcuts, since some non-US layouts report different characters
         // for the same physical key even when menu-equivalent semantics should still apply.
+        // When a non-Latin input source is active, treat non-ASCII event chars the same as
+        // absent chars — they carry no usable Latin key identity.
+        let hasUsableEventChars = hasEventChars && eventCharsAreASCII
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
                 && (
                     !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
+                        || (!hasUsableEventChars && (layoutCharacter?.isEmpty ?? true))
                 ))
         if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -15,12 +15,31 @@ class KeyboardLayout {
 
     /// Translate a physical keyCode to the character AppKit would use for shortcut matching,
     /// preserving command-aware layouts such as "Dvorak - QWERTY Command".
+    /// CJK input sources (Korean, Chinese, Japanese) lack kTISPropertyUnicodeKeyLayoutData,
+    /// so we fall back to TISCopyCurrentASCIICapableKeyboardInputSource() in that case.
     static func character(
         forKeyCode keyCode: UInt16,
         modifierFlags: NSEvent.ModifierFlags = []
     ) -> String? {
-        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
-              let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+        if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+           let result = characterFromInputSource(source, forKeyCode: keyCode, modifierFlags: modifierFlags) {
+            return result
+        }
+        // Current input source has no Unicode layout data (e.g. Korean, Chinese, Japanese IME).
+        // Fall back to the ASCII-capable source so shortcut matching still works.
+        if let asciiSource = TISCopyCurrentASCIICapableKeyboardInputSource()?.takeRetainedValue(),
+           let result = characterFromInputSource(asciiSource, forKeyCode: keyCode, modifierFlags: modifierFlags) {
+            return result
+        }
+        return nil
+    }
+
+    private static func characterFromInputSource(
+        _ source: TISInputSource,
+        forKeyCode keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> String? {
+        guard let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
             return nil
         }
 


### PR DESCRIPTION
## Summary

- Fix keyboard shortcuts (Cmd+P, Cmd+B, Cmd+D, etc.) not working when Korean, Chinese, or Japanese input method is active
- Add ASCII-capable input source fallback in `KeyboardLayout.character()` for CJK IMEs that lack `kTISPropertyUnicodeKeyLayoutData`
- Update `matchShortcut()` guard to skip early-return when `charactersIgnoringModifiers` contains non-ASCII characters

## Problem

When a CJK input source is active, `event.charactersIgnoringModifiers` returns non-Latin characters (e.g. Korean jamo "ㅔ" for the P key). The existing shortcut matching logic had two guards that treated these characters as valid Latin input, causing all fallback paths (layout-based and keyCode-based) to be blocked.

## Solution

**`KeyboardLayout.swift`**: `character(forKeyCode:modifierFlags:)` now tries the current input source first, then falls back to `TISCopyCurrentASCIICapableKeyboardInputSource()` when no Unicode layout data is available. Extracted shared logic into `characterFromInputSource()` helper.

**`AppDelegate.swift`**: Added `eventCharsAreASCII` check so non-ASCII event characters don't trigger the early-return guard for Cmd+letter shortcuts. Added `hasUsableEventChars` so the ANSI keyCode fallback correctly activates for CJK input sources.

## Scope

This covers shortcuts handled by `handleCustomShortcut` (local event monitor). Menu/SwiftUI `.keyboardShortcut()` shortcuts are not yet covered.

## Test plan

- [ ] Korean input (한글) + Cmd+P → command palette opens
- [ ] Korean input + Cmd+B → sidebar toggles
- [ ] Korean input + Cmd+D → split right
- [ ] English input + all shortcuts → no regression
- [ ] Dvorak layout + shortcuts → still layout-aware
- [ ] Japanese/Chinese IME + Cmd shortcuts → work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Command shortcuts (e.g., Cmd+P, Cmd+B, Cmd+D) not working when Korean, Chinese, or Japanese input sources are active. Adds an ASCII-capable layout fallback and smarter event-character checks so shortcuts work across layouts without regressions.

- **Bug Fixes**
  - `KeyboardLayout.character(...)` now tries the current input source first and falls back to `TISCopyCurrentASCIICapableKeyboardInputSource()` when `kTISPropertyUnicodeKeyLayoutData` is missing; shared logic extracted to `characterFromInputSource(...)`.
  - Updated shortcut matching in `AppDelegate` to ignore non-ASCII `charactersIgnoringModifiers` for Command-letter shortcuts and treat them as absent, enabling layout-based matching and ANSI keyCode fallback when needed.

<sup>Written for commit 19204c703852999c82fb461005b96633ae0b8d58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command shortcuts falsely triggering when using non-Latin input sources (Korean, Chinese, Japanese)
  * Enhanced keyboard layout detection and fallback handling for improved international input method support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->