### PR TITLE
feat(sidebar): workspace icons (iMessage-style circular design)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3277,8 +3277,10 @@ struct CMUXCLI {
         let (workspaceOpt, rem0) = parseOption(commandArgs, name: "--workspace")
         let (actionOpt, rem1) = parseOption(rem0, name: "--action")
         let (titleOpt, rem2) = parseOption(rem1, name: "--title")
+        let (iconOpt, rem3) = parseOption(rem2, name: "--icon")
+        let (colorOpt, rem4) = parseOption(rem3, name: "--color")
 
-        var positional = rem2
+        var positional = rem4
         let actionRaw: String
         if let actionOpt {
             actionRaw = actionOpt
@@ -3303,6 +3305,12 @@ struct CMUXCLI {
         if action == "rename", (title?.isEmpty ?? true) {
             throw CLIError(message: "workspace-action rename requires --title <text> (or a trailing title)")
         }
+        if action == "set_icon", (iconOpt?.isEmpty ?? true) {
+            throw CLIError(message: "workspace-action set-icon requires --icon <path-or-emoji>")
+        }
+        if action == "set_color", (colorOpt?.isEmpty ?? true) {
+            throw CLIError(message: "workspace-action set-color requires --color <hex>")
+        }
 
         var params: [String: Any] = ["action": action]
         if let workspaceId {
@@ -3310,6 +3318,12 @@ struct CMUXCLI {
         }
         if let title, !title.isEmpty {
             params["title"] = title
+        }
+        if let iconOpt, !iconOpt.isEmpty {
+            params["icon"] = iconOpt
+        }
+        if let colorOpt, !colorOpt.isEmpty {
+            params["color"] = colorOpt
         }
 
         let payload = try client.sendV2(method: "workspace.action", params: params)
@@ -6086,6 +6100,8 @@ struct CMUXCLI {
             Actions:
               pin | unpin
               rename | clear-name
+              set-color | clear-color
+              set-icon | clear-icon
               move-up | move-down | move-top
               close-others | close-above | close-below
               mark-read | mark-unread
@@ -6094,10 +6110,15 @@ struct CMUXCLI {
               --action <name>              Action name (required if not positional)
               --workspace <id|ref|index>   Target workspace (default: current/$CMUX_WORKSPACE_ID)
               --title <text>               Title for rename (or pass trailing title text)
+              --icon <path|emoji:X>        Icon for set-icon (file path or emoji:🚀)
+              --color <hex>                Color for set-color (e.g. #C0392B)
 
             Example:
               cmux workspace-action --workspace workspace:2 --action pin
               cmux workspace-action --action rename --title "infra"
+              cmux workspace-action --action set-icon --icon emoji:🚀
+              cmux workspace-action --action set-icon --icon /path/to/icon.png
+              cmux workspace-action --action set-color --color "#C0392B"
               cmux workspace-action close-others
             """
         case "tab-action":

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -28774,6 +28774,159 @@
         }
       }
     },
+    "contextMenu.workspaceIcon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Icon"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースアイコン"
+          }
+        }
+      }
+    },
+    "contextMenu.clearIcon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Icon"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイコンをクリア"
+          }
+        }
+      }
+    },
+    "contextMenu.setIconFromFile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Icon from File…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルからアイコンを設定…"
+          }
+        }
+      }
+    },
+    "contextMenu.setEmojiIcon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Emoji Icon…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字アイコンを設定…"
+          }
+        }
+      }
+    },
+    "alert.emojiIcon.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji Workspace Icon"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字ワークスペースアイコン"
+          }
+        }
+      }
+    },
+    "alert.emojiIcon.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter an emoji to use as the workspace icon."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースアイコンとして使用する絵文字を入力してください。"
+          }
+        }
+      }
+    },
+    "alert.emojiIcon.apply": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        }
+      }
+    },
+    "alert.emojiIcon.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
+    "openPanel.workspaceIcon.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Workspace Icon"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースアイコンを選択"
+          }
+        }
+      }
+    },
     "dialog.closeLastTabWindow.message": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -45144,13 +45144,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show favicon.png, favicon.ico, or .cmux-icon.png from the workspace directory as the workspace icon."
+            "value": "Detect favicon, app icon, or logo from the workspace directory and show it in the sidebar."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ワークスペースディレクトリのfavicon.pngやfavicon.ico、.cmux-icon.pngをワークスペースアイコンとして表示します。"
+            "value": "ワークスペースディレクトリからfavicon、アプリアイコン、ロゴを検出してサイドバーに表示します。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -45121,6 +45121,40 @@
         }
       }
     },
+    "settings.app.autoDetectFavicon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-detect Workspace Icon"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースアイコンを自動検出"
+          }
+        }
+      }
+    },
+    "settings.app.autoDetectFavicon.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show favicon.png, favicon.ico, or .cmux-icon.png from the workspace directory as the workspace icon."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースディレクトリのfavicon.pngやfavicon.ico、.cmux-icon.pngをワークスペースアイコンとして表示します。"
+          }
+        }
+      }
+    },
     "settings.app.showPorts": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -30,6 +30,44 @@ private func coloredCircleImage(color: NSColor) -> NSImage {
     return image
 }
 
+/// Circular workspace icon rendered in the sidebar, iMessage-style.
+/// Supports emoji (prefixed with "emoji:") or image file paths.
+private struct WorkspaceIconView: View {
+    let iconPath: String
+    let size: CGFloat
+
+    var body: some View {
+        if iconPath.hasPrefix("emoji:") {
+            let emoji = String(iconPath.dropFirst(6))
+            Text(emoji)
+                .font(.system(size: size * 0.55))
+                .frame(width: size, height: size)
+                .background(
+                    Circle()
+                        .fill(Color.primary.opacity(0.08))
+                )
+                .clipShape(Circle())
+        } else if let nsImage = NSImage(contentsOfFile: iconPath) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: size, height: size)
+                .clipShape(Circle())
+        } else {
+            // Fallback for missing/invalid file: show a placeholder circle
+            Image(systemName: "photo")
+                .font(.system(size: size * 0.4))
+                .foregroundColor(.secondary)
+                .frame(width: size, height: size)
+                .background(
+                    Circle()
+                        .fill(Color.primary.opacity(0.06))
+                )
+                .clipShape(Circle())
+        }
+    }
+}
+
 func sidebarActiveForegroundNSColor(
     opacity: CGFloat,
     appAppearance: NSAppearance? = NSApp?.effectiveAppearance
@@ -10623,6 +10661,11 @@ private struct TabItemView: View, Equatable {
             return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
         }()
 
+        HStack(alignment: .center, spacing: 10) {
+            if let iconPath = tab.customIconPath {
+                WorkspaceIconView(iconPath: iconPath, size: 36)
+            }
+
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 if unreadCount > 0 {
@@ -10850,7 +10893,8 @@ private struct TabItemView: View, Equatable {
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
-        }
+        } // VStack
+        } // HStack (icon + content)
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
@@ -11069,6 +11113,28 @@ private struct TabItemView: View, Equatable {
                         Image(nsImage: coloredCircleImage(color: tabColorSwatchColor(for: entry.hex)))
                     }
                 }
+            }
+        }
+
+        Menu(String(localized: "contextMenu.workspaceIcon", defaultValue: "Workspace Icon")) {
+            if tab.customIconPath != nil {
+                Button {
+                    applyTabIcon(nil, targetIds: targetIds)
+                } label: {
+                    Label(String(localized: "contextMenu.clearIcon", defaultValue: "Clear Icon"), systemImage: "xmark.circle")
+                }
+            }
+
+            Button {
+                promptIconFromFile(targetIds: targetIds)
+            } label: {
+                Label(String(localized: "contextMenu.setIconFromFile", defaultValue: "Set Icon from File…"), systemImage: "photo")
+            }
+
+            Button {
+                promptEmojiIcon(targetIds: targetIds)
+            } label: {
+                Label(String(localized: "contextMenu.setEmojiIcon", defaultValue: "Set Emoji Icon…"), systemImage: "face.smiling")
             }
         }
 
@@ -11712,6 +11778,48 @@ private struct TabItemView: View, Equatable {
         for targetId in targetIds {
             tabManager.setTabColor(tabId: targetId, color: hex)
         }
+    }
+
+    private func applyTabIcon(_ path: String?, targetIds: [UUID]) {
+        for targetId in targetIds {
+            tabManager.setTabIcon(tabId: targetId, iconPath: path)
+        }
+    }
+
+    private func promptIconFromFile(targetIds: [UUID]) {
+        let panel = NSOpenPanel()
+        panel.title = String(localized: "openPanel.workspaceIcon.title", defaultValue: "Choose Workspace Icon")
+        panel.allowedContentTypes = [.png, .jpeg, .svg, .ico, .heic, .tiff]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
+        applyTabIcon(url.path, targetIds: targetIds)
+    }
+
+    private func promptEmojiIcon(targetIds: [UUID]) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "alert.emojiIcon.title", defaultValue: "Emoji Workspace Icon")
+        alert.informativeText = String(localized: "alert.emojiIcon.message", defaultValue: "Enter an emoji to use as the workspace icon.")
+        let input = NSTextField(string: "")
+        input.placeholderString = "🚀"
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "alert.emojiIcon.apply", defaultValue: "Apply"))
+        alert.addButton(withTitle: String(localized: "alert.emojiIcon.cancel", defaultValue: "Cancel"))
+
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        DispatchQueue.main.async {
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return }
+        let trimmed = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        applyTabIcon("emoji:\(trimmed)", targetIds: targetIds)
     }
 
     private func promptCustomColor(targetIds: [UUID]) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10442,6 +10442,10 @@ private struct TabItemView: View, Equatable {
         draggedTabId == tab.id
     }
 
+    private var hasVisibleIcon: Bool {
+        tab.customIconPath != nil || (sidebarAutoDetectFavicon && tab.detectedFaviconPath != nil)
+    }
+
     private var activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
         SidebarActiveTabIndicatorSettings.resolvedStyle(rawValue: activeTabIndicatorStyleRaw)
     }
@@ -10899,7 +10903,8 @@ private struct TabItemView: View, Equatable {
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
-        .padding(.horizontal, 10)
+        .padding(.leading, hasVisibleIcon ? 6 : 10)
+        .padding(.trailing, 10)
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 6)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10432,6 +10432,7 @@ private struct TabItemView: View, Equatable {
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var activeTabIndicatorStyleRaw = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage("sidebarAutoDetectFavicon") private var sidebarAutoDetectFavicon = false
 
     var isMultiSelected: Bool {
         selectedTabIds.contains(tab.id)
@@ -10662,7 +10663,7 @@ private struct TabItemView: View, Equatable {
         }()
 
         HStack(alignment: .center, spacing: 10) {
-            if let iconPath = tab.customIconPath {
+            if let iconPath = tab.customIconPath ?? (sidebarAutoDetectFavicon ? tab.detectedFaviconPath : nil) {
                 WorkspaceIconView(iconPath: iconPath, size: 36)
             }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -331,6 +331,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var processTitle: String
     var customTitle: String?
     var customColor: String?
+    var customIconPath: String?
     var isPinned: Bool
     var currentDirectory: String
     var focusedPanelId: UUID?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1718,6 +1718,11 @@ class TabManager: ObservableObject {
         tab.setCustomColor(color)
     }
 
+    func setTabIcon(tabId: UUID, iconPath: String?) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        tab.setCustomIcon(iconPath)
+    }
+
     func togglePin(tabId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let tab = tabs[index]
@@ -4536,6 +4541,7 @@ extension TabManager {
             hasher.combine(workspace.currentDirectory)
             hasher.combine(workspace.customTitle ?? "")
             hasher.combine(workspace.customColor ?? "")
+            hasher.combine(workspace.customIconPath ?? "")
             hasher.combine(workspace.isPinned)
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3264,7 +3264,8 @@ class TerminalController {
                     "listening_ports": ws.listeningPorts,
                     "remote": ws.remoteStatusPayload(),
                     "current_directory": v2OrNull(ws.currentDirectory),
-                    "custom_color": v2OrNull(ws.customColor)
+                    "custom_color": v2OrNull(ws.customColor),
+                    "custom_icon": v2OrNull(ws.customIconPath)
                 ]
             }
         }
@@ -3899,6 +3900,7 @@ class TerminalController {
 
         let supportedActions = [
             "pin", "unpin", "rename", "clear_name",
+            "set_color", "clear_color", "set_icon", "clear_icon",
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread"
@@ -3970,6 +3972,34 @@ class TerminalController {
             case "clear_name":
                 tabManager.clearCustomTitle(tabId: workspace.id)
                 finish(["title": workspace.title])
+
+            case "set_color":
+                guard let colorRaw = v2String(params, "color"),
+                      !colorRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    result = .err(code: "invalid_params", message: "Missing or invalid color", data: nil)
+                    return
+                }
+                let color = colorRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+                tabManager.setTabColor(tabId: workspace.id, color: color)
+                finish(["custom_color": v2OrNull(workspace.customColor)])
+
+            case "clear_color":
+                tabManager.setTabColor(tabId: workspace.id, color: nil)
+                finish()
+
+            case "set_icon":
+                guard let iconRaw = v2String(params, "icon"),
+                      !iconRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    result = .err(code: "invalid_params", message: "Missing or invalid icon path", data: nil)
+                    return
+                }
+                let icon = iconRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+                tabManager.setTabIcon(tabId: workspace.id, iconPath: icon)
+                finish(["custom_icon": v2OrNull(workspace.customIconPath)])
+
+            case "clear_icon":
+                tabManager.setTabIcon(tabId: workspace.id, iconPath: nil)
+                finish()
 
             case "move_up":
                 guard let currentIndex = tabManager.tabs.firstIndex(where: { $0.id == workspace.id }) else {
@@ -14941,6 +14971,7 @@ class TerminalController {
             var lines: [String] = []
             lines.append("tab=\(tab.id.uuidString)")
             lines.append("color=\(tab.customColor ?? "none")")
+            lines.append("icon=\(tab.customIconPath ?? "none")")
             lines.append("cwd=\(tab.currentDirectory)")
 
             if let focused = tab.focusedPanelId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -199,6 +199,7 @@ extension Workspace {
             processTitle: processTitle,
             customTitle: customTitle,
             customColor: customColor,
+            customIconPath: customIconPath,
             isPinned: isPinned,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -238,6 +239,7 @@ extension Workspace {
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
+        setCustomIcon(snapshot.customIconPath)
         isPinned = snapshot.isPinned
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
@@ -4780,6 +4782,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customTitle: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    @Published var customIconPath: String?  // absolute path to icon image, or "emoji:<char>"
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -5618,6 +5621,15 @@ final class Workspace: Identifiable, ObservableObject {
             customColor = WorkspaceTabColorSettings.normalizedHex(hex)
         } else {
             customColor = nil
+        }
+    }
+
+    func setCustomIcon(_ path: String?) {
+        if let path {
+            let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            customIconPath = trimmed.isEmpty ? nil : trimmed
+        } else {
+            customIconPath = nil
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5651,17 +5651,13 @@ final class Workspace: Identifiable, ObservableObject {
     // MARK: - Favicon Detection
 
     /// File names to look for as workspace icons, checked in order.
-    /// Covers web projects (favicon), cmux-specific (.cmux-icon), app icons,
-    /// and common branding files.
     private static let faviconFilenames = [
-        ".cmux-icon.png", ".cmux-icon.svg", ".cmux-icon.jpg", ".cmux-icon.ico",
         "favicon.png", "favicon.ico", "favicon.svg",
         "icon.png", "icon.svg",
         "logo.png", "logo.svg",
     ]
 
-    /// Subdirectories to check (shallow, max 2 levels deep).
-    /// Covers web projects, iOS/macOS apps, and common asset locations.
+    /// Subdirectories to check for favicon filenames.
     private static let faviconSubdirs = [
         "",                          // root
         "public",                    // web: Next.js, Vite, CRA
@@ -5670,6 +5666,8 @@ final class Workspace: Identifiable, ObservableObject {
         "assets",                    // generic
         "images",                    // generic
         "Resources",                 // Xcode / Swift
+        ".github",                   // GitHub repo branding
+        "docs",                      // documentation sites
     ]
 
     func detectFavicon(in directory: String) {
@@ -5678,12 +5676,7 @@ final class Workspace: Identifiable, ObservableObject {
             let fm = FileManager.default
             var found: String? = nil
 
-            // Also check for iOS/macOS AppIcon in asset catalog
-            let appIconCandidates = [
-                "Assets.xcassets/AppIcon.appiconset",
-                "Resources/Assets.xcassets/AppIcon.appiconset",
-            ]
-
+            // 1. Check standard favicon filenames across known subdirs
             outer: for subdir in Self.faviconSubdirs {
                 let base = subdir.isEmpty ? dir : (dir as NSString).appendingPathComponent(subdir)
                 for filename in Self.faviconFilenames {
@@ -5695,17 +5688,53 @@ final class Workspace: Identifiable, ObservableObject {
                 }
             }
 
-            // Fallback: check for AppIcon asset catalog (pick largest PNG inside)
+            // 2. Xcode AppIcon asset catalog (iOS/macOS)
             if found == nil {
+                let appIconCandidates = [
+                    "Assets.xcassets/AppIcon.appiconset",
+                    "Resources/Assets.xcassets/AppIcon.appiconset",
+                ]
                 for candidate in appIconCandidates {
                     let iconsetPath = (dir as NSString).appendingPathComponent(candidate)
                     if let contents = try? fm.contentsOfDirectory(atPath: iconsetPath) {
-                        // Pick the largest PNG by filename (typically "AppIcon-1024.png" or similar)
                         let pngs = contents.filter { $0.hasSuffix(".png") }.sorted().reversed()
                         if let largest = pngs.first {
                             found = (iconsetPath as NSString).appendingPathComponent(largest)
                             break
                         }
+                    }
+                }
+            }
+
+            // 3. Android launcher icon
+            if found == nil {
+                let androidPaths = [
+                    "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+                    "android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+                    "app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+                    "app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+                ]
+                for candidate in androidPaths {
+                    let path = (dir as NSString).appendingPathComponent(candidate)
+                    if fm.fileExists(atPath: path) {
+                        found = path
+                        break
+                    }
+                }
+            }
+
+            // 4. Electron/desktop app icons
+            if found == nil {
+                let electronPaths = [
+                    "build/icon.png",
+                    "build/icons/icon.png",
+                    "resources/icon.png",
+                ]
+                for candidate in electronPaths {
+                    let path = (dir as NSString).appendingPathComponent(candidate)
+                    if fm.fileExists(atPath: path) {
+                        found = path
+                        break
                     }
                 }
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -218,6 +218,7 @@ extension Workspace {
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedCurrentDirectory.isEmpty {
             currentDirectory = normalizedCurrentDirectory
+            detectFavicon(in: normalizedCurrentDirectory)
         }
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
@@ -4783,6 +4784,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var customIconPath: String?  // absolute path to icon image, or "emoji:<char>"
+    @Published var detectedFaviconPath: String?  // auto-detected favicon from cwd (not persisted)
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -5138,6 +5140,8 @@ final class Workspace: Identifiable, ObservableObject {
             }
             bonsplitController.selectTab(initialTabId)
         }
+
+        detectFavicon(in: currentDirectory)
     }
 
     deinit {
@@ -5644,6 +5648,82 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    // MARK: - Favicon Detection
+
+    /// File names to look for as workspace icons, checked in order.
+    /// Covers web projects (favicon), cmux-specific (.cmux-icon), app icons,
+    /// and common branding files.
+    private static let faviconFilenames = [
+        ".cmux-icon.png", ".cmux-icon.svg", ".cmux-icon.jpg", ".cmux-icon.ico",
+        "favicon.png", "favicon.ico", "favicon.svg",
+        "icon.png", "icon.svg",
+        "logo.png", "logo.svg",
+    ]
+
+    /// Subdirectories to check (shallow, max 2 levels deep).
+    /// Covers web projects, iOS/macOS apps, and common asset locations.
+    private static let faviconSubdirs = [
+        "",                          // root
+        "public",                    // web: Next.js, Vite, CRA
+        "static",                    // web: Hugo, Gatsby
+        "src",                       // web: various
+        "assets",                    // generic
+        "images",                    // generic
+        "Resources",                 // Xcode / Swift
+    ]
+
+    func detectFavicon(in directory: String) {
+        let dir = directory
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let fm = FileManager.default
+            var found: String? = nil
+
+            // Also check for iOS/macOS AppIcon in asset catalog
+            let appIconCandidates = [
+                "Assets.xcassets/AppIcon.appiconset",
+                "Resources/Assets.xcassets/AppIcon.appiconset",
+            ]
+
+            outer: for subdir in Self.faviconSubdirs {
+                let base = subdir.isEmpty ? dir : (dir as NSString).appendingPathComponent(subdir)
+                for filename in Self.faviconFilenames {
+                    let path = (base as NSString).appendingPathComponent(filename)
+                    if fm.fileExists(atPath: path) {
+                        found = path
+                        break outer
+                    }
+                }
+            }
+
+            // Fallback: check for AppIcon asset catalog (pick largest PNG inside)
+            if found == nil {
+                for candidate in appIconCandidates {
+                    let iconsetPath = (dir as NSString).appendingPathComponent(candidate)
+                    if let contents = try? fm.contentsOfDirectory(atPath: iconsetPath) {
+                        // Pick the largest PNG by filename (typically "AppIcon-1024.png" or similar)
+                        let pngs = contents.filter { $0.hasSuffix(".png") }.sorted().reversed()
+                        if let largest = pngs.first {
+                            found = (iconsetPath as NSString).appendingPathComponent(largest)
+                            break
+                        }
+                    }
+                }
+            }
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if self.detectedFaviconPath != found {
+                    self.detectedFaviconPath = found
+                }
+            }
+        }
+    }
+
+    /// The icon to display: explicit custom icon takes priority, then auto-detected favicon.
+    var effectiveIconPath: String? {
+        customIconPath ?? detectedFaviconPath
+    }
+
     // MARK: - Directory Updates
 
     func updatePanelDirectory(panelId: UUID, directory: String) {
@@ -5655,6 +5735,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Update current directory if this is the focused panel
         if panelId == focusedPanelId, currentDirectory != trimmed {
             currentDirectory = trimmed
+            detectFavicon(in: trimmed)
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4439,7 +4439,7 @@ struct SettingsView: View {
 
                         SettingsCardRow(
                             String(localized: "settings.app.autoDetectFavicon", defaultValue: "Auto-detect Workspace Icon"),
-                            subtitle: String(localized: "settings.app.autoDetectFavicon.subtitle", defaultValue: "Show favicon.png, favicon.ico, or .cmux-icon.png from the workspace directory as the workspace icon.")
+                            subtitle: String(localized: "settings.app.autoDetectFavicon.subtitle", defaultValue: "Detect favicon, app icon, or logo from the workspace directory and show it in the sidebar.")
                         ) {
                             Toggle("", isOn: $sidebarAutoDetectFavicon)
                                 .labelsHidden()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3612,6 +3612,7 @@ struct SettingsView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
+    @AppStorage("sidebarAutoDetectFavicon") private var sidebarAutoDetectFavicon = false
     @AppStorage("sidebarTintHex") private var sidebarTintHex = SidebarTintDefaults.hex
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
@@ -4433,6 +4434,17 @@ struct SettingsView: View {
                                 .controlSize(.small)
                         }
                         .disabled(sidebarHideAllDetails)
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.autoDetectFavicon", defaultValue: "Auto-detect Workspace Icon"),
+                            subtitle: String(localized: "settings.app.autoDetectFavicon.subtitle", defaultValue: "Show favicon.png, favicon.ico, or .cmux-icon.png from the workspace directory as the workspace icon.")
+                        ) {
+                            Toggle("", isOn: $sidebarAutoDetectFavicon)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors"))


### PR DESCRIPTION
## Summary
- Workspaces can now display a custom icon as a 36px circular avatar in the sidebar, iMessage-style
- Supports image files (PNG, JPEG, SVG, ICO, HEIC, TIFF) via file picker, or emoji via text input
- Right-click context menu: "Workspace Icon" with Set Icon from File, Set Emoji Icon, Clear Icon
- Socket API: `set_icon`/`clear_icon` workspace actions, `custom_icon` field in `workspace.list`
- CLI: `cmux workspace-action --action set-icon --icon <path|emoji:🚀>`
- Bonus: also adds `set_color`/`clear_color` workspace actions (previously only settable via UI)
- Icons persist across app restarts via session snapshots

## Testing
- Right-click a workspace, Workspace Icon > Set Emoji Icon, enter an emoji
- Right-click a workspace, Workspace Icon > Set Icon from File, pick a PNG
- Verify icon renders as a circle to the left of the workspace title
- Clear the icon and verify it disappears
- Restart app and verify icon persists
- `cmux workspace-action --action set-icon --icon emoji:🚀`
- `cmux workspace-action --action clear-icon`

## Related
- Task: https://github.com/manaflow-ai/cmux/issues/1652

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add customizable workspace icons to the sidebar: a 36px circular avatar shown to the left of each workspace. Adds optional auto-detection from the workspace directory (web/mobile/desktop app icons), with custom icons taking priority. Implements #1652.

- **New Features**
  - Sidebar UI and context menu: Set from file (PNG, JPEG, SVG, ICO, HEIC, TIFF), set emoji, or clear.
  - Optional setting: Auto-detect icon from `favicon.*`, `icon.*`, `logo.*`, iOS/macOS AppIcon assets, Android launcher icons, or Electron app icons; scans root and common subfolders (e.g., `public`, `static`, `src`, `assets`, `Resources`, `.github`, `docs`); updates on directory changes; off by default.
  - API/CLI: `workspace.action` supports `set_icon`/`clear_icon` and `set_color`/`clear_color`; `custom_icon` added to `workspace.list`; CLI `cmux workspace-action --action set-icon --icon <path|emoji:🚀>`.
  - Persistence: Icons are saved in session snapshots.

- **Bug Fixes**
  - Reduced left padding when an icon is visible for better alignment.

<sup>Written for commit 2500e2d1471bae324e7ca3c73e100d899ed76379. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace icons (emoji or image) now show in the sidebar and tab headers; Clear / Set from File / Set Emoji actions added; session restore preserves custom icons; new "Auto-detect Workspace Icon" toggle.

* **CLI**
  * Workspace action supports icon and color flags with validation for set/clear operations.

* **Localization**
  * Multilingual translations added for all new workspace customization UI, settings, and related dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->