### PR TITLE
fix: save window position on session become active to prevent resize after unlock

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3020,6 +3020,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         lifecycleSnapshotObservers.append(sessionResignObserver)
 
+        let sessionBecomeActiveObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                _ = self.saveSessionSnapshot(includeScrollback: false)
+            }
+        }
+        lifecycleSnapshotObservers.append(sessionBecomeActiveObserver)
+
         let didWakeObserver = workspaceCenter.addObserver(
             forName: NSWorkspace.didWakeNotification,
             object: nil,


### PR DESCRIPTION
Adds an observer for `NSWorkspace.sessionDidBecomeActiveNotification` that saves the session snapshot when the user session becomes active again (e.g., after screen unlock). This ensures the correct window position is preserved if display geometry changes during screen lock.

Fixes #1648

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Save window position when the session becomes active to avoid unexpected window resize after unlocking the screen. Fixes #1648.

- **Bug Fixes**
  - Add observer for `NSWorkspace.sessionDidBecomeActiveNotification` to save a session snapshot (no scrollback) on unlock, preserving the window frame if display geometry changed while locked.

<sup>Written for commit 85f10dab8b81508932f630e123f704ac04008e30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session data synchronization is now automatic when the application becomes active, improving session restoration reliability and ensuring consistent state management across application lifecycle transitions. This prevents potential data inconsistencies when returning to the app after periods of inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->