### PR TITLE
experiment: test 12x runners on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
   tests:
     # Never run WarpBuild jobs for fork pull requests (avoid billing on external PRs).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -235,7 +235,7 @@ jobs:
     # XCUIApplication stuck "Running Background", 62s activation timeout per
     # test). Interactive UI tests run via test-e2e.yml on GitHub-hosted runners.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: warp-macos-15-arm64-12x
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -19,11 +19,11 @@ fi
 if ! awk '
   /^  tests:/ { in_tests=1; next }
   in_tests && /^  [^[:space:]]/ { in_tests=0 }
-  in_tests && /runs-on: warp-macos-15-arm64-6x/ { saw_warp=1 }
+  in_tests && /runs-on: warp-macos-15-arm64-(6|12)x/ { saw_warp=1 }
   in_tests && /github.event.pull_request.head.repo.full_name == github.repository/ { saw_guard=1 }
   END { exit !(saw_warp && saw_guard) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: tests block must keep both warp-macos-15-arm64-6x runner and fork guard"
+  echo "FAIL: tests block must keep both warp-macos runner and fork guard"
   exit 1
 fi
 
@@ -31,11 +31,11 @@ fi
 if ! awk '
   /^  tests-build-and-lag:/ { in_tests=1; next }
   in_tests && /^  [^[:space:]]/ { in_tests=0 }
-  in_tests && /runs-on: warp-macos-15-arm64-6x/ { saw_warp=1 }
+  in_tests && /runs-on: warp-macos-15-arm64-(6|12)x/ { saw_warp=1 }
   in_tests && /github.event.pull_request.head.repo.full_name == github.repository/ { saw_guard=1 }
   END { exit !(saw_warp && saw_guard) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: tests-build-and-lag block must keep both warp-macos-15-arm64-6x runner and fork guard"
+  echo "FAIL: tests-build-and-lag block must keep both warp-macos runner and fork guard"
   exit 1
 fi
 


### PR DESCRIPTION
Testing warp-macos-15-arm64-12x (12 vCPU, 44 GB RAM, 270 GB SSD, $0.16/min) vs current 6x (6 vCPU, 22 GB RAM, 120 GB SSD, $0.08/min) on the CI workflow.

**Baseline on 6x** (avg of 5 recent runs):
- `tests` job: ~6m41s (~$0.53/run)
- `tests-build-and-lag` job: ~4m34s (~$0.37/run)

**Break-even point:** if 12x cuts time by >50%, it's cheaper per run despite 2x $/min. Xcode builds are heavily parallelizable so this is plausible.

**What to compare after this runs:**
- Job durations on 12x vs baseline above
- WarpBuild observability: CPU/disk/memory utilization (should drop significantly with 270 GB disk and 12 cores)

Do not merge. Experiment only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI `tests` and `tests-build-and-lag` on `warp-macos-15-arm64-12x` to measure speed vs cost versus `6x`; break-even is ≥50% faster given 2x price/min. Updated the CI guard to allow `6x` or `12x` while keeping the fork billing guard.

- **Refactors**
  - Switched both jobs to `runs-on: warp-macos-15-arm64-12x`.
  - Updated `tests/test_ci_self_hosted_guard.sh` to accept `warp-macos-15-arm64-(6|12)x` and simplified error messages.

<sup>Written for commit e24b66bae3fe967f5b5cb72c8b55260d21400c69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure with improved runner configurations for enhanced test execution performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->