### PR TITLE
experiment: test 12x runners on macOS Compatibility

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: warp-macos-15-arm64-6x
+          - os: warp-macos-15-arm64-12x
             timeout: 20
             smoke: true
             skip_zig: false
-          - os: warp-macos-26-arm64-6x
+          - os: warp-macos-26-arm64-12x
             timeout: 20
             smoke: false
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26


### PR DESCRIPTION
Testing warp-macos-*-arm64-12x on the macOS Compatibility workflow. Companion to the CI experiment PR.

**Baseline on 6x** (avg of 5 recent runs):
- macOS 15 compat: ~6m17s (~$0.50/run)
- macOS 26 compat: ~3m54s (~$0.31/run)

12x runners also resolve the persistent 97.4% disk usage (120 GB → 270 GB SSD).

Do not merge. Experiment only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch macOS Compatibility CI runners from `warp-macos-*-arm64-6x` to `warp-macos-*-arm64-12x` to benchmark speed vs cost and resolve disk space warnings. Applies to macOS 15 and 26 jobs; 12x provides 2x CPU/RAM and a 270 GB SSD (vs 120 GB), which should reduce runtime and fix the 97.4% disk usage.

<sup>Written for commit c0055ad11684ac29ff1b0405fd1639907e6d31e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build configurations to optimize performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->