### PR TITLE
Rename "Import From Browser" to "Import Browser Data"

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -38278,13 +38278,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Import From Browser…"
+            "value": "Import Browser Data…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ブラウザーから取り込む…"
+            "value": "ブラウザーデータを取り込む…"
           }
         }
       }
@@ -51224,13 +51224,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Import From Browser"
+            "value": "Import Browser Data"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ブラウザーから取り込む"
+            "value": "ブラウザーデータを取り込む"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9809,7 +9809,7 @@ private struct SidebarHelpMenuButton: View {
                 isExternalLink: false
             )
             helpOptionButton(
-                title: String(localized: "menu.view.importFromBrowser", defaultValue: "Import From Browser…"),
+                title: String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…"),
                 action: .importBrowserData,
                 accessibilityIdentifier: "SidebarHelpMenuOptionImportBrowserData",
                 isExternalLink: false

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -965,7 +965,7 @@ struct BrowserPanelView: View {
             Button {
                 presentImportDialogFromProfileMenu()
             } label: {
-                Text(String(localized: "menu.view.importFromBrowser", defaultValue: "Import From Browser…"))
+                Text(String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…"))
                     .font(.system(size: 12))
             }
             .buttonStyle(.plain)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -628,7 +628,7 @@ struct cmuxApp: App {
                     BrowserHistoryStore.shared.clearHistory()
                 }
 
-                Button(String(localized: "menu.view.importFromBrowser", defaultValue: "Import From Browser…")) {
+                Button(String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…")) {
                     // Defer modal presentation until after AppKit finishes menu tracking.
                     DispatchQueue.main.async {
                         BrowserDataImportCoordinator.shared.presentImportDialog()
@@ -2167,7 +2167,7 @@ private struct BrowserProfilePopoverDebugView: View {
             Text(String(localized: "browser.profile.new", defaultValue: "New Profile..."))
                 .font(.system(size: 12))
 
-            Text(String(localized: "menu.view.importFromBrowser", defaultValue: "Import From Browser…"))
+            Text(String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…"))
                 .font(.system(size: 12))
         }
         .padding(.horizontal, BrowserProfilePopoverDebugSettings.resolvedHorizontalPadding(horizontalPaddingRaw))
@@ -4880,7 +4880,7 @@ struct SettingsView: View {
 
                         VStack(alignment: .leading, spacing: 12) {
                             VStack(alignment: .leading, spacing: 8) {
-                                Text(String(localized: "settings.browser.import", defaultValue: "Import From Browser"))
+                                Text(String(localized: "settings.browser.import", defaultValue: "Import Browser Data"))
                                     .font(.system(size: 13, weight: .semibold))
 
                                 VStack(alignment: .leading, spacing: 6) {


### PR DESCRIPTION
## Summary
- Renamed "Import From Browser…" to "Import Browser Data…" across help menu, app menu bar, browser profile popover, browser panel, and settings heading
- Updated English and Japanese localization strings

## Testing
- Visual: check help menu (bottom left), View menu bar, browser profile popover, browser panel profile menu, and browser settings heading all show "Import Browser Data"

## Related
- Task: rename menu item from "Import from Browser" to "Import Browser Data"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed "Import From Browser" to "Import Browser Data" across the app for clearer wording. Completes the rename task and updates English and Japanese strings in the help menu, menu bar, browser profile popover, browser panel, and browser settings.

<sup>Written for commit dc0c9fe24d6242e7e5c987d539c809b8a3b8b405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined user-facing text throughout the interface for improved clarity and consistency.
  * Updated menu labels, button text, and prompts across the application.
  * Enhanced localization strings and terminology consistency across multiple languages.
  * Improved wording for import and configuration-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->