### PR TITLE
fix(ContentView): allow terminal text selection at start of line

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1920,7 +1920,7 @@ struct ContentView: View {
                 scheduleSidebarResizerCursorRelease(force: true)
             }
             .gesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                DragGesture(minimumDistance: 3, coordinateSpace: .global)
                     .onChanged { value in
                         if !isResizerDragging {
                             isResizerDragging = true


### PR DESCRIPTION
The sidebar resizer DragGesture used `minimumDistance: 0`, which immediately captured all mouse events in the resizer hit area. This prevented terminal text selection when clicking near the sidebar divider—users couldn't select text starting at the first character of a line.

Changed `minimumDistance` to 3 points so simple clicks pass through to the terminal for text selection, while actual drags still activate resize as expected. A 3-point threshold matches the visual divider tolerance and keeps resize interactions responsive.

Fixes #1606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow terminal text selection at the start of a line by raising the sidebar resizer drag threshold. Changed the resizer’s DragGesture minimumDistance from 0 to 3 points so clicks near the divider go to the terminal while drags still resize; fixes #1606.

<sup>Written for commit c2772f6817aeb8e70140c962c5f43a0df75d534b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar resizer behavior by requiring a small movement threshold before responding to drag interactions, reducing unintended activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->