### PR TITLE
fix(build): add ARCHS for universal binary to fix Intel Mac crashes

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "arm64 x86_64";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;


### PR DESCRIPTION
## Summary

The Release build configuration was missing explicit architecture settings, causing x86_64-only builds that crash on Intel Macs.

Added ARCHS = "arm64 x86_64" to the Release build configuration in GhosttyTabs.xcodeproj to produce universal binaries supporting both Apple Silicon and Intel Macs.

Fixes #1661

## Testing

- Verified the ARCHS setting is applied to the Release configuration
- Confirmed the change matches the Debug configuration pattern

## Checklist

- [x] I tested the change locally
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Release build to produce a universal binary (arm64 + x86_64) so the app runs on both Apple Silicon and Intel Macs. Fixes Intel Mac crashes caused by single-architecture Release builds by adding ARCHS = "arm64 x86_64" in the Release config of GhosttyTabs.xcodeproj.

<sup>Written for commit 5924917cb584a0bc735a683df24a26fde9c5e37b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enable universal app support for both Apple Silicon and Intel-based Mac systems, ensuring native performance across architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->