### PR TITLE
fix: restore window position after screen unlock/lock cycle

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3030,6 +3030,51 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         lifecycleSnapshotObservers.append(didWakeObserver)
+
+        // Observe screen configuration changes (e.g., screen unlock, display arrangement changes)
+        // to restore window positions that may have been altered by the system.
+        let screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.restoreWindowPositionsAfterScreenChange()
+            }
+        }
+        lifecycleSnapshotObservers.append(screenChangeObserver)
+    }
+
+    /// Restores window positions after screen configuration changes (e.g., unlock, display changes).
+    /// Uses the last persisted window geometry to reposition windows on the correct display.
+    private func restoreWindowPositionsAfterScreenChange() {
+        let fallbackGeometry = persistedWindowGeometry()
+        let displays = currentDisplayGeometries()
+
+        for context in mainWindowContexts.values {
+            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { continue }
+
+            // Build a snapshot from the persisted geometry if available
+            let windowSnapshot: SessionWindowSnapshot? = fallbackGeometry.map { geometry in
+                SessionWindowSnapshot(
+                    frame: geometry.frame,
+                    display: geometry.display,
+                    tabManager: context.tabManager.sessionSnapshot(includeScrollback: false),
+                    sidebar: SessionSidebarSnapshot(
+                        isVisible: context.sidebarState.isVisible,
+                        selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
+                        width: SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth))
+                    )
+                )
+            }
+
+            if let restoredFrame = resolvedWindowFrame(from: windowSnapshot) {
+                window.setFrame(restoredFrame, display: true)
+            }
+        }
+
+        // Save the restored positions
+        _ = saveSessionSnapshot(includeScrollback: false)
     }
 
     private func socketListenerConfigurationIfEnabled() -> (mode: SocketControlMode, path: String)? {


### PR DESCRIPTION
## Summary

After screen lock/unlock or display configuration changes, window positions were being reset by macOS. This caused windows to resize and move unexpectedly.

Added an observer for `NSApplication.didChangeScreenParametersNotification` that restores window positions using the last persisted geometry when screen parameters change.

## Testing

- Verified the observer triggers on screen configuration changes
- Window positions are restored from persisted geometry after the notification
- Session snapshot is saved after restoration to maintain consistency

Fixes #1648

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix window positions being reset by macOS after screen unlock or display changes. We now listen for `NSApplication.didChangeScreenParametersNotification` and restore each window to its last persisted geometry, then save a new session snapshot.

- **Bug Fixes**
  - Add observer for screen parameter changes.
  - Rebuild per-window snapshot from persisted geometry and resolve the correct frame/display.
  - Save session snapshot after restoration to persist positions.

<sup>Written for commit 28589ddfb06627dfd54901b51ab924e305da843f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved window management during display configuration changes. The app now correctly restores and maintains your window positions and layouts when monitors are connected or disconnected, or when display resolutions are adjusted. Your saved window arrangements are now reliably preserved across screen changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->