### PR TITLE
fix(shell): check git repo before running git commands to prevent TCC prompts

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -485,6 +485,8 @@ _cmux_prompt_command() {
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
         {
+            # Skip git operations if not in a git repository to avoid TCC prompts
+            git rev-parse --git-dir >/dev/null 2>&1 || return 0
             local branch dirty_opt=""
             branch=$(git branch --show-current 2>/dev/null)
             if [[ -n "$branch" ]]; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -237,6 +237,9 @@ _cmux_report_git_branch_for_path() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
+    # Skip git operations if not in a git repository to avoid TCC prompts
+    git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || return 0
+
     local branch dirty_opt="" first
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     if [[ -n "$branch" ]]; then


### PR DESCRIPTION
Fixes #1534

## Problem
The shell integration scripts (bash and zsh) run git commands on every prompt to detect the current branch and repository state. When the current directory is not a git repository (especially TCC-protected directories on macOS), these git commands trigger unnecessary permission prompts.

## Solution
Add a git rev-parse --git-dir check before running git commands. This check:
- Returns the path to the .git directory if inside a git repo
- Silently exits with code 1 if not in a git repo (without triggering TCC prompts)
- Is fast and lightweight

## Changes
- Resources/shell-integration/cmux-zsh-integration.zsh: Add git check in _cmux_report_git_branch_for_path
- Resources/shell-integration/cmux-bash-integration.bash: Add git check in _cmux_prompt_command

## Testing
The fix ensures that git operations are only attempted when inside an actual git repository, preventing TCC permission prompts in protected directories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip git operations in shell prompts when not in a repository to prevent macOS TCC permission prompts. Adds a fast `git rev-parse --git-dir` check in the bash and zsh integrations.

- **Bug Fixes**
  - Bash: `_cmux_prompt_command` returns early if `git rev-parse --git-dir` fails.
  - Zsh: `_cmux_report_git_branch_for_path` returns early if `git -C "$repo_path" rev-parse --git-dir` fails.

<sup>Written for commit 1e383a7f2e7028acdf61cdeb78c950a6267723a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell integration performance by skipping unnecessary git operations when not inside a git repository, preventing system prompts and delays in bash and zsh environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->