### PR TITLE
fix(workspace): clear sidebar git branch and PR when focused panel closes

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9229,7 +9229,13 @@ extension Workspace: BonsplitDelegate {
         surfaceIdToPanelId.removeValue(forKey: tabId)
         panelDirectories.removeValue(forKey: panelId)
         panelGitBranches.removeValue(forKey: panelId)
+        if panelId == focusedPanelId {
+            gitBranch = nil
+        }
         panelPullRequests.removeValue(forKey: panelId)
+        if panelId == focusedPanelId {
+            pullRequest = nil
+        }
         panelTitles.removeValue(forKey: panelId)
         panelCustomTitles.removeValue(forKey: panelId)
         pinnedPanelIds.remove(panelId)
@@ -9379,6 +9385,10 @@ extension Workspace: BonsplitDelegate {
                 panelDirectories.removeValue(forKey: panelId)
                 panelGitBranches.removeValue(forKey: panelId)
                 panelPullRequests.removeValue(forKey: panelId)
+                if panelId == focusedPanelId {
+                    gitBranch = nil
+                    pullRequest = nil
+                }
                 panelTitles.removeValue(forKey: panelId)
                 panelCustomTitles.removeValue(forKey: panelId)
                 pinnedPanelIds.remove(panelId)


### PR DESCRIPTION
## Summary

- **What changed?** Clear workspace-level `gitBranch` and `pullRequest` properties when the focused panel is closed in `didCloseTab` and `splitTabBar(_:didClosePane:)`.
- **Why?** The sidebar notification message for a workspace (e.g., "PR opened: ...") was persisting even after all processes exited and the branch changed. This caused stale PR information to remain visible in the sidebar.

## Root Cause

When a panel was closed, the code correctly removed entries from `panelGitBranches` and `panelPullRequests` dictionaries, but the workspace-level `gitBranch` and `pullRequest` properties were not being cleared if the closed panel was the currently focused panel.

## Fix

Added checks after removing panel entries to clear `gitBranch` and `pullRequest` when `panelId == focusedPanelId` in both:
1. `didCloseTab` method (single tab close)
2. `splitTabBar(_:didClosePane:)` method (pane close with multiple tabs)

## Testing

- Verified the fix compiles successfully with `swiftc -parse`
- The change is minimal and follows the existing code patterns in `clearPanelGitBranch` and `clearPanelPullRequest`

Fixes #1642

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear workspace `gitBranch` and `pullRequest` when the focused panel or tab closes to stop stale branch/PR notifications in the sidebar.

- **Bug Fixes**
  - In `didCloseTab` and `splitTabBar(_:didClosePane:)`, when `panelId == focusedPanelId`, set `gitBranch` and `pullRequest` to `nil` after removing panel entries.
  - Addresses #1642 where the sidebar kept showing PR info from a closed panel.

<sup>Written for commit 765352d9d8750de29dac6515add4867eec9fc45e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where closing a focused panel could leave outdated Git branch and pull request data in the application state, potentially causing unexpected behavior or display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->