### PR TITLE
fix: enable macOS native Move & Resize window functionality

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5526,7 +5526,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.isMovable = false
+        window.isMovable = true
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)


### PR DESCRIPTION
## Summary

This PR fixes #1613 by enabling macOS native "Move & Resize" window functionality.

## Root Cause

The window was configured with `window.isMovable = false` which explicitly disables macOS native window movement features, including the Window menu "Move & Resize" options.

## Fix

Changed `window.isMovable = false` to `window.isMovable = true` in `createMainWindow()`.

The window still has `isMovableByWindowBackground = false` so users won't accidentally drag the window when clicking in the content area, but native Window menu Move & Resize options now work correctly.

## Changes

- `Sources/AppDelegate.swift`: Change window.isMovable from false to true

## Testing

- Native macOS Window → Move & Resize menu options now work with cmux windows
- Window can be moved via standard macOS window management shortcuts and menus

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables macOS native Move & Resize window actions by setting `window.isMovable` to true, fixing #1613. Background dragging stays off (`isMovableByWindowBackground` remains false) to prevent accidental drags.

<sup>Written for commit 2fcd00e22aac13aa4bca90d48a2ed5db6596ae1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application window can now be moved by dragging its background area, allowing for easier window repositioning on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->