### PR TITLE
fix(browser): restore DevTools when returning to workspace with DevTools open

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -615,6 +615,10 @@ struct BrowserPanelView: View {
         .onChange(of: isVisibleInUI) { visibleInUI in
             if visibleInUI {
                 panel.cancelPendingDeveloperToolsVisibilityLossCheck()
+                // When returning to a workspace with DevTools open, ensure they are restored.
+                // The visibility loss check may have run while hidden, or the DevTools UI
+                // may need refreshing after the portal host is reattached.
+                panel.restoreDeveloperToolsAfterAttachIfNeeded()
                 return
             }
             // Pane/workspace churn can briefly mark the browser hidden before the


### PR DESCRIPTION
## Problem

When switching workspaces and returning with DevTools open, the DevTools UI would be in a broken state.

## Root Cause

The restoration logic was only triggered during portal reattachment, but not when the view became visible again after a workspace switch. This meant that if the DevTools were supposed to be open when returning to a workspace, they might not be properly restored.

## Fix

Added an explicit call to `restoreDeveloperToolsAfterAttachIfNeeded()` in the `onChange(of: isVisibleInUI)` handler when the view becomes visible. This ensures DevTools are properly restored when returning to a workspace.

## Changes

- Modified `Sources/Panels/BrowserPanelView.swift`: Added `panel.restoreDeveloperToolsAfterAttachIfNeeded()` call when `isVisibleInUI` becomes true

Fixes #1494

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores DevTools when returning to a workspace so the DevTools UI isn’t broken after a workspace switch. Restoration now runs when the view becomes visible, not just on portal reattach.

- **Bug Fixes**
  - In Sources/Panels/BrowserPanelView.swift, call restoreDeveloperToolsAfterAttachIfNeeded() when isVisibleInUI becomes true to reinitialize DevTools after a workspace switch.

<sup>Written for commit 26c71a9ce309dc63e8c6a75c0f3e4f0fcc0974c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Developer Tools UI and state now properly refresh when the browser panel reappears in the workspace after being hidden and reattached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->