### PR TITLE
fix: prevent terminal flickering during layout changes (e.g., new-workspace)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2044,6 +2044,9 @@ struct ContentView: View {
                             )
                         }
                     )
+                    // Stable identity prevents view recreation when mountedWorkspaces changes,
+                    // avoiding terminal flicker during workspace layout transitions (e.g., new-workspace).
+                    .id(tab.id)
                     .opacity(workspaceRenderOpacity)
                     .allowsHitTesting(isSelectedWorkspace)
                     .accessibilityHidden(!isRenderedVisible)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3953,6 +3953,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         applySurfaceColorScheme(force: !isSameSurface || !isAlreadyAttached)
     }
 
+    /// Tracks the last window this view was attached to for optimizing re-parenting within the same window.
+    private var lastAttachedWindow: NSWindow?
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if let windowObserver {
@@ -3966,7 +3969,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             "pending=\(String(format: "%.1fx%.1f", pendingSurfaceSize?.width ?? 0, pendingSurfaceSize?.height ?? 0))"
         )
 #endif
-        guard let window else { return }
+        guard let window else {
+            // View is being detached from a window - clear the tracking reference
+            lastAttachedWindow = nil
+            return
+        }
+
+        // Check if this is a re-parenting within the same window (no actual window change)
+        let isReparentingWithinSameWindow = lastAttachedWindow === window
+        lastAttachedWindow = window
 
         // If the surface creation was deferred while detached, create/attach it now.
         terminalSurface?.attachToView(self)
@@ -3993,6 +4004,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
            let displayID = window.screen?.displayID,
            displayID != 0 {
             ghostty_surface_set_display_id(surface, displayID)
+        }
+
+        // Skip expensive layout and surface updates when re-parenting within the same window
+        // to avoid terminal flicker during workspace layout changes (e.g., new-workspace).
+        if isReparentingWithinSameWindow {
+            // Still invalidate text input coordinates as the view position may have changed
+            invalidateTextInputCoordinates()
+            return
         }
 
         // Recompute from current bounds after layout. Pending size is only a fallback


### PR DESCRIPTION
## Description

Fixes #1625 - All terminal content flickers when CLI commands trigger layout changes.

When using cmux CLI commands that modify the workspace/layout state (e.g., `cmux new-workspace`), all visible terminal surfaces would flicker — not just the affected workspace. The entire terminal content would briefly disappear and redraw.

## Root Cause

When a new workspace was added, the SwiftUI view hierarchy would update, causing existing terminal views to be temporarily detached and re-attached. This triggered expensive layout and surface update operations in `viewDidMoveToWindow`, resulting in visible flicker.

## Changes

1. **ContentView.swift**: Added `.id(tab.id)` to `WorkspaceContentView` to ensure stable view identity across `mountedWorkspaces` changes. This prevents SwiftUI from unnecessarily re-creating terminal views during layout transitions.

2. **GhosttyTerminalView.swift**: Added window tracking to detect when a view is being re-parented within the same window (rather than moving to a different window). When re-parenting within the same window, we now skip expensive layout and surface updates that were causing the flicker.

## Testing

- Verified that `new-workspace` commands no longer cause existing terminals to flicker
- Verified that terminal surfaces still properly resize and update when actually changing windows
- Verified that text input coordinates are still invalidated on re-parenting (needed for correct IME positioning)

## Related

- Fixes #1625
- May also help with #1291 (visual flicker when switching workspaces)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents terminal flicker when workspace layout changes. Keeps existing terminals stable during CLI actions like `cmux new-workspace`.

- **Bug Fixes**
  - ContentView: add `.id(tab.id)` to `WorkspaceContentView` to keep stable view identity and avoid unnecessary recreation.
  - GhosttyTerminalView: track the last attached window to detect same-window re-parenting; skip expensive layout/surface updates in that case while still invalidating text input coordinates.

<sup>Written for commit aeab5e0e66798aee937a09e3770d65253fb36209. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Significantly reduced terminal display flicker that occurred during workspace transitions and when switching between multiple mounted workspaces
  * Improved overall rendering stability, responsiveness, and visual consistency by preventing unnecessary view recreation during dynamic layout changes
  * Optimized window attachment and re-attachment operations to efficiently handle common workspace management scenarios without triggering expensive layout recalculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->