### PR TITLE
fix(browser): sync DevTools state before restore to prevent reappearance after X-close

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4401,6 +4401,17 @@ extension BrowserPanel {
             return
         }
         guard !isDeveloperToolsTransitionInFlight else { return }
+        // Sync preference from inspector before deciding to restore. This ensures that
+        // manual closes (e.g., clicking the X button) are respected when switching
+        // surfaces, preventing DevTools from reappearing after being closed.
+        syncDeveloperToolsPreferenceFromInspector()
+        // Re-check preferredDeveloperToolsVisible after syncing, as it may have changed
+        // if the user manually closed DevTools.
+        guard preferredDeveloperToolsVisible else {
+            cancelDeveloperToolsRestoreRetry()
+            forceDeveloperToolsRefreshOnNextAttach = false
+            return
+        }
         guard let inspector = webView.cmuxInspectorObject() else {
             scheduleDeveloperToolsRestoreRetry()
             return


### PR DESCRIPTION
## Problem
DevTools reappear after being closed with the X button when switching surfaces/workspaces.

## Root Cause
When DevTools are closed via the X button, the internal `preferredDeveloperToolsVisible` flag remained `true`. When switching surfaces, `restoreDeveloperToolsAfterAttachIfNeeded()` would see this stale flag and reopen DevTools unexpectedly.

## Fix
Sync the preference from the inspector before deciding to restore. This ensures that manual closes (e.g., clicking the X button) are respected when switching surfaces.

## Changes
- Added call to `syncDeveloperToolsPreferenceFromInspector()` in `restoreDeveloperToolsAfterAttachIfNeeded()`
- Added re-check of `preferredDeveloperToolsVisible` after syncing

Fixes #1623

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops DevTools from reappearing after closing with the X when switching surfaces/workspaces. The restore logic now syncs the inspector-backed preference and respects a hidden state.

- **Bug Fixes**
  - Call `syncDeveloperToolsPreferenceFromInspector()` inside `restoreDeveloperToolsAfterAttachIfNeeded()`.
  - After syncing, if `preferredDeveloperToolsVisible` is false, cancel restore retry and clear `forceDeveloperToolsRefreshOnNextAttach`.

<sup>Written for commit 16413cbdc74dedc5d49537a8c3f496c1144a2153. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where Developer Tools would unexpectedly reappear after being manually closed. User preferences for Developer Tools visibility are now properly respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->