### PR TITLE
fix: allow text selection at start of terminal lines

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1777,7 +1777,10 @@ struct ContentView: View {
 
     private func dividerBandContains(pointInContent point: NSPoint, contentBounds: NSRect) -> Bool {
         guard point.y >= contentBounds.minY, point.y <= contentBounds.maxY else { return false }
-        let minX = sidebarWidth - sidebarResizerHitWidthPerSide
+        // Only extend the hit area to the right of the divider (into terminal content),
+        // not to the left, to avoid capturing mouse events when selecting text at the
+        // start of terminal lines.
+        let minX = sidebarWidth
         let maxX = sidebarWidth + sidebarResizerHitWidthPerSide
         return point.x >= minX && point.x <= maxX
     }
@@ -1956,7 +1959,10 @@ struct ContentView: View {
         GeometryReader { proxy in
             let totalWidth = max(0, proxy.size.width)
             let dividerX = min(max(sidebarWidth, 0), totalWidth)
-            let leadingWidth = max(0, dividerX - sidebarResizerHitWidthPerSide)
+            // Only extend the hit area into the sidebar side, not into the terminal content area.
+            // This ensures users can select text at the start of terminal lines without the
+            // resizer overlay capturing mouse events.
+            let leadingWidth = max(0, dividerX)
 
             HStack(spacing: 0) {
                 Color.clear


### PR DESCRIPTION
The sidebar resizer overlay was capturing mouse events that extended 6 points into the terminal content area, preventing users from selecting text at the start of terminal lines.

Changes:
- Modified sidebarResizerOverlay to not extend hit area into terminal content
- Updated dividerBandContains to only check from sidebarWidth to the right, not extending into the terminal content area

Fixes #1606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows text selection at the start of terminal lines by keeping the sidebar resizer hit area out of the terminal content. Updates the overlay layout and `dividerBandContains` to avoid capturing mouse events in the terminal area (Fixes #1606).

<sup>Written for commit 0aab672c63e030f36173ae7e1543f4decdbe21cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar resizer hit-area detection to prevent interfering with text selection in the terminal when resizing the sidebar.
  * Added clarifying comments to better document sidebar resizer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->