### PR TITLE
fix(terminal): forward key events in panel host container to fix Esc key

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6526,6 +6526,11 @@ final class GhosttySurfaceScrollView: NSView {
         cancelFocusRequest()
     }
 
+    // MARK: - Public Accessors
+
+    /// The underlying terminal surface view. Exposed for key event forwarding from panel hosts.
+    var terminalSurfaceView: GhosttyNSView { surfaceView }
+
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
 
     // Avoid stealing focus on scroll; focus is managed explicitly by the surface view.
@@ -8753,6 +8758,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
     private final class HostContainerView: NSView {
         var onDidMoveToWindow: (() -> Void)?
         var onGeometryChanged: (() -> Void)?
+        weak var hostedView: GhosttySurfaceScrollView?
         private(set) var geometryRevision: UInt64 = 0
         private var lastReportedGeometryState: GeometryState?
 
@@ -8804,6 +8810,59 @@ struct GhosttyTerminalView: NSViewRepresentable {
         override func setFrameSize(_ newSize: NSSize) {
             super.setFrameSize(newSize)
             notifyGeometryChangedIfNeeded()
+        }
+
+        // MARK: - Key Event Forwarding
+        // Forward key events to the hosted terminal view so Esc and other keys work inside panels.
+        // The portal window system hosts the actual terminal view above SwiftUI, but key events
+        // need to be forwarded from this anchor view to ensure proper terminal input handling.
+
+        override var acceptsFirstResponder: Bool { true }
+
+        override func becomeFirstResponder() -> Bool {
+            // When this container becomes first responder, try to transfer focus to the hosted terminal view.
+            if let hostedView = hostedView,
+               hostedView.terminalSurfaceView.acceptsFirstResponder {
+                window?.makeFirstResponder(hostedView.terminalSurfaceView)
+                return true
+            }
+            return super.becomeFirstResponder()
+        }
+
+        override func keyDown(with event: NSEvent) {
+            // Forward key events to the hosted terminal view.
+            if let surfaceView = hostedView?.terminalSurfaceView {
+                surfaceView.keyDown(with: event)
+            } else {
+                super.keyDown(with: event)
+            }
+        }
+
+        override func keyUp(with event: NSEvent) {
+            // Forward key events to the hosted terminal view.
+            if let surfaceView = hostedView?.terminalSurfaceView {
+                surfaceView.keyUp(with: event)
+            } else {
+                super.keyUp(with: event)
+            }
+        }
+
+        override func flagsChanged(with event: NSEvent) {
+            // Forward modifier key events to the hosted terminal view.
+            if let surfaceView = hostedView?.terminalSurfaceView {
+                surfaceView.flagsChanged(with: event)
+            } else {
+                super.flagsChanged(with: event)
+            }
+        }
+
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            // Forward key equivalent events (like Esc) to the hosted terminal view.
+            // This is critical for keys like Escape to work inside panels.
+            if let surfaceView = hostedView?.terminalSurfaceView {
+                return surfaceView.performKeyEquivalent(with: event)
+            }
+            return super.performKeyEquivalent(with: event)
         }
     }
 
@@ -8900,6 +8959,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
 #endif
 
         let hostContainer = nsView as? HostContainerView
+        // Set the hosted view on the container so it can forward key events.
+        hostContainer?.hostedView = hostedView
         let hostOwnsPortalNow = hostContainer.map { host in
             terminalSurface.claimPortalHost(
                 hostId: ObjectIdentifier(host),


### PR DESCRIPTION
## Summary

Fixes #1610 - Esc key not working inside panels.

## Problem

When a terminal is embedded in a panel (via the bonsplit layout system), key events were not being properly routed to the terminal view. This was because the HostContainerView (the SwiftUI anchor for the portal-hosted terminal) did not forward key events to the actual GhosttyNSView that handles terminal input.

## Solution

Modified HostContainerView in GhosttyTerminalView.swift to forward key events to the hosted terminal surface view:

1. Added key event forwarding methods: keyDown, keyUp, flagsChanged, and performKeyEquivalent now forward events to the terminal surface view.

2. Added acceptsFirstResponder override: Returns true so the container can receive key events.

3. Added becomeFirstResponder override: Transfers focus directly to the terminal view when the container becomes first responder.

4. Added public terminalSurfaceView accessor: Exposes the underlying GhosttyNSView from GhosttySurfaceScrollView for event forwarding.

5. Connected hostedView reference: Sets the hosted view on HostContainerView during updateNSView so it can forward events.

## Testing

This fix ensures that keys like Escape are properly routed to the terminal when using panels, allowing terminal applications (like vim, less, etc.) to receive Esc key input correctly.

## Related

- Fixes #1610


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward key events from the panel host container to the terminal surface view so Esc and other keys work when the terminal is embedded in panels. Fixes #1610.

- **Bug Fixes**
  - Host container forwards keyDown/keyUp/flagsChanged/performKeyEquivalent to the hosted terminal.
  - Allows first responder and transfers focus to the terminal on becomeFirstResponder.
  - Adds a `terminalSurfaceView` accessor and wires `hostedView` during `updateNSView` for event routing.

<sup>Written for commit d9cb4788300dd9ef86a8d252f1cf68fb1b886bb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard input routing for embedded terminal views to ensure all keyboard events, including the Escape key, are properly handled and processed in terminal panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->