### PR TITLE
fix(cli): prevent stop hook from overwriting 'Needs input' status

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10118,13 +10118,19 @@ struct CMUXCLI {
                 _ = try? sendV1Command("notify_target \(workspaceId) \(resolvedSurface) \(payload)", client: client)
             }
 
-            try setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Idle",
-                icon: "pause.circle.fill",
-                color: "#8E8E93"
-            )
+            // Only set status to "Idle" if it's not already "Needs input".
+            // This prevents the stop hook from overwriting a pending notification
+            // that requires user input, ensuring consistent status display.
+            let currentStatus = try? getClaudeStatus(client: client, workspaceId: workspaceId)
+            if currentStatus?.lowercased() != "needs input" {
+                try setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Idle",
+                    icon: "pause.circle.fill",
+                    color: "#8E8E93"
+                )
+            }
             print("OK")
 
         case "prompt-submit":
@@ -10301,6 +10307,28 @@ struct CMUXCLI {
 
     private func clearClaudeStatus(client: SocketClient, workspaceId: String) throws {
         _ = try client.send(command: "clear_status claude_code --tab=\(workspaceId)")
+    }
+
+    /// Retrieves the current status value for the claude_code status entry.
+    /// Returns nil if the status entry doesn't exist or can't be retrieved.
+    private func getClaudeStatus(client: SocketClient, workspaceId: String) throws -> String? {
+        let response = try client.send(command: "list_status --tab=\(workspaceId)")
+        // Response format: "claude_code=<value> icon=<icon> color=<color> ..."
+        // or "No status entries" if empty
+        guard !response.contains("No status entries") else { return nil }
+        for line in response.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("claude_code=") {
+                // Extract value after "claude_code=" and before next space or end of line
+                let afterKey = trimmed.dropFirst("claude_code=".count)
+                if let spaceIndex = afterKey.firstIndex(of: " ") {
+                    return String(afterKey[..<spaceIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+                } else {
+                    return String(afterKey).trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+        }
+        return nil
     }
 
     private func describeAskUserQuestion(_ object: [String: Any]?) -> String? {


### PR DESCRIPTION
## Problem

The sidebar was showing inconsistent "Idle" vs "Needs Input" status for workspaces in the same state (manaflow-ai/cmux#1492).

When multiple workspaces have Claude Code sessions that are idle/waiting for input, some show "🔵 Idle" while others show "🔔 Needs input" — even though they're all in the same state.

## Root Cause

The \"stop\" hook unconditionally set the status to "Idle" at the end of each turn, overwriting any pending "Needs input" notification that required user attention.

The order of hook execution could vary:
1. If \"notification\" fired last → status was "Needs input"  
2. If \"stop\" fired last → status was overwritten to "Idle"

This caused workspaces in identical states to display different status indicators.

## Solution

The \"stop\" hook now checks the current status before setting "Idle". If the status is already "Needs input", it preserves that status instead of overwriting it.

The "Needs input" status is now only cleared when:
- User submits a prompt (\"prompt-submit\" hook)
- Session ends (\"session-end\" hook)

## Changes

- Modified the \"stop\" handler in \"CLI/cmux.swift\" to check current status before setting "Idle"
- Added \"getClaudeStatus()\" helper function to query the current status value
- Preserves "Needs input" status to ensure consistent display across all workspaces

## Testing

- Verified syntax with \"swiftc -parse\"
- The fix ensures that workspaces in the same state (waiting for user input) now show consistent status indicators

Fixes manaflow-ai/cmux#1492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CLI stop hook from overwriting a pending "Needs input" status, fixing inconsistent "Idle" vs "Needs input" indicators in the sidebar. Fixes manaflow-ai/cmux#1492.

- **Bug Fixes**
  - Stop hook now checks the current status before setting "Idle".
  - Preserves "Needs input"; only cleared on "prompt-submit" and "session-end".
  - Added `getClaudeStatus()` to read the current status from the workspace.

<sup>Written for commit 181ed8927419388f3cc4ad19cd9e1b97216b2f82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude's status notifications are now preserved when processing stops, preventing the loss of pending user input prompts during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->