### PR TITLE
fix: make Cmd+W shortcut configurable in Settings

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8963,7 +8963,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // browser NSTextView during split focus transitions.
         if matchShortcut(
             event: event,
-            shortcut: StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
+            shortcut: KeyboardShortcutSettings.shortcut(for: .closePanel)
         ) {
             // Browser popup windows primarily intercept Cmd+W in BrowserPopupPanel.
             // This AppDelegate path is a fallback for cases where AppKit routes the

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -22,6 +22,7 @@ enum KeyboardShortcutSettings {
         case prevSidebarTab
         case renameTab
         case renameWorkspace
+        case closePanel
         case closeWorkspace
         case newSurface
         case toggleTerminalCopyMode
@@ -61,6 +62,7 @@ enum KeyboardShortcutSettings {
             case .prevSidebarTab: return String(localized: "shortcut.previousWorkspace.label", defaultValue: "Previous Workspace")
             case .renameTab: return String(localized: "shortcut.renameTab.label", defaultValue: "Rename Tab")
             case .renameWorkspace: return String(localized: "shortcut.renameWorkspace.label", defaultValue: "Rename Workspace")
+            case .closePanel: return String(localized: "shortcut.closePanel.label", defaultValue: "Close Panel")
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
@@ -94,6 +96,7 @@ enum KeyboardShortcutSettings {
             case .prevSidebarTab: return "shortcut.prevSidebarTab"
             case .renameTab: return "shortcut.renameTab"
             case .renameWorkspace: return "shortcut.renameWorkspace"
+            case .closePanel: return "shortcut.closePanel"
             case .closeWorkspace: return "shortcut.closeWorkspace"
             case .focusLeft: return "shortcut.focusLeft"
             case .focusRight: return "shortcut.focusRight"
@@ -142,6 +145,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
             case .renameWorkspace:
                 return StoredShortcut(key: "r", command: true, shift: true, option: false, control: false)
+            case .closePanel:
+                return StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
             case .closeWorkspace:
                 return StoredShortcut(key: "w", command: true, shift: true, option: false, control: false)
             case .focusLeft:


### PR DESCRIPTION
**Issue:** Cmd+W was hardcoded to close the focused panel and could not be reconfigured in Settings, unlike other shortcuts.

**Fix:** Added a new `closePanel` action to `KeyboardShortcutSettings.Action` with a default shortcut of Cmd+W. Updated AppDelegate to use the configurable shortcut instead of the hardcoded one.

**Changes:**
- Added `closePanel` case to `KeyboardShortcutSettings.Action` enum
- Added label "Close Panel" for the settings UI
- Added `shortcut.closePanel` defaults key for persistence  
- Set default shortcut to Cmd+W (maintaining backward compatibility)
- Updated AppDelegate to use `KeyboardShortcutSettings.shortcut(for: .closePanel)` instead of hardcoded `StoredShortcut(key: "w", command: true, ...)`

**Testing:**
- The existing Cmd+W tests should continue to pass since they verify the key event handling, which now uses the configurable shortcut with the same default value

Fixes #1488

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Cmd+W “Close Panel” shortcut configurable in Settings, with Cmd+W as the default to preserve current behavior. Fixes #1488.

- **New Features**
  - Added a Close Panel action to Keyboard Shortcut Settings.
  - Added a settings label and persistence key: shortcut.closePanel.
  - App now reads the shortcut via KeyboardShortcutSettings instead of a hardcoded value.

<sup>Written for commit 8ad495e471da22438dcd0e7d204510b14f70a123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

