### PR TITLE
fix(workspace): correct CoreText font memory management for x86_64

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -26,7 +26,10 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
-    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
+    // ghostty_surface_quicklook_font returns a CTFontRef created via copyWithAttributes,
+    // which returns a +1 retained reference that the caller must release.
+    // Use takeRetainedValue() to properly transfer ownership and CFRelease it.
+    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeRetainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
     return points


### PR DESCRIPTION
## Summary

Fixes #1661

The x86_64-only builds were crashing on Intel Macs due to incorrect memory management of CoreText font objects returned from the Ghostty library.

## Root Cause

The `ghostty_surface_quicklook_font` function returns a `CTFontRef` created via `copyWithAttributes`, which according to CoreFoundation naming conventions returns a +1 retained reference that the caller must release.

The original code used `takeUnretainedValue()` which doesn't transfer ownership, causing a memory leak. On x86_64 Intel Macs, this memory leak manifests as a crash in the Objective-C runtime (`_objc_emptyCache` during `object_getIndexedIvars`).

## Fix

Changed `takeUnretainedValue()` to `takeRetainedValue()` in the `cmuxCurrentSurfaceFontSizePoints` function. This properly transfers ownership of the CoreFoundation object to Swift's ARC.

## Testing

This fix addresses the specific crash in `TerminalSurface.createSurface` on x86_64 Intel Macs as described in #1661.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes on Intel Macs (x86_64) by correctly retaining CoreText fonts returned by Ghostty, preventing leaks and runtime crashes in `TerminalSurface.createSurface`.

- **Bug Fixes**
  - Replace `takeUnretainedValue()` with `takeRetainedValue()` in `cmuxCurrentSurfaceFontSizePoints` to match +1 ownership from `copyWithAttributes`.

<sup>Written for commit e9b645fa44b2bf333786208b8a8335cac4acbe80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

