### PR TITLE
feat: add Cmd+Shift+E keyboard shortcut for equalize splits

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -62072,6 +62072,119 @@
         }
       }
     },
+    "shortcut.equalizeSplits.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Equalize Splits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分割を均等にする"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "均分面板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "均等分割"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "분할 균등화"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teilungen angleichen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Igualar divisiones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Égaliser les divisions"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Equalizza divisioni"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udlign opdelinger"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyrównaj podziały"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выровнять разделение"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izjednači podjele"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تسوية التقسيمات"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gjør delinger like"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Equalizar Divisões"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับขนาดช่องแยกให้เท่ากัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bölmeleri Eşitle"
+          }
+        }
+      }
+    },
     "shortcut.toggleSidebar.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9110,6 +9110,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .equalizeSplits)) {
+            if let workspace = tabManager?.selectedWorkspace {
+                _ = tabManager?.equalizeSplits(tabId: workspace.id)
+            }
+            return true
+        }
+
         // Split actions: Cmd+D / Cmd+Shift+D
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .splitRight)) {
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4778,6 +4778,8 @@ struct ContentView: View {
             return .splitDown
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
+        case "palette.equalizeSplits":
+            return .equalizeSplits
         case "palette.triggerFlash":
             return .triggerFlash
         default:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -34,6 +34,7 @@ enum KeyboardShortcutSettings {
         case splitRight
         case splitDown
         case toggleSplitZoom
+        case equalizeSplits
         case splitBrowserRight
         case splitBrowserDown
 
@@ -71,6 +72,7 @@ enum KeyboardShortcutSettings {
             case .splitRight: return String(localized: "shortcut.splitRight.label", defaultValue: "Split Right")
             case .splitDown: return String(localized: "shortcut.splitDown.label", defaultValue: "Split Down")
             case .toggleSplitZoom: return String(localized: "shortcut.togglePaneZoom.label", defaultValue: "Toggle Pane Zoom")
+            case .equalizeSplits: return String(localized: "shortcut.equalizeSplits.label", defaultValue: "Equalize Splits")
             case .splitBrowserRight: return String(localized: "shortcut.splitBrowserRight.label", defaultValue: "Split Browser Right")
             case .splitBrowserDown: return String(localized: "shortcut.splitBrowserDown.label", defaultValue: "Split Browser Down")
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
@@ -102,6 +104,7 @@ enum KeyboardShortcutSettings {
             case .splitRight: return "shortcut.splitRight"
             case .splitDown: return "shortcut.splitDown"
             case .toggleSplitZoom: return "shortcut.toggleSplitZoom"
+            case .equalizeSplits: return "shortcut.equalizeSplits"
             case .splitBrowserRight: return "shortcut.splitBrowserRight"
             case .splitBrowserDown: return "shortcut.splitBrowserDown"
             case .nextSurface: return "shortcut.nextSurface"
@@ -158,6 +161,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "d", command: true, shift: true, option: false, control: false)
             case .toggleSplitZoom:
                 return StoredShortcut(key: "\r", command: true, shift: true, option: false, control: false)
+            case .equalizeSplits:
+                return StoredShortcut(key: "e", command: true, shift: true, option: false, control: false)
             case .splitBrowserRight:
                 return StoredShortcut(key: "d", command: true, shift: false, option: true, control: false)
             case .splitBrowserDown:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3311,7 +3311,14 @@ class TabManager: ObservableObject {
                 return
             }
 
-            if !controller.setDividerPosition(0.5, forSplit: splitId) {
+            // Calculate ratio based on leaf weights (like ghostty's equalize algorithm).
+            // Children with the same orientation contribute their full leaf count,
+            // children with a different orientation count as 1.
+            let leftWeight = weightForDirection(splitNode.first, direction: splitNode.orientation)
+            let rightWeight = weightForDirection(splitNode.second, direction: splitNode.orientation)
+            let ratio = Double(leftWeight) / Double(leftWeight + rightWeight)
+
+            if !controller.setDividerPosition(ratio, forSplit: splitId) {
                 allSucceeded = false
             }
 
@@ -3327,6 +3334,23 @@ class TabManager: ObservableObject {
                 foundSplit: &foundSplit,
                 allSucceeded: &allSucceeded
             )
+        }
+    }
+
+    /// Calculate weight for equalization based on split direction.
+    /// Children with the same direction contribute their full leaf count,
+    /// children with a different direction count as 1.
+    private func weightForDirection(_ node: ExternalTreeNode, direction: String) -> Int {
+        switch node {
+        case .pane:
+            return 1
+        case .split(let splitNode):
+            if splitNode.orientation == direction {
+                return weightForDirection(splitNode.first, direction: direction)
+                     + weightForDirection(splitNode.second, direction: direction)
+            } else {
+                return 1
+            }
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3345,7 +3345,7 @@ class TabManager: ObservableObject {
         case .pane:
             return 1
         case .split(let splitNode):
-            if splitNode.orientation == direction {
+            if splitNode.orientation.lowercased() == direction.lowercased() {
                 return weightForDirection(splitNode.first, direction: direction)
                      + weightForDirection(splitNode.second, direction: direction)
             } else {


### PR DESCRIPTION
Add native keyboard shortcut support for equalizing split panes. The equalize algorithm now uses leaf-weight-based ratios (matching ghostty's implementation) instead of naively setting all dividers to 0.5, which produced uneven layouts with nested splits.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cmd+Shift+E and a command palette action to equalize split panes using leaf-weight ratios for consistent layouts with nested splits (matches `ghostty`). Fix case-insensitive split orientation comparison to prevent uneven results with mixed casing.

<sup>Written for commit 7cfdd10904b728aa870a1d983950a47663e52c60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Equalize Splits" action accessible via keyboard (Cmd+Shift+E) and the command palette
  * Improved equalization to distribute pane space proportionally based on content weight
  * Added localized labels for "Equalize Splits" in multiple languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->