### PR TITLE
fix: enable App Sandbox to prevent unauthorized file system scanning

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -2,18 +2,37 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- App Sandbox - restricts file system access to prevent unauthorized scanning -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	
+	<!-- User-selected files - for opening directories via file dialog -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	
+	<!-- Downloads folder access - commonly used in terminal workflows -->
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	
+	<!-- Code signing exceptions for Ghostty library integration -->
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	
+	<!-- Device access - explicitly requested by user action -->
 	<key>com.apple.security.device.camera</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	
+	<!-- Apple Events - for opening files in external editors -->
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	
+	<!-- Web browser capability for integrated browser panels -->
 	<key>com.apple.developer.web-browser</key>
 	<true/>
 </dict>


### PR DESCRIPTION
## Problem
cmux was triggering macOS TCC authorization requests for every protected user data category (Music, Photos, Calendar, Contacts, Desktop, Full Disk Access) within a single minute of launching. This was caused by the app running without App Sandbox restrictions, allowing spawned child processes (like \) to traverse TCC-protected directories.

Fixes #1534

## Solution
Enable App Sandbox with scoped file access entitlements:

- **\** - Enables the App Sandbox to restrict file system access
- **\** - Allows access to user-selected directories via file dialogs (for opening folders in cmux)
- **\** - Allows access to Downloads folder (commonly used in terminal workflows)

## What This Prevents
With App Sandbox enabled:
- Child processes spawned by cmux cannot traverse protected directories (~/Music, ~/Pictures, ~/Library/Calendars, ~/Library/AddressBook) without triggering user consent dialogs
- Unauthorized file system scanning is blocked at the sandbox level
- Users will only see TCC prompts when explicitly granting access via file picker dialogs

## Preserved Functionality
All existing entitlements are retained:
- Code signing exceptions for Ghostty library integration
- Camera and audio input access (triggered by user action)
- Apple Events automation (for opening files in external editors)
- Web browser capability (for integrated browser panels)

## Testing
The entitlements file has been validated with \.

---
**Note:** This is a security fix that restricts the app's file system access to only what is necessary for its functionality. Users who need to access specific directories can still do so by using the file picker dialog (Cmd+O) or by dragging folders into cmux.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable macOS App Sandbox and scoped file access to stop unauthorized file system scanning and TCC prompts at launch. cmux and its child processes can now only access user-selected folders or Downloads (fixes #1534).

- **Bug Fixes**
  - Added `com.apple.security.app-sandbox`, `com.apple.security.files.user-selected.read-write`, and `com.apple.security.files.downloads.read-write`.
  - Blocks traversal of TCC-protected paths by child processes; prompts only appear after file picker consent.
  - Preserves existing entitlements.

<sup>Written for commit ef794f4ef2eda156d516ecea3a30bdb151000333. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled application access to camera and audio input capabilities
  * Added permissions for reading and writing user-selected files and downloads folder
  * Enabled web browser and automation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->