### PR TITLE
fix(terminal): allow text selection from start of line

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -446,6 +446,17 @@ final class WindowBrowserHostView: NSView {
         )
         let splitPassThrough = dividerHit.map { !$0.isInHostedContent } ?? false
 
+        // Only pass through divider events during actual drag operations,
+        // not on mouse down which could be starting a text selection.
+        let eventType = NSApp.currentEvent?.type
+        let isDragEvent: Bool
+        switch eventType {
+        case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+            isDragEvent = true
+        default:
+            isDragEvent = false
+        }
+
         if titlebarPassThrough {
 #if DEBUG
             debugLogPointerRouting(
@@ -459,7 +470,7 @@ final class WindowBrowserHostView: NSView {
 #endif
             return nil
         }
-        if sidebarPassThrough {
+        if sidebarPassThrough && isDragEvent {
 #if DEBUG
             debugLogPointerRouting(
                 stage: "hitTest.sidebarPass",
@@ -472,7 +483,7 @@ final class WindowBrowserHostView: NSView {
 #endif
             return nil
         }
-        if splitPassThrough {
+        if splitPassThrough && isDragEvent {
 #if DEBUG
             debugLogPointerRouting(
                 stage: "hitTest.splitPass",

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -134,7 +134,8 @@ final class WindowTerminalHostView: NSView {
     override func hitTest(_ point: NSPoint) -> NSView? {
         let currentEvent = NSApp.currentEvent
         let isPointerEvent: Bool
-        switch currentEvent?.type {
+        let eventType = currentEvent?.type
+        switch eventType {
         case .mouseMoved, .mouseEntered, .mouseExited,
              .leftMouseDown, .leftMouseUp, .leftMouseDragged,
              .rightMouseDown, .rightMouseUp, .rightMouseDragged,
@@ -146,7 +147,17 @@ final class WindowTerminalHostView: NSView {
         }
 
         if isPointerEvent {
-            if shouldPassThroughToSidebarResizer(at: point) {
+            // Only pass through to sidebar resizer during actual drag operations,
+            // not on mouse down which could be starting a text selection.
+            let isDragEvent: Bool
+            switch eventType {
+            case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+                isDragEvent = true
+            default:
+                isDragEvent = false
+            }
+
+            if isDragEvent, shouldPassThroughToSidebarResizer(at: point) {
                 clearActiveDividerCursor(restoreArrow: false)
                 return nil
             }
@@ -155,13 +166,16 @@ final class WindowTerminalHostView: NSView {
             if let kind = splitDividerCursorKind(at: point) {
                 activeDividerCursorKind = kind
                 kind.cursor.set()
-                return nil
+                // Only consume the hit (return nil) during drag operations.
+                // On mouse down/up, allow terminal text selection to work.
+                if isDragEvent {
+                    return nil
+                }
             }
 
             clearActiveDividerCursor(restoreArrow: true)
 
             let dragPasteboardTypes = NSPasteboard(name: .drag).types
-            let eventType = currentEvent?.type
             let shouldPassThrough = DragOverlayRoutingPolicy.shouldPassThroughPortalHitTesting(
                 pasteboardTypes: dragPasteboardTypes,
                 eventType: eventType
@@ -182,7 +196,7 @@ final class WindowTerminalHostView: NSView {
 #if DEBUG
             logDragRouteDecision(
                 passThrough: false,
-                eventType: currentEvent?.type,
+                eventType: eventType,
                 pasteboardTypes: dragPasteboardTypes,
                 hitView: hitView
             )


### PR DESCRIPTION
## Problem

When attempting to select terminal text from the start of a line, the cursor would change to horizontal expander mode for adjusting the side panel width instead of allowing text selection.

The sidebar resizer hit region extends 6 points on each side of the divider. The `hitTest` method was returning `nil` for all events within this region, including mouse down events needed for text selection.

## Solution

Restrict the sidebar resizer and split divider hit-test pass-through to only apply during actual drag operations. This allows mouse down/up events to reach the terminal for text selection while still supporting sidebar resizing via dragging.

## Changes

- `TerminalWindowPortal.swift`: Modified `hitTest` to check for drag events before passing through to sidebar resizer  
- `BrowserWindowPortal.swift`: Applied same fix for consistency

Fixes #1606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where selecting terminal text from the start of a line was blocked by the sidebar resizer. Divider pass-through now only happens during drag, so mouse down/up reach the terminal while resizing still works. Fixes #1606.

- **Bug Fixes**
  - `TerminalWindowPortal.swift`: Gate sidebar/split divider pass-through on drag events; don’t consume hits on mouse down/up; keep divider cursor behavior.
  - `BrowserWindowPortal.swift`: Apply the same drag-only pass-through for consistency.

<sup>Written for commit dc0386f166bb59dd90ec84c19699fe39068498de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved text selection in terminal windows during mouse interactions by preventing unintended divider pass-through on non-drag mouse events
* Enhanced drag-only behavior for window resizing and divider operations to avoid interfering with normal text selection and interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->