### PR TITLE
fix(terminal): prevent cursor movement on double-click selection

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5619,7 +5619,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+        // Only update mouse position on the first click to prevent unwanted cursor
+        // movement during double-click selection (issue #1698)
+        if event.clickCount == 1 {
+            ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+        }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
     }
 


### PR DESCRIPTION
## Description

Double-clicking to select text in the terminal was causing unwanted cursor movement because the mouse position was being updated on both the first and second clicks. This disrupted the selection gesture and caused the cursor to jump to a different position than intended.

## Fix

Only update the mouse position on the first click (clickCount == 1), allowing the terminal'\''s selection logic to handle multi-click gestures without cursor interference.

## Changes

- Modified `GhosttyNSView.mouseDown(with:)` to skip `ghostty_surface_mouse_pos` on multi-click events

Fixes #1698

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent cursor movement during double-click selection in the terminal. In `GhosttyNSView.mouseDown(with:)`, we now send `ghostty_surface_mouse_pos` only on the first click, letting multi-click selection proceed without cursor jumps.

<sup>Written for commit 2e23b14d8eba772b7cc3bec30df98764d1aaf238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse pointer stability during double-click selection by preventing unnecessary cursor repositioning on subsequent mouse button presses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->