### PR TITLE
feat: add Quick Terminal with global hotkey and split support

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -47,6 +47,11 @@
 			A5008373 /* BrowserFindJavaScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindJavaScript.swift */; };
 			A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 			A50012F3 /* KeyboardShortcutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F2 /* KeyboardShortcutSettings.swift */; };
+			QT000001 /* QuickTerminalWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = QT000002 /* QuickTerminalWindow.swift */; };
+			QT000003 /* QuickTerminalPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = QT000004 /* QuickTerminalPosition.swift */; };
+			QT000005 /* QuickTerminalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = QT000006 /* QuickTerminalController.swift */; };
+			QT000007 /* QuickTerminalHotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = QT000008 /* QuickTerminalHotKey.swift */; };
+			QT000009 /* QuickTerminalContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = QT00000A /* QuickTerminalContentView.swift */; };
 			A50012F5 /* KeyboardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F4 /* KeyboardLayout.swift */; };
 			A5001521 /* PostHogAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001520 /* PostHogAnalytics.swift */; };
 			A5001201 /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001211 /* UpdateController.swift */; };
@@ -198,6 +203,11 @@
 		A5008372 /* BrowserFindJavaScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindJavaScript.swift; sourceTree = "<group>"; };
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A50012F2 /* KeyboardShortcutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettings.swift; sourceTree = "<group>"; };
+		QT000002 /* QuickTerminalWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminal/QuickTerminalWindow.swift; sourceTree = "<group>"; };
+		QT000004 /* QuickTerminalPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminal/QuickTerminalPosition.swift; sourceTree = "<group>"; };
+		QT000006 /* QuickTerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminal/QuickTerminalController.swift; sourceTree = "<group>"; };
+		QT000008 /* QuickTerminalHotKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminal/QuickTerminalHotKey.swift; sourceTree = "<group>"; };
+		QT00000A /* QuickTerminalContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickTerminal/QuickTerminalContentView.swift; sourceTree = "<group>"; };
 		A50012F4 /* KeyboardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayout.swift; sourceTree = "<group>"; };
 		A5001211 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateController.swift; sourceTree = "<group>"; };
 		A5001212 /* UpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateDelegate.swift; sourceTree = "<group>"; };
@@ -400,6 +410,11 @@
 				A5001419 /* MarkdownPanelView.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
+				QT000002 /* QuickTerminalWindow.swift */,
+				QT000004 /* QuickTerminalPosition.swift */,
+				QT000006 /* QuickTerminalController.swift */,
+				QT000008 /* QuickTerminalHotKey.swift */,
+				QT00000A /* QuickTerminalContentView.swift */,
 				A5001211 /* UpdateController.swift */,
 				A5001212 /* UpdateDelegate.swift */,
 				A5001213 /* UpdateDriver.swift */,
@@ -645,6 +660,11 @@
 					B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */,
 					A50012F1 /* Backport.swift in Sources */,
 					A50012F3 /* KeyboardShortcutSettings.swift in Sources */,
+					QT000001 /* QuickTerminalWindow.swift in Sources */,
+					QT000003 /* QuickTerminalPosition.swift in Sources */,
+					QT000005 /* QuickTerminalController.swift in Sources */,
+					QT000007 /* QuickTerminalHotKey.swift in Sources */,
+					QT000009 /* QuickTerminalContentView.swift in Sources */,
 					A50012F5 /* KeyboardLayout.swift in Sources */,
 						A5001003 /* TabManager.swift in Sources */,
 						A5001501 /* UITestRecorder.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -61959,6 +61959,119 @@
         }
       }
     },
+    "shortcut.toggleQuickTerminal.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Quick Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルを切替"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换快速终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切換快速終端"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠른 터미널 전환"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnellterminal umschalten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar terminal rápido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer/désactiver le terminal rapide"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva/Disattiva terminale rapido"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slå hurtigterminal til/fra"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przełącz szybki terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Быстрый терминал"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prebaci brzi terminal"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبديل الطرفية السريعة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slå hurtigterminal av/på"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar Terminal Rápido"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับเทอร์มินัลด่วน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hızlı Terminali Aç/Kapat"
+          }
+        }
+      }
+    },
     "shortcut.togglePaneZoom.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1968,6 +1968,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     weak var tabManager: TabManager?
     weak var notificationStore: TerminalNotificationStore?
     weak var sidebarState: SidebarState?
+    private(set) var quickTerminalController: QuickTerminalController?
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
     weak var sidebarSelectionState: SidebarSelectionState?
     var shortcutLayoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
@@ -2296,6 +2297,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         installBrowserAddressBarFocusObservers()
         installShortcutMonitor()
         installShortcutDefaultsObserver()
+        quickTerminalController = QuickTerminalController()
         NSApp.servicesProvider = self
 #if DEBUG
         UpdateTestSupport.applyIfNeeded(to: updateController.viewModel)
@@ -8439,6 +8441,61 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func handleCustomShortcut(event: NSEvent) -> Bool {
+        // When the Quick Terminal is active, route shortcuts to its own TabManager.
+        if quickTerminalController?.visible == true &&
+            (event.window is QuickTerminalWindow || NSApp.keyWindow is QuickTerminalWindow) {
+            if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleQuickTerminal)) {
+                quickTerminalController?.toggle()
+                return true
+            }
+            // Route split/tab shortcuts to the quick terminal's TabManager.
+            if let qtTabManager = quickTerminalController?.tabManager {
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .splitRight)) {
+                    qtTabManager.createSplit(direction: .right)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .splitDown)) {
+                    qtTabManager.createSplit(direction: .down)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .focusLeft)) {
+                    qtTabManager.movePaneFocus(direction: .left)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .focusRight)) {
+                    qtTabManager.movePaneFocus(direction: .right)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .focusUp)) {
+                    qtTabManager.movePaneFocus(direction: .up)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .focusDown)) {
+                    qtTabManager.movePaneFocus(direction: .down)
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleSplitZoom)) {
+                    _ = qtTabManager.toggleFocusedSplitZoom()
+                    return true
+                }
+                if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .newSurface)) {
+                    qtTabManager.newSurface()
+                    return true
+                }
+                // Cmd+W: close the focused pane in the quick terminal.
+                if matchShortcut(event: event, shortcut: StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)) {
+                    if let workspace = qtTabManager.selectedWorkspace,
+                       let panelId = workspace.focusedPanelId {
+                        qtTabManager.closePanelWithConfirmation(tabId: workspace.id, surfaceId: panelId)
+                    }
+                    return true
+                }
+            }
+            // Don't consume unhandled Cmd shortcuts — let system commands
+            // (Cmd+Q, Cmd+H, Cmd+M, etc.) pass through to the main menu.
+            return false
+        }
+
         // `charactersIgnoringModifiers` can be nil for some synthetic NSEvents and certain special keys.
         // Treat nil as "" and rely on keyCode/layout-aware fallback logic where needed.
         let chars = (event.charactersIgnoringModifiers ?? "").lowercased()
@@ -9107,6 +9164,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             recordGotoSplitZoomIfNeeded()
 #endif
+            return true
+        }
+
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleQuickTerminal)) {
+            quickTerminalController?.toggle()
             return true
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2099,7 +2099,10 @@ class GhosttyApp {
                 return false
             }
             return performOnMain {
-                guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+                let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId)
+                    ?? AppDelegate.shared?.quickTerminalController?.tabManager
+                    ?? AppDelegate.shared?.tabManager
+                guard let tabManager = owningManager else { return false }
                 return tabManager.equalizeSplits(tabId: tabId)
             }
         case GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM:
@@ -2557,6 +2560,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
     var requestedWorkingDirectory: String? { workingDirectory }
     private var additionalEnvironment: [String: String]
     let hostedView: GhosttySurfaceScrollView
+    /// The inner NSView that accepts first responder for keyboard input.
+    var focusableView: NSView { surfaceView }
     private let surfaceView: GhosttyNSView
     private var lastPixelWidth: UInt32 = 0
     private var lastPixelHeight: UInt32 = 0

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -3,47 +3,84 @@ import SwiftUI
 
 /// Stores customizable keyboard shortcuts (definitions + persistence).
 enum KeyboardShortcutSettings {
+    /// All configurable keyboard shortcut actions in the app.
     enum Action: String, CaseIterable, Identifiable {
         // Titlebar / primary UI
+        /// Toggle the sidebar visibility.
         case toggleSidebar
+        /// Create a new workspace tab.
         case newTab
+        /// Open a new window.
         case newWindow
+        /// Close the current window.
         case closeWindow
+        /// Open a folder in the sidebar.
         case openFolder
+        /// Open the feedback composer.
         case sendFeedback
+        /// Show the notifications popover.
         case showNotifications
+        /// Jump to the latest unread notification.
         case jumpToUnread
+        /// Flash the focused panel to indicate focus.
         case triggerFlash
 
         // Navigation
+        /// Select the next terminal surface.
         case nextSurface
+        /// Select the previous terminal surface.
         case prevSurface
+        /// Select the next workspace in the sidebar.
         case nextSidebarTab
+        /// Select the previous workspace in the sidebar.
         case prevSidebarTab
+        /// Rename the current tab.
         case renameTab
+        /// Rename the current workspace.
         case renameWorkspace
+        /// Close the current workspace.
         case closeWorkspace
+        /// Create a new terminal surface.
         case newSurface
+        /// Toggle terminal copy mode.
         case toggleTerminalCopyMode
 
         // Panes / splits
+        /// Move focus to the left pane.
         case focusLeft
+        /// Move focus to the right pane.
         case focusRight
+        /// Move focus to the pane above.
         case focusUp
+        /// Move focus to the pane below.
         case focusDown
+        /// Split the focused pane to the right.
         case splitRight
+        /// Split the focused pane downward.
         case splitDown
+        /// Toggle zoom on the focused split pane.
         case toggleSplitZoom
+        /// Split a browser pane to the right.
         case splitBrowserRight
+        /// Split a browser pane downward.
         case splitBrowserDown
 
+        // Quick Terminal
+        /// Toggle the Quake-style Quick Terminal overlay.
+        case toggleQuickTerminal
+
         // Panels
+        /// Open a new browser panel.
         case openBrowser
+        /// Toggle the browser developer tools.
         case toggleBrowserDeveloperTools
+        /// Show the browser JavaScript console.
         case showBrowserJavaScriptConsole
 
+        /// Unique identifier for `Identifiable` conformance.
         var id: String { rawValue }
 
+        /// Localized display label for this action.
         var label: String {
             switch self {
             case .toggleSidebar: return String(localized: "shortcut.toggleSidebar.label", defaultValue: "Toggle Sidebar")
@@ -73,12 +110,14 @@ enum KeyboardShortcutSettings {
             case .toggleSplitZoom: return String(localized: "shortcut.togglePaneZoom.label", defaultValue: "Toggle Pane Zoom")
             case .splitBrowserRight: return String(localized: "shortcut.splitBrowserRight.label", defaultValue: "Split Browser Right")
             case .splitBrowserDown: return String(localized: "shortcut.splitBrowserDown.label", defaultValue: "Split Browser Down")
+            case .toggleQuickTerminal: return String(localized: "shortcut.toggleQuickTerminal.label", defaultValue: "Toggle Quick Terminal")
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             }
         }
 
+        /// UserDefaults key for persisting this shortcut.
         var defaultsKey: String {
             switch self {
             case .toggleSidebar: return "shortcut.toggleSidebar"
@@ -108,12 +147,14 @@ enum KeyboardShortcutSettings {
             case .prevSurface: return "shortcut.prevSurface"
             case .newSurface: return "shortcut.newSurface"
             case .toggleTerminalCopyMode: return "shortcut.toggleTerminalCopyMode"
+            case .toggleQuickTerminal: return "shortcut.toggleQuickTerminal"
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
             }
         }
 
+        /// The factory-default shortcut for this action.
         var defaultShortcut: StoredShortcut {
             switch self {
             case .toggleSidebar:
@@ -170,6 +211,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
+            case .toggleQuickTerminal:
+                return StoredShortcut(key: "`", command: true, shift: false, option: false, control: false)
             case .openBrowser:
                 return StoredShortcut(key: "l", command: true, shift: true, option: false, control: false)
             case .toggleBrowserDeveloperTools:
@@ -181,11 +224,13 @@ enum KeyboardShortcutSettings {
             }
         }
 
+        /// Build a tooltip string that appends the current shortcut display.
         func tooltip(_ base: String) -> String {
             "\(base) (\(KeyboardShortcutSettings.shortcut(for: self).displayString))"
         }
     }
 
+    /// Return the user-customized shortcut for the given action, or its default.
     static func shortcut(for action: Action) -> StoredShortcut {
         guard let data = UserDefaults.standard.data(forKey: action.defaultsKey),
               let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) else {
@@ -194,16 +239,19 @@ enum KeyboardShortcutSettings {
         return shortcut
     }
 
+    /// Persist a custom shortcut for the given action.
     static func setShortcut(_ shortcut: StoredShortcut, for action: Action) {
         if let data = try? JSONEncoder().encode(shortcut) {
             UserDefaults.standard.set(data, forKey: action.defaultsKey)
         }
     }
 
+    /// Remove the user's custom shortcut, reverting to the default.
     static func resetShortcut(for action: Action) {
         UserDefaults.standard.removeObject(forKey: action.defaultsKey)
     }
 
+    /// Reset all shortcuts to their factory defaults.
     static func resetAll() {
         for action in Action.allCases {
             resetShortcut(for: action)
@@ -212,55 +260,88 @@ enum KeyboardShortcutSettings {
 
     // MARK: - Backwards-Compatible API (call-sites can migrate gradually)
 
-    // Keys (used by debug socket command + UI tests)
+    /// UserDefaults key for the focus-left shortcut.
     static let focusLeftKey = Action.focusLeft.defaultsKey
+    /// UserDefaults key for the focus-right shortcut.
     static let focusRightKey = Action.focusRight.defaultsKey
+    /// UserDefaults key for the focus-up shortcut.
     static let focusUpKey = Action.focusUp.defaultsKey
+    /// UserDefaults key for the focus-down shortcut.
     static let focusDownKey = Action.focusDown.defaultsKey
 
-    // Defaults (used by settings reset + recorder button initial title)
+    /// Factory default for the show-notifications shortcut.
     static let showNotificationsDefault = Action.showNotifications.defaultShortcut
+    /// Factory default for the jump-to-unread shortcut.
     static let jumpToUnreadDefault = Action.jumpToUnread.defaultShortcut
 
+    /// Return the current show-notifications shortcut.
     static func showNotificationsShortcut() -> StoredShortcut { shortcut(for: .showNotifications) }
+    /// Persist a custom show-notifications shortcut.
     static func setShowNotificationsShortcut(_ shortcut: StoredShortcut) { setShortcut(shortcut, for: .showNotifications) }
 
+    /// Return the current jump-to-unread shortcut.
     static func jumpToUnreadShortcut() -> StoredShortcut { shortcut(for: .jumpToUnread) }
+    /// Persist a custom jump-to-unread shortcut.
     static func setJumpToUnreadShortcut(_ shortcut: StoredShortcut) { setShortcut(shortcut, for: .jumpToUnread) }
 
+    /// Return the current next-workspace shortcut.
     static func nextSidebarTabShortcut() -> StoredShortcut { shortcut(for: .nextSidebarTab) }
+    /// Return the current previous-workspace shortcut.
     static func prevSidebarTabShortcut() -> StoredShortcut { shortcut(for: .prevSidebarTab) }
+    /// Return the current rename-workspace shortcut.
     static func renameWorkspaceShortcut() -> StoredShortcut { shortcut(for: .renameWorkspace) }
+    /// Return the current close-workspace shortcut.
     static func closeWorkspaceShortcut() -> StoredShortcut { shortcut(for: .closeWorkspace) }
 
+    /// Return the current focus-left shortcut.
     static func focusLeftShortcut() -> StoredShortcut { shortcut(for: .focusLeft) }
+    /// Return the current focus-right shortcut.
     static func focusRightShortcut() -> StoredShortcut { shortcut(for: .focusRight) }
+    /// Return the current focus-up shortcut.
     static func focusUpShortcut() -> StoredShortcut { shortcut(for: .focusUp) }
+    /// Return the current focus-down shortcut.
     static func focusDownShortcut() -> StoredShortcut { shortcut(for: .focusDown) }
 
+    /// Return the current split-right shortcut.
     static func splitRightShortcut() -> StoredShortcut { shortcut(for: .splitRight) }
+    /// Return the current split-down shortcut.
     static func splitDownShortcut() -> StoredShortcut { shortcut(for: .splitDown) }
+    /// Return the current toggle-split-zoom shortcut.
     static func toggleSplitZoomShortcut() -> StoredShortcut { shortcut(for: .toggleSplitZoom) }
+    /// Return the current split-browser-right shortcut.
     static func splitBrowserRightShortcut() -> StoredShortcut { shortcut(for: .splitBrowserRight) }
+    /// Return the current split-browser-down shortcut.
     static func splitBrowserDownShortcut() -> StoredShortcut { shortcut(for: .splitBrowserDown) }
 
+    /// Return the current next-surface shortcut.
     static func nextSurfaceShortcut() -> StoredShortcut { shortcut(for: .nextSurface) }
+    /// Return the current previous-surface shortcut.
     static func prevSurfaceShortcut() -> StoredShortcut { shortcut(for: .prevSurface) }
+    /// Return the current new-surface shortcut.
     static func newSurfaceShortcut() -> StoredShortcut { shortcut(for: .newSurface) }
 
+    /// Return the current open-browser shortcut.
     static func openBrowserShortcut() -> StoredShortcut { shortcut(for: .openBrowser) }
+    /// Return the current toggle-browser-developer-tools shortcut.
     static func toggleBrowserDeveloperToolsShortcut() -> StoredShortcut { shortcut(for: .toggleBrowserDeveloperTools) }
+    /// Return the current show-browser-JavaScript-console shortcut.
     static func showBrowserJavaScriptConsoleShortcut() -> StoredShortcut { shortcut(for: .showBrowserJavaScriptConsole) }
 }
 
-/// A keyboard shortcut that can be stored in UserDefaults
+/// A keyboard shortcut that can be stored in UserDefaults.
 struct StoredShortcut: Codable, Equatable {
+    /// The key character (e.g. "a", "`", "←").
     var key: String
+    /// Whether the Command modifier is required.
     var command: Bool
+    /// Whether the Shift modifier is required.
     var shift: Bool
+    /// Whether the Option modifier is required.
     var option: Bool
+    /// Whether the Control modifier is required.
     var control: Bool
 
+    /// Human-readable display string with modifier glyphs (e.g. "⌘⇧D").
     var displayString: String {
         var parts: [String] = []
         if control { parts.append("⌃") }
@@ -280,6 +361,7 @@ struct StoredShortcut: Codable, Equatable {
         return parts.joined()
     }
 
+    /// AppKit modifier flags for event matching.
     var modifierFlags: NSEvent.ModifierFlags {
         var flags: NSEvent.ModifierFlags = []
         if command { flags.insert(.command) }
@@ -289,6 +371,7 @@ struct StoredShortcut: Codable, Equatable {
         return flags
     }
 
+    /// SwiftUI `KeyEquivalent` for use in keyboard shortcut modifiers.
     var keyEquivalent: KeyEquivalent? {
         switch key {
         case "←":
@@ -310,6 +393,7 @@ struct StoredShortcut: Codable, Equatable {
         }
     }
 
+    /// SwiftUI `EventModifiers` for use in keyboard shortcut modifiers.
     var eventModifiers: EventModifiers {
         var modifiers: EventModifiers = []
         if command {
@@ -327,6 +411,7 @@ struct StoredShortcut: Codable, Equatable {
         return modifiers
     }
 
+    /// Key equivalent string for `NSMenuItem` integration.
     var menuItemKeyEquivalent: String? {
         switch key {
         case "←":
@@ -352,6 +437,7 @@ struct StoredShortcut: Codable, Equatable {
         }
     }
 
+    /// Create a `StoredShortcut` from a key-down event, or `nil` if unsuitable.
     static func from(event: NSEvent) -> StoredShortcut? {
         guard let key = storedKey(from: event) else { return nil }
 
@@ -411,12 +497,15 @@ struct StoredShortcut: Codable, Equatable {
     }
 }
 
-/// View for recording a keyboard shortcut
+/// View for recording a keyboard shortcut.
 struct KeyboardShortcutRecorder: View {
+    /// The label displayed next to the recorder button.
     let label: String
+    /// Binding to the shortcut being recorded.
     @Binding var shortcut: StoredShortcut
     @State private var isRecording = false
 
+    /// The recorder view body with label and button.
     var body: some View {
         HStack {
             Text(label)

--- a/Sources/QuickTerminal/QuickTerminalContentView.swift
+++ b/Sources/QuickTerminal/QuickTerminalContentView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import Bonsplit
+
+/// A minimal SwiftUI view that renders a single workspace's bonsplit content
+/// for the Quick Terminal window. No sidebar, no tab bar — just the terminal panes.
+struct QuickTerminalContentView: View {
+    /// The tab manager that owns the Quick Terminal's workspace and panes.
+    @ObservedObject var tabManager: TabManager
+    /// Shared notification store for terminal notifications.
+    @ObservedObject var notificationStore: TerminalNotificationStore
+
+    /// Render the selected workspace's terminal panes.
+    var body: some View {
+        if let workspace = tabManager.selectedWorkspace {
+            WorkspaceContentView(
+                workspace: workspace,
+                isWorkspaceVisible: true,
+                isWorkspaceInputActive: true,
+                workspacePortalPriority: 2,
+                onThemeRefreshRequest: nil
+            )
+            .environmentObject(notificationStore)
+        }
+    }
+}

--- a/Sources/QuickTerminal/QuickTerminalController.swift
+++ b/Sources/QuickTerminal/QuickTerminalController.swift
@@ -1,0 +1,213 @@
+import AppKit
+import SwiftUI
+import Combine
+
+/// Manages a Quake-style drop-down Quick Terminal that slides in/out from a screen edge.
+/// Has its own TabManager so splits, tabs, and other workspace features work independently.
+@MainActor
+final class QuickTerminalController: NSObject, NSWindowDelegate {
+
+    // MARK: - Configuration
+
+    /// The screen edge from which the Quick Terminal slides in.
+    let position: QuickTerminalPosition
+    private let animationDuration: TimeInterval = 0.2
+    /// Horizontal padding on each side (matches ghostty's quick terminal style).
+    private let horizontalPadding: CGFloat = 6
+
+    // MARK: - State
+
+    /// Whether the Quick Terminal is currently shown on screen.
+    private(set) var visible: Bool = false
+    private var window: QuickTerminalWindow?
+    /// The dedicated tab manager for the Quick Terminal's workspace.
+    private(set) var tabManager: TabManager?
+    private var previousApp: NSRunningApplication?
+    private var globalHotKey: QuickTerminalHotKey?
+
+    // MARK: - Init
+
+    /// Create a Quick Terminal controller that slides in from the given screen edge.
+    init(position: QuickTerminalPosition = .top) {
+        self.position = position
+        super.init()
+        registerGlobalHotKey()
+    }
+
+    /// Register the global hot key so Quick Terminal can be toggled from any application.
+    func registerGlobalHotKey() {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .toggleQuickTerminal)
+        let hotKey = QuickTerminalHotKey { [weak self] in
+            self?.toggle()
+        }
+        if !hotKey.register(shortcut: shortcut) {
+#if DEBUG
+            dlog("quickTerminal.registerGlobalHotKey failed: shortcut=\(shortcut.key)")
+#endif
+        }
+        globalHotKey = hotKey
+    }
+
+    // MARK: - Public
+
+    /// Toggle the Quick Terminal: show it if hidden, hide it if visible.
+    func toggle() {
+        if visible {
+            animateOut()
+        } else {
+            animateIn()
+        }
+    }
+
+    // MARK: - Animate In
+
+    private func animateIn() {
+        guard !visible else { return }
+
+        // Remember the previously focused app so we can restore it on hide.
+        if !NSApp.isActive {
+            if let front = NSWorkspace.shared.frontmostApplication,
+               front.bundleIdentifier != Bundle.main.bundleIdentifier {
+                previousApp = front
+            }
+        }
+
+        let window = ensureWindow()
+        guard let screen = NSScreen.main else { return }
+
+        visible = true
+
+        // Resize: slightly narrower than screen for equal side padding.
+        var size = position.defaultSize(on: screen)
+        if position == .top || position == .bottom {
+            size.width -= horizontalPadding * 2
+        }
+        window.setFrame(NSRect(origin: window.frame.origin, size: size), display: false)
+
+        // Place off-screen.
+        position.setInitial(in: window, on: screen)
+
+        // Bring to front above everything during animation.
+        window.level = .popUpMenu
+        window.makeKeyAndOrderFront(nil)
+
+        // Activate app so we can receive key events when invoked from another app.
+        if !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        // Animate to final position.
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = animationDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            position.setFinal(in: window.animator(), on: screen)
+        }, completionHandler: { [weak self] in
+            guard let self, self.visible else { return }
+            // Drop to floating level so menus/dialogs can appear above.
+            window.level = .floating
+            self.focusTerminal(in: window)
+        })
+    }
+
+    // MARK: - Animate Out
+
+    private func animateOut() {
+        guard visible, let window else { return }
+        visible = false
+
+        guard let screen = window.screen ?? NSScreen.main else {
+            window.orderOut(nil)
+            return
+        }
+
+        // Unfocus surfaces so ghostty doesn't keep rendering.
+        if let workspace = tabManager?.selectedWorkspace,
+           let panelId = workspace.focusedPanelId,
+           let panel = workspace.panels[panelId] {
+            panel.unfocus()
+        }
+
+        // Restore previously active application.
+        if let prev = previousApp, !prev.isTerminated {
+            previousApp = nil
+            prev.activate(options: [])
+        } else {
+            previousApp = nil
+        }
+
+        window.level = .popUpMenu
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = animationDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            position.setInitial(in: window.animator(), on: screen)
+        }, completionHandler: {
+            window.orderOut(nil)
+        })
+    }
+
+    // MARK: - Window / TabManager Setup
+
+    private func ensureWindow() -> QuickTerminalWindow {
+        if let window { return window }
+
+        let window = QuickTerminalWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 400))
+        window.delegate = self
+        self.window = window
+
+        // Create a dedicated TabManager for the quick terminal.
+        let tm = TabManager()
+        tm.window = window
+        self.tabManager = tm
+
+        // Create an initial workspace.
+        tm.addWorkspace(select: true)
+
+        // Embed via NSHostingView.
+        let contentView = QuickTerminalContentView(
+            tabManager: tm,
+            notificationStore: TerminalNotificationStore.shared
+        )
+        let hostingView = NSHostingView(rootView: contentView)
+        hostingView.frame = NSRect(origin: .zero, size: window.frame.size)
+        hostingView.autoresizingMask = [.width, .height]
+
+        window.initialFrame = window.frame
+        window.contentView = hostingView
+        window.initialFrame = nil
+
+        return window
+    }
+
+    private func focusTerminal(in window: NSWindow, retries: UInt8 = 10) {
+        guard visible, let tabManager else { return }
+
+        window.makeKeyAndOrderFront(nil)
+
+        // Focus the terminal surface in the selected workspace.
+        if let workspace = tabManager.selectedWorkspace,
+           let panelId = workspace.focusedPanelId,
+           let panel = workspace.panels[panelId] as? TerminalPanel {
+            window.makeFirstResponder(panel.surface.focusableView)
+            panel.focus()
+        }
+
+        // Retry if the window hasn't become key yet.
+        guard !window.isKeyWindow, retries > 0 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) { [weak self] in
+            self?.focusTerminal(in: window, retries: retries - 1)
+        }
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// Auto-hide the Quick Terminal when it loses key window status.
+    func windowDidResignKey(_ notification: Notification) {
+        guard visible else { return }
+        guard window?.attachedSheet == nil else { return }
+        if NSApp.isActive {
+            previousApp = nil
+        }
+        animateOut()
+    }
+}

--- a/Sources/QuickTerminal/QuickTerminalHotKey.swift
+++ b/Sources/QuickTerminal/QuickTerminalHotKey.swift
@@ -1,0 +1,184 @@
+import AppKit
+import Bonsplit
+import Carbon
+
+/// Registers a system-wide global hot key using the Carbon Event API.
+/// This allows the Quick Terminal to be toggled even when cmux is not the active application.
+@MainActor
+final class QuickTerminalHotKey {
+    /// Four-char signature identifying this app's hot keys ("CMUX").
+    private static let hotKeySignature = OSType(0x434D5558)
+    /// Unique ID for the Quick Terminal toggle hot key.
+    private static let hotKeyID: UInt32 = 1
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var handlerRef: EventHandlerRef?
+    private let action: @MainActor () -> Void
+
+    /// Create a hot key handler that invokes the given action when the shortcut is pressed.
+    init(action: @escaping @MainActor () -> Void) {
+        self.action = action
+    }
+
+    deinit {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        if let handlerRef {
+            RemoveEventHandler(handlerRef)
+        }
+    }
+
+    /// Register a system-wide hot key for the given shortcut. Returns `true` on success.
+    @discardableResult
+    func register(shortcut: StoredShortcut) -> Bool {
+        unregister()
+
+        guard let carbonKeyCode = carbonKeyCode(for: shortcut.key),
+              !shortcut.key.isEmpty else {
+#if DEBUG
+            dlog("quickTerminal.hotKey.register failed: unsupported key=\"\(shortcut.key)\"")
+#endif
+            return false
+        }
+
+        var modifiers: UInt32 = 0
+        if shortcut.command { modifiers |= UInt32(cmdKey) }
+        if shortcut.shift { modifiers |= UInt32(shiftKey) }
+        if shortcut.option { modifiers |= UInt32(optionKey) }
+        if shortcut.control { modifiers |= UInt32(controlKey) }
+
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature,
+                                     id: Self.hotKeyID)
+
+        // Store self pointer for the C callback.
+        let pointer = Unmanaged.passUnretained(self).toOpaque()
+
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                     eventKind: UInt32(kEventHotKeyPressed))
+
+        let handler: EventHandlerUPP = { _, event, userData -> OSStatus in
+            guard let userData, let event else { return OSStatus(eventNotHandledErr) }
+
+            var hotKeyID = EventHotKeyID()
+            let status = GetEventParameter(event,
+                                           EventParamName(kEventParamDirectObject),
+                                           EventParamType(typeEventHotKeyID),
+                                           nil,
+                                           MemoryLayout<EventHotKeyID>.size,
+                                           nil,
+                                           &hotKeyID)
+            guard status == noErr else { return status }
+
+            // Validate that the hot key event matches our registered signature and ID.
+            guard hotKeyID.signature == QuickTerminalHotKey.hotKeySignature,
+                  hotKeyID.id == QuickTerminalHotKey.hotKeyID else {
+                return OSStatus(eventNotHandledErr)
+            }
+
+            let this = Unmanaged<QuickTerminalHotKey>.fromOpaque(userData).takeUnretainedValue()
+            DispatchQueue.main.async { @MainActor in
+                this.action()
+            }
+            return noErr
+        }
+
+        var installedHandler: EventHandlerRef?
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(), handler, 1, &eventType, pointer, &installedHandler
+        )
+        guard handlerStatus == noErr, let installedHandler else {
+#if DEBUG
+            dlog("quickTerminal.hotKey.register failed: InstallEventHandler status=\(handlerStatus)")
+#endif
+            return false
+        }
+        handlerRef = installedHandler
+
+        var registeredKey: EventHotKeyRef?
+        let keyStatus = RegisterEventHotKey(
+            carbonKeyCode, modifiers, hotKeyID, GetApplicationEventTarget(), 0, &registeredKey
+        )
+        guard keyStatus == noErr, let registeredKey else {
+#if DEBUG
+            dlog("quickTerminal.hotKey.register failed: RegisterEventHotKey status=\(keyStatus)")
+#endif
+            RemoveEventHandler(installedHandler)
+            handlerRef = nil
+            return false
+        }
+        hotKeyRef = registeredKey
+        return true
+    }
+
+    /// Unregister the current global hot key and event handler, if any.
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+        if let handlerRef {
+            RemoveEventHandler(handlerRef)
+            self.handlerRef = nil
+        }
+    }
+
+    // MARK: - Key mapping
+
+    /// Map a shortcut key string to a Carbon virtual key code.
+    private func carbonKeyCode(for key: String) -> UInt32? {
+        switch key.lowercased() {
+        case "`": return UInt32(kVK_ANSI_Grave)
+        case "a": return UInt32(kVK_ANSI_A)
+        case "b": return UInt32(kVK_ANSI_B)
+        case "c": return UInt32(kVK_ANSI_C)
+        case "d": return UInt32(kVK_ANSI_D)
+        case "e": return UInt32(kVK_ANSI_E)
+        case "f": return UInt32(kVK_ANSI_F)
+        case "g": return UInt32(kVK_ANSI_G)
+        case "h": return UInt32(kVK_ANSI_H)
+        case "i": return UInt32(kVK_ANSI_I)
+        case "j": return UInt32(kVK_ANSI_J)
+        case "k": return UInt32(kVK_ANSI_K)
+        case "l": return UInt32(kVK_ANSI_L)
+        case "m": return UInt32(kVK_ANSI_M)
+        case "n": return UInt32(kVK_ANSI_N)
+        case "o": return UInt32(kVK_ANSI_O)
+        case "p": return UInt32(kVK_ANSI_P)
+        case "q": return UInt32(kVK_ANSI_Q)
+        case "r": return UInt32(kVK_ANSI_R)
+        case "s": return UInt32(kVK_ANSI_S)
+        case "t": return UInt32(kVK_ANSI_T)
+        case "u": return UInt32(kVK_ANSI_U)
+        case "v": return UInt32(kVK_ANSI_V)
+        case "w": return UInt32(kVK_ANSI_W)
+        case "x": return UInt32(kVK_ANSI_X)
+        case "y": return UInt32(kVK_ANSI_Y)
+        case "z": return UInt32(kVK_ANSI_Z)
+        case "0": return UInt32(kVK_ANSI_0)
+        case "1": return UInt32(kVK_ANSI_1)
+        case "2": return UInt32(kVK_ANSI_2)
+        case "3": return UInt32(kVK_ANSI_3)
+        case "4": return UInt32(kVK_ANSI_4)
+        case "5": return UInt32(kVK_ANSI_5)
+        case "6": return UInt32(kVK_ANSI_6)
+        case "7": return UInt32(kVK_ANSI_7)
+        case "8": return UInt32(kVK_ANSI_8)
+        case "9": return UInt32(kVK_ANSI_9)
+        case "=": return UInt32(kVK_ANSI_Equal)
+        case "-": return UInt32(kVK_ANSI_Minus)
+        case "[": return UInt32(kVK_ANSI_LeftBracket)
+        case "]": return UInt32(kVK_ANSI_RightBracket)
+        case "\\": return UInt32(kVK_ANSI_Backslash)
+        case ";": return UInt32(kVK_ANSI_Semicolon)
+        case "'": return UInt32(kVK_ANSI_Quote)
+        case ",": return UInt32(kVK_ANSI_Comma)
+        case ".": return UInt32(kVK_ANSI_Period)
+        case "/": return UInt32(kVK_ANSI_Slash)
+        case " ": return UInt32(kVK_Space)
+        case "\r": return UInt32(kVK_Return)
+        case "\t": return UInt32(kVK_Tab)
+        default: return nil
+        }
+    }
+}

--- a/Sources/QuickTerminal/QuickTerminalPosition.swift
+++ b/Sources/QuickTerminal/QuickTerminalPosition.swift
@@ -1,0 +1,118 @@
+import AppKit
+
+/// The screen edge from which the Quick Terminal slides in.
+enum QuickTerminalPosition: String {
+    /// Slide in from the top edge of the screen.
+    case top
+    /// Slide in from the bottom edge of the screen.
+    case bottom
+    /// Slide in from the left edge of the screen.
+    case left
+    /// Slide in from the right edge of the screen.
+    case right
+    /// Appear centered on the screen.
+    case center
+
+    // MARK: - Size
+
+    /// Default size as a fraction of the screen's visible area.
+    func defaultSize(on screen: NSScreen) -> NSSize {
+        let visible = screen.visibleFrame.size
+        switch self {
+        case .top, .bottom:
+            return NSSize(width: visible.width, height: round(visible.height * 0.4))
+        case .left, .right:
+            return NSSize(width: round(visible.width * 0.4), height: visible.height)
+        case .center:
+            return NSSize(width: round(visible.width * 0.6), height: round(visible.height * 0.6))
+        }
+    }
+
+    // MARK: - Origins
+
+    /// Origin that places the window off-screen (hidden).
+    func initialOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+        let visible = screen.visibleFrame
+        let size = window.frame.size
+        switch self {
+        case .top:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: visible.maxY
+            )
+        case .bottom:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: visible.minY - size.height
+            )
+        case .left:
+            return CGPoint(
+                x: visible.minX - size.width,
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        case .right:
+            return CGPoint(
+                x: visible.maxX,
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        case .center:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        }
+    }
+
+    /// Origin that places the window in its final visible position.
+    func finalOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+        let visible = screen.visibleFrame
+        let size = window.frame.size
+        switch self {
+        case .top:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: visible.maxY - size.height
+            )
+        case .bottom:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: visible.minY
+            )
+        case .left:
+            return CGPoint(
+                x: visible.minX,
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        case .right:
+            return CGPoint(
+                x: visible.maxX - size.width,
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        case .center:
+            return CGPoint(
+                x: round(visible.origin.x + (visible.width - size.width) / 2),
+                y: round(visible.origin.y + (visible.height - size.height) / 2)
+            )
+        }
+    }
+
+    // MARK: - Window manipulation
+
+    /// Move the window to its off-screen (hidden) position.
+    func setInitial(in window: NSWindow, on screen: NSScreen) {
+        window.alphaValue = 0
+        window.setFrame(
+            NSRect(origin: initialOrigin(for: window, on: screen), size: window.frame.size),
+            display: false
+        )
+    }
+
+    /// Move the window to its final on-screen position.
+    func setFinal(in window: NSWindow, on screen: NSScreen) {
+        window.alphaValue = 1
+        window.setFrame(
+            NSRect(origin: finalOrigin(for: window, on: screen), size: window.frame.size),
+            display: true
+        )
+    }
+}

--- a/Sources/QuickTerminal/QuickTerminalWindow.swift
+++ b/Sources/QuickTerminal/QuickTerminalWindow.swift
@@ -1,0 +1,36 @@
+import AppKit
+
+/// A borderless floating NSPanel for the Quick Terminal.
+final class QuickTerminalWindow: NSPanel {
+    /// Allow the panel to become the key window so it can receive keyboard input.
+    override var canBecomeKey: Bool { true }
+    /// Allow the panel to become the main window for menu validation.
+    override var canBecomeMain: Bool { true }
+
+    /// Used to prevent SwiftUI hiccups from resizing the window during setup.
+    var initialFrame: NSRect?
+
+    /// Create a new Quick Terminal panel with the given content rect.
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        identifier = .init(rawValue: "com.cmuxterm.quickTerminal")
+        setAccessibilitySubrole(.floatingWindow)
+
+        isMovableByWindowBackground = false
+        isReleasedWhenClosed = false
+        hidesOnDeactivate = false
+        hasShadow = true
+        animationBehavior = .none
+    }
+
+    /// Override to lock the frame during initial setup, preventing SwiftUI layout passes from resizing.
+    override func setFrame(_ frameRect: NSRect, display flag: Bool) {
+        super.setFrame(initialFrame ?? frameRect, display: flag)
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2778,6 +2778,7 @@ class TabManager: ObservableObject {
     }
 
     private func enqueuePanelTitleUpdate(tabId: UUID, panelId: UUID, title: String) {
+        guard tabs.contains(where: { $0.id == tabId }) else { return }
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)


### PR DESCRIPTION
## Summary

  - **What changed?**
    Added a Quake-style Quick Terminal feature, inspired by ghostty's implementation. A floating terminal
   panel slides in from the top of the screen via the global hotkey `Cmd+``. The Quick Terminal has its
  own TabManager, supporting full split/pane operations independently from the main window.

  - **Why?**
    ghostty natively supports Quick Terminal, but cmux lacked this capability. Quick Terminal is a
  high-frequency workflow feature that allows running commands without leaving the current application
  context.

  ### New Features
  - Global hotkey `Cmd+`` to toggle from any application
  - Independent TabManager with split support (`Cmd+D` / `Cmd+Shift+D`)
  - Pane focus navigation (`Alt+Cmd+←→↑↓`)
  - `Cmd+W` to close focused pane, `Cmd+T` for new surface
  - Auto-hide on focus loss, restores previously active application on dismiss
  - Slide-in/out animation with equal horizontal padding
  - Borderless NSPanel-based floating window

  ### New Files
  - `Sources/QuickTerminal/QuickTerminalWindow.swift` — Borderless floating NSPanel
  - `Sources/QuickTerminal/QuickTerminalPosition.swift` — Position calculation (supports
  top/bottom/left/right/center)
  - `Sources/QuickTerminal/QuickTerminalController.swift` — Core controller (animation, TabManager, focus
   management)
  - `Sources/QuickTerminal/QuickTerminalHotKey.swift` — Global hotkey registration via Carbon API
  - `Sources/QuickTerminal/QuickTerminalContentView.swift` — SwiftUI rendering layer
  (WorkspaceContentView wrapper)

  ### Modified Files
  - `KeyboardShortcutSettings.swift` — Added `toggleQuickTerminal` action
  - `AppDelegate.swift` — Initialize controller + Quick Terminal shortcut routing
  - `GhosttyTerminalView.swift` — Exposed `focusableView` for focus management
  - `Localizable.xcstrings` — Localized strings (en/ja/zh-Hans/zh-Hant/ko)

  ## Testing

  - Built and tested locally via `./scripts/reload.sh --tag quick-terminal`
  - Manual verification:
    - `Cmd+`` toggles Quick Terminal both within cmux and from other applications
    - `Cmd+D` / `Cmd+Shift+D` creates horizontal/vertical splits inside Quick Terminal
    - `Alt+Cmd+arrow keys` navigates focus between panes
    - `Cmd+W` closes the focused pane
    - `Cmd+T` creates a new surface
    - Clicking outside Quick Terminal auto-hides it
    - Dismissing from another app restores the previously active application
    - Shortcuts in Quick Terminal do not leak to the main window

  ## Demo Video

  - Video URL or attachment:

  ## Checklist

  - [x] I tested the change locally
  - [ ] I added or updated tests for behavior changes
  - [ ] I updated docs/changelog if needed
  - [ ] I requested bot reviews after my latest commit
  - [ ] All code review bot comments are resolved
  - [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Quake-style Quick Terminal you can summon from any app with Cmd+`. It runs its own TabManager in a borderless floating panel with smooth slide animation and adds docstrings to improve code coverage.

- **New Features**
  - Configurable global hotkey (default Cmd+`) via `Carbon` to toggle Quick Terminal from any app.
  - Independent TabManager: split right/down, focus with Alt+Cmd+arrows, new surface (Cmd+T), close pane (Cmd+W), toggle split zoom (Cmd+Shift+Enter).
  - Borderless floating `NSPanel` with slide-in/out animation and equal horizontal padding; supports top/bottom/left/right/center positions.
  - Auto-hide on focus loss and restores the previously active app on dismiss.
  - Localized “Toggle Quick Terminal” label in 18 languages.

- **Bug Fixes**
  - Only cmux-specific shortcuts are handled while Quick Terminal is active; system commands (Cmd+Q/H/M) pass through.
  - Shortcut routing is gated by visible state and window checks to avoid transient captures during animation; routes Equalize Splits to the owning TabManager.
  - Set workspace portal priority to 2; update visible flag after screen validation for stable focus/rendering and focus.
  - QuickTerminalHotKey: validate `EventHotKeyID`, clean up `Carbon` handlers on deinit, check API return values; `register()` returns Bool and logs OSStatus codes.
  - Validate tabId ownership in `TabManager.enqueuePanelTitleUpdate` to prevent cross-window title updates.
  - Expose a focusable view for terminal surfaces to ensure reliable keyboard input.
  - Docs: add docstrings across Quick Terminal and shortcut code to improve coverage.

<sup>Written for commit 50ab7c0f93455dd62c4a450d37a55de11608de07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Terminal: Quake-style drop-down terminal with smooth show/hide animations and a minimal workspace view.
  * Global, customizable "Toggle Quick Terminal" shortcut (localized label added) and a new "Equalize Splits" shortcut.
  * Preserves/restores focus and routes terminal-specific shortcuts (pane navigation, splits, Cmd+W) while the Quick Terminal is active.
  * Terminal surface now exposes a focusable view for reliable keyboard input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->