### PR TITLE
fix(ssh): normalize remote backspace erase setting

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3920,6 +3920,9 @@ struct CMUXCLI {
             "  cmux_term='xterm-ghostty'",
             "fi",
             "export TERM=\"$cmux_term\"",
+            "if command -v stty >/dev/null 2>&1; then",
+            "  stty erase '^?' >/dev/null 2>&1 || true",
+            "fi",
         ]
         guard let terminfoSource else { return lines }
         let trimmedTerminfoSource = terminfoSource.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/tests/fixtures/ssh-remote/Dockerfile
+++ b/tests/fixtures/ssh-remote/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:3.20
 
-RUN apk add --no-cache openssh python3 iproute2 net-tools ncurses
+RUN apk add --no-cache openssh python3 iproute2 net-tools ncurses bash
 
-RUN adduser -D -s /bin/sh dev \
+RUN adduser -D -s /bin/bash dev \
+    && awk -F: 'BEGIN { OFS=":" } $1 == "root" { $7 = "/bin/bash" } { print }' /etc/passwd > /etc/passwd.tmp \
+    && mv /etc/passwd.tmp /etc/passwd \
     && mkdir -p /home/dev/.ssh /run/sshd /srv/www \
     && chown -R dev:dev /home/dev/.ssh \
     && chmod 700 /home/dev/.ssh \

--- a/tests/fixtures/ssh-remote/run.sh
+++ b/tests/fixtures/ssh-remote/run.sh
@@ -12,11 +12,16 @@ REMOTE_WS_PORT="${REMOTE_WS_PORT:-43174}"
 mkdir -p /home/dev/.ssh /root/.ssh /run/sshd
 printf '%s\n' "$AUTHORIZED_KEY" > /home/dev/.ssh/authorized_keys
 printf '%s\n' "$AUTHORIZED_KEY" > /root/.ssh/authorized_keys
+printf "stty erase '^H' >/dev/null 2>&1 || true\n" > /home/dev/.bashrc
+printf "stty erase '^H' >/dev/null 2>&1 || true\n" > /root/.bashrc
 chown -R dev:dev /home/dev/.ssh
+chown dev:dev /home/dev/.bashrc
 chmod 700 /home/dev/.ssh
 chmod 600 /home/dev/.ssh/authorized_keys
+chmod 644 /home/dev/.bashrc
 chmod 700 /root/.ssh
 chmod 600 /root/.ssh/authorized_keys
+chmod 644 /root/.bashrc
 
 python3 -m http.server "$REMOTE_HTTP_PORT" --bind 127.0.0.1 --directory /srv/www >/tmp/http.log 2>&1 &
 HTTP_PID=$!

--- a/tests_v2/test_ssh_remote_shell_integration.py
+++ b/tests_v2/test_ssh_remote_shell_integration.py
@@ -27,11 +27,13 @@ OSC_ESCAPE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 
 
 def _must(cond: bool, msg: str) -> None:
+    """Raise a test failure with ``msg`` when ``cond`` is false."""
     if not cond:
         raise cmuxError(msg)
 
 
 def _find_cli_binary() -> str:
+    """Locate the most recent debug cmux CLI binary for integration tests."""
     env_cli = os.environ.get("CMUXTERM_CLI")
     if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
         return env_cli
@@ -50,6 +52,7 @@ def _find_cli_binary() -> str:
 
 
 def _run(cmd: list[str], *, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and raise ``cmuxError`` when ``check`` is enabled and it fails."""
     proc = subprocess.run(cmd, capture_output=True, text=True, env=env, check=False)
     if check and proc.returncode != 0:
         merged = f"{proc.stdout}\n{proc.stderr}".strip()
@@ -58,6 +61,7 @@ def _run(cmd: list[str], *, env: dict[str, str] | None = None, check: bool = Tru
 
 
 def _run_cli_json(cli: str, args: list[str]) -> dict:
+    """Run the cmux CLI with JSON output and decode the returned payload."""
     env = dict(os.environ)
     env.pop("CMUX_WORKSPACE_ID", None)
     env.pop("CMUX_SURFACE_ID", None)
@@ -71,6 +75,7 @@ def _run_cli_json(cli: str, args: list[str]) -> dict:
 
 
 def _docker_available() -> bool:
+    """Return whether Docker is installed and the daemon is reachable."""
     if shutil.which("docker") is None:
         return False
     probe = _run(["docker", "info"], check=False)
@@ -78,6 +83,7 @@ def _docker_available() -> bool:
 
 
 def _parse_host_port(docker_port_output: str) -> int:
+    """Extract the published host port from ``docker port`` output."""
     text = docker_port_output.strip()
     if not text:
         raise cmuxError("docker port output was empty")
@@ -85,10 +91,12 @@ def _parse_host_port(docker_port_output: str) -> int:
 
 
 def _shell_single_quote(value: str) -> str:
+    """Shell-quote a string for use inside a single-quoted POSIX literal."""
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
 def _ssh_run(host: str, host_port: int, key_path: Path, script: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a remote shell script over SSH against the Docker fixture host."""
     return _run(
         [
             "ssh",
@@ -110,6 +118,7 @@ def _ssh_run(host: str, host_port: int, key_path: Path, script: str, *, check: b
 
 
 def _wait_for_ssh(host: str, host_port: int, key_path: Path, timeout: float = 20.0) -> None:
+    """Poll the fixture SSH server until it accepts commands or times out."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         probe = _ssh_run(host, host_port, key_path, "echo ready", check=False)
@@ -120,6 +129,7 @@ def _wait_for_ssh(host: str, host_port: int, key_path: Path, timeout: float = 20
 
 
 def _wait_remote_connected(client: cmux, workspace_id: str, timeout: float) -> dict:
+    """Wait until the remote workspace and daemon both report a ready state."""
     deadline = time.time() + timeout
     last_status = {}
     while time.time() < deadline:
@@ -133,10 +143,12 @@ def _wait_remote_connected(client: cmux, workspace_id: str, timeout: float) -> d
 
 
 def _is_terminal_surface_not_found(exc: Exception) -> bool:
+    """Return whether an exception indicates a transient missing terminal surface."""
     return "terminal surface not found" in str(exc).lower()
 
 
 def _read_probe_value(client: cmux, surface_id: str, command: str, timeout: float = 20.0) -> str:
+    """Run a shell command in the surface and read back its numeric exit marker."""
     token = f"__CMUX_PROBE_{secrets.token_hex(6)}__"
     client.send_surface(surface_id, f"{command}; printf '{token}%s\\n' $?\\n")
 
@@ -165,6 +177,7 @@ def _read_probe_value(client: cmux, surface_id: str, command: str, timeout: floa
 
 
 def _read_probe_payload(client: cmux, surface_id: str, payload_command: str, timeout: float = 20.0) -> str:
+    """Run a shell payload command in the surface and read back its string output."""
     token = f"__CMUX_PAYLOAD_{secrets.token_hex(6)}__"
     client.send_surface(surface_id, f"printf '{token}%s\\n' \"$({payload_command})\"\\n")
 
@@ -193,6 +206,7 @@ def _read_probe_payload(client: cmux, surface_id: str, payload_command: str, tim
 
 
 def _wait_for(pred, timeout_s: float = 5.0, step_s: float = 0.05) -> None:
+    """Poll ``pred`` until it returns truthy or the timeout elapses."""
     deadline = time.time() + timeout_s
     while time.time() < deadline:
         if pred():
@@ -202,6 +216,7 @@ def _wait_for(pred, timeout_s: float = 5.0, step_s: float = 0.05) -> None:
 
 
 def _wait_for_pane_count(client: cmux, minimum_count: int, timeout: float = 8.0) -> list[str]:
+    """Wait until at least ``minimum_count`` panes are visible in the workspace."""
     deadline = time.time() + timeout
     last: list[str] = []
     while time.time() < deadline:
@@ -213,6 +228,7 @@ def _wait_for_pane_count(client: cmux, minimum_count: int, timeout: float = 8.0)
 
 
 def _surface_text_scrollback(client: cmux, workspace_id: str, surface_id: str) -> str:
+    """Read full scrollback text for a specific workspace surface."""
     payload = client._call(
         "surface.read_text",
         {"workspace_id": workspace_id, "surface_id": surface_id, "scrollback": True},
@@ -221,6 +237,7 @@ def _surface_text_scrollback(client: cmux, workspace_id: str, surface_id: str) -
 
 
 def _clean_line(raw: str) -> str:
+    """Strip OSC/ANSI escapes and carriage returns from captured terminal text."""
     line = OSC_ESCAPE_RE.sub("", raw)
     line = ANSI_ESCAPE_RE.sub("", line)
     line = line.replace("\r", "")
@@ -228,6 +245,7 @@ def _clean_line(raw: str) -> str:
 
 
 def _surface_text_scrollback_lines(client: cmux, workspace_id: str, surface_id: str) -> list[str]:
+    """Return cleaned scrollback lines for the target surface."""
     return [_clean_line(raw) for raw in _surface_text_scrollback(client, workspace_id, surface_id).splitlines()]
 
 
@@ -237,6 +255,7 @@ def _scrollback_has_all_lines(
     surface_id: str,
     lines: list[str],
 ) -> bool:
+    """Return whether all expected lines are present in the surface scrollback."""
     available = set(_surface_text_scrollback_lines(client, workspace_id, surface_id))
     return all(line in available for line in lines)
 
@@ -249,6 +268,7 @@ def _wait_surface_contains(
     *,
     timeout: float = 20.0,
 ) -> None:
+    """Wait until the target token appears in the surface scrollback."""
     deadline = time.time() + timeout
     saw_missing_surface = False
     while time.time() < deadline:
@@ -269,6 +289,7 @@ def _wait_surface_contains(
 
 
 def _probe_backspace_round_trip(client: cmux, workspace_id: str, surface_id: str, timeout: float = 20.0) -> str:
+    """Verify that sending Backspace deletes one character in the remote shell."""
     token = f"__CMUX_BACKSPACE_{secrets.token_hex(6)}__"
     expected = f"{token}abZ"
     client.send_surface(surface_id, f"printf '{token}'")
@@ -297,12 +318,14 @@ def _probe_backspace_round_trip(client: cmux, workspace_id: str, surface_id: str
 
 
 def _layout_panes(client: cmux) -> list[dict]:
+    """Fetch the current layout debug pane payload."""
     layout_payload = client.layout_debug() or {}
     layout = layout_payload.get("layout") or {}
     return list(layout.get("panes") or [])
 
 
 def _pane_extent(client: cmux, pane_id: str, axis: str) -> float:
+    """Return the width or height extent for a pane from layout debug data."""
     panes = _layout_panes(client)
     for pane in panes:
         pid = str(pane.get("paneId") or pane.get("pane_id") or "")
@@ -314,6 +337,7 @@ def _pane_extent(client: cmux, pane_id: str, axis: str) -> float:
 
 
 def _pane_for_surface(client: cmux, surface_id: str) -> str:
+    """Resolve the pane that currently hosts the given surface."""
     target_id = str(client._resolve_surface_id(surface_id))
     for _idx, pane_id, _count, _focused in client.list_panes():
         rows = client.list_pane_surfaces(pane_id)
@@ -328,6 +352,7 @@ def _pane_for_surface(client: cmux, surface_id: str) -> str:
 
 
 def _pick_resize_direction_for_pane(client: cmux, pane_ids: list[str], target_pane: str) -> tuple[str, str]:
+    """Choose a resize direction and axis that should grow the target pane."""
     panes = [p for p in _layout_panes(client) if str(p.get("paneId") or p.get("pane_id") or "") in pane_ids]
     if len(panes) < 2:
         raise cmuxError(f"Need >=2 panes for resize test, got {panes}")
@@ -352,6 +377,7 @@ def _pick_resize_direction_for_pane(client: cmux, pane_ids: list[str], target_pa
 
 
 def main() -> int:
+    """Run the Docker-backed SSH shell integration regression suite."""
     if not _docker_available():
         print("SKIP: docker is not available")
         return 0

--- a/tests_v2/test_ssh_remote_shell_integration.py
+++ b/tests_v2/test_ssh_remote_shell_integration.py
@@ -423,6 +423,17 @@ def main() -> int:
             _run(["ghostty", "+ssh-cache", f"--remove={host}"], check=False)
         _wait_for_ssh(host, host_ssh_port, key_path)
 
+        pre_bootstrap_erase = _ssh_run(
+            host,
+            host_ssh_port,
+            key_path,
+            "bash -ic " + _shell_single_quote("stty -a 2>/dev/null | sed -n 's/.*erase = \\([^;]*\\);.*/\\1/p' | head -n1"),
+        )
+        _must(
+            pre_bootstrap_erase.returncode == 0 and pre_bootstrap_erase.stdout.strip() == "^H",
+            f"fixture should start with erase=^H before cmux bootstrap runs: {pre_bootstrap_erase.stdout!r} {pre_bootstrap_erase.stderr!r}",
+        )
+
         pre = _ssh_run(host, host_ssh_port, key_path, "if infocmp xterm-ghostty >/dev/null 2>&1; then echo present; else echo missing; fi")
         _must("missing" in pre.stdout, f"Fresh container should not have xterm-ghostty terminfo preinstalled: {pre.stdout!r}")
 

--- a/tests_v2/test_ssh_remote_shell_integration.py
+++ b/tests_v2/test_ssh_remote_shell_integration.py
@@ -268,6 +268,34 @@ def _wait_surface_contains(
     raise cmuxError(f"Timed out waiting for terminal token: {token}")
 
 
+def _probe_backspace_round_trip(client: cmux, workspace_id: str, surface_id: str, timeout: float = 20.0) -> str:
+    token = f"__CMUX_BACKSPACE_{secrets.token_hex(6)}__"
+    expected = f"{token}abZ"
+    client.send_surface(surface_id, f"printf '{token}'")
+    client.send_surface(surface_id, "abc")
+    client.send_key_surface(surface_id, "backspace")
+    client.send_surface(surface_id, "Z\n")
+
+    deadline = time.time() + timeout
+    saw_missing_surface = False
+    while time.time() < deadline:
+        try:
+            text = _surface_text_scrollback(client, workspace_id, surface_id)
+        except cmuxError as exc:
+            if _is_terminal_surface_not_found(exc):
+                saw_missing_surface = True
+                time.sleep(0.2)
+                continue
+            raise
+        if expected in text:
+            return expected
+        time.sleep(0.2)
+
+    if saw_missing_surface:
+        raise cmuxError("terminal surface not found")
+    raise cmuxError("Timed out waiting for backspace probe output")
+
+
 def _layout_panes(client: cmux) -> list[dict]:
     layout_payload = client.layout_debug() or {}
     layout = layout_payload.get("layout") or {}
@@ -449,6 +477,22 @@ def main() -> int:
 
             term_program_version = _read_probe_payload(client, surface_id, "printf '%s' \"${TERM_PROGRAM_VERSION:-}\"")
             _must(bool(term_program_version), "ssh-env should propagate non-empty TERM_PROGRAM_VERSION")
+
+            stty_erase = _read_probe_payload(
+                client,
+                surface_id,
+                "stty -a 2>/dev/null | sed -n 's/.*erase = \\([^;]*\\);.*/\\1/p' | head -n1",
+            )
+            _must(
+                stty_erase == "^?",
+                f"ssh shell should normalize erase to ^? for Backspace, got: {stty_erase!r}",
+            )
+
+            backspace_probe = _probe_backspace_round_trip(client, workspace_id, surface_id)
+            _must(
+                backspace_probe.endswith("abZ"),
+                f"ssh Backspace round-trip regressed: {backspace_probe!r}",
+            )
 
             ls_stamp = secrets.token_hex(4)
             ls_entries = [f"CMUX_RESIZE_LS_{ls_stamp}_{index:02d}" for index in range(1, 17)]


### PR DESCRIPTION
## Summary
- normalize the remote tty erase character to `^?` during `cmux ssh` interactive shell bootstrap
- add an SSH shell integration regression that verifies both `stty erase` and an actual Backspace round-trip

## Problem
Some remote hosts still default to `stty erase ^H`. In `cmux ssh` sessions, Ghostty/cmux sends DEL (`^?`) for plain Backspace, so those hosts can ignore the key even though local terminal input works.

## Testing
- `python3 -m py_compile tests_v2/test_ssh_remote_shell_integration.py`
- full Docker SSH integration test not run locally because this environment does not have a built cmux app/Xcode available

Closes #1719

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize remote TTY erase to '^?' during interactive `cmux ssh` bootstrap so Backspace works on hosts that default to '^H'. Strengthens the SSH integration test by forcing the fixture to start with '^H', verifying normalization and a Backspace round-trip; adds SSH helper docstrings (addresses #1719).

- **Bug Fixes**
  - Run `stty erase '^?'` on SSH shell startup when `stty` is available; ignore failures.
  - Update Docker SSH fixture to use Bash and start with `erase='^H'`; test asserts pre-bootstrap '^H', normalized '^?' post-bootstrap, and that Backspace deletes one character.

<sup>Written for commit 91efb8e009001df5a7d61379a0f7fa675f56bf56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved backspace key behavior in SSH remote shell sessions by enhancing terminal initialization configuration.
  * Better shell environment setup for improved compatibility with interactive terminal sessions in remote connections.

* **Tests**
  * Expanded test coverage for SSH remote shell integration, including backspace functionality and terminal behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->