### PR TITLE
fix: remove restricted web-browser entitlement

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,7 +14,5 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
-	<key>com.apple.developer.web-browser</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- remove `com.apple.developer.web-browser` from `cmux.entitlements`
- stop applying a restricted entitlement to nightly/release signing without a matching provisioning profile
- keep the change narrow to the shared signing entitlement only

## Why
On the local installed NIGHTLY app, the failure is not quarantine or notarization:
- `spctl -a -vv /Applications/cmux NIGHTLY.app` accepts the app
- `codesign --verify --deep --strict` passes
- `xcrun stapler validate` passes
- `open -na /Applications/cmux NIGHTLY.app` fails with `NSPOSIXErrorDomain Code=163`
- direct exec exits `137`
- live `amfid` log reports `No matching profile found`

The installed NIGHTLY app is signed with `com.apple.developer.web-browser`, but there is no embedded provisioning profile. Stable `cmux.app` launches and does not have that entitlement.

## Verification
- `./scripts/reload.sh --tag remove-web-browser-entitlement`

## Notes
I did not add a source-text regression test here. The failure is artifact/runtime behavior in a signed app, and a fake test against checked-in entitlements would violate the repo test policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `com.apple.developer.web-browser` from `cmux.entitlements` to avoid applying a restricted entitlement without a matching provisioning profile. This fixes launch failures for locally installed Nightly builds and aligns Nightly/Release signing with Stable.

<sup>Written for commit f794a5357dc9d16285f6de9db59dc15804f58695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a web browser entitlement from the app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->