### PR TITLE
fix(input): don't swallow unbound Cmd+Shift combinations

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4886,8 +4886,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 }
             }
 
+            // First pass: instead of returning false and hoping for a redispatch
+            // (which AppKit may not do if no menu item matches), directly send
+            // unbound Cmd+Shift combinations through to keyDown so they reach the
+            // terminal application via the kitty keyboard protocol.
+            // This fixes issue #1718 where unbound Cmd+Shift+<key> was silently swallowed.
             lastPerformKeyEvent = event.timestamp
-            return false
+            keyDown(with: event)
+            return true
         }
 
         let finalEvent = NSEvent.keyEvent(


### PR DESCRIPTION
Fixes #1718

Unbound Cmd+Shift+<key> combinations were being silently swallowed.
Now properly passed through to terminal applications via the kitty keyboard protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed unbound Cmd+Shift keyboard shortcuts being silently ignored in the terminal. These key combinations are now properly dispatched and will work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure unbound Cmd+Shift+<key> shortcuts pass through to terminal apps instead of being swallowed by AppKit. We now route them directly to keyDown in performKeyEquivalent so they are sent via the kitty keyboard protocol (fixes #1718).

<sup>Written for commit 65f4c8653bcdb91dd001b0ed3bda1a2b163c3913. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

