### PR TITLE
Make founders email selectable in feedback success view

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9342,6 +9342,7 @@ private struct SidebarFeedbackComposerSheet: View {
             )
             .font(.system(size: 12))
             .foregroundStyle(.secondary)
+            .textSelection(.enabled)
 
             HStack {
                 Spacer()


### PR DESCRIPTION
## Summary
- Add `.textSelection(.enabled)` to the feedback success body text so users can select and copy `founders@manaflow.com`

## Testing
- Open feedback dialog, submit feedback, verify the email in the success view is selectable/copyable

## Related
- Task: Make founders@manaflow.com selectable in Send Feedback success screen

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the founders email selectable in the Send Feedback success view so users can copy it easily. Adds `.textSelection(.enabled)` to the success message body to meet the task requirement.

<sup>Written for commit dfbfcade7b745b6eed313e90e067f21739f2edc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select and copy text from feedback confirmation messages, including both the header and message body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->