### PR TITLE
fix(keybinding): allow remapping Cmd+R captured by View menu

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -60490,6 +60490,119 @@
         }
       }
     },
+    "shortcut.reloadPage.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload Page"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページを再読み込み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新加载页面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新載入頁面"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "페이지 새로고침"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seite neu laden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recargar página"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recharger la page"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricarica pagina"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genindlæs side"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odśwież stronę"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить страницу"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponovo učitaj stranicu"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تحميل الصفحة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last inn side på nytt"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recarregar Página"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหลดหน้าใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sayfayı Yenile"
+          }
+        }
+      }
+    },
     "shortcut.openFolder.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9266,6 +9266,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Handle reload page shortcut - only reload when browser is focused, otherwise pass through to terminal
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .reloadPage)) {
+            if let browserPanel = tabManager?.focusedBrowserPanel {
+                browserPanel.reload()
+                return true
+            }
+            // Pass through to terminal apps when not in browser
+            return false
+        }
+
         // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
         if flags == [.command],
            let manager = tabManager,

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -39,6 +39,7 @@ enum KeyboardShortcutSettings {
 
         // Panels
         case openBrowser
+        case reloadPage
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
@@ -74,6 +75,7 @@ enum KeyboardShortcutSettings {
             case .splitBrowserRight: return String(localized: "shortcut.splitBrowserRight.label", defaultValue: "Split Browser Right")
             case .splitBrowserDown: return String(localized: "shortcut.splitBrowserDown.label", defaultValue: "Split Browser Down")
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
+            case .reloadPage: return String(localized: "shortcut.reloadPage.label", defaultValue: "Reload Page")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             }
@@ -109,6 +111,7 @@ enum KeyboardShortcutSettings {
             case .newSurface: return "shortcut.newSurface"
             case .toggleTerminalCopyMode: return "shortcut.toggleTerminalCopyMode"
             case .openBrowser: return "shortcut.openBrowser"
+            case .reloadPage: return "shortcut.reloadPage"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
             }
@@ -172,6 +175,9 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
             case .openBrowser:
                 return StoredShortcut(key: "l", command: true, shift: true, option: false, control: false)
+            case .reloadPage:
+                // Default to Cmd+R for reload page, but can be remapped or cleared by user
+                return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
             case .toggleBrowserDeveloperTools:
                 // Safari default: Show Web Inspector.
                 return StoredShortcut(key: "i", command: true, shift: false, option: true, control: false)
@@ -249,6 +255,7 @@ enum KeyboardShortcutSettings {
     static func newSurfaceShortcut() -> StoredShortcut { shortcut(for: .newSurface) }
 
     static func openBrowserShortcut() -> StoredShortcut { shortcut(for: .openBrowser) }
+    static func reloadPageShortcut() -> StoredShortcut { shortcut(for: .reloadPage) }
     static func toggleBrowserDeveloperToolsShortcut() -> StoredShortcut { shortcut(for: .toggleBrowserDeveloperTools) }
     static func showBrowserJavaScriptConsoleShortcut() -> StoredShortcut { shortcut(for: .showBrowserJavaScriptConsole) }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -70,6 +70,8 @@ struct cmuxApp: App {
     private var toggleBrowserDeveloperToolsShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.showBrowserJavaScriptConsole.defaultsKey)
     private var showBrowserJavaScriptConsoleShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.reloadPage.defaultsKey)
+    private var reloadPageShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.splitBrowserRight.defaultsKey) private var splitBrowserRightShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.splitBrowserDown.defaultsKey) private var splitBrowserDownShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
@@ -630,10 +632,9 @@ struct cmuxApp: App {
                 }
                 .keyboardShortcut("]", modifiers: .command)
 
-                Button(String(localized: "menu.view.reloadPage", defaultValue: "Reload Page")) {
+                splitCommandButton(title: String(localized: "menu.view.reloadPage", defaultValue: "Reload Page"), shortcut: reloadPageMenuShortcut) {
                     activeTabManager.focusedBrowserPanel?.reload()
                 }
-                .keyboardShortcut("r", modifiers: .command)
 
                 splitCommandButton(title: String(localized: "menu.view.toggleDevTools", defaultValue: "Toggle Developer Tools"), shortcut: toggleBrowserDeveloperToolsMenuShortcut) {
                     let manager = activeTabManager
@@ -872,6 +873,13 @@ struct cmuxApp: App {
         decodeShortcut(
             from: closeWorkspaceShortcutData,
             fallback: KeyboardShortcutSettings.Action.closeWorkspace.defaultShortcut
+        )
+    }
+
+    private var reloadPageMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: reloadPageShortcutData,
+            fallback: KeyboardShortcutSettings.Action.reloadPage.defaultShortcut
         )
     }
 


### PR DESCRIPTION
Fixes #1708

Cmd+R was captured by the View menu's 'Reload Page' action and could not be remapped or passed to terminal applications like Neovim.

This change makes the 'Reload Page' shortcut configurable via KeyboardShortcutSettings:
- Users can now remap the shortcut to a different key combination
- Users can clear the shortcut entirely to pass Cmd+R to terminal apps
- The default behavior (Cmd+R reloads browser when focused) is preserved

Changes:
- Added reloadPage action to KeyboardShortcutSettings with default Cmd+R
- Changed menu item from hardcoded shortcut to configurable one  
- Added handleCustomShortcut handling that only reloads when browser is focused, passing through to terminal apps otherwise

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the “Reload Page” shortcut configurable and only trigger it when the in-app browser is focused. Users can remap or clear Cmd+R so terminal apps (e.g., Neovim) can receive it.

- **New Features**
  - Added `reloadPage` to `KeyboardShortcutSettings` (default Cmd+R); users can remap or clear it.
  - View menu now uses the configurable shortcut instead of a hardcoded one.
  - Shortcut only reloads when the browser is focused; otherwise it passes through to terminal apps.

- **Bug Fixes**
  - Added missing localizations for the “Reload Page” shortcut label.

<sup>Written for commit 61844653aa0aab2c40cfd952920f95ceccc0ee6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable "Reload Page" keyboard shortcut for the browser panel (default: Cmd+R). Shortcut can be remapped or cleared in settings and is respected when the browser panel is focused.
* **UI / Menu**
  * "Reload Page" is exposed in the main menu with its configured shortcut.
* **Localization**
  * Added localized label for the "Reload Page" shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->