### PR TITLE
fix(hooks): handle TabManager unavailable in SessionEnd/Start hooks

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13960,10 +13960,11 @@ class TerminalController {
     }
 
     private func resolveTabForReport(_ args: String) -> Tab? {
-        guard let tabManager else { return nil }
         let parsed = parseOptions(args)
         if let tabArg = parsed.options["tab"], !tabArg.isEmpty {
-            if let tab = resolveTab(from: tabArg, tabManager: tabManager) {
+            // First try the local tabManager if available
+            if let tabManager = self.tabManager,
+               let tab = resolveTab(from: tabArg, tabManager: tabManager) {
                 return tab
             }
             // The tab may belong to a different window — search all contexts.
@@ -13973,6 +13974,8 @@ class TerminalController {
             }
             return nil
         }
+        // Only require self.tabManager when using the selected tab (no --tab arg)
+        guard let tabManager = self.tabManager else { return nil }
         guard let selectedId = tabManager.selectedTabId else { return nil }
         return tabManager.tabs.first(where: { $0.id == selectedId })
     }
@@ -14077,7 +14080,6 @@ class TerminalController {
     }
 
     private func upsertSidebarMetadata(_ args: String, missingError: String) -> String {
-        guard tabManager != nil else { return "ERROR: TabManager not available" }
         let parsed = parseOptionsNoStop(args)
         guard parsed.positional.count >= 2 else { return missingError }
 


### PR DESCRIPTION
Fixes #1715

## Problem
SessionEnd/SessionStart hooks were failing with 'TabManager not available' error when Claude Code was launched via cmux tab.

## Root Cause
The `resolveTabForReport()` function had an early guard that returned `nil` when `self.tabManager` was nil, even when a valid `--tab` argument was provided via the CLI. This prevented the function from falling back to `AppDelegate.shared` to resolve tabs in other windows.

## Changes
- Modified `resolveTabForReport()` to allow tab resolution via `--tab` parameter even when `self.tabManager` is nil
- Removed early guard in `upsertSidebarMetadata()` that blocked resolution

## Verification
- `swift build` completed successfully
- The fix allows TabManager resolution through `AppDelegate.shared.tabManagerFor(tabId:)` when `self.tabManager` is nil but `--tab` is provided

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SessionEnd/SessionStart hooks failing with "TabManager not available" when launched via a cmux tab by resolving `--tab` via `AppDelegate.shared` if the local `tabManager` is missing. This allows hooks to find the correct tab across windows. Fixes #1715.

- **Bug Fixes**
  - Updated `resolveTabForReport()` to try the local `tabManager` first and fall back to `AppDelegate.shared.tabManagerFor(tabId:)` when `--tab` is provided.
  - Removed the early guard in `upsertSidebarMetadata()` that returned an error when `tabManager` was nil.

<sup>Written for commit d707a8d0201786d9f572c805474364a25f8b74c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tab resolution now supports cross-window lookup when using the --tab argument, allowing references to tabs across different windows.
  * Enhanced fallback logic for tab discovery across different application contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->