### PR TITLE
fix(keybinding): respect remapped Cmd+W for Close Tab

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -9,6 +9,7 @@ enum KeyboardShortcutSettings {
         case newTab
         case newWindow
         case closeWindow
+        case closeTab
         case openFolder
         case sendFeedback
         case showNotifications
@@ -50,6 +51,7 @@ enum KeyboardShortcutSettings {
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
             case .newWindow: return String(localized: "shortcut.newWindow.label", defaultValue: "New Window")
             case .closeWindow: return String(localized: "shortcut.closeWindow.label", defaultValue: "Close Window")
+            case .closeTab: return String(localized: "shortcut.closeTab.label", defaultValue: "Close Tab")
             case .openFolder: return String(localized: "shortcut.openFolder.label", defaultValue: "Open Folder")
             case .sendFeedback: return String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback")
             case .showNotifications: return String(localized: "shortcut.showNotifications.label", defaultValue: "Show Notifications")
@@ -85,6 +87,7 @@ enum KeyboardShortcutSettings {
             case .newTab: return "shortcut.newTab"
             case .newWindow: return "shortcut.newWindow"
             case .closeWindow: return "shortcut.closeWindow"
+            case .closeTab: return "shortcut.closeTab"
             case .openFolder: return "shortcut.openFolder"
             case .sendFeedback: return "shortcut.sendFeedback"
             case .showNotifications: return "shortcut.showNotifications"
@@ -124,6 +127,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "n", command: true, shift: true, option: false, control: false)
             case .closeWindow:
                 return StoredShortcut(key: "w", command: true, shift: false, option: false, control: true)
+            case .closeTab:
+                return StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
             case .openFolder:
                 return StoredShortcut(key: "o", command: true, shift: false, option: false, control: false)
             case .sendFeedback:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -75,6 +75,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.closeTab.defaultsKey) private var closeTabShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     private var browserToolbarAccessorySpacing: Int {
@@ -536,10 +537,9 @@ struct cmuxApp: App {
                 // default, closing the last surface also closes the workspace and the window
                 // if it was also the last workspace. Users can opt into keeping the workspace
                 // open instead.
-                Button(String(localized: "menu.file.closeTab", defaultValue: "Close Tab")) {
+                splitCommandButton(title: String(localized: "menu.file.closeTab", defaultValue: "Close Tab"), shortcut: closeTabMenuShortcut) {
                     closePanelOrWindow()
                 }
-                .keyboardShortcut("w", modifiers: .command)
 
                 Button(String(localized: "menu.file.closeOtherTabs", defaultValue: "Close Other Tabs in Pane")) {
                     closeOtherTabsInFocusedPane()
@@ -872,6 +872,13 @@ struct cmuxApp: App {
         decodeShortcut(
             from: closeWorkspaceShortcutData,
             fallback: KeyboardShortcutSettings.Action.closeWorkspace.defaultShortcut
+        )
+    }
+
+    private var closeTabMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: closeTabShortcutData,
+            fallback: KeyboardShortcutSettings.Action.closeTab.defaultShortcut
         )
     }
 


### PR DESCRIPTION
Fixes #1710

## Problem
Cmd+W was still being intercepted for Close Tab even after remapping. The menu item used a hardcoded `.keyboardShortcut("w", modifiers: .command)` which didn't respect user remapped shortcuts.

## Solution
Added a new keyboard shortcut action `closeTab` to `KeyboardShortcutSettings.Action` enum:
- Added `closeTab` case with default shortcut Cmd+W
- Added `@AppStorage` property to track the shortcut data
- Added `closeTabMenuShortcut` computed property
- Changed the "Close Tab" menu button to use `splitCommandButton` with the dynamic shortcut

Now when users remap the Close Tab shortcut, the menu item respects the new binding instead of always intercepting Cmd+W.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Close Tab menu now respects the user’s remapped shortcut instead of always intercepting Cmd+W. Fixes #1710.

- **Bug Fixes**
  - Added a configurable `closeTab` action with default Cmd+W.
  - Persist and decode its shortcut via `@AppStorage` and a new `closeTabMenuShortcut`.
  - Switched the Close Tab menu item to use `splitCommandButton` with the dynamic shortcut.

<sup>Written for commit f461cbb0d7ad20d67be97119535e1094545638c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a customizable Close Tab keyboard shortcut that operates independently from the Close Window shortcut. Close Tab defaults to Cmd+W, while Close Window retains its Ctrl+W binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->