### PR TITLE
SEO hardening: canonicals, sitemap x-default, legal dates

### DIFF
--- a/web/app/[locale]/(legal)/eula/page.tsx
+++ b/web/app/[locale]/(legal)/eula/page.tsx
@@ -3,13 +3,14 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "EULA — cmux",
   description: "End-User License Agreement for cmux",
+  alternates: { canonical: "./" },
 };
 
 export default function EulaPage() {
   return (
     <>
       <h1>EULA</h1>
-      <p>Last updated: December 2, 2025</p>
+      <p>Last updated: March 18, 2026</p>
 
       <p>
         Please read this End-User License Agreement carefully before

--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -4,13 +4,14 @@ import { Link } from "../../../../i18n/navigation";
 export const metadata: Metadata = {
   title: "Privacy Policy — cmux",
   description: "Privacy policy for cmux",
+  alternates: { canonical: "./" },
 };
 
 export default function PrivacyPolicyPage() {
   return (
     <>
       <h1>Privacy Policy</h1>
-      <p>Last updated: December 2, 2025</p>
+      <p>Last updated: March 18, 2026</p>
 
       <p>
         Manaflow (the &ldquo;Company&rdquo;) is committed to maintaining robust

--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -3,13 +3,14 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Terms of Service — cmux",
   description: "Terms of service for cmux",
+  alternates: { canonical: "./" },
 };
 
 export default function TermsOfServicePage() {
   return (
     <>
       <h1>Terms of Service</h1>
-      <p>Last revised on: December 2, 2025</p>
+      <p>Last revised on: March 18, 2026</p>
 
       <p>
         The website located at{" "}
@@ -180,7 +181,7 @@ export default function TermsOfServicePage() {
       </p>
 
       <p>
-        Copyright &copy; 2025 Manaflow. All rights reserved.
+        Copyright &copy; 2026 Manaflow. All rights reserved.
       </p>
     </>
   );

--- a/web/app/[locale]/community/page.tsx
+++ b/web/app/[locale]/community/page.tsx
@@ -8,6 +8,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: { canonical: "./" },
   };
 }
 

--- a/web/app/[locale]/nightly/page.tsx
+++ b/web/app/[locale]/nightly/page.tsx
@@ -12,6 +12,7 @@ export async function generateMetadata({
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: { canonical: "./" },
   };
 }
 

--- a/web/app/[locale]/wall-of-love/page.tsx
+++ b/web/app/[locale]/wall-of-love/page.tsx
@@ -9,6 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: { canonical: "./" },
   };
 }
 

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -5,23 +5,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://cmux.com";
 
   const paths = [
-    { path: "", lastModified: new Date(), changeFrequency: "weekly" as const, priority: 1 },
-    { path: "/blog", lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
+    { path: "", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 1 },
+    { path: "/blog", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.8 },
     { path: "/blog/show-hn-launch", lastModified: "2026-02-21", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/introducing-cmux", lastModified: "2026-02-12", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/zen-of-cmux", lastModified: "2026-02-27", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/cmd-shift-u", lastModified: "2026-03-04", changeFrequency: "monthly" as const, priority: 0.7 },
-    { path: "/docs/getting-started", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.9 },
-    { path: "/docs/concepts", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/docs/configuration", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/docs/keyboard-shortcuts", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
-    { path: "/docs/api", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/docs/notifications", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/docs/changelog", lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.5 },
-    { path: "/docs/browser-automation", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/community", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.5 },
-    { path: "/wall-of-love", lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.5 },
-    { path: "/nightly", lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.6 },
+    { path: "/docs/getting-started", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.9 },
+    { path: "/docs/concepts", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/docs/configuration", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/docs/keyboard-shortcuts", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.7 },
+    { path: "/docs/api", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/docs/notifications", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/docs/changelog", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.5 },
+    { path: "/docs/browser-automation", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/community", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.5 },
+    { path: "/wall-of-love", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.5 },
+    { path: "/nightly", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.6 },
+    { path: "/privacy-policy", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
+    { path: "/terms-of-service", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
+    { path: "/eula", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
   ];
 
   const entries: MetadataRoute.Sitemap = [];
@@ -32,6 +35,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       alternates[locale] =
         locale === "en" ? `${base}${path}` : `${base}/${locale}${path}`;
     }
+    alternates["x-default"] = `${base}${path}`;
 
     entries.push({
       url: `${base}${path}`,


### PR DESCRIPTION
## Summary

Post-migration SEO hardening from the cmux.dev -> cmux.com ensemble audit.

**Sitemap:**
- Added `x-default` hreflang to all sitemap entries (was missing, inconsistent with HTTP Link headers)
- Added legal pages (privacy-policy, terms-of-service, eula) to sitemap
- Stabilized `lastModified` to fixed dates instead of `new Date()` (prevents noisy lastmod on every deploy, which wastes crawl budget)

**Canonical tags:**
- Added `alternates: { canonical: "./" }` to community, nightly, wall-of-love, and all legal pages
- These pages previously had no canonical, creating duplicate content risk with `skipTrailingSlashRedirect: true`

**Legal pages:**
- Updated "last updated" dates to March 18, 2026 (domain migration changed the "Site" definition)
- Updated copyright year to 2026

## Test plan
- [ ] Verify sitemap.xml includes x-default and legal pages in Vercel preview
- [ ] Check canonical tags render on community, nightly, wall-of-love pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SEO after the cmux.dev → cmux.com migration by adding canonical tags, `x-default` hreflang, and stable sitemap dates. This reduces duplicate content and avoids noisy crawls.

- **New Features**
  - Canonicals: Set `alternates: { canonical: "./" }` on community, nightly, wall-of-love, and all legal pages.
  - Sitemap: Added `x-default` hreflang; included `/privacy-policy`, `/terms-of-service`, `/eula`; switched to fixed `lastModified` dates.
  - Legal pages: Updated “Last updated” to March 18, 2026 and copyright to 2026.

<sup>Written for commit f8a8287525615c523d65d25fb7748ff01d163220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated End-User License Agreement, privacy policy, and terms of service with current dates (March 18, 2026)
  * Updated copyright year from 2025 to 2026
  * Enhanced metadata configuration across all pages with canonical URL information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->