### PR TITLE
Use dynamic copyright year in Terms of Service

### DIFF
--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -181,7 +181,7 @@ export default function TermsOfServicePage() {
       </p>
 
       <p>
-        Copyright &copy; 2026 Manaflow. All rights reserved.
+        Copyright &copy; {new Date().getFullYear()} Manaflow. All rights reserved.
       </p>
     </>
   );


### PR DESCRIPTION
SSR the current year instead of hardcoding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SSR the current year in the Terms of Service footer. Removes the hardcoded year so it stays up to date automatically.

<sup>Written for commit 2d40f7fbed7886ee0c6dadc80574029c73f77d81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated copyright year display on the Terms of Service page to automatically reflect the current calendar year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->