### PR TITLE
Wire split test files into build phase, add test timeout

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -778,6 +778,21 @@
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
+					E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
+					1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
+					46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,
+					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */,
+					063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
+					1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */,
+					CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
+					4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,
+					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
+					B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
+					DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
+					0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
+					CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
+					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
+					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -15,6 +15,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        // Prevent a single hanging test from consuming the entire CI timeout budget.
+        executionTimeAllowance = 30
         actionsWithPersistedShortcut = Set(
             KeyboardShortcutSettings.Action.allCases.filter {
                 UserDefaults.standard.object(forKey: $0.defaultsKey) != nil


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/manaflow-ai/cmux/pull/1717. Fixes two issues found in CI:

- The 15 split test files had PBXBuildFile entries but were never added to the cmuxTests Sources build phase (`F1000005`), so they were never compiled. Addresses the [cubic-dev P1 comment](https://github.com/manaflow-ai/cmux/pull/1717#discussion_r2103399693).
- `testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace` in `AppDelegateShortcutRoutingTests` hangs indefinitely on CI (no display, window close path never completes). Added `executionTimeAllowance = 30` so it fails fast instead of consuming the entire 30-minute budget.

## Test plan

- [ ] CI `ci-macos-compat` completes within timeout
- [ ] Split test files appear in xcodebuild compilation output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire 15 split test files into the `cmuxTests` Sources build phase so they compile and run in CI. Add a 30s `executionTimeAllowance` in `AppDelegateShortcutRoutingTests` to fail fast for the window-close test that hangs on headless CI.

<sup>Written for commit b6333295f50ae94eee86badd4bee7bc909bca3e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for multiple application components.
  * Adjusted test execution timeout settings to optimize CI pipeline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->