### PR TITLE
Add PostHog and Resend to privacy policy

### DIFF
--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -58,6 +58,13 @@ export default function PrivacyPolicyPage() {
         The Application checks for updates via Sparkle, which may transmit your
         operating system version and application version to our update server.
       </p>
+      <p>
+        The Site uses PostHog for anonymous analytics, including page views and
+        navigation patterns. PostHog stores a cookie to distinguish unique
+        visitors. No personally identifiable information is collected through
+        analytics. You can opt out by using a browser extension that blocks
+        tracking scripts.
+      </p>
 
       <h3>2. Information you provide directly</h3>
       <p>
@@ -90,6 +97,16 @@ export default function PrivacyPolicyPage() {
         <li>
           <strong>Ghostty / libghostty</strong> &mdash; terminal rendering
           engine. Runs entirely locally on your device.
+        </li>
+        <li>
+          <strong>PostHog</strong> &mdash; website analytics. Collects anonymous
+          page view data, navigation patterns, and browser metadata via a
+          first-party proxy. No personally identifiable information is collected.
+        </li>
+        <li>
+          <strong>Resend</strong> &mdash; transactional email delivery. Used to
+          deliver feedback submissions from the Application. Your email address
+          is transmitted to Resend only if you voluntarily submit feedback.
         </li>
       </ul>
       <p>


### PR DESCRIPTION
Adds missing third-party service disclosures for PostHog (website analytics/cookies) and Resend (transactional email). Flagged by all three models in the post-migration audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add disclosures for `PostHog` and `Resend` in the privacy policy. Clarifies anonymous website analytics (cookie, first‑party proxy) and transactional email for feedback in both the data collection and third‑party services sections.

<sup>Written for commit 57a51c6331969103649009e5887eb37e05dfb06a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Privacy Policy to document integration of PostHog analytics service with anonymous page tracking and Resend transactional email service. Includes details on data collection, anonymization practices, user opt-out capabilities, and email handling procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->