### PR TITLE
fix(shell): add Fish shell integration for listening port detection

### DIFF
--- a/Resources/shell-integration/cmux-fish-integration.fish
+++ b/Resources/shell-integration/cmux-fish-integration.fish
@@ -1,0 +1,121 @@
+# cmux shell integration for fish
+# Injected automatically — do not source manually
+
+function _cmux_send
+    set -l payload "$argv[1]"
+    if command -q ncat
+        printf '%s\n' "$payload" | ncat -w 1 -U "$CMUX_SOCKET_PATH" --send-only 2>/dev/null
+    else if command -q socat
+        printf '%s\n' "$payload" | socat -T 1 - "UNIX-CONNECT:$CMUX_SOCKET_PATH" 2>/dev/null
+    else if command -q nc
+        # Prefer flags that guarantee we exit after sending
+        if printf '%s\n' "$payload" | nc -N -U "$CMUX_SOCKET_PATH" 2>/dev/null
+            return 0
+        else
+            printf '%s\n' "$payload" | nc -w 1 -U "$CMUX_SOCKET_PATH" 2>/dev/null
+        end
+    end
+end
+
+function _cmux_restore_scrollback_once
+    set -l path "$CMUX_RESTORE_SCROLLBACK_FILE"
+    test -n "$path" || return 0
+    set -e CMUX_RESTORE_SCROLLBACK_FILE
+
+    if test -r "$path"
+        /bin/cat -- "$path" 2>/dev/null || true
+        /bin/rm -f -- "$path" 2>/dev/null || true
+    end
+end
+_cmux_restore_scrollback_once
+
+# State variables
+set -g _cmux_pwd_last_pwd ""
+set -g _cmux_ports_last_run 0
+set -g _cmux_tty_name ""
+set -g _cmux_tty_reported 0
+set -g _cmux_shell_activity_last ""
+set -g _cmux_cmd_start 0
+
+function _cmux_report_tty_once
+    test "$_cmux_tty_reported" = 1 && return 0
+    test -S "$CMUX_SOCKET_PATH" || return 0
+    test -n "$CMUX_TAB_ID" || return 0
+    test -n "$CMUX_PANEL_ID" || return 0
+    test -n "$_cmux_tty_name" || return 0
+
+    set -g _cmux_tty_reported 1
+    _cmux_send "report_tty $_cmux_tty_name --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" &
+end
+
+function _cmux_report_shell_activity_state
+    set -l state "$argv[1]"
+    test -n "$state" || return 0
+    test -S "$CMUX_SOCKET_PATH" || return 0
+    test -n "$CMUX_TAB_ID" || return 0
+    test -n "$CMUX_PANEL_ID" || return 0
+    test "$_cmux_shell_activity_last" = "$state" && return 0
+
+    set -g _cmux_shell_activity_last "$state"
+    _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" &
+end
+
+function _cmux_ports_kick
+    test -S "$CMUX_SOCKET_PATH" || return 0
+    test -n "$CMUX_TAB_ID" || return 0
+    test -n "$CMUX_PANEL_ID" || return 0
+
+    set -g _cmux_ports_last_run (date +%s)
+    _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" &
+end
+
+function _cmux_preexec --on-event fish_preexec
+    # Resolve TTY name once
+    if test -z "$_cmux_tty_name"
+        set -g _cmux_tty_name (tty 2>/dev/null | string replace -r '^.*/' '')
+    end
+
+    set -g _cmux_cmd_start (date +%s)
+    _cmux_report_shell_activity_state running
+    _cmux_report_tty_once
+    _cmux_ports_kick
+end
+
+function _cmux_precmd --on-event fish_prompt
+    test -S "$CMUX_SOCKET_PATH" || return 0
+    test -n "$CMUX_TAB_ID" || return 0
+    test -n "$CMUX_PANEL_ID" || return 0
+
+    _cmux_report_shell_activity_state prompt
+
+    # Resolve TTY name once
+    if test -z "$_cmux_tty_name"
+        set -g _cmux_tty_name (tty 2>/dev/null | string replace -r '^.*/' '')
+    end
+
+    _cmux_report_tty_once
+
+    set -l now (date +%s)
+    set -l pwd "$PWD"
+    set -l cmd_start "$_cmux_cmd_start"
+    set -g _cmux_cmd_start 0
+
+    # CWD: keep the app in sync
+    if test "$pwd" != "$_cmux_pwd_last_pwd"
+        set -g _cmux_pwd_last_pwd "$pwd"
+        set -l qpwd (string replace -a '"' '\\"' "$pwd")
+        _cmux_send "report_pwd \"$qpwd\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" &
+    end
+
+    # Ports: lightweight kick to the app's batched scanner
+    # - Periodic scan to avoid stale values
+    # - Forced scan when a long-running command returns
+    set -l cmd_dur 0
+    if test -n "$cmd_start" && test "$cmd_start" != 0
+        set cmd_dur (math "$now - $cmd_start")
+    end
+
+    if test "$cmd_dur" -ge 2 2>/dev/null || test (math "$now - $_cmux_ports_last_run") -ge 10 2>/dev/null
+        _cmux_ports_kick
+    end
+end

--- a/Resources/shell-integration/fish/vendor_conf.d/cmux.fish
+++ b/Resources/shell-integration/fish/vendor_conf.d/cmux.fish
@@ -1,0 +1,6 @@
+# cmux fish integration - auto-generated, do not modify
+if test "$CMUX_SHELL_INTEGRATION" != "0" -a -n "$CMUX_SHELL_INTEGRATION_DIR"
+    set -l _cmux_fish "$CMUX_SHELL_INTEGRATION_DIR/cmux-fish-integration.fish"
+    test -r "$_cmux_fish"; and source "$_cmux_fish"
+    set -e _cmux_fish
+end

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3214,6 +3214,35 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 unset _cmux_ghostty_bash _cmux_bash_integration; \
                 if declare -F _cmux_prompt_command >/dev/null 2>&1; then _cmux_prompt_command; fi
                 """)
+            } else if shellName == "fish" {
+                // Fish shell integration: create a config snippet in conf.d/
+                // Fish automatically sources all .fish files in $XDG_CONFIG_HOME/fish/conf.d/
+                // We create a temporary conf.d path that Fish will load via environment.
+                let fishConfDir = URL(fileURLWithPath: integrationDir).appendingPathComponent("fish/conf.d")
+                let fishConfFile = fishConfDir.appendingPathComponent("cmux.fish")
+                let fishIntegrationContent = """
+                # cmux fish integration - auto-generated, do not modify
+                if test "$CMUX_SHELL_INTEGRATION" != "0" -a -n "$CMUX_SHELL_INTEGRATION_DIR"
+                    set -l _cmux_fish "$CMUX_SHELL_INTEGRATION_DIR/cmux-fish-integration.fish"
+                    test -r "$_cmux_fish"; and source "$_cmux_fish"
+                    set -e _cmux_fish
+                end
+                """
+                do {
+                    try FileManager.default.createDirectory(at: fishConfDir, withIntermediateDirectories: true)
+                    try fishIntegrationContent.write(to: fishConfFile, atomically: true, encoding: .utf8)
+                    // Point Fish to our integration directory via XDG_CONFIG_HOME
+                    // We prepend our path so it takes precedence
+                    let currentXdgConfig = env["XDG_CONFIG_HOME"] ?? ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"] ?? FileManager.default.homeDirectoryForCurrentUser?.appendingPathComponent(".config").path ?? ""
+                    if !currentXdgConfig.isEmpty {
+                        setManagedEnvironmentValue("XDG_CONFIG_HOME", integrationDir + ":" + currentXdgConfig)
+                    } else {
+                        setManagedEnvironmentValue("XDG_CONFIG_HOME", integrationDir)
+                    }
+                } catch {
+                    // If we can't set up Fish integration, continue without it
+                    NSLog("[cmux] Failed to set up Fish shell integration: \(error)")
+                }
             }
         }
         env = Self.mergedStartupEnvironment(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3215,33 +3215,21 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 if declare -F _cmux_prompt_command >/dev/null 2>&1; then _cmux_prompt_command; fi
                 """)
             } else if shellName == "fish" {
-                // Fish shell integration: create a config snippet in conf.d/
-                // Fish automatically sources all .fish files in $XDG_CONFIG_HOME/fish/conf.d/
-                // We create a temporary conf.d path that Fish will load via environment.
-                let fishConfDir = URL(fileURLWithPath: integrationDir).appendingPathComponent("fish/conf.d")
-                let fishConfFile = fishConfDir.appendingPathComponent("cmux.fish")
-                let fishIntegrationContent = """
-                # cmux fish integration - auto-generated, do not modify
-                if test "$CMUX_SHELL_INTEGRATION" != "0" -a -n "$CMUX_SHELL_INTEGRATION_DIR"
-                    set -l _cmux_fish "$CMUX_SHELL_INTEGRATION_DIR/cmux-fish-integration.fish"
-                    test -r "$_cmux_fish"; and source "$_cmux_fish"
-                    set -e _cmux_fish
-                end
-                """
-                do {
-                    try FileManager.default.createDirectory(at: fishConfDir, withIntermediateDirectories: true)
-                    try fishIntegrationContent.write(to: fishConfFile, atomically: true, encoding: .utf8)
-                    // Point Fish to our integration directory via XDG_CONFIG_HOME
-                    // We prepend our path so it takes precedence
-                    let currentXdgConfig = env["XDG_CONFIG_HOME"] ?? ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"] ?? FileManager.default.homeDirectoryForCurrentUser?.appendingPathComponent(".config").path ?? ""
-                    if !currentXdgConfig.isEmpty {
-                        setManagedEnvironmentValue("XDG_CONFIG_HOME", integrationDir + ":" + currentXdgConfig)
-                    } else {
-                        setManagedEnvironmentValue("XDG_CONFIG_HOME", integrationDir)
-                    }
-                } catch {
-                    // If we can't set up Fish integration, continue without it
-                    NSLog("[cmux] Failed to set up Fish shell integration: \(error)")
+                // Fish shell integration via XDG_DATA_DIRS vendor_conf.d.
+                // Fish automatically sources .fish files in $XDG_DATA_DIRS/*/fish/vendor_conf.d/.
+                // Prefix integrationDir/fish/vendor_conf.d so our snippet loads.
+                func normalizedEnvValue(_ value: String?) -> String? {
+                    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                          !trimmed.isEmpty else { return nil }
+                    return trimmed
+                }
+                let currentXdgDataDirs =
+                    normalizedEnvValue(env["XDG_DATA_DIRS"]) ??
+                    normalizedEnvValue(ProcessInfo.processInfo.environment["XDG_DATA_DIRS"])
+                if let currentXdgDataDirs {
+                    setManagedEnvironmentValue("XDG_DATA_DIRS", integrationDir + "/fish/vendor_conf.d:" + currentXdgDataDirs)
+                } else {
+                    setManagedEnvironmentValue("XDG_DATA_DIRS", integrationDir + "/fish/vendor_conf.d")
                 }
             }
         }


### PR DESCRIPTION
Fixes #1669

Adds Fish shell integration to enable listening port detection in the sidebar for Fish users. The implementation mirrors the existing Bash and Zsh integrations.

Changes:
- Create `cmux-fish-integration.fish` with `ports_kick`, `report_tty`, and `report_pwd` functions
- Add Fish shell detection in `GhosttyTerminalView.swift`
- Set up Fish `conf.d/` snippet for automatic loading via `XDG_CONFIG_HOME`

The port scanner hooks are triggered on `fish_preexec` (when a command starts) and `fish_prompt` (when returning to prompt), matching the behavior of the Bash/Zsh integrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Fish shell integration for listening port detection in the sidebar. Mirrors Bash/Zsh behavior and fixes #1669.

- **New Features**
  - Fish script hooks `fish_preexec` and `fish_prompt` to send `ports_kick`, `report_tty`, and `report_pwd` (plus shell state) over the cmux socket; non-blocking with short timeouts and minimal repeats.
  - Integration loads via Fish `vendor_conf.d` using `XDG_DATA_DIRS`; we ship `Resources/shell-integration/fish/vendor_conf.d/cmux.fish` and set `XDG_DATA_DIRS` in `GhosttyTerminalView.swift` (no `XDG_CONFIG_HOME` writes).

<sup>Written for commit f128bf6dfbc9ec46641d3ff24755a9ba9b842b5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fish shell integration to enable communication between the shell and the app for directory tracking, terminal state synchronization, activity-state reporting, and periodic maintenance triggers.
  * Ensures Fish integration is discovered and loaded alongside existing shell integrations for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->