### PR TITLE
fix(font): correct Korean font style/size mismatch

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1288,8 +1288,10 @@ class GhosttyApp {
                 font = "Hiragino Sans"
                 langRanges = japaneseRanges
             } else if lower.hasPrefix("ko") {
-                font = "Apple SD Gothic Neo"
-                langRanges = koreanRanges
+                // Skip Korean font injection to let Ghostty's native CTFontCreateForString
+                // handle Hangul with proper font matching to the primary terminal font.
+                // See: https://github.com/manaflow-ai/cmux/issues/1693
+                continue
             } else if lower.hasPrefix("zh-hant") || lower.hasPrefix("zh-tw") || lower.hasPrefix("zh-hk") {
                 font = "PingFang TC"
             } else if lower.hasPrefix("zh") {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2016,16 +2016,27 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsAppleSDGothicNeoWithHangulForKorean() {
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"])!
+    func testCJKFontMappingsReturnsNilForKorean() {
+        // Korean font injection is bypassed to let Ghostty's native CTFontCreateForString
+        // handle Hangul with proper font matching to the primary terminal font.
+        // See: https://github.com/manaflow-ai/cmux/issues/1693
+        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
+        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko"]))
+    }
+
+    func testCJKFontMappingsKoreanBypassedInMixedLanguageList() {
+        // When Korean is mixed with Japanese, Korean entries are skipped entirely.
+        // The Japanese portion still works normally.
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR", "ja-JP"])!
         let fonts = Set(mappings.map(\.1))
         let ranges = mappings.map(\.0)
 
-        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
-        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"), "Should include Hangul Syllables")
-        XCTAssertTrue(ranges.contains("U+1100-U+11FF"), "Should include Hangul Jamo")
-        XCTAssertTrue(ranges.contains("U+4E00-U+9FFF"), "Should include CJK Ideographs")
-        XCTAssertFalse(ranges.contains("U+3040-U+309F"), "Should NOT include Hiragana")
+        // Japanese should work
+        XCTAssertTrue(fonts.contains("Hiragino Sans"))
+        XCTAssertTrue(ranges.contains("U+3040-U+309F"), "Should include Hiragana")
+        // Korean should NOT contribute any mappings
+        XCTAssertFalse(fonts.contains("Apple SD Gothic Neo"))
+        XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul from Korean entry")
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2045,15 +2056,16 @@ final class GhosttyMouseFocusTests: XCTestCase {
     }
 
     func testCJKFontMappingsMultiLanguageMapsScriptSpecificRanges() {
+        // Korean is bypassed, so only Japanese contributes script-specific ranges.
         let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
 
         let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
-        let sdGothicRanges = mappings.filter { $0.1 == "Apple SD Gothic Neo" }.map(\.0)
 
         XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
         XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
-        XCTAssertTrue(sdGothicRanges.contains("U+AC00-U+D7AF"), "Hangul → Apple SD Gothic Neo")
-        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
+        // Korean entries are bypassed entirely — no Apple SD Gothic Neo
+        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" })
+        XCTAssertFalse(mappings.contains { $0.0 == "U+AC00-U+D7AF" })
     }
 
     // MARK: userConfigContainsCJKCodepointMap


### PR DESCRIPTION
Fixes #1693

**Problem:**
Korean characters render with a different font style and size compared to ASCII text. The CJK `font-codepoint-map` auto-injection from PR #1017 force-maps Korean ranges to `Apple SD Gothic Neo`, which has a noticeably different weight/style from the primary terminal font.

**Solution:**
Skip the hardcoded font injection for Korean (`ko`) language preference. This allows Ghostty's native `CTFontCreateForString` to handle Hangul with proper font matching to the primary terminal font, matching standalone Ghostty's behavior.

**Testing:**
- Syntax check passed: `swiftc -parse Sources/GhosttyTerminalView.swift`
- Verified the fix matches the approach suggested in the issue report

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop force-mapping Korean to `Apple SD Gothic Neo`; use native fallback so Hangul matches the primary terminal font. Add regression tests for the Korean bypass (including mixed-language lists) while keeping Japanese/Chinese behavior unchanged (fixes #1693).

<sup>Written for commit 9b0f47eb1920dcb0882cc88875a2df41ff7345e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Korean text rendering now bypasses dedicated font injection and uses the primary terminal font; Japanese and Chinese handling remains unchanged.
* **Tests**
  * Updated and added tests to reflect that Korean font mappings are no longer produced, including mixed-language scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->