### PR TITLE
fix: align titlebar icons with traffic-light buttons

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -806,9 +806,22 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         contentSize = cachedFittingSize ?? .zero
 
         guard contentSize.width > 0, contentSize.height > 0 else { return }
-        let titlebarHeight = view.window.map { window in
-            window.frame.height - window.contentLayoutRect.height
-        } ?? contentSize.height
+        // Use the traffic-light close button's superview height as the true
+        // titlebar height. This excludes the tab bar so the icons align with
+        // the traffic-light buttons (like Slack does) instead of centering in
+        // the full non-content area which includes the tab strip.
+        let titlebarHeight: CGFloat = {
+            if let window = view.window,
+               let closeButton = window.standardWindowButton(.closeButton),
+               let titlebarView = closeButton.superview,
+               titlebarView.frame.height > 0 {
+                return titlebarView.frame.height
+            }
+            // Fallback: derive from the window geometry.
+            return view.window.map { window in
+                window.frame.height - window.contentLayoutRect.height
+            } ?? contentSize.height
+        }()
         let containerHeight = max(contentSize.height, titlebarHeight)
         let yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
         let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(


### PR DESCRIPTION
## Summary

- **Problem**: Titlebar control icons (sidebar, bell, new tab) were vertically misaligned — they were centered within the full titlebar + tab-bar area instead of just the titlebar, causing them to sit lower than the traffic-light buttons.
- **Root cause**: `updateSize()` in `TitlebarControlsAccessoryViewController` computed `titlebarHeight` as `window.frame.height - window.contentLayoutRect.height`, which includes the tab strip height.
- **Fix**: Use `window.standardWindowButton(.closeButton).superview.frame.height` as the true titlebar height. This gives the exact height of the titlebar view that contains the traffic lights, excluding the tab bar. Falls back to the previous calculation when the close button is unavailable.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/7dadcf82-69bf-4fd9-a154-11ae86eec41e) | ![after](https://github.com/user-attachments/assets/ed29ee36-bb76-4eaa-a651-fd5ffafef199) |

## Test plan

- [x] Built and launched via `reload.sh --tag fix-icon-valign`
- [x] Verified icons align with traffic-light buttons visually
- [x] Fullscreen mode — uses SwiftUI layout directly, not `updateSize()`, so unaffected
- [x] All `titlebarControlsStyle` variants — `closeButton.superview.frame.height` is style-independent; only `contentSize` varies per style, centering logic is shared