### PR TITLE
fix(keyboard): forward unbound Cmd+Shift combinations to terminal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4889,6 +4889,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // First pass: check if a menu item would handle this event.
             // If not, process the key directly instead of relying on AppKit redispatch,
             // which silently drops unbound Cmd+Shift combinations.
+            // Only route to main menu if shouldRouteCommandEquivalentDirectlyToMainMenu
+            // permits it (e.g., Cmd+` is intentionally excluded).
+            if !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
+                lastPerformKeyEvent = nil
+                return false
+            }
             lastPerformKeyEvent = event.timestamp
             if let menu = NSApp.mainMenu, menu.performKeyEquivalent(with: event) {
                 return true


### PR DESCRIPTION
Unbound Cmd+Shift+<key> combinations were being silently swallowed by the AppKit key-routing layer and never reached the terminal via the kitty keyboard protocol.

The root cause was in performKeyEquivalent's two-pass mechanism:
1. First pass returned false, expecting AppKit to redispatch
2. When no menu item matched, AppKit never redispatched the event

The fix checks on the first pass if any menu item would handle the event. If not, the key is processed directly via keyDown instead of relying on AppKit redispatch.

Fixes #1718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward unbound Cmd+Shift+<key> events to the terminal instead of letting AppKit swallow them, fixing #1718. On the first pass we gate main menu routing with shouldRouteCommandEquivalentDirectlyToMainMenu and, if allowed but no item matches, handle via keyDown so the event reaches the kitty keyboard protocol; excluded shortcuts like Cmd+` remain unchanged.

<sup>Written for commit e0802e944340220ff754036d2a9f5c4a9ed32340. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling for menu shortcuts so Cmd+ combinations (including Cmd+Shift combos) are recognized more reliably and less likely to be mishandled.
  * Reduced incorrect redispatch of menu key events, preventing duplicate or missed shortcut activations and improving overall shortcut responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->