### PR TITLE
fix(keyboard): forward unbound Cmd+Shift combinations to terminal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4878,18 +4878,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 return false
             }
 
-            if let lastPerformKeyEvent {
-                self.lastPerformKeyEvent = nil
-                if lastPerformKeyEvent == event.timestamp {
-                    equivalent = event.characters ?? ""
-                    break
-                }
-            }
-
-            lastPerformKeyEvent = event.timestamp
-            return false
+            // For unbound Command-modified keys (e.g., Cmd+Shift+K with no binding),
+            // forward directly to the terminal rather than relying on AppKit's redispatch.
+            // AppKit may drop the event if no menu item matches, preventing the key from
+            // reaching the terminal via the kitty keyboard protocol.
+            // See: https://github.com/manaflow-ai/cmux/issues/1718
+            lastPerformKeyEvent = nil
+            keyDown(with: event)
+            return true
         }
 
+        // Handle \r and / cases by creating a modified event and forwarding to keyDown.
         let finalEvent = NSEvent.keyEvent(
             with: .keyDown,
             location: event.locationInWindow,


### PR DESCRIPTION
Fixes #1718

## Problem

Unbound `Cmd+Shift+\<key\>` key combinations were being silently swallowed by the AppKit key-routing layer. They never reached the terminal application via the kitty keyboard protocol.

The root cause was in `performKeyEquivalent`: the two-pass timestamp mechanism returned `false` on the first pass, expecting AppKit to redispatch. However, AppKit never redispatches events that don't match any menu item or Ghostty binding.

## Solution

Forward unbound Command-modified keys directly to `keyDown` instead of relying on AppKit's redispatch mechanism. This ensures the kitty keyboard protocol receives the events for applications like Neovim that rely on `super` modifier keys.

## Changes

- Modified `GhosttyTerminalView.swift` performKeyEquivalent method
- Removed the two-pass timestamp mechanism for unbound keys
- Unbound Cmd+Shift combinations now flow directly to the terminal

## Testing

- Unbound `Cmd+Shift+K` should now reach the terminal as CSI escape sequence
- Applications using kitty keyboard protocol (Neovim \u2265 0.10) can now receive `\<S-D-J\>` / `\<S-D-K\>` mappings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward unbound Cmd+Shift key combinations directly to the terminal so they are no longer dropped by AppKit. Fixes missing key events in apps using the kitty keyboard protocol (e.g., Neovim).

- **Bug Fixes**
  - Forward unbound Command-modified keys to `keyDown` in `performKeyEquivalent`.
  - Remove the two-pass timestamp redispatch logic that AppKit never delivers.
  - Cmd+Shift combos now reach the terminal (e.g., Neovim mappings like <S-D-J>/<S-D-K>).

<sup>Written for commit f0f297a63a6724b3074a85bdc4e84ef3ed7de0b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined keyboard event handling for command-modified keys to ensure they are correctly processed and routed to the terminal application. Enhanced key translation paths for specific key combinations to provide more predictable and consistent behavior with keyboard shortcuts and input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->