### PR TITLE
added_chrome_support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to cmux are documented here.
 
+## [Unreleased]
+
+### Added
+- Preferred Browser setting: choose Chrome (or any installed browser) to open ⌘L and terminal links externally, with a toolbar button to send the current page there
+- One-click "Import Cookies from [Browser]" in Settings > Browser when an external browser is selected, so existing login sessions carry over to the built-in browser without re-authenticating
+
 ## [0.62.2] - 2026-03-14
 
 ### Added

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -8908,6 +8908,23 @@
         }
       }
     },
+    "browser.openInExternalBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@で開く"
+          }
+        }
+      }
+    },
     "browser.popup.loadingTitle": {
       "extractionState": "manual",
       "localizations": {
@@ -53141,6 +53158,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kapalıyken, `open https://...` ve `open http://...` her zaman varsayılan tarayıcınızı kullanır."
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferred Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "優先ブラウザー"
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser.builtin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Built-in"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "組み込み"
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose which browser opens when you press ⌘L or click terminal links."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⌘Lを押すかターミナルのリンクをクリックしたときに開くブラウザーを選択します。"
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser.importCookies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Cookies from %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@からCookieをインポート"
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser.importCookies.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート…"
+          }
+        }
+      }
+    },
+    "settings.browser.preferredBrowser.importCookies.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy your %@ login sessions into the built-in browser so you stay signed in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のログインセッションを組み込みブラウザーにコピーして、サインイン状態を維持します。"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9225,6 +9225,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return true
             }
 
+            if PreferredBrowserSettings.isUsingExternalBrowser() {
+                PreferredBrowserSettings.activatePreferredBrowser()
+                return true
+            }
+
             if openBrowserAndFocusAddressBar(insertAtEnd: true) != nil {
                 return true
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2310,6 +2310,18 @@ class GhosttyApp {
                 #endif
                 return false
             }
+            if PreferredBrowserSettings.isUsingExternalBrowser() {
+                #if DEBUG
+                dlog("link.openURL preferredExternalBrowser=set, opening in preferred browser url=\(target.url)")
+                #endif
+                return performOnMain {
+                    if PreferredBrowserSettings.openURLInPreferredBrowser(target.url) {
+                        return true
+                    }
+                    NSWorkspace.shared.open(target.url)
+                    return true
+                }
+            }
             if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
                 #if DEBUG
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -659,6 +659,48 @@ enum BrowserLinkOpenSettings {
     }
 }
 
+enum PreferredBrowserSettings {
+    static let preferredBrowserKey = "preferredExternalBrowserBundleID"
+    static let defaultPreferredBrowser: String = "" // empty = built-in WebKit browser
+
+    static func preferredBrowserBundleID(defaults: UserDefaults = .standard) -> String {
+        defaults.string(forKey: preferredBrowserKey) ?? defaultPreferredBrowser
+    }
+
+    static func isUsingExternalBrowser(defaults: UserDefaults = .standard) -> Bool {
+        !preferredBrowserBundleID(defaults: defaults).isEmpty
+    }
+
+    static func preferredBrowserAppURL(defaults: UserDefaults = .standard) -> URL? {
+        let bundleID = preferredBrowserBundleID(defaults: defaults)
+        guard !bundleID.isEmpty else { return nil }
+        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
+    }
+
+    static func preferredBrowserDisplayName(defaults: UserDefaults = .standard) -> String? {
+        guard let appURL = preferredBrowserAppURL(defaults: defaults) else { return nil }
+        return (try? appURL.resourceValues(forKeys: [.localizedNameKey]))?.localizedName
+            ?? appURL.deletingPathExtension().lastPathComponent
+    }
+
+    @discardableResult
+    static func activatePreferredBrowser(defaults: UserDefaults = .standard) -> Bool {
+        guard let appURL = preferredBrowserAppURL(defaults: defaults) else { return false }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        NSWorkspace.shared.open(appURL, configuration: config) { _, _ in }
+        return true
+    }
+
+    @discardableResult
+    static func openURLInPreferredBrowser(_ url: URL, defaults: UserDefaults = .standard) -> Bool {
+        guard let appURL = preferredBrowserAppURL(defaults: defaults) else { return false }
+        let config = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: config) { _, _ in }
+        return true
+    }
+}
+
 enum BrowserInsecureHTTPSettings {
     static let allowlistKey = "browserInsecureHTTPAllowlist"
     static let defaultAllowlistPatterns = [
@@ -8763,6 +8805,12 @@ final class BrowserDataImportCoordinator {
 
     func presentImportDialog(defaultDestinationProfileID: UUID? = nil) {
         presentImportDialog(prefilledBrowsers: nil, defaultDestinationProfileID: defaultDestinationProfileID)
+    }
+
+    func presentImportDialog(forBrowserDescriptorID descriptorID: String, defaultDestinationProfileID: UUID? = nil) {
+        let allBrowsers = InstalledBrowserDetector.detectInstalledBrowsers()
+        let filtered = allBrowsers.filter { $0.descriptor.id == descriptorID }
+        presentImportDialog(prefilledBrowsers: filtered.isEmpty ? nil : filtered, defaultDestinationProfileID: defaultDestinationProfileID)
     }
 
     private struct ImportSelection {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -299,6 +299,8 @@ struct BrowserPanelView: View {
     @AppStorage(BrowserImportHintSettings.dismissedKey) private var isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed
     @AppStorage(KeyboardShortcutSettings.Action.toggleBrowserDeveloperTools.defaultsKey)
     private var toggleBrowserDeveloperToolsShortcutData = Data()
+    @AppStorage(PreferredBrowserSettings.preferredBrowserKey)
+    private var preferredExternalBrowserBundleID = PreferredBrowserSettings.defaultPreferredBrowser
     @State private var suggestionTask: Task<Void, Never>?
     @State private var isLoadingRemoteSuggestions: Bool = false
     @State private var latestRemoteSuggestionQuery: String = ""
@@ -732,6 +734,7 @@ struct BrowserPanelView: View {
                 if shouldShowToolbarImportHintChip {
                     browserImportHintToolbarChip
                 }
+                openInExternalBrowserButton
                 browserProfileButton
                 browserThemeModeButton
                 developerToolsButton
@@ -820,6 +823,47 @@ struct BrowserPanelView: View {
                 .padding(.leading, 6)
                 .safeHelp(String(localized: "browser.downloadInProgress", defaultValue: "Download in progress"))
             }
+        }
+    }
+
+    private var preferredBrowserDisplayName: String {
+        guard !preferredExternalBrowserBundleID.isEmpty,
+              let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferredExternalBrowserBundleID) else {
+            return ""
+        }
+        return (try? appURL.resourceValues(forKeys: [.localizedNameKey]))?.localizedName
+            ?? appURL.deletingPathExtension().lastPathComponent
+    }
+
+    @ViewBuilder
+    private var openInExternalBrowserButton: some View {
+        if !preferredExternalBrowserBundleID.isEmpty {
+            Button(action: {
+                if let url = panel.currentURL {
+                    PreferredBrowserSettings.openURLInPreferredBrowser(url)
+                } else {
+                    PreferredBrowserSettings.activatePreferredBrowser()
+                }
+            }) {
+                Image(systemName: "arrow.up.right.square")
+                    .symbolRenderingMode(.monochrome)
+                    .cmuxFlatSymbolColorRendering()
+                    .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                    .foregroundStyle(devToolsColorOption.color)
+                    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            }
+            .buttonStyle(OmnibarAddressButtonStyle())
+            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+            .safeHelp(
+                String(
+                    format: String(
+                        localized: "browser.openInExternalBrowser",
+                        defaultValue: "Open in %@"
+                    ),
+                    preferredBrowserDisplayName
+                )
+            )
+            .accessibilityIdentifier("BrowserOpenInExternalBrowserButton")
         }
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3577,6 +3577,7 @@ struct SettingsView: View {
     @AppStorage(BrowserLinkOpenSettings.browserExternalOpenPatternsKey)
     private var browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
     @AppStorage(BrowserInsecureHTTPSettings.allowlistKey) private var browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
+    @AppStorage(PreferredBrowserSettings.preferredBrowserKey) private var preferredExternalBrowserBundleID = PreferredBrowserSettings.defaultPreferredBrowser
     @AppStorage(NotificationSoundSettings.key) private var notificationSound = NotificationSoundSettings.defaultValue
     @AppStorage(NotificationSoundSettings.customFilePathKey)
     private var notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
@@ -4705,6 +4706,59 @@ struct SettingsView: View {
                         .id(SettingsNavigationTarget.browser)
                         .accessibilityIdentifier("SettingsBrowserSection")
                     SettingsCard {
+                        SettingsCardRow(
+                            String(localized: "settings.browser.preferredBrowser", defaultValue: "Preferred Browser"),
+                            subtitle: String(localized: "settings.browser.preferredBrowser.subtitle", defaultValue: "Choose which browser opens when you press ⌘L or click terminal links.")
+                        ) {
+                            Picker("", selection: $preferredExternalBrowserBundleID) {
+                                Text(String(localized: "settings.browser.preferredBrowser.builtin", defaultValue: "Built-in"))
+                                    .tag("")
+                                ForEach(detectedImportBrowsers, id: \.descriptor.id) { browser in
+                                    Text(browser.displayName)
+                                        .tag(browser.descriptor.bundleIdentifiers.first ?? "")
+                                }
+                            }
+                            .labelsHidden()
+                            .controlSize(.small)
+                            .frame(width: pickerColumnWidth)
+                            .accessibilityIdentifier("SettingsBrowserPreferredBrowserPicker")
+                        }
+
+                        if !preferredExternalBrowserBundleID.isEmpty,
+                           let preferredBrowser = detectedImportBrowsers.first(where: {
+                               $0.descriptor.bundleIdentifiers.contains(preferredExternalBrowserBundleID)
+                           }) {
+                            SettingsCardDivider()
+
+                            SettingsCardRow(
+                                String(
+                                    format: String(
+                                        localized: "settings.browser.preferredBrowser.importCookies",
+                                        defaultValue: "Import Cookies from %@"
+                                    ),
+                                    preferredBrowser.displayName
+                                ),
+                                subtitle: String(
+                                    format: String(
+                                        localized: "settings.browser.preferredBrowser.importCookies.subtitle",
+                                        defaultValue: "Copy your %@ login sessions into the built-in browser so you stay signed in."
+                                    ),
+                                    preferredBrowser.displayName
+                                )
+                            ) {
+                                Button(String(localized: "settings.browser.preferredBrowser.importCookies.button", defaultValue: "Import…")) {
+                                    DispatchQueue.main.async {
+                                        BrowserDataImportCoordinator.shared.presentImportDialog(forBrowserDescriptorID: preferredBrowser.descriptor.id)
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsBrowserPreferredBrowserImportCookiesButton")
+                            }
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsPickerRow(
                             String(localized: "settings.browser.searchEngine", defaultValue: "Default Search Engine"),
                             subtitle: String(localized: "settings.browser.searchEngine.subtitle", defaultValue: "Used by the browser address bar when input is not a URL."),
@@ -5209,6 +5263,7 @@ struct SettingsView: View {
         interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser
         browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
         browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
+        preferredExternalBrowserBundleID = PreferredBrowserSettings.defaultPreferredBrowser
         browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
         browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText
         notificationSound = NotificationSoundSettings.defaultValue


### PR DESCRIPTION

  Changes Made 
  preferred external browser + one-click Chrome cookie import

  - **What changed?**
    - Added a **Preferred Browser** picker in Settings > Browser. Users can choose
   Chrome (or any detected browser — Arc, Brave, Edge, Firefox, etc.) as their
  external browser.

    - When an external browser is set, pressing ⌘L or clicking terminal links
  opens that browser instead of the built-in WebKit browser.

    - A toolbar button ("Open in [Browser]") appears in the built-in browser to
  send the current page to the preferred browser with one click.

    - When an external browser is selected, a new **"Import Cookies from
  [Browser]"** row appears in Settings > Browser. Clicking **Import…** opens the
  import wizard pre-filtered to that browser, copying login sessions into the
  built-in browser so users stay signed in without re-authenticating.

  - **Why?**
    Users already signed into Chrome shouldn't have to re-login in cmux's built-in
   browser. This makes it a single setting change + one import step to have full
  session continuity, plus a persistent button to pop any page out to Chrome.

  ## Testing

  - Built and ran a Release build (`./scripts/reloadp.sh`) and verified
  end-to-end:
    - Setting Preferred Browser to Chrome shows the "Import Cookies from Google
  Chrome" row immediately
    - Clicking Import… opens the wizard pre-filtered to Chrome only
    - ⌘L activates Chrome instead of opening the built-in browser
    - Terminal link clicks route to Chrome when the setting is active
    - "Open in Chrome" toolbar button appears only when a preferred browser is
  configured
    - Resetting settings clears `preferredExternalBrowserBundleID`
    - With Chrome not installed: picker shows no external options, import row
  stays hidden

  - No automated tests added — UI-only settings change. Cookie import execution is
   covered by existing infrastructure;
  `presentImportDialog(forBrowserDescriptorID:)` is a thin filter wrapper over the
   existing `presentImportDialog(prefilledBrowsers:)`.

  ## Demo Video


https://github.com/user-attachments/assets/36988231-2765-4d32-a529-cab0ccbdcced



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Preferred Browser setting to open ⌘L and terminal links in Chrome (or any detected browser), plus a one-click cookie import to keep you signed in in the built-in browser.

- **New Features**
  - Settings > Browser: Preferred Browser picker (Built‑in or detected browsers like Chrome, Arc, Brave, Edge, Firefox).
  - When an external browser is selected:
    - ⌘L activates that browser; terminal links open there.
    - Built‑in browser shows an “Open in [Browser]” button to send the current page out (or focus the browser if no URL).
    - “Import Cookies from [Browser]” opens the import wizard pre‑filtered to that browser to copy login sessions.

- **Migration**
  - No action needed. Default stays Built‑in. Pick a browser to enable the new behavior and import.

<sup>Written for commit 5ec4ff8f46d5a0197d9e2940b6e0dc3199a93faa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Preferred Browser setting to open terminal links in an external browser, with a toolbar button to send the current page
  * Added one-click cookie import from supported browsers in Settings > Browser to carry over existing login sessions without re-authentication
  * Added multi-language support for all new features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->