### PR TITLE
fix(keyboard): support CJK input methods for custom shortcuts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10271,8 +10271,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // For command-based shortcuts, trust AppKit's layout-aware characters when present.
         // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
         // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
-        let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
-        if hasEventChars,
+        //
+        // When a CJK input method (Korean, Japanese, Chinese) is active,
+        // charactersIgnoringModifiers returns non-ASCII characters (e.g. "ㅅ" for the T key
+        // on Korean 2-Set). These cannot match ASCII shortcut keys, so treat them as absent
+        // to allow keyCode-based fallback — matching the behavior of AppKit menu shortcuts
+        // which work regardless of input source.
+        let hasUsableEventChars: Bool = {
+            guard let chars = eventCharsIgnoringModifiers, !chars.isEmpty else { return false }
+            return chars.unicodeScalars.allSatisfy { $0.isASCII }
+        }()
+        if hasUsableEventChars,
            flags.contains(.command),
            !flags.contains(.control),
            shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
@@ -10295,12 +10304,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // so keep ANSI keyCode fallback for control-modified shortcuts. Also allow fallback for
         // command punctuation shortcuts, since some non-US layouts report different characters
         // for the same physical key even when menu-equivalent semantics should still apply.
+        // When a CJK input source is active, the layout provider also returns non-ASCII
+        // characters, so apply the same ASCII-usability check to layoutCharacter.
+        let hasUsableLayoutChar = layoutCharacter.map {
+            !$0.isEmpty && $0.unicodeScalars.allSatisfy { $0.isASCII }
+        } ?? false
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
                 && (
                     !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
+                        || (!hasUsableEventChars && !hasUsableLayoutChar)
                 ))
         if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2793,7 +2793,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         modifiers: NSEvent.ModifierFlags,
         keyCode: UInt16,
         windowNumber: Int,
-        isARepeat: Bool = false
+        isARepeat: Bool = false,
+        charsIgnoringModifiers: String? = nil
     ) -> NSEvent? {
         NSEvent.keyEvent(
             with: type,
@@ -2803,7 +2804,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             windowNumber: windowNumber,
             context: nil,
             characters: key,
-            charactersIgnoringModifiers: key,
+            charactersIgnoringModifiers: charsIgnoringModifiers ?? key,
             isARepeat: isARepeat,
             keyCode: keyCode
         )
@@ -2911,6 +2912,102 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             }
             return UUID(uuidString: String(raw.dropFirst("cmux.main.".count)))
         })
+    }
+
+    // MARK: - CJK IME shortcut tests
+
+    /// When a CJK input method is active, charactersIgnoringModifiers returns
+    /// non-ASCII characters (e.g. "ㅅ" for the T key on Korean 2-Set).
+    /// matchShortcut must fall through to keyCode-based matching in this case.
+    func testCmdTMatchesNewSurfaceWithKoreanIMECharacters() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let window = window(withId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected window context")
+            return
+        }
+
+        let surfaceCountBefore = workspace.panels.count
+        appDelegate.tabManager = manager
+
+        // Simulate Korean 2-Set IME: physical T key (keyCode 17) but chars = "ㅅ"
+        // Also stub layout provider to return Korean character (simulating CJK input source)
+        let savedProvider = appDelegate.shortcutLayoutCharacterProvider
+        appDelegate.shortcutLayoutCharacterProvider = { _, _ in "ㅅ" }
+        defer { appDelegate.shortcutLayoutCharacterProvider = savedProvider }
+
+        guard let event = makeKeyEvent(
+            type: .keyDown,
+            key: "ㅅ",
+            modifiers: [.command],
+            keyCode: 17, // kVK_ANSI_T
+            windowNumber: window.windowNumber,
+            charsIgnoringModifiers: "ㅅ"
+        ) else {
+            XCTFail("Failed to construct Korean IME Cmd+T event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event),
+                       "Cmd+T should match newSurface even with Korean IME active")
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertEqual(workspace.panels.count, surfaceCountBefore + 1,
+                        "Cmd+T with Korean IME should create a new surface")
+    }
+
+    func testCmdShiftLMatchesOpenBrowserWithKoreanIMECharacters() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let window = window(withId: windowId) else {
+            XCTFail("Expected window context")
+            return
+        }
+
+        appDelegate.tabManager = manager
+
+        // Simulate Korean 2-Set IME: physical L key (keyCode 37) but chars = "ㄹ"
+        let savedProvider = appDelegate.shortcutLayoutCharacterProvider
+        appDelegate.shortcutLayoutCharacterProvider = { _, _ in "ㄹ" }
+        defer { appDelegate.shortcutLayoutCharacterProvider = savedProvider }
+
+        guard let event = makeKeyEvent(
+            type: .keyDown,
+            key: "ㄹ",
+            modifiers: [.command, .shift],
+            keyCode: 37, // kVK_ANSI_L
+            windowNumber: window.windowNumber,
+            charsIgnoringModifiers: "ㄹ"
+        ) else {
+            XCTFail("Failed to construct Korean IME Cmd+Shift+L event")
+            return
+        }
+
+#if DEBUG
+        let handled = appDelegate.debugHandleCustomShortcut(event: event)
+        XCTAssertTrue(handled,
+                       "Cmd+Shift+L should match openBrowser even with Korean IME active")
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
     }
 
     private func closeWindow(withId windowId: UUID) {


### PR DESCRIPTION
## Summary

Keyboard shortcuts handled through `handleCustomShortcut` (not registered as SwiftUI menu items) fail when a CJK input method (Korean, Japanese, Chinese) is active. For example, Cmd+T (New Terminal) and Cmd+Shift+L (Open Browser) do not work with Korean 2-Set IME, while menu-registered shortcuts like Cmd+B (Toggle Sidebar) and Cmd+D (Split Right) work fine because AppKit's menu system processes them before the IME.

**Root cause:** When a CJK IME is active, `event.charactersIgnoringModifiers` returns non-ASCII characters (e.g. "ㅅ" for the T key). Two gates in `matchShortcut` treat these non-ASCII characters as valid character data and block the ANSI keyCode fallback path:

1. The strict character-match gate returns `false` early for letter-based Command shortcuts when characters are present but don't match
2. The ANSI keyCode fallback condition requires both event characters and layout characters to be absent, but Korean characters are non-empty

**Fix:** Treat non-ASCII characters from CJK input methods as absent for shortcut matching purposes — they cannot match ASCII shortcut keys, so the function falls through to keyCode-based matching which correctly identifies the physical key.

## Test plan

- [x] Manually verified: Cmd+T creates new terminal with Korean 2-Set IME active
- [x] Manually verified: Cmd+Shift+L opens browser with Korean 2-Set IME active
- [x] Manually verified: Both shortcuts still work with English input source
- [x] Manually verified: Menu-registered shortcuts (Cmd+B, Cmd+D) unaffected
- [ ] Added unit tests simulating Korean IME events for Cmd+T and Cmd+Shift+L
- [ ] CI: existing shortcut routing tests pass

Fixes #1545

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom keyboard shortcuts failing when a CJK IME is active by ignoring non-ASCII IME characters and falling back to ANSI keyCode matching. Restores shortcuts like Cmd+T and Cmd+Shift+L under Korean/Japanese/Chinese IMEs without affecting menu-registered shortcuts.

- **Bug Fixes**
  - Only treat `charactersIgnoringModifiers` and layout characters as usable when they are ASCII; otherwise match by physical `keyCode`.
  - Added tests simulating Korean IME for Cmd+T and Cmd+Shift+L; existing shortcut routing tests continue to pass.

<sup>Written for commit d7acb86cd2c9786875996612c9d71bb87a5f8d41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Command-key shortcut handling with Asian input methods (Korean, Japanese, Chinese). Shortcuts now reliably trigger when using CJK input method editors, fixing cases where non-ASCII characters previously prevented keyboard shortcuts from functioning.

* **Tests**
  * Added test coverage for Command-key shortcut behavior with Korean IME input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->