### PR TITLE
Fix Claude remote-control wrapper passthrough in cmux

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -18,6 +18,65 @@ find_real_claude() {
     return 1
 }
 
+# Return 0 for Claude global options that require a separate value.
+claude_option_requires_value() {
+    case "${1:-}" in
+        --add-dir|--agent|--agents|--allowedTools|--allowed-tools|--append-system-prompt|--betas|--debug-file|--disallowedTools|--disallowed-tools|--effort|--fallback-model|--file|--input-format|--json-schema|--max-budget-usd|--mcp-config|--model|--name|--output-format|--permission-mode|--plugin-dir|--session-id|--setting-sources|--settings|--system-prompt|--tools|-n)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Return 0 when the first Claude subcommand should bypass cmux hook/session
+# injection entirely. These commands manage Claude itself rather than launching
+# a normal interactive coding session, and some of them reject --session-id.
+claude_passthrough_subcommand() {
+    case "${1:-}" in
+        api-key|auth|config|doctor|help|install|mcp|plugin|plugins|rc|remote-control|setup-token|update|upgrade)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+claude_invocation_has_passthrough_subcommand() {
+    local arg
+    local pending_value=0
+
+    for arg in "$@"; do
+        if [[ "$pending_value" == "1" ]]; then
+            pending_value=0
+            continue
+        fi
+
+        case "$arg" in
+            --)
+                return 1
+                ;;
+            --*=*)
+                continue
+                ;;
+            -*)
+                if claude_option_requires_value "$arg"; then
+                    pending_value=1
+                fi
+                continue
+                ;;
+            *)
+                claude_passthrough_subcommand "$arg"
+                return $?
+                ;;
+        esac
+    done
+
+    return 1
+}
+
 # Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
 cmux_socket_available() {
     local socket="${CMUX_SOCKET_PATH:-}"
@@ -55,14 +114,14 @@ fi
 # Find real claude.
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
-# Pass through subcommands that don't support session/hook flags.
-case "${1:-}" in
-    mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
-esac
-
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
 # independent sessions even when the parent shell was launched from Claude Code.
 unset CLAUDECODE
+
+# Pass through subcommands that don't support session/hook flags.
+if claude_invocation_has_passthrough_subcommand "$@"; then
+    exec "$REAL_CLAUDE" "$@"
+fi
 
 # Check if the user already specified a session/resume flag.
 # If so, don't inject our own --session-id (it would conflict).

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -18,10 +18,35 @@ find_real_claude() {
     return 1
 }
 
-# Return 0 for Claude global options that require a separate value.
-claude_option_requires_value() {
+# Return 0 for Claude global options that require exactly one separate value.
+claude_option_requires_single_value() {
     case "${1:-}" in
-        --add-dir|--agent|--agents|--allowedTools|--allowed-tools|--append-system-prompt|--betas|--debug-file|--disallowedTools|--disallowed-tools|--effort|--fallback-model|--file|--input-format|--json-schema|--max-budget-usd|--mcp-config|--model|--name|--output-format|--permission-mode|--plugin-dir|--session-id|--setting-sources|--settings|--system-prompt|--tools|-n)
+        --agent|--agents|--append-system-prompt|--debug-file|--effort|--fallback-model|--input-format|--json-schema|--max-budget-usd|--model|--name|--output-format|--permission-mode|--plugin-dir|--session-id|--setting-sources|--settings|--system-prompt|-n)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Return 0 for Claude global options whose separate-value form consumes all
+# following positional values until the next option token.
+claude_option_takes_variadic_values() {
+    case "${1:-}" in
+        --add-dir|--allowedTools|--allowed-tools|--betas|--disallowedTools|--disallowed-tools|--file|--mcp-config|--tools)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Return 0 for Claude global options with an optional separate value.
+claude_option_may_take_value() {
+    case "${1:-}" in
+        --debug|--from-pr|--resume|--worktree|-d|-r|-w)
             return 0
             ;;
         *)
@@ -31,11 +56,11 @@ claude_option_requires_value() {
 }
 
 # Return 0 when the first Claude subcommand should bypass cmux hook/session
-# injection entirely. These commands manage Claude itself rather than launching
-# a normal interactive coding session, and some of them reject --session-id.
+# injection entirely. Keep this list limited to real management commands so
+# prompts like "help" or legacy aliases do not get misclassified.
 claude_passthrough_subcommand() {
     case "${1:-}" in
-        api-key|auth|config|doctor|help|install|mcp|plugin|plugins|rc|remote-control|setup-token|update|upgrade)
+        agents|auth|doctor|install|mcp|plugin|plugins|rc|remote-control|setup-token|update|upgrade)
             return 0
             ;;
         *)
@@ -46,12 +71,31 @@ claude_passthrough_subcommand() {
 
 claude_invocation_has_passthrough_subcommand() {
     local arg
-    local pending_value=0
+    local pending_required_value=0
+    local pending_optional_value=0
+    local pending_variadic_values=0
 
     for arg in "$@"; do
-        if [[ "$pending_value" == "1" ]]; then
-            pending_value=0
+        if [[ "$pending_required_value" == "1" ]]; then
+            pending_required_value=0
             continue
+        fi
+
+        if [[ "$pending_optional_value" == "1" ]]; then
+            pending_optional_value=0
+            if [[ "$arg" != -- && "$arg" != -* ]]; then
+                continue
+            fi
+        fi
+
+        if [[ "$pending_variadic_values" == "1" ]]; then
+            if [[ "$arg" == -- ]]; then
+                return 1
+            fi
+            if [[ "$arg" != -* ]]; then
+                continue
+            fi
+            pending_variadic_values=0
         fi
 
         case "$arg" in
@@ -62,8 +106,12 @@ claude_invocation_has_passthrough_subcommand() {
                 continue
                 ;;
             -*)
-                if claude_option_requires_value "$arg"; then
-                    pending_value=1
+                if claude_option_requires_single_value "$arg"; then
+                    pending_required_value=1
+                elif claude_option_takes_variadic_values "$arg"; then
+                    pending_variadic_values=1
+                elif claude_option_may_take_value "$arg"; then
+                    pending_optional_value=1
                 fi
                 continue
                 ;;
@@ -128,7 +176,7 @@ fi
 SKIP_SESSION_ID=false
 for arg in "$@"; do
     case "$arg" in
-        --resume|--resume=*|--session-id|--session-id=*|--continue|-c)
+        --resume|--resume=*|--from-pr|--from-pr=*|--session-id|--session-id=*|--continue|-c|-r)
             SKIP_SESSION_ID=true
             break
             ;;

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -178,11 +178,40 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
 
 
+def test_remote_control_passthrough_skips_hook_injection(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(socket_state="live", argv=["remote-control"])
+    expect(code == 0, f"remote-control: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["remote-control"], f"remote-control: expected passthrough args, got {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"remote-control: expected cmux ping probe, got {cmux_log}", failures)
+    expect("--settings" not in real_argv, f"remote-control: should not inject --settings, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"remote-control: should not inject --session-id, got {real_argv}", failures)
+    expect(claudecode == "__UNSET__", f"remote-control: expected CLAUDECODE unset, got {claudecode!r}", failures)
+
+
+def test_remote_control_passthrough_after_global_option(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(
+        socket_state="live",
+        argv=["--model", "sonnet", "rc"],
+    )
+    expect(code == 0, f"--model rc: wrapper exited {code}: {stderr}", failures)
+    expect(
+        real_argv == ["--model", "sonnet", "rc"],
+        f"--model rc: expected passthrough args, got {real_argv}",
+        failures,
+    )
+    expect(any(" ping" in line for line in cmux_log), f"--model rc: expected cmux ping probe, got {cmux_log}", failures)
+    expect("--settings" not in real_argv, f"--model rc: should not inject --settings, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"--model rc: should not inject --session-id, got {real_argv}", failures)
+    expect(claudecode == "__UNSET__", f"--model rc: expected CLAUDECODE unset, got {claudecode!r}", failures)
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_remote_control_passthrough_skips_hook_injection(failures)
+    test_remote_control_passthrough_after_global_option(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -205,6 +205,61 @@ def test_remote_control_passthrough_after_global_option(failures: list[str]) -> 
     expect(claudecode == "__UNSET__", f"--model rc: expected CLAUDECODE unset, got {claudecode!r}", failures)
 
 
+def test_remote_control_passthrough_after_inline_global_option(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(
+        socket_state="live",
+        argv=["--model=sonnet", "rc"],
+    )
+    expect(code == 0, f"--model= rc: wrapper exited {code}: {stderr}", failures)
+    expect(
+        real_argv == ["--model=sonnet", "rc"],
+        f"--model= rc: expected passthrough args, got {real_argv}",
+        failures,
+    )
+    expect(any(" ping" in line for line in cmux_log), f"--model= rc: expected cmux ping probe, got {cmux_log}", failures)
+    expect("--settings" not in real_argv, f"--model= rc: should not inject --settings, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"--model= rc: should not inject --session-id, got {real_argv}", failures)
+    expect(claudecode == "__UNSET__", f"--model= rc: expected CLAUDECODE unset, got {claudecode!r}", failures)
+
+
+def test_resume_value_named_like_passthrough_command_keeps_injection(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(
+        socket_state="live",
+        argv=["-r", "remote-control"],
+    )
+    expect(code == 0, f"-r remote-control: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"-r remote-control: missing --settings in args: {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"-r remote-control: should not inject --session-id, got {real_argv}", failures)
+    expect(real_argv[-2:] == ["-r", "remote-control"], f"-r remote-control: expected original args at tail, got {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"-r remote-control: expected cmux ping probe, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"-r remote-control: expected CLAUDECODE unset, got {claudecode!r}", failures)
+
+
+def test_variadic_global_option_value_named_like_passthrough_command_keeps_injection(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(
+        socket_state="live",
+        argv=["--mcp-config", "a.json", "remote-control"],
+    )
+    expect(code == 0, f"--mcp-config remote-control: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"--mcp-config remote-control: missing --settings in args: {real_argv}", failures)
+    expect("--session-id" in real_argv, f"--mcp-config remote-control: missing --session-id in args: {real_argv}", failures)
+    expect(
+        real_argv[-3:] == ["--mcp-config", "a.json", "remote-control"],
+        f"--mcp-config remote-control: expected original args at tail, got {real_argv}",
+        failures,
+    )
+    expect(
+        any(" ping" in line for line in cmux_log),
+        f"--mcp-config remote-control: expected cmux ping probe, got {cmux_log}",
+        failures,
+    )
+    expect(
+        claudecode == "__UNSET__",
+        f"--mcp-config remote-control: expected CLAUDECODE unset, got {claudecode!r}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
@@ -212,6 +267,9 @@ def main() -> int:
     test_stale_socket_skips_hook_injection(failures)
     test_remote_control_passthrough_skips_hook_injection(failures)
     test_remote_control_passthrough_after_global_option(failures)
+    test_remote_control_passthrough_after_inline_global_option(failures)
+    test_resume_value_named_like_passthrough_command_keeps_injection(failures)
+    test_variadic_global_option_value_named_like_passthrough_command_keeps_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
## Summary
- add regression coverage for Claude wrapper passthrough when invoking `claude rc` / `claude remote-control`
- stop cmux from injecting `--session-id` / `--settings` into passthrough Claude subcommands after leading global options
- clear nested `CLAUDECODE` markers before passthrough execs so cmux-launched sessions stay isolated

## Verification
- built and launched `./scripts/reload.sh --tag issue-1782-claude-rc`
- verified the tagged app bundle includes the updated `Resources/bin/claude` wrapper
- verified the tagged bundle's wrapper reaches Claude's own remote-control path instead of failing with `Unknown argument: <uuid>`

Fixes #1782

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `claude` wrapper in `cmux` to correctly passthrough `rc`/`remote-control` and other management commands without injecting session/settings flags. Improves option parsing so values aren’t mistaken for subcommands and clears `CLAUDECODE` to isolate sessions. Fixes #1782.

- **Bug Fixes**
  - Treat `rc`/`remote-control` and other management commands as passthrough, even after global options (including inline forms).
  - For passthrough, do not inject `--session-id` or `--settings`; always unset `CLAUDECODE`. Honor `--resume`/`-r` and `--from-pr` by skipping `--session-id`.
  - Add regression tests for passthrough after options and for edge cases where option values resemble subcommands.

<sup>Written for commit b7f0d16bcd7ab7a1e936f2880a15237a9b1af7fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI wrapper now more reliably detects management/configuration/update commands and skips injecting internal session/settings parameters (includes broader command set and resume-like flag handling).

* **Tests**
  * Added regression tests covering passthrough behavior for management commands (including cases with global options and resume-like flags) to ensure correct injection or skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->