### PR TITLE
Fix keyboard shortcuts not working with non-Latin IME (#1790)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10446,6 +10446,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return false
     }
 
+    /// Whether every character in the string is in the Basic Latin range (U+0020–U+007E).
+    /// Returns `false` for CJK characters, Korean jamo, etc. so that non-Latin
+    /// `charactersIgnoringModifiers` from an active IME are treated as absent.
+    private func isBasicLatinCharacters(_ string: String) -> Bool {
+        string.unicodeScalars.allSatisfy { $0.value >= 0x0020 && $0.value <= 0x007E }
+    }
+
     /// Match a shortcut against an event, handling normal keys.
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
         // Some keys can include extra flags (e.g. .function) depending on the responder chain.
@@ -10472,7 +10479,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // For command-based shortcuts, trust AppKit's layout-aware characters when present.
         // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
         // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
-        let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
+        let hasEventChars = {
+            guard let chars = eventCharsIgnoringModifiers, !chars.isEmpty else { return false }
+            return isBasicLatinCharacters(chars)
+        }()
         if hasEventChars,
            flags.contains(.command),
            !flags.contains(.control),

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -19,7 +19,7 @@ class KeyboardLayout {
         forKeyCode keyCode: UInt16,
         modifierFlags: NSEvent.ModifierFlags = []
     ) -> String? {
-        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
               let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
             return nil
         }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3146,6 +3146,175 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             defaults.removeObject(forKey: key)
         }
     }
+
+    // MARK: - Korean (CJK) IME shortcut routing
+
+    func testCmdPMatchesViaLayoutFallbackWhenCharactersAreKoreanJamo() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        // Simulate Korean IME: layout provider returns the correct Latin letter
+        // for the underlying QWERTY layout.
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 35 ? "p" : nil // kVK_ANSI_P
+        }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        let switcherExpectation = expectation(
+            description: "Cmd+P with Korean jamo characters should match via layout fallback"
+        )
+        let token = NotificationCenter.default.addObserver(
+            forName: .commandPaletteSwitcherRequested,
+            object: nil,
+            queue: nil
+        ) { _ in
+            switcherExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        // Korean jamo "ㅔ" in charactersIgnoringModifiers (as Korean IME would produce for P key)
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "ㅔ",
+            charactersIgnoringModifiers: "ㅔ",
+            isARepeat: false,
+            keyCode: 35 // kVK_ANSI_P
+        ) else {
+            XCTFail("Failed to construct Cmd+P event with Korean jamo characters")
+            return
+        }
+
+        XCTAssertTrue(appDelegate.handleBrowserSurfaceKeyEquivalent(event))
+        wait(for: [switcherExpectation], timeout: 0.15)
+    }
+
+    func testKoreanIMERespectUnderlyingLayoutNotJustKeyCode() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        // Simulate Korean IME over a non-QWERTY layout (e.g. QWERTZ) where
+        // keyCode 35 maps to a different letter than "p".
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 35 ? "z" : nil // QWERTZ: physical P key produces "z"
+        }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        let switcherExpectation = expectation(
+            description: "Cmd+P should NOT fire when underlying layout maps keyCode to a different letter"
+        )
+        switcherExpectation.isInverted = true
+        let token = NotificationCenter.default.addObserver(
+            forName: .commandPaletteSwitcherRequested,
+            object: nil,
+            queue: nil
+        ) { _ in
+            switcherExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "ㅔ",
+            charactersIgnoringModifiers: "ㅔ",
+            isARepeat: false,
+            keyCode: 35 // kVK_ANSI_P
+        ) else {
+            XCTFail("Failed to construct Cmd+P event with Korean jamo characters")
+            return
+        }
+
+        _ = appDelegate.handleBrowserSurfaceKeyEquivalent(event)
+        wait(for: [switcherExpectation], timeout: 0.15)
+    }
+
+    func testLatinCharactersTrustedOverLayoutTranslation() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        // Layout provider returns a different letter, but AppKit gives valid Latin "p".
+        // The Latin character should be trusted (no regression for normal keyboard layouts).
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 35 ? "z" : nil
+        }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        let switcherExpectation = expectation(
+            description: "Cmd+P with Latin characters should fire even if layout returns a different letter"
+        )
+        let token = NotificationCenter.default.addObserver(
+            forName: .commandPaletteSwitcherRequested,
+            object: nil,
+            queue: nil
+        ) { _ in
+            switcherExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "p",
+            charactersIgnoringModifiers: "p",
+            isARepeat: false,
+            keyCode: 35 // kVK_ANSI_P
+        ) else {
+            XCTFail("Failed to construct Cmd+P event with Latin characters")
+            return
+        }
+
+        XCTAssertTrue(appDelegate.handleBrowserSurfaceKeyEquivalent(event))
+        wait(for: [switcherExpectation], timeout: 0.15)
+    }
 }
 
 private final class CommandPaletteMarkedTextFieldEditor: NSTextView {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3257,7 +3257,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        _ = appDelegate.handleBrowserSurfaceKeyEquivalent(event)
+        XCTAssertFalse(
+            appDelegate.handleBrowserSurfaceKeyEquivalent(event),
+            "Cmd+P should not be consumed when layout translation resolves to a different letter"
+        )
         wait(for: [switcherExpectation], timeout: 0.15)
     }
 


### PR DESCRIPTION
## Summary
- Fix Cmd+letter shortcuts (Cmd+T, Cmd+Shift+L, Cmd+Shift+M, etc.) not
  firing when a non-Latin IME (Korean, Japanese, Chinese) is active
- Use `TISCopyCurrentKeyboardLayoutInputSource()` to resolve the
  underlying keyboard layout through the IME
- Treat non-Basic-Latin `charactersIgnoringModifiers` as absent to allow
  layout translation fallback

Closes #1790

## Test plan
- [x] Manual: Korean IME active → Cmd+T, Cmd+Shift+L, Cmd+Shift+M work
- [ ] CI: 3 new unit tests for IME shortcut routing
- [ ] Regression: English/Dvorak shortcuts still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+letter shortcuts not firing with non‑Latin IMEs by resolving the ASCII‑capable layout and ignoring non‑Latin event characters. Shortcuts like Cmd+P, Cmd+T, and Cmd+Shift+L/M now work without regressing English/Dvorak.

- **Bug Fixes**
  - Use `TISCopyCurrentKeyboardLayoutInputSource()` to resolve the ASCII‑capable layout through IMEs.
  - Only trust `charactersIgnoringModifiers` when all chars are Basic Latin (U+0020–U+007E); add a helper to enforce this so CJK/jamo are treated as absent for Command shortcuts.
  - Add 3 tests (Korean jamo fallback Cmd+P; respect underlying layout over raw keyCode; trust Latin chars when present) and explicitly assert non‑consumption in the negative case.

<sup>Written for commit 40f9280b4d1fb00b6438145211e7840b9f23a4cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut recognition for non-Latin input so shortcuts use typed Latin characters when present and correctly fall back to keyboard layout when IME produces non-Basic-Latin characters.

* **Tests**
  * Added tests verifying shortcut routing with Korean IME, layout-fallback behavior, and precedence of Latin event characters for shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->