### PR TITLE
Skip hanging test in compat CI to match ci.yml

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -130,7 +130,9 @@ jobs:
             xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug \
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -disableAutomaticPackageResolution \
-              -destination "platform=macOS" test 2>&1
+              -destination "platform=macOS" \
+              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
+              test 2>&1
           }
 
           set +e


### PR DESCRIPTION
## Summary
- PR #1783 added `-skip-testing` for `testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace` in `ci.yml` but missed `ci-macos-compat.yml`
- The test hangs on headless runners because Ghostty PTY teardown blocks without a TTY, causing both compat jobs to hit the 30-minute timeout

## Test plan
- [ ] Verify `compat-tests (warp-macos-15-arm64-6x)` passes
- [ ] Verify `compat-tests (warp-macos-26-arm64-6x)` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added -skip-testing for `cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace` in `ci-macos-compat.yml` to match `ci.yml`. This prevents hangs on headless runners (PTY teardown without a TTY) and stops compat jobs from hitting the 30‑minute timeout.

<sup>Written for commit c252c6e3fae27012a17b3bc73232fa8777f49c9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified macOS unit test configuration in the continuous integration pipeline to skip a specific test case during automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->