### PR TITLE
Fix headless Cmd+W shortcut test on CI

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -131,7 +131,6 @@ jobs:
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
-              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               test 2>&1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
-              -skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace \
               test 2>&1
           }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -676,10 +676,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertNil(self.window(withId: windowId), "Confirming Cmd+Ctrl+W should close the window")
     }
 
-    // NOTE: This test is skipped in CI via -skip-testing in ci.yml because closing
-    // the last Ghostty surface tears down the PTY/shell, which blocks indefinitely
-    // on headless runners. The xcodebuild test host doesn't inherit CI env vars,
-    // so XCTSkip can't detect CI from inside the test.
     func testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -693,13 +689,28 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         defer { closeWindow(withId: windowId) }
 
         guard let targetWindow = window(withId: windowId),
-              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
-            XCTFail("Expected test window and manager")
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let terminalPanel = workspace.focusedTerminalPanel,
+              let targetSurfaceView = surfaceView(in: terminalPanel.hostedView) else {
+            XCTFail("Expected test window, manager, workspace, and terminal panel")
             return
         }
 
         XCTAssertEqual(manager.tabs.count, 1)
         XCTAssertEqual(manager.tabs[0].panels.count, 1)
+        targetWindow.makeKeyAndOrderFront(nil)
+        XCTAssertTrue(targetWindow.makeFirstResponder(targetSurfaceView), "Expected Ghostty view to become first responder")
+        XCTAssertTrue(targetWindow.firstResponder === targetSurfaceView, "Expected Ghostty view to own first responder")
+
+#if DEBUG
+        // Keep the real Ghostty view for shortcut routing, but release the runtime
+        // surface so headless CI does not have to tear down a live PTY on window close.
+        terminalPanel.surface.releaseSurfaceForTesting()
+        XCTAssertNil(terminalPanel.surface.surface, "Expected test helper to release the runtime surface")
+#else
+        XCTFail("releaseSurfaceForTesting is only available in DEBUG")
+#endif
 
         guard let event = makeKeyDownEvent(
             key: "w",


### PR DESCRIPTION
## Summary
- release the runtime Ghostty surface before the Cmd+W shortcut test closes the last window so the test can run on headless CI
- remove the AppDelegateShortcutRoutingTests skip from both unit-test workflows

## Testing
- `./scripts/setup.sh`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1803-headless-ci-test-hang build`

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/1803


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the headless Cmd+W shortcut test by releasing the runtime Ghostty surface before closing the last window, preventing CI hangs. Re-enables the test in both macOS unit-test workflows (closes #1803).

- **Bug Fixes**
  - In `AppDelegateShortcutRoutingTests`, ensure the Ghostty view is first responder, then call `releaseSurfaceForTesting()` (DEBUG) before Cmd+W to avoid PTY teardown on headless CI.
  - Removed `-skip-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdWClosesWindowWhenClosingLastSurfaceInLastWorkspace` from `.github/workflows/ci.yml` and `.github/workflows/ci-macos-compat.yml`.

<sup>Written for commit adce2dd3124c5c66fd397c44cb5155cfc9584ea6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled a previously excluded test case in the CI workflow and enhanced its validation logic with improved setup checks and first responder assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->