### PR TITLE
feat: add set-workspace-color CLI command and socket handler

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2202,11 +2202,25 @@ struct CMUXCLI {
         case "set-workspace-color":
             let (colorFlag, r1) = parseOption(commandArgs, name: "--color")
             let (wsFlag, r2) = parseOption(r1, name: "--workspace")
+            let clearRequested = r2.contains("--clear")
+
+            // Reject dangling flags (e.g. --color with no value consumed by parseOption)
+            if r2.contains("--color") {
+                throw CLIError(message: "set-workspace-color: --color requires a value")
+            }
+            if r2.contains("--workspace") {
+                throw CLIError(message: "set-workspace-color: --workspace requires a value")
+            }
+            if let unknown = r2.first(where: { $0.hasPrefix("--") && $0 != "--clear" && $0 != "--" }) {
+                throw CLIError(message: "set-workspace-color: unknown flag '\(unknown)'")
+            }
 
             let color: String
-            if let colorFlag {
+            if let colorFlag, !clearRequested {
                 color = colorFlag
-            } else if let positional = r2.first(where: { $0 != "--clear" && !$0.hasPrefix("--") }) {
+            } else if clearRequested {
+                color = "clear"
+            } else if let positional = r2.first(where: { !$0.hasPrefix("--") }) {
                 color = positional
             } else {
                 color = "clear"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2199,6 +2199,24 @@ struct CMUXCLI {
                 throw error
             }
 
+        case "set-workspace-color":
+            let (colorFlag, r1) = parseOption(commandArgs, name: "--color")
+            let (wsFlag, r2) = parseOption(r1, name: "--workspace")
+
+            let color: String
+            if let colorFlag {
+                color = colorFlag
+            } else if let positional = r2.first(where: { $0 != "--clear" && !$0.hasPrefix("--") }) {
+                color = positional
+            } else {
+                color = "clear"
+            }
+
+            let workspaceArg = wsFlag ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let wsId = try resolveWorkspaceId(workspaceArg, client: client)
+            let socketCmd = "set_workspace_color \(socketQuote(color)) --tab=\(wsId)"
+            let response = try sendV1Command(socketCmd, client: client)
+            print(response)
         case "set-app-focus":
             guard let value = commandArgs.first else { throw CLIError(message: "set-app-focus requires a value") }
             let response = try sendV1Command("set_app_focus \(value)", client: client)
@@ -6815,6 +6833,24 @@ struct CMUXCLI {
             Example:
               cmux clear-progress
             """
+        case "set-workspace-color":
+            return """
+            Usage: cmux set-workspace-color [flags] [<#hex|clear>]
+
+            Set or clear the workspace tab color. This is the same visual effect
+            as right-click > Workspace Color in the UI.
+
+            Flags:
+              --color <#hex>         Hex color (e.g. "#007AFF", "#ff9500")
+              --clear                Clear the custom color
+              --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
+
+            Example:
+              cmux set-workspace-color --color "#007AFF"
+              cmux set-workspace-color "#ff9500" --workspace workspace:2
+              cmux set-workspace-color --clear
+              cmux set-workspace-color clear
+            """
         case "log":
             return """
             Usage: cmux log [flags] [--] <message>
@@ -11076,6 +11112,7 @@ struct CMUXCLI {
           list-notifications
           clear-notifications
           claude-hook <session-start|stop|notification> [--workspace <id|ref>] [--surface <id|ref>]
+          set-workspace-color [--color <#hex> | --clear] [--workspace <id|ref>]
           set-app-focus <active|inactive|clear>
           simulate-app-active
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1731,6 +1731,9 @@ class TerminalController {
         case "set_status":
             return setStatus(args)
 
+        case "set_workspace_color":
+            return setWorkspaceColor(args)
+
         case "report_meta":
             return reportMeta(args)
 
@@ -14252,6 +14255,36 @@ class TerminalController {
             args,
             missingError: "ERROR: Missing status key or value — usage: set_status <key> <value> [--icon=X] [--color=#hex] [--url=X] [--priority=N] [--format=plain|markdown] [--tab=X]"
         )
+    }
+
+    /// Set or clear the workspace tab color.
+    /// Usage: set_workspace_color <#hex|clear|none> [--tab=X]
+    private func setWorkspaceColor(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        guard let colorArg = parsed.positional.first else {
+            return "ERROR: Missing color argument — usage: set_workspace_color <#hex|clear|none> [--tab=X]"
+        }
+
+        let color: String?
+        let lowered = colorArg.lowercased()
+        if lowered == "clear" || lowered == "none" {
+            color = nil
+        } else {
+            guard let normalized = WorkspaceTabColorSettings.normalizedHex(colorArg) else {
+                return "ERROR: Invalid hex color: \(colorArg)"
+            }
+            color = normalized
+        }
+
+        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
+        guard let targetTabId = tabResolution.tabId else {
+            return tabResolution.error ?? "ERROR: No tab selected"
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+            tab.setCustomColor(color)
+        }
+        return "OK"
     }
 
     private func reportMeta(_ args: String) -> String {


### PR DESCRIPTION
## Summary

Add `set-workspace-color` CLI command and socket handler to programmatically set workspace tab colors — the same visual effect as right-click → Workspace Color in the UI.

**Motivation**: Automation tools (e.g. Emacs integration, scripts) need to visually distinguish workspaces by project. Currently workspace color can only be set via the UI context menu. This PR exposes it via the CLI and socket API.

## Usage

```bash
# Set workspace color by hex
cmux set-workspace-color --color "#007AFF"
cmux set-workspace-color --color "#FF3B30" --workspace workspace:5

# Clear workspace color
cmux set-workspace-color --clear

# Positional syntax also works
cmux set-workspace-color "#34C759"
cmux set-workspace-color clear
```

Socket protocol: `set_workspace_color <#hex|clear|none> [--tab=UUID]`

## Implementation

- **CLI** (`CLI/cmux.swift`): `parseOption` for flags, `resolveWorkspaceId` for workspace resolution, `socketQuote` for injection safety
- **Socket handler** (`Sources/TerminalController.swift`): `resolveTabIdForSidebarMutation` (off-main) + `DispatchQueue.main.async` mutation — follows the same threading pattern as `upsertSidebarMetadata`
- Reuses `WorkspaceTabColorSettings.normalizedHex()` for hex validation (6-digit hex, `#` optional)
- Reuses `Workspace.setCustomColor()` for the actual mutation
- No new dependencies or types — purely wires existing internals to the socket/CLI layer

## Testing

Tested manually via the dev build (`reload.sh --tag emacs-test`):

| Test | Input | Expected | Result |
|------|-------|----------|--------|
| Set blue | `#007AFF` | `sidebar-state` shows `color=#007AFF` | ✅ |
| Set red | `#FF3B30` | `color=#FF3B30` | ✅ |
| Set green | `#34C759` | `color=#34C759` | ✅ |
| Clear | `clear` | `color=none` | ✅ |
| Invalid hex | `xyz` | `ERROR: Invalid hex color: xyz` | ✅ |
| Injection attempt | `"#007AFF --tab=evil"` | Rejected as invalid hex | ✅ |
| No `#` prefix | `007AFF` | `color=#007AFF` (accepted) | ✅ |

Visual verification: workspace tab color changes immediately in the sidebar after each command.

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `set-workspace-color` CLI command to customize workspace tab colors using hex codes or clear custom colors.
  * Accepts positional color or `--color`/`--clear` flags and targets a workspace via option or environment fallback when no window is selected.
  * Sends the change to the server and prints the response immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->