### PR TITLE
feat: configurable browser homepage URL

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -8914,13 +8914,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Loading\u2026"
+            "value": "Loading…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\u8aad\u307f\u8fbc\u307f\u4e2d\u2026"
+            "value": "読み込み中…"
           }
         }
       }
@@ -77511,6 +77511,54 @@
           "stringUnit": {
             "state": "translated",
             "value": "Varsayılan"
+          }
+        }
+      }
+    },
+    "settings.browser.homepage": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homepage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホームページ"
+          }
+        }
+      }
+    },
+    "settings.browser.homepage.subtitle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL to open in new browser tabs. Leave empty for blank page."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブラウザタブで開くURL。空白ページの場合は空のままにしてください。"
+          }
+        }
+      }
+    },
+    "settings.browser.homepage.placeholder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com"
           }
         }
       }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -157,9 +157,14 @@ enum BrowserHomepageSettings {
     static let homepageURLKey = "browserHomepageURL"
 
     static func currentHomepageURL(defaults: UserDefaults = .standard) -> URL? {
-        guard let raw = defaults.string(forKey: homepageURLKey),
-              !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              let url = URL(string: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard let raw = defaults.string(forKey: homepageURLKey) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              components.host?.isEmpty == false,
+              let url = components.url
         else {
             return nil
         }
@@ -2559,6 +2564,7 @@ final class BrowserPanel: Panel, ObservableObject {
         workspaceId: UUID,
         profileID: UUID? = nil,
         initialURL: URL? = nil,
+        useHomepageFallback: Bool = true,
         bypassInsecureHTTPHostOnce: String? = nil,
         proxyEndpoint: BrowserProxyEndpoint? = nil,
         isRemoteWorkspace: Bool = false,
@@ -2680,7 +2686,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
 
         // Navigate to initial URL if provided, otherwise to homepage if configured
-        let effectiveURL = initialURL ?? BrowserHomepageSettings.currentHomepageURL()
+        let effectiveURL = initialURL ?? (useHomepageFallback ? BrowserHomepageSettings.currentHomepageURL() : nil)
         if let url = effectiveURL {
             shouldRenderWebView = true
             navigate(to: url)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -153,6 +153,20 @@ enum BrowserSearchSettings {
     }
 }
 
+enum BrowserHomepageSettings {
+    static let homepageURLKey = "browserHomepageURL"
+
+    static func currentHomepageURL(defaults: UserDefaults = .standard) -> URL? {
+        guard let raw = defaults.string(forKey: homepageURLKey),
+              !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let url = URL(string: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return nil
+        }
+        return url
+    }
+}
+
 enum BrowserThemeMode: String, CaseIterable, Identifiable {
     case system
     case light
@@ -2665,8 +2679,9 @@ final class BrowserPanel: Panel, ObservableObject {
             self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
 
-        // Navigate to initial URL if provided
-        if let url = initialURL {
+        // Navigate to initial URL if provided, otherwise to homepage if configured
+        let effectiveURL = initialURL ?? BrowserHomepageSettings.currentHomepageURL()
+        if let url = effectiveURL {
             shouldRenderWebView = true
             navigate(to: url)
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3567,7 +3567,8 @@ class TabManager: ObservableObject {
                inPane: originalPane,
                url: snapshot.url,
                focus: true,
-               preferredProfileID: snapshot.profileID
+               preferredProfileID: snapshot.profileID,
+               useHomepageFallback: false
            ) {
             let tabCount = workspace.bonsplitController.tabs(inPane: originalPane).count
             let maxIndex = max(0, tabCount - 1)
@@ -3586,7 +3587,8 @@ class TabManager: ObservableObject {
                orientation: orientation,
                insertFirst: snapshot.fallbackSplitInsertFirst,
                url: snapshot.url,
-               preferredProfileID: snapshot.profileID
+               preferredProfileID: snapshot.profileID,
+               useHomepageFallback: false
            )?.id {
             return browserPanelId
         }
@@ -3598,7 +3600,8 @@ class TabManager: ObservableObject {
             inPane: focusedPane,
             url: snapshot.url,
             focus: true,
-            preferredProfileID: snapshot.profileID
+            preferredProfileID: snapshot.profileID,
+            useHomepageFallback: false
         )?.id
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6933,7 +6933,8 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         url: URL? = nil,
         preferredProfileID: UUID? = nil,
-        focus: Bool = true
+        focus: Bool = true,
+        useHomepageFallback: Bool = true
     ) -> BrowserPanel? {
         // Find the pane containing the source panel
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
@@ -6956,6 +6957,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: panelId
             ),
             initialURL: url,
+            useHomepageFallback: useHomepageFallback,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
             remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil
@@ -7020,7 +7022,8 @@ final class Workspace: Identifiable, ObservableObject {
         focus: Bool? = nil,
         insertAtEnd: Bool = false,
         preferredProfileID: UUID? = nil,
-        bypassInsecureHTTPHostOnce: String? = nil
+        bypassInsecureHTTPHostOnce: String? = nil,
+        useHomepageFallback: Bool = true
     ) -> BrowserPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let sourcePanelId = effectiveSelectedPanelId(inPane: paneId)
@@ -7034,6 +7037,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: sourcePanelId
             ),
             initialURL: url,
+            useHomepageFallback: useHomepageFallback,
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3789,6 +3789,7 @@ struct SettingsView: View {
     @AppStorage("cmuxPortRange") private var cmuxPortRange = 10
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
     @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
+    @AppStorage(BrowserHomepageSettings.homepageURLKey) private var browserHomepageURL = ""
     @AppStorage(BrowserThemeSettings.modeKey) private var browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
     @AppStorage(BrowserImportHintSettings.variantKey) private var browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
     @AppStorage(BrowserImportHintSettings.showOnBlankTabsKey) private var showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
@@ -5059,6 +5060,20 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardRow(
+                            String(localized: "settings.browser.homepage", defaultValue: "Homepage"),
+                            subtitle: String(localized: "settings.browser.homepage.subtitle", defaultValue: "URL to open in new browser tabs. Leave empty for blank page."),
+                            controlWidth: pickerColumnWidth
+                        ) {
+                            TextField(
+                                String(localized: "settings.browser.homepage.placeholder", defaultValue: "https://example.com"),
+                                text: $browserHomepageURL
+                            )
+                            .textFieldStyle(.roundedBorder)
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsPickerRow(
                             String(localized: "settings.browser.theme", defaultValue: "Browser Theme"),
                             subtitle: selectedBrowserThemeMode == .system
@@ -5534,6 +5549,7 @@ struct SettingsView: View {
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
+        browserHomepageURL = ""
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
         browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
         showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2679,6 +2679,30 @@ final class BrowserHomepageSettingsTests: XCTestCase {
         let url = try XCTUnwrap(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
         XCTAssertEqual(url.absoluteString, "https://example.com")
     }
+
+    func testRejectsURLWithoutScheme() {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("example.com", forKey: BrowserHomepageSettings.homepageURLKey)
+        XCTAssertNil(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+    }
+
+    func testRejectsNonHTTPScheme() {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("ftp://example.com", forKey: BrowserHomepageSettings.homepageURLKey)
+        XCTAssertNil(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+    }
 }
 
 final class BrowserSearchSettingsTests: XCTestCase {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2618,6 +2618,69 @@ final class BrowserSearchEngineTests: XCTestCase {
 }
 
 
+final class BrowserHomepageSettingsTests: XCTestCase {
+    func testReturnsNilWhenUnset() {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertNil(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+    }
+
+    func testReturnsNilForEmptyString() {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("", forKey: BrowserHomepageSettings.homepageURLKey)
+        XCTAssertNil(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+    }
+
+    func testReturnsNilForWhitespaceOnly() {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("   ", forKey: BrowserHomepageSettings.homepageURLKey)
+        XCTAssertNil(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+    }
+
+    func testReturnsURLForValidString() throws {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("https://github.com", forKey: BrowserHomepageSettings.homepageURLKey)
+        let url = try XCTUnwrap(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+        XCTAssertEqual(url.absoluteString, "https://github.com")
+    }
+
+    func testTrimsWhitespace() throws {
+        let suiteName = "BrowserHomepageSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("  https://example.com  ", forKey: BrowserHomepageSettings.homepageURLKey)
+        let url = try XCTUnwrap(BrowserHomepageSettings.currentHomepageURL(defaults: defaults))
+        XCTAssertEqual(url.absoluteString, "https://example.com")
+    }
+}
+
 final class BrowserSearchSettingsTests: XCTestCase {
     func testCurrentSearchSuggestionsEnabledDefaultsToTrueWhenUnset() {
         let suiteName = "BrowserSearchSettingsTests.\(UUID().uuidString)"


### PR DESCRIPTION
## Summary

Add a homepage URL setting for the built-in browser. When configured, new browser tabs/splits open the homepage instead of `about:blank`.

- `BrowserHomepageSettings` in `BrowserPanel.swift` — defaults key + helper
- `BrowserPanel.init`: fallback to homepage when `initialURL` is nil
- Settings UI: text field in Browser section
- Reset to empty on "Reset All Settings"
- 5 unit tests for the settings helper

Configurable via Settings UI or `defaults write`:

```bash
defaults write com.cmux.app browserHomepageURL "https://example.com"
```

## Test plan

- [x] Unit tests pass: `BrowserHomepageSettingsTests` (5/5)
- [ ] Manual: set homepage in Settings, open new browser tab — should navigate to homepage
- [ ] Manual: clear homepage, open new browser tab — should show blank page
- [ ] Manual: `defaults write` sets homepage, new tab respects it
- [ ] Manual: "Reset All Settings" clears homepage

Closes #1807

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a homepage URL setting for the built-in browser. New tabs and splits open the homepage instead of about:blank when no URL is provided.

- **New Features**
  - Text field in Browser settings to set the homepage URL (empty = blank page).
  - Uses homepage only when no initial URL; restore/duplicate flows preserve blank tabs.
  - Validates URL (requires http/https and host); ignores invalid or schemeless entries.
  - "Reset All Settings" clears the homepage. Also configurable via: defaults write com.cmux.app browserHomepageURL "https://example.com"

<sup>Written for commit 9590ee3b19d7e16873942578292bd7107996cc10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser homepage customization in Settings with URL validation and trimming; empty/invalid values disable automatic homepage navigation.

* **Behavior Change**
  * Restored or reopened browser panels will not automatically replace their previous content with the homepage unless explicitly allowed.

* **Localization**
  * Added localized strings for the homepage setting (English and Japanese).

* **Tests**
  * Added unit tests covering homepage validation and trimming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->