### PR TITLE
feat: custom keyword search engines for browser omnibar

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -129,6 +129,53 @@ enum BrowserSearchEngine: String, CaseIterable, Identifiable {
     }
 }
 
+// MARK: - Custom Keyword Search Engines
+
+struct CustomSearchEngine: Codable, Identifiable, Hashable {
+    var id: UUID
+    var keyword: String
+    var name: String
+    var urlTemplate: String  // contains %s as placeholder
+
+    func searchURL(query: String) -> URL? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, urlTemplate.contains("%s") else { return nil }
+        // For path-position %s (before ?) don't encode slashes
+        let isInQuery = urlTemplate.contains("?") && urlTemplate.range(of: "%s")!.lowerBound > urlTemplate.range(of: "?")!.lowerBound
+        let encoded = isInQuery
+            ? trimmed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? trimmed
+            : trimmed
+        let resolved = urlTemplate.replacingOccurrences(of: "%s", with: encoded)
+        return URL(string: resolved)
+    }
+}
+
+enum CustomSearchEngineSettings {
+    static let enginesKey = "browserCustomSearchEngines"
+
+    static func currentEngines(defaults: UserDefaults = .standard) -> [CustomSearchEngine] {
+        guard let data = defaults.data(forKey: enginesKey) else { return [] }
+        return (try? JSONDecoder().decode([CustomSearchEngine].self, from: data)) ?? []
+    }
+
+    static func save(_ engines: [CustomSearchEngine], defaults: UserDefaults = .standard) {
+        guard let data = try? JSONEncoder().encode(engines) else { return }
+        defaults.set(data, forKey: enginesKey)
+    }
+
+    /// Match keyword prefix in input. Returns (engine, query) or nil.
+    static func match(input: String, defaults: UserDefaults = .standard) -> (engine: CustomSearchEngine, query: String)? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let spaceIndex = trimmed.firstIndex(of: " ") else { return nil }
+        let keyword = String(trimmed[trimmed.startIndex..<spaceIndex])
+        let query = String(trimmed[trimmed.index(after: spaceIndex)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !keyword.isEmpty, !query.isEmpty else { return nil }
+        let engines = currentEngines(defaults: defaults)
+        guard let engine = engines.first(where: { $0.keyword.lowercased() == keyword.lowercased() }) else { return nil }
+        return (engine, query)
+    }
+}
+
 enum BrowserSearchSettings {
     static let searchEngineKey = "browserSearchEngine"
     static let searchSuggestionsEnabledKey = "browserSearchSuggestionsEnabled"
@@ -3595,6 +3642,13 @@ final class BrowserPanel: Panel, ObservableObject {
         guard !trimmed.isEmpty else { return }
 
         if let url = resolveNavigableURL(from: trimmed) {
+            navigate(to: url, recordTypedNavigation: true)
+            return
+        }
+
+        // Custom keyword search engines (e.g. "gh anthropics/claude-code")
+        if let (customEngine, query) = CustomSearchEngineSettings.match(input: trimmed),
+           let url = customEngine.searchURL(query: query) {
             navigate(to: url, recordTypedNavigation: true)
             return
         }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2386,6 +2386,8 @@ func buildOmnibarSuggestions(
 
     func suggestionPriority(for kind: OmnibarSuggestion.Kind) -> Int {
         switch kind {
+        case .customSearch:
+            return 0  // high-score already guarantees top position
         case .search:
             return 300
         case .remote:
@@ -2445,6 +2447,20 @@ func buildOmnibarSuggestions(
         } else {
             bestByCompletion[key] = ranked
         }
+    }
+
+    // Custom keyword search engines — highest priority when keyword matches
+    if let (customEngine, customQuery) = CustomSearchEngineSettings.match(input: trimmedQuery),
+       let customURL = customEngine.searchURL(query: customQuery) {
+        insert(
+            OmnibarSuggestion(kind: .customSearch(
+                engineName: customEngine.name,
+                keyword: customEngine.keyword,
+                query: customQuery,
+                url: customURL.absoluteString
+            )),
+            score: 1_100  // above all other suggestions
+        )
     }
 
     if !(isSingleCharacterQuery && shouldSuppressSingleCharacterSearchResult) {
@@ -3016,6 +3032,7 @@ func omnibarReduce(state: inout OmnibarState, event: OmnibarEvent) -> OmnibarEff
 struct OmnibarSuggestion: Identifiable, Hashable {
     enum Kind: Hashable {
         case search(engineName: String, query: String)
+        case customSearch(engineName: String, keyword: String, query: String, url: String)
         case navigate(url: String)
         case history(url: String, title: String?)
         case switchToTab(tabId: UUID, panelId: UUID, url: String, title: String?)
@@ -3029,6 +3046,8 @@ struct OmnibarSuggestion: Identifiable, Hashable {
         switch kind {
         case .search(let engineName, let query):
             return "search|\(engineName.lowercased())|\(query.lowercased())"
+        case .customSearch(_, let keyword, let query, _):
+            return "custom-search|\(keyword.lowercased())|\(query.lowercased())"
         case .navigate(let url):
             return "navigate|\(url.lowercased())"
         case .history(let url, _):
@@ -3043,6 +3062,7 @@ struct OmnibarSuggestion: Identifiable, Hashable {
     var completion: String {
         switch kind {
         case .search(_, let q): return q
+        case .customSearch(_, _, _, let url): return url
         case .navigate(let url): return url
         case .history(let url, _): return url
         case .switchToTab(_, _, let url, _): return url
@@ -3054,6 +3074,8 @@ struct OmnibarSuggestion: Identifiable, Hashable {
         switch kind {
         case .search(let engineName, let q):
             return "Search \(engineName) for \"\(q)\""
+        case .customSearch(let engineName, let keyword, let q, _):
+            return "\(keyword): \(q) — \(engineName)"
         case .navigate(let url):
             return Self.displayURLText(for: url)
         case .history(let url, let title):

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3789,6 +3789,7 @@ struct SettingsView: View {
     @AppStorage("cmuxPortRange") private var cmuxPortRange = 10
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
     @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
+    @State private var customSearchEngines: [CustomSearchEngine] = CustomSearchEngineSettings.currentEngines()
     @AppStorage(BrowserThemeSettings.modeKey) private var browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
     @AppStorage(BrowserImportHintSettings.variantKey) private var browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
     @AppStorage(BrowserImportHintSettings.showOnBlankTabsKey) private var showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
@@ -5059,6 +5060,10 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        CustomSearchEnginesSettingsSection(engines: $customSearchEngines)
+
+                        SettingsCardDivider()
+
                         SettingsPickerRow(
                             String(localized: "settings.browser.theme", defaultValue: "Browser Theme"),
                             subtitle: selectedBrowserThemeMode == .system
@@ -5534,6 +5539,8 @@ struct SettingsView: View {
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
+        customSearchEngines = []
+        CustomSearchEngineSettings.save([])
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
         browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
         showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
@@ -6165,5 +6172,87 @@ private struct SettingsRootView: View {
 
     private func applyCurrentSettingsWindowStyle(to window: NSWindow) {
         SettingsAboutTitlebarDebugStore.shared.applyCurrentOptions(to: window, for: .settings)
+    }
+}
+
+// MARK: - Custom Search Engines Settings Section
+
+private struct CustomSearchEnginesSettingsSection: View {
+    @Binding var engines: [CustomSearchEngine]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader
+            enginesList
+            addButton
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var sectionHeader: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(String(localized: "settings.browser.customEngines", defaultValue: "Keyword Search Engines"))
+                .font(.system(size: 13, weight: .medium))
+            Text(String(localized: "settings.browser.customEngines.subtitle", defaultValue: "Type \u{201c}keyword query\u{201d} in the address bar to search with a custom engine. URL template uses %s as placeholder."))
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var enginesList: some View {
+        ForEach(engines) { engine in
+            CustomSearchEngineRow(engine: engine) {
+                engines.removeAll { $0.id == engine.id }
+                CustomSearchEngineSettings.save(engines)
+            }
+        }
+    }
+
+    private var addButton: some View {
+        Button {
+            let engine = CustomSearchEngine(
+                id: UUID(),
+                keyword: "",
+                name: "",
+                urlTemplate: "https://example.com/search?q=%s"
+            )
+            engines.append(engine)
+            CustomSearchEngineSettings.save(engines)
+        } label: {
+            Label(
+                String(localized: "settings.browser.customEngines.add", defaultValue: "Add Engine"),
+                systemImage: "plus"
+            )
+            .font(.system(size: 12))
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.accentColor)
+    }
+}
+
+private struct CustomSearchEngineRow: View {
+    let engine: CustomSearchEngine
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(engine.keyword)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .frame(width: 60, alignment: .leading)
+            Text(engine.name)
+                .font(.system(size: 12))
+                .frame(width: 100, alignment: .leading)
+            Text(engine.urlTemplate)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "minus.circle")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        }
     }
 }

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2594,6 +2594,120 @@ final class BrowserZoomShortcutRoutingPolicyTests: XCTestCase {
 }
 
 
+final class CustomSearchEngineTests: XCTestCase {
+    func testSearchURLReplacesPlaceholder() throws {
+        let engine = CustomSearchEngine(id: UUID(), keyword: "gh", name: "GitHub", urlTemplate: "https://github.com/%s")
+        let url = try XCTUnwrap(engine.searchURL(query: "anthropics/claude-code"))
+        XCTAssertEqual(url.absoluteString, "https://github.com/anthropics/claude-code")
+    }
+
+    func testSearchURLEncodesQueryParams() throws {
+        let engine = CustomSearchEngine(id: UUID(), keyword: "ciu", name: "Can I Use", urlTemplate: "https://caniuse.com/?search=%s")
+        let url = try XCTUnwrap(engine.searchURL(query: "flex box"))
+        XCTAssertTrue(url.absoluteString.contains("search=flex"))
+    }
+
+    func testSearchURLReturnsNilForEmptyQuery() {
+        let engine = CustomSearchEngine(id: UUID(), keyword: "gh", name: "GitHub", urlTemplate: "https://github.com/%s")
+        XCTAssertNil(engine.searchURL(query: ""))
+        XCTAssertNil(engine.searchURL(query: "   "))
+    }
+
+    func testSearchURLReturnsNilWithoutPlaceholder() {
+        let engine = CustomSearchEngine(id: UUID(), keyword: "x", name: "X", urlTemplate: "https://example.com")
+        XCTAssertNil(engine.searchURL(query: "test"))
+    }
+}
+
+final class CustomSearchEngineSettingsTests: XCTestCase {
+    func testSaveAndLoad() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let engines = [
+            CustomSearchEngine(id: UUID(), keyword: "gh", name: "GitHub", urlTemplate: "https://github.com/%s"),
+            CustomSearchEngine(id: UUID(), keyword: "mdn", name: "MDN", urlTemplate: "https://developer.mozilla.org/en-US/search?q=%s"),
+        ]
+        CustomSearchEngineSettings.save(engines, defaults: defaults)
+        let loaded = CustomSearchEngineSettings.currentEngines(defaults: defaults)
+        XCTAssertEqual(loaded.count, 2)
+        XCTAssertEqual(loaded[0].keyword, "gh")
+        XCTAssertEqual(loaded[1].keyword, "mdn")
+    }
+
+    func testReturnsEmptyWhenUnset() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(CustomSearchEngineSettings.currentEngines(defaults: defaults).count, 0)
+    }
+
+    func testMatchFindsKeyword() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let engines = [CustomSearchEngine(id: UUID(), keyword: "gh", name: "GitHub", urlTemplate: "https://github.com/%s")]
+        CustomSearchEngineSettings.save(engines, defaults: defaults)
+
+        let result = CustomSearchEngineSettings.match(input: "gh anthropics/claude-code", defaults: defaults)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.engine.keyword, "gh")
+        XCTAssertEqual(result?.query, "anthropics/claude-code")
+    }
+
+    func testMatchReturnsNilForUnknownKeyword() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertNil(CustomSearchEngineSettings.match(input: "unknown query", defaults: defaults))
+    }
+
+    func testMatchReturnsNilWithoutSpace() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let engines = [CustomSearchEngine(id: UUID(), keyword: "gh", name: "GitHub", urlTemplate: "https://github.com/%s")]
+        CustomSearchEngineSettings.save(engines, defaults: defaults)
+
+        XCTAssertNil(CustomSearchEngineSettings.match(input: "ghrepo", defaults: defaults))
+    }
+
+    func testMatchIsCaseInsensitive() {
+        let suiteName = "CustomSearchEngineSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let engines = [CustomSearchEngine(id: UUID(), keyword: "GH", name: "GitHub", urlTemplate: "https://github.com/%s")]
+        CustomSearchEngineSettings.save(engines, defaults: defaults)
+
+        let result = CustomSearchEngineSettings.match(input: "gh test", defaults: defaults)
+        XCTAssertNotNil(result)
+    }
+}
+
 final class BrowserSearchEngineTests: XCTestCase {
     func testGoogleSearchURL() throws {
         let url = try XCTUnwrap(BrowserSearchEngine.google.searchURL(query: "hello world"))


### PR DESCRIPTION
## Summary

Add user-defined keyword search engines for the browser omnibar. Type `keyword query` in the address bar to search with a custom engine.

**Examples:**
- `gh anthropics/claude-code` → `https://github.com/anthropics/claude-code`
- `mdn fetch` → `https://developer.mozilla.org/en-US/search?q=fetch`
- `npm express` → `https://www.npmjs.com/search?q=express`

**Changes:**
- `CustomSearchEngine` model + `CustomSearchEngineSettings` in `BrowserPanel.swift` (JSON-encoded array in UserDefaults)
- Keyword matching in `navigateSmart` — between URL resolution and default search engine fallback
- New `OmnibarSuggestion.Kind.customSearch` — highest-priority suggestion when keyword matches
- Settings UI: list engines with add/remove buttons
- Reset on "Reset All Settings"
- 10 unit tests covering model, settings persistence, match logic, case-insensitivity

Configurable via Settings UI or `defaults write`:
```bash
defaults write com.cmux.app browserCustomSearchEngines "$(python3 -c "
import json; print(json.dumps([
  {'id':'1','keyword':'gh','name':'GitHub','urlTemplate':'https://github.com/%s'},
  {'id':'2','keyword':'mdn','name':'MDN','urlTemplate':'https://developer.mozilla.org/en-US/search?q=%s'}
]))")"
```

## Test plan

- [x] Unit tests pass: `CustomSearchEngineTests` (4/4) + `CustomSearchEngineSettingsTests` (6/6)
- [ ] Manual: add engine in Settings, type `keyword query` in omnibar — navigates to resolved URL
- [ ] Manual: omnibar shows custom engine suggestion at top when keyword matches
- [ ] Manual: remove engine, keyword no longer matches
- [ ] Manual: "Reset All Settings" clears custom engines

Closes #1806

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-defined keyword search engines to the browser omnibar. Type "keyword query" to jump directly using a `%s` URL template.

- **New Features**
  - Case-insensitive "keyword query" matching; resolves and navigates to the engine URL.
  - Omnibar: shows a top-ranked custom engine suggestion with the resolved URL.
  - Settings: add/remove engines; cleared by "Reset All Settings".
  - Tests: cover URL templating, matching, and persistence.

- **Migration**
  - Settings → Browser → Keyword Search Engines: add entries with keyword, name, and a `%s` URL template.
  - Use by typing "keyword query" (e.g., "gh anthropics/claude-code", "mdn fetch").

<sup>Written for commit 487e02664c9a2e56b5b1967868be0c3c93d4e257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom keyword search engines: create, edit, delete, and persist personalized engines with keyword-triggered searches from the omnibar.
  * Settings UI: manage keyword search engines in Settings and reset clears them.

* **Enhancements**
  * Omnibar now surfaces matching custom-search suggestions at the top (case-insensitive keyword matching).

* **Tests**
  * Added tests covering custom search URL generation, matching, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->