### PR TITLE
feat: Support localized ANSI number-row shortcuts for switching

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9470,7 +9470,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
         if flags == [.command],
            let manager = tabManager,
-           let num = Int(chars),
+           let num = shortcutDigit(for: event),
            let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
 #if DEBUG
             dlog(
@@ -9483,7 +9483,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
         if flags == [.control] {
-            if let num = Int(chars), num >= 1 && num <= 9 {
+            if let num = shortcutDigit(for: event), num >= 1 && num <= 9 {
                 if num == 9 {
                     tabManager?.selectLastSurface()
                 } else {
@@ -10507,6 +10507,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return event.keyCode == expectedKeyCode
         }
         return false
+    }
+
+    private func shortcutDigit(for event: NSEvent) -> Int? {
+        if let digit = KeyboardLayout.ansiNumberRowDigit(forKeyCode: event.keyCode) {
+            return digit
+        }
+        guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else {
+            return nil
+        }
+        return Int(chars)
     }
 
     private func shouldRequireCharacterMatchForCommandShortcut(shortcutKey: String) -> Bool {

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -2,6 +2,26 @@ import AppKit
 import Carbon
 
 class KeyboardLayout {
+    /// Map physical ANSI number-row keys to decimal digits regardless of the active layout.
+    /// This keeps Cmd/Ctrl+digit shortcuts working on layouts like Slovak where the top row
+    /// can emit localized symbols or letters instead of ASCII digits.
+    static func ansiNumberRowDigit(forKeyCode keyCode: UInt16) -> Int? {
+        switch keyCode {
+        case 18: return 1 // kVK_ANSI_1
+        case 19: return 2 // kVK_ANSI_2
+        case 20: return 3 // kVK_ANSI_3
+        case 21: return 4 // kVK_ANSI_4
+        case 23: return 5 // kVK_ANSI_5
+        case 22: return 6 // kVK_ANSI_6
+        case 26: return 7 // kVK_ANSI_7
+        case 28: return 8 // kVK_ANSI_8
+        case 25: return 9 // kVK_ANSI_9
+        case 29: return 0 // kVK_ANSI_0
+        default:
+            return nil
+        }
+    }
+
     /// Return a string ID of the current keyboard input source.
     static var id: String? {
         if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -396,6 +396,10 @@ struct StoredShortcut: Codable, Equatable {
     }
 
     private static func storedKey(from event: NSEvent) -> String? {
+        if let digit = KeyboardLayout.ansiNumberRowDigit(forKeyCode: event.keyCode) {
+            return String(digit)
+        }
+
         // Prefer keyCode mapping so shifted symbol keys (e.g. "}") record as "]".
         switch event.keyCode {
         case 123: return "←" // left arrow

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1664,6 +1664,170 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
     }
 
+    func testCmdDigitShortcutUsesANSINumberRowDigitOnSlovakLayout() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+            XCTFail("Expected test window and manager")
+            return
+        }
+
+        _ = manager.addTab(select: true)
+        guard manager.tabs.count >= 2 else {
+            XCTFail("Expected second workspace")
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        manager.selectTab(at: 0)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let expectedTabId = manager.tabs[1].id
+        XCTAssertNotEqual(manager.selectedTabId, expectedTabId, "Precondition: second workspace should not already be selected")
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "ľ",
+            charactersIgnoringModifiers: "ľ",
+            isARepeat: false,
+            keyCode: 19 // kVK_ANSI_2
+        ) else {
+            XCTFail("Failed to construct Slovak Cmd+2 event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(manager.selectedTabId, expectedTabId, "Cmd+ľ on ANSI 2 should select workspace 2")
+    }
+
+    func testCtrlDigitShortcutUsesANSINumberRowDigitOnSlovakLayout() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window, manager, and workspace")
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        manager.newSurface()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        manager.newSurface()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let expectedLastSurfaceId = workspace.focusedPanelId else {
+            XCTFail("Expected focused surface after creating additional surfaces")
+            return
+        }
+
+        workspace.selectSurface(at: 0)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertNotEqual(
+            workspace.focusedPanelId,
+            expectedLastSurfaceId,
+            "Precondition: last surface should not already be focused"
+        )
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "í",
+            charactersIgnoringModifiers: "í",
+            isARepeat: false,
+            keyCode: 25 // kVK_ANSI_9
+        ) else {
+            XCTFail("Failed to construct Slovak Ctrl+9 event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(workspace.focusedPanelId, expectedLastSurfaceId, "Ctrl+í on ANSI 9 should select the last surface")
+    }
+
+    func testCmdNonDigitSymbolFromNonNumberRowDoesNotTriggerBuiltInWorkspaceDigitShortcut() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+            XCTFail("Expected test window and manager")
+            return
+        }
+
+        _ = manager.addTab(select: true)
+        guard let firstTabId = manager.tabs.first?.id else {
+            XCTFail("Expected at least one workspace")
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        manager.selectTab(at: 0)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "*",
+            charactersIgnoringModifiers: "*",
+            isARepeat: false,
+            keyCode: 30 // kVK_ANSI_RightBracket
+        ) else {
+            XCTFail("Failed to construct Cmd+* event from non-number-row key")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(manager.selectedTabId, firstTabId, "Cmd+* on RightBracket must not be treated as a workspace digit shortcut")
+    }
+
     func testCmdShiftNonDigitKeySymbolDoesNotMatchShiftedDigitShortcut() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -211,6 +211,33 @@ final class WorkspaceShortcutMapperTests: XCTestCase {
     }
 }
 
+final class StoredShortcutRecordingTests: XCTestCase {
+    func testStoredShortcutFromEventUsesANSINumberRowDigitsOnLocalizedLayouts() {
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "ľ",
+            charactersIgnoringModifiers: "ľ",
+            isARepeat: false,
+            keyCode: 19 // kVK_ANSI_2
+        ) else {
+            XCTFail("Failed to construct localized ANSI 2 event")
+            return
+        }
+
+        let shortcut = StoredShortcut.from(event: event)
+        XCTAssertEqual(shortcut?.key, "2")
+        XCTAssertEqual(shortcut?.command, true)
+        XCTAssertEqual(shortcut?.shift, false)
+        XCTAssertEqual(shortcut?.option, false)
+        XCTAssertEqual(shortcut?.control, false)
+    }
+}
+
 
 final class WorkspacePlacementSettingsTests: XCTestCase {
     func testCurrentPlacementDefaultsToAfterCurrentWhenUnset() {


### PR DESCRIPTION
## Summary

- **Completely generated by Codex, please review thoroughly**, I'm not very experienced in macOS Swift development.
- Fix built-in `⌘ + <number>` workspace switching and `⌃ + <number>` tab/surface switching on localized keyboard layouts such as Slovak, where the ANSI top row emits non-digit characters like `+ľščťžýáíé`.
- Add a shared ANSI number-row keycode-to-digit mapper and use it both in runtime shortcut handling and in shortcut recording, so localized top-row digit keys still resolve to `1...0`.
- Keep existing letter-shortcut semantics unchanged and limit the behavior change to the physical ANSI number row.

Why:
- The previous implementation relied on `charactersIgnoringModifiers` and `Int(...)`, which works on English layouts but fails on Slovak and similar layouts because the top row does not produce ASCII digits.
- Recording custom shortcuts had the same issue, storing localized characters instead of the intended digit.

## Testing

- How did you test this change?
	- Added regression tests for:
	  - `⌘` workspace switching from a Slovak ANSI number-row key
	  - `⌃` surface switching from a Slovak ANSI number-row key
	  - a negative case proving non-number-row symbols do not trigger digit shortcuts
	  - shortcut recording storing ANSI Slovak top-row input as `"2"` instead of `"ľ"`
	- Per repo policy, I did not run the test suite locally.
	- I built and launched a tagged debug app locally with `./scripts/reload.sh --tag slovak-shortcuts`.


- What did you verify manually?

I tested switching both workspaces and tabs with Slovak and English (US) keyboards.

## Demo Video


https://github.com/user-attachments/assets/50650e81-23b2-41c0-afe5-0df06643ec2c



## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+<number> workspace switching and Ctrl+<number> surface switching on localized layouts (e.g., Slovak) by mapping ANSI number-row keycodes to digits. Shortcut recording now stores digits for top-row keys.

- **Bug Fixes**
  - Add `KeyboardLayout.ansiNumberRowDigit(...)` and use `AppDelegate.shortcutDigit(for:)` to normalize ANSI number-row keys in runtime handling and shortcut recording, with a safe fallback to parsed characters.
  - Keep letter shortcuts unchanged; non-number-row symbols don’t trigger digit shortcuts. Add regression tests for Slovak layout and shortcut recording.

<sup>Written for commit 689a1c419ba5e42ee639b792550b0da61809bad2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

