### PR TITLE
feat: add mouse-hide-while-typing config option (sync from Ghostty)

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -39,6 +39,9 @@ struct GhosttyConfig {
     // Palette colors (0-15)
     var palette: [Int: NSColor] = [:]
 
+    // Mouse behavior
+    var mouseHideWhileTyping: Bool = false
+
     var unfocusedSplitOverlayOpacity: Double {
         let clamped = min(1.0, max(0.15, unfocusedSplitOpacity))
         return min(1.0, max(0.0, 1.0 - clamped))
@@ -304,6 +307,9 @@ struct GhosttyConfig {
                     if let opacity = Double(value) {
                         sidebarTintOpacity = min(max(opacity, 0), 1)
                     }
+                case "mouse-hide-while-typing":
+                    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    mouseHideWhileTyping = (trimmed == "true" || trimmed == "1" || trimmed == "yes" || trimmed == "on")
                 default:
                     break
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3763,6 +3763,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var deferredSurfaceSizeRetryQueued = false
     private var lastDrawableSize: CGSize = .zero
     private var isFindEscapeSuppressionArmed = false
+    private var mouseHidden: Bool = false
+
+    /// Reveal the mouse cursor if it was hidden by mouse-hide-while-typing.
+    /// Must be called at the start of all pointer event handlers.
+    private func revealMouseIfNeeded() {
+        guard mouseHidden else { return }
+        NSCursor.setHiddenUntilMouseMoves(false)
+        mouseHidden = false
+    }
 #if DEBUG
     private var lastSizeSkipSignature: String?
 #endif
@@ -4958,6 +4967,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #if DEBUG
         ensureSurfaceMs = (ProcessInfo.processInfo.systemUptime - ensureSurfaceStart) * 1000.0
 #endif
+        // Hide mouse while typing (only when key produces actual text, not bare modifiers)
+        // Use GhosttyConfig.load() which has internal caching (invalidated on config reload)
+        // Use textForKeyEvent + shouldSendText to match the actual text sending logic
+        if GhosttyConfig.load().mouseHideWhileTyping && !mouseHidden {
+            let text = textForKeyEvent(event).flatMap { shouldSendText($0) ? $0 : nil }
+            if text != nil {
+                NSCursor.setHiddenUntilMouseMoves(true)
+                mouseHidden = true
+            }
+        }
         if let terminalSurface {
 #if DEBUG
             let dismissNotificationStart = ProcessInfo.processInfo.systemUptime
@@ -5606,6 +5625,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func mouseDown(with event: NSEvent) {
+        revealMouseIfNeeded()
         #if DEBUG
         let debugPoint = convert(event.locationInWindow, from: nil)
         dlog("terminal.mouseDown surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))] clickCount=\(event.clickCount) point=(\(String(format: "%.0f", debugPoint.x)),\(String(format: "%.0f", debugPoint.y)))")
@@ -5628,6 +5648,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func mouseUp(with event: NSEvent) {
+        revealMouseIfNeeded()
         #if DEBUG
         dlog("terminal.mouseUp surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))]")
         #endif
@@ -5636,6 +5657,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard let surface = surface else { return }
         if !ghostty_surface_mouse_captured(surface) {
             requestPointerFocusRecovery()
@@ -5651,6 +5673,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func rightMouseUp(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard let surface = surface else { return }
         if !ghostty_surface_mouse_captured(surface) {
             super.rightMouseUp(with: event)
@@ -5661,6 +5684,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func otherMouseDown(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard event.buttonNumber == 2 else {
             super.otherMouseDown(with: event)
             return
@@ -5674,6 +5698,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func otherMouseUp(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard event.buttonNumber == 2 else {
             super.otherMouseUp(with: event)
             return
@@ -5767,6 +5792,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func mouseMoved(with event: NSEvent) {
+        revealMouseIfNeeded()
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
@@ -5775,6 +5801,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
+        revealMouseIfNeeded()
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
@@ -5807,12 +5834,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func mouseDragged(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
     }
 
     override func scrollWheel(with event: NSEvent) {
+        revealMouseIfNeeded()
         guard let surface = surface else { return }
         lastScrollEventTime = CACurrentMediaTime()
         Self.focusLog("scrollWheel: surface=\(terminalSurface?.id.uuidString ?? "nil") firstResponder=\(String(describing: window?.firstResponder))")


### PR DESCRIPTION
Implements the \+mouse-hide-while-typing+ feature from Ghostty that hides the mouse cursor when typing text in the terminal.

## Changes
- Add `mouseHideWhileTyping` config option (default: false)
- Hide cursor on keyDown when feature is enabled and key produces text
- Reset mouseHidden state on any mouse interaction
- Support multiple truthy values: `true`, `1`, `yes`, `on`
- Trim whitespace from config value
- Use `GhosttyConfig.load()` directly (uses internal cache that's invalidated on config reload)

## Usage
Add to your Ghostty config file (~/.config/ghostty/config):
```
mouse-hide-while-typing = true
```

## Technical Details
- The feature only hides the cursor when the key event produces actual text (not bare modifiers or dead keys)
- The cursor is automatically shown again on any mouse interaction (click, move, scroll, etc.)
- The implementation uses `NSCursor.setHiddenUntilMouseMoves(true)` which is the system-preferred way to hide the cursor until the user moves the mouse

This syncs the feature from upstream Ghostty's implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in `mouse-hide-while-typing` setting to hide the mouse cursor while typing in the terminal. The cursor reappears on any mouse interaction.

- **New Features**
  - Added `mouse-hide-while-typing` config (default: false); accepts true/1/yes/on and trims whitespace.
  - Hides cursor only when keyDown produces text (uses `textForKeyEvent` + `shouldSendText`); reveals on move, click, drag, or scroll via `revealMouseIfNeeded()`.
  - Uses `NSCursor.setHiddenUntilMouseMoves(true)` and reads config via cached `GhosttyConfig.load()`.

<sup>Written for commit a5008b90e15e5ed3ee1716ae8ddcdcfabc150eeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "mouse hide while typing" option (off by default). When enabled, the cursor automatically hides during typing to reduce distractions and immediately reappears on any mouse movement or click. This behavior can be toggled in your configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->