### PR TITLE
allow configuring key prefix for tab and workspace changes

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
 					063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 					1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */; };
+					A1B2C3D4E5F60718A9B0C1D2 /* DigitShortcutModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4F5A6B7C80D19E2F3A4B5 /* DigitShortcutModifierTests.swift */; };
 					CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
 					4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
@@ -274,6 +275,7 @@
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
+					D3E4F5A6B7C80D19E2F3A4B5 /* DigitShortcutModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DigitShortcutModifierTests.swift; sourceTree = "<group>"; };
 				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 					71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 					BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
 					6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
+						D3E4F5A6B7C80D19E2F3A4B5 /* DigitShortcutModifierTests.swift */,
 					BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
 					B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
 					D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
@@ -784,6 +787,7 @@
 					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */,
 					063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 					1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */,
+						A1B2C3D4E5F60718A9B0C1D2 /* DigitShortcutModifierTests.swift in Sources */,
 					CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
 					4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,
 					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57411,8 +57411,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "CmdまたはCtrlを長押ししてもショートカットヒントピルは非表示のままです。"
+            "state": "needs_review",
+            "value": "修飾キーを長押ししてもショートカットヒントピルは非表示のままです。"
           }
         },
         "zh-Hans": {
@@ -57524,8 +57524,8 @@
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Cmd（サイドバー/タイトルバー）またはCtrl/Cmd（ペインタブ）を長押しするとショートカットヒントピルが表示されます。"
+            "state": "needs_review",
+            "value": "ワークスペースまたはサーフェスの修飾キーを長押しするとショートカットヒントピルが表示されます。"
           }
         },
         "zh-Hans": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57293,13 +57293,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show Cmd/Ctrl-Hold Shortcut Hints"
+            "value": "Show Modifier-Hold Shortcut Hints"
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Cmd/Ctrl長押しのショートカットヒントを表示"
+            "state": "needs_review",
+            "value": "修飾キー長押しのショートカットヒントを表示"
           }
         },
         "zh-Hans": {
@@ -57406,7 +57406,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Holding Cmd or Ctrl keeps shortcut hint pills hidden."
+            "value": "Modifier-hold shortcut hint pills are hidden."
           }
         },
         "ja": {
@@ -57519,7 +57519,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Holding Cmd (sidebar/titlebar) or Ctrl/Cmd (pane tabs) shows shortcut hint pills."
+            "value": "Holding the workspace or surface modifier key shows shortcut hint pills."
           }
         },
         "ja": {
@@ -57622,6 +57622,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cmd (kenar çubuğu/başlık çubuğu) veya Ctrl/Cmd (bölme sekmeleri) basılı tutulduğunda kısayol ipucu rozetleri gösterilir."
+          }
+        }
+      }
+    },
+    "settings.shortcuts.workspaceDigitModifier": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace 1-9 Modifier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース 1-9 修飾キー"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.workspaceDigitModifier.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier key(s) for jumping to workspace by number."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "番号でワークスペースに移動する修飾キー。"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.surfaceDigitModifier": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface 1-9 Modifier"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェス 1-9 修飾キー"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.surfaceDigitModifier.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier key(s) for jumping to surface by number."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "番号でサーフェスに移動する修飾キー。"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.digitModifierConflict": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warning: same modifier as workspace shortcuts. Both will fire on the same key."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告: ワークスペースのショートカットと同じ修飾キーです。同じキーで両方が発動します。"
+          }
+        }
+      }
+    },
+    "shortcut.pressModifier.prompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press modifier…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修飾キーを押す…"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2003,6 +2003,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var splitButtonTooltipRefreshScheduled = false
     private var ghosttyConfigObserver: NSObjectProtocol?
+    private var workspaceDigitFlags: NSEvent.ModifierFlags = DigitShortcutModifierSettings.defaultWorkspaceFlags
+    private var surfaceDigitFlags: NSEvent.ModifierFlags = DigitShortcutModifierSettings.defaultSurfaceFlags
+    private var digitModifierObserver: NSObjectProtocol?
     private var ghosttyGotoSplitLeftShortcut: StoredShortcut?
     private var ghosttyGotoSplitRightShortcut: StoredShortcut?
     private var ghosttyGotoSplitUpShortcut: StoredShortcut?
@@ -2334,6 +2337,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         installBrowserAddressBarFocusObservers()
         installShortcutMonitor()
         installShortcutDefaultsObserver()
+        installDigitModifierObserver()
         NSApp.servicesProvider = self
 #if DEBUG
         UpdateTestSupport.applyIfNeeded(to: updateController.viewModel)
@@ -8677,6 +8681,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    private func installDigitModifierObserver() {
+        guard digitModifierObserver == nil else { return }
+        refreshDigitModifierFlags()
+        digitModifierObserver = NotificationCenter.default.addObserver(
+            forName: DigitShortcutModifierSettings.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshDigitModifierFlags()
+        }
+    }
+
+    private func refreshDigitModifierFlags() {
+        workspaceDigitFlags = DigitShortcutModifierSettings.workspaceFlags()
+        surfaceDigitFlags = DigitShortcutModifierSettings.surfaceFlags()
+    }
+
     /// Coalesce shortcut-default changes and refresh on the next runloop turn to
     /// avoid mutating Bonsplit/SwiftUI-observed state during an active update pass.
     private func scheduleSplitButtonTooltipRefreshAcrossWorkspaces() {
@@ -9467,8 +9488,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
-        if flags == [.command],
+        // Numeric shortcuts for specific sidebar tabs: modifier+1-9 (9 = last workspace)
+        if flags == workspaceDigitFlags,
            let manager = tabManager,
            let num = Int(chars),
            let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
@@ -9481,8 +9502,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
-        if flags == [.control] {
+        // Numeric shortcuts for surfaces within pane: modifier+1-9 (9 = last)
+        if flags == surfaceDigitFlags {
             if let num = Int(chars), num >= 1 && num <= 9 {
                 if num == 9 {
                     tabManager?.selectLastSurface()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10703,7 +10703,7 @@ private struct TabItemView: View, Equatable {
 
     private var workspaceShortcutLabel: String? {
         guard let workspaceShortcutDigit else { return nil }
-        let flags = workspaceDigitModifierStored != 0
+        let flags = workspaceDigitModifierStored > 0
             ? NSEvent.ModifierFlags(rawValue: UInt(workspaceDigitModifierStored)).intersection(.deviceIndependentFlagsMask)
             : DigitShortcutModifierSettings.defaultWorkspaceFlags
         let symbol = DigitShortcutModifierSettings.symbolString(for: flags)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8325,7 +8325,9 @@ enum ShortcutHintModifierPolicy {
         defaults: UserDefaults = .standard
     ) -> Bool {
         let normalized = modifierFlags.intersection(.deviceIndependentFlagsMask)
-        guard normalized == [.command] else {
+        let workspaceFlags = DigitShortcutModifierSettings.workspaceFlags(defaults: defaults)
+        let surfaceFlags = DigitShortcutModifierSettings.surfaceFlags(defaults: defaults)
+        guard normalized == workspaceFlags || normalized == surfaceFlags else {
             return false
         }
         return ShortcutHintDebugSettings.showHintsOnCommandHoldEnabled(defaults: defaults)
@@ -10605,6 +10607,8 @@ private struct TabItemView: View, Equatable {
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
+    @AppStorage(DigitShortcutModifierSettings.workspaceModifierKey)
+    private var workspaceDigitModifierStored = DigitShortcutModifierSettings.defaultWorkspaceStored
     @AppStorage("sidebarShowGitBranch") private var sidebarShowGitBranch = true
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
@@ -10699,7 +10703,11 @@ private struct TabItemView: View, Equatable {
 
     private var workspaceShortcutLabel: String? {
         guard let workspaceShortcutDigit else { return nil }
-        return "⌘\(workspaceShortcutDigit)"
+        let flags = workspaceDigitModifierStored != 0
+            ? NSEvent.ModifierFlags(rawValue: UInt(workspaceDigitModifierStored)).intersection(.deviceIndependentFlagsMask)
+            : DigitShortcutModifierSettings.defaultWorkspaceFlags
+        let symbol = DigitShortcutModifierSettings.symbolString(for: flags)
+        return "\(symbol)\(workspaceShortcutDigit)"
     }
 
     private var showsWorkspaceShortcutHint: Bool {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -274,6 +274,235 @@ enum KeyboardShortcutSettings {
     static func showBrowserJavaScriptConsoleShortcut() -> StoredShortcut { shortcut(for: .showBrowserJavaScriptConsole) }
 }
 
+// MARK: - Digit Shortcut Modifier Flags (configurable modifier combo for 1-9 shortcuts)
+
+enum DigitShortcutModifierSettings {
+    static let workspaceModifierKey = "digitShortcutWorkspaceModifierFlags"
+    static let surfaceModifierKey = "digitShortcutSurfaceModifierFlags"
+    /// Stored as `Int(NSEvent.ModifierFlags.rawValue)`. Zero means "use default".
+    static let defaultWorkspaceFlags: NSEvent.ModifierFlags = [.command]
+    static let defaultSurfaceFlags: NSEvent.ModifierFlags = [.control]
+    static let defaultWorkspaceStored: Int = Int(defaultWorkspaceFlags.rawValue)
+    static let defaultSurfaceStored: Int = Int(defaultSurfaceFlags.rawValue)
+    static let didChangeNotification = Notification.Name("cmux.digitShortcutModifierDidChange")
+
+    static func workspaceFlags(defaults: UserDefaults = .standard) -> NSEvent.ModifierFlags {
+        flagsFor(key: workspaceModifierKey, fallback: defaultWorkspaceFlags, defaults: defaults)
+    }
+
+    static func surfaceFlags(defaults: UserDefaults = .standard) -> NSEvent.ModifierFlags {
+        flagsFor(key: surfaceModifierKey, fallback: defaultSurfaceFlags, defaults: defaults)
+    }
+
+    private static func flagsFor(
+        key: String,
+        fallback: NSEvent.ModifierFlags,
+        defaults: UserDefaults
+    ) -> NSEvent.ModifierFlags {
+        let raw = defaults.integer(forKey: key)
+        guard raw != 0 else { return fallback }
+        return NSEvent.ModifierFlags(rawValue: UInt(raw))
+            .intersection(.deviceIndependentFlagsMask)
+    }
+
+    // MARK: Display helpers
+
+    static func symbolString(for flags: NSEvent.ModifierFlags) -> String {
+        var parts: [String] = []
+        if flags.contains(.control) { parts.append("⌃") }
+        if flags.contains(.option) { parts.append("⌥") }
+        if flags.contains(.shift) { parts.append("⇧") }
+        if flags.contains(.command) { parts.append("⌘") }
+        return parts.joined()
+    }
+
+    static func displayName(for flags: NSEvent.ModifierFlags) -> String {
+        var parts: [String] = []
+        if flags.contains(.control) { parts.append("Control") }
+        if flags.contains(.option) { parts.append("Option") }
+        if flags.contains(.shift) { parts.append("Shift") }
+        if flags.contains(.command) { parts.append("Command") }
+        return parts.joined(separator: "+")
+    }
+
+    static func eventModifiers(for storedValue: Int, fallback: NSEvent.ModifierFlags) -> EventModifiers {
+        let flags = storedValue != 0
+            ? NSEvent.ModifierFlags(rawValue: UInt(storedValue)).intersection(.deviceIndependentFlagsMask)
+            : fallback
+        var modifiers: EventModifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        return modifiers
+    }
+}
+
+// MARK: - Modifier Recorder (captures modifier key combos)
+
+struct ModifierRecorderRow: View {
+    let label: String
+    let subtitle: String?
+    @Binding var storedFlags: Int
+    let defaultFlags: NSEvent.ModifierFlags
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            ModifierRecorderButton(storedFlags: $storedFlags, defaultFlags: defaultFlags)
+                .frame(width: 120)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+    }
+}
+
+private struct ModifierRecorderButton: NSViewRepresentable {
+    @Binding var storedFlags: Int
+    let defaultFlags: NSEvent.ModifierFlags
+
+    func makeNSView(context: Context) -> ModifierRecorderNSButton {
+        let button = ModifierRecorderNSButton()
+        button.currentFlags = resolvedFlags
+        button.onModifierRecorded = { newFlags in
+            storedFlags = Int(newFlags.rawValue)
+        }
+        return button
+    }
+
+    func updateNSView(_ nsView: ModifierRecorderNSButton, context: Context) {
+        nsView.currentFlags = resolvedFlags
+        nsView.updateTitle()
+    }
+
+    private var resolvedFlags: NSEvent.ModifierFlags {
+        storedFlags != 0
+            ? NSEvent.ModifierFlags(rawValue: UInt(storedFlags)).intersection(.deviceIndependentFlagsMask)
+            : defaultFlags
+    }
+}
+
+private class ModifierRecorderNSButton: NSButton {
+    var currentFlags: NSEvent.ModifierFlags = [.command]
+    var onModifierRecorded: ((NSEvent.ModifierFlags) -> Void)?
+    private var isRecording = false
+    private var eventMonitor: Any?
+    private var pendingFlags: NSEvent.ModifierFlags = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        bezelStyle = .rounded
+        setButtonType(.momentaryPushIn)
+        target = self
+        action = #selector(buttonClicked)
+        updateTitle()
+    }
+
+    func updateTitle() {
+        if isRecording {
+            if pendingFlags.isEmpty {
+                title = String(localized: "shortcut.pressModifier.prompt", defaultValue: "Press modifier…")
+            } else {
+                title = DigitShortcutModifierSettings.symbolString(for: pendingFlags)
+            }
+        } else {
+            title = DigitShortcutModifierSettings.symbolString(for: currentFlags)
+        }
+    }
+
+    @objc private func buttonClicked() {
+        if isRecording {
+            stopRecording(commit: false)
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        isRecording = true
+        pendingFlags = []
+        updateTitle()
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { [weak self] event in
+            guard let self else { return event }
+
+            if event.type == .keyDown {
+                if event.keyCode == 53 { // Escape — cancel
+                    self.stopRecording(commit: false)
+                    return nil
+                }
+                // Consume other keyDown events while recording.
+                return nil
+            }
+
+            // flagsChanged
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                .intersection([.command, .shift, .option, .control])
+            if !flags.isEmpty {
+                // Union so releasing one key before another keeps the combo.
+                self.pendingFlags = self.pendingFlags.union(flags)
+                self.updateTitle()
+            } else if !self.pendingFlags.isEmpty {
+                // All modifiers released — commit the accumulated combo.
+                self.stopRecording(commit: true)
+            }
+            return event
+        }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowResigned),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+    }
+
+    private func stopRecording(commit: Bool) {
+        let captured = pendingFlags
+        isRecording = false
+        pendingFlags = []
+
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: window)
+
+        if commit && !captured.isEmpty {
+            currentFlags = captured
+            onModifierRecorded?(captured)
+        }
+        updateTitle()
+    }
+
+    @objc private func windowResigned() {
+        stopRecording(commit: false)
+    }
+
+    deinit {
+        stopRecording(commit: false)
+    }
+}
+
 /// A keyboard shortcut that can be stored in UserDefaults
 struct StoredShortcut: Codable, Equatable {
     var key: String

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -300,7 +300,7 @@ enum DigitShortcutModifierSettings {
         defaults: UserDefaults
     ) -> NSEvent.ModifierFlags {
         let raw = defaults.integer(forKey: key)
-        guard raw != 0 else { return fallback }
+        guard raw > 0 else { return fallback }
         return NSEvent.ModifierFlags(rawValue: UInt(raw))
             .intersection(.deviceIndependentFlagsMask)
     }
@@ -326,7 +326,7 @@ enum DigitShortcutModifierSettings {
     }
 
     static func eventModifiers(for storedValue: Int, fallback: NSEvent.ModifierFlags) -> EventModifiers {
-        let flags = storedValue != 0
+        let flags = storedValue > 0
             ? NSEvent.ModifierFlags(rawValue: UInt(storedValue)).intersection(.deviceIndependentFlagsMask)
             : fallback
         var modifiers: EventModifiers = []
@@ -386,7 +386,7 @@ private struct ModifierRecorderButton: NSViewRepresentable {
     }
 
     private var resolvedFlags: NSEvent.ModifierFlags {
-        storedFlags != 0
+        storedFlags > 0
             ? NSEvent.ModifierFlags(rawValue: UInt(storedFlags)).intersection(.deviceIndependentFlagsMask)
             : defaultFlags
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -158,7 +158,13 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
+    @AppStorage(DigitShortcutModifierSettings.workspaceModifierKey)
+    private var workspaceDigitModifierStored = DigitShortcutModifierSettings.defaultWorkspaceStored
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    private var workspaceDigitEventModifiers: EventModifiers {
+        DigitShortcutModifierSettings.eventModifiers(for: workspaceDigitModifierStored, fallback: DigitShortcutModifierSettings.defaultWorkspaceFlags)
+    }
 
     private var browserToolbarAccessorySpacing: Int {
         BrowserToolbarAccessorySpacingDebugSettings.resolved(browserToolbarAccessorySpacingRaw)
@@ -790,7 +796,7 @@ struct cmuxApp: App {
 
                 Divider()
 
-                // Cmd+1 through Cmd+9 for workspace selection (9 = last workspace)
+                // Modifier+1 through Modifier+9 for workspace selection (9 = last workspace)
                 ForEach(1...9, id: \.self) { number in
                     Button(String(localized: "menu.view.workspace", defaultValue: "Workspace \(number)")) {
                         let manager = activeTabManager
@@ -798,7 +804,7 @@ struct cmuxApp: App {
                             manager.selectTab(at: targetIndex)
                         }
                     }
-                    .keyboardShortcut(KeyEquivalent(Character("\(number)")), modifiers: .command)
+                    .keyboardShortcut(KeyEquivalent(Character("\(number)")), modifiers: workspaceDigitEventModifiers)
                 }
 
                 Divider()
@@ -3823,6 +3829,10 @@ struct SettingsView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @AppStorage(ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
     private var showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+    @AppStorage(DigitShortcutModifierSettings.workspaceModifierKey)
+    private var settingsWorkspaceDigitModifier = DigitShortcutModifierSettings.defaultWorkspaceStored
+    @AppStorage(DigitShortcutModifierSettings.surfaceModifierKey)
+    private var settingsSurfaceDigitModifier = DigitShortcutModifierSettings.defaultSurfaceStored
     @AppStorage("sidebarShowSSH") private var sidebarShowSSH = true
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
@@ -5258,14 +5268,40 @@ struct SettingsView: View {
                         .accessibilityIdentifier("SettingsKeyboardShortcutsSection")
                     SettingsCard {
                         SettingsCardRow(
-                            String(localized: "settings.shortcuts.showHints", defaultValue: "Show Cmd/Ctrl-Hold Shortcut Hints"),
+                            String(localized: "settings.shortcuts.showHints", defaultValue: "Show Modifier-Hold Shortcut Hints"),
                             subtitle: showShortcutHintsOnCommandHold
-                                ? String(localized: "settings.shortcuts.showHints.subtitleOn", defaultValue: "Holding Cmd (sidebar/titlebar) or Ctrl/Cmd (pane tabs) shows shortcut hint pills.")
-                                : String(localized: "settings.shortcuts.showHints.subtitleOff", defaultValue: "Holding Cmd or Ctrl keeps shortcut hint pills hidden.")
+                                ? String(localized: "settings.shortcuts.showHints.subtitleOn", defaultValue: "Holding the workspace or surface modifier key shows shortcut hint pills.")
+                                : String(localized: "settings.shortcuts.showHints.subtitleOff", defaultValue: "Modifier-hold shortcut hint pills are hidden.")
                         ) {
                             Toggle("", isOn: $showShortcutHintsOnCommandHold)
                                 .labelsHidden()
                                 .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        ModifierRecorderRow(
+                            label: String(localized: "settings.shortcuts.workspaceDigitModifier", defaultValue: "Workspace 1-9 Modifier"),
+                            subtitle: String(localized: "settings.shortcuts.workspaceDigitModifier.subtitle", defaultValue: "Modifier key(s) for jumping to workspace by number."),
+                            storedFlags: $settingsWorkspaceDigitModifier,
+                            defaultFlags: DigitShortcutModifierSettings.defaultWorkspaceFlags
+                        )
+                        .onChange(of: settingsWorkspaceDigitModifier) { _ in
+                            NotificationCenter.default.post(name: DigitShortcutModifierSettings.didChangeNotification, object: nil)
+                        }
+
+                        SettingsCardDivider()
+
+                        ModifierRecorderRow(
+                            label: String(localized: "settings.shortcuts.surfaceDigitModifier", defaultValue: "Surface 1-9 Modifier"),
+                            subtitle: settingsSurfaceDigitModifier == settingsWorkspaceDigitModifier
+                                ? String(localized: "settings.shortcuts.digitModifierConflict", defaultValue: "Warning: same modifier as workspace shortcuts. Both will fire on the same key.")
+                                : String(localized: "settings.shortcuts.surfaceDigitModifier.subtitle", defaultValue: "Modifier key(s) for jumping to surface by number."),
+                            storedFlags: $settingsSurfaceDigitModifier,
+                            defaultFlags: DigitShortcutModifierSettings.defaultSurfaceFlags
+                        )
+                        .onChange(of: settingsSurfaceDigitModifier) { _ in
+                            NotificationCenter.default.post(name: DigitShortcutModifierSettings.didChangeNotification, object: nil)
                         }
 
                         SettingsCardDivider()
@@ -5539,6 +5575,9 @@ struct SettingsView: View {
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        settingsWorkspaceDigitModifier = DigitShortcutModifierSettings.defaultWorkspaceStored
+        settingsSurfaceDigitModifier = DigitShortcutModifierSettings.defaultSurfaceStored
+        NotificationCenter.default.post(name: DigitShortcutModifierSettings.didChangeNotification, object: nil)
         sidebarShowSSH = true
         sidebarShowPorts = true
         sidebarShowLog = true

--- a/cmuxTests/DigitShortcutModifierTests.swift
+++ b/cmuxTests/DigitShortcutModifierTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+import AppKit
+import SwiftUI
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// MARK: - DigitShortcutModifierSettings Tests
+
+final class DigitShortcutModifierSettingsTests: XCTestCase {
+
+    private func withDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "DigitShortcutModifierSettingsTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create defaults suite")
+            return
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        body(defaults)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    // MARK: Defaults
+
+    func testWorkspaceFlagsDefaultToCommand() {
+        withDefaults { defaults in
+            let flags = DigitShortcutModifierSettings.workspaceFlags(defaults: defaults)
+            XCTAssertEqual(flags, [.command])
+        }
+    }
+
+    func testSurfaceFlagsDefaultToControl() {
+        withDefaults { defaults in
+            let flags = DigitShortcutModifierSettings.surfaceFlags(defaults: defaults)
+            XCTAssertEqual(flags, [.control])
+        }
+    }
+
+    // MARK: Custom single modifier
+
+    func testWorkspaceFlagsReadsStoredOption() {
+        withDefaults { defaults in
+            defaults.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            let flags = DigitShortcutModifierSettings.workspaceFlags(defaults: defaults)
+            XCTAssertEqual(flags, [.option])
+        }
+    }
+
+    func testSurfaceFlagsReadsStoredCommand() {
+        withDefaults { defaults in
+            defaults.set(Int(NSEvent.ModifierFlags.command.rawValue), forKey: DigitShortcutModifierSettings.surfaceModifierKey)
+            let flags = DigitShortcutModifierSettings.surfaceFlags(defaults: defaults)
+            XCTAssertEqual(flags, [.command])
+        }
+    }
+
+    // MARK: Combo modifiers
+
+    func testWorkspaceFlagsReadsComboModifier() {
+        withDefaults { defaults in
+            let combo: NSEvent.ModifierFlags = [.command, .shift]
+            defaults.set(Int(combo.rawValue), forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            let flags = DigitShortcutModifierSettings.workspaceFlags(defaults: defaults)
+            XCTAssertTrue(flags.contains(.command))
+            XCTAssertTrue(flags.contains(.shift))
+            XCTAssertFalse(flags.contains(.option))
+            XCTAssertFalse(flags.contains(.control))
+        }
+    }
+
+    func testSurfaceFlagsReadsTripleCombo() {
+        withDefaults { defaults in
+            let combo: NSEvent.ModifierFlags = [.control, .option, .shift]
+            defaults.set(Int(combo.rawValue), forKey: DigitShortcutModifierSettings.surfaceModifierKey)
+            let flags = DigitShortcutModifierSettings.surfaceFlags(defaults: defaults)
+            XCTAssertTrue(flags.contains(.control))
+            XCTAssertTrue(flags.contains(.option))
+            XCTAssertTrue(flags.contains(.shift))
+            XCTAssertFalse(flags.contains(.command))
+        }
+    }
+
+    // MARK: Zero stored value falls back to default
+
+    func testZeroStoredValueFallsBackToDefault() {
+        withDefaults { defaults in
+            defaults.set(0, forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            let flags = DigitShortcutModifierSettings.workspaceFlags(defaults: defaults)
+            XCTAssertEqual(flags, [.command], "Zero should fall back to default workspace modifier")
+        }
+    }
+
+    // MARK: Symbol strings
+
+    func testSymbolStringCommand() {
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: [.command]), "⌘")
+    }
+
+    func testSymbolStringControl() {
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: [.control]), "⌃")
+    }
+
+    func testSymbolStringOption() {
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: [.option]), "⌥")
+    }
+
+    func testSymbolStringShift() {
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: [.shift]), "⇧")
+    }
+
+    func testSymbolStringComboOrdering() {
+        // Symbols should follow standard macOS ordering: ⌃⌥⇧⌘
+        let combo: NSEvent.ModifierFlags = [.command, .shift, .option, .control]
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: combo), "⌃⌥⇧⌘")
+    }
+
+    func testSymbolStringCommandShift() {
+        let combo: NSEvent.ModifierFlags = [.command, .shift]
+        XCTAssertEqual(DigitShortcutModifierSettings.symbolString(for: combo), "⇧⌘")
+    }
+
+    // MARK: Display name
+
+    func testDisplayNameSingleModifier() {
+        XCTAssertEqual(DigitShortcutModifierSettings.displayName(for: [.command]), "Command")
+    }
+
+    func testDisplayNameCombo() {
+        let combo: NSEvent.ModifierFlags = [.command, .shift]
+        XCTAssertEqual(DigitShortcutModifierSettings.displayName(for: combo), "Shift+Command")
+    }
+
+    // MARK: EventModifiers conversion
+
+    func testEventModifiersFromStoredCommand() {
+        let stored = Int(NSEvent.ModifierFlags.command.rawValue)
+        let modifiers = DigitShortcutModifierSettings.eventModifiers(
+            for: stored, fallback: DigitShortcutModifierSettings.defaultWorkspaceFlags
+        )
+        XCTAssertTrue(modifiers.contains(.command))
+        XCTAssertFalse(modifiers.contains(.shift))
+    }
+
+    func testEventModifiersFromStoredCombo() {
+        let combo: NSEvent.ModifierFlags = [.command, .shift]
+        let stored = Int(combo.rawValue)
+        let modifiers = DigitShortcutModifierSettings.eventModifiers(
+            for: stored, fallback: DigitShortcutModifierSettings.defaultWorkspaceFlags
+        )
+        XCTAssertTrue(modifiers.contains(.command))
+        XCTAssertTrue(modifiers.contains(.shift))
+    }
+
+    func testEventModifiersZeroFallsBackToDefault() {
+        let modifiers = DigitShortcutModifierSettings.eventModifiers(
+            for: 0, fallback: [.control]
+        )
+        XCTAssertTrue(modifiers.contains(.control))
+        XCTAssertFalse(modifiers.contains(.command))
+    }
+}
+
+// MARK: - Configurable Hint Modifier Tests
+
+final class ConfigurableHintModifierTests: XCTestCase {
+
+    private func withDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "ConfigurableHintModifierTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create defaults suite")
+            return
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        body(defaults)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    // MARK: Default modifiers
+
+    func testDefaultCommandTriggersHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+        }
+    }
+
+    func testDefaultControlTriggersHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+        }
+    }
+
+    func testDefaultOptionDoesNotTriggerHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.option], defaults: defaults))
+        }
+    }
+
+    func testEmptyFlagsDoNotTriggerHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [], defaults: defaults))
+        }
+    }
+
+    // MARK: Custom modifiers
+
+    func testCustomWorkspaceModifierTriggersHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            let combo: NSEvent.ModifierFlags = [.option, .shift]
+            defaults.set(Int(combo.rawValue), forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: combo, defaults: defaults))
+        }
+    }
+
+    func testOldDefaultCommandDoesNotTriggerAfterCustomWorkspace() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            let combo: NSEvent.ModifierFlags = [.option, .shift]
+            defaults.set(Int(combo.rawValue), forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+        }
+    }
+
+    func testCustomSurfaceModifierTriggersHints() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: DigitShortcutModifierSettings.surfaceModifierKey)
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.option], defaults: defaults))
+        }
+    }
+
+    func testOldDefaultControlDoesNotTriggerAfterCustomSurface() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: DigitShortcutModifierSettings.surfaceModifierKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+        }
+    }
+
+    // MARK: Hints disabled
+
+    func testHintsDisabledReturnsFalseEvenForMatchingModifier() {
+        withDefaults { defaults in
+            defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+        }
+    }
+
+    // MARK: Partial match does not trigger
+
+    func testPartialComboDoesNotTrigger() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            let combo: NSEvent.ModifierFlags = [.command, .shift]
+            defaults.set(Int(combo.rawValue), forKey: DigitShortcutModifierSettings.workspaceModifierKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+        }
+    }
+
+    func testSupersetDoesNotTrigger() {
+        withDefaults { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command, .shift, .option], defaults: defaults))
+        }
+    }
+}

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -503,13 +503,15 @@ final class CommandPaletteSelectionScrollBehaviorTests: XCTestCase {
 
 
 final class ShortcutHintModifierPolicyTests: XCTestCase {
-    func testShortcutHintRequiresEnabledCommandOnlyModifier() {
+    func testShortcutHintRequiresConfiguredModifiers() {
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
 
+            // Default workspace=Command, surface=Control both trigger hints.
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [], defaults: defaults))
+            // Combos that don't exactly match either configured modifier are rejected.
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command, .shift], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control, .shift], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command, .option], defaults: defaults))
@@ -531,8 +533,9 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
         withDefaultsSuite { defaults in
             defaults.removeObject(forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
 
+            // Both default modifiers trigger hints when the setting hasn't been explicitly set.
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
@@ -606,7 +609,8 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
                 )
             )
 
-            XCTAssertFalse(
+            // Control is the default surface modifier, so it also triggers hints.
+            XCTAssertTrue(
                 ShortcutHintModifierPolicy.shouldShowHints(
                     for: [.control],
                     hostWindowNumber: 42,


### PR DESCRIPTION
## Summary

The default tab modifer is control, which is also the default modifier for changing desktops in macos. I'd like to be able to change it. So I made both configurable, you can now configure tab and workspace modifier keys

it should resolve this issue: https://github.com/manaflow-ai/cmux/issues/645

https://github.com/manaflow-ai/bonsplit/pull/32

## Testing

- How did you test this change?
- What did you verify manually?
- 
I verified it all works manually, however it doesn't fully work to show the tabs up top, that will require a bonesplit change. I am going to submit a PR here.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

https://github.com/user-attachments/assets/6b00d0e9-69b1-4938-bd56-6034afe7c6e0

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the 1–9 shortcuts configurable so users can choose the modifier key(s) for switching workspaces and surfaces. Replaces the hardcoded Cmd/Ctrl behavior, updates hints and menus to match, and applies changes live.

- **New Features**
  - Settings: add “Workspace 1–9 Modifier” and “Surface 1–9 Modifier” with a press-to-record control and a warning if both use the same modifier; reset-to-defaults also resets these and broadcasts changes.
  - Keyboard/UI: digit shortcuts now use the chosen modifiers across the app (event handling, menu shortcuts, tab labels); labels show symbols like ⌃⌥⇧⌘; updates propagate via a change notification.
  - Hints/Tests: “Modifier-Hold Shortcut Hints” work with either configured modifier; copy/localizations updated; new tests cover defaults, combos, symbol labels, event modifier conversion, and hint policy.

<sup>Written for commit 2b0a2e7aa8a3b8ff9af250e86e48f81b64bf94ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable modifier keys for digit-based workspace and surface shortcuts (1–9).
  * Interactive modifier-key recorder in Settings with persistent storage.

* **Improvements**
  * Keyboard hint wording changed from “Cmd/Ctrl-Hold” to “Modifier-Hold”.
  * Shortcut hints and digit shortcuts now respect configured modifiers and detect conflicts when workspace and surface modifiers match.

* **Localization**
  * Added new localization keys (including a “Press modifier…” prompt); updated English copy and marked Japanese entries as needing review.

* **Tests**
  * Added and updated unit tests for configurable modifier behavior and hint-matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->