### PR TITLE
feat: sidebar folder drop — open workspace or add terminal split

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -877,7 +877,11 @@ private func findFileDropOverlayView(in root: NSView?) -> FileDropOverlayView? {
 private func configureFileDropOverlay(_ overlay: FileDropOverlayView, tabManager: TabManager) {
     overlay.onDrop = { [weak tabManager] urls in
         MainActor.assumeIsolated {
-            guard let tabManager, let terminal = tabManager.selectedWorkspace?.focusedTerminalPanel else { return false }
+            guard let tabManager else { return false }
+            // Plain-directory drops onto the sidebar open or extend a workspace.
+            if tabManager.handleSidebarFolderDrop(urls) { return true }
+            // Otherwise fall back to pasting the path into the focused terminal.
+            guard let terminal = tabManager.selectedWorkspace?.focusedTerminalPanel else { return false }
             return terminal.hostedView.handleDroppedURLs(urls)
         }
     }

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -305,7 +305,9 @@ final class FileDropOverlayView: NSView {
             preparedDragWebView = accepted ? webView : nil
             return accepted
         }
-        return hasPaneTarget
+        // Allow the folder-drop fallback path (e.g. sidebar) when no pane target is under
+        // the cursor — performDragOperation will route the URLs through `onDrop`.
+        return hasPaneTarget || onDrop != nil
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
@@ -394,7 +396,15 @@ final class FileDropOverlayView: NSView {
             return handled
         }
         activeDragWebView = nil
-        guard let terminal else { return false }
+        guard let terminal else {
+            // No terminal/browser/pane target under the drop point — delegate to the folder-drop
+            // handler. In practice the only non-pane area visible to this overlay is the sidebar.
+            let urls = sender.draggingPasteboard.readObjects(
+                forClasses: [NSURL.self],
+                options: [.urlReadingFileURLsOnly: true]
+            ) as? [URL] ?? []
+            return onDrop?(urls) ?? false
+        }
         return terminal.performDragOperation(sender)
     }
 

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -62,6 +62,39 @@ final class FileDropOverlayView: NSView {
     var lastHitTestLogSignature: String?
     var lastDragRouteLogSignatureByPhase: [String: String] = [:]
 
+    /// Cached "pasteboard contains at least one plain directory" result for the current
+    /// drag session, keyed by pasteboard `changeCount`. Avoids re-reading the pasteboard
+    /// and running filesystem stat on every `draggingUpdated` event.
+    private var plainDirectoryCacheChangeCount: Int = -1
+    private var plainDirectoryCacheResult: Bool = false
+
+    /// Reads file URLs from the dragging pasteboard.
+    func fileURLs(from sender: any NSDraggingInfo) -> [URL] {
+        return sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+    }
+
+    /// Returns true when the dragging pasteboard contains at least one plain directory
+    /// URL (not a filesystem package such as `.app` / `.xcworkspace`). Cached per
+    /// pasteboard `changeCount` so repeated calls during a drag session are cheap.
+    func draggingPayloadContainsPlainDirectory(_ sender: any NSDraggingInfo) -> Bool {
+        let current = sender.draggingPasteboard.changeCount
+        if plainDirectoryCacheChangeCount == current {
+            return plainDirectoryCacheResult
+        }
+        let urls = fileURLs(from: sender)
+        let result = urls.contains { url in
+            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isPackageKey])
+            else { return false }
+            return values.isDirectory == true && values.isPackage != true
+        }
+        plainDirectoryCacheChangeCount = current
+        plainDirectoryCacheResult = result
+        return result
+    }
+
     override var acceptsFirstResponder: Bool { false }
 
     override init(frame frameRect: NSRect) {
@@ -399,11 +432,7 @@ final class FileDropOverlayView: NSView {
         guard let terminal else {
             // No terminal/browser/pane target under the drop point — delegate to the folder-drop
             // handler. In practice the only non-pane area visible to this overlay is the sidebar.
-            let urls = sender.draggingPasteboard.readObjects(
-                forClasses: [NSURL.self],
-                options: [.urlReadingFileURLsOnly: true]
-            ) as? [URL] ?? []
-            return onDrop?(urls) ?? false
+            return onDrop?(fileURLs(from: sender)) ?? false
         }
         return terminal.performDragOperation(sender)
     }

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -91,8 +91,25 @@ extension FileDropOverlayView {
             hasPaneTarget: hasPaneTarget
         )
 #endif
-        guard shouldCapture, hasPaneTarget else { return [] }
-        return .copy
+        guard shouldCapture else { return [] }
+        if hasPaneTarget { return .copy }
+        // Sidebar / non-pane area: only show the copy cursor when the payload contains
+        // at least one plain directory (not a package like .app/.xcworkspace). Files
+        // and packages should not advertise copy here since they cannot open as a workspace.
+        if onDrop != nil, pasteboardContainsPlainDirectory(sender) { return .copy }
+        return []
+    }
+
+    private func pasteboardContainsPlainDirectory(_ sender: any NSDraggingInfo) -> Bool {
+        let urls = sender.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+        return urls.contains { url in
+            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isPackageKey])
+            else { return false }
+            return values.isDirectory == true && values.isPackage != true
+        }
     }
 
     private func fileDropPaneTargetsAreIdentical(

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -96,20 +96,8 @@ extension FileDropOverlayView {
         // Sidebar / non-pane area: only show the copy cursor when the payload contains
         // at least one plain directory (not a package like .app/.xcworkspace). Files
         // and packages should not advertise copy here since they cannot open as a workspace.
-        if onDrop != nil, pasteboardContainsPlainDirectory(sender) { return .copy }
+        if onDrop != nil, draggingPayloadContainsPlainDirectory(sender) { return .copy }
         return []
-    }
-
-    private func pasteboardContainsPlainDirectory(_ sender: any NSDraggingInfo) -> Bool {
-        let urls = sender.draggingPasteboard.readObjects(
-            forClasses: [NSURL.self],
-            options: [.urlReadingFileURLsOnly: true]
-        ) as? [URL] ?? []
-        return urls.contains { url in
-            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isPackageKey])
-            else { return false }
-            return values.isDirectory == true && values.isPackage != true
-        }
     }
 
     private func fileDropPaneTargetsAreIdentical(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2065,6 +2065,75 @@ class TabManager: ObservableObject {
     }
 #endif
 
+    /// Handles a folder drag-and-drop onto the sidebar or non-terminal window area.
+    ///
+    /// - If an existing workspace has the same working directory, selects it and adds a new
+    ///   terminal split. If the workspace contains only non-terminal panels (e.g. browser-only),
+    ///   the terminal split is anchored beside the existing panel rather than creating a new workspace.
+    /// - Otherwise, creates a new workspace rooted at the dropped folder.
+    ///
+    /// Only the first plain-directory URL is acted upon. Non-directory URLs and filesystem
+    /// packages (.app, .xcworkspace, .playground, etc.) are silently ignored.
+    @discardableResult
+    func handleSidebarFolderDrop(_ urls: [URL]) -> Bool {
+        let folderURLs = urls.filter { url in
+            // Accept only plain directories; exclude filesystem packages (.app, .xcworkspace,
+            // .playground, etc.) which report isDirectory=true but should be ignored like files.
+            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isPackageKey])
+            else { return false }
+            return values.isDirectory == true && values.isPackage != true
+        }
+        let directories = FinderServicePathResolver.orderedUniqueDirectories(
+            from: folderURLs.filter { $0.isFileURL }
+        )
+        guard let path = directories.first else { return false }
+
+#if DEBUG
+        cmuxDebugLog("sidebar.folderDrop path=\(path) tabCount=\(tabs.count)")
+#endif
+
+        // Note: resolvingSymlinksInPath is intentionally not applied here.
+        // orderedUniqueDirectories already uses standardizedFileURL which resolves /tmp → /private/tmp
+        // on macOS. Adding resolvingSymlinksInPath to both sides would be equivalent but adds
+        // unnecessary cost; /tmp symlink matching already passes without it.
+        let existing = tabs.first { workspace in
+            var cd = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+            while cd.count > 1 && cd.hasSuffix("/") { cd.removeLast() }
+            return cd == path
+        }
+
+        if let existing {
+            // Prefer a focused or existing TerminalPanel as the split source.
+            // If the workspace has only non-terminal panels (e.g. browser-only), use any panel
+            // so a new terminal appears as a split beside it rather than creating a new workspace.
+            let panelId = existing.focusedPanelId
+                ?? existing.panels.values.compactMap { $0 as? TerminalPanel }.first?.id
+                ?? existing.panels.values.first?.id
+            guard let panelId else {
+                // No panel to split from — drop is not handled.
+                return false
+            }
+            let newPanel = existing.newTerminalSplit(from: panelId, orientation: .horizontal)
+            guard newPanel != nil else {
+#if DEBUG
+                cmuxDebugLog("sidebar.folderDrop.splitFailed panelId=\(panelId.uuidString.prefix(5))")
+#endif
+                return false
+            }
+            // Switch workspace selection only after a successful split.
+            selectedTabId = existing.id
+#if DEBUG
+            cmuxDebugLog("sidebar.folderDrop.existing workspaceId=\(existing.id.uuidString.prefix(5))")
+#endif
+        } else {
+            addWorkspace(workingDirectory: path, select: true)
+#if DEBUG
+            cmuxDebugLog("sidebar.folderDrop.new path=\(path)")
+#endif
+        }
+        return true
+    }
+
     @discardableResult
     func addWorkspace(
         title: String? = nil,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9925,11 +9925,26 @@ final class Workspace: Identifiable, ObservableObject {
         // Suppress the old view's becomeFirstResponder side-effects during SwiftUI reparenting.
         // Without this, reparenting triggers onFocus + ghostty_surface_set_focus on the old view,
         // stealing focus from the new panel and creating model/surface divergence.
+        let browserSourcePanel = panels[panelId] as? BrowserPanel
         if focus {
             previousHostedView?.suppressReparentFocus()
-            focusPanel(newPanel.id, previousHostedView: previousHostedView)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                previousHostedView?.clearSuppressReparentFocus()
+            if let browserSourcePanel {
+                // WKWebView portal still covers the full workspace until SwiftUI layout
+                // shrinks it to the new split bounds. Focus the browser first (matches
+                // existing geometry), then move focus to the new terminal on the next
+                // runloop after layout has updated, so its first click is not swallowed
+                // by the stale portal.
+                focusPanel(browserSourcePanel.id, previousHostedView: previousHostedView)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.focusPanel(newPanel.id, previousHostedView: nil)
+                    previousHostedView?.clearSuppressReparentFocus()
+                }
+            } else {
+                focusPanel(newPanel.id, previousHostedView: previousHostedView)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    previousHostedView?.clearSuppressReparentFocus()
+                }
             }
         } else {
             preserveFocusAfterNonFocusSplit(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9936,9 +9936,12 @@ final class Workspace: Identifiable, ObservableObject {
                 // by the stale portal.
                 focusPanel(browserSourcePanel.id, previousHostedView: previousHostedView)
                 DispatchQueue.main.async { [weak self] in
+                    // Always clear suppression, even if Workspace was deallocated
+                    // in the meantime — otherwise the previous browser hosted view
+                    // is left permanently muted, blocking future onFocus delivery.
+                    defer { previousHostedView?.clearSuppressReparentFocus() }
                     guard let self else { return }
                     self.focusPanel(newPanel.id, previousHostedView: nil)
-                    previousHostedView?.clearSuppressReparentFocus()
                 }
             } else {
                 focusPanel(newPanel.id, previousHostedView: previousHostedView)


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/cf14e807-2a21-4b80-9e7f-6727096c458f

## Summary

- Dropping a folder from Finder onto the cmux sidebar opens a terminal in that directory
- If a workspace with the same path already exists, it is selected and a new terminal split is added inside it
- If no matching workspace exists, a new workspace is created at that path
- Browser-only workspaces are supported — the terminal appears as a split beside the browser, and the first click works immediately

## Behavior

| Drop target | Action |
|---|---|
| Sidebar + plain folder, workspace exists | Select workspace + add terminal split |
| Sidebar + plain folder, browser-only workspace | Add terminal split beside browser |
| Sidebar + plain folder, no match | Create new workspace |
| Sidebar + file | Silently ignored |
| Sidebar + package (`.app`, `.xcworkspace`, etc.) | Silently ignored |
| Terminal panel (any item) | Unchanged — path text pasted as before |
| Browser panel (any item) | Unchanged — browser handles the drop |

## Implementation

**`Sources/ContentView.swift`** (`FileDropOverlayView`)
- `performDragOperation`: when no terminal is under the cursor, reads folder URLs from the pasteboard and delegates to `onFolderDrop`
- `updateDragTarget`: returns `.copy` only when the payload contains at least one plain-directory URL (`hasDirectoryPath && !isPackage`). Packages are excluded via `resourceValues(forKeys: [.isDirectoryKey, .isPackageKey])` with fail-closed guard. Drops on terminal panels preserve the existing behavior.

**`Sources/TabManager.swift`** (`handleSidebarFolderDrop`)
- Filters to plain directories via `isDirectory + isPackage` resource keys (same exclusion logic as `updateDragTarget`)
- Normalises paths via `FinderServicePathResolver.orderedUniqueDirectories` (handles `/tmp → /private/tmp` and trailing slashes)
- Matches against `workspace.currentDirectory`; prefers `focusedPanelId`, falls back to any `TerminalPanel`, then any panel (for browser-only workspaces)
- Returns `false` when no terminal was created (drop not consumed)

**`Sources/Workspace.swift`** (`newTerminalSplit`)
- When the split source is a `BrowserPanel`, focuses the browser panel first (synchronously), then hands focus to the new terminal on the next runloop — after SwiftUI has repositioned the WKWebView portal to its new (smaller) rect. This prevents the first click on the terminal from being swallowed by the stale portal geometry.

## Focus fix detail

After splitting from a browser-only workspace, the WKWebView portal window covers the full workspace rect until SwiftUI layout shrinks it. Directly focusing the new terminal caused its first click to be intercepted by the stale portal.

Fix: `focusPanel(browser)` synchronously → `DispatchQueue.main.async { focusPanel(terminal) }`. SwiftUI updates the portal geometry between the two calls, so clicks land correctly on the terminal immediately.

Only `Workspace.swift` and `TabManager.swift` are changed for this fix — `BrowserPanel` and `BrowserWindowPortal` are untouched.

## Testing

```bash
./scripts/reload.sh --tag drag-folder-sidebar
tail -f /tmp/cmux-debug-drag-folder-sidebar.log | grep "sidebar.folderDrop"
```

1. Drag a plain folder onto the sidebar → new workspace opens at that path
2. Drag the same folder again → existing workspace selected, new split added (`sidebar.folderDrop.existing` in log)
3. Drag onto a browser-only workspace → terminal split opens beside the browser; first click works immediately
4. Drag a file → nothing happens, no copy cursor shown
5. Drag a `.app` bundle → nothing happens, no copy cursor shown
6. Drag a folder onto a terminal panel → path text pasted as before

## Related

Builds on #1571 (dock icon drag support).

## Checklist

- [x] Tested locally (all 6 scenarios above)
- [x] No new UI strings (no localization changes needed)
- [x] All code review bot comments resolved
- [x] Existing terminal and browser drop behavior unchanged

## Summary by CodeRabbit

Updated file-drop routing to forward dropped folder URLs to `TabManager.handleSidebarFolderDrop(_)`, changed copy-advertising to require a non-package directory payload, and adjusted terminal-split focus sequencing to defer focusing the new terminal when split originates from a `BrowserPanel`.

| File | Summary |
|---|---|
| `Sources/ContentView.swift` | When no terminal is under the drop point, read dropped URLs and call `onDrop?(urls)`; advertise `.copy` only if payload contains at least one non-package directory |
| `Sources/TabManager.swift` | Added `handleSidebarFolderDrop` — selects first plain directory, matches existing workspace by path, attempts a horizontal terminal split or creates a new workspace |
| `Sources/Workspace.swift` | In `newTerminalSplit`, special-case `BrowserPanel` sources: focus browser first, then focus new terminal on the next main-queue turn |

## Summary by cubic

Drag a plain folder from Finder onto the sidebar to open a terminal in that directory. Existing workspaces are reused with a split when possible; files and filesystem packages like `.app` are ignored.

- **New Features**
  - Matching workspace at path → select and add a terminal split; browser-only → split beside the browser; otherwise create a new workspace.
  - Drops on terminal or browser panels are unchanged; the sidebar handles folder drops only. The copy cursor is shown only for plain directories (non-packages).

- **Bug Fixes**
  - Allow sidebar folder drops by approving the prepare step when no terminal is under the cursor.
  - Restore first-click focus after splitting from a browser-only workspace by focusing the browser first, then the new terminal on the next runloop.
  - Return false when no terminal is created so the drop isn't consumed.
  - Switch workspace selection only after a successful split to avoid changing tabs on rejected drops.

<sup>Written for commit 53cc9fccd379a818d02d16d92963af02a7f36c51.</sup>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folder drag-and-drop to the sidebar to open or create workspaces.

* **Bug Fixes**
  * Fallback handling for folder drops when no pane/terminal is under the cursor.
  * More reliable terminal split creation and focus when splitting from browser panels.
  * Improved drag-cursor feedback and detection for droppable folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->