### PR TITLE
Fix 8 macOS issues + resolve all Dependabot security vulnerabilities

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10145,7 +10145,7 @@ struct CMUXCLI {
             fallbackWorkspaceId = try resolveWorkspaceIdForClaudeHook(workspaceArg, client: client)
         } catch {
             // If we can't resolve the workspace, lifecycle hooks are no-ops.
-            // session-start is the only hook that truly needs a workspace;
+            // Only session-start and active require a live workspace;
             // for all others, print OK and return.
             if subcommand != "session-start" && subcommand != "active" {
                 print("OK")
@@ -10313,7 +10313,7 @@ struct CMUXCLI {
                 )
             }
 
-            let response = (try? client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")) ?? "OK"
+            let response = (try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)) ?? "OK"
             _ = try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
@@ -10522,6 +10522,10 @@ struct CMUXCLI {
             if probe != nil {
                 return candidate
             }
+            // The specific workspace is gone. Don't fall back to
+            // workspace.current — that would target an unrelated workspace
+            // with notifications/status updates meant for this one.
+            throw CLIError(message: "Workspace no longer available: \(raw)")
         }
         return try resolveWorkspaceId(nil, client: client)
     }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10136,7 +10136,23 @@ struct CMUXCLI {
                 "has_surface_flag": optionValue(hookArgs, name: "--surface") != nil
             ]
         )
-        let fallbackWorkspaceId = try resolveWorkspaceIdForClaudeHook(workspaceArg, client: client)
+        // Best-effort workspace resolution: if TabManager is already torn
+        // down (app or workspace closing), lifecycle hooks (stop, session-end,
+        // etc.) should succeed silently rather than surfacing errors to the
+        // user (issues #1775, #1715).
+        let fallbackWorkspaceId: String
+        do {
+            fallbackWorkspaceId = try resolveWorkspaceIdForClaudeHook(workspaceArg, client: client)
+        } catch {
+            // If we can't resolve the workspace, lifecycle hooks are no-ops.
+            // session-start is the only hook that truly needs a workspace;
+            // for all others, print OK and return.
+            if subcommand != "session-start" && subcommand != "active" {
+                print("OK")
+                return
+            }
+            throw error
+        }
         let fallbackSurfaceId = try? resolveSurfaceId(surfaceArg, workspaceId: fallbackWorkspaceId, client: client)
 
         switch subcommand {
@@ -10208,19 +10224,23 @@ struct CMUXCLI {
             }
 
             if let completion {
-                let resolvedSurface = try resolveSurfaceIdForClaudeHook(
+                // Best-effort: TabManager may be torn down if workspace/app is
+                // closing while the Claude session ends (issues #1775, #1715).
+                if let resolvedSurface = try? resolveSurfaceIdForClaudeHook(
                     surfaceId,
                     workspaceId: workspaceId,
                     client: client
-                )
-                let title = "Claude Code"
-                let subtitle = sanitizeNotificationField(completion.subtitle)
-                let body = sanitizeNotificationField(completion.body)
-                let payload = "\(title)|\(subtitle)|\(body)"
-                _ = try? sendV1Command("notify_target \(workspaceId) \(resolvedSurface) \(payload)", client: client)
+                ) {
+                    let title = "Claude Code"
+                    let subtitle = sanitizeNotificationField(completion.subtitle)
+                    let body = sanitizeNotificationField(completion.body)
+                    let payload = "\(title)|\(subtitle)|\(body)"
+                    _ = try? sendV1Command("notify_target \(workspaceId) \(resolvedSurface) \(payload)", client: client)
+                }
             }
 
-            try setClaudeStatus(
+            // Best-effort: benign if TabManager is already torn down.
+            try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
                 value: "Idle",
@@ -10237,8 +10257,9 @@ struct CMUXCLI {
                let mappedWorkspace = try? resolveWorkspaceIdForClaudeHook(mapped.workspaceId, client: client) {
                 workspaceId = mappedWorkspace
             }
-            _ = try sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
-            try setClaudeStatus(
+            // Best-effort: benign if TabManager is already torn down.
+            _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+            try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
                 value: "Running",
@@ -10266,11 +10287,15 @@ struct CMUXCLI {
                 }
             }
 
-            let surfaceId = try resolveSurfaceIdForClaudeHook(
+            // Best-effort: benign if TabManager is already torn down.
+            guard let surfaceId = try? resolveSurfaceIdForClaudeHook(
                 preferredSurface,
                 workspaceId: workspaceId,
                 client: client
-            )
+            ) else {
+                print("OK")
+                return
+            }
 
             let title = "Claude Code"
             let subtitle = sanitizeNotificationField(summary.subtitle)
@@ -10288,7 +10313,7 @@ struct CMUXCLI {
                 )
             }
 
-            let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
+            let response = (try? client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")) ?? "OK"
             _ = try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
@@ -10363,7 +10388,8 @@ struct CMUXCLI {
             } else {
                 statusValue = "Running"
             }
-            try setClaudeStatus(
+            // Best-effort: benign if TabManager is already torn down.
+            try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
                 value: statusValue,

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -94,7 +94,22 @@ else
     # Verify that the resolved claude binary supports --session-id.
     # Some environments (e.g. nvm not yet initialized in a fresh tab)
     # may resolve to an older binary that rejects this flag (#1818).
-    if "$REAL_CLAUDE" --help 2>&1 | grep -q -- '--session-id'; then
+    # Cache the result per binary path+mtime so the --help subprocess
+    # only runs once per shell session or binary update.
+    _claude_real_mtime="$(stat -f '%m' "$REAL_CLAUDE" 2>/dev/null || stat -c '%Y' "$REAL_CLAUDE" 2>/dev/null || echo 0)"
+    _claude_cache_key="${REAL_CLAUDE}:${_claude_real_mtime}"
+    if [[ "${_CMUX_CLAUDE_SESSION_ID_CACHE_KEY:-}" == "$_claude_cache_key" ]]; then
+        _claude_has_session_id="$_CMUX_CLAUDE_SESSION_ID_CACHE_VAL"
+    else
+        if "$REAL_CLAUDE" --help 2>&1 | grep -q -- '--session-id'; then
+            _claude_has_session_id=1
+        else
+            _claude_has_session_id=0
+        fi
+        export _CMUX_CLAUDE_SESSION_ID_CACHE_KEY="$_claude_cache_key"
+        export _CMUX_CLAUDE_SESSION_ID_CACHE_VAL="$_claude_has_session_id"
+    fi
+    if [[ "$_claude_has_session_id" == "1" ]]; then
         SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
         exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
     else

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -91,6 +91,14 @@ HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
-    SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    # Verify that the resolved claude binary supports --session-id.
+    # Some environments (e.g. nvm not yet initialized in a fresh tab)
+    # may resolve to an older binary that rejects this flag (#1818).
+    if "$REAL_CLAUDE" --help 2>&1 | grep -q -- '--session-id'; then
+        SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+        exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    else
+        # Fall back: inject hooks but skip session tracking.
+        exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
+    fi
 fi

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -99,9 +99,11 @@ _cmux_report_tty_once() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ -n "$_CMUX_TTY_NAME" ]] || return 0
     _CMUX_TTY_REPORTED=1
-    {
+    # Use subshell ( ) instead of { } & disown to avoid bash job completion
+    # notifications — subshells are never added to the job table (#1565).
+    (
         _cmux_send "report_tty $_CMUX_TTY_NAME --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    ) >/dev/null 2>&1 &
 }
 
 _cmux_report_shell_activity_state() {
@@ -112,9 +114,9 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
+    (
         _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    ) >/dev/null 2>&1 &
 }
 
 _cmux_ports_kick() {
@@ -124,9 +126,9 @@ _cmux_ports_kick() {
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     _CMUX_PORTS_LAST_RUN=$SECONDS
-    {
+    (
         _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    ) >/dev/null 2>&1 &
 }
 
 _cmux_clear_pr_for_panel() {
@@ -332,15 +334,14 @@ _cmux_start_pr_poll_loop() {
     _cmux_stop_pr_poll_loop
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
-    {
+    (
         while :; do
             kill -0 "$watch_shell_pid" 2>/dev/null || break
             _cmux_run_pr_probe_with_timeout "$watch_pwd" || true
             sleep "$interval"
         done
-    } >/dev/null 2>&1 &
+    ) >/dev/null 2>&1 &
     _CMUX_PR_POLL_PID=$!
-    disown "$_CMUX_PR_POLL_PID" 2>/dev/null || disown
 }
 
 _cmux_bash_cleanup() {
@@ -403,10 +404,10 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
+        (
             local qpwd="${pwd//\"/\\\"}"
             _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+        ) >/dev/null 2>&1 &
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -450,9 +451,9 @@ _cmux_prompt_command() {
     if [[ -z "$_CMUX_GIT_JOB_PID" ]] || ! kill -0 "$_CMUX_GIT_JOB_PID" 2>/dev/null; then
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
-        {
+        (
             # Skip git operations if not in a git repository to avoid TCC prompts
-            git rev-parse --git-dir >/dev/null 2>&1 || return 0
+            git rev-parse --git-dir >/dev/null 2>&1 || exit 0
             local branch dirty_opt=""
             branch=$(git branch --show-current 2>/dev/null)
             if [[ -n "$branch" ]]; then
@@ -463,9 +464,8 @@ _cmux_prompt_command() {
             else
                 _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
             fi
-        } >/dev/null 2>&1 &
+        ) >/dev/null 2>&1 &
         _CMUX_GIT_JOB_PID=$!
-        disown
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -99,11 +99,12 @@ _cmux_report_tty_once() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ -n "$_CMUX_TTY_NAME" ]] || return 0
     _CMUX_TTY_REPORTED=1
-    # Use subshell ( ) instead of { } & disown to avoid bash job completion
-    # notifications — subshells are never added to the job table (#1565).
+    # Subshell for process isolation + disown to remove from bash job table,
+    # preventing "[N]+ Done" notifications at the next prompt (#1565).
     (
         _cmux_send "report_tty $_CMUX_TTY_NAME --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     ) >/dev/null 2>&1 &
+    disown 2>/dev/null
 }
 
 _cmux_report_shell_activity_state() {
@@ -117,6 +118,7 @@ _cmux_report_shell_activity_state() {
     (
         _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     ) >/dev/null 2>&1 &
+    disown 2>/dev/null
 }
 
 _cmux_ports_kick() {
@@ -129,6 +131,7 @@ _cmux_ports_kick() {
     (
         _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     ) >/dev/null 2>&1 &
+    disown 2>/dev/null
 }
 
 _cmux_clear_pr_for_panel() {
@@ -342,6 +345,7 @@ _cmux_start_pr_poll_loop() {
         done
     ) >/dev/null 2>&1 &
     _CMUX_PR_POLL_PID=$!
+    disown 2>/dev/null
 }
 
 _cmux_bash_cleanup() {
@@ -408,6 +412,7 @@ _cmux_prompt_command() {
             local qpwd="${pwd//\"/\\\"}"
             _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
         ) >/dev/null 2>&1 &
+        disown 2>/dev/null
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -466,6 +471,7 @@ _cmux_prompt_command() {
             fi
         ) >/dev/null 2>&1 &
         _CMUX_GIT_JOB_PID=$!
+        disown 2>/dev/null
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5357,6 +5357,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         mainWindowContexts.values.first(where: { $0.windowId == windowId })?.sidebarState.isVisible
     }
 
+    /// Toggle the sidebar for the window identified by the given NSWindow.
+    /// Used by titlebar accessory buttons so they affect their own window
+    /// rather than the currently focused/key window (#1779).
+    func toggleSidebarForWindow(_ window: NSWindow?) -> Bool {
+        if let context = contextForMainWindow(window) {
+            context.sidebarState.toggle()
+            return true
+        }
+        return toggleSidebarInActiveMainWindow()
+    }
+
     @objc func openNewMainWindow(_ sender: Any?) {
         _ = createMainWindow()
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5361,7 +5361,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// Used by titlebar accessory buttons so they affect their own window
     /// rather than the currently focused/key window (#1779).
     func toggleSidebarForWindow(_ window: NSWindow?) -> Bool {
-        if let context = contextForMainWindow(window) {
+        if let window {
+            guard let context = contextForMainTerminalWindow(window) else {
+                return false
+            }
             context.sidebarState.toggle()
             return true
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2533,6 +2533,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// temporarily unattached (surface not yet created / reparenting) even while the panel
     /// is already in the window.
     var isViewInWindow: Bool { hostedView.window != nil }
+    /// Whether the runtime surface pointer is non-nil **and** the surface has
+    /// not yet entered the close/teardown lifecycle.  Use this before passing
+    /// `surface` to any Ghostty C API — a non-nil `surface` can become a
+    /// dangling pointer once teardown is in progress (the actual free happens
+    /// asynchronously on the next main-actor turn).
+    var isSurfaceLive: Bool { surface != nil && portalLifecycleState == .live }
     let id: UUID
     private(set) var tabId: UUID
     /// Port ordinal for CMUX_PORT range assignment

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3311,7 +3311,19 @@ class TabManager: ObservableObject {
                 return
             }
 
-            if !controller.setDividerPosition(0.5, forSplit: splitId) {
+            // Count the number of leaf panes along this split's axis
+            // on each side. For a tree A | (B | C) with all horizontal
+            // splits, the left side has 1 leaf and the right side has 2,
+            // so the divider should be 1/3 (not 0.5). Nested splits on
+            // the *other* axis count as 1, since they don't subdivide
+            // this axis further (#1622).
+            let orientation = splitNode.orientation.lowercased()
+            let leftLeaves = countLeaves(in: splitNode.first, along: orientation)
+            let rightLeaves = countLeaves(in: splitNode.second, along: orientation)
+            let total = leftLeaves + rightLeaves
+            let position = total > 0 ? Double(leftLeaves) / Double(total) : 0.5
+
+            if !controller.setDividerPosition(position, forSplit: splitId) {
                 allSucceeded = false
             }
 
@@ -3327,6 +3339,24 @@ class TabManager: ObservableObject {
                 foundSplit: &foundSplit,
                 allSucceeded: &allSucceeded
             )
+        }
+    }
+
+    /// Count the number of leaf panes that subdivide the given axis.
+    /// A nested split along the same axis expands into its children;
+    /// a nested split along the perpendicular axis counts as one unit.
+    private func countLeaves(in node: ExternalTreeNode, along axis: String) -> Int {
+        switch node {
+        case .pane:
+            return 1
+        case .split(let splitNode):
+            if splitNode.orientation.lowercased() == axis {
+                return countLeaves(in: splitNode.first, along: axis)
+                     + countLeaves(in: splitNode.second, along: axis)
+            } else {
+                // Perpendicular split: counts as a single unit on this axis.
+                return 1
+            }
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -784,10 +784,26 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     private var userDefaultsObserver: NSObjectProtocol?
     var popoverIsShownForTesting: Bool { notificationsPopover.isShown }
     private var showsWorkspaceTitlebar: Bool { !WorkspacePresentationModeSettings.isMinimal() }
+    /// Box for deferred weak-self capture so the sidebar toggle closure
+    /// can resolve the window this accessory is attached to (#1779).
+    private final class WeakSelfBox {
+        weak var vc: TitlebarControlsAccessoryViewController?
+    }
+    private let weakSelfBox = WeakSelfBox()
 
     init(notificationStore: TerminalNotificationStore) {
         self.notificationStore = notificationStore
-        let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
+        // Capture the box (which will hold a weak ref to self after super.init).
+        // This lets the sidebar toggle target the window this accessory belongs to
+        // rather than the currently focused/key window (#1779).
+        let box = weakSelfBox
+        let toggleSidebar = {
+            if let window = box.vc?.view.window {
+                _ = AppDelegate.shared?.toggleSidebarForWindow(window)
+            } else {
+                _ = AppDelegate.shared?.sidebarState?.toggle()
+            }
+        }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
         let newTab = { _ = AppDelegate.shared?.tabManager?.addTab() }
 
@@ -803,6 +819,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         )
 
         super.init(nibName: nil, bundle: nil)
+        weakSelfBox.vc = self
 
         view = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = true

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6595,7 +6595,8 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
         lastTerminalConfigInheritancePanelId = terminalPanel.id
-        if let sourceSurface = terminalPanel.surface.surface,
+        if terminalPanel.surface.isSurfaceLive,
+           let sourceSurface = terminalPanel.surface.surface,
            let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface) {
             let existing = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
             if existing == nil || abs((existing ?? runtimePoints) - runtimePoints) > 0.05 {
@@ -6693,7 +6694,12 @@ final class Workspace: Identifiable, ObservableObject {
             preferredPanelId: preferredPanelId,
             inPane: preferredPaneId
         ) {
-            guard let sourceSurface = terminalPanel.surface.surface else { continue }
+            // Check both that the pointer is non-nil AND the surface lifecycle
+            // hasn't started teardown. Without this, we can pass a dangling
+            // pointer to ghostty_surface_inherited_config (use-after-free crash
+            // on Intel — issues #1558, #1608, #1767, #1815).
+            guard terminalPanel.surface.isSurfaceLive,
+                  let sourceSurface = terminalPanel.surface.surface else { continue }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT
@@ -7978,6 +7984,12 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func moveFocus(direction: NavigationDirection) {
+        // If a pane is zoomed, un-zoom before navigating so the target
+        // pane becomes visible — matches tmux behavior (#1605).
+        if bonsplitController.isSplitZoomed {
+            _ = clearSplitZoom()
+        }
+
         // Unfocus the currently-focused panel before navigating.
         if let prevPanelId = focusedPanelId, let prev = panels[prevPanelId] {
             prev.unfocus()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7987,7 +7987,7 @@ final class Workspace: Identifiable, ObservableObject {
         // If a pane is zoomed, un-zoom before navigating so the target
         // pane becomes visible — matches tmux behavior (#1605).
         if bonsplitController.isSplitZoomed {
-            _ = clearSplitZoom()
+            _ = clearSplitZoom(reason: "workspace.moveFocus")
         }
 
         // Unfocus the currently-focused panel before navigating.
@@ -8059,8 +8059,12 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
-    func clearSplitZoom() -> Bool {
-        bonsplitController.clearPaneZoom()
+    func clearSplitZoom(reason: String = "workspace.clearSplitZoom") -> Bool {
+        guard bonsplitController.clearPaneZoom() else { return false }
+        reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+        reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: reason)
+        beginEventDrivenLayoutFollowUp(reason: reason, includeGeometry: true)
+        return true
     }
 
     @discardableResult
@@ -8069,8 +8073,11 @@ final class Workspace: Identifiable, ObservableObject {
         guard let paneId = paneId(forPanelId: panelId) else { return false }
         guard bonsplitController.togglePaneZoom(inPane: paneId) else { return false }
         focusPanel(panelId)
-        reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
-        reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: "workspace.toggleSplitZoom")
+        if !bonsplitController.isSplitZoomed {
+            // Un-zooming: use centralized reconciliation
+            reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+            reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: "workspace.toggleSplitZoom")
+        }
         if let browserPanel = browserPanel(for: panelId) {
             browserPanel.preparePortalHostReplacementForNextDistinctClaim(
                 inPane: paneId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8060,7 +8060,23 @@ final class Workspace: Identifiable, ObservableObject {
 
     @discardableResult
     func clearSplitZoom(reason: String = "workspace.clearSplitZoom") -> Bool {
+        // Capture the zoomed pane's browser panel (if any) before clearing zoom,
+        // so we can prime its portal host replacement afterward.
+        let zoomedBrowser: (paneId: PaneID, panel: BrowserPanel)? = {
+            guard let zoomedPaneId = bonsplitController.zoomedPaneId,
+                  let tabId = bonsplitController.selectedTab(inPane: zoomedPaneId)?.id,
+                  let panelId = panelIdFromSurfaceId(tabId),
+                  let browser = browserPanel(for: panelId) else { return nil }
+            return (zoomedPaneId, browser)
+        }()
+
         guard bonsplitController.clearPaneZoom() else { return false }
+        if let zoomedBrowser {
+            zoomedBrowser.panel.preparePortalHostReplacementForNextDistinctClaim(
+                inPane: zoomedBrowser.paneId,
+                reason: reason
+            )
+        }
         reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
         reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: reason)
         beginEventDrivenLayoutFollowUp(reason: reason, includeGeometry: true)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -366,12 +366,6 @@ struct cmuxApp: App {
                     appDelegate.openPreferencesWindow(debugSource: "menu.cmdComma")
                 }
                 .keyboardShortcut(",", modifiers: .command)
-            }
-
-            CommandGroup(replacing: .appInfo) {
-                Button(String(localized: "menu.app.about", defaultValue: "About cmux")) {
-                    showAboutPanel()
-                }
                 Button(String(localized: "menu.app.ghosttySettings", defaultValue: "Ghostty Settings…")) {
                     GhosttyApp.shared.openConfigurationInTextEdit()
                 }
@@ -379,6 +373,12 @@ struct cmuxApp: App {
                     GhosttyApp.shared.reloadConfiguration(source: "menu.reload_configuration")
                 }
                 .keyboardShortcut(",", modifiers: [.command, .shift])
+            }
+
+            CommandGroup(replacing: .appInfo) {
+                Button(String(localized: "menu.app.about", defaultValue: "About cmux")) {
+                    showAboutPanel()
+                }
                 Divider()
                 Button(String(localized: "menu.app.checkForUpdates", defaultValue: "Check for Updates…")) {
                     appDelegate.checkForUpdates(nil)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@t3-oss/env-nextjs": "^0.13.10",
         "@vercel/firewall": "^1.1.2",
-        "next": "16.1.6",
+        "next": "16.1.7",
         "next-intl": "^4.8.3",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.350.0",
@@ -29,7 +29,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "16.1.6",
+        "eslint-config-next": "16.1.7",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -78,6 +78,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1098,15 +1099,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
+      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.7.tgz",
+      "integrity": "sha512-v/bRGOJlfRCO+NDKt0bZlIIWjhMKU8xbgEQBo+rV9C8S6czZvs96LZ/v24/GvpEnovZlL4QDpku/RzWHVbmPpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1114,9 +1115,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
+      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
       "cpu": [
         "arm64"
       ],
@@ -1130,9 +1131,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
+      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
       "cpu": [
         "x64"
       ],
@@ -1146,9 +1147,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
+      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
       "cpu": [
         "arm64"
       ],
@@ -1162,9 +1163,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
+      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
       "cpu": [
         "arm64"
       ],
@@ -1178,9 +1179,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
+      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
       "cpu": [
         "x64"
       ],
@@ -1194,9 +1195,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
+      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
       "cpu": [
         "x64"
       ],
@@ -1210,9 +1211,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
+      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
       "cpu": [
         "arm64"
       ],
@@ -1226,9 +1227,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
+      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
       "cpu": [
         "x64"
       ],
@@ -1294,6 +1295,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2582,6 +2584,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2654,6 +2657,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2808,13 +2812,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3181,6 +3185,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3524,6 +3529,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3929,9 +3935,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4186,6 +4192,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4241,13 +4248,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.7.tgz",
+      "integrity": "sha512-FTq1i/QDltzq+zf9aB/cKWAiZ77baG0V7h8dRQh3thVx7I4dwr6ZXQrWKAaTB7x5VwVXlzoUTyMLIVQPLj2gJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.6",
+        "@next/eslint-plugin-next": "16.1.7",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -4371,6 +4378,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4741,9 +4749,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6242,9 +6250,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6322,14 +6330,14 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
+      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.1.7",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -6341,14 +6349,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
+        "@next/swc-darwin-arm64": "16.1.7",
+        "@next/swc-darwin-x64": "16.1.7",
+        "@next/swc-linux-arm64-gnu": "16.1.7",
+        "@next/swc-linux-arm64-musl": "16.1.7",
+        "@next/swc-linux-x64-gnu": "16.1.7",
+        "@next/swc-linux-x64-musl": "16.1.7",
+        "@next/swc-win32-arm64-msvc": "16.1.7",
+        "@next/swc-win32-x64-msvc": "16.1.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -6966,6 +6974,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6975,6 +6984,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7803,6 +7813,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7975,6 +7986,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8392,6 +8404,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.13.10",
     "@vercel/firewall": "^1.1.2",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "next-intl": "^4.8.3",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.350.0",
@@ -30,7 +30,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.1.6",
+    "eslint-config-next": "16.1.7",
     "tailwindcss": "^4",
     "typescript": "^5"
   },


### PR DESCRIPTION
## Summary

Community contribution addressing 8 open macOS issues and all 7 Dependabot security alerts.

### Bug Fixes

**SIGSEGV crash in `inheritedTerminalConfig`** (#1558, #1608, #1767, #1815)
- Added `isSurfaceLive` guard on `TerminalSurface` that checks both non-nil pointer AND live portal lifecycle state before passing the surface to any Ghostty C API. Prevents use-after-free when the surface is in async teardown.

**"TabManager not available" hook errors** (#1775, #1715)
- Lifecycle hooks (`stop`, `session-end`, `notification`, `prompt-submit`) now degrade gracefully when TabManager is already torn down during app/workspace close. Only `session-start` requires a live workspace.

**CLI shim `--session-id` error in fresh tabs** (#1818)
- The `claude` wrapper now verifies the resolved binary supports `--session-id` via `--help` before using it. Falls back to hooks-only mode if the flag isn't supported (e.g., stale nvm-resolved binary).

**Side panel toggle affects wrong window** (#1779)
- Added `toggleSidebarForWindow(_:)` to `AppDelegate`. Titlebar accessory buttons now capture their own `view.window` via a `WeakSelfBox` pattern, targeting the correct window instead of whichever happens to be key.

**Zoomed pane doesn't un-zoom on focus navigation** (#1605)
- `moveFocus(direction:)` now calls `clearSplitZoom()` when a pane is zoomed, matching tmux behavior.

**Bash job termination notification spam** (#1565)
- Replaced `{ ... } & disown` with `( ... ) &` for all background telemetry commands. Subshells are never added to bash's job table, eliminating spurious "Done" notifications.

**Equalize Splits produces uneven layouts** (#1622)
- Added `countLeaves(in:along:)` to calculate proportional divider positions based on leaf pane count per axis. `A | (B | C)` now produces 33/33/33 instead of 50/25/25.

**Menu order — Ghostty Settings above Settings** (#1680)
- Moved "Ghostty Settings..." and "Reload Configuration" from `.appInfo` into `.appSettings`, placing them after the Preferences item.

### Security (Dependabot)

Resolves all 7 open Dependabot alerts (3 high, 3 moderate, 1 low):

| Package | From | To | Severity | Issue |
|---------|------|----|----------|-------|
| `next` | 16.1.6 | 16.1.7 | Medium | HTTP smuggling, CSRF bypass, DoS |
| `flatted` | 3.3.3 | 3.4.2 | High | Prototype pollution, unbounded recursion DoS |
| `dompurify` | 3.3.1 | 3.3.3 | Medium | XSS |
| `minimatch` | 3.1.2 | 3.1.5 | High | ReDoS via combinatorial backtracking |
| `minimatch` (nested) | 9.0.5 | 9.0.9 | High | ReDoS via combinatorial backtracking |

### Files Changed

| File | Change |
|------|--------|
| `Sources/GhosttyTerminalView.swift` | `isSurfaceLive` computed property |
| `Sources/Workspace.swift` | Surface lifecycle guards + un-zoom on focus nav |
| `CLI/cmux.swift` | Graceful hook degradation |
| `Resources/bin/claude` | `--session-id` compatibility check |
| `Sources/AppDelegate.swift` | `toggleSidebarForWindow(_:)` |
| `Sources/Update/UpdateTitlebarAccessory.swift` | WeakSelfBox window targeting |
| `Sources/TabManager.swift` | Proportional leaf-counting equalize |
| `Sources/cmuxApp.swift` | Menu item reordering |
| `Resources/shell-integration/cmux-bash-integration.bash` | Subshell background jobs |
| `web/package.json` | next + eslint-config-next bump |
| `web/package-lock.json` | All transitive dependency updates |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eight macOS bugs to improve stability and window behavior, and closes all Dependabot security alerts by upgrading vulnerable web dependencies.

- **Bug Fixes**
  - Prevented SIGSEGV in inherited terminal config by guarding C API calls with `isSurfaceLive`.
  - Lifecycle hooks now degrade gracefully if TabManager is torn down; only `session-start` and `active` require a live workspace. No fallback to other workspaces, and notifications/status updates are best‑effort.
  - `claude` wrapper verifies `--session-id` support via `--help`, caches the check per binary path+mtime, and falls back to hooks‑only mode if unsupported.
  - Sidebar toggle buttons target their own window (WeakSelfBox + `toggleSidebarForWindow(_:)`), not the key window.
  - Focus navigation clears split zoom first, primes browser portal host replacement, then reconciles layout/portals for consistent visibility, matching tmux behavior.
  - Suppressed bash “Done” notifications by running background commands in a subshell and disowning the job.
  - Equalize Splits uses leaf‑counted proportions along the axis for even layouts in nested splits.
  - Moved “Ghostty Settings…” and “Reload Configuration” below Preferences in the app menu.

- **Dependencies**
  - Resolved security alerts by upgrading:
    - `next` 16.1.6 → 16.1.7
    - `flatted` 3.3.3 → 3.4.2
    - `dompurify` 3.3.1 → 3.3.3
    - `minimatch` 3.1.2 → 3.1.5 and 9.0.5 → 9.0.9
  - Also aligned `eslint-config-next` to `16.1.7`; lockfile updated with safe transitive versions.

<sup>Written for commit 2e8222a48a8c547d26e4195525c3d8e3649a95e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient workspace/session lifecycle and notifications: failed resolutions now no longer surface errors and often return success.
  * Safer terminal/surface handling during teardown and improved split-pane navigation when zoomed.
  * More robust background shell jobs with suppressed disown errors.
  * Prevented targeting of unavailable workspaces when probes fail.

* **New Features**
  * Window-context-aware sidebar toggle.

* **Chores**
  * Session ID injection now performed only when the target tool supports it (with caching).
  * Updated web build dependencies and adjusted app menu ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->