### PR TITLE
fix: AppleScript count windows returns 0 + working directory returns empty

### DIFF
--- a/Sources/AppleScriptSupport.swift
+++ b/Sources/AppleScriptSupport.swift
@@ -538,7 +538,10 @@ final class ScriptTerminal: NSObject {
     @objc(workingDirectory)
     var workingDirectory: String {
         guard NSApp.isAppleScriptEnabled else { return "" }
-        return terminal?.directory ?? ""
+        // TerminalPanel.directory is never updated (updateDirectory is never called).
+        // Read from Workspace.panelDirectories instead, which is kept up to date
+        // via updatePanelDirectory() from OSC 7 / shell integration.
+        return workspace?.panelDirectories[terminalId] ?? terminal?.directory ?? ""
     }
 
     func input(text: String) -> Bool {


### PR DESCRIPTION
## Summary

Fix two AppleScript bugs:
1. `count windows` always returns 0
2. `working directory` of terminals always returns empty string

## Bug 1: `count windows` returns 0

### Root Cause

`isAppleScriptEnabled` calls `GhosttyApp.shared.appleScriptAutomationEnabled()`, which reads the `macos-applescript` Ghostty config key. The Ghostty fork used by cmux (`bc9be90a2`, 2026-03-13) does not include this config key — it was added in upstream Ghostty commit `25fa58143` (2026-03-06) as `@"macos-applescript": bool = true`.

Since the key doesn't exist, `ghostty_config_get` returns `false`, and `guard isAppleScriptEnabled` silently returns empty arrays for all window/tab/terminal queries.

### Fix

Always return `true` from `isAppleScriptEnabled` until the fork is updated.

## Bug 2: `working directory` returns empty string

### Root Cause

`ScriptTerminal.workingDirectory` reads `terminal?.directory`, which is `TerminalPanel.directory`. However, `TerminalPanel.updateDirectory()` is **never called anywhere in the codebase** — so `directory` stays at its initial value `""`.

Meanwhile, `Workspace.panelDirectories` *is* kept up to date via `updatePanelDirectory()` from OSC 7 / shell integration — and is what `sidebar-state` uses to report cwd.

### Fix

Read from `workspace?.panelDirectories[terminalId]` instead of `terminal?.directory`.

## Test Results

**Before fix:**
```
$ osascript -e 'tell application "cmux" to count windows'
0
$ osascript -e 'tell application "cmux" to get working directory of terminal 1 of tab 1 of window 1'
(fails — no windows)
```

**After fix (DEV build):**
```
$ osascript -e 'tell application "cmux DEV fix-applescript" to count windows'
1
$ osascript -e 'tell application "cmux DEV fix-applescript" to get working directory of terminal 1 of tab 1 of window 1'
/Users/grimmer
```

Other AppleScript commands also work: `input text`, `count tabs`, `count terminals`, `get version`.

## Context

I'm building [CodeV](https://github.com/grimmerk/codev), an Electron app that switches between Claude Code sessions running in different terminals (iTerm2, Ghostty, cmux). Ghostty's identical `.sdef` structure works perfectly — `count windows` returns correct values and `working directory` returns correct cwd. These two fixes bring cmux's AppleScript to parity with Ghostty.

## Remaining Limitation

When multiple terminals share the same `working directory` (e.g. two sessions both in `/Users/grimmer`), AppleScript matching will switch to the first one found — there's no way to distinguish them. This would require exposing per-terminal `pid` or `tty` in the scripting dictionary, which is a separate feature request.

## Alternative Fix for Bug 1

Cherry-pick upstream Ghostty commit `25fa58143` (`macos: add macos-applescript config`) into the fork, which adds `macos-applescript` with default `true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AppleScript automation is now always enabled and available.

* **Behavioral Changes**
  * AppleScript-exposed working directory now reflects the workspace's panel directory first, improving script accuracy when multiple panels/workspaces are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
