### PR TITLE
feat: add background-blur-radius support

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -23,6 +23,7 @@ struct GhosttyConfig {
     // Colors (from theme or config)
     var backgroundColor: NSColor = NSColor(hex: "#272822")!
     var backgroundOpacity: Double = 1.0
+    var backgroundBlurRadius: Int = 0
     var foregroundColor: NSColor = NSColor(hex: "#fdfff1")!
     var cursorColor: NSColor = NSColor(hex: "#c0c1b5")!
     var cursorTextColor: NSColor = NSColor(hex: "#8d8e82")!
@@ -257,6 +258,10 @@ struct GhosttyConfig {
                 case "background-opacity":
                     if let opacity = Double(value) {
                         backgroundOpacity = opacity
+                    }
+                case "background-blur-radius":
+                    if let radius = Int(value) {
+                        backgroundBlurRadius = max(0, min(255, radius))
                     }
                 case "foreground":
                     if let color = NSColor(hex: value) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -41,7 +41,7 @@ private func CGSSetWindowBackgroundBlurRadius(
 @_silgen_name("CGSDefaultConnectionForThread")
 private func CGSDefaultConnectionForThread() -> OpaquePointer
 
-func cmuxApplyBackgroundBlur(to window: NSWindow, radius: Int) {
+private func cmuxApplyBackgroundBlur(to window: NSWindow, radius: Int) {
     let connection = CGSDefaultConnectionForThread()
     let windowNumber = window.windowNumber
     _ = CGSSetWindowBackgroundBlurRadius(connection, windowNumber, Int32(radius))
@@ -2446,11 +2446,12 @@ class GhosttyApp {
             }
         }
 
-        // Apply background blur if opacity < 1.0 and blur radius is configured
+        // Apply or clear background blur. CGS blur is window-stateful, so we must
+        // explicitly set radius to 0 when blur should be disabled.
         let blurConfig = GhosttyConfig.load()
-        if blurConfig.backgroundBlurRadius > 0, defaultBackgroundOpacity < 1.0 {
-            cmuxApplyBackgroundBlur(to: window, radius: blurConfig.backgroundBlurRadius)
-        }
+        let effectiveBlurRadius = (blurConfig.backgroundBlurRadius > 0 && defaultBackgroundOpacity < 1.0)
+            ? blurConfig.backgroundBlurRadius : 0
+        cmuxApplyBackgroundBlur(to: window, radius: effectiveBlurRadius)
     }
 
     private func activeMainWindow() -> NSWindow? {
@@ -3918,11 +3919,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             window.isOpaque = color.alphaComponent >= 1.0
         }
 
-        // Apply background blur if configured
-        let blurConfig2 = GhosttyConfig.load()
-        if blurConfig2.backgroundBlurRadius > 0, color.alphaComponent < 1.0 {
-            cmuxApplyBackgroundBlur(to: window, radius: blurConfig2.backgroundBlurRadius)
-        }
+        // Apply or clear background blur. CGS blur is window-stateful, so we must
+        // explicitly set radius to 0 when blur should be disabled.
+        let blurConfig = GhosttyConfig.load()
+        let effectiveBlur = (blurConfig.backgroundBlurRadius > 0 && color.alphaComponent < 1.0)
+            ? blurConfig.backgroundBlurRadius : 0
+        cmuxApplyBackgroundBlur(to: window, radius: effectiveBlur)
 
         if GhosttyApp.shared.backgroundLogEnabled {
             let signature = "\(cmuxShouldUseClearWindowBackground(for: color.alphaComponent) ? "transparent" : color.hexString()):\(String(format: "%.3f", color.alphaComponent))"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -27,6 +27,25 @@ private func cmuxTransparentWindowBaseColor() -> NSColor {
     // avoids visual artifacts that can happen with a fully clear window background.
     NSColor.white.withAlphaComponent(0.001)
 }
+
+// MARK: - Background Blur (private Core Graphics API)
+// Uses the same undocumented CGS API that Ghostty and Terminal.app use for window blur.
+// See: ghostty-org/ghostty/src/apprt/embedded.zig (ghostty_set_window_background_blur)
+@_silgen_name("CGSSetWindowBackgroundBlurRadius")
+private func CGSSetWindowBackgroundBlurRadius(
+    _ connection: OpaquePointer,
+    _ windowNumber: Int,
+    _ radius: Int32
+) -> Int32
+
+@_silgen_name("CGSDefaultConnectionForThread")
+private func CGSDefaultConnectionForThread() -> OpaquePointer
+
+func cmuxApplyBackgroundBlur(to window: NSWindow, radius: Int) {
+    let connection = CGSDefaultConnectionForThread()
+    let windowNumber = window.windowNumber
+    _ = CGSSetWindowBackgroundBlurRadius(connection, windowNumber, Int32(radius))
+}
 #endif
 
 #if DEBUG
@@ -1686,6 +1705,7 @@ class GhosttyApp {
         let opacityKey = "background-opacity"
         _ = ghostty_config_get(config, &opacity, opacityKey, UInt(opacityKey.lengthOfBytes(using: .utf8)))
         opacity = min(1.0, max(0.0, opacity))
+
         applyDefaultBackground(
             color: resolvedColor,
             opacity: opacity,
@@ -2424,6 +2444,12 @@ class GhosttyApp {
             if backgroundLogEnabled {
                 logBackground("applied default window background color=\(color) opacity=\(String(format: "%.3f", color.alphaComponent))")
             }
+        }
+
+        // Apply background blur if opacity < 1.0 and blur radius is configured
+        let blurConfig = GhosttyConfig.load()
+        if blurConfig.backgroundBlurRadius > 0, defaultBackgroundOpacity < 1.0 {
+            cmuxApplyBackgroundBlur(to: window, radius: blurConfig.backgroundBlurRadius)
         }
     }
 
@@ -3891,6 +3917,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             window.backgroundColor = color
             window.isOpaque = color.alphaComponent >= 1.0
         }
+
+        // Apply background blur if configured
+        let blurConfig2 = GhosttyConfig.load()
+        if blurConfig2.backgroundBlurRadius > 0, color.alphaComponent < 1.0 {
+            cmuxApplyBackgroundBlur(to: window, radius: blurConfig2.backgroundBlurRadius)
+        }
+
         if GhosttyApp.shared.backgroundLogEnabled {
             let signature = "\(cmuxShouldUseClearWindowBackground(for: color.alphaComponent) ? "transparent" : color.hexString()):\(String(format: "%.3f", color.alphaComponent))"
             if signature != lastLoggedWindowBackgroundSignature {


### PR DESCRIPTION
## Summary

- Parse `background-blur-radius` from Ghostty config
- Apply blur using the same private `CGSSetWindowBackgroundBlurRadius` Core Graphics API that Ghostty and Terminal.app use
- Blur is only applied when `background-opacity < 1.0` (matching Ghostty's behavior)

Closes #1371

## How I found the issue

I was investigating why `background-opacity` doesn't apply to terminal panes in cmux (issue #879). During that research I discovered that `background-blur-radius` is also unsupported. I traced how Ghostty implements blur in its source (`ghostty-org/ghostty/src/apprt/embedded.zig` lines 2083-2111) and found it's a single call to the undocumented `CGSSetWindowBackgroundBlurRadius` API — the same one Terminal.app has used for years.

Looking at cmux's `GhosttyConfig.swift`, I found that `background-blur-radius` simply has no `case` in the config parser — it's silently ignored. The window transparency infrastructure already exists in cmux (`window.isOpaque = false`, clear backgrounds, etc.), so the blur API just needed to be called.

## What changed

**`Sources/GhosttyConfig.swift`** (2 additions):
- Added `backgroundBlurRadius: Int` property (default 0)
- Added config parsing for `"background-blur-radius"` key, clamped to 0-255

**`Sources/GhosttyTerminalView.swift`** (3 additions):
- Declared private CG API functions via `@_silgen_name`: `CGSSetWindowBackgroundBlurRadius` and `CGSDefaultConnectionForThread`
- Added `cmuxApplyBackgroundBlur(to:radius:)` helper
- Called blur in both `applyBackgroundToKeyWindow()` and `applyWindowBackgroundIfActive()` — the two places where window opacity is already configured

## How I verified it

1. Built cmux from source with `./scripts/reload.sh --tag blur-fix`
2. Config: `background-opacity = 0.5` + `background-blur-radius = 20`
3. Confirmed frosted glass blur visible through terminal panes — matching standalone Ghostty behavior
4. Confirmed blur only applies when opacity < 1.0
5. Confirmed standalone Ghostty has this working (as a reference)

### Screenshot — cmux DEV with blur working

The Tux wallpaper is visible and blurred behind the terminal, matching Ghostty's native `background-blur-radius` behavior:

*(screenshot of working blur in cmux DEV build was verified locally)*

## Note on code quality

I'm not deeply familiar with the cmux codebase conventions, so this implementation may not be up to your standards. A few things I'm unsure about:

- **`GhosttyConfig.load()` called in both blur sites**: I followed the existing pattern of loading config on demand rather than storing blur radius on `GhosttyApp.shared`. If there's a preferred way to access config values at these call sites, happy to refactor.
- **`@_silgen_name` for private CG APIs**: This is the standard pattern for calling undocumented CoreGraphics functions from Swift (used by iTerm2, Ghostty, etc.), but if cmux has a different approach for private API access, let me know.
- **Two call sites**: Blur is applied in both `applyBackgroundToKeyWindow()` and `applyWindowBackgroundIfActive()` because both paths configure window opacity. If there's a single canonical place for this, happy to consolidate.

Open to any feedback or requested changes.

## Related issues

- #1371 — Ghostty Blur Not Supported (this PR fixes it)
- #879 — background-opacity not applied to terminal rendering area (separate issue, related investigation)
- #1674 — background-blur-radius not supported; background-opacity rendering differs

## Test plan

- [x] Build succeeds (Debug configuration)
- [x] Blur visible with `background-blur-radius = 20` + `background-opacity = 0.5`
- [x] No blur when `background-opacity = 1.0` (correctly skipped)
- [x] No blur when `background-blur-radius = 0` (correctly skipped)
- [ ] Blur persists across workspace switches
- [ ] Blur updates on config reload
- [ ] Different radius values (5, 20, 50, 80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `background-blur-radius` from Ghostty config using the same CGS window blur API. Blur only applies when `background-opacity` < 1.0, and stale blur is cleared on config changes; closes #1371.

- **New Features**
  - Parse `background-blur-radius` in `GhosttyConfig` (0–255, default 0).
  - Add CGS blur bindings and `cmuxApplyBackgroundBlur` in `GhosttyTerminalView`.
  - Apply blur in both window background code paths.

- **Bug Fixes**
  - Always call `CGSSetWindowBackgroundBlurRadius` with radius 0 when disabled to clear stale blur.
  - Mark `cmuxApplyBackgroundBlur` as `private` and fix inconsistent variable naming.

<sup>Written for commit 02dd2ddfca7355508238a39161a4a080b4fda412. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable background blur for terminal windows when transparency is enabled.
  * Blur intensity adjustable via the background-blur-radius setting (0–255); 0 disables blur.

* **Bug Fixes**
  * Explicitly clears blur when disabled to prevent stale visual effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->