### PR TITLE
Localize bare strings in BrowserSearchOverlay and EmptyPanelView

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -8914,13 +8914,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Loading\u2026"
+            "value": "Loading…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "\u8aad\u307f\u8fbc\u307f\u4e2d\u2026"
+            "value": "読み込み中…"
           }
         }
       }
@@ -77511,6 +77511,345 @@
           "stringUnit": {
             "state": "translated",
             "value": "Varsayılan"
+          }
+        }
+      }
+    },
+    "emptyPane.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty Panel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空のパネル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빈 패널"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空面板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空面板"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeres Panel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel vacío"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panneau vide"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pannello vuoto"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tomt panel"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pusty panel"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пустая панель"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prazan panel"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوحة فارغة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tomt panel"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Painel vazio"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แผงว่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boş Panel"
+          }
+        }
+      }
+    },
+    "emptyPane.action.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Терминал"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طرفية"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เทอร์มินัล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        }
+      }
+    },
+    "emptyPane.action.browser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "브라우저"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏覽器"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeglądarka"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Браузер"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preglednik"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متصفح"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettleser"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegador"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เบราว์เซอร์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarayıcı"
           }
         }
       }

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -76,7 +76,7 @@ struct BrowserSearchOverlay: View {
     var body: some View {
         GeometryReader { geo in
             HStack(spacing: 4) {
-                TextField("Search", text: $searchState.needle)
+                TextField(String(localized: "search.placeholder", defaultValue: "Search"), text: $searchState.needle)
                     .textFieldStyle(.plain)
                     .accessibilityIdentifier("BrowserFindSearchTextField")
                     .frame(width: 180)
@@ -123,7 +123,7 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "chevron.up")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Next match (Return)")
+                .safeHelp(String(localized: "search.nextMatch.help", defaultValue: "Next match (Return)"))
 
                 Button(action: {
                     #if DEBUG
@@ -134,7 +134,7 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "chevron.down")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Previous match (Shift+Return)")
+                .safeHelp(String(localized: "search.previousMatch.help", defaultValue: "Previous match (Shift+Return)"))
 
                 Button(action: {
                     #if DEBUG
@@ -145,7 +145,7 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "xmark")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Close (Esc)")
+                .safeHelp(String(localized: "search.close.help", defaultValue: "Close (Esc)"))
             }
             .padding(8)
             .background(.background)

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -409,20 +409,20 @@ struct EmptyPanelView: View {
                 .font(.system(size: 48))
                 .foregroundStyle(.tertiary)
 
-            Text("Empty Panel")
+            Text(String(localized: "emptyPane.title", defaultValue: "Empty Panel"))
                 .font(.headline)
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 12) {
                 emptyPaneActionButton(
-                    title: "Terminal",
+                    title: String(localized: "emptyPane.action.terminal", defaultValue: "Terminal"),
                     systemImage: "terminal.fill",
                     shortcut: newSurfaceShortcut,
                     action: createTerminal
                 )
 
                 emptyPaneActionButton(
-                    title: "Browser",
+                    title: String(localized: "emptyPane.action.browser", defaultValue: "Browser"),
                     systemImage: "globe",
                     shortcut: openBrowserShortcut,
                     action: createBrowser


### PR DESCRIPTION
## Summary

Two UI surfaces had hardcoded English strings that were missed during the localization pass, breaking the translated experience for non-English users:

1. **`BrowserSearchOverlay`** — The search placeholder and three tooltip labels (`"Search"`, `"Next match (Return)"`, `"Previous match (Shift+Return)"`, `"Close (Esc)"`) were bare strings, while the equivalent `SurfaceSearchOverlay` already used `String(localized:defaultValue:)` with translated keys.

2. **`EmptyPanelView`** (in `WorkspaceContentView.swift`) — The heading `"Empty Panel"` and the two action button labels `"Terminal"` / `"Browser"` were bare strings.

## What changed

### `BrowserSearchOverlay.swift` (4 lines)

Replaced bare strings with the **existing** localization keys that `SurfaceSearchOverlay` already uses:

| Before | After | Key (already translated in 18 languages) |
|--------|-------|------------------------------------------|
| `TextField("Search", ...)` | `TextField(String(localized: "search.placeholder", defaultValue: "Search"), ...)` | `search.placeholder` |
| `.safeHelp("Next match (Return)")` | `.safeHelp(String(localized: "search.nextMatch.help", ...))` | `search.nextMatch.help` |
| `.safeHelp("Previous match (Shift+Return)")` | `.safeHelp(String(localized: "search.previousMatch.help", ...))` | `search.previousMatch.help` |
| `.safeHelp("Close (Esc)")` | `.safeHelp(String(localized: "search.close.help", ...))` | `search.close.help` |

No new keys needed — these four keys already exist with translations in all 18 supported languages (en, ja, ko, zh-Hans, zh-Hant, de, es, fr, it, da, pl, ru, bs, ar, nb, pt-BR, th, tr).

### `WorkspaceContentView.swift` (3 lines)

Replaced bare strings with **new** localization keys:

| Before | After | New key |
|--------|-------|---------|
| `Text("Empty Panel")` | `Text(String(localized: "emptyPane.title", defaultValue: "Empty Panel"))` | `emptyPane.title` |
| `title: "Terminal"` | `title: String(localized: "emptyPane.action.terminal", defaultValue: "Terminal")` | `emptyPane.action.terminal` |
| `title: "Browser"` | `title: String(localized: "emptyPane.action.browser", defaultValue: "Browser")` | `emptyPane.action.browser` |

### `Localizable.xcstrings`

Added the 3 new keys with translations in all 18 languages. Translations were derived from existing keys:
- **Terminal** / **Browser** labels: extracted from `command.newTerminalTab.title` / `command.newBrowserTab.title` (e.g. ja: ターミナル / ブラウザ, ko: 터미널 / 브라우저)
- **Empty Panel**: translated to match the UI tone of existing strings (e.g. ja: 空のパネル, ko: 빈 패널)

## Why this matters

- Non-English users see English text in the browser find bar and empty pane view, which breaks an otherwise fully-translated UI
- `SurfaceSearchOverlay` was already localized — this was simply missed for `BrowserSearchOverlay`, creating an inconsistency
- The project's `CLAUDE.md` explicitly requires all user-facing strings to use `String(localized:defaultValue:)`

## Test plan

- [ ] Open browser pane → Cmd+F → verify search placeholder and button tooltips appear in the configured locale
- [ ] Close all panes in a workspace → verify "Empty Panel", "Terminal", and "Browser" labels appear in the configured locale
- [ ] Verify English locale still shows the same strings as before (defaultValue fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized bare strings in the browser search overlay and empty panel view so non‑English users see translated UI. Reused existing search keys and added three new `emptyPane.*` keys with translations in 18 languages.

- **Bug Fixes**
  - `BrowserSearchOverlay`: switched placeholder and tooltips to `String(localized:)` using existing keys `search.placeholder`, `search.nextMatch.help`, `search.previousMatch.help`, `search.close.help`.
  - `EmptyPanelView`: replaced "Empty Panel", "Terminal", and "Browser" with new keys `emptyPane.title`, `emptyPane.action.terminal`, `emptyPane.action.browser`.
  - `Localizable.xcstrings`: added translations for the three new keys in all supported languages, reusing established terms.

<sup>Written for commit 0085a58baff205bb21bd82e43cdb3937876df299. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Extended translation support across 18 languages for interface labels and messaging
  * Improved localized text throughout the search interface and empty state displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->