### PR TITLE
Add debug logging to silent catch blocks in BrowserPanel

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -982,6 +982,9 @@ final class BrowserHistoryStore: ObservableObject {
         do {
             data = try Data(contentsOf: fileURL)
         } catch {
+#if DEBUG
+            dlog("browser.history.load.readError path=\(fileURL.path) error=\(error)")
+#endif
             return
         }
 
@@ -989,6 +992,9 @@ final class BrowserHistoryStore: ObservableObject {
         do {
             decoded = try JSONDecoder().decode([Entry].self, from: data)
         } catch {
+#if DEBUG
+            dlog("browser.history.load.decodeError path=\(fileURL.path) error=\(error)")
+#endif
             return
         }
 
@@ -1288,6 +1294,9 @@ final class BrowserHistoryStore: ObservableObject {
             do {
                 try Self.persistSnapshot(snapshot, to: fileURL)
             } catch {
+#if DEBUG
+                dlog("browser.history.save.persistError path=\(fileURL.path) error=\(error)")
+#endif
                 return
             }
         }
@@ -1307,6 +1316,9 @@ final class BrowserHistoryStore: ObservableObject {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
             try fm.copyItem(at: legacyURL, to: targetURL)
         } catch {
+#if DEBUG
+            dlog("browser.history.migrate.error from=\(legacyURL.path) to=\(targetURL.path) error=\(error)")
+#endif
             return
         }
     }
@@ -1627,6 +1639,9 @@ actor BrowserSearchSuggestionService {
         do {
             (data, response) = try await URLSession.shared.data(for: req)
         } catch {
+#if DEBUG
+            dlog("browser.suggestions.fetchError url=\(url.absoluteString) error=\(error)")
+#endif
             return []
         }
 


### PR DESCRIPTION
## Summary

Five `catch` blocks in `BrowserHistoryStore` and `BrowserSearchSuggestionService` silently discard errors with bare `catch { return }`, making it impossible to diagnose file I/O, JSON decoding, or network failures during development.

This PR adds `dlog()` calls (wrapped in `#if DEBUG`) to each silent catch block, consistent with the existing logging pattern used elsewhere in `BrowserPanel.swift`.

## Problem

When browser history fails to load, save, migrate, or when search suggestions fail to fetch, the errors are completely swallowed. A developer debugging "why is my history empty?" or "why aren't suggestions appearing?" has no log trail to follow — the operations silently return with no indication of failure.

For comparison, other catch blocks in the same file already log properly:
- `BrowserFindInPage` uses `NSLog("Find: browser JS search error: %@", ...)`
- `download(_:didFinishDownloading:)` uses `NSLog("BrowserPanel download move failed: ...")`
- `navigateWithErrorHandling` uses `dlog(...)` in `#if DEBUG`

## What changed

**`BrowserPanel.swift`** — 5 catch blocks, +15 lines (3 lines each: `#if DEBUG` / `dlog(...)` / `#endif`)

| Location | Function | Error context | Log key |
|----------|----------|---------------|---------|
| Line 984 | `loadIfNeeded()` | Failed to read history file from disk | `browser.history.load.readError` |
| Line 991 | `loadIfNeeded()` | Failed to decode history JSON | `browser.history.load.decodeError` |
| Line 1290 | `scheduleSave()` | Failed to persist history snapshot | `browser.history.save.persistError` |
| Line 1309 | `migrateLegacyTaggedHistoryFileIfNeeded()` | Failed to copy legacy history file | `browser.history.migrate.error` |
| Line 1629 | `BrowserSearchSuggestionService` | Failed to fetch search suggestions | `browser.suggestions.fetchError` |

Each log message includes the relevant file path or URL and the full error description, following the structured `dlog("component.event key=value")` convention used throughout the codebase.

## What was intentionally left unchanged

The `Task.sleep` cancellation catch at line 1283 (`try await Task.sleep(nanoseconds: debounceNanoseconds)`) is **not** modified — `CancellationError` from `Task.sleep` is expected control flow (the save task is cancelled and re-created on each keystroke for debouncing), not an error condition.

## Impact

- **Zero runtime impact** — all logging is inside `#if DEBUG`, so Release builds are unaffected
- **Zero behavioral change** — catch blocks still return as before; only debug logging is added
- **Improved developer experience** — errors now surface in the debug log (`tail -f /tmp/cmux-debug.log`) instead of being silently lost

## Test plan

- [ ] Build in Debug configuration — verify no compile errors
- [ ] Temporarily corrupt or remove the browser history file → open omnibar → verify `browser.history.load.readError` appears in debug log
- [ ] Verify Release build has no change in binary (logging is `#if DEBUG` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add debug-only logging to previously silent catch blocks in `BrowserPanel.swift`, surfacing file I/O, JSON decode, and network errors during development. No behavior change; Release builds are unaffected.

- **Bug Fixes**
  - History load: log read and decode errors with path (`browser.history.load.readError`, `browser.history.load.decodeError`).
  - History write/migration: log persist and legacy copy errors with path(s) (`browser.history.save.persistError`, `browser.history.migrate.error`).
  - Suggestions: log fetch errors with URL (`browser.suggestions.fetchError`).
  - Debounce: keep `Task.sleep` cancellation unlogged (expected).

<sup>Written for commit 326a37e89bcaaf06989c12f99c529329b8a48bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added debug logging for browser history persistence operations and remote search suggestion failures to improve diagnostic capabilities during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->