### PR TITLE
feat: add set-color/clear-color to workspace-action CLI

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11050,7 +11050,7 @@ struct CMUXCLI {
           close-window --window <id>
           move-workspace-to-window --workspace <id|ref> --window <id|ref>
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>]
-          workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <hex>]
+          workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <#hex|name>]
           list-workspaces
           new-workspace [--cwd <path>] [--command <text>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [-- <remote-command-args>]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4068,7 +4068,11 @@ class TerminalController {
                 // Resolve named color to hex via palette lookup
                 let resolved: String
                 if colorRaw.hasPrefix("#") {
-                    resolved = colorRaw
+                    guard let normalized = WorkspaceTabColorSettings.normalizedHex(colorRaw) else {
+                        result = .err(code: "invalid_params", message: "Invalid hex color '\(colorRaw)'. Expected #RRGGBB", data: nil)
+                        return
+                    }
+                    resolved = normalized
                 } else if let entry = WorkspaceTabColorSettings.defaultPalette.first(where: {
                     $0.name.lowercased() == colorRaw.lowercased()
                 }) {


### PR DESCRIPTION
## Summary

Add CLI support for setting workspace tab colors via `workspace-action`.

## Usage

```bash
# Set color by name
cmux workspace-action --action set-color --workspace workspace:1 --color Red

# Set color by hex
cmux workspace-action --action set-color --workspace workspace:1 --color '#C0392B'

# Clear color
cmux workspace-action --action clear-color --workspace workspace:1
```

## Changes

- **CLI/cmux.swift**: Add `--color` option parsing, validation for `set_color` action, help text and synopsis updates
- **Sources/TerminalController.swift**: Add `set_color`/`clear_color` to `supportedActions`, implement switch cases with:
  - Named color → hex resolution via `WorkspaceTabColorSettings.defaultPalette`
  - Hex input validation via `normalizedHex()`
  - Proper error messages for invalid colors

## Motivation

Currently workspace colors can only be set via the UI context menu. This enables scripting use cases like:
- Auto-assigning colors based on project name hash when creating workspaces
- Batch color assignment across workspaces
- Hook-driven color normalization

No model changes needed — `tabManager.setTabColor(tabId:color:)` and `WorkspaceTabColorSettings` already exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `set-color` and `clear-color` to `cmux workspace-action` so you can script workspace tab colors. Supports named colors and `#RRGGBB` with validation and clear errors.

- **New Features**
  - Parse `--color` in the CLI, require it for `set-color`, and pass it in the v2 payload.
  - Resolve color names via `WorkspaceTabColorSettings.defaultPalette` and validate hex via `normalizedHex()`.
  - Handle `set_color`/`clear_color` in `TerminalController`; update help text and synopsis.

<sup>Written for commit c9f59038365eeea6ac7d26dfbf4f433155dac71f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added ability to set and clear workspace tab colors using new `--color` option
* Supports color specification via hex values or named colors from the default palette
* Includes validation with clear error messaging for invalid or missing color inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->