### PR TITLE
Replace force-unwrapped .data(using: .utf8)! with Data(string.utf8)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -987,7 +987,7 @@ class GhosttyApp {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: initLogPath) {
             handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
+            handle.write(Data(line.utf8))
             handle.closeFile()
         } else {
             FileManager.default.createFile(atPath: initLogPath, contents: line.data(using: .utf8))
@@ -2933,7 +2933,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: surfaceLogPath) {
             handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
+            handle.write(Data(line.utf8))
             handle.closeFile()
         } else {
             FileManager.default.createFile(atPath: surfaceLogPath, contents: line.data(using: .utf8))
@@ -2947,7 +2947,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: sizeLogPath) {
             handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
+            handle.write(Data(line.utf8))
             handle.closeFile()
         } else {
             FileManager.default.createFile(atPath: sizeLogPath, contents: line.data(using: .utf8))

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -305,7 +305,7 @@ extension WorkspaceContentView {
             let logPath = "/tmp/cmux-panel-debug.log"
             if let handle = FileHandle(forWritingAtPath: logPath) {
                 handle.seekToEndOfFile()
-                handle.write(line.data(using: .utf8)!)
+                handle.write(Data(line.utf8))
                 handle.closeFile()
             } else {
                 FileManager.default.createFile(atPath: logPath, contents: line.data(using: .utf8))


### PR DESCRIPTION
## Summary

Four call sites convert a `String` to `Data` for `FileHandle.write()` using `.data(using: .utf8)!`. While this force unwrap is safe in practice (UTF-8 encoding never fails for Swift strings), `Data(string.utf8)` is the idiomatic Swift equivalent that eliminates the force unwrap entirely — shorter, clearer, and no `!` needed.

## Before / After

```swift
// Before — force unwrap (safe but noisy)
handle.write(line.data(using: .utf8)!)

// After — idiomatic, no unwrap needed
handle.write(Data(line.utf8))
```

Both produce identical `Data` output. `String.utf8` returns a `String.UTF8View` which `Data.init(_:)` accepts directly.

## What changed

**4 lines across 2 files:**

| File | Line | Context |
|------|------|---------|
| `GhosttyTerminalView.swift` | 990 | `GhosttyApp` init log writer |
| `GhosttyTerminalView.swift` | 2936 | `TerminalSurface` surface log writer |
| `GhosttyTerminalView.swift` | 2950 | `TerminalSurface` size log writer |
| `WorkspaceContentView.swift` | 308 | Panel debug log writer |

All four are the same pattern: `FileHandle.seekToEndOfFile()` → `FileHandle.write(...)` → `FileHandle.closeFile()` inside `#if DEBUG` or debug-only logging paths.

## Why not change the `else` branch too?

Each call site has a corresponding `else` branch:
```swift
FileManager.default.createFile(atPath: path, contents: line.data(using: .utf8))
```
This call uses `.data(using: .utf8)` **without** the `!` (it returns `Data?`, and `createFile(contents:)` accepts `Data?`), so there is no force unwrap to remove. Left as-is to keep this PR focused on force unwrap elimination only.

## Impact

- **Zero behavioral change** — `Data(string.utf8)` produces identical bytes to `.data(using: .utf8)!`
- **Removes 4 force unwraps** — reduces `!` count in the codebase, improving code safety posture
- **No risk of regression** — the transformation is mechanical and semantically equivalent

## Test plan

- [ ] Build in Debug configuration — verify no compile errors
- [ ] Verify debug log files (`/tmp/cmux-debug.log`, surface logs) still receive log output after the change
- [ ] `grep -rn '.data(using: .utf8)!' Sources/` returns no remaining force-unwrapped `.utf8` encoding calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced force-unwrapped UTF-8 conversions with `Data(string.utf8)` in debug log writers. This removes `!` usage while keeping behavior identical.

- **Refactors**
  - Swapped `.data(using: .utf8)!` for `Data(string.utf8)` at 4 call sites in `GhosttyTerminalView.swift` and `WorkspaceContentView.swift`.
  - No behavior change; bytes are identical. Left optional `.data(using: .utf8)` in `createFile(contents:)` calls as-is.

<sup>Written for commit 8ad794f61349bac3aeff960f31f65a73a1b743db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of debug logging functionality to prevent potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->