### PR TITLE
Fix browser freeze after pane split

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6064,6 +6064,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 visibleInUI: coordinator.desiredPortalVisibleInUI,
                 zPriority: coordinator.desiredPortalZPriority
             )
+            BrowserWindowPortalRegistry.refresh(
+                webView: webView,
+                reason: "portalHostBind.didMoveToWindow"
+            )
             BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                 for: webView,
                 height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
@@ -6094,6 +6098,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
                     zPriority: coordinator.desiredPortalZPriority
+                )
+                BrowserWindowPortalRegistry.refresh(
+                    webView: webView,
+                    reason: "portalHostBind.geometryChanged"
                 )
                 BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                     for: webView,
@@ -6131,6 +6139,14 @@ struct WebViewRepresentable: NSViewRepresentable {
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
                     zPriority: coordinator.desiredPortalZPriority
+                )
+                // Force a rendering-state reattach after portal host replacement
+                // (e.g. after a pane split). Without this, WKWebView can freeze
+                // because _exitInWindow/_enterInWindow are never cycled when the
+                // web view is reparented to a new container during bind.
+                BrowserWindowPortalRegistry.refresh(
+                    webView: webView,
+                    reason: "portalHostBind"
                 )
                 coordinator.lastPortalHostId = hostId
                 coordinator.lastSynchronizedHostGeometryRevision = geometryRevision


### PR DESCRIPTION
## Summary
- Fix built-in browser freezing after a pane split by adding `BrowserWindowPortalRegistry.refresh()` calls after portal host rebinds
- When a split occurs, SwiftUI recreates host views and the portal rebinds the WKWebView to a new container, but WebKit's rendering state (`_exitInWindow`/`_enterInWindow`) was never cycled — causing the web view to freeze
- The refresh is a no-op when no reattach is needed, so normal rendering is unaffected

## Root cause
In `BrowserPanelView`, the three portal bind paths (`shouldBindNow`, `onDidMoveToWindow`, `onGeometryChanged`) call `BrowserWindowPortalRegistry.bind()` but never follow up with `refresh()`. After a split reparents the WKWebView to a new container, the stale rendering state leaves the web view frozen.

## Test plan
- [ ] Open a browser tab (e.g. preview an HTML file)
- [ ] Split the pane (horizontal or vertical)
- [ ] Verify the browser in the original pane continues rendering (no freeze)
- [ ] Verify popup windows (window.open / OAuth flows) still work correctly
- [ ] Verify tab switches and workspace changes don't cause unnecessary redraws

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the built-in browser freezing after a pane split by reattaching `WKWebView` rendering state when the portal rebinds to a new host. Keeps rendering alive after splits without affecting normal behavior.

- Bug Fixes
  - Call `BrowserWindowPortalRegistry.refresh(webView:reason:)` after portal host bind in three paths: `shouldBindNow`, `onDidMoveToWindow`, and `onGeometryChanged`.
  - Cycles `_exitInWindow` / `_enterInWindow` after reparenting to prevent freezes.
  - No-op when no reattach is needed to avoid unnecessary redraws.

<sup>Written for commit 9323f12f75f745189d3561d5e0a11c8113fb6752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of window portal rendering during lifecycle transitions by ensuring proper refresh behavior when window hosts are repositioned or reattached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->