### PR TITLE
Add configurable split layout mode for panes vs tabs

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9467,8 +9467,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
-        if flags == [.command],
+        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 or Ctrl+1-9 (9 = last workspace)
+        if (flags == [.command] || flags == [.control]),
            let manager = tabManager,
            let num = Int(chars),
            let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
@@ -9481,8 +9481,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
-        if flags == [.control] {
+        // Numeric shortcuts for surfaces within pane: Ctrl+Shift+1-9 (9 = last)
+        if flags == [.control, .shift] {
             if let num = Int(chars), num >= 1 && num <= 9 {
                 if num == 9 {
                     tabManager?.selectLastSurface()
@@ -10270,13 +10270,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         prepareFocusedBrowserDevToolsForSplit(directionLabel: directionLabel)
         let didCreateSplit: Bool = {
             if let terminalContext {
-                return terminalContext.tabManager.createSplit(
+                return terminalContext.tabManager.performConfiguredTerminalSplitAction(
                     tabId: terminalContext.workspaceId,
                     surfaceId: terminalContext.panelId,
                     direction: direction
                 ) != nil
             }
-            return tabManager?.createSplit(direction: direction) != nil
+            return tabManager?.performConfiguredTerminalSplitAction(direction: direction) != nil
         }()
 #if DEBUG
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
@@ -10327,7 +10327,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         #endif
 
-        guard let panelId = tabManager?.createBrowserSplit(direction: direction) else {
+        guard let panelId = tabManager?.performConfiguredBrowserSplitAction(direction: direction) else {
             #if DEBUG
             dlog("split.browser.shortcut failed dir=\(directionLabel)")
             #endif

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5981,14 +5981,14 @@ struct ContentView: View {
             BrowserHistoryStore.shared.clearHistory()
         }
         registry.register(commandId: "palette.browserSplitRight") {
-            _ = tabManager.createBrowserSplit(direction: .right)
+            _ = tabManager.performConfiguredBrowserSplitAction(direction: .right)
         }
         registry.register(commandId: "palette.browserSplitDown") {
-            _ = tabManager.createBrowserSplit(direction: .down)
+            _ = tabManager.performConfiguredBrowserSplitAction(direction: .down)
         }
         registry.register(commandId: "palette.browserDuplicateRight") {
             let url = tabManager.focusedBrowserPanel?.preferredURLStringForOmnibar().flatMap(URL.init(string:))
-            _ = tabManager.createBrowserSplit(direction: .right, url: url)
+            _ = tabManager.performConfiguredBrowserSplitAction(direction: .right, url: url)
         }
 
         for target in TerminalDirectoryOpenTarget.commandPaletteShortcutTargets {
@@ -6022,16 +6022,16 @@ struct ContentView: View {
             tabManager.searchSelection()
         }
         registry.register(commandId: "palette.terminalSplitRight") {
-            tabManager.createSplit(direction: .right)
+            tabManager.performConfiguredTerminalSplitAction(direction: .right)
         }
         registry.register(commandId: "palette.terminalSplitDown") {
-            tabManager.createSplit(direction: .down)
+            tabManager.performConfiguredTerminalSplitAction(direction: .down)
         }
         registry.register(commandId: "palette.terminalSplitBrowserRight") {
-            _ = tabManager.createBrowserSplit(direction: .right)
+            _ = tabManager.performConfiguredBrowserSplitAction(direction: .right)
         }
         registry.register(commandId: "palette.terminalSplitBrowserDown") {
-            _ = tabManager.createBrowserSplit(direction: .down)
+            _ = tabManager.performConfiguredBrowserSplitAction(direction: .down)
         }
         registry.register(commandId: "palette.toggleSplitZoom") {
             if !tabManager.toggleFocusedSplitZoom() {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Foundation
+import AppKit
 import Bonsplit
 
 /// View that renders the appropriate panel view based on panel type
@@ -14,47 +15,96 @@ struct PanelContentView: View {
     let appearance: PanelAppearance
     let hasUnreadNotification: Bool
     let onFocus: () -> Void
+    let onHoverFocusRequest: () -> Void
     let onRequestPanelFocus: () -> Void
     let onTriggerFlash: () -> Void
 
     var body: some View {
-        switch panel.panelType {
-        case .terminal:
-            if let terminalPanel = panel as? TerminalPanel {
-                TerminalPanelView(
-                    panel: terminalPanel,
-                    paneId: paneId,
-                    isFocused: isFocused,
-                    isVisibleInUI: isVisibleInUI,
-                    portalPriority: portalPriority,
-                    isSplit: isSplit,
-                    appearance: appearance,
-                    hasUnreadNotification: hasUnreadNotification,
-                    onFocus: onFocus,
-                    onTriggerFlash: onTriggerFlash
-                )
-            }
-        case .browser:
-            if let browserPanel = panel as? BrowserPanel {
-                BrowserPanelView(
-                    panel: browserPanel,
-                    paneId: paneId,
-                    isFocused: isFocused,
-                    isVisibleInUI: isVisibleInUI,
-                    portalPriority: portalPriority,
-                    onRequestPanelFocus: onRequestPanelFocus
-                )
-            }
-        case .markdown:
-            if let markdownPanel = panel as? MarkdownPanel {
-                MarkdownPanelView(
-                    panel: markdownPanel,
-                    isFocused: isFocused,
-                    isVisibleInUI: isVisibleInUI,
-                    portalPriority: portalPriority,
-                    onRequestPanelFocus: onRequestPanelFocus
-                )
+        Group {
+            switch panel.panelType {
+            case .terminal:
+                if let terminalPanel = panel as? TerminalPanel {
+                    TerminalPanelView(
+                        panel: terminalPanel,
+                        paneId: paneId,
+                        isFocused: isFocused,
+                        isVisibleInUI: isVisibleInUI,
+                        portalPriority: portalPriority,
+                        isSplit: isSplit,
+                        appearance: appearance,
+                        hasUnreadNotification: hasUnreadNotification,
+                        onFocus: onFocus,
+                        onTriggerFlash: onTriggerFlash
+                    )
+                }
+            case .browser:
+                if let browserPanel = panel as? BrowserPanel {
+                    BrowserPanelView(
+                        panel: browserPanel,
+                        paneId: paneId,
+                        isFocused: isFocused,
+                        isVisibleInUI: isVisibleInUI,
+                        portalPriority: portalPriority,
+                        onRequestPanelFocus: onRequestPanelFocus
+                    )
+                }
+            case .markdown:
+                if let markdownPanel = panel as? MarkdownPanel {
+                    MarkdownPanelView(
+                        panel: markdownPanel,
+                        isFocused: isFocused,
+                        isVisibleInUI: isVisibleInUI,
+                        portalPriority: portalPriority,
+                        onRequestPanelFocus: onRequestPanelFocus
+                    )
+                }
             }
         }
+        .overlay(PaneHoverFocusOverlay(onHoverEntered: onHoverFocusRequest))
+    }
+}
+
+private struct PaneHoverFocusOverlay: NSViewRepresentable {
+    let onHoverEntered: () -> Void
+
+    func makeNSView(context: Context) -> PaneHoverFocusTrackingView {
+        let view = PaneHoverFocusTrackingView()
+        view.onHoverEntered = onHoverEntered
+        return view
+    }
+
+    func updateNSView(_ nsView: PaneHoverFocusTrackingView, context: Context) {
+        nsView.onHoverEntered = onHoverEntered
+    }
+}
+
+private final class PaneHoverFocusTrackingView: NSView {
+    var onHoverEntered: (() -> Void)?
+    private var trackingAreaRef: NSTrackingArea?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaRef {
+            removeTrackingArea(trackingAreaRef)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        trackingAreaRef = trackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        onHoverEntered?()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -235,6 +235,50 @@ enum WorkspacePlacementSettings {
     }
 }
 
+enum SplitLayoutMode: String, CaseIterable, Identifiable {
+    case paneGrid
+    case tabStack
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .paneGrid:
+            return String(localized: "split.layout.paneGrid", defaultValue: "Pane Grid")
+        case .tabStack:
+            return String(localized: "split.layout.tabStack", defaultValue: "Tab Stack")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .paneGrid:
+            return String(
+                localized: "split.layout.paneGrid.description",
+                defaultValue: "Split actions create adjacent panes inside the current workspace."
+            )
+        case .tabStack:
+            return String(
+                localized: "split.layout.tabStack.description",
+                defaultValue: "Split actions open another tab in the current pane instead of changing the pane layout."
+            )
+        }
+    }
+}
+
+enum SplitLayoutSettings {
+    static let modeKey = "splitLayoutMode"
+    static let defaultMode: SplitLayoutMode = .paneGrid
+
+    static func current(defaults: UserDefaults = .standard) -> SplitLayoutMode {
+        guard let rawValue = defaults.string(forKey: modeKey),
+              let mode = SplitLayoutMode(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+}
+
 struct WorkspaceTabColorEntry: Equatable, Identifiable {
     let name: String
     let hex: String
@@ -3110,6 +3154,67 @@ class TabManager: ObservableObject {
     }
 
     // MARK: - Split Creation
+
+    /// Perform the user-facing split action, honoring the split layout preference.
+    @discardableResult
+    func performConfiguredTerminalSplitAction(direction: SplitDirection) -> UUID? {
+        guard let selectedTabId,
+              let tab = tabs.first(where: { $0.id == selectedTabId }),
+              let focusedPanelId = tab.focusedPanelId else { return nil }
+        return performConfiguredTerminalSplitAction(
+            tabId: selectedTabId,
+            surfaceId: focusedPanelId,
+            direction: direction
+        )
+    }
+
+    /// Perform the user-facing split action from an explicit source panel.
+    @discardableResult
+    func performConfiguredTerminalSplitAction(
+        tabId: UUID,
+        surfaceId: UUID,
+        direction: SplitDirection
+    ) -> UUID? {
+        guard let tab = tabs.first(where: { $0.id == tabId }),
+              tab.panels[surfaceId] != nil else { return nil }
+
+        switch SplitLayoutSettings.current() {
+        case .paneGrid:
+            return createSplit(tabId: tabId, surfaceId: surfaceId, direction: direction)
+        case .tabStack:
+            tab.clearSplitZoom()
+            guard let paneId = tab.paneId(forPanelId: surfaceId),
+                  let panel = tab.newTerminalSurface(inPane: paneId, focus: true) else {
+                return nil
+            }
+            rememberFocusedSurface(tabId: tabId, surfaceId: panel.id)
+            return panel.id
+        }
+    }
+
+    /// Perform the user-facing browser split action, honoring the split layout preference.
+    @discardableResult
+    func performConfiguredBrowserSplitAction(direction: SplitDirection, url: URL? = nil) -> UUID? {
+        guard let selectedTabId,
+              let tab = tabs.first(where: { $0.id == selectedTabId }),
+              let focusedPanelId = tab.focusedPanelId else { return nil }
+
+        switch SplitLayoutSettings.current() {
+        case .paneGrid:
+            return createBrowserSplit(direction: direction, url: url)
+        case .tabStack:
+            tab.clearSplitZoom()
+            let targetPaneId = tab.paneId(forPanelId: focusedPanelId)
+                ?? tab.bonsplitController.focusedPaneId
+                ?? tab.bonsplitController.allPaneIds.first
+            guard let targetPaneId,
+                  let panel = tab.newBrowserSurface(inPane: targetPaneId, url: url, focus: true) else {
+                return nil
+            }
+            rememberFocusedSurface(tabId: selectedTabId, surfaceId: panel.id)
+            return panel.id
+        }
+    }
 
     /// Create a new split in the current tab
     @discardableResult

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -91,6 +91,13 @@ struct WorkspaceContentView: View {
                         guard workspace.panels[panel.id] != nil else { return }
                         workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
                     },
+                    onHoverFocusRequest: {
+                        guard isWorkspaceInputActive else { return }
+                        guard workspace.bonsplitController.allPaneIds.count > 1 else { return }
+                        guard workspace.panels[panel.id] != nil else { return }
+                        guard workspace.focusedPanelId != panel.id else { return }
+                        workspace.focusPanel(panel.id)
+                    },
                     onRequestPanelFocus: {
                         guard isWorkspaceInputActive else { return }
                         guard workspace.panels[panel.id] != nil else { return }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1002,14 +1002,14 @@ struct cmuxApp: App {
         if AppDelegate.shared?.performSplitShortcut(direction: direction) == true {
             return
         }
-        tabManager.createSplit(direction: direction)
+        _ = tabManager.performConfiguredTerminalSplitAction(direction: direction)
     }
 
     private func performBrowserSplitFromMenu(direction: SplitDirection) {
         if AppDelegate.shared?.performBrowserSplitShortcut(direction: direction) == true {
             return
         }
-        _ = tabManager.createBrowserSplit(direction: direction)
+        _ = tabManager.performConfiguredBrowserSplitAction(direction: direction)
     }
 
     private func selectedWorkspaceIndex(in manager: TabManager, workspaceId: UUID) -> Int? {
@@ -3816,6 +3816,7 @@ struct SettingsView: View {
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey)
     private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @AppStorage(WorkspacePlacementSettings.placementKey) private var newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
+    @AppStorage(SplitLayoutSettings.modeKey) private var splitLayoutMode = SplitLayoutSettings.defaultMode.rawValue
     @AppStorage(LastSurfaceCloseShortcutSettings.key)
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(PaneFirstClickFocusSettings.enabledKey)
@@ -3872,6 +3873,10 @@ struct SettingsView: View {
         NewWorkspacePlacement(rawValue: newWorkspacePlacement) ?? WorkspacePlacementSettings.defaultPlacement
     }
 
+    private var selectedSplitLayoutMode: SplitLayoutMode {
+        SplitLayoutMode(rawValue: splitLayoutMode) ?? SplitLayoutSettings.defaultMode
+    }
+
     private var minimalModeEnabled: Bool {
         WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
     }
@@ -3887,6 +3892,10 @@ struct SettingsView: View {
             localized: "settings.app.minimalMode.subtitleOff",
             defaultValue: "Use the standard workspace title bar and controls."
         )
+    }
+
+    private var splitLayoutSubtitle: String {
+        selectedSplitLayoutMode.description
     }
 
     private var keepWorkspaceOpenOnLastSurfaceShortcut: Bool {
@@ -4364,6 +4373,19 @@ struct SettingsView: View {
                         ) {
                             ForEach(NewWorkspacePlacement.allCases) { placement in
                                 Text(placement.displayName).tag(placement.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.app.splitLayoutMode", defaultValue: "Split Action Layout"),
+                            subtitle: splitLayoutSubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: $splitLayoutMode
+                        ) {
+                            ForEach(SplitLayoutMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
                             }
                         }
 
@@ -5561,6 +5583,7 @@ struct SettingsView: View {
         ShortcutHintDebugSettings.resetVisibilityDefaults()
         alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
         newWorkspacePlacement = WorkspacePlacementSettings.defaultPlacement.rawValue
+        splitLayoutMode = SplitLayoutSettings.defaultMode.rawValue
         workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: WorkspaceTitlebarSettings.showTitlebarKey)

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -551,6 +551,91 @@ final class TabManagerPendingUnfocusPolicyTests: XCTestCase {
 
 
 @MainActor
+final class TabManagerConfiguredSplitActionTests: XCTestCase {
+    private func withSplitLayoutMode<T>(
+        _ mode: SplitLayoutMode?,
+        run body: () throws -> T
+    ) rethrows -> T {
+        let defaults = UserDefaults.standard
+        let originalValue = defaults.object(forKey: SplitLayoutSettings.modeKey)
+        if let mode {
+            defaults.set(mode.rawValue, forKey: SplitLayoutSettings.modeKey)
+        } else {
+            defaults.removeObject(forKey: SplitLayoutSettings.modeKey)
+        }
+        defer {
+            if let originalValue {
+                defaults.set(originalValue, forKey: SplitLayoutSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: SplitLayoutSettings.modeKey)
+            }
+        }
+        return try body()
+    }
+
+    func testConfiguredTerminalSplitActionDefaultsToPaneGrid() throws {
+        try withSplitLayoutMode(nil) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let paneId = workspace.bonsplitController.focusedPaneId else {
+                XCTFail("Expected focused workspace and pane")
+                return
+            }
+
+            let paneCountBefore = workspace.bonsplitController.allPaneIds.count
+            let tabsInPaneBefore = workspace.bonsplitController.tabs(inPane: paneId).count
+
+            let createdPanelId = try XCTUnwrap(
+                manager.performConfiguredTerminalSplitAction(direction: .right)
+            )
+
+            XCTAssertEqual(
+                workspace.bonsplitController.allPaneIds.count,
+                paneCountBefore + 1,
+                "Expected default split action to create a new pane"
+            )
+            XCTAssertEqual(
+                workspace.bonsplitController.tabs(inPane: paneId).count,
+                tabsInPaneBefore,
+                "Expected original pane tab count to remain unchanged in pane-grid mode"
+            )
+            XCTAssertEqual(workspace.focusedPanelId, createdPanelId, "Expected created pane to be focused")
+        }
+    }
+
+    func testConfiguredTerminalSplitActionUsesTabStackMode() throws {
+        try withSplitLayoutMode(.tabStack) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let paneId = workspace.bonsplitController.focusedPaneId else {
+                XCTFail("Expected focused workspace and pane")
+                return
+            }
+
+            let paneCountBefore = workspace.bonsplitController.allPaneIds.count
+            let tabsInPaneBefore = workspace.bonsplitController.tabs(inPane: paneId).count
+
+            let createdPanelId = try XCTUnwrap(
+                manager.performConfiguredTerminalSplitAction(direction: .right)
+            )
+
+            XCTAssertEqual(
+                workspace.bonsplitController.allPaneIds.count,
+                paneCountBefore,
+                "Expected tab-stack mode to reuse the current pane"
+            )
+            XCTAssertEqual(
+                workspace.bonsplitController.tabs(inPane: paneId).count,
+                tabsInPaneBefore + 1,
+                "Expected tab-stack mode to create a new surface in the existing pane"
+            )
+            XCTAssertEqual(workspace.focusedPanelId, createdPanelId, "Expected created surface to be focused")
+        }
+    }
+}
+
+
+@MainActor
 final class TabManagerSurfaceCreationTests: XCTestCase {
     func testNewSurfaceFocusesCreatedSurface() {
         let manager = TabManager()


### PR DESCRIPTION
This adds a new split behavior setting so split actions can work in one of two modes:

Pane: split actions create adjacent panes in the current workspace
Tab: split actions open a new tab in the current pane instead of changing pane layout
The setting is exposed in Settings > App as Split Action Layout.

## Changes
Added SplitLayoutMode / SplitLayoutSettings as the source of truth for split behavior
Routed terminal split actions through the new setting
Routed browser split actions through the new setting
Updated menu actions and command-palette split actions to respect the selected split layout mode
Added pane hover-to-focus for active split layouts

According to the settings, Cmd+D/ Cmd+Shift+D with split tab/pane

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable split layout so split actions either create adjacent panes or open new tabs in the current pane. All split shortcuts, menu items, and palette commands honor this setting, and panes can now focus on hover for quicker switching.

- **New Features**
  - New setting: Settings > App > Split Action Layout with “Pane Grid” (default) and “Tab Stack”.
  - Terminal and browser splits now use the selected mode across Cmd+D/Cmd+Shift+D, menu, and command palette. In “Tab Stack”, splits add a new surface in the current pane without changing the pane layout.
  - Pane hover-to-focus when multiple panes are present and workspace input is active.
  - Shortcut updates: workspace selection now Cmd+1–9 or Ctrl+1–9; surfaces within a pane moved to Ctrl+Shift+1–9.

<sup>Written for commit 0abf7f9a50f3676b45be803cb092fffad23d247d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split layout mode preference: choose between Pane Grid and Tab Stack in Settings
  * Hover over a panel to focus it for quicker navigation
  * Cmd key now triggers numeric workspace shortcuts (in addition to Ctrl)

* **Changes**
  * Numeric surface selection shortcuts changed to Ctrl+Shift+1-9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->