### PR TITLE
feat: add Leader Key mode and Workspace Tags

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 			A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 			A50012F3 /* KeyboardShortcutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F2 /* KeyboardShortcutSettings.swift */; };
 			A5F10011A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F10010A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift */; };
+			A50012F7 /* LeaderKeySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F6 /* LeaderKeySettings.swift */; };
 			A50012F5 /* KeyboardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F4 /* KeyboardLayout.swift */; };
 			A5001521 /* PostHogAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001520 /* PostHogAnalytics.swift */; };
 			A5001201 /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001211 /* UpdateController.swift */; };
@@ -263,6 +264,7 @@
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		A50012F2 /* KeyboardShortcutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettings.swift; sourceTree = "<group>"; };
 		A5F10010A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsFileStore.swift; sourceTree = "<group>"; };
+		A50012F6 /* LeaderKeySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderKeySettings.swift; sourceTree = "<group>"; };
 		A50012F4 /* KeyboardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayout.swift; sourceTree = "<group>"; };
 		A5001211 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateController.swift; sourceTree = "<group>"; };
 		A5001212 /* UpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateDelegate.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 					A50012F0 /* Backport.swift */,
 					A50012F2 /* KeyboardShortcutSettings.swift */,
 					A5F10010A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift */,
+					A50012F6 /* LeaderKeySettings.swift */,
 					A50012F4 /* KeyboardLayout.swift */,
 					A5001013 /* TabManager.swift */,
 					A5001511 /* UITestRecorder.swift */,
@@ -807,6 +810,7 @@
 					A50012F1 /* Backport.swift in Sources */,
 					A50012F3 /* KeyboardShortcutSettings.swift in Sources */,
 					A5F10011A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift in Sources */,
+					A50012F7 /* LeaderKeySettings.swift in Sources */,
 					A50012F5 /* KeyboardLayout.swift in Sources */,
 						A5001003 /* TabManager.swift in Sources */,
 						A5001501 /* UITestRecorder.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4627,6 +4627,57 @@
         }
       }
     },
+    "alert.setWorkspaceTag.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a short tag prefix for this workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このワークスペースの短いタグプレフィックスを入力してください。"
+          }
+        }
+      }
+    },
+    "alert.setWorkspaceTag.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tag (e.g., api, web)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タグ（例：api、web）"
+          }
+        }
+      }
+    },
+    "alert.setWorkspaceTag.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Workspace Tag"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタグを設定"
+          }
+        }
+      }
+    },
     "appIcon.automatic": {
       "extractionState": "manual",
       "localizations": {
@@ -64650,6 +64701,584 @@
         }
       }
     },
+    "settings.section.leaderKey": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leader Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーキー"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Leader Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーキーを有効化"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.enabled.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press the leader key prefix, then a sub-key to trigger an action."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーキーを押した後、サブキーでアクションを実行します。"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.enabled.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leader key is disabled. The prefix key will pass through to the terminal."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーキーは無効です。プレフィックスキーはターミナルに送信されます。"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.timeout": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウト"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.timeout.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seconds to wait for the sub-key before cancelling leader mode."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーモードをキャンセルするまでのサブキー待機秒数。"
+          }
+        }
+      }
+    },
+    "leaderKey.recorder.press": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press key…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーを押してください…"
+          }
+        }
+      }
+    },
+    "leader.action.splitRight.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右に分割"
+          }
+        }
+      }
+    },
+    "leader.action.splitDown.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Down"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下に分割"
+          }
+        }
+      }
+    },
+    "leader.action.focusNextPane.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Next Pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次のペインにフォーカス"
+          }
+        }
+      }
+    },
+    "leader.action.closePane.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインを閉じる"
+          }
+        }
+      }
+    },
+    "leader.action.newTab.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Tab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいタブ"
+          }
+        }
+      }
+    },
+    "leader.action.nextTab.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Tab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次のタブ"
+          }
+        }
+      }
+    },
+    "leader.action.previousTab.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Tab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前のタブ"
+          }
+        }
+      }
+    },
+    "leader.action.focusLeft.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左にフォーカス"
+          }
+        }
+      }
+    },
+    "leader.action.focusRight.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右にフォーカス"
+          }
+        }
+      }
+    },
+    "leader.action.focusDown.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Down"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下にフォーカス"
+          }
+        }
+      }
+    },
+    "leader.action.focusUp.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Up"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上にフォーカス"
+          }
+        }
+      }
+    },
+    "leader.action.setWorkspaceTag.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Workspace Tag"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタグを設定"
+          }
+        }
+      }
+    },
+    "leader.action.toggleCopyMode.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Copy Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピーモード切替"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab0.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 10"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ10を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab1.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 1"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ1を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab2.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 2"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ2を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab3.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ3を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab4.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 4"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ4を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab5.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 5"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ5を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab6.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 6"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ6を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab7.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 7"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ7を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab8.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 8"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ8を選択"
+          }
+        }
+      }
+    },
+    "leader.action.selectTab9.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab 9"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ9を選択"
+          }
+        }
+      }
+    },
+    "leader.mode.indicator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEADER"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEADER"
+          }
+        }
+      }
+    },
+    "settings.app.workspaceTags": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Tags"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタグ"
+          }
+        }
+      }
+    },
+    "settings.app.workspaceTags.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace tags are shown as [tag] prefix in the workspace switcher and tab bar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタグはワークスペーススイッチャーとタブバーで[タグ]プレフィックスとして表示されます。"
+          }
+        }
+      }
+    },
+    "settings.app.workspaceTags.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace tag display and assignment are disabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースタグの表示と割り当ては無効です。"
+          }
+        }
+      }
+    },
     "settings.section.keyboardShortcuts": {
       "extractionState": "manual",
       "localizations": {
@@ -68277,6 +68906,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перейти до останнього непрочитаного"
+          }
+        }
+      }
+    },
+    "shortcut.leaderKey.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leader Key (tmux prefix)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リーダーキー（tmuxプレフィックス）"
           }
         }
       }
@@ -84433,6 +85079,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "고정된 워크스페이스는 고정된 상태에서 닫을 수 없습니다. 먼저 워크스페이스의 고정을 해제하세요."
+          }
+        }
+      }
+    },
+    "workspace.displayTitle.tagged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[%@] %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[%@] %@"
+          }
+        }
+      }
+    },
+    "settings.leaderKey.timeout.value": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1fs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1f秒"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2311,6 +2311,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private let windowDecorationsController = WindowDecorationsController()
     private var menuBarExtraController: MenuBarExtraController?
     private static let serviceErrorNoPath = NSString(string: String(localized: "error.clipboardFolderPath", defaultValue: "Could not load any folder path from the clipboard."))
+
+    // MARK: - Leader Key State
+
+    private enum LeaderKeyState {
+        case inactive
+        case waitingForSecondKey
+    }
+
+    private var leaderKeyState: LeaderKeyState = .inactive
+    private var leaderKeyWorkItem: DispatchWorkItem?
+    private weak var leaderKeyOwner: TabManager?
+    private var leaderKeyDisableObserver: NSObjectProtocol?
+#if DEBUG
+    struct DebugWorkspaceTagPromptResult {
+        let response: NSApplication.ModalResponse
+        let tag: String
+    }
+
+    var debugWorkspaceTagPromptHandler: ((Workspace) -> DebugWorkspaceTagPromptResult)?
+#endif
+
     private static let didInstallWindowKeyEquivalentSwizzle: Void = {
         let targetClass: AnyClass = NSWindow.self
         let originalSelector = #selector(NSWindow.performKeyEquivalent(with:))
@@ -2644,6 +2665,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         refreshGhosttyGotoSplitShortcuts()
         installGhosttyConfigObserver()
         installWindowResponderSwizzles()
+        installLeaderKeyDisableObserver()
         installBrowserAddressBarFocusObservers()
         installShortcutMonitor()
         installShortcutDefaultsObserver()
@@ -10596,6 +10618,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 #endif
 
+        // MARK: Leader Key — second-key dispatch (before guards)
+        // When leader mode is already armed, dispatch the second key immediately.
+        // This must run before modal/alert guards so that an already-armed leader
+        // session is not blocked by intervening guard code.
+        if LeaderKeySettings.isEnabled, leaderKeyState == .waitingForSecondKey {
+            if synchronizeShortcutRoutingContext(event: event) {
+                cancelLeaderMode()
+                let leaderShortcut = KeyboardShortcutSettings.shortcut(for: .leaderKey)
+                // Double-press leader key: send the raw key through to terminal
+                if matchShortcut(event: event, shortcut: leaderShortcut) {
+                    return false
+                }
+                // ESC cancels leader mode
+                if event.keyCode == 53 {
+                    return true
+                }
+                // Try to dispatch the second key
+                if executeLeaderAction(event: event) {
+                    return true
+                }
+                // Unrecognized second key: beep and consume
+                NSSound.beep()
+                return true
+            } else {
+                cancelLeaderMode()
+            }
+        }
+
         // Don't steal shortcuts from close-confirmation alerts. Keep standard alert key
         // equivalents working and avoid surprising actions while the confirmation is up.
         let closeConfirmationTitles = [
@@ -10634,6 +10684,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if NSApp.modalWindow != nil || NSApp.keyWindow?.attachedSheet != nil {
             return false
+        }
+
+        // MARK: Leader Key — arming (after guards)
+        // Only handle arming (.inactive → .waitingForSecondKey) here.
+        // Placed after modal/alert guards so leader mode cannot arm from Settings,
+        // close-confirmation alerts, or the command palette.
+        // Second-key dispatch is handled earlier, before the guards.
+        if LeaderKeySettings.isEnabled, leaderKeyState == .inactive {
+            if synchronizeShortcutRoutingContext(event: event) {
+                let leaderShortcut = KeyboardShortcutSettings.shortcut(for: .leaderKey)
+                if matchShortcut(event: event, shortcut: leaderShortcut) {
+                    leaderKeyState = .waitingForSecondKey
+                    leaderKeyOwner = tabManager
+                    tabManager?.isLeaderModeActive = true
+                    startLeaderKeyTimer()
+                    return true
+                }
+            }
         }
 
         let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
@@ -12401,9 +12469,219 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return false
     }
 
+    // MARK: - Leader Key Helpers
+
+    private func startLeaderKeyTimer() {
+        cancelLeaderKeyTimer()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.cancelLeaderMode()
+        }
+        leaderKeyWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + LeaderKeySettings.timeout, execute: workItem)
+    }
+
+    private func cancelLeaderKeyTimer() {
+        leaderKeyWorkItem?.cancel()
+        leaderKeyWorkItem = nil
+    }
+
+    private func cancelLeaderMode() {
+        leaderKeyState = .inactive
+        // Clear on the originating window's tabManager, not the currently focused one
+        leaderKeyOwner?.isLeaderModeActive = false
+        leaderKeyOwner = nil
+        cancelLeaderKeyTimer()
+    }
+
+    private func installLeaderKeyDisableObserver() {
+        guard leaderKeyDisableObserver == nil else { return }
+        leaderKeyDisableObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            if !LeaderKeySettings.isEnabled, self?.leaderKeyState != .inactive {
+                self?.cancelLeaderMode()
+            }
+        }
+    }
+
+    /// Dispatch the second key after leader key activation.
+    /// Returns true if the key was recognized and handled.
+    private func executeLeaderAction(event: NSEvent) -> Bool {
+#if DEBUG
+        dlog("leader.action chars=\(event.charactersIgnoringModifiers ?? "") shifted=\(event.characters ?? "") keyCode=\(event.keyCode) mods=\(event.modifierFlags.rawValue)")
+#endif
+
+        // Table-driven: match configurable keys to actions.
+        // Check both base key (unshifted) and shifted output to support rebound shifted symbols.
+        for action in LeaderKeySettings.LeaderAction.allCases {
+            let configuredKey = LeaderKeySettings.key(for: action)
+            if leaderActionMatches(event: event, action: action, configuredKey: configuredKey) {
+                return performLeaderAction(action)
+            }
+        }
+        return false
+    }
+
     /// Match a shortcut stroke against an event, handling normal keys.
     private func matchShortcutStroke(event: NSEvent, stroke: ShortcutStroke) -> Bool {
         stroke.matches(event: event, layoutCharacterProvider: shortcutLayoutCharacterProvider)
+    }
+
+    private func leaderActionMatches(
+        event: NSEvent,
+        action: LeaderKeySettings.LeaderAction,
+        configuredKey: String
+    ) -> Bool {
+        let chars = event.charactersIgnoringModifiers ?? ""
+        let shifted = event.characters ?? ""
+        if chars.lowercased() == configuredKey || shifted == configuredKey {
+            return true
+        }
+
+        // Keep broader leader matching behavior unchanged for all other actions.
+        guard action == .setWorkspaceTag, configuredKey == LeaderKeySettings.LeaderAction.setWorkspaceTag.defaultKey else {
+            return false
+        }
+
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        let applyShiftNormalization = flags.contains(.shift)
+
+        if shortcutCharacterMatches(
+            eventCharacter: chars,
+            shortcutKey: configuredKey,
+            applyShiftSymbolNormalization: applyShiftNormalization,
+            eventKeyCode: event.keyCode
+        ) {
+            return true
+        }
+
+        if shortcutCharacterMatches(
+            eventCharacter: shifted,
+            shortcutKey: configuredKey,
+            applyShiftSymbolNormalization: applyShiftNormalization,
+            eventKeyCode: event.keyCode
+        ) {
+            return true
+        }
+
+        let layoutCharacter = shortcutLayoutCharacterProvider(event.keyCode, event.modifierFlags)
+        if shortcutCharacterMatches(
+            eventCharacter: layoutCharacter,
+            shortcutKey: configuredKey,
+            applyShiftSymbolNormalization: applyShiftNormalization,
+            eventKeyCode: event.keyCode
+        ) {
+            return true
+        }
+
+        if let expectedKeyCode = keyCodeForShortcutKey(configuredKey) {
+            return event.keyCode == expectedKeyCode
+        }
+        return false
+    }
+
+    /// Execute a resolved leader action.
+    private func performLeaderAction(_ action: LeaderKeySettings.LeaderAction) -> Bool {
+        // Actions that don't require a workspace
+        switch action {
+        case .splitRight:
+            _ = performSplitShortcut(direction: .right)
+            return true
+        case .splitDown:
+            _ = performSplitShortcut(direction: .down)
+            return true
+        case .setWorkspaceTag:
+            return beginSetWorkspaceTagFlow()
+        default:
+            break
+        }
+
+        guard let tabManager, let ws = tabManager.selectedWorkspace else { return false }
+
+        switch action {
+        case .focusNextPane:
+            ws.focusNextPane()
+        case .closePane:
+            if let paneId = ws.bonsplitController.focusedPaneId {
+                ws.bonsplitController.closePane(paneId)
+            }
+        case .newTab:
+            ws.newTerminalSurfaceInFocusedPane()
+        case .nextTab:
+            ws.selectNextSurface()
+        case .previousTab:
+            ws.selectPreviousSurface()
+        case .focusLeft:
+            tabManager.movePaneFocus(direction: .left)
+        case .focusRight:
+            tabManager.movePaneFocus(direction: .right)
+        case .focusDown:
+            tabManager.movePaneFocus(direction: .down)
+        case .focusUp:
+            tabManager.movePaneFocus(direction: .up)
+        case .toggleCopyMode:
+            _ = tabManager.toggleFocusedTerminalCopyMode()
+        case .selectTab0:
+            ws.selectSurface(at: 9)
+        case .selectTab1:
+            ws.selectSurface(at: 0)
+        case .selectTab2:
+            ws.selectSurface(at: 1)
+        case .selectTab3:
+            ws.selectSurface(at: 2)
+        case .selectTab4:
+            ws.selectSurface(at: 3)
+        case .selectTab5:
+            ws.selectSurface(at: 4)
+        case .selectTab6:
+            ws.selectSurface(at: 5)
+        case .selectTab7:
+            ws.selectSurface(at: 6)
+        case .selectTab8:
+            ws.selectSurface(at: 7)
+        case .selectTab9:
+            ws.selectSurface(at: 8)
+        case .splitRight, .splitDown, .setWorkspaceTag:
+            break // Already handled above
+        }
+        return true
+    }
+
+    private func beginSetWorkspaceTagFlow() -> Bool {
+        guard LeaderKeySettings.workspaceTagsEnabled else {
+            NSSound.beep()
+            return true
+        }
+        guard let tabManager, let workspace = tabManager.selectedWorkspace else {
+            NSSound.beep()
+            return true
+        }
+#if DEBUG
+        if let debugWorkspaceTagPromptHandler {
+            let result = debugWorkspaceTagPromptHandler(workspace)
+            if result.response == .alertFirstButtonReturn {
+                workspace.setTag(result.tag)
+            }
+            return true
+        }
+#endif
+        let alert = NSAlert()
+        alert.messageText = String(localized: "alert.setWorkspaceTag.title", defaultValue: "Set Workspace Tag")
+        alert.informativeText = String(localized: "alert.setWorkspaceTag.message", defaultValue: "Enter a short tag prefix for this workspace.")
+        let input = NSTextField(string: workspace.tag ?? "")
+        input.placeholderString = String(localized: "alert.setWorkspaceTag.placeholder", defaultValue: "Tag (e.g., api, web)")
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        if alert.runModal() == .alertFirstButtonReturn {
+            workspace.setTag(input.stringValue)
+        }
+        return true
     }
 
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
@@ -12506,6 +12784,80 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case 26: return 7 // kVK_ANSI_7
         case 28: return 8 // kVK_ANSI_8
         case 25: return 9 // kVK_ANSI_9
+        default:
+            return nil
+        }
+    }
+
+    private func shortcutCharacterMatches(
+        eventCharacter: String?,
+        shortcutKey: String,
+        applyShiftSymbolNormalization: Bool,
+        eventKeyCode: UInt16
+    ) -> Bool {
+        guard let eventCharacter, !eventCharacter.isEmpty else { return false }
+        return normalizedShortcutEventCharacter(
+            eventCharacter,
+            applyShiftSymbolNormalization: applyShiftSymbolNormalization,
+            eventKeyCode: eventKeyCode
+        ) == shortcutKey
+    }
+
+    private func keyCodeForShortcutKey(_ key: String) -> UInt16? {
+        switch key {
+        case "a": return 0
+        case "s": return 1
+        case "d": return 2
+        case "f": return 3
+        case "h": return 4
+        case "g": return 5
+        case "z": return 6
+        case "x": return 7
+        case "c": return 8
+        case "v": return 9
+        case "b": return 11
+        case "q": return 12
+        case "w": return 13
+        case "e": return 14
+        case "r": return 15
+        case "y": return 16
+        case "t": return 17
+        case "1": return 18
+        case "2": return 19
+        case "3": return 20
+        case "4": return 21
+        case "6": return 22
+        case "5": return 23
+        case "=": return 24
+        case "9": return 25
+        case "7": return 26
+        case "-": return 27
+        case "8": return 28
+        case "0": return 29
+        case "]": return 30
+        case "o": return 31
+        case "u": return 32
+        case "[": return 33
+        case "i": return 34
+        case "p": return 35
+        case "l": return 37
+        case "j": return 38
+        case "'": return 39
+        case "k": return 40
+        case ";": return 41
+        case "\\": return 42
+        case ",": return 43
+        case "/": return 44
+        case "n": return 45
+        case "m": return 46
+        case ".": return 47
+        case "\t": return 48
+        case "`": return 50
+        case "\r": return 36
+        case "←": return 123
+        case "→": return 124
+        case "↓": return 125
+        case "↑": return 126
         default:
             return nil
         }
@@ -14341,6 +14693,16 @@ private extension NSWindow {
         }
         let firstResponderHasMarkedText = browserResponderHasMarkedText(self.firstResponder)
         if let ghosttyView = firstResponderGhosttyView {
+            // While leader key mode is active, don't route keystrokes to the terminal.
+            // Let them flow through to the local event monitor so executeLeaderAction
+            // can dispatch the second key.
+            if AppDelegate.shared?.tabManager?.isLeaderModeActive == true {
+#if DEBUG
+                dlog("  → leader mode active, skipping ghostty direct routing")
+#endif
+                return false
+            }
+
             // If the IME is composing and the key has no Cmd modifier, don't intercept —
             // let it flow through normal AppKit event dispatch so the input method can
             // process it. Cmd-based shortcuts should still work during composition since

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7665,12 +7665,7 @@ struct ContentView: View {
     }
 
     private static func commandPaletteWorkspaceDisplayName(_ workspace: Workspace) -> String {
-        let custom = workspace.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !custom.isEmpty {
-            return custom
-        }
-        let title = workspace.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        return title.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : title
+        workspace.displayTitle
     }
 
     private func workspaceDisplayName(_ workspace: Workspace) -> String {
@@ -8711,7 +8706,13 @@ struct ContentView: View {
         }
         let target = CommandPaletteRenameTarget(
             kind: .workspace(workspaceId: workspace.id),
-            currentName: workspaceDisplayName(workspace)
+            currentName: {
+                if let custom = workspace.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !custom.isEmpty {
+                    return custom
+                }
+                return workspace.title
+            }()
         )
         startRenameFlow(target)
     }
@@ -10148,6 +10149,21 @@ struct VerticalTabsSidebar: View {
             selectedRemoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
 
         VStack(spacing: 0) {
+            // Leader key mode indicator — pinned above the scroll area
+            if tabManager.isLeaderModeActive {
+                HStack {
+                    Spacer()
+                    Text(String(localized: "leader.mode.indicator", defaultValue: "LEADER"))
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.2))
+                        .cornerRadius(3)
+                    Spacer()
+                }
+                .padding(.vertical, 4)
+            }
+
             GeometryReader { proxy in
                 ScrollView {
                     VStack(spacing: 0) {
@@ -12971,7 +12987,7 @@ private struct TabItemView: View, Equatable {
                         .safeHelp(protectedWorkspaceTooltip)
                 }
 
-                Text(tab.title)
+                Text(tab.displayTitle)
                     .font(.system(size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
@@ -13684,7 +13700,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var accessibilityTitle: String {
-        String(localized: "accessibility.workspacePosition", defaultValue: "\(tab.title), workspace \(index + 1) of \(accessibilityWorkspaceCount)")
+        String(localized: "accessibility.workspacePosition", defaultValue: "\(tab.displayTitle), workspace \(index + 1) of \(accessibilityWorkspaceCount)")
     }
 
     private func moveBy(_ delta: Int) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1153,6 +1153,10 @@ func terminalKeyboardCopyModeAction(
         return .exit
     }
 
+    if keyCode == 36 || keyCode == 76 { // Return or keypad Enter
+        return .exit
+    }
+
     switch keyCode {
     case 126: // Up
         return hasSelection ? .adjustSelection(.up) : .scrollLines(-1)
@@ -1253,6 +1257,11 @@ func terminalKeyboardCopyModeResolve(
     let chars = terminalKeyboardCopyModeChars(charactersIgnoringModifiers)
 
     if keyCode == 53 { // Escape
+        state.reset()
+        return .perform(.exit, count: 1)
+    }
+
+    if keyCode == 36 || keyCode == 76 { // Return or keypad Enter
         state.reset()
         return .perform(.exit, count: 1)
     }
@@ -5940,14 +5949,42 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyboardCopyModeVisualActive = false
         keyboardCopyModeActive = active
         if active, let surface {
-            keyboardCopyModeViewportRow = keyboardCopyModeSelectionAnchor(surface: surface)?.row
+            // Capture the current viewport top row BEFORE any selection work
+            // so we can restore it afterward. This matches tmux's
+            // freeze-in-place behavior: entering copy mode must never move
+            // the view, even if new output is streaming or the user has
+            // scrolled up into scrollback. Defense-in-depth against drift
+            // from either the Ghostty pin or the NSScrollView wrapper.
+            let savedScrollRow = scrollbar.map { Int($0.offset) }
+
+            // Clear any stale selection from a prior mouse drag.
             _ = ghostty_surface_clear_selection_compat(surface)
-            if keyboardCopyModeViewportRow == nil {
+
+            // Create a 1-cell selection as the visible cursor indicator.
+            // Ghostty's selectCursorCell falls back to getTopLeft(.viewport)
+            // when the write-cursor is outside the visible viewport, so the
+            // indicator is guaranteed to land inside the visible bounds.
+            _ = ghostty_surface_select_cursor_cell_compat(surface)
+
+            // Restore the viewport to where the user was before we entered
+            // copy mode. No-op if nothing moved.
+            if let savedScrollRow {
+                _ = performBindingAction("scroll_to_row:\(savedScrollRow)")
+            }
+
+            // Derive the viewport row for line-yank bookkeeping, relative to
+            // the restored viewport.
+            var text = ghostty_text_s()
+            if ghostty_surface_read_selection(surface, &text) {
+                defer { ghostty_surface_free_text(surface, &text) }
+                let size = ghostty_surface_size(surface)
+                let cols = max(Int(size.columns), 1)
+                let rows = max(Int(size.rows), 1)
+                let rawRow = Int(text.offset_start) / cols
+                keyboardCopyModeViewportRow = max(0, min(rows - 1, rawRow))
+            } else {
                 keyboardCopyModeViewportRow = keyboardCopyModeImeViewportRow(surface: surface)
             }
-            // Create a 1-cell selection at the terminal cursor to serve as a
-            // visible cursor indicator in copy mode.
-            _ = ghostty_surface_select_cursor_cell_compat(surface)
         } else {
             keyboardCopyModeViewportRow = nil
         }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -84,6 +84,9 @@ enum KeyboardShortcutSettings {
         case showBrowserJavaScriptConsole
         case toggleReactGrab
 
+        // Leader key (tmux-style prefix)
+        case leaderKey
+
         var id: String { rawValue }
 
         var label: String {
@@ -145,6 +148,7 @@ enum KeyboardShortcutSettings {
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             case .toggleReactGrab: return String(localized: "shortcut.toggleReactGrab.label", defaultValue: "Toggle React Grab")
+            case .leaderKey: return String(localized: "shortcut.leaderKey.label", defaultValue: "Leader Key (tmux prefix)")
             }
         }
 
@@ -272,6 +276,9 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
             case .toggleReactGrab:
                 return StoredShortcut(key: "g", command: true, shift: true, option: false, control: false)
+            case .leaderKey:
+                // tmux default: Ctrl+B
+                return StoredShortcut(key: "b", command: false, shift: false, option: false, control: true)
             }
         }
 

--- a/Sources/LeaderKeySettings.swift
+++ b/Sources/LeaderKeySettings.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Stores leader key sub-binding configuration (timeout, enable/disable, per-action key overrides).
+enum LeaderKeySettings {
+    // MARK: - Master Toggle
+
+    static let enabledKey = "leaderKey.enabled"
+    static let enabledDefault = false
+
+    static var isEnabled: Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: enabledKey) == nil { return enabledDefault }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    // MARK: - Timeout
+
+    static let timeoutKey = "leaderKey.timeout"
+    static let timeoutDefault: Double = 0.5
+    static let timeoutRange: ClosedRange<Double> = 0.2...3.0
+
+    static var timeout: Double {
+        let defaults = UserDefaults.standard
+        let value = defaults.double(forKey: timeoutKey)
+        if value == 0 { return timeoutDefault }
+        return value.clamped(to: timeoutRange)
+    }
+
+    // MARK: - Workspace Tags Toggle
+
+    static let workspaceTagsEnabledKey = "workspaceTagsEnabled"
+    static let workspaceTagsEnabledDefault = false
+
+    static var workspaceTagsEnabled: Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: workspaceTagsEnabledKey) == nil { return workspaceTagsEnabledDefault }
+        return defaults.bool(forKey: workspaceTagsEnabledKey)
+    }
+
+    // MARK: - Leader Sub-Actions
+
+    /// All leader key sub-actions with their default key bindings.
+    enum LeaderAction: String, CaseIterable, Identifiable {
+        case splitRight
+        case splitDown
+        case focusNextPane
+        case closePane
+        case newTab
+        case nextTab
+        case previousTab
+        case focusLeft
+        case focusRight
+        case focusDown
+        case focusUp
+        case setWorkspaceTag
+        case toggleCopyMode
+        case selectTab0
+        case selectTab1
+        case selectTab2
+        case selectTab3
+        case selectTab4
+        case selectTab5
+        case selectTab6
+        case selectTab7
+        case selectTab8
+        case selectTab9
+
+        var id: String { rawValue }
+
+        var defaultsKey: String { "leader.action.\(rawValue)" }
+
+        /// The default key character (what the user presses after the leader key).
+        /// Shifted symbols use the produced character; letters use lowercase.
+        var defaultKey: String {
+            switch self {
+            case .splitRight: return "\\"
+            case .splitDown: return "-"
+            case .focusNextPane: return "o"
+            case .closePane: return "x"
+            case .newTab: return "c"
+            case .nextTab: return "n"
+            case .previousTab: return "p"
+            case .focusLeft: return "h"
+            case .focusRight: return "l"
+            case .focusDown: return "j"
+            case .focusUp: return "k"
+            case .setWorkspaceTag: return ","
+            case .toggleCopyMode: return "["
+            case .selectTab0: return "0"
+            case .selectTab1: return "1"
+            case .selectTab2: return "2"
+            case .selectTab3: return "3"
+            case .selectTab4: return "4"
+            case .selectTab5: return "5"
+            case .selectTab6: return "6"
+            case .selectTab7: return "7"
+            case .selectTab8: return "8"
+            case .selectTab9: return "9"
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .splitRight:
+                return String(localized: "leader.action.splitRight.label", defaultValue: "Split Right")
+            case .splitDown:
+                return String(localized: "leader.action.splitDown.label", defaultValue: "Split Down")
+            case .focusNextPane:
+                return String(localized: "leader.action.focusNextPane.label", defaultValue: "Focus Next Pane")
+            case .closePane:
+                return String(localized: "leader.action.closePane.label", defaultValue: "Close Pane")
+            case .newTab:
+                return String(localized: "leader.action.newTab.label", defaultValue: "New Tab")
+            case .nextTab:
+                return String(localized: "leader.action.nextTab.label", defaultValue: "Next Tab")
+            case .previousTab:
+                return String(localized: "leader.action.previousTab.label", defaultValue: "Previous Tab")
+            case .focusLeft:
+                return String(localized: "leader.action.focusLeft.label", defaultValue: "Focus Left")
+            case .focusRight:
+                return String(localized: "leader.action.focusRight.label", defaultValue: "Focus Right")
+            case .focusDown:
+                return String(localized: "leader.action.focusDown.label", defaultValue: "Focus Down")
+            case .focusUp:
+                return String(localized: "leader.action.focusUp.label", defaultValue: "Focus Up")
+            case .setWorkspaceTag:
+                return String(localized: "leader.action.setWorkspaceTag.label", defaultValue: "Set Workspace Tag")
+            case .toggleCopyMode:
+                return String(localized: "leader.action.toggleCopyMode.label", defaultValue: "Toggle Copy Mode")
+            case .selectTab0:
+                return String(localized: "leader.action.selectTab0.label", defaultValue: "Select Tab 10")
+            case .selectTab1:
+                return String(localized: "leader.action.selectTab1.label", defaultValue: "Select Tab 1")
+            case .selectTab2:
+                return String(localized: "leader.action.selectTab2.label", defaultValue: "Select Tab 2")
+            case .selectTab3:
+                return String(localized: "leader.action.selectTab3.label", defaultValue: "Select Tab 3")
+            case .selectTab4:
+                return String(localized: "leader.action.selectTab4.label", defaultValue: "Select Tab 4")
+            case .selectTab5:
+                return String(localized: "leader.action.selectTab5.label", defaultValue: "Select Tab 5")
+            case .selectTab6:
+                return String(localized: "leader.action.selectTab6.label", defaultValue: "Select Tab 6")
+            case .selectTab7:
+                return String(localized: "leader.action.selectTab7.label", defaultValue: "Select Tab 7")
+            case .selectTab8:
+                return String(localized: "leader.action.selectTab8.label", defaultValue: "Select Tab 8")
+            case .selectTab9:
+                return String(localized: "leader.action.selectTab9.label", defaultValue: "Select Tab 9")
+            }
+        }
+
+        /// Display string for the key (human-readable).
+        var keyDisplayString: String {
+            let k = LeaderKeySettings.key(for: self)
+            switch k {
+            case "\"": return "\\\""
+            case ",": return ","
+            case "[": return "["
+            default: return k.uppercased()
+            }
+        }
+    }
+
+    /// Non-tab-selector actions shown as configurable rows in settings.
+    static let configurableActions: [LeaderAction] = [
+        .splitRight, .splitDown, .focusNextPane, .closePane,
+        .newTab, .nextTab, .previousTab, .focusLeft, .focusRight, .focusDown, .focusUp,
+        .setWorkspaceTag, .toggleCopyMode,
+    ]
+
+    // MARK: - Per-Action Key Accessors
+
+    static func key(for action: LeaderAction) -> String {
+        UserDefaults.standard.string(forKey: action.defaultsKey) ?? action.defaultKey
+    }
+
+    static func setKey(_ key: String, for action: LeaderAction) {
+        if key == action.defaultKey {
+            UserDefaults.standard.removeObject(forKey: action.defaultsKey)
+        } else {
+            UserDefaults.standard.set(key, forKey: action.defaultsKey)
+        }
+    }
+
+    // MARK: - Reset
+
+    static func resetAll() {
+        UserDefaults.standard.removeObject(forKey: enabledKey)
+        UserDefaults.standard.removeObject(forKey: timeoutKey)
+        UserDefaults.standard.removeObject(forKey: workspaceTagsEnabledKey)
+        for action in LeaderAction.allCases {
+            UserDefaults.standard.removeObject(forKey: action.defaultsKey)
+        }
+    }
+}
+
+// MARK: - Comparable Clamping
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -331,6 +331,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var processTitle: String
     var customTitle: String?
     var customDescription: String?
+    var tag: String?
     var customColor: String?
     var isPinned: Bool
     var terminalScrollBarHidden: Bool?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -9,6 +9,13 @@ import Combine
 // The old Tab class is replaced by Workspace
 typealias Tab = Workspace
 
+// KVO-observable accessor for workspace tags toggle
+extension UserDefaults {
+    @objc dynamic var workspaceTagsEnabled: Bool {
+        bool(forKey: LeaderKeySettings.workspaceTagsEnabledKey)
+    }
+}
+
 enum NewWorkspacePlacement: String, CaseIterable, Identifiable {
     case top
     case afterCurrent
@@ -865,6 +872,7 @@ class TabManager: ObservableObject {
     weak var window: NSWindow?
 
     @Published var tabs: [Workspace] = []
+    @Published var isLeaderModeActive: Bool = false
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
@@ -956,6 +964,7 @@ class TabManager: ObservableObject {
         }
     }
     private var observers: [NSObjectProtocol] = []
+    private var workspaceTagsObservation: NSKeyValueObservation?
     private var suppressFocusFlash = false
     private var lastFocusedPanelByTab: [UUID: UUID] = [:]
     private struct PanelTitleUpdateKey: Hashable {
@@ -1057,6 +1066,19 @@ class TabManager: ObservableObject {
                 dismissPanelNotificationOnFocusIfActive(tabId: tabId, panelId: surfaceId)
             }
         })
+
+        workspaceTagsObservation = UserDefaults.standard.observe(
+            \.workspaceTagsEnabled,
+            options: [.old, .new]
+        ) { [weak self] _, change in
+            guard change.oldValue != change.newValue else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                for workspace in tabs {
+                    workspace.objectWillChange.send()
+                }
+            }
+        }
 
         startAgentPIDSweepTimer()
         startWorkspaceGitMetadataPollTimer()

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2087,6 +2087,8 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceReorder(params: params))
         case "workspace.rename":
             return v2Result(id: id, self.v2WorkspaceRename(params: params))
+        case "workspace.set_tag":
+            return v2Result(id: id, self.v2WorkspaceSetTag(params: params))
         case "workspace.action":
             return v2Result(id: id, self.v2WorkspaceAction(params: params))
         case "workspace.next":
@@ -2471,6 +2473,7 @@ class TerminalController {
             "workspace.move_to_window",
             "workspace.reorder",
             "workspace.rename",
+            "workspace.set_tag",
             "workspace.action",
             "workspace.next",
             "workspace.previous",
@@ -3329,7 +3332,8 @@ class TerminalController {
             "listening_ports": workspace.listeningPorts,
             "remote": workspace.remoteStatusPayload(),
             "current_directory": v2OrNull(workspace.currentDirectory),
-            "custom_color": v2OrNull(workspace.customColor)
+            "custom_color": v2OrNull(workspace.customColor),
+            "tag": v2OrNull(workspace.tag)
         ]
         if let index {
             payload["index"] = index
@@ -3671,6 +3675,50 @@ class TerminalController {
             "title": title
         ])
     }
+
+    private func v2WorkspaceSetTag(params: [String: Any]) -> V2CallResult {
+        guard LeaderKeySettings.workspaceTagsEnabled else {
+            return .err(code: "disabled", message: "Workspace tags are disabled in settings", data: nil)
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let workspaceId = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+
+        guard let tagRaw = v2RawString(params, "tag") else {
+            return .err(code: "invalid_params", message: "Missing 'tag' parameter. Pass empty string to clear.", data: nil)
+        }
+        let tag = tagRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveTag = tag.isEmpty ? nil : tag
+
+        var success = false
+        var storedTag: String?
+        v2MainSync {
+            guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+            ws.setTag(effectiveTag)
+            storedTag = ws.tag
+            success = true
+        }
+
+        guard success else {
+            return .err(code: "not_found", message: "Workspace not found", data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId)
+            ])
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "workspace_id": workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "tag": v2OrNull(storedTag)
+        ])
+    }
+
     private func v2WorkspaceNext(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -296,6 +296,7 @@ extension Workspace {
             processTitle: processTitle,
             customTitle: customTitle,
             customDescription: customDescription,
+            tag: tag,
             customColor: customColor,
             isPinned: isPinned,
             terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
@@ -337,6 +338,7 @@ extension Workspace {
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
         setCustomDescription(snapshot.customDescription)
+        setTag(snapshot.tag)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
         setTerminalScrollBarHidden(snapshot.terminalScrollBarHidden ?? false)
@@ -6490,6 +6492,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var title: String
     @Published var customTitle: String?
     @Published var customDescription: String?
+    @Published var tag: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published private(set) var terminalScrollBarHidden: Bool = false
@@ -7579,6 +7582,29 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
         customDescription = normalizedDescription
+    }
+
+    func setTag(_ newTag: String?) {
+        let normalized = newTag?
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ") ?? ""
+        let capped = String(normalized.prefix(20))
+        tag = capped.isEmpty ? nil : capped
+    }
+
+    /// Title with tag prefix for sidebar display, respecting customTitle when set.
+    var displayTitle: String {
+        let custom = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let base: String
+        if !custom.isEmpty {
+            base = custom
+        } else {
+            let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            base = t.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : t
+        }
+        guard LeaderKeySettings.workspaceTagsEnabled, let tag, !tag.isEmpty else { return base }
+        return String(format: String(localized: "workspace.displayTitle.tagged", defaultValue: "[%@] %@"), tag, base)
     }
 
     // MARK: - Directory Updates
@@ -10154,6 +10180,65 @@ final class Workspace: Identifiable, ObservableObject {
             applyTabSelection(tabId: tabId, inPane: paneId)
         }
 
+    }
+
+    /// Shared helper: unfocus current panel, focus the target pane, and reconcile tab selection.
+    private func switchFocusToPane(_ targetPaneId: PaneID) {
+        if let prevPanelId = focusedPanelId, let prev = panels[prevPanelId] {
+            prev.unfocus()
+        }
+        bonsplitController.focusPane(targetPaneId)
+        if let paneId = bonsplitController.focusedPaneId,
+           let tabId = bonsplitController.selectedTab(inPane: paneId)?.id {
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        }
+    }
+
+    /// Pane IDs in visual (layout) order derived from the split tree.
+    /// Falls back to `allPaneIds` if the tree snapshot yields no panes.
+    private func visuallyOrderedPaneIds() -> [PaneID] {
+        let allPaneIds = bonsplitController.allPaneIds
+        let tree = bonsplitController.treeSnapshot()
+        let orderedStrings = SidebarBranchOrdering.orderedPaneIds(tree: tree)
+        let byId = Dictionary(uniqueKeysWithValues: allPaneIds.map { ($0.id.uuidString, $0) })
+        let mapped = orderedStrings.compactMap { byId[$0] }
+        return mapped.count == allPaneIds.count ? mapped : allPaneIds
+    }
+
+    /// Cycle focus to the previous pane.
+    func focusPreviousPane() {
+        let paneIds = visuallyOrderedPaneIds()
+#if DEBUG
+        dlog("pane.cyclePrev count=\(paneIds.count) focusedId=\(bonsplitController.focusedPaneId.map { "\($0)" } ?? "nil")")
+#endif
+        guard paneIds.count > 1 else { return }
+        let currentId = bonsplitController.focusedPaneId ?? paneIds[0]
+        if let idx = paneIds.firstIndex(of: currentId) {
+            switchFocusToPane(paneIds[(idx - 1 + paneIds.count) % paneIds.count])
+        }
+    }
+
+    /// Cycle focus to the next pane (tmux prefix+o behavior).
+    func focusNextPane() {
+        let paneIds = visuallyOrderedPaneIds()
+#if DEBUG
+        dlog("pane.cycleNext count=\(paneIds.count) focusedId=\(bonsplitController.focusedPaneId.map { "\($0)" } ?? "nil")")
+#endif
+        guard paneIds.count > 1 else { return }
+        let currentId = bonsplitController.focusedPaneId ?? paneIds[0]
+        if let idx = paneIds.firstIndex(of: currentId) {
+            switchFocusToPane(paneIds[(idx + 1) % paneIds.count])
+        }
+    }
+
+    /// Focus a pane by its index in the ordered pane list.
+    func focusPaneByIndex(_ index: Int) {
+        let paneIds = visuallyOrderedPaneIds()
+#if DEBUG
+        dlog("pane.focusByIndex index=\(index) count=\(paneIds.count) focusedId=\(bonsplitController.focusedPaneId.map { "\($0)" } ?? "nil")")
+#endif
+        guard index >= 0, index < paneIds.count else { return }
+        switchFocusToPane(paneIds[index])
     }
 
     // MARK: - Surface Navigation

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4464,6 +4464,7 @@ struct SettingsView: View {
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @StateObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @State private var shortcutResetToken = UUID()
+    @State private var leaderKeyResetToken = UUID()
     @State private var topBlurOpacity: Double = 0
     @State private var topBlurBaselineOffset: CGFloat?
     @State private var settingsTitleLeadingInset: CGFloat = 92
@@ -6244,6 +6245,9 @@ struct SettingsView: View {
 
                     GlobalHotkeySection()
 
+                    LeaderKeySettingsSection()
+                        .id(leaderKeyResetToken)
+
                     SettingsSectionHeader(title: String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts"))
                         .id(SettingsNavigationTarget.keyboardShortcuts)
                         .accessibilityIdentifier("SettingsKeyboardShortcutsSection")
@@ -6599,6 +6603,8 @@ struct SettingsView: View {
         refreshDetectedImportBrowsers()
         SystemWideHotkeySettings.reset()
         KeyboardShortcutSettings.resetAll()
+        LeaderKeySettings.resetAll()
+        leaderKeyResetToken = UUID()
         WorkspaceTabColorSettings.reset()
         reloadWorkspaceTabColorSettings()
         shortcutResetToken = UUID()
@@ -7313,6 +7319,281 @@ private struct GlobalHotkeySection: View {
         if latestShortcut != shortcut {
             shortcut = latestShortcut
         }
+    }
+}
+
+private struct LeaderKeySettingsSection: View {
+    @AppStorage(LeaderKeySettings.enabledKey) private var leaderKeyEnabled = LeaderKeySettings.enabledDefault
+    @AppStorage(LeaderKeySettings.timeoutKey) private var leaderKeyTimeout = LeaderKeySettings.timeoutDefault
+    @AppStorage(LeaderKeySettings.workspaceTagsEnabledKey) private var workspaceTagsEnabled = LeaderKeySettings.workspaceTagsEnabledDefault
+
+    var body: some View {
+        SettingsSectionHeader(title: String(localized: "settings.section.leaderKey", defaultValue: "Leader Key"))
+            .accessibilityIdentifier("SettingsLeaderKeySection")
+        SettingsCard {
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.leaderKey.enabled", defaultValue: "Enable Leader Key"),
+                subtitle: leaderKeyEnabled
+                    ? String(localized: "settings.leaderKey.enabled.subtitleOn", defaultValue: "Press the leader key prefix, then a sub-key to trigger an action.")
+                    : String(localized: "settings.leaderKey.enabled.subtitleOff", defaultValue: "Leader key is disabled. The prefix key will pass through to the terminal.")
+            ) {
+                Toggle("", isOn: $leaderKeyEnabled)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityLabel(
+                        String(localized: "settings.leaderKey.enabled", defaultValue: "Enable Leader Key")
+                    )
+            }
+
+            if leaderKeyEnabled {
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    configurationReview: .settingsOnly,
+                    String(localized: "settings.leaderKey.timeout", defaultValue: "Timeout"),
+                    subtitle: String(localized: "settings.leaderKey.timeout.subtitle", defaultValue: "Seconds to wait for the sub-key before cancelling leader mode.")
+                ) {
+                    HStack(spacing: 8) {
+                        Slider(value: $leaderKeyTimeout, in: 0.2...3.0, step: 0.1)
+                            .frame(width: 120)
+                        Text(String(format: String(localized: "settings.leaderKey.timeout.value", defaultValue: "%.1fs"), leaderKeyTimeout))
+                            .font(.system(.body, design: .monospaced))
+                            .frame(width: 40, alignment: .trailing)
+                    }
+                }
+
+                SettingsCardDivider()
+
+                let actions = LeaderKeySettings.configurableActions
+                ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
+                    LeaderBindingRow(action: action)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 9)
+                    if index < actions.count - 1 {
+                        SettingsCardDivider()
+                    }
+                }
+            }
+        }
+
+        SettingsCard {
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.app.workspaceTags", defaultValue: "Workspace Tags"),
+                subtitle: workspaceTagsEnabled
+                    ? String(localized: "settings.app.workspaceTags.subtitleOn", defaultValue: "Workspace tags are shown as [tag] prefix in the workspace switcher and tab bar.")
+                    : String(localized: "settings.app.workspaceTags.subtitleOff", defaultValue: "Workspace tag display and assignment are disabled.")
+            ) {
+                Toggle("", isOn: $workspaceTagsEnabled)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityLabel(
+                        String(localized: "settings.app.workspaceTags", defaultValue: "Workspace Tags")
+                    )
+            }
+        }
+    }
+}
+
+private struct LeaderBindingRow: View {
+    let action: LeaderKeySettings.LeaderAction
+    @State private var currentKey: String
+
+    init(action: LeaderKeySettings.LeaderAction) {
+        self.action = action
+        _currentKey = State(initialValue: LeaderKeySettings.key(for: action))
+    }
+
+    var body: some View {
+        HStack {
+            Text(action.label)
+            Spacer()
+            LeaderKeyRecorderButton(key: $currentKey, actionLabel: action.label)
+                .frame(width: 120)
+        }
+        .onChange(of: currentKey) { newValue in
+            LeaderKeySettings.setKey(newValue, for: action)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            let latest = LeaderKeySettings.key(for: action)
+            if latest != currentKey {
+                currentKey = latest
+            }
+        }
+    }
+}
+
+private struct LeaderKeyRecorderButton: NSViewRepresentable {
+    @Binding var key: String
+    let actionLabel: String
+
+    func makeNSView(context: Context) -> LeaderKeyRecorderNSButton {
+        let button = LeaderKeyRecorderNSButton()
+        button.currentKey = key
+        button.accessibilityContextLabel = actionLabel
+        button.onKeyRecorded = { newKey in
+            key = newKey
+        }
+        button.refreshAccessibility()
+        return button
+    }
+
+    func updateNSView(_ nsView: LeaderKeyRecorderNSButton, context: Context) {
+        nsView.currentKey = key
+        nsView.accessibilityContextLabel = actionLabel
+        nsView.updateTitle()
+    }
+}
+
+private class LeaderKeyRecorderNSButton: NSButton {
+    var currentKey: String = ""
+    var onKeyRecorded: ((String) -> Void)?
+    var accessibilityContextLabel: String = ""
+    private var isRecording = false
+    private var eventMonitor: Any?
+    private static weak var activeRecorder: LeaderKeyRecorderNSButton?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        bezelStyle = .rounded
+        setButtonType(.momentaryPushIn)
+        target = self
+        action = #selector(buttonClicked)
+        updateTitle()
+    }
+
+    func updateTitle() {
+        if isRecording {
+            title = String(localized: "leaderKey.recorder.press", defaultValue: "Press key…")
+        } else {
+            title = displayString(for: currentKey)
+        }
+        refreshAccessibility()
+    }
+
+    func refreshAccessibility() {
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(accessibilityContextLabel)
+        setAccessibilityValue(displayString(for: currentKey))
+    }
+
+    private func displayString(for key: String) -> String {
+        switch key {
+        case "\"": return "\""
+        case ",": return ","
+        case "[": return "["
+        case "%": return "%"
+        default: return key.uppercased()
+        }
+    }
+
+    @objc private func buttonClicked() {
+        if isRecording {
+            stopRecording()
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        // Cancel any other active recorder first
+        if let other = Self.activeRecorder, other !== self {
+            other.stopRecording()
+        }
+        Self.activeRecorder = self
+        isRecording = true
+        updateTitle()
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self = self else { return event }
+
+            if event.keyCode == 53 { // Escape — cancel
+                self.stopRecording()
+                return nil
+            }
+
+            // Reject Command/Control/Option/fn chords so e.g. Cmd+B doesn't
+            // collapse to "b". Shift is still allowed for shifted symbols.
+            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let unsupported: NSEvent.ModifierFlags = [.command, .control, .option, .function]
+            guard modifiers.intersection(unsupported).isEmpty else {
+                return nil
+            }
+
+            // For shifted symbols, use the produced character; for letters/digits, use unshifted
+            let shifted = event.characters ?? ""
+            let unshifted = event.charactersIgnoringModifiers ?? ""
+
+            // Prefer the shifted output for symbols (e.g. Shift+5 → "%"), unshifted for alphanumerics
+            let recorded: String
+            if !shifted.isEmpty,
+               shifted != unshifted,
+               let shiftedFirst = shifted.first,
+               !(shiftedFirst.isLetter || shiftedFirst.isNumber) {
+                recorded = shifted
+            } else if let first = unshifted.first, first.isLetter || first.isNumber {
+                recorded = unshifted.lowercased()
+            } else if !shifted.isEmpty {
+                recorded = shifted
+            } else {
+                recorded = unshifted
+            }
+
+            guard !recorded.isEmpty else {
+                return nil
+            }
+            // Reject non-printable, whitespace, and multi-character sequences
+            guard recorded.count == 1,
+                  let char = recorded.first,
+                  !char.isWhitespace,
+                  !char.unicodeScalars.allSatisfy({ CharacterSet.controlCharacters.contains($0) })
+            else {
+                return nil
+            }
+
+            self.currentKey = recorded
+            self.onKeyRecorded?(recorded)
+            self.stopRecording()
+            return nil
+        }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowResigned),
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+    }
+
+    private func stopRecording() {
+        isRecording = false
+        if Self.activeRecorder === self {
+            Self.activeRecorder = nil
+        }
+        updateTitle()
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: window)
+    }
+
+    @objc private func windowResigned() {
+        stopRecording()
+    }
+
+    deinit {
+        stopRecording()
     }
 }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -64,6 +64,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         AppDelegate.shared?.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
         AppDelegate.shared?.debugCloseMainWindowConfirmationHandler = nil
         AppDelegate.shared?.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
+#if DEBUG
+        AppDelegate.shared?.debugWorkspaceTagPromptHandler = nil
+#endif
         AppDelegate.shared?.dismissNotificationsPopoverIfShown()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         for action in KeyboardShortcutSettings.Action.allCases {
@@ -4403,12 +4406,181 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(searchField.stringValue, "a", "Typing repair should preserve the first key in the search field")
     }
 
+    func testLeaderCommaRequestsWorkspaceTagDialogWhenWorkspaceTagsEnabled() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window with selected workspace")
+            return
+        }
+
+        var requestedWorkspaceId: UUID?
+#if DEBUG
+        appDelegate.debugWorkspaceTagPromptHandler = { candidate in
+            requestedWorkspaceId = candidate.id
+            return AppDelegate.DebugWorkspaceTagPromptResult(
+                response: .alertSecondButtonReturn,
+                tag: candidate.tag ?? ""
+            )
+        }
+#endif
+
+        withTemporaryLeaderWorkspaceTagSettings(workspaceTagsEnabled: true) {
+            guard let leaderEvent = makeKeyDownEvent(
+                key: "b",
+                modifiers: [.control],
+                keyCode: 11,
+                windowNumber: window.windowNumber
+            ), let commaEvent = makeKeyDownEvent(
+                key: ",",
+                modifiers: [],
+                keyCode: 43,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct leader workspace-tag events")
+                return
+            }
+
+#if DEBUG
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: leaderEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: commaEvent))
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+
+        XCTAssertEqual(requestedWorkspaceId, workspace.id)
+        XCTAssertNil(workspace.tag)
+    }
+
+    func testLeaderCommaUsesLayoutCharacterFallbackWhenEventCharactersAreNotLiteralComma() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window with selected workspace")
+            return
+        }
+
+        var requestedWorkspaceId: UUID?
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 15 ? "," : nil
+        }
+#if DEBUG
+        appDelegate.debugWorkspaceTagPromptHandler = { candidate in
+            requestedWorkspaceId = candidate.id
+            return AppDelegate.DebugWorkspaceTagPromptResult(
+                response: .alertSecondButtonReturn,
+                tag: candidate.tag ?? ""
+            )
+        }
+#endif
+
+        withTemporaryLeaderWorkspaceTagSettings(workspaceTagsEnabled: true) {
+            guard let leaderEvent = makeKeyDownEvent(
+                key: "b",
+                modifiers: [.control],
+                keyCode: 11,
+                windowNumber: window.windowNumber
+            ), let commaEvent = makeKeyDownEvent(
+                key: "x",
+                modifiers: [],
+                keyCode: 15,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct layout-fallback leader events")
+                return
+            }
+
+#if DEBUG
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: leaderEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: commaEvent))
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+
+        XCTAssertEqual(requestedWorkspaceId, workspace.id)
+    }
+
+    func testLeaderCommaDoesNotRequestWorkspaceTagDialogWhenWorkspaceTagsDisabled() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window with selected workspace")
+            return
+        }
+
+        var requestCount = 0
+#if DEBUG
+        appDelegate.debugWorkspaceTagPromptHandler = { candidate in
+            requestCount += 1
+            return AppDelegate.DebugWorkspaceTagPromptResult(
+                response: .alertSecondButtonReturn,
+                tag: candidate.tag ?? ""
+            )
+        }
+#endif
+
+        withTemporaryLeaderWorkspaceTagSettings(workspaceTagsEnabled: false) {
+            guard let leaderEvent = makeKeyDownEvent(
+                key: "b",
+                modifiers: [.control],
+                keyCode: 11,
+                windowNumber: window.windowNumber
+            ), let commaEvent = makeKeyDownEvent(
+                key: ",",
+                modifiers: [],
+                keyCode: 43,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct leader workspace-tag events")
+                return
+            }
+
+#if DEBUG
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: leaderEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: commaEvent))
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+
+        XCTAssertEqual(requestCount, 0)
+        XCTAssertNil(workspace.tag)
+    }
+
     private func makeKeyDownEvent(
         key: String,
         modifiers: NSEvent.ModifierFlags,
         keyCode: UInt16,
         windowNumber: Int,
-        isARepeat: Bool = false
+        isARepeat: Bool = false,
+        characters: String? = nil,
+        charactersIgnoringModifiers: String? = nil
     ) -> NSEvent? {
         makeKeyEvent(
             type: .keyDown,
@@ -4416,7 +4588,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             modifiers: modifiers,
             keyCode: keyCode,
             windowNumber: windowNumber,
-            isARepeat: isARepeat
+            isARepeat: isARepeat,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers
         )
     }
 
@@ -4426,7 +4600,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         modifiers: NSEvent.ModifierFlags,
         keyCode: UInt16,
         windowNumber: Int,
-        isARepeat: Bool = false
+        isARepeat: Bool = false,
+        characters: String? = nil,
+        charactersIgnoringModifiers: String? = nil
     ) -> NSEvent? {
         NSEvent.keyEvent(
             with: type,
@@ -4435,8 +4611,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             timestamp: ProcessInfo.processInfo.systemUptime,
             windowNumber: windowNumber,
             context: nil,
-            characters: key,
-            charactersIgnoringModifiers: key,
+            characters: characters ?? key,
+            charactersIgnoringModifiers: charactersIgnoringModifiers ?? key,
             isARepeat: isARepeat,
             keyCode: keyCode
         )
@@ -4457,6 +4633,39 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             }
         }
         KeyboardShortcutSettings.setShortcut(shortcut ?? action.defaultShortcut, for: action)
+        body()
+    }
+
+    private func withTemporaryLeaderWorkspaceTagSettings(
+        workspaceTagsEnabled: Bool,
+        _ body: () -> Void
+    ) {
+        let defaults = UserDefaults.standard
+        let leaderChordKey = KeyboardShortcutSettings.Action.leaderKey.defaultsKey
+        let savedValues: [(String, Any?)] = [
+            (LeaderKeySettings.enabledKey, defaults.object(forKey: LeaderKeySettings.enabledKey)),
+            (LeaderKeySettings.workspaceTagsEnabledKey, defaults.object(forKey: LeaderKeySettings.workspaceTagsEnabledKey)),
+            (
+                LeaderKeySettings.LeaderAction.setWorkspaceTag.defaultsKey,
+                defaults.object(forKey: LeaderKeySettings.LeaderAction.setWorkspaceTag.defaultsKey)
+            ),
+            (leaderChordKey, defaults.object(forKey: leaderChordKey)),
+        ]
+
+        defer {
+            for (key, value) in savedValues {
+                if let value {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
+        defaults.set(true, forKey: LeaderKeySettings.enabledKey)
+        defaults.set(workspaceTagsEnabled, forKey: LeaderKeySettings.workspaceTagsEnabledKey)
+        defaults.removeObject(forKey: LeaderKeySettings.LeaderAction.setWorkspaceTag.defaultsKey)
+        defaults.removeObject(forKey: leaderChordKey)
         body()
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1052,6 +1052,48 @@ final class TerminalKeyboardCopyModeActionTests: XCTestCase {
             .exit
         )
     }
+
+    func testReturnAlwaysExits() {
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 36, // kVK_Return
+                charactersIgnoringModifiers: "\r",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .exit
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 36,
+                charactersIgnoringModifiers: "\r",
+                modifierFlags: [],
+                hasSelection: true
+            ),
+            .exit
+        )
+    }
+
+    func testKeypadEnterAlwaysExits() {
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 76, // kVK_ANSI_KeypadEnter
+                charactersIgnoringModifiers: "\u{3}",
+                modifierFlags: [],
+                hasSelection: false
+            ),
+            .exit
+        )
+        XCTAssertEqual(
+            terminalKeyboardCopyModeAction(
+                keyCode: 76,
+                charactersIgnoringModifiers: "\u{3}",
+                modifierFlags: [],
+                hasSelection: true
+            ),
+            .exit
+        )
+    }
 }
 
 
@@ -1134,6 +1176,63 @@ final class TerminalKeyboardCopyModeResolveTests: XCTestCase {
         var state = TerminalKeyboardCopyModeInputState()
         XCTAssertEqual(resolve(18, chars: "2", hasSelection: false, state: &state), .consume)
         XCTAssertEqual(resolve(7, chars: "x", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testReturnExitsFromCleanState() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(36, chars: "\r", hasSelection: false, state: &state),
+            .perform(.exit, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testReturnExitsWithSelection() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(36, chars: "\r", hasSelection: true, state: &state),
+            .perform(.exit, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testReturnClearsCountPrefix() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(20, chars: "3", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(
+            resolve(36, chars: "\r", hasSelection: false, state: &state),
+            .perform(.exit, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testReturnClearsPendingYankLine() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(16, chars: "y", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(
+            resolve(36, chars: "\r", hasSelection: false, state: &state),
+            .perform(.exit, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testReturnClearsPendingG() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(resolve(5, chars: "g", hasSelection: false, state: &state), .consume)
+        XCTAssertEqual(
+            resolve(36, chars: "\r", hasSelection: false, state: &state),
+            .perform(.exit, count: 1)
+        )
+        XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
+    }
+
+    func testKeypadEnterExits() {
+        var state = TerminalKeyboardCopyModeInputState()
+        XCTAssertEqual(
+            resolve(76, chars: "\u{3}", hasSelection: false, state: &state),
+            .perform(.exit, count: 1)
+        )
         XCTAssertEqual(state, TerminalKeyboardCopyModeInputState())
     }
 

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -244,6 +244,62 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertFalse(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: focusedPanelId))
     }
 
+    private func withTemporaryDefault(key: String, value: Any, _ body: () async throws -> Void) async rethrows {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defaults.set(value, forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        try await body()
+    }
+
+    func testWorkspaceSetTagFailsWhenTagsDisplayIsDisabled() async throws {
+        try await withTemporaryDefault(key: LeaderKeySettings.workspaceTagsEnabledKey, value: false) {
+            let socketPath = self.makeSocketPath("workspace-tag")
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace else {
+                XCTFail("Expected selected workspace")
+                return
+            }
+
+            TerminalController.shared.start(
+                tabManager: manager,
+                socketPath: socketPath,
+                accessMode: .allowAll
+            )
+            try self.waitForSocket(at: socketPath)
+
+            let response = try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        let response = try self.sendV2Request(
+                            method: "workspace.set_tag",
+                            params: [
+                                "workspace_id": workspace.id.uuidString,
+                                "tag": "api"
+                            ],
+                            to: socketPath
+                        )
+                        continuation.resume(returning: response)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+
+            XCTAssertEqual(response["ok"] as? Bool, false, "Unexpected JSON-RPC response: \(response)")
+            let error = try XCTUnwrap(response["error"] as? [String: Any], "Unexpected JSON-RPC response: \(response)")
+            XCTAssertEqual(error["code"] as? String, "disabled")
+            XCTAssertEqual(error["message"] as? String, "Workspace tags are disabled in settings")
+            XCTAssertNil(workspace.tag)
+        }
+    }
+
     func testSurfaceRelayRPCsReturnResolvedFocusedSurfaceWhenSurfaceIDOmitted() async throws {
         let socketPath = makeSocketPath("relay-fallback")
         let manager = TabManager()

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1457,6 +1457,40 @@ final class WorkspaceCustomDescriptionTests: XCTestCase {
         XCTAssertFalse(workspace.hasCustomDescription)
     }
 }
+
+
+@MainActor
+final class WorkspaceTagDisplayTitleTests: XCTestCase {
+    private func withSavedDefault(key: String, _ body: () -> Void) {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        body()
+    }
+
+    func testDisplayTitleShowsStoredTagOnlyWhenWorkspaceTagsDisplayIsEnabled() {
+        withSavedDefault(key: LeaderKeySettings.workspaceTagsEnabledKey) {
+            let workspace = Workspace(title: "Project")
+            workspace.setTag("api")
+
+            UserDefaults.standard.set(false, forKey: LeaderKeySettings.workspaceTagsEnabledKey)
+            XCTAssertEqual(workspace.displayTitle, "Project")
+
+            UserDefaults.standard.set(true, forKey: LeaderKeySettings.workspaceTagsEnabledKey)
+            let expected = String(format: String(localized: "workspace.displayTitle.tagged", defaultValue: "[%@] %@"), "api", "Project")
+            XCTAssertEqual(workspace.displayTitle, expected)
+        }
+    }
+}
+
+
+
 final class WorkspacePlacementSettingsTests: XCTestCase {
     func testCurrentPlacementDefaultsToAfterCurrentWhenUnset() {
         let suiteName = "WorkspacePlacementSettingsTests.Default.\(UUID().uuidString)"


### PR DESCRIPTION
Implements tmux-style Leader Key mode that intercepts a configurable key chord (default: Ctrl+B) to activate a one-shot command mode for workspace navigation and management.

Leader Key features:
- Configurable leader key with timeout (default 1500ms)
- Visual indicator when leader mode is active
- Key bindings: n/p (next/prev workspace), number keys (jump to workspace), c (create), x (close), , (rename), d (detach/split), q (quit mode)

Workspace Tags features:
- Assign short tags/labels to workspaces for quick identification
- Tags shown in workspace switcher and tab bar
- Persistent across sessions via SessionPersistence
- Reactive updates across all windows via objectWillChange

Also adds LeaderKeySettings.swift with settings model, updates KeyboardShortcutSettings for leader key configuration, wires up routing in AppDelegate to handle leader key intercept before normal shortcut processing.

All user-facing strings localized in English and Japanese.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tmux‑style Leader Key mode and Workspace Tags to speed up navigation and label workspaces, plus copy‑mode stability fixes. Both features are configurable in Settings and off by default.

- **New Features**
  - Leader Key mode (default `Ctrl+B`): arms only outside Settings/alerts/command palette; ESC cancels; double‑press passes through; window‑scoped; “LEADER” sidebar indicator; configurable timeout (0.2–3.0s) and per‑action sub‑keys via a simple recorder; added `leaderKey` in `KeyboardShortcutSettings`.
  - Actions: split right/down; pane focus (h/j/k/l, next); new tab; next/prev tab; select tab 1–10; close pane; toggle copy mode; set Workspace Tag.
  - Workspace Tags: set a short tag per workspace; shown as [tag] in the workspace switcher, tab bar, and command palette; toggle in Settings; persisted via `SessionPersistence`; set via leader action or v2 API `workspace.set_tag`; v2 workspace payloads include `tag`.

- **Bug Fixes**
  - Leader mode routing: second‑key dispatch runs before guards and pauses terminal input; owner is window‑scoped and cancels if disabled mid‑session; beep on unknown second key; if routing context is missing, don’t swallow other shortcuts.
  - Tag handling/API: normalize whitespace, cap at 20 chars, empty clears; `workspace.set_tag` returns the stored tag and errors when tags are disabled; matching honors shifted symbols and keyboard layout fallbacks.
  - Navigation/UI/Accessibility: pane focus next/prev uses visual layout order with safe fallback; LEADER indicator stays visible; rename flow uses the raw workspace title (not the [tag] display title); command palette and VoiceOver use `displayTitle` for tagged names.
  - Copy mode: freeze viewport on entry to prevent scroll jumps; Return and keypad Enter always exit copy mode.

<sup>Written for commit d22b224b458b4875559deb13e52fa07923dbb9b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leader key mode: two-step keybindings (default Ctrl+B) with configurable per-action bindings, timeout, and workspace-tag actions (including prompt via chord).

* **UI**
  * Settings UI to enable leader key, adjust timeout, record bindings, reset leader settings, and toggle workspace tags.
  * Sidebar/tab titles show workspace tags; visual “LEADER” indicator when active.

* **Persistence & Sync**
  * Workspace tags persist in session snapshots.

* **Localization**
  * Added localized strings for leader-key UI, actions, prompts, and tab labels.

* **Tests**
  * New tests covering leader-key shortcuts and workspace-tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->