### PR TITLE
Stop canceling in-progress nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,9 +13,8 @@ on:
 
 concurrency:
   group: nightly-build-${{ github.ref_name }}
-  # Only the newest nightly matters. Cancel older runs so a fresh main push
-  # does not sit behind an outdated build that would be discarded anyway.
-  cancel-in-progress: true
+  # Queue concurrent runs instead of canceling them so no build is lost.
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Set `cancel-in-progress: false` in the nightly workflow concurrency block so concurrent runs queue instead of being killed.

## Testing
- CI-only change, no runtime impact. Verify by triggering two nightly builds in quick succession and confirming neither is canceled.

## Related
- Task: stop nightly GitHub Actions from canceling in-progress jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `concurrency.cancel-in-progress: false` in the nightly GitHub Actions workflow so overlapping runs queue instead of being canceled, ensuring no builds are lost and meeting the task requirement to stop nightly cancellations.

<sup>Written for commit e7bea693d7b4bf78e0363adecf45ad97099014d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build workflow configuration to allow concurrent builds instead of canceling previous executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->