### PR TITLE
fix: apply background-opacity and background-blur to terminal rendering area (#879)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2411,6 +2411,7 @@ class GhosttyApp {
         if cmuxShouldUseClearWindowBackground(for: defaultBackgroundOpacity) {
             window.backgroundColor = cmuxTransparentWindowBaseColor()
             window.isOpaque = false
+            applyWindowBlurIfNeeded(window)
             if backgroundLogEnabled {
                 logBackground("applied transparent window background opacity=\(String(format: "%.3f", defaultBackgroundOpacity))")
             }
@@ -2422,6 +2423,16 @@ class GhosttyApp {
                 logBackground("applied default window background color=\(color) opacity=\(String(format: "%.3f", color.alphaComponent))")
             }
         }
+    }
+
+    func applyWindowBlurIfNeeded(_ window: NSWindow) {
+        guard let app = self.app else { return }
+        // ghostty_set_window_background_blur reads background-blur and
+        // background-opacity from the app config internally and calls
+        // CGSSetWindowBackgroundBlurRadius — a compositor-level setter that is
+        // idempotent.  It is a no-op when opacity >= 1.0 or blur is disabled,
+        // so we can call it unconditionally whenever the window is transparent.
+        ghostty_set_window_background_blur(app, Unmanaged.passUnretained(window).toOpaque())
     }
 
     private func activeMainWindow() -> NSWindow? {
@@ -3849,6 +3860,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         setup()
     }
 
+    override func makeBackingLayer() -> CALayer {
+        let metalLayer = CAMetalLayer()
+        metalLayer.pixelFormat = .bgra8Unorm
+        metalLayer.isOpaque = false
+        // framebufferOnly=false lets the macOS compositor read the drawable
+        // when blending translucent or blurred window layers.  This matches
+        // standalone Ghostty's SurfaceView and is required for background-opacity
+        // and background-blur to render correctly.
+        metalLayer.framebufferOnly = false
+        return metalLayer
+    }
+
     private func setup() {
         // Only enable our instrumented CAMetalLayer in targeted debug/test scenarios.
         // The lock in GhosttyMetalLayer.nextDrawable() adds overhead we don't want in normal runs.
@@ -3931,6 +3954,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if cmuxShouldUseClearWindowBackground(for: color.alphaComponent) {
             window.backgroundColor = cmuxTransparentWindowBaseColor()
             window.isOpaque = false
+            GhosttyApp.shared.applyWindowBlurIfNeeded(window)
         } else {
             window.backgroundColor = color
             window.isOpaque = color.alphaComponent >= 1.0


### PR DESCRIPTION
## Problem

Fixes #879. Two independent bugs prevented `background-opacity` and `background-blur` from affecting the terminal rendering area.

## Root causes & fixes

### 1. `background-opacity` — opaque Metal layer (`makeBackingLayer`)

`GhosttyNSView` had no `makeBackingLayer()` override, so AppKit supplied a generic `CALayer` as the backing layer. libghostty expects the view's own layer to be a `CAMetalLayer` — evidenced by the `(view.layer as? CAMetalLayer) != nil` guard already in the file — and when it finds one it uses it directly for Metal rendering. Without it, the Metal surface defaulted to `isOpaque = true`, making the terminal completely opaque regardless of the configured `background-opacity`.

**Fix:** override `makeBackingLayer()` in `GhosttyNSView` to return a `CAMetalLayer` with:
- `isOpaque = false` — allows the compositor to blend the layer
- `pixelFormat = .bgra8Unorm` — standard BGRA format with alpha channel
- `framebufferOnly = false` — lets the macOS compositor read the drawable when blending translucent/blurred window layers; matches standalone Ghostty's `SurfaceView`

### 2. `background-blur` — `ghostty_set_window_background_blur` never called

`ghostty_set_window_background_blur` is declared in `ghostty.h` but was never invoked in cmux. Its Zig implementation calls `CGSSetWindowBackgroundBlurRadius`, a private CoreGraphics compositor API that sets the blur radius on the window's compositor layer — not an NSVisualEffectView. It reads `background-blur` and `background-opacity` from the app config internally, and is a no-op when opacity ≥ 1.0 or blur is disabled/zero. Because it is a direct compositor setter, it is idempotent.

**Fix:** add `applyWindowBlurIfNeeded(_ window: NSWindow)` on `GhosttyApp` that calls `ghostty_set_window_background_blur` unconditionally (the function self-guards). Called from `applyBackgroundToKeyWindow()` and `applyWindowBackgroundIfActive()` whenever the window is set transparent — covering both initial window setup and per-surface activation.

## Reviewer notes

- The `ghostty_config_get` read for `background-blur` was removed from an earlier draft. `BackgroundBlur` is a Zig tagged union whose `cval()` returns `i16`; reading it via `ghostty_config_get` with a Swift integer pointer would silently fail. The Zig function reads its own config, so no Swift-side config read is needed.
- `CGSSetWindowBackgroundBlurRadius` is idempotent — repeated calls from focus/tab events do not stack, they overwrite.

## Test plan

- Set `background-opacity = 0.8` and `background-blur = 1` in `~/Library/Application Support/com.mitchellh.ghostty/config`
- Launch cmux — the terminal rendering area should be semi-transparent with a blurred backdrop
- Verify the tab bar and terminal area both appear semi-transparent (matching standalone Ghostty behavior)
- Set `background-opacity = 1` — confirm terminal returns to fully opaque with no blur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window background blur is now applied for transparent windows, providing consistent translucent effects.
  * Backing layer updated to improve rendering of transparent/blurred content.

* **Style**
  * Enhanced visual quality of terminal windows when using transparent or blurred backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->