### PR TITLE
fix: add recovery for stuck Sparkle extraction updates

### DIFF
--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -99,6 +99,7 @@ class UpdateController {
     /// Start the updater. If startup fails, the error is shown via the custom UI.
     func startUpdaterIfNeeded() {
         guard !didStartUpdater else { return }
+        cleanStaleInstallationCache()
         ensureSparkleInstallationCache()
 #if DEBUG
         // Keep the permission-related defaults resettable for UI tests even though the
@@ -327,6 +328,29 @@ class UpdateController {
             try? data.write(to: url)
         }
 #endif
+    }
+
+    private func cleanStaleInstallationCache() {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
+        guard let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { return }
+
+        let installURL = cachesURL
+            .appendingPathComponent(bundleIdentifier)
+            .appendingPathComponent("org.sparkle-project.Sparkle")
+            .appendingPathComponent("Installation")
+
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(at: installURL, includingPropertiesForKeys: nil),
+              !contents.isEmpty else { return }
+
+        for item in contents {
+            do {
+                try fm.removeItem(at: item)
+                UpdateLogStore.shared.append("cleaned stale installation cache: \(item.lastPathComponent)")
+            } catch {
+                UpdateLogStore.shared.append("failed to clean installation cache item \(item.lastPathComponent): \(error)")
+            }
+        }
     }
 
     private func ensureSparkleInstallationCache() {

--- a/Sources/Update/UpdateDriver.swift
+++ b/Sources/Update/UpdateDriver.swift
@@ -9,6 +9,8 @@ class UpdateDriver: NSObject, SPUUserDriver {
     private var pendingCheckTransition: DispatchWorkItem?
     private var checkTimeoutWorkItem: DispatchWorkItem?
     private var lastFeedURLString: String?
+    private var extractionTimeoutWorkItem: DispatchWorkItem?
+    private var extractionStartDate: Date?
 
     init(viewModel: UpdateViewModel, hostBundle _: Bundle) {
         self.viewModel = viewModel
@@ -117,21 +119,23 @@ class UpdateDriver: NSObject, SPUUserDriver {
 
     func showDownloadDidStartExtractingUpdate() {
         UpdateLogStore.shared.append("show extraction started")
-        setState(.extracting(.init(progress: 0)))
+        beginExtraction(progress: 0)
     }
 
     func showExtractionReceivedProgress(_ progress: Double) {
         UpdateLogStore.shared.append(String(format: "show extraction progress: %.2f", progress))
-        setState(.extracting(.init(progress: progress)))
+        beginExtraction(progress: progress)
     }
 
     func showReady(toInstallAndRelaunch reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
-        UpdateLogStore.shared.append("show ready to install")
+        let elapsed = extractionStartDate.map { String(format: "%.1fs", Date().timeIntervalSince($0)) } ?? "unknown"
+        UpdateLogStore.shared.append("show ready to install (extractionElapsed=\(elapsed))")
         reply(.install)
     }
 
     func showInstallingUpdate(withApplicationTerminated applicationTerminated: Bool, retryTerminatingApplication: @escaping () -> Void) {
-        UpdateLogStore.shared.append("show installing update")
+        let elapsed = extractionStartDate.map { String(format: "%.1fs", Date().timeIntervalSince($0)) } ?? "unknown"
+        UpdateLogStore.shared.append("show installing update (appTerminated=\(applicationTerminated), extractionElapsed=\(elapsed))")
         setState(.installing(.init(
             retryTerminatingApplication: retryTerminatingApplication,
             dismiss: { [weak viewModel] in
@@ -222,6 +226,9 @@ class UpdateDriver: NSObject, SPUUserDriver {
             checkTimeoutWorkItem?.cancel()
             checkTimeoutWorkItem = nil
             lastCheckStart = nil
+            extractionTimeoutWorkItem?.cancel()
+            extractionTimeoutWorkItem = nil
+            extractionStartDate = nil
             applyState(newState)
         }
     }
@@ -234,6 +241,61 @@ class UpdateDriver: NSObject, SPUUserDriver {
         }
         checkTimeoutWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + UpdateTiming.checkTimeoutDuration, execute: workItem)
+    }
+
+    private func beginExtraction(progress: Double) {
+        runOnMain { [weak self] in
+            guard let self else { return }
+            pendingCheckTransition?.cancel()
+            pendingCheckTransition = nil
+            checkTimeoutWorkItem?.cancel()
+            checkTimeoutWorkItem = nil
+            lastCheckStart = nil
+            extractionTimeoutWorkItem?.cancel()
+            extractionTimeoutWorkItem = nil
+            if extractionStartDate == nil {
+                extractionStartDate = Date()
+            }
+            let cancel: () -> Void = { [weak self] in
+                self?.cancelExtraction()
+            }
+            applyState(.extracting(.init(progress: progress, cancel: cancel)))
+            scheduleExtractionTimeout()
+        }
+    }
+
+    private func scheduleExtractionTimeout() {
+        extractionTimeoutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard case .extracting = self.viewModel.state else { return }
+            let elapsed = self.extractionStartDate.map { String(format: "%.0fs", Date().timeIntervalSince($0)) } ?? "unknown"
+            UpdateLogStore.shared.append("extraction timed out after \(elapsed)")
+            self.setState(.error(.init(
+                error: NSError(
+                    domain: "cmux.update",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: String(localized: "update.error.extractionStalled", defaultValue: "The update appears to be stuck. Try checking for updates again.")]
+                ),
+                retry: { [weak viewModel = self.viewModel] in
+                    viewModel?.state = .idle
+                    DispatchQueue.main.async {
+                        guard let delegate = NSApp.delegate as? AppDelegate else { return }
+                        delegate.checkForUpdates(nil)
+                    }
+                },
+                dismiss: { [weak viewModel = self.viewModel] in
+                    viewModel?.state = .idle
+                }
+            )))
+        }
+        extractionTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + UpdateTiming.extractionTimeoutDuration, execute: workItem)
+    }
+
+    private func cancelExtraction() {
+        UpdateLogStore.shared.append("extraction cancelled by user")
+        setState(.idle)
     }
 
     private func applyState(_ newState: UpdateState) {

--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -26,7 +26,7 @@ struct UpdatePopoverView: View {
                 DownloadingView(download: download, dismiss: dismiss)
 
             case .extracting(let extracting):
-                ExtractingView(extracting: extracting)
+                ExtractingView(extracting: extracting, dismiss: dismiss)
 
             case .installing(let installing):
                 InstallingView(installing: installing, dismiss: dismiss)
@@ -247,17 +247,30 @@ fileprivate struct DownloadingView: View {
 
 fileprivate struct ExtractingView: View {
     let extracting: UpdateState.Extracting
+    let dismiss: DismissAction
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "update.popover.preparingUpdate", defaultValue: "Preparing Update"))
-                .font(.system(size: 13, weight: .semibold))
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "update.popover.preparingUpdate", defaultValue: "Preparing Update"))
+                    .font(.system(size: 13, weight: .semibold))
 
-            VStack(alignment: .leading, spacing: 6) {
-                ProgressView(value: min(1, max(0, extracting.progress)), total: 1.0)
-                Text(String(format: "%.0f%%", min(1, max(0, extracting.progress)) * 100))
-                    .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: min(1, max(0, extracting.progress)), total: 1.0)
+                    Text(String(format: "%.0f%%", min(1, max(0, extracting.progress)) * 100))
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button(String(localized: "common.cancel", defaultValue: "Cancel")) {
+                    extracting.cancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                .controlSize(.small)
             }
         }
         .padding(16)

--- a/Sources/Update/UpdateTiming.swift
+++ b/Sources/Update/UpdateTiming.swift
@@ -4,4 +4,5 @@ enum UpdateTiming {
     static let minimumCheckDisplayDuration: TimeInterval = 2.0
     static let noUpdateDisplayDuration: TimeInterval = 5.0
     static let checkTimeoutDuration: TimeInterval = 10.0
+    static let extractionTimeoutDuration: TimeInterval = 300.0
 }

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -418,6 +418,8 @@ enum UpdateState: Equatable {
             available.reply(.dismiss)
         case .downloading(let downloading):
             downloading.cancel()
+        case .extracting(let extracting):
+            extracting.cancel()
         case .notFound(let notFound):
             notFound.acknowledgement()
         case .error(let err):
@@ -568,6 +570,7 @@ enum UpdateState: Equatable {
 
     struct Extracting {
         let progress: Double
+        let cancel: () -> Void
     }
 
     struct Installing {


### PR DESCRIPTION
## Summary

The Sparkle updater can get permanently stuck at "Preparing: XX%" if the XPC connection to the installer helper drops or macOS Gatekeeper stalls during validation. Previously there was no timeout, no cancel button, and no recovery path for this state.

- Add 5-minute extraction timeout that transitions to an error state with retry button
- Add cancel button to the preparing/extracting popover view (matching the downloading view)
- Clean stale Sparkle installation cache contents on app launch so failed extractions don't persist across restarts
- Log extraction elapsed time in `showReady` and `showInstallingUpdate`, and log `applicationTerminated` flag

## Testing

- Build verified: `xcodebuild -scheme cmux -configuration Debug` passes
- Manual verification: the extraction timeout, cancel button, and stale cache cleanup are straightforward additions following existing patterns (check timeout, download cancel button)
- No behavioral test is practical for this (requires simulating a Sparkle XPC stall)

## Related

- Observed in dogfooding: cmux NIGHTLY stuck at "Preparing: 11%" for 12+ hours with idle Sparkle helper processes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `Sparkle` updates from stalling at “Preparing: XX%” by adding a 5‑minute extraction timeout, a cancel action, and startup cache cleanup. This gives users a clear recovery path and avoids failures persisting across restarts.

- **Bug Fixes**
  - Add 5‑minute extraction timeout; on timeout, show error with retry.
  - Add Cancel to the extracting popover to abort and return to idle.
  - Clean stale `Sparkle` Installation cache on app launch.
  - Improve logs (extraction elapsed time, applicationTerminated) and reset timers on state changes.

<sup>Written for commit 3b11e265b22e778bb56c093edf33eea383143470. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now cancel in-progress app updates during the extraction phase using a new Cancel button
  * Added automatic timeout protection (5 minutes) during extraction to prevent the update process from hanging indefinitely

* **Bug Fixes**
  * Improved installation reliability by cleaning stale cache data on app startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->