### PR TITLE
fix: harden scroll guard with directional check, font-zoom bypass, and action deadline

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3624,6 +3624,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func performBindingAction(_ action: String) -> Bool {
         guard let surface = surface else { return false }
+        if isViewportMutatingAction(action) {
+            hostedView.markUserInitiatedViewportScroll()
+        }
         return action.withCString { cString in
             ghostty_surface_binding_action(surface, cString, UInt(strlen(cString)))
         }
@@ -4338,6 +4341,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     func performBindingAction(_ action: String) -> Bool {
         guard let surface = surface else { return false }
+        if isViewportMutatingAction(action) {
+            terminalSurface?.hostedView.markUserInitiatedViewportScroll()
+        }
         return action.withCString { cString in
             ghostty_surface_binding_action(surface, cString, UInt(strlen(cString)))
         }
@@ -6137,6 +6143,20 @@ private final class GhosttyPassthroughVisualEffectView: NSVisualEffectView {
     }
 }
 
+/// Identifies binding actions that intentionally move the terminal viewport.
+/// Used by the directional scroll guard to distinguish user-initiated viewport
+/// changes from programmatic ones (forceRefresh, geometry reconcile, agent output).
+private func isViewportMutatingAction(_ action: String) -> Bool {
+    action.hasPrefix("scroll_") ||
+        action.hasPrefix("jump_to_prompt:") ||
+        action.hasPrefix("navigate_search:") ||
+        action.hasPrefix("search") ||
+        action == "start_search" ||
+        action == "clear_screen" ||
+        action == "end_search" ||
+        action.hasPrefix("adjust_selection:")
+}
+
 func shouldAllowEnsureFocusWindowActivation(
     activeTabManager: TabManager?,
     targetTabManager: TabManager,
@@ -6198,6 +6218,14 @@ final class GhosttySurfaceScrollView: NSView {
     private var userScrolledAwayFromBottom = false
     /// Threshold in points from bottom to consider "at bottom" (allows for minor float drift)
     private static let scrollToBottomThreshold: CGFloat = 5.0
+    /// Bumped on cell size changes (font zoom). When the generation changes, the scroll
+    /// guard is bypassed so the viewport can reposition freely after Cmd+/- font size changes.
+    private var cellSizeGeneration: UInt64 = 0
+    private var lastSyncCellSizeGeneration: UInt64 = 0
+    /// Timestamp-based deadline for allowing programmatic scroll toward the top of scrollback.
+    /// Set by user-initiated viewport actions (scroll bindings, search, clear_screen).
+    /// Expires automatically after 0.5s — no explicit reset needed.
+    private var allowScrollTowardTopDeadline: CFTimeInterval = 0
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
     private var activeDropZone: DropZone?
@@ -6205,6 +6233,12 @@ final class GhosttySurfaceScrollView: NSView {
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
+
+    /// Mark that the user initiated a viewport-changing action (scroll, search, clear_screen).
+    /// Sets a 0.5s deadline during which the directional scroll guard allows movement toward the top.
+    fileprivate func markUserInitiatedViewportScroll() {
+        allowScrollTowardTopDeadline = CACurrentMediaTime() + 0.5
+    }
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
     /// when the window becomes key while the find bar is open.
@@ -6571,6 +6605,7 @@ final class GhosttySurfaceScrollView: NSView {
             object: surfaceView,
             queue: .main
         ) { [weak self] _ in
+            self?.cellSizeGeneration &+= 1
             self?.synchronizeScrollView()
         })
     }
@@ -8454,34 +8489,46 @@ final class GhosttySurfaceScrollView: NSView {
                 let offsetY =
                     CGFloat(scrollbar.total - scrollbar.offset - scrollbar.len) * cellHeight
                 let targetOrigin = CGPoint(x: 0, y: offsetY)
-
-                // Check if we're currently at the bottom (with threshold for float drift)
                 let currentOrigin = scrollView.contentView.bounds.origin
+
+                // Track whether the user scrolled away from the bottom
                 let documentHeight = documentView.frame.height
                 let viewportHeight = scrollView.contentView.bounds.height
                 let distanceFromBottom = documentHeight - currentOrigin.y - viewportHeight
-                let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
-
-                // Update userScrolledAwayFromBottom based on current position
-                if isAtBottom {
+                if distanceFromBottom <= Self.scrollToBottomThreshold {
                     userScrolledAwayFromBottom = false
                 }
 
-                // Only auto-scroll if user hasn't manually scrolled away from bottom
-                // or if we're following terminal output (scrollbar shows we're at bottom)
-                let shouldAutoScroll = !userScrolledAwayFromBottom ||
-                    (scrollbar.offset + scrollbar.len >= scrollbar.total)
+                if !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                    // Directional scroll guard: only toward-top movement needs scrutiny.
+                    // Downward scrolls (following new output) are always safe.
+                    let movingTowardTop = targetOrigin.y < currentOrigin.y
+                    let cellSizeChanged = cellSizeGeneration != lastSyncCellSizeGeneration
+                    lastSyncCellSizeGeneration = cellSizeGeneration
+                    let userInitiated = CACurrentMediaTime() <= allowScrollTowardTopDeadline
 
-                if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                    let suppress = movingTowardTop
+                        && !cellSizeChanged
+                        && !userInitiated
+                        && userScrolledAwayFromBottom
+
+                    if suppress {
 #if DEBUG
-                    logDragGeometryChange(
-                        event: "scrollOrigin",
-                        old: currentOrigin,
-                        new: targetOrigin
-                    )
+                        dlog("scrollGuard: suppressed toward-top "
+                            + "from=\(String(format: "%.1f", currentOrigin.y)) "
+                            + "to=\(String(format: "%.1f", targetOrigin.y))")
 #endif
-                    scrollView.contentView.scroll(to: targetOrigin)
-                    didChangeGeometry = true
+                    } else {
+#if DEBUG
+                        logDragGeometryChange(
+                            event: "scrollOrigin",
+                            old: currentOrigin,
+                            new: targetOrigin
+                        )
+#endif
+                        scrollView.contentView.scroll(to: targetOrigin)
+                        didChangeGeometry = true
+                    }
                 }
                 lastSentRow = Int(scrollbar.offset)
             }


### PR DESCRIPTION
## Problem

The doomscroll fix in #1616 introduced a `userScrolledAwayFromBottom` boolean that prevents `synchronizeScrollView()` from fighting the user's scroll position. This works for the core case but misses three edge cases:

| Scenario | Current behavior |
|----------|-----------------|
| **Font zoom** (Cmd +/-) | Cell size change triggers `synchronizeScrollView()` — the boolean may block the viewport from repositioning correctly |
| **User-initiated binding actions** (search, `clear_screen`, `jump_to_prompt`) | These intentionally move the viewport toward the top, but the boolean can't distinguish them from programmatic triggers |
| **Downward scroll while flag is set** | `shouldAutoScroll` blocks *all* directions when the flag is true, including valid toward-bottom output following |

## Solution

Three targeted additions on top of the existing `userScrolledAwayFromBottom` tracking — no removal, no redesign:

### 1. Directional guard
Only toward-top scrolls are scrutinized. Downward scrolls (following new terminal output) are always allowed:
```swift
let movingTowardTop = targetOrigin.y < currentOrigin.y
// ...
let suppress = movingTowardTop && !cellSizeChanged && !userInitiated && userScrolledAwayFromBottom
```

### 2. Cell-size generation counter
Font zoom bumps a generation counter. When it changes, the guard is bypassed for that sync cycle:
```swift
// In the cellSize notification observer:
self?.cellSizeGeneration &+= 1

// In synchronizeScrollView:
let cellSizeChanged = cellSizeGeneration != lastSyncCellSizeGeneration
```

### 3. Timestamp-based action deadline
`performBindingAction()` detects viewport-mutating actions and sets a 0.5 s deadline. The deadline auto-expires — no explicit reset, no stale flag:
```swift
fileprivate func markUserInitiatedViewportScroll() {
    allowScrollTowardTopDeadline = CACurrentMediaTime() + 0.5
}
```

Recognized actions: `scroll_*`, `jump_to_prompt:*`, `navigate_search:*`, `search*`, `start_search`, `clear_screen`, `end_search`, `adjust_selection:*`.

## What stays the same
- `userScrolledAwayFromBottom` boolean and `handleLiveScroll()` — unchanged
- `scrollToBottomThreshold` (5 pt) — unchanged
- `didEndLiveScrollNotification` observer — unchanged

## Testing
- Build verified (Debug, macOS)
- Manual verification: scroll up during active output → viewport stays put; scroll back to bottom → output following resumes; Cmd+/- while scrolled up → viewport repositions correctly; Ctrl+L (clear_screen) while scrolled up → viewport follows the clear

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the terminal scroll guard to avoid fighting the user's position while still following new output. Fixes edge cases for font zoom, user-initiated viewport moves, and downward scrolling.

- **Bug Fixes**
  - Directional guard: suppress only upward moves; always allow downward follow-on output.
  - Font zoom bypass: bump a cell-size generation on Cmd +/- to let the viewport reposition.
  - Action deadline: 0.5s grace after scroll/search/clear_screen/jump-to-prompt to allow intended upward moves.

<sup>Written for commit d00203857538bd6aa2ceb8e585e57c23f0468d2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll view responsiveness to user actions like searching, jumping, and selecting text in the terminal.
  * Fixed unintended auto-scrolling behavior that occurred when users scrolled away from the bottom, preventing the view from jumping unexpectedly during cell size or font zoom changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->