### PR TITLE
docs: add Copilot CLI hook setup to notifications guide

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -95,28 +95,28 @@ Copilot CLI supports [hooks](https://docs.github.com/en/copilot/how-tos/use-copi
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "command -v cmux &>/dev/null && cmux clear-notifications && cmux set-status copilot_cli Running --icon=bolt.fill --color=#4C8DFF || true",
+        "bash": "if command -v cmux &>/dev/null; then cmux set-status copilot_cli Running; fi",
         "timeoutSec": 3
       }
     ],
     "agentStop": [
       {
         "type": "command",
-        "bash": "command -v cmux &>/dev/null && cmux notify --title 'Copilot CLI' --body 'Done' && cmux set-status copilot_cli Idle --icon=pause.circle.fill --color=#8E8E93 || osascript -e 'display notification \"Done\" with title \"Copilot CLI\"'",
+        "bash": "if command -v cmux &>/dev/null; then cmux notify --title 'Copilot CLI' --body 'Done'; cmux set-status copilot_cli Idle; else osascript -e 'display notification \"Done\" with title \"Copilot CLI\"'; fi",
         "timeoutSec": 5
       }
     ],
     "errorOccurred": [
       {
         "type": "command",
-        "bash": "command -v cmux &>/dev/null && cmux notify --title 'Copilot CLI' --subtitle 'Error' --body \"$(cat | jq -r '.error.message // \"An error occurred\"' 2>/dev/null | head -c 100)\" && cmux set-status copilot_cli Error --icon=exclamationmark.triangle.fill --color=#FF3B30 || osascript -e 'display notification \"An error occurred\" with title \"Copilot CLI\"'",
+        "bash": "if command -v cmux &>/dev/null; then cmux notify --title 'Copilot CLI' --subtitle 'Error' --body \"$(cat | jq -r '.errorMessage // \"An error occurred\"' 2>/dev/null | head -c 100)\"; cmux set-status copilot_cli Error; else osascript -e 'display notification \"An error occurred\" with title \"Copilot CLI\"'; fi",
         "timeoutSec": 5
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "bash": "command -v cmux &>/dev/null && cmux clear-status copilot_cli || true",
+        "bash": "if command -v cmux &>/dev/null; then cmux clear-status copilot_cli; fi",
         "timeoutSec": 3
       }
     ]
@@ -124,7 +124,17 @@ Copilot CLI supports [hooks](https://docs.github.com/en/copilot/how-tos/use-copi
 }
 ```
 
-Or for repo-level hooks, create `.github/hooks/notify.json` with the same `hooks` object wrapped in `{ "version": 1, "hooks": { ... } }`.
+Or for repo-level hooks, create `.github/hooks/notify.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "userPromptSubmitted": [ ... ],
+    "agentStop": [ ... ]
+  }
+}
+```
 
 ### OpenAI Codex
 
@@ -187,6 +197,8 @@ cmux sets these in child shells:
 cmux notify --title <text> [--subtitle <text>] [--body <text>] [--tab <id|index>] [--panel <id|index>]
 cmux list-notifications
 cmux clear-notifications
+cmux set-status <key> <value>
+cmux clear-status <key>
 cmux ping
 ```
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -85,6 +85,47 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
+### GitHub Copilot CLI
+
+Copilot CLI supports [hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/use-hooks) that run shell commands at key lifecycle events. Add to `~/.copilot/config.json`:
+
+```json
+{
+  "hooks": {
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "command -v cmux &>/dev/null && cmux clear-notifications && cmux set-status copilot_cli Running --icon=bolt.fill --color=#4C8DFF || true",
+        "timeoutSec": 3
+      }
+    ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "command -v cmux &>/dev/null && cmux notify --title 'Copilot CLI' --body 'Done' && cmux set-status copilot_cli Idle --icon=pause.circle.fill --color=#8E8E93 || osascript -e 'display notification \"Done\" with title \"Copilot CLI\"'",
+        "timeoutSec": 5
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "command -v cmux &>/dev/null && cmux notify --title 'Copilot CLI' --subtitle 'Error' --body \"$(cat | jq -r '.error.message // \"An error occurred\"' 2>/dev/null | head -c 100)\" && cmux set-status copilot_cli Error --icon=exclamationmark.triangle.fill --color=#FF3B30 || osascript -e 'display notification \"An error occurred\" with title \"Copilot CLI\"'",
+        "timeoutSec": 5
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "command -v cmux &>/dev/null && cmux clear-status copilot_cli || true",
+        "timeoutSec": 3
+      }
+    ]
+  }
+}
+```
+
+Or for repo-level hooks, create `.github/hooks/notify.json` with the same `hooks` object wrapped in `{ "version": 1, "hooks": { ... } }`.
+
 ### OpenAI Codex
 
 Add to `~/.codex/config.toml`:


### PR DESCRIPTION
Adds a GitHub Copilot CLI section to `docs/notifications.md` with manual hook configuration for notifications and sidebar status pills.

**Hooks included:**
- `userPromptSubmitted` — sets status to Running
- `agentStop` — notifies "Done", sets status to Idle
- `errorOccurred` — notifies with error message, sets status to Error
- `sessionEnd` — clears the status pill

Also adds a link to the [official GitHub hooks docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/use-hooks).

Also, big fan of cmux, thanks for the great work folks!


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Copilot CLI section to `docs/notifications.md` with ready‑to‑use hooks for notifications and sidebar status pills via `cmux` (macOS `osascript` fallback). Includes global and repo‑level setup, docs for `cmux set-status/clear-status`, and a link to GitHub’s hooks guide; examples now use safer if/else fallback and parse `.errorMessage`.

- **New Features**
  - Copy‑paste hooks for `userPromptSubmitted`, `agentStop`, `errorOccurred`, `sessionEnd`
  - Concrete repo‑level `.github/hooks/notify.json` example
  - Clarifies clear‑notifications side‑effects; drops `--icon/--color` in examples

<sup>Written for commit 78fe8da155ff55dc77421fd483384079dff56aef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Copilot CLI docs for configuring hooks and event handlers to enable notifications, status updates, error handling, and session management via both global and repository-level configuration.
  * Documented two new CLI commands for setting and clearing per-key status and updated examples for hook-triggered notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->