### PR TITLE
fix: signing order, @available guards, redundant popup call for FIDO2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -372,13 +372,15 @@ jobs:
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+            # Sign app bundle first (--deep signs all nested content with full entitlements),
+            # then re-sign embedded binaries with narrower entitlements.
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
             if [ -f "$CLI_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
             fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,13 +238,15 @@ jobs:
           EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+          # Sign app bundle first (--deep signs all nested content with full entitlements),
+          # then re-sign embedded binaries with narrower entitlements.
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
           if [ -f "$CLI_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
           fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 
       - name: Notarize app

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1755,6 +1755,7 @@ private struct BrowserPasskeyAuthorizationReply {
     }
 }
 
+@available(macOS 15.0, *)
 @MainActor
 private final class BrowserPasskeyAuthorizationCoordinator: NSObject, WKScriptMessageHandlerWithReply {
     weak var panel: BrowserPanel?
@@ -1972,6 +1973,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     /// Popup windows owned by this panel (for lifecycle cleanup)
     private var popupControllers: [BrowserPopupWindowController] = []
+    @available(macOS 15.0, *)
     private lazy var passkeyAuthorizationCoordinator = BrowserPasskeyAuthorizationCoordinator(panel: self)
 
     static let telemetryHookBootstrapScriptSource = """
@@ -2935,6 +2937,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func configurePasskeyAuthorizationBridge(on configuration: WKWebViewConfiguration) {
+        guard #available(macOS 15.0, *) else { return }
         let userContentController = configuration.userContentController
         if !userContentController.userScripts.contains(where: { $0.source == Self.passkeyAuthorizationBootstrapScriptSource }) {
             userContentController.addUserScript(

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -298,7 +298,6 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
             #endif
             return nil
         }
-        openerPanel?.configurePasskeyAuthorizationBridge(on: configuration)
         let child = BrowserPopupWindowController(
             configuration: configuration,
             windowFeatures: windowFeatures,

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -94,13 +94,16 @@ echo "Sparkle keys injected"
 # --- Codesign ---
 echo "Codesigning..."
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
+# Sign app bundle first (--deep signs all nested content with full entitlements),
+# then re-sign embedded binaries with narrower entitlements so they don't inherit
+# the restricted public-key-credential entitlement.
+/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
 if [ -f "$CLI_PATH" ]; then
   /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
 fi
 if [ -f "$HELPER_PATH" ]; then
   /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
 fi
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
 /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 echo "Codesign verified"
 


### PR DESCRIPTION
Fixes for #1823 @ [manaflow-ai:issue-124-passkeys-webauthn](https://github.com/manaflow-ai/cmux/tree/issue-124-passkeys-webauthn)

From earlier comments made here https://github.com/manaflow-ai/cmux/pull/1823#issuecomment-4097999818  

- **Codesign order**: sign app `--deep` first, then re-sign embedded binaries with narrow entitlements
- **`@available(macOS 15.0, *)`**: guards on `BrowserPasskeyAuthorizationCoordinator` — crashes on Sonoma without this
- **Redundant popup bridge call**: remove duplicate `configurePasskeyAuthorizationBridge` in `createNestedPopup`

-Jess


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes passkey WebAuthn crashes on macOS 14 and prevents CAPTCHA failures from cross‑iframe script injection. Also corrects codesign order so embedded binaries keep narrow entitlements (fixes #1823, #1429).

- **Bug Fixes**
  - Codesign: sign app bundle first with --deep, then re-sign `cmux`/`ghostty` with embedded entitlements (workflows and build script updated).
  - Availability: add `@available(macOS 15.0, *)` to the passkey coordinator and call sites; guard bridge setup so it no-ops on macOS 14.
  - Popups: remove duplicate `configurePasskeyAuthorizationBridge` call in `createNestedPopup`.
  - CAPTCHA: set `forMainFrameOnly: true` for telemetry, focus tracking, and passkey scripts to avoid tampering detection in third‑party iframes.

<sup>Written for commit 0ac23356733a0a6f779630eeb9ded83e6a553b9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



