### PR TITLE
fix: Cloudflare/CAPTCHA verification failures in browser panel

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2482,20 +2482,24 @@ final class BrowserPanel: Panel, ObservableObject {
         // Enable JavaScript
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         // Keep browser console/error/dialog telemetry active from document start on every navigation.
+        // Main frame only — injecting into cross-origin iframes causes CAPTCHA providers
+        // (reCAPTCHA, hCaptcha, Cloudflare Turnstile) to detect the overridden console.*
+        // methods and __cmux* globals as environment tampering, failing the challenge.
         configuration.userContentController.addUserScript(
             WKUserScript(
                 source: Self.telemetryHookBootstrapScriptSource,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+                forMainFrameOnly: true
             )
         )
         // Track the last editable focused element continuously so omnibar exit can
         // restore page input focus even if capture runs after first-responder handoff.
+        // Main frame only — same CAPTCHA interference concern as telemetry hooks.
         configuration.userContentController.addUserScript(
             WKUserScript(
                 source: Self.addressBarFocusTrackingBootstrapScript,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: false
+                forMainFrameOnly: true
             )
         )
     }


### PR DESCRIPTION
Fixes #1429

`telemetryHookBootstrapScriptSource` and `addressBarFocusTrackingBootstrapScript` are injected with `forMainFrameOnly: false`, so they run inside cross-origin CAPTCHA iframes (`challenges.cloudflare.com`, `google.com/recaptcha`, `hcaptcha.com`).

CAPTCHA providers fingerprint the JS environment inside their iframe and detect:

- Overridden `console.log`/`warn`/`error`/`info`/`debug` (the telemetry hook replaces all five)
- Non-standard `window.__cmux*` globals (`__cmuxHooksInstalled`, `__cmuxConsoleLog`, `__cmuxErrorLog`, `__cmuxAddressBarFocusState`, etc.)

This causes Cloudflare Turnstile, reCAPTCHA, and hCaptcha to fail or score the session as a bot — which is the behavior described in #1429 (Cloudflare verification stuck on `claude.ai` and other protected sites).

Fix: `forMainFrameOnly: false` → `forMainFrameOnly: true`. Both scripts only need to run in the top-level page context — sub-frame telemetry isn't needed, and address bar focus tracking only applies to the main document.

-Jess

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CAPTCHA verification failures in the browser panel by scoping injected scripts to the main frame only. Prevents console overrides and `__cmux*` globals from running inside cross-origin CAPTCHA iframes.

- **Bug Fixes**
  - Set `forMainFrameOnly: true` for `telemetryHookBootstrapScriptSource` and `addressBarFocusTrackingBootstrapScript` to avoid running in CAPTCHA iframes (reCAPTCHA, hCaptcha, Cloudflare Turnstile).
  - Telemetry and focus tracking continue to run in the top-level page where they’re needed.

<sup>Written for commit 9394774ab0c89b9a3a1a8d0e7cf2cf00c20029fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted telemetry and address bar tracking to the main frame, preventing unnecessary execution in cross-origin iframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->