### PR TITLE
Add cmd+click to open files in editor

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -507,6 +507,38 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     return .external(fallback)
 }
 
+/// Opens a URL using the preferred external editor if configured and the URL is a file,
+/// otherwise falls back to the system default handler.
+@discardableResult
+func openURLWithPreferredEditor(_ url: URL) -> Bool {
+    let editorPath = BrowserLinkOpenSettings.externalFileEditorPath()
+
+    // Only use custom editor for file URLs and when editor path is set
+    if url.isFileURL, !editorPath.isEmpty {
+        let editorURL = URL(fileURLWithPath: editorPath)
+        guard FileManager.default.fileExists(atPath: editorPath) else {
+            #if DEBUG
+            dlog("link.openWithEditor editorPath not found, falling back to system default path=\(editorPath)")
+            #endif
+            return NSWorkspace.shared.open(url)
+        }
+        #if DEBUG
+        dlog("link.openWithEditor opening with custom editor=\(editorPath) file=\(url.path)")
+        #endif
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open([url], withApplicationAt: editorURL, configuration: configuration) { _, error in
+            #if DEBUG
+            if let error {
+                dlog("link.openWithEditor failed error=\(error)")
+            }
+            #endif
+        }
+        return true
+    }
+
+    return NSWorkspace.shared.open(url)
+}
+
 enum TerminalKeyboardCopyModeSelectionMove: String, Equatable {
     case left
     case right
@@ -2301,6 +2333,11 @@ class GhosttyApp {
             #if DEBUG
             dlog("link.openURL raw=\(urlString)")
             #endif
+
+            // Capture IDs for main-thread workspace lookup
+            let sourceTabId = callbackTabId ?? surfaceView.tabId
+            let sourcePanelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
+
             guard let target = resolveTerminalOpenURLTarget(urlString) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")
@@ -2312,7 +2349,7 @@ class GhosttyApp {
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
                 #endif
                 return performOnMain {
-                    NSWorkspace.shared.open(target.url)
+                    openURLWithPreferredEditor(target.url)
                 }
             }
             switch target {
@@ -2321,9 +2358,40 @@ class GhosttyApp {
                 dlog("link.openURL target=external, opening externally url=\(url)")
                 #endif
                 return performOnMain {
-                    NSWorkspace.shared.open(url)
+                    openURLWithPreferredEditor(url)
                 }
             case let .embeddedBrowser(url):
+                // Check if this might be a relative file path that got misinterpreted as a URL
+                if BrowserLinkOpenSettings.openRelativeFilePathsExternally() {
+                    let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+                    // If the original string doesn't look like a URL scheme, it might be a relative path
+                    if !trimmed.hasPrefix("http://") && !trimmed.hasPrefix("https://") && !trimmed.hasPrefix("/") {
+                        return performOnMain {
+                            // Get working directory from workspace
+                            guard let app = AppDelegate.shared,
+                                  let tabId = sourceTabId,
+                                  let panelId = sourcePanelId,
+                                  let resolved = app.workspaceContainingPanel(panelId: panelId, preferredWorkspaceId: tabId) else {
+                                #if DEBUG
+                                dlog("link.openURL relativeFile check: workspace lookup failed, falling back to browser")
+                                #endif
+                                return NSWorkspace.shared.open(url)
+                            }
+                            let workingDirectory = resolved.workspace.panelDirectories[panelId] ?? resolved.workspace.currentDirectory
+                            let fullPath = (workingDirectory as NSString).appendingPathComponent(trimmed)
+                            if FileManager.default.fileExists(atPath: fullPath) {
+                                #if DEBUG
+                                dlog("link.openURL opening as relative file path=\(fullPath)")
+                                #endif
+                                return openURLWithPreferredEditor(URL(fileURLWithPath: fullPath))
+                            }
+                            #if DEBUG
+                            dlog("link.openURL relativeFile not found at path=\(fullPath), falling back to browser")
+                            #endif
+                            return NSWorkspace.shared.open(url)
+                        }
+                    }
+                }
                 if BrowserLinkOpenSettings.shouldOpenExternally(url) {
                     #if DEBUG
                     dlog("link.openURL target=embedded but shouldOpenExternally=true url=\(url)")
@@ -5395,6 +5463,47 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
+
+        // Semantic history: Cmd+click on any word that exists as a file opens it
+        if BrowserLinkOpenSettings.openRelativeFilePathsExternally(),
+           event.modifierFlags.contains(.command) {
+            // Update mouse position so quicklook_word knows where to look
+            ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+
+            // Get the word under the cursor
+            var textResult = ghostty_text_s()
+            if ghostty_surface_quicklook_word(surface, &textResult) {
+                defer { ghostty_surface_free_text(surface, &textResult) }
+                if let ptr = textResult.text, textResult.text_len > 0 {
+                    let word = String(
+                        data: Data(bytes: ptr, count: Int(textResult.text_len)),
+                        encoding: .utf8
+                    ) ?? ""
+                    let trimmedWord = word.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+
+                    if !trimmedWord.isEmpty {
+                        // Get working directory from workspace
+                        if let app = AppDelegate.shared,
+                           let tabId = terminalSurface?.tabId,
+                           let panelId = terminalSurface?.id,
+                           let resolved = app.workspaceContainingPanel(panelId: panelId, preferredWorkspaceId: tabId) {
+                            let workingDirectory = resolved.workspace.panelDirectories[panelId] ?? resolved.workspace.currentDirectory
+                            let fullPath = (workingDirectory as NSString).appendingPathComponent(trimmedWord)
+
+                            // Check if the word is an existing file
+                            if FileManager.default.fileExists(atPath: fullPath) {
+                                #if DEBUG
+                                dlog("terminal.mouseDown semanticHistory opening file=\(fullPath)")
+                                #endif
+                                _ = openURLWithPreferredEditor(URL(fileURLWithPath: fullPath))
+                                return // Don't pass click to Ghostty
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -456,6 +456,14 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     }
 
     if NSString(string: trimmed).isAbsolutePath {
+        // Strip :line[:col] suffix if the literal path doesn't exist but the base does
+        let parsed = parseFilePathLineColumn(trimmed)
+        if parsed.line != nil && !FileManager.default.fileExists(atPath: trimmed) && FileManager.default.fileExists(atPath: parsed.path) {
+            #if DEBUG
+            dlog("link.resolve result=external(absolutePath+line) url=\(parsed.path) line=\(parsed.line ?? 0) col=\(parsed.column ?? 0)")
+            #endif
+            return .external(URL(fileURLWithPath: parsed.path))
+        }
         #if DEBUG
         dlog("link.resolve result=external(absolutePath) url=\(trimmed)")
         #endif
@@ -507,24 +515,114 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     return .external(fallback)
 }
 
+/// Parses a trailing `:line[:col]` suffix from a file path string.
+/// Returns the base path and optional line/column numbers.
+func parseFilePathLineColumn(_ raw: String) -> (path: String, line: Int?, column: Int?) {
+    // Match patterns like /path/to/file.ts:350 or /path/to/file.ts:350:12
+    // Only match if the part before the colon looks like a file (not a URL scheme)
+    guard let lastColon = raw.lastIndex(of: ":") else {
+        return (raw, nil, nil)
+    }
+
+    let afterLastColon = String(raw[raw.index(after: lastColon)...])
+
+    // Check if everything after the last colon is a number (line or col)
+    if let num = Int(afterLastColon), num > 0 {
+        let beforeLastColon = String(raw[..<lastColon])
+
+        // Check for a second colon (line:col pattern)
+        if let secondColon = beforeLastColon.lastIndex(of: ":") {
+            let afterSecondColon = String(beforeLastColon[beforeLastColon.index(after: secondColon)...])
+            if let lineNum = Int(afterSecondColon), lineNum > 0 {
+                let basePath = String(beforeLastColon[..<secondColon])
+                // Avoid stripping colons from drive letters or URL schemes
+                if !basePath.isEmpty && !basePath.hasSuffix("/") {
+                    return (basePath, lineNum, num)
+                }
+            }
+        }
+
+        // Single :line pattern
+        if !beforeLastColon.isEmpty {
+            return (beforeLastColon, num, nil)
+        }
+    }
+
+    return (raw, nil, nil)
+}
+
 /// Opens a URL using the preferred external editor if configured and the URL is a file,
 /// otherwise falls back to the system default handler.
 @discardableResult
-func openURLWithPreferredEditor(_ url: URL) -> Bool {
+func openURLWithPreferredEditor(_ url: URL, line: Int? = nil, column: Int? = nil) -> Bool {
     let editorPath = BrowserLinkOpenSettings.externalFileEditorPath()
 
     // Only use custom editor for file URLs and when editor path is set
     if url.isFileURL, !editorPath.isEmpty {
-        let editorURL = URL(fileURLWithPath: editorPath)
         guard FileManager.default.fileExists(atPath: editorPath) else {
             #if DEBUG
             dlog("link.openWithEditor editorPath not found, falling back to system default path=\(editorPath)")
             #endif
             return NSWorkspace.shared.open(url)
         }
+
+        // When line number is specified, use emacsclient/CLI for .app bundles
+        if let lineNum = line, editorPath.hasSuffix(".app") {
+            #if DEBUG
+            dlog("link.openWithEditor opening .app with line editor=\(editorPath) file=\(url.path) line=\(lineNum) col=\(column ?? 0)")
+            #endif
+            // For Emacs.app, use emacsclient which supports +line:col
+            let editorName = (editorPath as NSString).lastPathComponent.replacingOccurrences(of: ".app", with: "").lowercased()
+            if editorName == "emacs" {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                let lineArg = column != nil ? "+\(lineNum):\(column!)" : "+\(lineNum)"
+                process.arguments = ["emacsclient", "-n", lineArg, url.path]
+                do {
+                    try process.run()
+                    return true
+                } catch {
+                    #if DEBUG
+                    dlog("link.openWithEditor emacsclient failed error=\(error), trying open -a")
+                    #endif
+                }
+            }
+            // Generic fallback for .app editors: use `open -a` with --args +line
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            let lineArg = column != nil ? "+\(lineNum):\(column!)" : "+\(lineNum)"
+            process.arguments = ["-a", editorPath, url.path, "--args", lineArg]
+            do {
+                try process.run()
+                return true
+            } catch {
+                #if DEBUG
+                dlog("link.openWithEditor open -a failed error=\(error), falling back to NSWorkspace")
+                #endif
+            }
+        } else if let lineNum = line {
+            // Direct executable (e.g., /usr/local/bin/emacsclient)
+            #if DEBUG
+            dlog("link.openWithEditor opening with editor=\(editorPath) file=\(url.path) line=\(lineNum) col=\(column ?? 0)")
+            #endif
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: editorPath)
+            let lineArg = column != nil ? "+\(lineNum):\(column!)" : "+\(lineNum)"
+            process.arguments = [lineArg, url.path]
+            do {
+                try process.run()
+                return true
+            } catch {
+                #if DEBUG
+                dlog("link.openWithEditor process launch failed error=\(error), falling back to NSWorkspace")
+                #endif
+            }
+        }
+
         #if DEBUG
         dlog("link.openWithEditor opening with custom editor=\(editorPath) file=\(url.path)")
         #endif
+        let editorURL = URL(fileURLWithPath: editorPath)
         let configuration = NSWorkspace.OpenConfiguration()
         NSWorkspace.shared.open([url], withApplicationAt: editorURL, configuration: configuration) { _, error in
             #if DEBUG
@@ -2338,6 +2436,11 @@ class GhosttyApp {
             let sourceTabId = callbackTabId ?? surfaceView.tabId
             let sourcePanelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
 
+            // Parse :line[:col] suffix for file paths
+            let parsedLink = parseFilePathLineColumn(urlString.trimmingCharacters(in: .whitespacesAndNewlines))
+            let linkLine = parsedLink.line
+            let linkColumn = parsedLink.column
+
             guard let target = resolveTerminalOpenURLTarget(urlString) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")
@@ -2349,7 +2452,7 @@ class GhosttyApp {
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
                 #endif
                 return performOnMain {
-                    openURLWithPreferredEditor(target.url)
+                    openURLWithPreferredEditor(target.url, line: linkLine, column: linkColumn)
                 }
             }
             switch target {
@@ -2358,7 +2461,7 @@ class GhosttyApp {
                 dlog("link.openURL target=external, opening externally url=\(url)")
                 #endif
                 return performOnMain {
-                    openURLWithPreferredEditor(url)
+                    openURLWithPreferredEditor(url, line: linkLine, column: linkColumn)
                 }
             case let .embeddedBrowser(url):
                 // Check if this might be a relative file path that got misinterpreted as a URL
@@ -2378,12 +2481,15 @@ class GhosttyApp {
                                 return NSWorkspace.shared.open(url)
                             }
                             let workingDirectory = resolved.workspace.panelDirectories[panelId] ?? resolved.workspace.currentDirectory
-                            let fullPath = (workingDirectory as NSString).appendingPathComponent(trimmed)
+
+                            // Parse :line[:col] suffix
+                            let parsed = parseFilePathLineColumn(trimmed)
+                            let fullPath = (workingDirectory as NSString).appendingPathComponent(parsed.path)
                             if FileManager.default.fileExists(atPath: fullPath) {
                                 #if DEBUG
-                                dlog("link.openURL opening as relative file path=\(fullPath)")
+                                dlog("link.openURL opening as relative file path=\(fullPath) line=\(parsed.line ?? 0) col=\(parsed.column ?? 0)")
                                 #endif
-                                return openURLWithPreferredEditor(URL(fileURLWithPath: fullPath))
+                                return openURLWithPreferredEditor(URL(fileURLWithPath: fullPath), line: parsed.line, column: parsed.column)
                             }
                             #if DEBUG
                             dlog("link.openURL relativeFile not found at path=\(fullPath), falling back to browser")
@@ -5488,14 +5594,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                            let panelId = terminalSurface?.id,
                            let resolved = app.workspaceContainingPanel(panelId: panelId, preferredWorkspaceId: tabId) {
                             let workingDirectory = resolved.workspace.panelDirectories[panelId] ?? resolved.workspace.currentDirectory
-                            let fullPath = (workingDirectory as NSString).appendingPathComponent(trimmedWord)
 
-                            // Check if the word is an existing file
+                            // Parse :line[:col] suffix from the path
+                            let parsed = parseFilePathLineColumn(trimmedWord)
+                            let fullPath: String
+                            if parsed.path.hasPrefix("/") {
+                                fullPath = parsed.path
+                            } else {
+                                fullPath = (workingDirectory as NSString).appendingPathComponent(parsed.path)
+                            }
+
                             if FileManager.default.fileExists(atPath: fullPath) {
                                 #if DEBUG
-                                dlog("terminal.mouseDown semanticHistory opening file=\(fullPath)")
+                                dlog("terminal.mouseDown semanticHistory opening file=\(fullPath) line=\(parsed.line ?? 0) col=\(parsed.column ?? 0)")
                                 #endif
-                                _ = openURLWithPreferredEditor(URL(fileURLWithPath: fullPath))
+                                _ = openURLWithPreferredEditor(URL(fileURLWithPath: fullPath), line: parsed.line, column: parsed.column)
                                 return // Don't pass click to Ghostty
                             }
                         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -193,6 +193,11 @@ enum BrowserLinkOpenSettings {
     static let browserExternalOpenPatternsKey = "browserExternalOpenPatterns"
     static let defaultBrowserExternalOpenPatterns: String = ""
 
+    static let openRelativeFilePathsExternallyKey = "browserOpenRelativeFilePathsExternally"
+    static let defaultOpenRelativeFilePathsExternally: Bool = false
+    static let externalFileEditorPathKey = "browserExternalFileEditorPath"
+    static let defaultExternalFileEditorPath: String = ""
+
     static func openTerminalLinksInCmuxBrowser(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: openTerminalLinksInCmuxBrowserKey) == nil {
             return defaultOpenTerminalLinksInCmuxBrowser
@@ -222,6 +227,17 @@ enum BrowserLinkOpenSettings {
 
     static func initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: UserDefaults = .standard) -> Bool {
         interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+    }
+
+    static func openRelativeFilePathsExternally(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: openRelativeFilePathsExternallyKey) == nil {
+            return defaultOpenRelativeFilePathsExternally
+        }
+        return defaults.bool(forKey: openRelativeFilePathsExternallyKey)
+    }
+
+    static func externalFileEditorPath(defaults: UserDefaults = .standard) -> String {
+        defaults.string(forKey: externalFileEditorPathKey) ?? defaultExternalFileEditorPath
     }
 
     static func hostWhitelist(defaults: UserDefaults = .standard) -> [String] {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3102,6 +3102,10 @@ struct SettingsView: View {
     @AppStorage(BrowserLinkOpenSettings.browserHostWhitelistKey) private var browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
     @AppStorage(BrowserLinkOpenSettings.browserExternalOpenPatternsKey)
     private var browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
+    @AppStorage(BrowserLinkOpenSettings.openRelativeFilePathsExternallyKey)
+    private var openRelativeFilePathsExternally = BrowserLinkOpenSettings.defaultOpenRelativeFilePathsExternally
+    @AppStorage(BrowserLinkOpenSettings.externalFileEditorPathKey)
+    private var externalFileEditorPath = BrowserLinkOpenSettings.defaultExternalFileEditorPath
     @AppStorage(BrowserInsecureHTTPSettings.allowlistKey) private var browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
     @AppStorage(NotificationSoundSettings.key) private var notificationSound = NotificationSoundSettings.defaultValue
     @AppStorage(NotificationSoundSettings.customFilePathKey)
@@ -4232,6 +4236,36 @@ struct SettingsView: View {
                                 .controlSize(.small)
                         }
 
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.browser.openRelativeFilePaths", defaultValue: "Open Relative File Paths Externally"),
+                            subtitle: String(localized: "settings.browser.openRelativeFilePaths.subtitle", defaultValue: "When enabled, cmd+clicking relative file paths (like those in git status) opens them in your external editor instead of treating them as URLs.")
+                        ) {
+                            Toggle("", isOn: $openRelativeFilePathsExternally)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        if openRelativeFilePathsExternally {
+                            SettingsCardDivider()
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                SettingsCardRow(
+                                    String(localized: "settings.browser.externalFileEditor", defaultValue: "External File Editor"),
+                                    subtitle: String(localized: "settings.browser.externalFileEditor.subtitle", defaultValue: "Path to application for opening files (e.g., /Applications/Emacs.app). Leave empty to use system default.")
+                                ) {
+                                    EmptyView()
+                                }
+
+                                TextField("", text: $externalFileEditorPath)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(.body, design: .monospaced))
+                                    .padding(.horizontal, 16)
+                                    .padding(.bottom, 12)
+                            }
+                        }
+
                         if openTerminalLinksInCmuxBrowser || interceptTerminalOpenCommandInCmuxBrowser {
                             SettingsCardDivider()
 
@@ -4605,6 +4639,8 @@ struct SettingsView: View {
         interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser
         browserHostWhitelist = BrowserLinkOpenSettings.defaultBrowserHostWhitelist
         browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
+        openRelativeFilePathsExternally = BrowserLinkOpenSettings.defaultOpenRelativeFilePathsExternally
+        externalFileEditorPath = BrowserLinkOpenSettings.defaultExternalFileEditorPath
         browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
         browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText
         notificationSound = NotificationSoundSettings.defaultValue

--- a/scripts/build-ghostty-cli-helper.sh
+++ b/scripts/build-ghostty-cli-helper.sh
@@ -80,9 +80,19 @@ if [[ ! -f "$GHOSTTY_DIR/build.zig" ]]; then
   exit 1
 fi
 
+PREBUILT_HELPER="$GHOSTTY_DIR/zig-out/bin/ghostty"
+
 build_helper() {
   local prefix="$1"
   local target="${2:-}"
+
+  # Use pre-built binary if available — avoids Zig dependency fetches
+  if [[ -x "$PREBUILT_HELPER" ]]; then
+    mkdir -p "$prefix/bin"
+    cp "$PREBUILT_HELPER" "$prefix/bin/ghostty"
+    return 0
+  fi
+
   local args=(
     zig build
     cli-helper
@@ -98,10 +108,12 @@ build_helper() {
     args+=("-Dtarget=$target")
   fi
 
-  (
-    cd "$GHOSTTY_DIR"
-    "${args[@]}"
-  )
+  if (cd "$GHOSTTY_DIR" && "${args[@]}"); then
+    return 0
+  fi
+
+  echo "error: zig build failed and no pre-built helper found at $PREBUILT_HELPER" >&2
+  return 1
 }
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cmux-ghostty-helper.XXXXXX")"


### PR DESCRIPTION
## Summary
- Cmd+click on any word that exists as a file opens it (semantic history)
- New setting to open relative file paths externally
- New setting to configure external file editor path (e.g., `/Applications/Emacs.app`)
- Works with bare filenames in `git status` and `ls` output

## Dependencies
This PR depends on the ghostty submodule update: https://github.com/manaflow-ai/ghostty/pull/17

## Test plan
- [x] Cmd+click on `routing.tsx` in git status output opens in configured editor
- [x] Cmd+click on filenames in all `ls` columns works
- [x] Underline appears on hover with Cmd held for bare filenames
- [x] Settings UI for external editor path works
- [x] Falls back to system default when editor path is empty

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cmd+click semantic history to open files from the terminal in your editor, now including support for paths with line/column (e.g., file.ts:350:12). Adds settings to open relative file paths externally and to choose a preferred external editor.

- **New Features**
  - Cmd+click opens files in your preferred editor (underline on Cmd hover; works with bare filenames in `git status`/`ls`).
  - Supports `:line[:col]` suffixes; strips the suffix to resolve the file and opens at that location (uses `emacsclient` for Emacs.app; falls back to `open -a --args` for other `.app` editors).
  - Option to open relative file paths externally; falls back to browser/system when not found.
  - Setting to specify external editor path; empty uses system default.

- **Dependencies**
  - Updates `ghostty` submodule: https://github.com/manaflow-ai/ghostty/pull/17
  - Build: prefer prebuilt `ghostty` helper binary when available to avoid Zig dependency downloads.

<sup>Written for commit 9ca58492452c91b9740d207950eebf26efee098f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External editor integration to open files with a configured application.
  * Cmd‑click on terminal content to quickly open resolved relative file paths.
  * New browser settings: toggle for opening relative file paths externally and a field to set the external editor path.

* **Bug Fixes / Improvements**
  * Resolve relative paths against the workspace and support optional :line and :col suffixes when opening files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->