### PR TITLE
feat: add setting to swap Cmd/Ctrl modifiers for number shortcuts

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -57677,6 +57677,39 @@
         }
       }
     },
+    "settings.shortcuts.swapNumberModifiers": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swap Workspace/Surface Number Shortcuts"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.swapNumberModifiers.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+1–9 switches workspaces, Ctrl+1–9 switches surfaces."
+          }
+        }
+      }
+    },
+    "settings.shortcuts.swapNumberModifiers.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ctrl+1–9 switches workspaces, Cmd+1–9 switches surfaces."
+          }
+        }
+      }
+    },
     "settings.state.active": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1114,8 +1114,8 @@ final class ServeWebOutputCollector {
 }
 
 enum WorkspaceShortcutMapper {
-    /// Maps Cmd+digit workspace shortcuts to a zero-based workspace index.
-    /// Cmd+1...Cmd+8 target fixed indices; Cmd+9 always targets the last workspace.
+    /// Maps digit workspace shortcuts (Cmd+digit or Ctrl+digit, depending on settings) to a zero-based workspace index.
+    /// Digits 1...8 target fixed indices; 9 always targets the last workspace.
     static func workspaceIndex(forCommandDigit digit: Int, workspaceCount: Int) -> Int? {
         guard workspaceCount > 0 else { return nil }
         guard (1...9).contains(digit) else { return nil }
@@ -9474,8 +9474,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 (9 = last workspace)
-        if flags == [.command],
+        // Numeric shortcuts for specific sidebar tabs: Cmd+1-9 or Ctrl+1-9 (configurable, 9 = last workspace)
+        let workspaceMod = ShortcutHintDebugSettings.workspaceNumberModifier()
+        if flags == workspaceMod,
            let manager = tabManager,
            let num = Int(chars),
            let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forCommandDigit: num, workspaceCount: manager.tabs.count) {
@@ -9488,8 +9489,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Numeric shortcuts for surfaces within pane: Ctrl+1-9 (9 = last)
-        if flags == [.control] {
+        // Numeric shortcuts for surfaces within pane: Ctrl+1-9 or Cmd+1-9 (configurable, 9 = last)
+        let surfaceMod = ShortcutHintDebugSettings.surfaceNumberModifier()
+        if flags == surfaceMod {
             if let num = Int(chars), num >= 1 && num <= 9 {
                 if num == 9 {
                     tabManager?.selectLastSurface()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8424,6 +8424,7 @@ enum ShortcutHintDebugSettings {
     static let paneHintYKey = "shortcutHintPaneTabYOffset"
     static let alwaysShowHintsKey = "shortcutHintAlwaysShow"
     static let showHintsOnCommandHoldKey = "shortcutHintShowOnCommandHold"
+    static let swapNumberShortcutModifiersKey = "swapNumberShortcutModifiers"
 
     static let defaultSidebarHintX = 0.0
     static let defaultSidebarHintY = 0.0
@@ -8433,6 +8434,7 @@ enum ShortcutHintDebugSettings {
     static let defaultPaneHintY = 0.0
     static let defaultAlwaysShowHints = false
     static let defaultShowHintsOnCommandHold = true
+    static let defaultSwapNumberShortcutModifiers = false
 
     static let offsetRange: ClosedRange<Double> = -20...20
 
@@ -8447,9 +8449,34 @@ enum ShortcutHintDebugSettings {
         return defaults.bool(forKey: showHintsOnCommandHoldKey)
     }
 
+    static func swapNumberShortcutModifiersEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: swapNumberShortcutModifiersKey)
+    }
+
+    /// Returns the modifier flag to use for workspace (sidebar) number shortcuts.
+    static func workspaceNumberModifier(defaults: UserDefaults = .standard) -> NSEvent.ModifierFlags {
+        swapNumberShortcutModifiersEnabled(defaults: defaults) ? [.control] : [.command]
+    }
+
+    /// Returns the modifier flag to use for surface (pane tab) number shortcuts.
+    static func surfaceNumberModifier(defaults: UserDefaults = .standard) -> NSEvent.ModifierFlags {
+        swapNumberShortcutModifiersEnabled(defaults: defaults) ? [.command] : [.control]
+    }
+
+    /// Returns the symbol string for workspace number shortcuts ("⌘" or "⌃").
+    static var workspaceNumberModifierSymbol: String {
+        swapNumberShortcutModifiersEnabled() ? "⌃" : "⌘"
+    }
+
+    /// Returns the symbol string for surface number shortcuts ("⌃" or "⌘").
+    static var surfaceNumberModifierSymbol: String {
+        swapNumberShortcutModifiersEnabled() ? "⌘" : "⌃"
+    }
+
     static func resetVisibilityDefaults(defaults: UserDefaults = .standard) {
         defaults.set(defaultAlwaysShowHints, forKey: alwaysShowHintsKey)
         defaults.set(defaultShowHintsOnCommandHold, forKey: showHintsOnCommandHoldKey)
+        defaults.set(defaultSwapNumberShortcutModifiers, forKey: swapNumberShortcutModifiersKey)
     }
 }
 
@@ -10772,7 +10799,7 @@ private struct TabItemView: View, Equatable {
 
     private var workspaceShortcutLabel: String? {
         guard let workspaceShortcutDigit else { return nil }
-        return "⌘\(workspaceShortcutDigit)"
+        return "\(ShortcutHintDebugSettings.workspaceNumberModifierSymbol)\(workspaceShortcutDigit)"
     }
 
     private var showsWorkspaceShortcutHint: Bool {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3834,6 +3834,8 @@ struct SettingsView: View {
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @AppStorage(ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
     private var showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+    @AppStorage(ShortcutHintDebugSettings.swapNumberShortcutModifiersKey)
+    private var swapNumberShortcutModifiers = ShortcutHintDebugSettings.defaultSwapNumberShortcutModifiers
     @AppStorage("sidebarShowSSH") private var sidebarShowSSH = true
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
@@ -5308,6 +5310,19 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardRow(
+                            String(localized: "settings.shortcuts.swapNumberModifiers", defaultValue: "Swap Workspace/Surface Number Shortcuts"),
+                            subtitle: swapNumberShortcutModifiers
+                                ? String(localized: "settings.shortcuts.swapNumberModifiers.subtitleOn", defaultValue: "Ctrl+1–9 switches workspaces, Cmd+1–9 switches surfaces.")
+                                : String(localized: "settings.shortcuts.swapNumberModifiers.subtitleOff", defaultValue: "Cmd+1–9 switches workspaces, Ctrl+1–9 switches surfaces.")
+                        ) {
+                            Toggle("", isOn: $swapNumberShortcutModifiers)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
                         let actions = KeyboardShortcutSettings.Action.allCases
                         ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
                             ShortcutSettingRow(action: action)
@@ -5578,6 +5593,7 @@ struct SettingsView: View {
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        swapNumberShortcutModifiers = ShortcutHintDebugSettings.defaultSwapNumberShortcutModifiers
         sidebarShowSSH = true
         sidebarShowPorts = true
         sidebarShowLog = true


### PR DESCRIPTION
## Summary

- Adds a **"Swap Workspace/Surface Number Shortcuts"** toggle in Settings > Keyboard Shortcuts
- When off (default): `Cmd+1–9` switches workspaces, `Ctrl+1–9` switches surfaces (current behavior, unchanged)
- When on: `Ctrl+1–9` switches workspaces, `Cmd+1–9` switches surfaces
- Sidebar shortcut hint labels (⌘1, ⌘2, etc.) update dynamically to reflect the active modifier

## Motivation

Users coming from other terminal multiplexers or IDEs may prefer `Cmd+number` for switching pane tabs (surfaces) and `Ctrl+number` for switching workspaces. This is a common request per #135 — this PR adds a simple toggle for the number-key modifier assignment without changing any other shortcuts.

## Changes

| File | Change |
|------|--------|
| `Sources/ContentView.swift` | Added `swapNumberShortcutModifiers` setting key/default, helper methods for modifier resolution, dynamic sidebar hint label |
| `Sources/AppDelegate.swift` | Replaced hardcoded `[.command]`/`[.control]` checks with configurable modifier lookup |
| `Sources/cmuxApp.swift` | Added `@AppStorage` property and Settings UI toggle with descriptive subtitles |
| `Resources/Localizable.xcstrings` | Added English localization entries (translations needed for other languages) |

## Test plan

- [ ] Toggle off (default): verify `Cmd+1–9` switches workspaces, `Ctrl+1–9` switches surfaces
- [ ] Toggle on: verify `Ctrl+1–9` switches workspaces, `Cmd+1–9` switches surfaces
- [ ] Sidebar shortcut hint pills show correct modifier symbol (⌘ vs ⌃)
- [ ] "Reset All Settings" resets the toggle to off
- [ ] Existing shortcut routing for non-number shortcuts is unaffected

Partially addresses #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a setting to swap the Cmd/Ctrl modifiers for number shortcuts so users can choose which switches workspaces vs surfaces. Default behavior stays the same; sidebar hint labels update live.

- **New Features**
  - New toggle in Settings > Keyboard Shortcuts: “Swap Workspace/Surface Number Shortcuts”.
  - When enabled: Ctrl+1–9 selects workspaces; Cmd+1–9 selects surfaces (9 = last).
  - Shortcut handling uses the configured modifier; hint pills show ⌘/⌃ accordingly.
  - Added localization strings and included in “Reset All Settings”.

<sup>Written for commit f532bc2a16b7d8a654809fce6ed4d929ac20b741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings toggle to swap modifier keys for number shortcuts—users can now choose whether Cmd+1–9 or Ctrl+1–9 switches workspaces, with the other modifier controlling surfaces.

* **Documentation**
  * Updated shortcut documentation to reflect configurable modifier behavior for keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->