### PR TITLE
feat: implement resize_split keybind via BonsplitController

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3296,7 +3296,16 @@ class TabManager: ObservableObject {
         let requested = candidate.dividerPosition + (sign * delta)
         let clamped = min(max(requested, 0.1), 0.9)
 
-        return controller.setDividerPosition(clamped, forSplit: candidate.splitId, fromExternal: true)
+        let result = controller.setDividerPosition(clamped, forSplit: candidate.splitId, fromExternal: true)
+#if DEBUG
+        dlog(
+            "split.resize workspace=\(tabId.uuidString.prefix(5)) surface=\(surfaceId.uuidString.prefix(5)) " +
+            "direction=\(direction) amount=\(amount) split=\(candidate.splitId.uuidString.prefix(5)) " +
+            "from=\(String(format: "%.3f", candidate.dividerPosition)) to=\(String(format: "%.3f", clamped)) " +
+            "success=\(result ? 1 : 0)"
+        )
+#endif
+        return result
     }
 
     // MARK: - Resize split helpers


### PR DESCRIPTION
## Summary

- Implement `TabManager.resizeSplit()` which was previously stubbed as a no-op returning `false`
- Port the tree-walking divider adjustment logic from the existing v2 pane resize API (`TerminalController.v2PaneResize`) into `TabManager`
- Ghostty `resize_split` keybindings (e.g. `keybind = ctrl+shift+up=resize_split:up,30`) now work as expected

The approach walks the bonsplit tree to find split ancestors of the target pane, filters by orientation matching the resize direction, computes a normalized divider position delta from the pixel amount, and calls `BonsplitController.setDividerPosition` — the same mechanism used by `equalize_splits` and the v2 socket API.

Fixes #1882
Related: #1756

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Ghostty `resize_split` keybinds by implementing `TabManager.resizeSplit()` to move bonsplit dividers via `BonsplitController`. Adds `#if DEBUG` dlog output for resize operations.

- **New Features**
  - Walks the bonsplit tree to find the matching split and nearest divider based on direction.
  - Converts pixel amount to a normalized delta and calls `BonsplitController.setDividerPosition` (same path as `equalize_splits` and the v2 API).

<sup>Written for commit 24e67111cd1073e6693ea2a5a5fffb4b93ba8341. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Split pane resizing now works reliably: divider adjustments respond correctly to directional resize gestures and amount values.
  * Resizes are constrained to reasonable bounds to avoid extreme layouts, and layout updates are applied immediately for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->