### PR TITLE
Fix reload.sh stale-artifact launch after failed builds

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -284,8 +284,11 @@ fi
 XCODEBUILD_ARGS+=(build)
 
 XCODE_LOG="/tmp/cmux-xcodebuild-${TAG_SLUG}.log"
-xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$XCODE_LOG" | grep -E '(warning:|error:|fatal:|BUILD FAILED|BUILD SUCCEEDED|\*\* BUILD)' || true
-XCODE_EXIT="${PIPESTATUS[0]}"
+set +e
+xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$XCODE_LOG" | grep -E '(warning:|error:|fatal:|BUILD FAILED|BUILD SUCCEEDED|\*\* BUILD)'
+XCODE_PIPESTATUS=("${PIPESTATUS[@]}")
+set -e
+XCODE_EXIT="${XCODE_PIPESTATUS[0]}"
 echo "Full build log: $XCODE_LOG"
 if [[ "$XCODE_EXIT" -ne 0 ]]; then
   echo "error: xcodebuild failed with exit code $XCODE_EXIT" >&2


### PR DESCRIPTION
## Summary

- Fix `scripts/reload.sh` so a failed `xcodebuild` cannot fall through into the post-build launch path.
- Capture the build pipeline status immediately instead of masking it with a trailing `|| true`.
- This prevents stale tagged app artifacts from relaunching after failed builds.

## Testing

- Ran `bash -n scripts/reload.sh`.
- Verified the failure path with a temporary fake `xcodebuild` that emitted `** BUILD FAILED **` and exited `65`; confirmed the script returned `65`, printed the build log path, and did not launch a tagged app.
- Built a real `good-build` tagged artifact, then removed an import and ran a failing `bad-build` tagged build; verified the prior `good-build` artifact did not relaunch.
- Ran a failing rebuild of the existing `good-build` tag after removing the import; verified the existing `good-build` artifact still did not relaunch.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes (N/A: shell-script fix with no existing automated harness for this failure path)
- [ ] I updated docs/changelog if needed (N/A: no docs or changelog change needed for this script fix)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stale tagged app artifacts from launching after failed builds by fixing exit handling in `scripts/reload.sh`. We now capture the real `xcodebuild` exit code from the pipeline using `PIPESTATUS` and remove the trailing `|| true` so the post-build launch path only runs on success.

<sup>Written for commit 08bf1721417076c01b26b325011c19aed7aab13c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in the build script for more reliable failure detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
