### PR TITLE
ci: add concurrency groups to prevent WarpBuild runner contention

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-ghosttykit:
     # Never run WarpBuild jobs for fork pull requests (avoid billing on external PRs).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   workflow-guard-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rapid pushes to main spawn 7+ WarpBuild jobs simultaneously, causing intermittent runner failures (shutdown during submodule clone, lost communication). Both ci.yml and build-ghosttykit.yml lacked concurrency settings.

Adds workflow-level concurrency groups. On PRs, stale runs are canceled when a new push arrives. On main, runs queue serially (cancel-in-progress is false to avoid red X pollution from GitHub treating cancelled runs as failures, per https://github.com/orgs/community/discussions/8336).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workflow concurrency to `ci.yml` and `build-ghosttykit.yml` to prevent WarpBuild runner contention and flaky CI failures.

- **Bug Fixes**
  - Set workflow-level concurrency group to `${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — PRs cancel stale runs; `main` queues to avoid canceled-run failures

<sup>Written for commit 4fcbe2a696e4765c7acc090ea95c800177021673. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD efficiency by configuring workflow concurrency to automatically cancel redundant runs during pull request updates, reducing resource consumption and faster feedback cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->