### PR TITLE
Honor Ghostty working-directory for new workspaces

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1072,7 +1072,7 @@ class TabManager: ObservableObject {
         let nextTabCount = snapshot.tabs.count + 1
         sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-        let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectoryForNewTab(snapshot: snapshot)
+        let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectoryForNewWorkspace(snapshot: snapshot)
         let inheritedConfig = inheritedTerminalConfigForNewWorkspace(snapshot: snapshot)
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
@@ -1903,6 +1903,20 @@ class TabManager: ObservableObject {
 
     private func preferredWorkingDirectoryForNewTab() -> String? {
         preferredWorkingDirectoryForNewTab(snapshot: workspaceCreationSnapshot())
+    }
+
+    private func preferredWorkingDirectoryForNewWorkspace(
+        snapshot: WorkspaceCreationSnapshot
+    ) -> String? {
+        configuredWorkingDirectoryForNewWorkspace() ?? preferredWorkingDirectoryForNewTab(snapshot: snapshot)
+    }
+
+    private func configuredWorkingDirectoryForNewWorkspace() -> String? {
+        guard let configuredDirectory = loadGhosttyConfig().workingDirectory else {
+            return nil
+        }
+        let expandedDirectory = NSString(string: configuredDirectory).expandingTildeInPath
+        return normalizedWorkingDirectory(expandedDirectory)
     }
 
     private func preferredWorkingDirectoryForNewTab(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -798,6 +798,7 @@ class TabManager: ObservableObject {
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     private var sidebarSelectedWorkspaceIds: Set<UUID> = []
     var confirmCloseHandler: ((String, String, Bool) -> Bool)?
+    private let loadGhosttyConfig: () -> GhosttyConfig
     private struct WorkspaceCreationSnapshot {
         let tabs: [Workspace]
         let selectedTabId: UUID?
@@ -825,7 +826,11 @@ class TabManager: ObservableObject {
     private var uiTestCancellables = Set<AnyCancellable>()
 #endif
 
-    init(initialWorkingDirectory: String? = nil) {
+    init(
+        initialWorkingDirectory: String? = nil,
+        loadGhosttyConfig: @escaping () -> GhosttyConfig = { GhosttyConfig.load() }
+    ) {
+        self.loadGhosttyConfig = loadGhosttyConfig
         addWorkspace(workingDirectory: initialWorkingDirectory)
         observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidSetTitle,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -805,6 +805,46 @@ final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
     }
 }
 
+@MainActor
+final class TabManagerWorkspaceWorkingDirectoryPreferenceTests: XCTestCase {
+    func testConfiguredGhosttyWorkingDirectoryOverridesInheritedWorkspaceDirectory() {
+        let configuredDirectory = NSString(string: "~/Projects").expandingTildeInPath
+        var config = GhosttyConfig()
+        config.workingDirectory = "~/Projects"
+        let inheritedDirectory = "/tmp/cmux-inherited-cwd-\(UUID().uuidString)"
+        let manager = TabManager(
+            initialWorkingDirectory: inheritedDirectory,
+            loadGhosttyConfig: { config }
+        )
+
+        let newWorkspace = manager.addWorkspace()
+
+        XCTAssertEqual(
+            newWorkspace.currentDirectory,
+            configuredDirectory,
+            "Expected Ghostty's configured working-directory to override inherited workspace cwd"
+        )
+        XCTAssertEqual(
+            newWorkspace.focusedTerminalPanel?.requestedWorkingDirectory,
+            configuredDirectory,
+            "Expected new workspace terminal to start in Ghostty's configured working-directory"
+        )
+    }
+
+    func testFallsBackToInheritedWorkspaceDirectoryWhenGhosttyWorkingDirectoryIsUnset() {
+        let inheritedDirectory = "/tmp/cmux-inherited-cwd-\(UUID().uuidString)"
+        let manager = TabManager(
+            initialWorkingDirectory: inheritedDirectory,
+            loadGhosttyConfig: { GhosttyConfig() }
+        )
+
+        let newWorkspace = manager.addWorkspace()
+
+        XCTAssertEqual(newWorkspace.currentDirectory, inheritedDirectory)
+        XCTAssertEqual(newWorkspace.focusedTerminalPanel?.requestedWorkingDirectory, inheritedDirectory)
+    }
+}
+
 
 @MainActor
 final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {


### PR DESCRIPTION
## Summary
- honor Ghosttys configured `working-directory` when creating a new workspace
- fall back to inheriting the active workspace cwd only when Ghostty does not define one
- add regression coverage for both behaviors

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-new-workspace-default-path-tests -only-testing:cmuxTests/TabManagerWorkspaceWorkingDirectoryPreferenceTests test`
- Commit `71aff415` is the red test-only commit, HEAD makes the same slice pass

## Task
- User report: new workspaces were inheriting the active workspace path instead of respecting Ghostty `working-directory`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New workspaces now honor `Ghostty`’s configured `working-directory`. If none is set, they fall back to the active workspace’s path.

- **Bug Fixes**
  - Use `GhosttyConfig.workingDirectory` (tilde-expanded) as the default for new workspaces.
  - Added unit tests covering configured directory and fallback behavior.

<sup>Written for commit 8de5a27b9a97353efc1d5c5a6158a86f1c71e3b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New workspaces now respect working directory settings from Ghostty configuration.
  * Improved working directory resolution for workspace creation with enhanced fallback behavior.

* **Tests**
  * Added comprehensive test coverage for workspace working directory preference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->