### PR TITLE
Fix issue #1797 workspace switch terminal redraw

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6204,6 +6204,8 @@ final class GhosttySurfaceScrollView: NSView {
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
+    private var pendingWorkspaceSwitchRedraw = false
+    private var pendingWorkspaceSwitchRedrawTrigger = "unknown"
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
@@ -7392,6 +7394,9 @@ final class GhosttySurfaceScrollView: NSView {
             }
         } else {
             scheduleAutomaticFirstResponderApply(reason: "setVisibleInUI")
+            if !wasVisible {
+                scheduleWorkspaceSwitchRedraw(trigger: "visible")
+            }
         }
     }
 
@@ -7423,6 +7428,9 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
         if active {
             scheduleAutomaticFirstResponderApply(reason: "setActive")
+            if !wasActive {
+                scheduleWorkspaceSwitchRedraw(trigger: "active")
+            }
         } else {
             resignOwnedFirstResponderIfNeeded(reason: "setActive(false)")
         }
@@ -7789,6 +7797,73 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
             self.applyFirstResponderIfNeeded()
         }
+    }
+
+    private func scheduleWorkspaceSwitchRedraw(trigger: String) {
+        pendingWorkspaceSwitchRedrawTrigger = trigger
+        guard !pendingWorkspaceSwitchRedraw else {
+#if DEBUG
+            let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+            dlog("ws.redraw.defer surface=\(surfaceShort) trigger=\(trigger) result=skip reason=pending")
+#endif
+            return
+        }
+        pendingWorkspaceSwitchRedraw = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pendingWorkspaceSwitchRedraw = false
+            let trigger = self.pendingWorkspaceSwitchRedrawTrigger
+            self.pendingWorkspaceSwitchRedrawTrigger = "unknown"
+            self.runWorkspaceSwitchRedrawIfNeeded(trigger: trigger)
+        }
+    }
+
+    private func runWorkspaceSwitchRedrawIfNeeded(trigger: String) {
+        let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+        let size = bounds.size
+        let hiddenInHierarchy = isHiddenOrHasHiddenAncestor || surfaceView.isHiddenOrHasHiddenAncestor
+
+        guard surfaceView.terminalSurface != nil else {
+#if DEBUG
+            dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=no_surface")
+#endif
+            return
+        }
+        guard surfaceView.isVisibleInUI else {
+#if DEBUG
+            dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=not_visible")
+#endif
+            return
+        }
+        guard isActive else {
+#if DEBUG
+            dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=inactive")
+#endif
+            return
+        }
+        guard window != nil else {
+#if DEBUG
+            dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=no_window")
+#endif
+            return
+        }
+        guard !hiddenInHierarchy, size.width > 1, size.height > 1 else {
+#if DEBUG
+            let sizeText = String(format: "%.1fx%.1f", size.width, size.height)
+            dlog(
+                "ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip " +
+                "reason=hidden_or_tiny hidden=\(hiddenInHierarchy ? 1 : 0) frame=\(sizeText)"
+            )
+#endif
+            return
+        }
+
+#if DEBUG
+        let sizeText = String(format: "%.1fx%.1f", size.width, size.height)
+        dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=run frame=\(sizeText)")
+#endif
+        reconcileGeometryNow()
+        refreshSurfaceNow(reason: "workspace.\(trigger)")
     }
 
     private func reassertTerminalSurfaceFocus(reason: String) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6205,6 +6205,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
     private var pendingWorkspaceSwitchRedraw = false
+    private var workspaceSwitchRedrawDrainScheduled = false
     private var pendingWorkspaceSwitchRedrawTrigger = "unknown"
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
 
@@ -6604,6 +6605,7 @@ final class GhosttySurfaceScrollView: NSView {
     override func layout() {
         super.layout()
         synchronizeGeometryAndContent()
+        drainWorkspaceSwitchRedrawIfNeeded()
     }
 
     override func viewDidMoveToSuperview() {
@@ -6855,6 +6857,7 @@ final class GhosttySurfaceScrollView: NSView {
         if window.isKeyWindow {
             scheduleAutomaticFirstResponderApply(reason: "viewDidMoveToWindow")
         }
+        drainWorkspaceSwitchRedrawIfNeeded()
     }
 
     func attachSurface(_ terminalSurface: TerminalSurface) {
@@ -7428,9 +7431,7 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
         if active {
             scheduleAutomaticFirstResponderApply(reason: "setActive")
-            if !wasActive {
-                scheduleWorkspaceSwitchRedraw(trigger: "active")
-            }
+            drainWorkspaceSwitchRedrawIfNeeded()
         } else {
             resignOwnedFirstResponderIfNeeded(reason: "setActive(false)")
         }
@@ -7801,24 +7802,32 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func scheduleWorkspaceSwitchRedraw(trigger: String) {
         pendingWorkspaceSwitchRedrawTrigger = trigger
-        guard !pendingWorkspaceSwitchRedraw else {
+        pendingWorkspaceSwitchRedraw = true
+        guard !workspaceSwitchRedrawDrainScheduled else {
 #if DEBUG
             let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
-            dlog("ws.redraw.defer surface=\(surfaceShort) trigger=\(trigger) result=skip reason=pending")
+            dlog("ws.redraw.defer surface=\(surfaceShort) trigger=\(trigger) result=skip reason=drain_scheduled")
 #endif
             return
         }
-        pendingWorkspaceSwitchRedraw = true
+        workspaceSwitchRedrawDrainScheduled = true
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.pendingWorkspaceSwitchRedraw = false
-            let trigger = self.pendingWorkspaceSwitchRedrawTrigger
-            self.pendingWorkspaceSwitchRedrawTrigger = "unknown"
-            self.runWorkspaceSwitchRedrawIfNeeded(trigger: trigger)
+            self.workspaceSwitchRedrawDrainScheduled = false
+            self.drainWorkspaceSwitchRedrawIfNeeded()
         }
     }
 
-    private func runWorkspaceSwitchRedrawIfNeeded(trigger: String) {
+    private func drainWorkspaceSwitchRedrawIfNeeded() {
+        guard pendingWorkspaceSwitchRedraw else { return }
+        let trigger = pendingWorkspaceSwitchRedrawTrigger
+        guard runWorkspaceSwitchRedrawIfNeeded(trigger: trigger) else { return }
+        pendingWorkspaceSwitchRedraw = false
+        pendingWorkspaceSwitchRedrawTrigger = "unknown"
+    }
+
+    @discardableResult
+    private func runWorkspaceSwitchRedrawIfNeeded(trigger: String) -> Bool {
         let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
         let size = bounds.size
         let hiddenInHierarchy = isHiddenOrHasHiddenAncestor || surfaceView.isHiddenOrHasHiddenAncestor
@@ -7827,25 +7836,25 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
             dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=no_surface")
 #endif
-            return
+            return false
         }
         guard surfaceView.isVisibleInUI else {
 #if DEBUG
             dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=not_visible")
 #endif
-            return
+            return false
         }
         guard isActive else {
 #if DEBUG
             dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=inactive")
 #endif
-            return
+            return false
         }
         guard window != nil else {
 #if DEBUG
             dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=skip reason=no_window")
 #endif
-            return
+            return false
         }
         guard !hiddenInHierarchy, size.width > 1, size.height > 1 else {
 #if DEBUG
@@ -7855,7 +7864,7 @@ final class GhosttySurfaceScrollView: NSView {
                 "reason=hidden_or_tiny hidden=\(hiddenInHierarchy ? 1 : 0) frame=\(sizeText)"
             )
 #endif
-            return
+            return false
         }
 
 #if DEBUG
@@ -7864,6 +7873,7 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
         reconcileGeometryNow()
         refreshSurfaceNow(reason: "workspace.\(trigger)")
+        return true
     }
 
     private func reassertTerminalSurfaceFocus(reason: String) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3463,7 +3463,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     /// Force a full size recalculation and surface redraw.
-    func forceRefresh(reason: String = "unspecified") {
+    @discardableResult
+    func forceRefresh(reason: String = "unspecified") -> Bool {
         let hasSurface = surface != nil
         let viewState: String
         if let view = attachedView {
@@ -3482,9 +3483,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
               view.window != nil,
               view.bounds.width > 0,
               view.bounds.height > 0 else {
-            return
+            return false
         }
-        guard let currentSurface = self.surface else { return }
+        guard let currentSurface = self.surface else { return false }
 
         // Re-read self.surface before each ghostty call to guard against the surface
         // being freed during wake-from-sleep geometry reconciliation (issue #432).
@@ -3500,8 +3501,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         view.forceRefreshSurface()
-        guard let surface = self.surface else { return }
+        guard let surface = self.surface else { return false }
         ghostty_surface_refresh(surface)
+        return true
     }
 
     func applyWindowBackgroundIfActive() {
@@ -6634,8 +6636,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     /// Request an immediate terminal redraw after geometry updates so stale IOSurface
     /// contents do not remain stretched during live resize churn.
-    func refreshSurfaceNow(reason: String = "portal.refreshSurfaceNow") {
-        surfaceView.terminalSurface?.forceRefresh(reason: reason)
+    @discardableResult
+    func refreshSurfaceNow(reason: String = "portal.refreshSurfaceNow") -> Bool {
+        surfaceView.terminalSurface?.forceRefresh(reason: reason) ?? false
     }
 
     @discardableResult
@@ -7872,8 +7875,7 @@ final class GhosttySurfaceScrollView: NSView {
         dlog("ws.redraw.run surface=\(surfaceShort) trigger=\(trigger) result=run frame=\(sizeText)")
 #endif
         reconcileGeometryNow()
-        refreshSurfaceNow(reason: "workspace.\(trigger)")
-        return true
+        return refreshSurfaceNow(reason: "workspace.\(trigger)")
     }
 
     private func reassertTerminalSurfaceFocus(reason: String) {


### PR DESCRIPTION
## Summary
- defer a terminal redraw after workspace switches when the surface becomes visible again
- trigger the same redraw path when the surface becomes active again after switching back
- guard the redraw so it only runs when the surface is attached, visible, active, and has usable bounds

## Notes
- this PR only includes the Ghostty terminal redraw fix for issue #1797

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers and retries terminal redraw after workspace switches, draining only when the terminal view is visible, active, and attached to its window. Fixes #1797 by preventing blank or stale frames when switching back.

- **Bug Fixes**
  - Queues a single pending redraw and drains it on layout, window attachment, visibility, or activation changes; keeps the retry queued until a redraw actually succeeds.
  - When guards pass (surface exists, visible, active, window present, usable bounds), runs `reconcileGeometryNow()` and `refreshSurfaceNow("workspace.*")`.

<sup>Written for commit 19d09748aa141a9137f7bf790836954f4afeec2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable terminal refreshes when switching workspaces, reducing missed or delayed updates.
  * Coalesced redraw scheduling to avoid redundant work and ensure a single prompt redraw once conditions allow.
  * Redraws now run promptly when the terminal becomes visible, active, laid out, or moved to a window, preventing flicker and improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->