### PR TITLE
Extend theme customization: contrast text, scrim toggle, monochrome icons, pane accent

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -119,10 +119,13 @@ func sidebarSelectedWorkspaceBackgroundNSColor(for colorScheme: ColorScheme) -> 
 func sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat, for colorScheme: ColorScheme = .dark) -> NSColor {
     let clampedOpacity = max(0, min(opacity, 1))
     let accent = cmuxAccentNSColor(for: colorScheme)
-    // Calculate relative luminance (ITU-R BT.709) to pick a contrasting text color
-    let r = accent.redComponent
-    let g = accent.greenComponent
-    let b = accent.blueComponent
+    // Linearize sRGB channels before applying BT.709 luminance formula
+    func linearize(_ c: CGFloat) -> CGFloat {
+        c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+    }
+    let r = linearize(accent.redComponent)
+    let g = linearize(accent.greenComponent)
+    let b = linearize(accent.blueComponent)
     let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
     let baseColor: NSColor = luminance > 0.5 ? .black : .white
     return baseColor.withAlphaComponent(clampedOpacity)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -116,9 +116,16 @@ func sidebarSelectedWorkspaceBackgroundNSColor(for colorScheme: ColorScheme) -> 
     cmuxAccentNSColor(for: colorScheme)
 }
 
-func sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat) -> NSColor {
+func sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat, for colorScheme: ColorScheme = .dark) -> NSColor {
     let clampedOpacity = max(0, min(opacity, 1))
-    return NSColor.white.withAlphaComponent(clampedOpacity)
+    let accent = cmuxAccentNSColor(for: colorScheme)
+    // Calculate relative luminance (ITU-R BT.709) to pick a contrasting text color
+    let r = accent.redComponent
+    let g = accent.greenComponent
+    let b = accent.blueComponent
+    let luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    let baseColor: NSColor = luminance > 0.5 ? .black : .white
+    return baseColor.withAlphaComponent(clampedOpacity)
 }
 
 #if compiler(>=6.2)
@@ -10410,22 +10417,25 @@ private struct SidebarDevFooter: View {
 
 private struct SidebarTopScrim: View {
     let height: CGFloat
+    @AppStorage("sidebarScrimEnabled") private var sidebarScrimEnabled = true
 
     var body: some View {
-        SidebarTopBlurEffect()
-            .frame(height: height)
-            .mask(
-                LinearGradient(
-                    colors: [
-                        Color.black.opacity(0.95),
-                        Color.black.opacity(0.75),
-                        Color.black.opacity(0.35),
-                        Color.clear
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
+        if sidebarScrimEnabled {
+            SidebarTopBlurEffect()
+                .frame(height: height)
+                .mask(
+                    LinearGradient(
+                        colors: [
+                            Color.black.opacity(0.95),
+                            Color.black.opacity(0.75),
+                            Color.black.opacity(0.35),
+                            Color.clear
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
                 )
-            )
+        }
     }
 }
 
@@ -10740,13 +10750,13 @@ private struct TabItemView: View, Equatable {
 
     private var activePrimaryTextColor: Color {
         usesInvertedActiveForeground
-            ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 1.0))
+            ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 1.0, for: colorScheme))
             : .primary
     }
 
     private func activeSecondaryColor(_ opacity: Double = 0.75) -> Color {
         usesInvertedActiveForeground
-            ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity)))
+            ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity), for: colorScheme))
             : .secondary
     }
 
@@ -13053,9 +13063,51 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     }
 
     func updateIcon() {
-        let icon = NSWorkspace.shared.icon(forFile: directory)
-        icon.size = NSSize(width: 16, height: 16)
-        imageView.image = icon
+        let useMonochrome = UserDefaults.standard.bool(forKey: "sidebarMonochromeIcons")
+        if useMonochrome {
+            let sfName = sfSymbolName(for: directory)
+            if let sfImage = NSImage(systemSymbolName: sfName, accessibilityDescription: nil) {
+                let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
+                let configured = sfImage.withSymbolConfiguration(config) ?? sfImage
+                imageView.image = configured
+                imageView.contentTintColor = NSColor.secondaryLabelColor
+                imageView.symbolConfiguration = config
+            } else {
+                let icon = NSWorkspace.shared.icon(forFile: directory)
+                icon.size = NSSize(width: 16, height: 16)
+                imageView.image = icon
+                imageView.contentTintColor = nil
+            }
+        } else {
+            let icon = NSWorkspace.shared.icon(forFile: directory)
+            icon.size = NSSize(width: 16, height: 16)
+            imageView.image = icon
+            imageView.contentTintColor = nil
+        }
+    }
+
+    private func sfSymbolName(for path: String) -> String {
+        let expanded = NSString(string: path).expandingTildeInPath
+        let home = NSHomeDirectory()
+        if expanded == home {
+            return "folder"
+        }
+        if expanded.hasPrefix(home + "/") {
+            let childName = String(expanded.dropFirst(home.count + 1)).components(separatedBy: "/").first ?? ""
+            switch childName {
+            case "Desktop": return "menubar.dock.rectangle"
+            case "Documents": return "doc.text"
+            case "Downloads": return "arrow.down.circle"
+            case "Music": return "music.note"
+            case "Pictures", "Photos": return "photo"
+            case "Movies": return "film"
+            case "Library": return "building.columns"
+            case "Applications": return "square.grid.2x2"
+            case "Developer": return "hammer"
+            default: break
+            }
+        }
+        return "folder"
     }
 
     func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {


### PR DESCRIPTION
## Summary

Four additive, backward-compatible enhancements that give theme authors more control over cmux's appearance. All features are opt-in via UserDefaults and preserve existing behavior when keys are absent.

- **Auto-contrast sidebar text**: `sidebarSelectedWorkspaceForegroundNSColor` now calculates luminance of the accent color and returns black text for bright accents (luminance > 0.5), making custom `sidebarAccentHex` values readable on any background
- **`sidebarScrimEnabled`** (AppStorage, default `true`): when `false`, hides the `LinearGradient` blur scrim at the top of the sidebar, allowing solid-color sidebar backgrounds without the gradient overlay
- **`sidebarMonochromeIcons`** (UserDefaults, default `false`): when `true`, replaces colorful `NSWorkspace` folder icons with matching SF Symbols (`folder`, `doc.text`, `arrow.down.circle`, etc.) rendered in `secondaryLabelColor`
- **Bonsplit pane tab accent**: `TabBarColors` reads `sidebarAccentHex` so the active-tab indicator, focus ring, and drop placeholders match the sidebar accent color instead of always using `Color.accentColor`

## New UserDefaults Keys

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `sidebarScrimEnabled` | Bool | `true` | Show/hide the top sidebar gradient scrim |
| `sidebarMonochromeIcons` | Bool | `false` | Use SF Symbol folder icons instead of colorful system icons |

The existing `sidebarAccentHex` key is now also read by Bonsplit's tab bar for consistency.

## Test plan

- [ ] Verify default behavior unchanged (no UserDefaults set → blue accent, white text, scrim visible, colorful icons)
- [ ] Set `sidebarAccentHex` to a bright color (e.g. `#28fe14`) → text on selected tab should be black
- [ ] Set `sidebarAccentHex` to a dark color (e.g. `#282a36`) → text should remain white
- [ ] Set `sidebarScrimEnabled` to `false` → top sidebar gradient disappears
- [ ] Set `sidebarMonochromeIcons` to `true` → folder icon in titlebar becomes SF Symbol outline
- [ ] Split panes and verify the pane tab bar indicator uses the accent color
- [ ] Verify drag-and-drop between panes uses the accent color for placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four opt-in theme controls: auto-contrast sidebar text, a sidebar scrim toggle, monochrome sidebar icons, and pane tab accents synced to `sidebarAccentHex`. Defaults keep the current look; also fixes luminance calculation by linearizing sRGB for accurate contrast.

- **New Features**
  - Auto-contrast sidebar text: picks black or white based on accent luminance for readability.
  - `sidebarScrimEnabled` (AppStorage, default `true`): when `false`, removes the top sidebar gradient.
  - `sidebarMonochromeIcons` (UserDefaults, default `false`): swaps colorful folder icons for SF Symbols tinted with `secondaryLabelColor`.
  - Pane tab bar uses `sidebarAccentHex` for the active indicator, focus ring, and drag placeholders; falls back to `Color.accentColor`.

<sup>Written for commit 4b1b8d218836cca45d54bef39fa67569fc2d3fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle to enable/disable the sidebar scrim visual effect (blur + gradient).
  * Added an option to render sidebar folder icons as monochrome SF Symbols with improved folder-specific symbols.
  * Improved sidebar text color contrast by deriving foreground colors from the accent color and current color scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->