### PR TITLE
Add file browser drawer and text editor panel

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -37,6 +37,11 @@
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		FB200011 /* FileBrowserDrawerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB200001 /* FileBrowserDrawerState.swift */; };
+		FB200012 /* TextEditorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB200002 /* TextEditorPanel.swift */; };
+		FB200013 /* TextEditorPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB200003 /* TextEditorPanelView.swift */; };
+		FB200014 /* FileBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB200004 /* FileBrowserView.swift */; };
+		FB200015 /* FileBrowserDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB200005 /* FileBrowserDrawerView.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
@@ -240,6 +245,11 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		FB200001 /* FileBrowserDrawerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserDrawerState.swift; sourceTree = "<group>"; };
+		FB200002 /* TextEditorPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TextEditorPanel.swift; sourceTree = "<group>"; };
+		FB200003 /* TextEditorPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TextEditorPanelView.swift; sourceTree = "<group>"; };
+		FB200004 /* FileBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserView.swift; sourceTree = "<group>"; };
+		FB200005 /* FileBrowserDrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileBrowserDrawerView.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -494,7 +504,11 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				FB200002 /* TextEditorPanel.swift */,
+				FB200003 /* TextEditorPanelView.swift */,
 				A5001510 /* CmuxWebView.swift */,
+				FB200001 /* FileBrowserDrawerState.swift */,
+				FB200020 /* FileBrowser */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
 				A5001212 /* UpdateDelegate.swift */,
@@ -518,6 +532,15 @@
 				A5001655 /* CmuxDirectoryTrust.swift */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		FB200020 /* FileBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				FB200004 /* FileBrowserView.swift */,
+				FB200005 /* FileBrowserDrawerView.swift */,
+			);
+			path = FileBrowser;
 			sourceTree = "<group>";
 		};
 		B9000003A1B2C3D4E5F60719 /* CLI */ = {
@@ -640,6 +663,8 @@
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
 					A5001291 /* MarkdownUI */,
+					FB300001 /* Highlightr */,
+					FB400001 /* CodeEditor */,
 				);
 			name = GhosttyTabs;
 			productName = GhosttyTabs;
@@ -760,6 +785,8 @@
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
+					FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */,
+					FB400002 /* XCRemoteSwiftPackageReference "CodeEditor" */,
 				);
 			productRefGroup = A5001042 /* Products */;
 			projectDirPath = "";
@@ -818,6 +845,11 @@
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				FB200011 /* FileBrowserDrawerState.swift in Sources */,
+				FB200012 /* TextEditorPanel.swift in Sources */,
+				FB200013 /* TextEditorPanelView.swift in Sources */,
+				FB200014 /* FileBrowserView.swift in Sources */,
+				FB200015 /* FileBrowserDrawerView.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
@@ -1284,6 +1316,22 @@
 				isa = XCLocalSwiftPackageReference;
 				relativePath = vendor/bonsplit;
 			};
+			FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */ = {
+				isa = XCRemoteSwiftPackageReference;
+				repositoryURL = "https://github.com/raspu/Highlightr.git";
+				requirement = {
+					kind = upToNextMajorVersion;
+					minimumVersion = 2.2.1;
+				};
+			};
+			FB400002 /* XCRemoteSwiftPackageReference "CodeEditor" */ = {
+				isa = XCRemoteSwiftPackageReference;
+				repositoryURL = "https://github.com/tayl0r/CodeEditor.git";
+				requirement = {
+					kind = branch;
+					branch = main;
+				};
+			};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1311,6 +1359,16 @@
 				isa = XCSwiftPackageProductDependency;
 				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 				productName = MarkdownUI;
+			};
+			FB300001 /* Highlightr */ = {
+				isa = XCSwiftPackageProductDependency;
+				package = FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */;
+				productName = Highlightr;
+			};
+			FB400001 /* CodeEditor */ = {
+				isa = XCSwiftPackageProductDependency;
+				package = FB400002 /* XCRemoteSwiftPackageReference "CodeEditor" */;
+				productName = CodeEditor;
 			};
 /* End XCSwiftPackageProductDependency section */
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -663,7 +663,6 @@
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
 					A5001291 /* MarkdownUI */,
-					FB300001 /* Highlightr */,
 					FB400001 /* CodeEditor */,
 				);
 			name = GhosttyTabs;
@@ -785,7 +784,6 @@
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
-					FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */,
 					FB400002 /* XCRemoteSwiftPackageReference "CodeEditor" */,
 				);
 			productRefGroup = A5001042 /* Products */;
@@ -1316,20 +1314,12 @@
 				isa = XCLocalSwiftPackageReference;
 				relativePath = vendor/bonsplit;
 			};
-			FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */ = {
-				isa = XCRemoteSwiftPackageReference;
-				repositoryURL = "https://github.com/raspu/Highlightr.git";
-				requirement = {
-					kind = upToNextMajorVersion;
-					minimumVersion = 2.2.1;
-				};
-			};
 			FB400002 /* XCRemoteSwiftPackageReference "CodeEditor" */ = {
 				isa = XCRemoteSwiftPackageReference;
 				repositoryURL = "https://github.com/tayl0r/CodeEditor.git";
 				requirement = {
 					kind = branch;
-					branch = main;
+					branch = develop;
 				};
 			};
 /* End XCRemoteSwiftPackageReference section */
@@ -1359,11 +1349,6 @@
 				isa = XCSwiftPackageProductDependency;
 				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 				productName = MarkdownUI;
-			};
-			FB300001 /* Highlightr */ = {
-				isa = XCSwiftPackageProductDependency;
-				package = FB300002 /* XCRemoteSwiftPackageReference "Highlightr" */;
-				productName = Highlightr;
 			};
 			FB400001 /* CodeEditor */ = {
 				isa = XCSwiftPackageProductDependency;

--- a/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "b66d812c506be67c70b46c63421ab2eb2db013613c74252ad1205f662ada079b",
+  "originHash" : "92cfd3ee05443bd8f26d9cd84c2995c3adece8e6a2deb6d7f8b3c1339e7e6849",
   "pins" : [
+    {
+      "identity" : "codeeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tayl0r/CodeEditor.git",
+      "state" : {
+        "branch" : "develop",
+        "revision" : "0b14784dbe52c95d57ac39481bce18d3793e3ec9"
+      }
+    },
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/helje5/Highlightr",
+      "state" : {
+        "revision" : "bd0358056ff1f12ea83833a9fc1b3b5a396a9da0",
+        "version" : "3.0.2"
+      }
+    },
     {
       "identity" : "networkimage",
       "kind" : "remoteSourceControl",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -62969,6 +62969,57 @@
         }
       }
     },
+    "settings.section.textEditor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text Editor"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストエディタ"
+          }
+        }
+      }
+    },
+    "settings.textEditor.darkTheme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Theme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークテーマ"
+          }
+        }
+      }
+    },
+    "settings.textEditor.lightTheme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light Theme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライトテーマ"
+          }
+        }
+      }
+    },
     "settings.section.keyboardShortcuts": {
       "extractionState": "manual",
       "localizations": {
@@ -69064,23 +69115,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "ファイルブラウザを切替"
-          }
-        }
-      }
-    },
-    "fileBrowser.header.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Files"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイル"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69051,6 +69051,176 @@
         }
       }
     },
+    "shortcut.toggleFileBrowserDrawer.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle File Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルブラウザを切替"
+          }
+        }
+      }
+    },
+    "fileBrowser.header.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル"
+          }
+        }
+      }
+    },
+    "fileBrowser.emptyState": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus a terminal to browse its working directory."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルにフォーカスして作業ディレクトリを参照"
+          }
+        }
+      }
+    },
+    "textEditor.panel.kindLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text Editor"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストエディタ"
+          }
+        }
+      }
+    },
+    "textEditor.externalChange.banner": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File changed on disk"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスク上のファイルが変更されました"
+          }
+        }
+      }
+    },
+    "textEditor.externalChange.reload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再読み込み"
+          }
+        }
+      }
+    },
+    "textEditor.save.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save file"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルの保存に失敗しました"
+          }
+        }
+      }
+    },
+    "textEditor.fileUnavailable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルが利用できません"
+          }
+        }
+      }
+    },
+    "textEditor.fileUnavailable.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The file may have been moved or deleted."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルが移動または削除された可能性があります。"
+          }
+        }
+      }
+    },
+    "menu.view.toggleFileBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle File Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルブラウザを切替"
+          }
+        }
+      }
+    },
     "shortcut.toggleTerminalCopyMode.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69187,6 +69187,23 @@
         }
       }
     },
+    "textEditor.dirty.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsaved changes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未保存の変更"
+          }
+        }
+      }
+    },
     "textEditor.save.error": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2150,6 +2150,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let tabManager: TabManager
         let sidebarState: SidebarState
         let sidebarSelectionState: SidebarSelectionState
+        let fileBrowserDrawerState: FileBrowserDrawerState
         weak var window: NSWindow?
 
         init(
@@ -2157,12 +2158,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             tabManager: TabManager,
             sidebarState: SidebarState,
             sidebarSelectionState: SidebarSelectionState,
+            fileBrowserDrawerState: FileBrowserDrawerState,
             window: NSWindow?
         ) {
             self.windowId = windowId
             self.tabManager = tabManager
             self.sidebarState = sidebarState
             self.sidebarSelectionState = sidebarSelectionState
+            self.fileBrowserDrawerState = fileBrowserDrawerState
             self.window = window
         }
     }
@@ -3209,6 +3212,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             SessionPersistencePolicy.sanitizedSidebarWidth(snapshot.sidebar.width)
         )
         context.sidebarSelectionState.selection = snapshot.sidebar.selection.sidebarSelection
+        if let drawerSnapshot = snapshot.fileBrowserDrawer {
+            context.fileBrowserDrawerState.isVisible = drawerSnapshot.isVisible
+            context.fileBrowserDrawerState.persistedWidth = CGFloat(
+                SessionPersistencePolicy.sanitizedDrawerWidth(drawerSnapshot.width)
+            )
+        }
 
         if let restoredFrame = resolvedWindowFrame(from: snapshot), let window {
             window.setFrame(restoredFrame, display: true)
@@ -3691,6 +3700,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             hasher.combine(
                 Int(SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth)).rounded())
             )
+            hasher.combine(context.fileBrowserDrawerState.isVisible)
+            hasher.combine(
+                Int(SessionPersistencePolicy.sanitizedDrawerWidth(Double(context.fileBrowserDrawerState.persistedWidth)).rounded())
+            )
 
             switch context.sidebarSelectionState.selection {
             case .tabs:
@@ -3997,6 +4010,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         isVisible: context.sidebarState.isVisible,
                         selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
                         width: SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth))
+                    ),
+                    fileBrowserDrawer: SessionFileBrowserDrawerSnapshot(
+                        isVisible: context.fileBrowserDrawerState.isVisible,
+                        width: SessionPersistencePolicy.sanitizedDrawerWidth(Double(context.fileBrowserDrawerState.persistedWidth))
                     )
                 )
             }
@@ -4068,7 +4085,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowId: UUID,
         tabManager: TabManager,
         sidebarState: SidebarState,
-        sidebarSelectionState: SidebarSelectionState
+        sidebarSelectionState: SidebarSelectionState,
+        fileBrowserDrawerState: FileBrowserDrawerState? = nil
     ) {
         tabManager.window = window
 
@@ -4087,6 +4105,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 tabManager: tabManager,
                 sidebarState: sidebarState,
                 sidebarSelectionState: sidebarSelectionState,
+                fileBrowserDrawerState: fileBrowserDrawerState ?? FileBrowserDrawerState(),
                 window: window
             )
             NotificationCenter.default.addObserver(
@@ -5684,6 +5703,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return false
     }
 
+    @discardableResult
+    func toggleFileBrowserDrawerInActiveMainWindow() -> Bool {
+        if let activeManager = tabManager,
+           let activeContext = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }) {
+            if let window = activeContext.window ?? windowForMainWindowId(activeContext.windowId) {
+                setActiveMainWindow(window)
+            }
+            activeContext.fileBrowserDrawerState.toggle()
+            return true
+        }
+        if let keyContext = contextForMainWindow(NSApp.keyWindow) {
+            if let window = keyContext.window ?? windowForMainWindowId(keyContext.windowId) {
+                setActiveMainWindow(window)
+            }
+            keyContext.fileBrowserDrawerState.toggle()
+            return true
+        }
+        if let mainContext = contextForMainWindow(NSApp.mainWindow) {
+            if let window = mainContext.window ?? windowForMainWindowId(mainContext.windowId) {
+                setActiveMainWindow(window)
+            }
+            mainContext.fileBrowserDrawerState.toggle()
+            return true
+        }
+        if let fallbackContext = mainWindowContexts.values.first {
+            if let window = fallbackContext.window ?? windowForMainWindowId(fallbackContext.windowId) {
+                setActiveMainWindow(window)
+            }
+            fallbackContext.fileBrowserDrawerState.toggle()
+            return true
+        }
+        return false
+    }
+
     func sidebarVisibility(windowId: UUID) -> Bool? {
         mainWindowContexts.values.first(where: { $0.windowId == windowId })?.sidebarState.isVisible
     }
@@ -6239,6 +6292,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let sidebarSelectionState = SidebarSelectionState(
             selection: sessionWindowSnapshot?.sidebar.selection.sidebarSelection ?? .tabs
         )
+        let drawerWidth = sessionWindowSnapshot?.fileBrowserDrawer?.width
+            .map(SessionPersistencePolicy.sanitizedDrawerWidth)
+            ?? SessionPersistencePolicy.defaultDrawerWidth
+        let fileBrowserDrawerState = FileBrowserDrawerState(
+            isVisible: sessionWindowSnapshot?.fileBrowserDrawer?.isVisible ?? false,
+            persistedWidth: CGFloat(drawerWidth)
+        )
         let notificationStore = TerminalNotificationStore.shared
 
         let cmuxConfigStore = CmuxConfigStore()
@@ -6251,6 +6311,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarState)
             .environmentObject(sidebarSelectionState)
             .environmentObject(cmuxConfigStore)
+            .environmentObject(fileBrowserDrawerState)
 
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.
@@ -6330,7 +6391,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             windowId: windowId,
             tabManager: tabManager,
             sidebarState: sidebarState,
-            sidebarSelectionState: sidebarSelectionState
+            sidebarSelectionState: sidebarSelectionState,
+            fileBrowserDrawerState: fileBrowserDrawerState
         )
         installFileDropOverlay(on: window, tabManager: tabManager)
         if TerminalController.shouldSuppressSocketCommandActivation() {
@@ -9915,6 +9977,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Primary UI shortcuts
         if matchConfiguredShortcut(event: event, action: .toggleSidebar) {
             _ = toggleSidebarInActiveMainWindow()
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .toggleFileBrowserDrawer) {
+            _ = toggleFileBrowserDrawerInActiveMainWindow()
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2205,6 +2205,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     weak var tabManager: TabManager?
     weak var notificationStore: TerminalNotificationStore?
     weak var sidebarState: SidebarState?
+    weak var fileBrowserDrawerState: FileBrowserDrawerState?
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
     weak var sidebarSelectionState: SidebarSelectionState?
     var shortcutLayoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
@@ -2938,10 +2939,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
     }
 
-    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState) {
+    func configure(tabManager: TabManager, notificationStore: TerminalNotificationStore, sidebarState: SidebarState, fileBrowserDrawerState: FileBrowserDrawerState) {
         self.tabManager = tabManager
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
+        self.fileBrowserDrawerState = fileBrowserDrawerState
         disableSuddenTerminationIfNeeded()
         installLifecycleSnapshotObserversIfNeeded()
         prepareStartupSessionSnapshotIfNeeded()
@@ -4086,7 +4088,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         tabManager: TabManager,
         sidebarState: SidebarState,
         sidebarSelectionState: SidebarSelectionState,
-        fileBrowserDrawerState: FileBrowserDrawerState? = nil
+        fileBrowserDrawerState: FileBrowserDrawerState
     ) {
         tabManager.window = window
 
@@ -4105,7 +4107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 tabManager: tabManager,
                 sidebarState: sidebarState,
                 sidebarSelectionState: sidebarSelectionState,
-                fileBrowserDrawerState: fileBrowserDrawerState ?? FileBrowserDrawerState(),
+                fileBrowserDrawerState: fileBrowserDrawerState,
                 window: window
             )
             NotificationCenter.default.addObserver(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2743,6 +2743,14 @@ struct ContentView: View {
                             }
                     )
                     .modifier(SidebarResizerAccessibilityModifier(accessibilityIdentifier: "FileBrowserDrawerResizer"))
+                    .onDisappear {
+                        if isDrawerResizerDragging {
+                            TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                            isDrawerResizerDragging = false
+                            drawerDragStartWidth = nil
+                        }
+                        scheduleSidebarResizerCursorRelease(force: true)
+                    }
 
                 Color.clear
                     .frame(maxWidth: .infinity)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2632,9 +2632,6 @@ struct ContentView: View {
             directory: directory,
             onFileSelected: { path in
                 openFileInTextEditor(path)
-            },
-            onClose: {
-                fileBrowserDrawerState.toggle()
             }
         )
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1799,7 +1799,11 @@ struct ContentView: View {
     @EnvironmentObject var sidebarState: SidebarState
     @EnvironmentObject var sidebarSelectionState: SidebarSelectionState
     @EnvironmentObject var cmuxConfigStore: CmuxConfigStore
+    @EnvironmentObject var fileBrowserDrawerState: FileBrowserDrawerState
     @State private var sidebarWidth: CGFloat = 200
+    @State private var drawerWidth: CGFloat = 250
+    @State private var isDrawerResizerDragging = false
+    @State private var drawerDragStartWidth: CGFloat?
     @State private var hoveredResizerHandles: Set<SidebarResizerHandle> = []
     @State private var isResizerDragging = false
     @State private var sidebarDragStartWidth: CGFloat?
@@ -2358,7 +2362,7 @@ struct ContentView: View {
     private func releaseSidebarResizerCursorIfNeeded(force: Bool = false) {
         let isLeftMouseButtonDown = CGEventSource.buttonState(.combinedSessionState, button: .left)
         let shouldKeepCursor = !force
-            && (isResizerDragging || isResizerBandActive || !hoveredResizerHandles.isEmpty || isLeftMouseButtonDown)
+            && (isResizerDragging || isDrawerResizerDragging || isResizerBandActive || !hoveredResizerHandles.isEmpty || isLeftMouseButtonDown)
         guard !shouldKeepCursor else { return }
         guard isSidebarResizerCursorActive else { return }
         isSidebarResizerCursorActive = false
@@ -2386,9 +2390,18 @@ struct ContentView: View {
         return point.x >= minX && point.x <= maxX
     }
 
+    private func drawerDividerBandContains(pointInContent point: NSPoint, contentBounds: NSRect) -> Bool {
+        guard fileBrowserDrawerState.isVisible else { return false }
+        guard point.y >= contentBounds.minY, point.y <= contentBounds.maxY else { return false }
+        let drawerHitWidth: CGFloat = 12
+        let drawerEdge = (sidebarState.isVisible ? sidebarWidth : 0) + drawerWidth
+        let minX = drawerEdge - drawerHitWidth
+        let maxX = drawerEdge + drawerHitWidth
+        return point.x >= minX && point.x <= maxX
+    }
+
     private func updateSidebarResizerBandState(using event: NSEvent? = nil) {
-        guard sidebarState.isVisible,
-              let window = observedWindow,
+        guard let window = observedWindow,
               let contentView = window.contentView else {
             isResizerBandActive = false
             scheduleSidebarResizerCursorRelease(force: true)
@@ -2400,10 +2413,11 @@ struct ContentView: View {
         // event locations during cursor updates, which causes visible cursor flicker.
         let pointInWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
         let pointInContent = contentView.convert(pointInWindow, from: nil)
-        let isInDividerBand = dividerBandContains(pointInContent: pointInContent, contentBounds: contentView.bounds)
-        isResizerBandActive = isInDividerBand
+        let isInSidebarDividerBand = sidebarState.isVisible && dividerBandContains(pointInContent: pointInContent, contentBounds: contentView.bounds)
+        let isInDrawerDividerBand = drawerDividerBandContains(pointInContent: pointInContent, contentBounds: contentView.bounds)
+        isResizerBandActive = isInSidebarDividerBand || isInDrawerDividerBand
 
-        if isInDividerBand || isResizerDragging {
+        if isInSidebarDividerBand || isInDrawerDividerBand || isResizerDragging || isDrawerResizerDragging {
             activateSidebarResizerCursor()
             startSidebarResizerCursorStabilizer()
             // AppKit cursorUpdate handlers from overlapped portal/web views can run
@@ -2424,7 +2438,7 @@ struct ContentView: View {
         timer.schedule(deadline: .now(), repeating: .milliseconds(16), leeway: .milliseconds(2))
         timer.setEventHandler {
             updateSidebarResizerBandState()
-            if isResizerBandActive || isResizerDragging {
+            if isResizerBandActive || isResizerDragging || isDrawerResizerDragging {
                 Self.fixedSidebarResizeCursor.set()
             } else {
                 stopSidebarResizerCursorStabilizer()
@@ -2464,7 +2478,7 @@ struct ContentView: View {
                     return false
                 }
             }()
-            if shouldOverrideCursorEvent, (isResizerBandActive || isResizerDragging) {
+            if shouldOverrideCursorEvent, (isResizerBandActive || isResizerDragging || isDrawerResizerDragging) {
                 // Consume hover motion in divider band so overlapped views cannot
                 // continuously reassert their own cursor while we are resizing.
                 activateSidebarResizerCursor()
@@ -2600,6 +2614,145 @@ struct ContentView: View {
         )
         .frame(width: sidebarWidth)
         .frame(maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - File browser drawer
+
+    private var fileBrowserDrawerContent: some View {
+        let directory: String? = {
+            guard let workspace = tabManager.selectedWorkspace else { return nil }
+            if let focusedPanelId = workspace.focusedPanelId,
+               let dir = workspace.panelDirectories[focusedPanelId], !dir.isEmpty {
+                return dir
+            }
+            let cwd = workspace.currentDirectory
+            return cwd.isEmpty ? nil : cwd
+        }()
+        return FileBrowserDrawerView(
+            directory: directory,
+            onFileSelected: { path in
+                openFileInTextEditor(path)
+            },
+            onClose: {
+                fileBrowserDrawerState.toggle()
+            }
+        )
+    }
+
+    private func openFileInTextEditor(_ path: String) {
+        guard let workspace = tabManager.selectedWorkspace else { return }
+
+        // If this file is already open, just focus it.
+        for paneId in workspace.bonsplitController.allPaneIds {
+            for tab in workspace.bonsplitController.tabs(inPane: paneId) {
+                guard let panelId = workspace.panelIdFromSurfaceId(tab.id),
+                      let textEditor = workspace.textEditorPanel(for: panelId),
+                      textEditor.filePath == path else { continue }
+                workspace.bonsplitController.focusPane(paneId)
+                workspace.bonsplitController.selectTab(tab.id)
+                return
+            }
+        }
+
+        // If a text editor already exists in this workspace, open the new file
+        // as a tab in the same pane.
+        for paneId in workspace.bonsplitController.allPaneIds {
+            let tabs = workspace.bonsplitController.tabs(inPane: paneId)
+            let hasTextEditor = tabs.contains { tab in
+                guard let panelId = workspace.panelIdFromSurfaceId(tab.id) else { return false }
+                return workspace.textEditorPanel(for: panelId) != nil
+            }
+            if hasTextEditor {
+                _ = workspace.newTextEditorSurface(
+                    inPane: paneId,
+                    filePath: path,
+                    focus: true
+                )
+                return
+            }
+        }
+
+        // No existing text editor — split from the focused panel.
+        if let focusedPanelId = workspace.focusedPanelId {
+            _ = workspace.newTextEditorSplit(
+                from: focusedPanelId,
+                orientation: .horizontal,
+                filePath: path,
+                focus: true
+            )
+        } else if let paneId = workspace.bonsplitController.focusedPaneId {
+            _ = workspace.newTextEditorSurface(
+                inPane: paneId,
+                filePath: path,
+                focus: true
+            )
+        }
+    }
+
+    private func clampedDrawerWidth(_ candidate: CGFloat) -> CGFloat {
+        let minW = CGFloat(SessionPersistencePolicy.minimumDrawerWidth)
+        let maxW = CGFloat(SessionPersistencePolicy.maximumDrawerWidth)
+        guard candidate.isFinite else { return CGFloat(SessionPersistencePolicy.defaultDrawerWidth) }
+        return max(minW, min(maxW, candidate))
+    }
+
+    private var drawerResizerOverlay: some View {
+        GeometryReader { proxy in
+            let totalWidth = max(0, proxy.size.width)
+            let sidebarPortion = sidebarState.isVisible ? sidebarWidth : 0
+            let dividerX = min(max(sidebarPortion + drawerWidth, 0), totalWidth)
+            let drawerHitWidth: CGFloat = 12
+            let leadingWidth = max(0, dividerX - drawerHitWidth)
+
+            HStack(spacing: 0) {
+                Color.clear
+                    .frame(width: leadingWidth)
+                    .allowsHitTesting(false)
+
+                Color.clear
+                    .frame(width: drawerHitWidth * 2)
+                    .frame(maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        if hovering {
+                            activateSidebarResizerCursor()
+                        } else {
+                            scheduleSidebarResizerCursorRelease()
+                        }
+                    }
+                    .gesture(
+                        DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                            .onChanged { value in
+                                if !isDrawerResizerDragging {
+                                    TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+                                    isDrawerResizerDragging = true
+                                    drawerDragStartWidth = drawerWidth
+                                }
+                                activateSidebarResizerCursor()
+                                let startWidth = drawerDragStartWidth ?? drawerWidth
+                                let nextWidth = clampedDrawerWidth(startWidth + value.translation.width)
+                                withTransaction(Transaction(animation: nil)) {
+                                    drawerWidth = nextWidth
+                                }
+                            }
+                            .onEnded { _ in
+                                if isDrawerResizerDragging {
+                                    TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                                    isDrawerResizerDragging = false
+                                    drawerDragStartWidth = nil
+                                }
+                                fileBrowserDrawerState.persistedWidth = drawerWidth
+                                scheduleSidebarResizerCursorRelease()
+                            }
+                    )
+                    .modifier(SidebarResizerAccessibilityModifier(accessibilityIdentifier: "FileBrowserDrawerResizer"))
+
+                Color.clear
+                    .frame(maxWidth: .infinity)
+                    .allowsHitTesting(false)
+            }
+            .frame(width: totalWidth, height: proxy.size.height, alignment: .leading)
+        }
     }
 
     /// Space at top of content area for the titlebar. This must be at least the actual titlebar
@@ -2868,6 +3021,10 @@ struct ContentView: View {
         return dir.isEmpty ? nil : dir
     }
 
+    private var effectiveDrawerWidth: CGFloat {
+        fileBrowserDrawerState.isVisible ? drawerWidth : 0
+    }
+
     private var contentAndSidebarLayout: AnyView {
         let layout: AnyView
         // When matching terminal background, use HStack so both sidebar and terminal
@@ -2877,12 +3034,19 @@ struct ContentView: View {
         if useWithinWindow {
             // Overlay mode: terminal extends full width, sidebar on top
             // This allows withinWindow blur to see the terminal content
+            let leftPadding = (sidebarState.isVisible ? sidebarWidth : 0) + effectiveDrawerWidth
             layout = AnyView(
                 ZStack(alignment: .leading) {
                     terminalContentWithSidebarDropOverlay
-                        .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
+                        .padding(.leading, leftPadding)
                     if sidebarState.isVisible {
                         sidebarView
+                    }
+                    if fileBrowserDrawerState.isVisible {
+                        fileBrowserDrawerContent
+                            .frame(width: drawerWidth)
+                            .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
+                            .transaction { $0.animation = nil }
                     }
                 }
             )
@@ -2892,6 +3056,11 @@ struct ContentView: View {
                 HStack(spacing: 0) {
                     if sidebarState.isVisible {
                         sidebarView
+                    }
+                    if fileBrowserDrawerState.isVisible {
+                        fileBrowserDrawerContent
+                            .frame(width: drawerWidth)
+                            .transaction { $0.animation = nil }
                     }
                     terminalContentWithSidebarDropOverlay
                 }
@@ -2904,6 +3073,10 @@ struct ContentView: View {
                     if sidebarState.isVisible {
                         sidebarResizerOverlay
                             .zIndex(1000)
+                    }
+                    if fileBrowserDrawerState.isVisible {
+                        drawerResizerOverlay
+                            .zIndex(1001)
                     }
                 }
         )
@@ -2935,6 +3108,10 @@ struct ContentView: View {
             }
             if abs(sidebarState.persistedWidth - restoredWidth) > 0.5 {
                 sidebarState.persistedWidth = restoredWidth
+            }
+            let restoredDrawerWidth = CGFloat(SessionPersistencePolicy.sanitizedDrawerWidth(Double(fileBrowserDrawerState.persistedWidth)))
+            if abs(drawerWidth - restoredDrawerWidth) > 0.5 {
+                drawerWidth = restoredDrawerWidth
             }
             if selectedTabIds.isEmpty, let selectedId = tabManager.selectedTabId {
                 selectedTabIds = [selectedId]
@@ -3496,7 +3673,8 @@ struct ContentView: View {
                 windowId: windowId,
                 tabManager: tabManager,
                 sidebarState: sidebarState,
-                sidebarSelectionState: sidebarSelectionState
+                sidebarSelectionState: sidebarSelectionState,
+                fileBrowserDrawerState: fileBrowserDrawerState
             )
             installFileDropOverlay(on: window, tabManager: tabManager)
         }))
@@ -6025,6 +6203,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.kind.browser", defaultValue: "Browser")
         case .markdown:
             return String(localized: "commandPalette.kind.markdown", defaultValue: "Markdown")
+        case .textEditor:
+            return String(localized: "textEditor.panel.kindLabel", defaultValue: "Text Editor")
         }
     }
 
@@ -6036,6 +6216,8 @@ struct ContentView: View {
             return ["browser", "web", "page"]
         case .markdown:
             return ["markdown", "note", "preview"]
+        case .textEditor:
+            return ["editor", "text", "file"]
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3573,6 +3573,18 @@ struct ContentView: View {
             syncTrafficLightInset()
         })
 
+        view = AnyView(view.onChange(of: drawerWidth) { _ in
+            if let observedWindow {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+            }
+        })
+
+        view = AnyView(view.onChange(of: fileBrowserDrawerState.isVisible) { _ in
+            if let observedWindow {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+            }
+        })
+
         view = AnyView(view.onChange(of: sidebarState.persistedWidth) { newValue in
             let sanitized = normalizedSidebarWidth(newValue)
             if abs(newValue - sanitized) > 0.5 {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2670,13 +2670,14 @@ struct ContentView: View {
         }
 
         // No existing text editor — split from the focused panel.
-        if let focusedPanelId = workspace.focusedPanelId {
-            _ = workspace.newTextEditorSplit(
-                from: focusedPanelId,
-                orientation: .horizontal,
-                filePath: path,
-                focus: true
-            )
+        if let focusedPanelId = workspace.focusedPanelId,
+           workspace.newTextEditorSplit(
+               from: focusedPanelId,
+               orientation: .horizontal,
+               filePath: path,
+               focus: true
+           ) != nil {
+            // Split succeeded
         } else if let paneId = workspace.bonsplitController.focusedPaneId {
             _ = workspace.newTextEditorSurface(
                 inPane: paneId,
@@ -2748,6 +2749,7 @@ struct ContentView: View {
                             TerminalWindowPortalRegistry.endInteractiveGeometryResize()
                             isDrawerResizerDragging = false
                             drawerDragStartWidth = nil
+                            fileBrowserDrawerState.persistedWidth = drawerWidth
                         }
                         scheduleSidebarResizerCursorRelease(force: true)
                     }
@@ -3576,12 +3578,16 @@ struct ContentView: View {
         view = AnyView(view.onChange(of: drawerWidth) { _ in
             if let observedWindow {
                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+            } else {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
             }
         })
 
         view = AnyView(view.onChange(of: fileBrowserDrawerState.isVisible) { _ in
             if let observedWindow {
                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+            } else {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
             }
         })
 

--- a/Sources/FileBrowser/FileBrowserDrawerView.swift
+++ b/Sources/FileBrowser/FileBrowserDrawerView.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 
 /// Structural container for the file browser drawer.
-/// Shows a header with title + close button, and the file browser tree.
+/// Shows the file browser tree with a spacer for titlebar button clearance.
 struct FileBrowserDrawerView: View {
     let directory: String?
     let onFileSelected: (String) -> Void
-    let onClose: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -34,22 +33,6 @@ struct FileBrowserDrawerView: View {
                 .fill(Color.primary.opacity(0.12))
                 .frame(width: 1)
         }
-    }
-
-    private var headerView: some View {
-        HStack {
-            Button {
-                onClose()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
     }
 
     private var emptyStateView: some View {

--- a/Sources/FileBrowser/FileBrowserDrawerView.swift
+++ b/Sources/FileBrowser/FileBrowserDrawerView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Structural container for the file browser drawer.
+/// Shows a header with title + close button, and the file browser tree.
+struct FileBrowserDrawerView: View {
+    let directory: String?
+    let onFileSelected: (String) -> Void
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                // Empty header bar for titlebar button clearance.
+                Spacer()
+                    .frame(height: 28)
+                Divider()
+
+                if let directory {
+                    FileBrowserView(
+                        rootPath: directory,
+                        onFileSelected: onFileSelected
+                    )
+                } else {
+                    emptyStateView
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(backgroundColor)
+
+            // Visible right-edge divider so users can find the resize handle.
+            Rectangle()
+                .fill(Color.primary.opacity(0.12))
+                .frame(width: 1)
+        }
+    }
+
+    private var headerView: some View {
+        HStack {
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "folder")
+                .font(.system(size: 28))
+                .foregroundColor(.secondary)
+            Text(String(localized: "fileBrowser.emptyState", defaultValue: "Focus a terminal to browse its working directory."))
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var backgroundColor: Color {
+        colorScheme == .dark
+            ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
+            : Color(nsColor: NSColor(white: 0.95, alpha: 1.0))
+    }
+}

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -21,7 +21,7 @@ struct FileBrowserView: View {
             coordinator.setRootPath(rootPath)
         }
         .onDisappear {
-            coordinator.stopDirectoryWatcher()
+            coordinator.reset()
         }
         .onChange(of: rootPath) { newPath in
             coordinator.setRootPath(newPath)
@@ -236,6 +236,11 @@ final class FileBrowserCoordinator: ObservableObject {
     func stopDirectoryWatcher() {
         directoryWatchSource?.cancel()
         directoryWatchSource = nil
+    }
+
+    /// Called on disappear — clears root path so reappear with same path re-arms.
+    func reset() {
+        stopDirectoryWatcher()
         currentRootPath = nil
     }
 

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -105,6 +105,7 @@ final class FileBrowserCoordinator: ObservableObject {
 
     private var currentRootPath: String?
     private nonisolated(unsafe) var directoryWatchSource: DispatchSourceFileSystemObject?
+    private var loadGeneration: UInt64 = 0
 
     private static let loadQueue = DispatchQueue(label: "com.cmux.file-browser", qos: .userInitiated)
 
@@ -147,19 +148,25 @@ final class FileBrowserCoordinator: ObservableObject {
 
     private func loadRootDirectory() {
         guard let path = currentRootPath else { return }
+        loadGeneration &+= 1
+        let generation = loadGeneration
         Self.loadQueue.async { [weak self] in
             let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
             DispatchQueue.main.async {
-                self?.rootEntries = entries
+                guard let self, generation == self.loadGeneration else { return }
+                self.rootEntries = entries
             }
         }
     }
 
     private func loadSubdirectory(_ path: String) {
+        loadGeneration &+= 1
+        let generation = loadGeneration
         Self.loadQueue.async { [weak self] in
             let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
             DispatchQueue.main.async {
-                self?.directoryContents[path] = entries
+                guard let self, generation == self.loadGeneration else { return }
+                self.directoryContents[path] = entries
             }
         }
     }
@@ -228,6 +235,7 @@ final class FileBrowserCoordinator: ObservableObject {
     func stopDirectoryWatcher() {
         directoryWatchSource?.cancel()
         directoryWatchSource = nil
+        currentRootPath = nil
     }
 
     deinit {

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -105,7 +105,8 @@ final class FileBrowserCoordinator: ObservableObject {
 
     private var currentRootPath: String?
     private nonisolated(unsafe) var directoryWatchSource: DispatchSourceFileSystemObject?
-    private var loadGeneration: UInt64 = 0
+    private var rootLoadGeneration: UInt64 = 0
+    private var subdirLoadGeneration: UInt64 = 0
 
     private static let loadQueue = DispatchQueue(label: "com.cmux.file-browser", qos: .userInitiated)
 
@@ -148,24 +149,24 @@ final class FileBrowserCoordinator: ObservableObject {
 
     private func loadRootDirectory() {
         guard let path = currentRootPath else { return }
-        loadGeneration &+= 1
-        let generation = loadGeneration
+        rootLoadGeneration &+= 1
+        let generation = rootLoadGeneration
         Self.loadQueue.async { [weak self] in
             let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: true)
             DispatchQueue.main.async {
-                guard let self, generation == self.loadGeneration else { return }
+                guard let self, generation == self.rootLoadGeneration else { return }
                 self.rootEntries = entries
             }
         }
     }
 
     private func loadSubdirectory(_ path: String) {
-        loadGeneration &+= 1
-        let generation = loadGeneration
+        subdirLoadGeneration &+= 1
+        let generation = subdirLoadGeneration
         Self.loadQueue.async { [weak self] in
             let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: true)
             DispatchQueue.main.async {
-                guard let self, generation == self.loadGeneration else { return }
+                guard let self, generation == self.subdirLoadGeneration else { return }
                 self.directoryContents[path] = entries
             }
         }

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -106,7 +106,6 @@ final class FileBrowserCoordinator: ObservableObject {
     private var currentRootPath: String?
     private nonisolated(unsafe) var directoryWatchSource: DispatchSourceFileSystemObject?
     private var rootLoadGeneration: UInt64 = 0
-    private var subdirLoadGeneration: UInt64 = 0
 
     private static let loadQueue = DispatchQueue(label: "com.cmux.file-browser", qos: .userInitiated)
 
@@ -161,12 +160,10 @@ final class FileBrowserCoordinator: ObservableObject {
     }
 
     private func loadSubdirectory(_ path: String) {
-        subdirLoadGeneration &+= 1
-        let generation = subdirLoadGeneration
         Self.loadQueue.async { [weak self] in
             let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: true)
             DispatchQueue.main.async {
-                guard let self, generation == self.subdirLoadGeneration else { return }
+                guard let self, self.expandedDirectories.contains(path) else { return }
                 self.directoryContents[path] = entries
             }
         }

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+import Foundation
+
+/// A file browser tree view that displays the contents of a directory.
+struct FileBrowserView: View {
+    let rootPath: String
+    let onFileSelected: (String) -> Void
+
+    @StateObject private var coordinator = FileBrowserCoordinator()
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(coordinator.flattenedEntries) { item in
+                    fileBrowserRow(item: item)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .onAppear {
+            coordinator.setRootPath(rootPath)
+        }
+        .onDisappear {
+            coordinator.stopDirectoryWatcher()
+        }
+        .onChange(of: rootPath) { newPath in
+            coordinator.setRootPath(newPath)
+        }
+    }
+
+    // MARK: - Row view
+
+    private func fileBrowserRow(item: FileBrowserFlatItem) -> some View {
+        let entry = item.entry
+        return Button {
+            if entry.isDirectory {
+                coordinator.toggleDirectory(entry.path)
+            } else {
+                onFileSelected(entry.path)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                if entry.isDirectory {
+                    Image(systemName: coordinator.expandedDirectories.contains(entry.path) ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .frame(width: 12)
+                } else {
+                    Color.clear.frame(width: 12)
+                }
+                Image(systemName: entry.isDirectory ? "folder.fill" : fileIcon(for: entry.name))
+                    .font(.system(size: 12))
+                    .foregroundColor(entry.isDirectory ? .accentColor : .secondary)
+                    .frame(width: 16)
+                Text(entry.name)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+            }
+            .padding(.leading, CGFloat(item.depth) * 16 + 8)
+            .padding(.vertical, 3)
+            .padding(.trailing, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - File icons
+
+    private func fileIcon(for name: String) -> String {
+        let ext = (name as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift", "py", "js", "ts", "rb", "go", "rs", "c", "cpp", "h", "m", "java", "kt", "zig":
+            return "doc.text"
+        case "json", "yaml", "yml", "toml", "xml", "plist":
+            return "doc.badge.gearshape"
+        case "md", "markdown", "txt", "rtf":
+            return "doc.plaintext"
+        case "png", "jpg", "jpeg", "gif", "svg", "ico", "webp":
+            return "photo"
+        case "pdf":
+            return "doc.richtext"
+        default:
+            return "doc"
+        }
+    }
+}
+
+// MARK: - Flat item for non-recursive rendering
+
+struct FileBrowserFlatItem: Identifiable {
+    let entry: FileBrowserEntry
+    let depth: Int
+    var id: String { "\(depth):\(entry.path)" }
+}
+
+// MARK: - Coordinator (reference type for DispatchSource safety)
+
+@MainActor
+final class FileBrowserCoordinator: ObservableObject {
+    @Published var rootEntries: [FileBrowserEntry] = []
+    @Published var expandedDirectories: Set<String> = []
+    @Published var directoryContents: [String: [FileBrowserEntry]] = [:]
+
+    private var currentRootPath: String?
+    private nonisolated(unsafe) var directoryWatchSource: DispatchSourceFileSystemObject?
+
+    private static let loadQueue = DispatchQueue(label: "com.cmux.file-browser", qos: .userInitiated)
+
+    /// Flattened tree for non-recursive ForEach rendering.
+    var flattenedEntries: [FileBrowserFlatItem] {
+        var result: [FileBrowserFlatItem] = []
+        func flatten(_ entries: [FileBrowserEntry], depth: Int) {
+            for entry in entries {
+                result.append(FileBrowserFlatItem(entry: entry, depth: depth))
+                if entry.isDirectory && expandedDirectories.contains(entry.path),
+                   let children = directoryContents[entry.path] {
+                    flatten(children, depth: depth + 1)
+                }
+            }
+        }
+        flatten(rootEntries, depth: 0)
+        return result
+    }
+
+    func setRootPath(_ path: String) {
+        guard path != currentRootPath else { return }
+        currentRootPath = path
+        expandedDirectories.removeAll()
+        directoryContents.removeAll()
+        stopDirectoryWatcher()
+        loadRootDirectory()
+        startDirectoryWatcher()
+    }
+
+    func toggleDirectory(_ path: String) {
+        if expandedDirectories.contains(path) {
+            expandedDirectories.remove(path)
+        } else {
+            expandedDirectories.insert(path)
+            loadSubdirectory(path)
+        }
+    }
+
+    // MARK: - Directory loading
+
+    private func loadRootDirectory() {
+        guard let path = currentRootPath else { return }
+        Self.loadQueue.async { [weak self] in
+            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
+            DispatchQueue.main.async {
+                self?.rootEntries = entries
+            }
+        }
+    }
+
+    private func loadSubdirectory(_ path: String) {
+        Self.loadQueue.async { [weak self] in
+            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
+            DispatchQueue.main.async {
+                self?.directoryContents[path] = entries
+            }
+        }
+    }
+
+    /// Pure function — safe to call from any thread.
+    nonisolated static func loadDirectorySync(atPath path: String, showHidden: Bool) -> [FileBrowserEntry] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(atPath: path) else {
+            return []
+        }
+
+        var dirs: [FileBrowserEntry] = []
+        var files: [FileBrowserEntry] = []
+
+        for name in contents {
+            if !showHidden && name.hasPrefix(".") { continue }
+
+            let fullPath = (path as NSString).appendingPathComponent(name)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: fullPath, isDirectory: &isDir) else { continue }
+
+            let entry = FileBrowserEntry(name: name, path: fullPath, isDirectory: isDir.boolValue)
+            if isDir.boolValue {
+                dirs.append(entry)
+            } else {
+                files.append(entry)
+            }
+        }
+
+        dirs.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        files.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        return dirs + files
+    }
+
+    // MARK: - Directory watcher
+
+    func startDirectoryWatcher() {
+        guard let path = currentRootPath else { return }
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename, .extend],
+            queue: Self.loadQueue
+        )
+
+        source.setEventHandler { [weak self] in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.loadRootDirectory()
+                for dir in self.expandedDirectories {
+                    self.loadSubdirectory(dir)
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            Darwin.close(fd)
+        }
+
+        source.resume()
+        directoryWatchSource = source
+    }
+
+    func stopDirectoryWatcher() {
+        directoryWatchSource?.cancel()
+        directoryWatchSource = nil
+    }
+
+    deinit {
+        directoryWatchSource?.cancel()
+    }
+}
+
+struct FileBrowserEntry: Identifiable {
+    let name: String
+    let path: String
+    let isDirectory: Bool
+    var id: String { path }
+}

--- a/Sources/FileBrowser/FileBrowserView.swift
+++ b/Sources/FileBrowser/FileBrowserView.swift
@@ -151,7 +151,7 @@ final class FileBrowserCoordinator: ObservableObject {
         loadGeneration &+= 1
         let generation = loadGeneration
         Self.loadQueue.async { [weak self] in
-            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
+            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: true)
             DispatchQueue.main.async {
                 guard let self, generation == self.loadGeneration else { return }
                 self.rootEntries = entries
@@ -163,7 +163,7 @@ final class FileBrowserCoordinator: ObservableObject {
         loadGeneration &+= 1
         let generation = loadGeneration
         Self.loadQueue.async { [weak self] in
-            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: false)
+            let entries = FileBrowserCoordinator.loadDirectorySync(atPath: path, showHidden: true)
             DispatchQueue.main.async {
                 guard let self, generation == self.loadGeneration else { return }
                 self.directoryContents[path] = entries

--- a/Sources/FileBrowserDrawerState.swift
+++ b/Sources/FileBrowserDrawerState.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Observable state for the file browser drawer panel.
+/// Mirrors the pattern used by `SidebarState` in `ContentView.swift`.
+@MainActor
+final class FileBrowserDrawerState: ObservableObject {
+    @Published var isVisible: Bool
+    @Published var persistedWidth: CGFloat
+
+    init(
+        isVisible: Bool = false,
+        persistedWidth: CGFloat = CGFloat(SessionPersistencePolicy.defaultDrawerWidth)
+    ) {
+        self.isVisible = isVisible
+        let sanitized = SessionPersistencePolicy.sanitizedDrawerWidth(Double(persistedWidth))
+        self.persistedWidth = CGFloat(sanitized)
+    }
+
+    func toggle() {
+        isVisible.toggle()
+    }
+}

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -77,6 +77,7 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
         case toggleReactGrab
+        case toggleFileBrowserDrawer
 
         var id: String { rawValue }
 
@@ -137,6 +138,7 @@ enum KeyboardShortcutSettings {
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             case .toggleReactGrab: return String(localized: "shortcut.toggleReactGrab.label", defaultValue: "Toggle React Grab")
+            case .toggleFileBrowserDrawer: return String(localized: "shortcut.toggleFileBrowserDrawer.label", defaultValue: "Toggle File Browser")
             }
         }
 
@@ -256,6 +258,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
             case .toggleReactGrab:
                 return StoredShortcut(key: "g", command: true, shift: false, option: true, control: false)
+            case .toggleFileBrowserDrawer:
+                return StoredShortcut(key: "b", command: true, shift: true, option: false, control: false)
             }
         }
 

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -7,6 +7,7 @@ public enum PanelType: String, Codable, Sendable {
     case terminal
     case browser
     case markdown
+    case textEditor
 }
 
 public enum TerminalPanelFocusIntent: Equatable {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -55,6 +55,16 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .textEditor:
+            if let textEditorPanel = panel as? TextEditorPanel {
+                TextEditorPanelView(
+                    panel: textEditorPanel,
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    portalPriority: portalPriority,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         }
     }
 }

--- a/Sources/Panels/TextEditorPanel.swift
+++ b/Sources/Panels/TextEditorPanel.swift
@@ -50,17 +50,17 @@ final class TextEditorPanel: Panel, ObservableObject {
 
     // MARK: - Init
 
+    private static let ioQueue = DispatchQueue(label: "com.cmux.text-editor-io", qos: .userInitiated)
+    private var loadGeneration: UInt64 = 0
+
     init(workspaceId: UUID, filePath: String) {
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = (filePath as NSString).lastPathComponent
 
-        loadFileContent()
+        loadFileContentAsync()
         startFileWatcher()
-        if isFileUnavailable && fileWatchSource == nil {
-            scheduleReattach(attempt: 1)
-        }
     }
 
     // MARK: - Panel protocol
@@ -104,26 +104,50 @@ final class TextEditorPanel: Panel, ObservableObject {
 
     /// Reload content from disk, discarding any unsaved edits.
     func reloadFromDisk() {
-        loadFileContent()
+        loadFileContentAsync()
         isDirty = false
         hasExternalChange = false
     }
 
     // MARK: - File I/O
 
-    private func loadFileContent() {
-        do {
-            let newContent = try String(contentsOfFile: filePath, encoding: .utf8)
-            content = newContent
-            isFileUnavailable = false
-        } catch {
-            if let data = FileManager.default.contents(atPath: filePath),
-               let decoded = String(data: data, encoding: .isoLatin1) {
-                content = decoded
-                isFileUnavailable = false
-            } else {
-                isFileUnavailable = true
+    /// Read file content on a background queue to avoid blocking the main thread.
+    private func loadFileContentAsync() {
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        let path = filePath
+        Self.ioQueue.async { [weak self] in
+            let result = Self.readFile(atPath: path)
+            DispatchQueue.main.async {
+                guard let self, self.loadGeneration == generation else { return }
+                switch result {
+                case .success(let text):
+                    self.content = text
+                    self.isFileUnavailable = false
+                    if self.fileWatchSource == nil && !self.isClosed {
+                        self.startFileWatcher()
+                    }
+                case .failure:
+                    self.isFileUnavailable = true
+                    if self.fileWatchSource == nil && !self.isClosed {
+                        self.scheduleReattach(attempt: 1)
+                    }
+                }
             }
+        }
+    }
+
+    /// Pure function — safe to call from any thread.
+    private static func readFile(atPath path: String) -> Result<String, Error> {
+        do {
+            let text = try String(contentsOfFile: path, encoding: .utf8)
+            return .success(text)
+        } catch {
+            if let data = FileManager.default.contents(atPath: path),
+               let decoded = String(data: data, encoding: .isoLatin1) {
+                return .success(decoded)
+            }
+            return .failure(error)
         }
     }
 
@@ -157,7 +181,7 @@ final class TextEditorPanel: Panel, ObservableObject {
                             self.scheduleReattach(attempt: 1)
                         }
                     } else {
-                        self.loadFileContent()
+                        self.loadFileContentAsync()
                         if self.isFileUnavailable {
                             self.scheduleReattach(attempt: 1)
                         } else {
@@ -170,7 +194,7 @@ final class TextEditorPanel: Panel, ObservableObject {
                     if self.isDirty {
                         self.hasExternalChange = true
                     } else {
-                        self.loadFileContent()
+                        self.loadFileContentAsync()
                     }
                 }
             }
@@ -193,7 +217,7 @@ final class TextEditorPanel: Panel, ObservableObject {
                 if FileManager.default.fileExists(atPath: self.filePath) {
                     self.isFileUnavailable = false
                     if !self.isDirty {
-                        self.loadFileContent()
+                        self.loadFileContentAsync()
                     }
                     self.startFileWatcher()
                 } else {

--- a/Sources/Panels/TextEditorPanel.swift
+++ b/Sources/Panels/TextEditorPanel.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Combine
+import AppKit
+
+/// A panel that displays and edits a text file with live file-watching.
+@MainActor
+final class TextEditorPanel: Panel, ObservableObject {
+    let id: UUID
+    let panelType: PanelType = .textEditor
+
+    /// Absolute path to the file being edited.
+    let filePath: String
+
+    /// The workspace this panel belongs to.
+    private(set) var workspaceId: UUID
+
+    /// Current text content (read-write).
+    @Published var content: String = ""
+
+    /// Title shown in the tab bar (filename).
+    @Published private(set) var displayTitle: String = ""
+
+    /// SF Symbol icon for the tab bar.
+    var displayIcon: String? { "doc.text" }
+
+    /// Whether the content has unsaved changes.
+    @Published private(set) var isDirty: Bool = false
+
+    /// Whether the file has been modified on disk while there are unsaved edits.
+    @Published private(set) var hasExternalChange: Bool = false
+
+    /// Whether the file has been deleted or is unreadable.
+    @Published private(set) var isFileUnavailable: Bool = false
+
+    /// Token incremented to trigger focus flash animation.
+    @Published private(set) var focusFlashToken: Int = 0
+
+    /// Callback to make the NSTextView first responder.
+    var focusTextView: (() -> Void)?
+
+    // MARK: - File watching
+
+    private nonisolated(unsafe) var fileWatchSource: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+    private var isClosed: Bool = false
+    private let watchQueue = DispatchQueue(label: "com.cmux.text-editor-file-watch", qos: .utility)
+
+    private static let maxReattachAttempts = 6
+    private static let reattachDelay: TimeInterval = 0.5
+
+    // MARK: - Init
+
+    init(workspaceId: UUID, filePath: String) {
+        self.id = UUID()
+        self.workspaceId = workspaceId
+        self.filePath = filePath
+        self.displayTitle = (filePath as NSString).lastPathComponent
+
+        loadFileContent()
+        startFileWatcher()
+        if isFileUnavailable && fileWatchSource == nil {
+            scheduleReattach(attempt: 1)
+        }
+    }
+
+    // MARK: - Panel protocol
+
+    func focus() {
+        focusTextView?()
+    }
+
+    func unfocus() {
+        // No-op; NSTextView resignFirstResponder is handled by AppKit.
+    }
+
+    func close() {
+        isClosed = true
+        stopFileWatcher()
+    }
+
+    func triggerFlash() {
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
+        focusFlashToken += 1
+    }
+
+    // MARK: - Public API
+
+    /// Update content from the view layer (NSTextView delegate).
+    func setContentFromEditor(_ newContent: String) {
+        guard content != newContent else { return }
+        content = newContent
+        isDirty = true
+    }
+
+    /// Save content to disk atomically. UTF-8 only.
+    func save() throws {
+        guard let data = content.data(using: .utf8) else {
+            throw TextEditorSaveError.encodingFailed
+        }
+        try data.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+        isDirty = false
+        hasExternalChange = false
+    }
+
+    /// Reload content from disk, discarding any unsaved edits.
+    func reloadFromDisk() {
+        loadFileContent()
+        isDirty = false
+        hasExternalChange = false
+    }
+
+    // MARK: - File I/O
+
+    private func loadFileContent() {
+        do {
+            let newContent = try String(contentsOfFile: filePath, encoding: .utf8)
+            content = newContent
+            isFileUnavailable = false
+        } catch {
+            if let data = FileManager.default.contents(atPath: filePath),
+               let decoded = String(data: data, encoding: .isoLatin1) {
+                content = decoded
+                isFileUnavailable = false
+            } else {
+                isFileUnavailable = true
+            }
+        }
+    }
+
+    // MARK: - File watcher via DispatchSource
+
+    private func startFileWatcher() {
+        stopFileWatcher()
+        let fd = open(filePath, O_EVTONLY)
+        guard fd >= 0 else { return }
+        fileDescriptor = fd
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .delete, .rename, .extend],
+            queue: watchQueue
+        )
+
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            let flags = source.data
+            if flags.contains(.delete) || flags.contains(.rename) {
+                DispatchQueue.main.async {
+                    self.stopFileWatcher()
+                    if self.isDirty {
+                        self.hasExternalChange = true
+                        // Try to reattach watcher for future events.
+                        if FileManager.default.fileExists(atPath: self.filePath) {
+                            self.startFileWatcher()
+                        } else {
+                            self.isFileUnavailable = true
+                            self.scheduleReattach(attempt: 1)
+                        }
+                    } else {
+                        self.loadFileContent()
+                        if self.isFileUnavailable {
+                            self.scheduleReattach(attempt: 1)
+                        } else {
+                            self.startFileWatcher()
+                        }
+                    }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    if self.isDirty {
+                        self.hasExternalChange = true
+                    } else {
+                        self.loadFileContent()
+                    }
+                }
+            }
+        }
+
+        source.setCancelHandler {
+            Darwin.close(fd)
+        }
+
+        source.resume()
+        fileWatchSource = source
+    }
+
+    private func scheduleReattach(attempt: Int) {
+        guard attempt <= Self.maxReattachAttempts else { return }
+        watchQueue.asyncAfter(deadline: .now() + Self.reattachDelay) { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                guard !self.isClosed else { return }
+                if FileManager.default.fileExists(atPath: self.filePath) {
+                    self.isFileUnavailable = false
+                    if !self.isDirty {
+                        self.loadFileContent()
+                    }
+                    self.startFileWatcher()
+                } else {
+                    self.scheduleReattach(attempt: attempt + 1)
+                }
+            }
+        }
+    }
+
+    private func stopFileWatcher() {
+        if let source = fileWatchSource {
+            source.cancel()
+            fileWatchSource = nil
+        }
+        fileDescriptor = -1
+    }
+
+    deinit {
+        fileWatchSource?.cancel()
+    }
+}
+
+enum TextEditorSaveError: LocalizedError {
+    case encodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .encodingFailed:
+            return String(localized: "textEditor.save.error", defaultValue: "Failed to save file")
+        }
+    }
+}

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -1,0 +1,357 @@
+import AppKit
+import SwiftUI
+import CodeEditor
+
+// MARK: - Text Editor Theme Settings
+
+enum TextEditorThemeSettings {
+    static let darkThemeKey = "editorThemeDark"
+    static let lightThemeKey = "editorThemeLight"
+    static let defaultDarkTheme = "monokai-sublime"
+    static let defaultLightTheme = "github"
+
+    /// Dark themes (background luminance < 0.5), sorted alphabetically.
+    static let darkThemes: [String] = [
+        "3024", "a11y-dark", "agate", "an-old-hope", "androidstudio", "apathy",
+        "apprentice", "arta", "ashes", "atelier-cave-dark", "atelier-cave",
+        "atelier-dune-dark", "atelier-dune", "atelier-estuary-dark", "atelier-estuary",
+        "atelier-forest-dark", "atelier-forest", "atelier-heath-dark", "atelier-heath",
+        "atelier-lakeside-dark", "atelier-lakeside", "atelier-plateau-dark",
+        "atelier-plateau", "atelier-savanna-dark", "atelier-savanna",
+        "atelier-seaside-dark", "atelier-seaside", "atelier-sulphurpool-dark",
+        "atelier-sulphurpool", "atlas", "atom-one-dark-reasonable", "atom-one-dark",
+        "bespin", "black-metal-bathory", "black-metal-burzum",
+        "black-metal-dark-funeral", "black-metal-gorgoroth", "black-metal-immortal",
+        "black-metal-khold", "black-metal-marduk", "black-metal-mayhem",
+        "black-metal-nile", "black-metal-venom", "black-metal", "brewer", "bright",
+        "brogrammer", "brush-trees-dark", "chalk", "circus", "classic-dark",
+        "codepen-embed", "codeschool", "colors", "cybertopia-cherry",
+        "cybertopia-dimmer", "cybertopia-icecap", "cybertopia-saturated", "danqing",
+        "darcula", "dark-violet", "dark", "darkmoss", "darktooth", "decaf",
+        "default-dark", "devibeans", "dracula", "edge-dark", "eighties", "embers",
+        "equilibrium-dark", "equilibrium-gray-dark", "espresso", "eva-dim", "eva",
+        "felipec", "flat", "framer", "gigavolt", "github-dark-dimmed", "github-dark",
+        "gml", "google-dark", "gradient-dark", "grayscale-dark", "green-screen",
+        "gruvbox-dark-hard", "gruvbox-dark-medium", "gruvbox-dark-pale",
+        "gruvbox-dark-soft", "gruvbox-dark", "hardcore", "harmonic16-dark",
+        "heetch-dark", "helios", "hopscotch", "horizon-dark", "humanoid-dark",
+        "hybrid", "ia-dark", "icy-dark", "ir-black", "isbl-editor-dark", "isotope",
+        "kimber", "kimbie-dark", "kimbie.dark", "lioshi", "london-tube", "macintosh",
+        "marrakesh", "materia", "material-darker", "material-palenight",
+        "material-vivid", "material", "mellow-purple", "mocha", "monokai-sublime",
+        "monokai", "nebula", "night-owl", "nnfx-dark", "nord", "nova", "obsidian",
+        "ocean", "oceanicnext", "onedark", "outrun-dark", "panda-syntax-dark",
+        "papercolor-dark", "paraiso-dark", "paraiso", "pasque", "phd", "pico", "pop",
+        "porple", "qtcreator-dark", "qtcreator_dark", "qualia", "railscasts",
+        "rainbow", "rebecca", "ros-pine-moon", "ros-pine", "rose-pine-moon",
+        "rose-pine", "sandcastle", "seti-ui", "shades-of-purple", "silk-dark",
+        "snazzy", "solar-flare", "solarized-dark", "spacemacs", "srcery",
+        "stackoverflow-dark", "summercamp", "summerfruit-dark", "sunburst",
+        "synth-midnight-terminal-dark", "tango", "tender", "tokyo-night-dark",
+        "tomorrow-night-blue", "tomorrow-night-bright", "tomorrow-night-eighties",
+        "tomorrow-night", "twilight", "unikitty-dark", "vs2015", "vulcan",
+        "windows-10", "windows-95", "windows-high-contrast", "windows-nt",
+        "woodland", "xcode-dark", "xcode-dusk", "xt256", "zenburn"
+    ]
+
+    /// Light themes (background luminance >= 0.5), sorted alphabetically.
+    static let lightThemes: [String] = [
+        "1c-light", "a11y-light", "arduino-light", "ascetic", "atelier-cave-light",
+        "atelier-dune-light", "atelier-estuary-light", "atelier-forest-light",
+        "atelier-heath-light", "atelier-lakeside-light", "atelier-plateau-light",
+        "atelier-savanna-light", "atelier-seaside-light", "atelier-sulphurpool-light",
+        "atom-one-light", "brush-trees", "classic-light", "color-brewer", "cupcake",
+        "cupertino", "default-light", "default", "dirtysea", "docco", "edge-light",
+        "equilibrium-gray-light", "equilibrium-light", "foundation", "fruit-soda",
+        "github", "google-light", "googlecode", "gradient-light", "grayscale-light",
+        "grayscale", "gruvbox-light-hard", "gruvbox-light-medium",
+        "gruvbox-light-soft", "gruvbox-light", "harmonic16-light", "heetch-light",
+        "horizon-light", "humanoid-light", "ia-light", "idea", "intellij-light",
+        "isbl-editor-light", "kimbie-light", "kimbie.light", "lightfair", "magula",
+        "material-lighter", "mexico-light", "mono-blue", "nnfx-light", "one-light",
+        "panda-syntax-light", "papercolor-light", "paraiso-light", "purebasic",
+        "qtcreator-light", "qtcreator_light", "ros-pine-dawn", "rose-pine-dawn",
+        "routeros", "sagelight", "school-book", "shapeshifter", "silk-light",
+        "solar-flare-light", "solarized-light", "stackoverflow-light",
+        "summerfruit-light", "synth-midnight-terminal-light", "tokyo-night-light",
+        "tomorrow", "unikitty-light", "vs", "windows-10-light", "windows-95-light",
+        "windows-high-contrast-light", "windows-nt-light", "xcode"
+    ]
+
+    /// Display-friendly name: "monokai-sublime" → "Monokai Sublime"
+    static func displayName(for theme: String) -> String {
+        theme.replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}
+
+/// SwiftUI view that renders a TextEditorPanel's content with syntax highlighting.
+struct TextEditorPanelView: View {
+    @ObservedObject var panel: TextEditorPanel
+    let isFocused: Bool
+    let isVisibleInUI: Bool
+    let portalPriority: Int
+    let onRequestPanelFocus: () -> Void
+
+    @State private var focusFlashOpacity: Double = 0.0
+    @State private var focusFlashAnimationGeneration: Int = 0
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(TextEditorThemeSettings.darkThemeKey) private var darkTheme = TextEditorThemeSettings.defaultDarkTheme
+    @AppStorage(TextEditorThemeSettings.lightThemeKey) private var lightTheme = TextEditorThemeSettings.defaultLightTheme
+
+    var body: some View {
+        Group {
+            if panel.isFileUnavailable {
+                fileUnavailableView
+            } else {
+                editorContentView
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(backgroundColor)
+        .overlay {
+            RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
+                .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
+                .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
+                .padding(FocusFlashPattern.ringInset)
+                .allowsHitTesting(false)
+        }
+        .overlay {
+            if isVisibleInUI {
+                TextEditorPointerObserver(onPointerDown: onRequestPanelFocus)
+            }
+        }
+        .onChange(of: panel.focusFlashToken) { _ in
+            triggerFocusFlashAnimation()
+        }
+    }
+
+    // MARK: - Content
+
+    private var editorContentView: some View {
+        VStack(spacing: 0) {
+            filePathHeader
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
+
+            if panel.hasExternalChange {
+                externalChangeBanner
+            }
+
+            Divider()
+                .padding(.horizontal, 12)
+
+            CodeEditor(
+                source: Binding(
+                    get: { panel.content },
+                    set: { panel.setContentFromEditor($0) }
+                ),
+                language: codeLanguage,
+                theme: codeTheme,
+                fontSize: .constant(13),
+                flags: [.selectable, .editable, .smartIndent],
+                autoscroll: false
+            )
+        }
+    }
+
+    // MARK: - Language detection
+
+    private var codeLanguage: CodeEditor.Language {
+        let ext = (panel.filePath as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return .swift
+        case "py": return .python
+        case "js", "mjs", "cjs", "jsx": return .javascript
+        case "ts", "mts", "cts", "tsx": return .typescript
+        case "rb": return .ruby
+        case "go": return .go
+        case "rs": return .rust
+        case "c", "h": return .c
+        case "cpp", "cc", "cxx", "hpp": return .cpp
+        case "m": return .objectivec
+        case "java": return .java
+        case "kt", "kts": return .init(rawValue: "kotlin")
+        case "json": return .json
+        case "yaml", "yml": return .yaml
+        case "xml", "plist": return .xml
+        case "html", "htm": return .init(rawValue: "html")
+        case "css": return .css
+        case "scss": return .init(rawValue: "scss")
+        case "less": return .init(rawValue: "less")
+        case "sh", "bash", "zsh": return .bash
+        case "sql": return .sql
+        case "md", "markdown": return .markdown
+        case "lua": return .lua
+        case "pl", "pm": return .init(rawValue: "perl")
+        case "php": return .php
+        case "cs": return .cs
+        case "dockerfile": return .dockerfile
+        default: return .init(rawValue: "plaintext")
+        }
+    }
+
+    private var codeTheme: CodeEditor.ThemeName {
+        CodeEditor.ThemeName(rawValue: colorScheme == .dark ? darkTheme : lightTheme)
+    }
+
+    // MARK: - Subviews
+
+    private var filePathHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "doc.text")
+                .foregroundColor(.secondary)
+                .font(.system(size: 12))
+            Text(panel.filePath)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if panel.isDirty {
+                Circle()
+                    .fill(Color.primary.opacity(0.4))
+                    .frame(width: 6, height: 6)
+            }
+            Spacer()
+        }
+    }
+
+    private var externalChangeBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+                .font(.system(size: 12))
+            Text(String(localized: "textEditor.externalChange.banner", defaultValue: "File changed on disk"))
+                .font(.system(size: 12))
+                .foregroundColor(.primary)
+            Spacer()
+            Button(String(localized: "textEditor.externalChange.reload", defaultValue: "Reload")) {
+                panel.reloadFromDisk()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Color.orange.opacity(0.1))
+    }
+
+    private var fileUnavailableView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "doc.questionmark")
+                .font(.system(size: 40))
+                .foregroundColor(.secondary)
+            Text(String(localized: "textEditor.fileUnavailable.title", defaultValue: "File unavailable"))
+                .font(.headline)
+                .foregroundColor(.primary)
+            Text(panel.filePath)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 24)
+            Text(String(localized: "textEditor.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Styling
+
+    private var backgroundColor: Color {
+        colorScheme == .dark
+            ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
+            : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
+    }
+
+    // MARK: - Focus Flash
+
+    private func triggerFocusFlashAnimation() {
+        focusFlashAnimationGeneration &+= 1
+        let generation = focusFlashAnimationGeneration
+        focusFlashOpacity = FocusFlashPattern.values.first ?? 0
+
+        for segment in FocusFlashPattern.segments {
+            DispatchQueue.main.asyncAfter(deadline: .now() + segment.delay) {
+                guard focusFlashAnimationGeneration == generation else { return }
+                withAnimation(focusFlashAnimation(for: segment.curve, duration: segment.duration)) {
+                    focusFlashOpacity = segment.targetOpacity
+                }
+            }
+        }
+    }
+
+    private func focusFlashAnimation(for curve: FocusFlashCurve, duration: TimeInterval) -> Animation {
+        switch curve {
+        case .easeIn:
+            return .easeIn(duration: duration)
+        case .easeOut:
+            return .easeOut(duration: duration)
+        }
+    }
+}
+
+// MARK: - Click observer (AppKit-level, doesn't consume events)
+
+private struct TextEditorPointerObserver: NSViewRepresentable {
+    let onPointerDown: () -> Void
+
+    func makeNSView(context: Context) -> TextEditorPointerObserverView {
+        let view = TextEditorPointerObserverView()
+        view.onPointerDown = onPointerDown
+        return view
+    }
+
+    func updateNSView(_ nsView: TextEditorPointerObserverView, context: Context) {
+        nsView.onPointerDown = onPointerDown
+    }
+}
+
+final class TextEditorPointerObserverView: NSView {
+    var onPointerDown: (() -> Void)?
+    private var eventMonitor: Any?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        installEventMonitor()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    private func installEventMonitor() {
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
+            guard let self,
+                  event.type == .leftMouseDown,
+                  let window = self.window,
+                  event.window === window,
+                  !self.isHiddenOrHasHiddenAncestor else { return event }
+            let point = self.convert(event.locationInWindow, from: nil)
+            if self.bounds.contains(point) {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onPointerDown?()
+                }
+            }
+            return event
+        }
+    }
+}

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -87,8 +87,9 @@ struct TextEditorPanelView: View {
             if isVisibleInUI {
                 TextEditorPointerObserver(
                     onPointerDown: onRequestPanelFocus,
+                    isFocused: isFocused,
                     onSave: {
-                        try? panel.save()
+                        do { try panel.save() } catch { NSSound.beep() }
                     }
                 )
             }
@@ -131,6 +132,8 @@ struct TextEditorPanelView: View {
     // MARK: - Language detection
 
     private var codeLanguage: CodeEditor.Language {
+        let basename = (panel.filePath as NSString).lastPathComponent.lowercased()
+        if basename == "dockerfile" || basename.hasPrefix("dockerfile.") { return .dockerfile }
         let ext = (panel.filePath as NSString).pathExtension.lowercased()
         switch ext {
         case "swift": return .swift
@@ -270,23 +273,27 @@ struct TextEditorPanelView: View {
 
 private struct TextEditorPointerObserver: NSViewRepresentable {
     let onPointerDown: () -> Void
+    var isFocused: Bool = false
     var onSave: (() -> Void)?
 
     func makeNSView(context: Context) -> TextEditorPointerObserverView {
         let view = TextEditorPointerObserverView()
         view.onPointerDown = onPointerDown
+        view.isFocused = isFocused
         view.onSave = onSave
         return view
     }
 
     func updateNSView(_ nsView: TextEditorPointerObserverView, context: Context) {
         nsView.onPointerDown = onPointerDown
+        nsView.isFocused = isFocused
         nsView.onSave = onSave
     }
 }
 
 final class TextEditorPointerObserverView: NSView {
     var onPointerDown: (() -> Void)?
+    var isFocused: Bool = false
     var onSave: (() -> Void)?
     private var pointerMonitor: Any?
     private var keyMonitor: Any?
@@ -333,6 +340,7 @@ final class TextEditorPointerObserverView: NSView {
 
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
             guard let self,
+                  self.isFocused,
                   event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
                   event.charactersIgnoringModifiers == "s",
                   let window = self.window,

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -347,6 +347,10 @@ final class TextEditorPointerObserverView: NSView {
                   let window = self.window,
                   event.window === window,
                   !self.isHiddenOrHasHiddenAncestor else { return event }
+            // Don't consume Cmd+S when the command palette is open.
+            if let app = AppDelegate.shared, app.isCommandPaletteVisible(for: window) {
+                return event
+            }
             DispatchQueue.main.async { [weak self] in
                 self?.onSave?()
             }

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -85,7 +85,12 @@ struct TextEditorPanelView: View {
         }
         .overlay {
             if isVisibleInUI {
-                TextEditorPointerObserver(onPointerDown: onRequestPanelFocus)
+                TextEditorPointerObserver(
+                    onPointerDown: onRequestPanelFocus,
+                    onSave: {
+                        try? panel.save()
+                    }
+                )
             }
         }
         .onChange(of: panel.focusFlashToken) { _ in
@@ -265,27 +270,32 @@ struct TextEditorPanelView: View {
 
 private struct TextEditorPointerObserver: NSViewRepresentable {
     let onPointerDown: () -> Void
+    var onSave: (() -> Void)?
 
     func makeNSView(context: Context) -> TextEditorPointerObserverView {
         let view = TextEditorPointerObserverView()
         view.onPointerDown = onPointerDown
+        view.onSave = onSave
         return view
     }
 
     func updateNSView(_ nsView: TextEditorPointerObserverView, context: Context) {
         nsView.onPointerDown = onPointerDown
+        nsView.onSave = onSave
     }
 }
 
 final class TextEditorPointerObserverView: NSView {
     var onPointerDown: (() -> Void)?
-    private var eventMonitor: Any?
+    var onSave: (() -> Void)?
+    private var pointerMonitor: Any?
+    private var keyMonitor: Any?
 
     override var mouseDownCanMoveWindow: Bool { false }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        installEventMonitor()
+        installEventMonitors()
     }
 
     required init?(coder: NSCoder) {
@@ -293,8 +303,11 @@ final class TextEditorPointerObserverView: NSView {
     }
 
     deinit {
-        if let eventMonitor {
-            NSEvent.removeMonitor(eventMonitor)
+        if let pointerMonitor {
+            NSEvent.removeMonitor(pointerMonitor)
+        }
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
         }
     }
 
@@ -302,8 +315,8 @@ final class TextEditorPointerObserverView: NSView {
         nil
     }
 
-    private func installEventMonitor() {
-        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
+    private func installEventMonitors() {
+        pointerMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak self] event in
             guard let self,
                   event.type == .leftMouseDown,
                   let window = self.window,
@@ -316,6 +329,20 @@ final class TextEditorPointerObserverView: NSView {
                 }
             }
             return event
+        }
+
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            guard let self,
+                  event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  event.charactersIgnoringModifiers == "s",
+                  let window = self.window,
+                  event.window === window,
+                  !self.isHiddenOrHasHiddenAncestor else { return event }
+            DispatchQueue.main.async { [weak self] in
+                self?.onSave?()
+            }
+            // Consume the event so it doesn't propagate further.
+            return nil
         }
     }
 }

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -11,71 +11,32 @@ enum TextEditorThemeSettings {
     static let defaultLightTheme = "github"
 
     /// Dark themes (background luminance < 0.5), sorted alphabetically.
+    /// Derived from the bundled Highlightr v3 theme CSS files.
     static let darkThemes: [String] = [
-        "3024", "a11y-dark", "agate", "an-old-hope", "androidstudio", "apathy",
-        "apprentice", "arta", "ashes", "atelier-cave-dark", "atelier-cave",
-        "atelier-dune-dark", "atelier-dune", "atelier-estuary-dark", "atelier-estuary",
-        "atelier-forest-dark", "atelier-forest", "atelier-heath-dark", "atelier-heath",
-        "atelier-lakeside-dark", "atelier-lakeside", "atelier-plateau-dark",
-        "atelier-plateau", "atelier-savanna-dark", "atelier-savanna",
-        "atelier-seaside-dark", "atelier-seaside", "atelier-sulphurpool-dark",
-        "atelier-sulphurpool", "atlas", "atom-one-dark-reasonable", "atom-one-dark",
-        "bespin", "black-metal-bathory", "black-metal-burzum",
-        "black-metal-dark-funeral", "black-metal-gorgoroth", "black-metal-immortal",
-        "black-metal-khold", "black-metal-marduk", "black-metal-mayhem",
-        "black-metal-nile", "black-metal-venom", "black-metal", "brewer", "bright",
-        "brogrammer", "brush-trees-dark", "chalk", "circus", "classic-dark",
-        "codepen-embed", "codeschool", "colors", "cybertopia-cherry",
-        "cybertopia-dimmer", "cybertopia-icecap", "cybertopia-saturated", "danqing",
-        "darcula", "dark-violet", "dark", "darkmoss", "darktooth", "decaf",
-        "default-dark", "devibeans", "dracula", "edge-dark", "eighties", "embers",
-        "equilibrium-dark", "equilibrium-gray-dark", "espresso", "eva-dim", "eva",
-        "felipec", "flat", "framer", "gigavolt", "github-dark-dimmed", "github-dark",
-        "gml", "google-dark", "gradient-dark", "grayscale-dark", "green-screen",
-        "gruvbox-dark-hard", "gruvbox-dark-medium", "gruvbox-dark-pale",
-        "gruvbox-dark-soft", "gruvbox-dark", "hardcore", "harmonic16-dark",
-        "heetch-dark", "helios", "hopscotch", "horizon-dark", "humanoid-dark",
-        "hybrid", "ia-dark", "icy-dark", "ir-black", "isbl-editor-dark", "isotope",
-        "kimber", "kimbie-dark", "kimbie.dark", "lioshi", "london-tube", "macintosh",
-        "marrakesh", "materia", "material-darker", "material-palenight",
-        "material-vivid", "material", "mellow-purple", "mocha", "monokai-sublime",
-        "monokai", "nebula", "night-owl", "nnfx-dark", "nord", "nova", "obsidian",
-        "ocean", "oceanicnext", "onedark", "outrun-dark", "panda-syntax-dark",
-        "papercolor-dark", "paraiso-dark", "paraiso", "pasque", "phd", "pico", "pop",
-        "porple", "qtcreator-dark", "qtcreator_dark", "qualia", "railscasts",
-        "rainbow", "rebecca", "ros-pine-moon", "ros-pine", "rose-pine-moon",
-        "rose-pine", "sandcastle", "seti-ui", "shades-of-purple", "silk-dark",
-        "snazzy", "solar-flare", "solarized-dark", "spacemacs", "srcery",
-        "stackoverflow-dark", "summercamp", "summerfruit-dark", "sunburst",
-        "synth-midnight-terminal-dark", "tango", "tender", "tokyo-night-dark",
-        "tomorrow-night-blue", "tomorrow-night-bright", "tomorrow-night-eighties",
-        "tomorrow-night", "twilight", "unikitty-dark", "vs2015", "vulcan",
-        "windows-10", "windows-95", "windows-high-contrast", "windows-nt",
-        "woodland", "xcode-dark", "xcode-dusk", "xt256", "zenburn"
+        "a11y-dark", "agate", "an-old-hope", "androidstudio", "arta",
+        "atelier-cave-dark", "atelier-dune-dark", "atelier-estuary-dark",
+        "atelier-forest-dark", "atelier-heath-dark", "atelier-lakeside-dark",
+        "atelier-plateau-dark", "atelier-savanna-dark", "atelier-seaside-dark",
+        "atelier-sulphurpool-dark", "atom-one-dark", "atom-one-dark-reasonable",
+        "codepen-embed", "darcula", "dark", "dracula", "far", "gml", "gruvbox-dark",
+        "hopscotch", "hybrid", "ir-black", "isbl-editor-dark", "kimbie.dark",
+        "monokai", "monokai-sublime", "nord", "obsidian", "ocean", "paraiso-dark",
+        "qtcreator_dark", "railscasts", "rainbow", "shades-of-purple",
+        "solarized-dark", "sunburst", "tomorrow-night", "tomorrow-night-blue",
+        "tomorrow-night-eighties", "vs2015", "xcode-dark", "xt256", "zenburn"
     ]
 
     /// Light themes (background luminance >= 0.5), sorted alphabetically.
+    /// Derived from the bundled Highlightr v3 theme CSS files.
     static let lightThemes: [String] = [
-        "1c-light", "a11y-light", "arduino-light", "ascetic", "atelier-cave-light",
-        "atelier-dune-light", "atelier-estuary-light", "atelier-forest-light",
-        "atelier-heath-light", "atelier-lakeside-light", "atelier-plateau-light",
-        "atelier-savanna-light", "atelier-seaside-light", "atelier-sulphurpool-light",
-        "atom-one-light", "brush-trees", "classic-light", "color-brewer", "cupcake",
-        "cupertino", "default-light", "default", "dirtysea", "docco", "edge-light",
-        "equilibrium-gray-light", "equilibrium-light", "foundation", "fruit-soda",
-        "github", "google-light", "googlecode", "gradient-light", "grayscale-light",
-        "grayscale", "gruvbox-light-hard", "gruvbox-light-medium",
-        "gruvbox-light-soft", "gruvbox-light", "harmonic16-light", "heetch-light",
-        "horizon-light", "humanoid-light", "ia-light", "idea", "intellij-light",
-        "isbl-editor-light", "kimbie-light", "kimbie.light", "lightfair", "magula",
-        "material-lighter", "mexico-light", "mono-blue", "nnfx-light", "one-light",
-        "panda-syntax-light", "papercolor-light", "paraiso-light", "purebasic",
-        "qtcreator-light", "qtcreator_light", "ros-pine-dawn", "rose-pine-dawn",
-        "routeros", "sagelight", "school-book", "shapeshifter", "silk-light",
-        "solar-flare-light", "solarized-light", "stackoverflow-light",
-        "summerfruit-light", "synth-midnight-terminal-light", "tokyo-night-light",
-        "tomorrow", "unikitty-light", "vs", "windows-10-light", "windows-95-light",
-        "windows-high-contrast-light", "windows-nt-light", "xcode"
+        "a11y-light", "arduino-light", "atelier-cave-light", "atelier-dune-light",
+        "atelier-estuary-light", "atelier-forest-light", "atelier-heath-light",
+        "atelier-lakeside-light", "atelier-plateau-light", "atelier-savanna-light",
+        "atelier-seaside-light", "atelier-sulphurpool-light", "atom-one-light",
+        "brown-paper", "color-brewer", "default", "docco", "foundation", "github",
+        "grayscale", "gruvbox-light", "idea", "kimbie.light", "magula", "mono-blue",
+        "paraiso-light", "purebasic", "qtcreator_light", "routeros",
+        "solarized-light", "xcode"
     ]
 
     /// Display-friendly name: "monokai-sublime" → "Monokai Sublime"

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -187,6 +187,7 @@ struct TextEditorPanelView: View {
                 Circle()
                     .fill(Color.primary.opacity(0.4))
                     .frame(width: 6, height: 6)
+                    .accessibilityLabel(String(localized: "textEditor.dirty.accessibilityLabel", defaultValue: "Unsaved changes"))
             }
             Spacer()
         }

--- a/Sources/Panels/TextEditorPanelView.swift
+++ b/Sources/Panels/TextEditorPanelView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import CodeEditor
+import Highlightr
 
 // MARK: - Text Editor Theme Settings
 
@@ -10,34 +11,36 @@ enum TextEditorThemeSettings {
     static let defaultDarkTheme = "monokai-sublime"
     static let defaultLightTheme = "github"
 
-    /// Dark themes (background luminance < 0.5), sorted alphabetically.
-    /// Derived from the bundled Highlightr v3 theme CSS files.
-    static let darkThemes: [String] = [
-        "a11y-dark", "agate", "an-old-hope", "androidstudio", "arta",
-        "atelier-cave-dark", "atelier-dune-dark", "atelier-estuary-dark",
-        "atelier-forest-dark", "atelier-heath-dark", "atelier-lakeside-dark",
-        "atelier-plateau-dark", "atelier-savanna-dark", "atelier-seaside-dark",
-        "atelier-sulphurpool-dark", "atom-one-dark", "atom-one-dark-reasonable",
-        "codepen-embed", "darcula", "dark", "dracula", "far", "gml", "gruvbox-dark",
-        "hopscotch", "hybrid", "ir-black", "isbl-editor-dark", "kimbie.dark",
-        "monokai", "monokai-sublime", "nord", "obsidian", "ocean", "paraiso-dark",
-        "qtcreator_dark", "railscasts", "rainbow", "shades-of-purple",
-        "solarized-dark", "sunburst", "tomorrow-night", "tomorrow-night-blue",
-        "tomorrow-night-eighties", "vs2015", "xcode-dark", "xt256", "zenburn"
-    ]
+    /// Classified theme lists, built once at launch from the actual bundled themes.
+    /// Uses Highlightr to load each theme and check its background luminance.
+    static let darkThemes: [String] = classifiedThemes.dark
+    static let lightThemes: [String] = classifiedThemes.light
 
-    /// Light themes (background luminance >= 0.5), sorted alphabetically.
-    /// Derived from the bundled Highlightr v3 theme CSS files.
-    static let lightThemes: [String] = [
-        "a11y-light", "arduino-light", "atelier-cave-light", "atelier-dune-light",
-        "atelier-estuary-light", "atelier-forest-light", "atelier-heath-light",
-        "atelier-lakeside-light", "atelier-plateau-light", "atelier-savanna-light",
-        "atelier-seaside-light", "atelier-sulphurpool-light", "atom-one-light",
-        "brown-paper", "color-brewer", "default", "docco", "foundation", "github",
-        "grayscale", "gruvbox-light", "idea", "kimbie.light", "magula", "mono-blue",
-        "paraiso-light", "purebasic", "qtcreator_light", "routeros",
-        "solarized-light", "xcode"
-    ]
+    private static let classifiedThemes: (dark: [String], light: [String]) = {
+        var dark: [String] = []
+        var light: [String] = []
+        guard let highlightr = Highlightr() else { return (dark, light) }
+
+        for theme in CodeEditor.availableThemes {
+            let name = theme.rawValue
+            highlightr.setTheme(to: name)
+            guard let bg = highlightr.theme?.themeBackgroundColor else { continue }
+            #if canImport(AppKit)
+            guard let rgb = bg.usingColorSpace(.sRGB) else { continue }
+            let luminance = 0.299 * rgb.redComponent + 0.587 * rgb.greenComponent + 0.114 * rgb.blueComponent
+            #else
+            var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0
+            bg.getRed(&r, green: &g, blue: &b, alpha: nil)
+            let luminance = 0.299 * r + 0.587 * g + 0.114 * b
+            #endif
+            if luminance < 0.5 {
+                dark.append(name)
+            } else {
+                light.append(name)
+            }
+        }
+        return (dark.sorted(), light.sorted())
+    }()
 
     /// Display-friendly name: "monokai-sublime" → "Monokai Sublime"
     static func displayName(for theme: String) -> String {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -19,10 +19,20 @@ enum SessionPersistencePolicy {
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
 
+    static let defaultDrawerWidth: Double = 250
+    static let minimumDrawerWidth: Double = 180
+    static let maximumDrawerWidth: Double = 500
+
     static func sanitizedSidebarWidth(_ candidate: Double?) -> Double {
         let fallback = defaultSidebarWidth
         guard let candidate, candidate.isFinite else { return fallback }
         return min(max(candidate, minimumSidebarWidth), maximumSidebarWidth)
+    }
+
+    static func sanitizedDrawerWidth(_ candidate: Double?) -> Double {
+        let fallback = defaultDrawerWidth
+        guard let candidate, candidate.isFinite else { return fallback }
+        return min(max(candidate, minimumDrawerWidth), maximumDrawerWidth)
     }
 
     static func truncatedScrollback(_ text: String?) -> String? {
@@ -240,6 +250,10 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     var filePath: String
 }
 
+struct SessionTextEditorPanelSnapshot: Codable, Sendable {
+    var filePath: String
+}
+
 struct SessionPanelSnapshot: Codable, Sendable {
     var id: UUID
     var type: PanelType
@@ -254,6 +268,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?
+    var textEditor: SessionTextEditorPanelSnapshot?
 }
 
 enum SessionSplitOrientation: String, Codable, Sendable {
@@ -348,11 +363,17 @@ struct SessionTabManagerSnapshot: Codable, Sendable {
     var workspaces: [SessionWorkspaceSnapshot]
 }
 
+struct SessionFileBrowserDrawerSnapshot: Codable, Sendable {
+    var isVisible: Bool
+    var width: Double?
+}
+
 struct SessionWindowSnapshot: Codable, Sendable {
     var frame: SessionRectSnapshot?
     var display: SessionDisplaySnapshot?
     var tabManager: SessionTabManagerSnapshot
     var sidebar: SessionSidebarSnapshot
+    var fileBrowserDrawer: SessionFileBrowserDrawerSnapshot?
 }
 
 struct AppSessionSnapshot: Codable, Sendable {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12112,7 +12112,17 @@ extension Workspace: BonsplitDelegate {
             if let panelId = panelIdFromSurfaceId(tab.id),
                let textEditorPanel = panels[panelId] as? TextEditorPanel,
                textEditorPanel.isDirty {
-                pendingPaneClosePanelIds.removeValue(forKey: pane.id)
+                let tabId = tab.id
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    Task { @MainActor in
+                        let confirmed = await self.confirmClosePanel(for: tabId)
+                        if confirmed {
+                            self.forceCloseTabIds.insert(tabId)
+                            self.bonsplitController.closePane(pane)
+                        }
+                    }
+                }
                 return false
             }
             if let panelId = panelIdFromSurfaceId(tab.id),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -449,6 +449,7 @@ extension Workspace {
         let terminalSnapshot: SessionTerminalPanelSnapshot?
         let browserSnapshot: SessionBrowserPanelSnapshot?
         let markdownSnapshot: SessionMarkdownPanelSnapshot?
+        let textEditorSnapshot: SessionTextEditorPanelSnapshot?
         switch panel.panelType {
         case .terminal:
             guard let terminalPanel = panel as? TerminalPanel else { return nil }
@@ -472,6 +473,7 @@ extension Workspace {
             )
             browserSnapshot = nil
             markdownSnapshot = nil
+            textEditorSnapshot = nil
         case .browser:
             guard let browserPanel = panel as? BrowserPanel else { return nil }
             terminalSnapshot = nil
@@ -486,11 +488,19 @@ extension Workspace {
                 forwardHistoryURLStrings: historySnapshot.forwardHistoryURLStrings
             )
             markdownSnapshot = nil
+            textEditorSnapshot = nil
         case .markdown:
             guard let markdownPanel = panel as? MarkdownPanel else { return nil }
             terminalSnapshot = nil
             browserSnapshot = nil
             markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
+            textEditorSnapshot = nil
+        case .textEditor:
+            guard let textEditorPanel = panel as? TextEditorPanel else { return nil }
+            terminalSnapshot = nil
+            browserSnapshot = nil
+            markdownSnapshot = nil
+            textEditorSnapshot = SessionTextEditorPanelSnapshot(filePath: textEditorPanel.filePath)
         }
 
         return SessionPanelSnapshot(
@@ -506,7 +516,8 @@ extension Workspace {
             ttyName: ttyName,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
-            markdown: markdownSnapshot
+            markdown: markdownSnapshot,
+            textEditor: textEditorSnapshot
         )
     }
 
@@ -681,6 +692,17 @@ extension Workspace {
             }
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
             return markdownPanel.id
+        case .textEditor:
+            guard let filePath = snapshot.textEditor?.filePath,
+                  let textEditorPanel = newTextEditorSurface(
+                    inPane: paneId,
+                    filePath: filePath,
+                    focus: false
+                  ) else {
+                return nil
+            }
+            applySessionPanelMetadata(snapshot, toPanelId: textEditorPanel.id)
+            return textEditorPanel.id
         }
     }
 
@@ -6719,6 +6741,7 @@ final class Workspace: Identifiable, ObservableObject {
         static let terminal = "terminal"
         static let browser = "browser"
         static let markdown = "markdown"
+        static let textEditor = "textEditor"
     }
 
     enum PanelShellActivityState: String {
@@ -7187,6 +7210,36 @@ final class Workspace: Identifiable, ObservableObject {
         panelSubscriptions[markdownPanel.id] = subscription
     }
 
+    private func installTextEditorPanelSubscription(_ textEditorPanel: TextEditorPanel) {
+        let subscription = Publishers.CombineLatest(
+            textEditorPanel.$displayTitle.removeDuplicates(),
+            textEditorPanel.$isDirty.removeDuplicates()
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self, weak textEditorPanel] newTitle, isDirty in
+            guard let self,
+                  let textEditorPanel,
+                  let tabId = self.surfaceIdFromPanelId(textEditorPanel.id) else { return }
+            guard let existing = self.bonsplitController.tab(tabId) else { return }
+
+            if self.panelTitles[textEditorPanel.id] != newTitle {
+                self.panelTitles[textEditorPanel.id] = newTitle
+            }
+            let resolvedTitle = self.resolvedPanelTitle(panelId: textEditorPanel.id, fallback: newTitle)
+            let titleUpdate: String? = existing.title == resolvedTitle ? nil : resolvedTitle
+            let dirtyUpdate: Bool? = existing.isDirty == isDirty ? nil : isDirty
+
+            guard titleUpdate != nil || dirtyUpdate != nil else { return }
+            self.bonsplitController.updateTab(
+                tabId,
+                title: titleUpdate,
+                hasCustomTitle: self.panelCustomTitles[textEditorPanel.id] != nil,
+                isDirty: dirtyUpdate
+            )
+        }
+        panelSubscriptions[textEditorPanel.id] = subscription
+    }
+
     private func browserRemoteWorkspaceStatusSnapshot() -> BrowserRemoteWorkspaceStatus? {
         guard let target = remoteDisplayTarget else { return nil }
         return BrowserRemoteWorkspaceStatus(
@@ -7224,6 +7277,10 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] as? MarkdownPanel
     }
 
+    func textEditorPanel(for panelId: UUID) -> TextEditorPanel? {
+        panels[panelId] as? TextEditorPanel
+    }
+
     private func surfaceKind(for panel: any Panel) -> String {
         switch panel.panelType {
         case .terminal:
@@ -7232,6 +7289,8 @@ final class Workspace: Identifiable, ObservableObject {
             return SurfaceKind.browser
         case .markdown:
             return SurfaceKind.markdown
+        case .textEditor:
+            return SurfaceKind.textEditor
         }
     }
 
@@ -9255,6 +9314,115 @@ final class Workspace: Identifiable, ObservableObject {
         return markdownPanel
     }
 
+    // MARK: - Text Editor panel factory methods
+
+    func newTextEditorSplit(
+        from panelId: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool = false,
+        filePath: String,
+        focus: Bool = true
+    ) -> TextEditorPanel? {
+        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
+        var sourcePaneId: PaneID?
+        for paneId in bonsplitController.allPaneIds {
+            let tabs = bonsplitController.tabs(inPane: paneId)
+            if tabs.contains(where: { $0.id == sourceTabId }) {
+                sourcePaneId = paneId
+                break
+            }
+        }
+
+        guard let paneId = sourcePaneId else { return nil }
+
+        let textEditorPanel = TextEditorPanel(workspaceId: id, filePath: filePath)
+        panels[textEditorPanel.id] = textEditorPanel
+        panelTitles[textEditorPanel.id] = textEditorPanel.displayTitle
+
+        let newTab = Bonsplit.Tab(
+            title: textEditorPanel.displayTitle,
+            icon: textEditorPanel.displayIcon,
+            kind: SurfaceKind.textEditor,
+            isDirty: textEditorPanel.isDirty,
+            isLoading: false,
+            isPinned: false
+        )
+        surfaceIdToPanelId[newTab.id] = textEditorPanel.id
+        let previousFocusedPanelId = focusedPanelId
+
+        isProgrammaticSplit = true
+        defer { isProgrammaticSplit = false }
+        guard bonsplitController.splitPane(paneId, orientation: orientation, withTab: newTab, insertFirst: insertFirst) != nil else {
+            surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            panels.removeValue(forKey: textEditorPanel.id)
+            panelTitles.removeValue(forKey: textEditorPanel.id)
+            return nil
+        }
+
+        let previousHostedView = focusedTerminalPanel?.hostedView
+        if focus {
+            previousHostedView?.suppressReparentFocus()
+            focusPanel(textEditorPanel.id)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                previousHostedView?.clearSuppressReparentFocus()
+            }
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: textEditorPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installTextEditorPanelSubscription(textEditorPanel)
+        return textEditorPanel
+    }
+
+    @discardableResult
+    func newTextEditorSurface(
+        inPane paneId: PaneID,
+        filePath: String,
+        focus: Bool? = nil
+    ) -> TextEditorPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+
+        let textEditorPanel = TextEditorPanel(workspaceId: id, filePath: filePath)
+        panels[textEditorPanel.id] = textEditorPanel
+        panelTitles[textEditorPanel.id] = textEditorPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: textEditorPanel.displayTitle,
+            icon: textEditorPanel.displayIcon,
+            kind: SurfaceKind.textEditor,
+            isDirty: textEditorPanel.isDirty,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: textEditorPanel.id)
+            panelTitles.removeValue(forKey: textEditorPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = textEditorPanel.id
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: textEditorPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installTextEditorPanelSubscription(textEditorPanel)
+        return textEditorPanel
+    }
+
     /// Tear down all panels in this workspace, freeing their Ghostty surfaces.
     /// Called before the workspace is removed from TabManager to ensure child
     /// processes receive SIGHUP even if ARC deallocation is delayed.
@@ -9745,6 +9913,10 @@ final class Workspace: Identifiable, ObservableObject {
                 remoteStatus: browserRemoteWorkspaceStatusSnapshot()
             )
             installBrowserPanelSubscription(browserPanel)
+        } else if let markdownPanel = detached.panel as? MarkdownPanel {
+            installMarkdownPanelSubscription(markdownPanel)
+        } else if let textEditorPanel = detached.panel as? TextEditorPanel {
+            installTextEditorPanelSubscription(textEditorPanel)
         }
 
         if let directory = detached.directory {
@@ -10283,6 +10455,9 @@ final class Workspace: Identifiable, ObservableObject {
         for (panelId, panel) in panels {
             if let terminalPanel = panel as? TerminalPanel,
                panelNeedsConfirmClose(panelId: panelId, fallbackNeedsConfirmClose: terminalPanel.needsConfirmClose()) {
+                return true
+            }
+            if let textEditorPanel = panel as? TextEditorPanel, textEditorPanel.isDirty {
                 return true
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11783,6 +11783,35 @@ extension Workspace: BonsplitDelegate {
             return false
         }
 
+        // Check if a dirty text editor needs close confirmation
+        if let panelId = panelIdFromSurfaceId(tab.id),
+           let textEditorPanel = panels[panelId] as? TextEditorPanel,
+           textEditorPanel.isDirty {
+            clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
+            if pendingCloseConfirmTabIds.contains(tab.id) {
+                return false
+            }
+
+            pendingCloseConfirmTabIds.insert(tab.id)
+            let tabId = tab.id
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                Task { @MainActor in
+                    defer { self.pendingCloseConfirmTabIds.remove(tabId) }
+
+                    guard self.panelIdFromSurfaceId(tabId) != nil else { return }
+
+                    let confirmed = await self.confirmClosePanel(for: tabId)
+                    guard confirmed else { return }
+
+                    self.forceCloseTabIds.insert(tabId)
+                    self.bonsplitController.closeTab(tabId)
+                }
+            }
+
+            return false
+        }
+
         // Check if the panel needs close confirmation
         guard let panelId = panelIdFromSurfaceId(tab.id),
               let terminalPanel = terminalPanel(for: panelId) else {
@@ -12080,6 +12109,12 @@ extension Workspace: BonsplitDelegate {
         let tabs = controller.tabs(inPane: pane)
         for tab in tabs {
             if forceCloseTabIds.contains(tab.id) { continue }
+            if let panelId = panelIdFromSurfaceId(tab.id),
+               let textEditorPanel = panels[panelId] as? TextEditorPanel,
+               textEditorPanel.isDirty {
+                pendingPaneClosePanelIds.removeValue(forKey: pane.id)
+                return false
+            }
             if let panelId = panelIdFromSurfaceId(tab.id),
                let terminalPanel = terminalPanel(for: panelId),
                panelNeedsConfirmClose(panelId: panelId, fallbackNeedsConfirmClose: terminalPanel.needsConfirmClose()) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -141,6 +141,7 @@ struct cmuxApp: App {
     @StateObject private var sidebarSelectionState = SidebarSelectionState()
     @StateObject private var cmuxConfigStore = CmuxConfigStore()
     @StateObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
+    @StateObject private var fileBrowserDrawerState = FileBrowserDrawerState()
     private let primaryWindowId = UUID()
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyle = TitlebarControlsStyle.classic.rawValue
@@ -320,6 +321,7 @@ struct cmuxApp: App {
                 .environmentObject(sidebarState)
                 .environmentObject(sidebarSelectionState)
                 .environmentObject(cmuxConfigStore)
+                .environmentObject(fileBrowserDrawerState)
                 .onAppear {
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
@@ -667,6 +669,12 @@ struct cmuxApp: App {
                 splitCommandButton(title: String(localized: "menu.view.toggleSidebar", defaultValue: "Toggle Sidebar"), shortcut: menuShortcut(for: .toggleSidebar)) {
                     if AppDelegate.shared?.toggleSidebarInActiveMainWindow() != true {
                         sidebarState.toggle()
+                    }
+                }
+
+                splitCommandButton(title: String(localized: "menu.view.toggleFileBrowser", defaultValue: "Toggle File Browser"), shortcut: menuShortcut(for: .toggleFileBrowserDrawer)) {
+                    if AppDelegate.shared?.toggleFileBrowserDrawerInActiveMainWindow() != true {
+                        fileBrowserDrawerState.toggle()
                     }
                 }
 
@@ -3971,6 +3979,8 @@ struct SettingsView: View {
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarMatchTerminalBackground") private var sidebarMatchTerminalBackground = false
+    @AppStorage(TextEditorThemeSettings.darkThemeKey) private var editorDarkTheme = TextEditorThemeSettings.defaultDarkTheme
+    @AppStorage(TextEditorThemeSettings.lightThemeKey) private var editorLightTheme = TextEditorThemeSettings.defaultLightTheme
 
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @StateObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
@@ -5612,6 +5622,32 @@ struct SettingsView: View {
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                             .disabled(browserHistoryEntryCount == 0)
+                        }
+                    }
+
+                    SettingsSectionHeader(title: String(localized: "settings.section.textEditor", defaultValue: "Text Editor"))
+                        .accessibilityIdentifier("SettingsTextEditorSection")
+                    SettingsCard {
+                        SettingsPickerRow(
+                            String(localized: "settings.textEditor.darkTheme", defaultValue: "Dark Theme"),
+                            controlWidth: pickerColumnWidth,
+                            selection: $editorDarkTheme
+                        ) {
+                            ForEach(TextEditorThemeSettings.darkThemes, id: \.self) { theme in
+                                Text(TextEditorThemeSettings.displayName(for: theme)).tag(theme)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.textEditor.lightTheme", defaultValue: "Light Theme"),
+                            controlWidth: pickerColumnWidth,
+                            selection: $editorLightTheme
+                        ) {
+                            ForEach(TextEditorThemeSettings.lightThemes, id: \.self) { theme in
+                                Text(TextEditorThemeSettings.displayName(for: theme)).tag(theme)
+                            }
                         }
                     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -196,7 +196,7 @@ struct cmuxApp: App {
 
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
-        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState)
+        appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState, fileBrowserDrawerState: fileBrowserDrawerState)
     }
 
     private static func terminateForMissingLaunchTag() -> Never {
@@ -330,7 +330,7 @@ struct cmuxApp: App {
 #endif
                     // Start the Unix socket controller for programmatic access
                     updateSocketController()
-                    appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState)
+                    appDelegate.configure(tabManager: tabManager, notificationStore: notificationStore, sidebarState: sidebarState, fileBrowserDrawerState: fileBrowserDrawerState)
                     cmuxConfigStore.wireDirectoryTracking(tabManager: tabManager)
                     cmuxConfigStore.loadAll()
                     applyAppearance()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5988,6 +5988,8 @@ struct SettingsView: View {
         socketPasswordStatusIsError = false
         refreshDetectedImportBrowsers()
         KeyboardShortcutSettings.resetAll()
+        UserDefaults.standard.removeObject(forKey: TextEditorThemeSettings.darkThemeKey)
+        UserDefaults.standard.removeObject(forKey: TextEditorThemeSettings.lightThemeKey)
         WorkspaceTabColorSettings.reset()
         reloadWorkspaceTabColorSettings()
         shortcutResetToken = UUID()


### PR DESCRIPTION
## Summary

- **File browser drawer** (Cmd+Shift+B): hideable left panel between sidebar and terminal that shows the focused terminal's working directory. Click a file to open it in a text editor split.
- **Text editor panel**: new panel type with syntax highlighting via CodeEditor/Highlightr (180+ languages), configurable dark/light themes in Settings.
- Clicking a file opens it in a text editor split; subsequent files open as tabs in the same pane; already-open files are focused instead of duplicated.
- Drawer state (visibility + width) persists across sessions.
- Full keyboard shortcut support, View menu item, session restore.
- All UI strings localized (English + Japanese).
- Cmd+S saves, Cmd+W closes text editor tabs.
- Theme settings in Settings > Text Editor with dark/light dropdowns auto-classified from bundled themes.

## Test plan

- [ ] Toggle drawer with Cmd+Shift+B — should appear/disappear between sidebar and terminal
- [ ] Resize drawer by dragging right edge — cursor should change, no jitter
- [ ] `cd` in terminal — drawer should update to show new directory
- [ ] Click a file — text editor panel opens as horizontal split with syntax highlighting
- [ ] Click another file — opens as new tab in same pane
- [ ] Click already-open file — focuses existing tab
- [ ] Edit text, Cmd+S to save, verify file on disk
- [ ] Cmd+W with text editor focused — closes the editor tab
- [ ] Close and reopen app — drawer visibility/width and text editor panels restore
- [ ] Settings > Text Editor — change dark/light themes, verify instant update
- [ ] Both sidebar and drawer visible simultaneously with independent resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hideable file browser drawer and a tabbed text editor with syntax highlighting. Browse the focused terminal’s directory (including dotfiles) and edit files without leaving the app.

- **New Features**
  - File browser drawer (Cmd+Shift+B) between sidebar and terminal; resizable with a visible divider, toggled from View > Toggle File Browser; width/visibility persist and restore; shows the focused terminal’s working directory, including dotfiles.
  - Clicking a file opens it in a text editor split; already-open files are focused; new files open as tabs in the same pane, with a fallback to the focused pane if a split can’t be created.
  - Text editor panel with syntax highlighting via `tayl0r/CodeEditor`; dark/light theme pickers in Settings show only bundled themes (classified at runtime). Reload banner on external changes and a file-unavailable state; Cmd+S saves (scoped to the focused panel), Cmd+W closes; all UI strings localized (EN/JA). Session restore for the drawer and editor tabs.

- **Bug Fixes**
  - Editor: fixed bold text flicker; moved file I/O off the main thread with generation guards; scoped Cmd+S to the focused panel and ignore it when the command palette is open; play a system beep on save failure; improved Dockerfile language detection; close confirmations for dirty tabs and panes; accessibility and localized label for the dirty indicator; Reset All Settings clears editor theme preferences.
  - Drawer: watcher restarts after hide/show; show dotfiles; prevent blank states and fix subdirectory load races; resizer drag state cleaned on disappear and width persists mid-drag; portal geometry resync on width/visibility changes with a nil fallback; pass drawer state through `AppDelegate.configure` to ensure per-window toggling and session restore.

<sup>Written for commit fd9ffed71660d816d9a146b544a74a3d1c590542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resizable, toggleable file browser drawer with persisted width and empty-state UI; opens files into editors. Default shortcut: Cmd+Shift+B; View menu toggle added.
  * New text editor panel: open/save, external-change detection with reload banner, file-unavailable UI, syntax highlighting, selectable dark/light themes, and focus/flash UX.

* **Session**
  * Session restore/persistence now includes drawer visibility/width and text editor panel state.

* **Localization**
  * Added strings for text editor, drawer, menu and shortcut labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->