### PR TITLE
Fix keyboard shortcuts not working with Korean input mode

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8889,7 +8889,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func handleCustomShortcut(event: NSEvent) -> Bool {
         // `charactersIgnoringModifiers` can be nil for some synthetic NSEvents and certain special keys.
         // Treat nil as "" and rely on keyCode/layout-aware fallback logic where needed.
-        let chars = (event.charactersIgnoringModifiers ?? "").lowercased()
+        // When a non-Latin input source is active (Korean, Chinese, Japanese, etc.),
+        // charactersIgnoringModifiers returns non-ASCII characters that never match
+        // Latin shortcut keys. Normalize via KeyboardLayout so downstream comparisons
+        // (Cmd+1-9, Ctrl+1-9, omnibar N/P, command palette, etc.) work correctly.
+        let chars = KeyboardLayout.normalizedCharacters(for: event)
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let hasControl = flags.contains(.control)
         let hasCommand = flags.contains(.command)

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -15,23 +15,39 @@ class KeyboardLayout {
 
     /// Translate a physical keyCode to the character AppKit would use for shortcut matching,
     /// preserving command-aware layouts such as "Dvorak - QWERTY Command".
-    /// CJK input sources (Korean, Chinese, Japanese) lack kTISPropertyUnicodeKeyLayoutData,
-    /// so we fall back to TISCopyCurrentASCIICapableKeyboardInputSource() in that case.
+    /// Some CJK input sources lack kTISPropertyUnicodeKeyLayoutData, and others (Korean
+    /// 두벌식) have it but UCKeyTranslate still returns non-ASCII characters. In either
+    /// case we fall back to TISCopyCurrentASCIICapableKeyboardInputSource().
     static func character(
         forKeyCode keyCode: UInt16,
         modifierFlags: NSEvent.ModifierFlags = []
     ) -> String? {
         if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
-           let result = characterFromInputSource(source, forKeyCode: keyCode, modifierFlags: modifierFlags) {
+           let result = characterFromInputSource(source, forKeyCode: keyCode, modifierFlags: modifierFlags),
+           result.allSatisfy(\.isASCII) {
             return result
         }
-        // Current input source has no Unicode layout data (e.g. Korean, Chinese, Japanese IME).
-        // Fall back to the ASCII-capable source so shortcut matching still works.
+        // Current input source has no Unicode layout data or returned a non-ASCII
+        // character (e.g. Korean 두벌식 has layout data but UCKeyTranslate still
+        // produces Hangul). Fall back to the ASCII-capable source so shortcut
+        // matching still works.
         if let asciiSource = TISCopyCurrentASCIICapableKeyboardInputSource()?.takeRetainedValue(),
            let result = characterFromInputSource(asciiSource, forKeyCode: keyCode, modifierFlags: modifierFlags) {
             return result
         }
         return nil
+    }
+
+    /// Return the ASCII-normalized equivalent of `event.charactersIgnoringModifiers`,
+    /// falling back through the ASCII-capable input source for non-Latin input methods.
+    /// Use this wherever code compares raw event characters against Latin shortcut keys.
+    static func normalizedCharacters(for event: NSEvent) -> String {
+        let raw = (event.charactersIgnoringModifiers ?? "").lowercased()
+        if raw.allSatisfy(\.isASCII) { return raw }
+        if let layoutChar = character(forKeyCode: event.keyCode, modifierFlags: []) {
+            return layoutChar
+        }
+        return raw
     }
 
     private static func characterFromInputSource(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3735,7 +3735,10 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 #endif
             let keyCode = event.keyCode
             let modifiers = event.modifierFlags.intersection([.command, .control, .shift, .option, .function])
-            let lowered = event.charactersIgnoringModifiers?.lowercased() ?? ""
+            // When a non-Latin input source is active (Korean, Chinese, Japanese),
+            // charactersIgnoringModifiers returns non-ASCII characters. Normalize
+            // via KeyboardLayout so Cmd/Ctrl+N/P navigation works across input sources.
+            let lowered = KeyboardLayout.normalizedCharacters(for: event)
             let hasCommandOrControl = modifiers.contains(.command) || modifiers.contains(.control)
 
             // Cmd/Ctrl+N and Cmd/Ctrl+P should repeat while held.

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -50,7 +50,7 @@ private class BrowserPopupPanel: NSPanel {
         // Cmd+W: close this popup panel only
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if flags == .command,
-           event.charactersIgnoringModifiers == "w" {
+           KeyboardLayout.normalizedCharacters(for: event) == "w" {
             #if DEBUG
             dlog("popup.panel.cmdW close")
             #endif


### PR DESCRIPTION
## Summary

- Keyboard shortcuts (Cmd+T, Cmd+D, Cmd+1-9, Ctrl+N/P, etc.) fail when a non-Latin input source like Korean 두벌식 is active
- Root cause: `KeyboardLayout.character(forKeyCode:modifierFlags:)` assumed CJK input sources lack `kTISPropertyUnicodeKeyLayoutData`, but Korean 두벌식 has it — `UCKeyTranslate` returned Hangul characters and the ASCII fallback was never reached
- Additionally, `handleCustomShortcut` compared raw `event.charactersIgnoringModifiers` (which returns Korean chars like ㅅ for T) against Latin shortcut keys
- Ghostty handles this correctly by matching on `event.keyCode` (hardware scan codes) which are input-method-invariant

## Changes

- **`KeyboardLayout.swift`**: `character(forKeyCode:modifierFlags:)` now checks if the result is ASCII before accepting; non-ASCII results fall through to `TISCopyCurrentASCIICapableKeyboardInputSource()`. Added `normalizedCharacters(for:)` helper for reusable event character normalization.
- **`AppDelegate.swift`**: `handleCustomShortcut` uses `KeyboardLayout.normalizedCharacters(for:)` instead of raw `event.charactersIgnoringModifiers` — fixes Cmd+1-9 workspace switching, Ctrl+1-9 surface selection, omnibar Cmd/Ctrl+N/P, command palette shortcuts, and all `matchShortcut`-based shortcuts.
- **`BrowserPanelView.swift`**: Omnibar key handler uses normalized characters for Cmd/Ctrl+N/P navigation.
- **`BrowserPopupWindowController.swift`**: Popup Cmd+W close handler uses normalized characters.

## Test plan

- [ ] Switch to Korean 두벌식 input mode
- [ ] Verify Cmd+T (new tab), Cmd+D (split right), Cmd+W (close tab) work
- [ ] Verify Cmd+1-9 workspace switching works
- [ ] Verify Ctrl+N/P navigation works in command palette and browser omnibar
- [ ] Verify Cmd+W closes browser popup windows
- [ ] Switch back to English and verify all shortcuts still work
- [ ] Test with Japanese and Chinese input methods if available
- [ ] Verify Dvorak/other non-QWERTY Latin layouts are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes character-based shortcuts failing when Korean 두벌식 or other non‑Latin input sources are active. Shortcuts now normalize to ASCII so Cmd+T, Cmd+D, Cmd+1–9, Ctrl+N/P, and Cmd+W work regardless of input method.

- **Bug Fixes**
  - In KeyboardLayout: accept only ASCII results; fall back to the ASCII-capable input source; added normalizedCharacters(for:).
  - Switched shortcut handlers to use normalizedCharacters in AppDelegate, omnibar, and popup close.
  - Shortcuts now work across Korean/JP/CN IMEs and still respect layouts like “Dvorak – QWERTY Command.”

<sup>Written for commit 8cd9cd96c1cb99e0a3ca6d0ec1f6ec95f75e81c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved keyboard shortcut recognition when using non-Latin keyboard layouts (e.g., CJK, Korean)
  * Enhanced character normalization in keyboard input handling for consistent behavior across different keyboard sources
  * Fixed navigation shortcuts and special key handling to work reliably with international input methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->