### PR TITLE
fix: prevent spurious new window creation on tab/notification events

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11294,7 +11294,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         window.makeKeyAndOrderFront(nil)
         // Improve reliability across Spaces / when other helper panels are key.
-        NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        // Note: .activateAllWindows removed to prevent SwiftUI WindowGroup from
+        // interpreting activation as a request to create a new window. (fixes #872, #616)
+        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // When visible windows exist, prevent macOS from asking SwiftUI to create
+        // a new window on dock-click or app reactivation. (fixes #872)
+        if flag { return false }
+        return true
     }
 
     private func markReadIfFocused(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -336,6 +336,7 @@ struct cmuxApp: App {
                 .environmentObject(notificationStore)
                 .environmentObject(sidebarState)
                 .environmentObject(sidebarSelectionState)
+                .handlesExternalEvents(preferring: [], allowing: [])
                 .onAppear {
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
@@ -359,6 +360,7 @@ struct cmuxApp: App {
                     updateSocketController()
                 }
         }
+        .handlesExternalEvents(matching: [])
         .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .appSettings) {


### PR DESCRIPTION
## Summary

Fixes the issue where clicking the sidebar "+" button, receiving Claude notifications, or dock-clicking creates a **new OS window** instead of adding a workspace tab to the existing window.

- Add `.handlesExternalEvents(matching: [])` to `WindowGroup` scene to prevent SwiftUI from auto-creating windows on external events
- Add `.handlesExternalEvents(preferring: [], allowing: [])` to content view for defense-in-depth
- Remove `.activateAllWindows` from `bringToFront()` — only `.activateIgnoringOtherApps` is needed
- Implement `applicationShouldHandleReopen(_:hasVisibleWindows:)` to prevent dock-click from spawning new windows

## Root cause

SwiftUI's `WindowGroup` responds to `NSRunningApplication.activate(options: [.activateAllWindows])` by creating a new window instance when no `handlesExternalEvents` restriction is set. The `bringToFront()` helper was called on every notification/tab focus, repeatedly triggering this behavior.

## Test plan

- [x] Click sidebar "+" button → new workspace tab created in same window (not a new OS window)
- [ ] Receive Claude Code notification → window brought to front without creating new window
- [ ] Click dock icon when app is running → existing window focused, no new window
- [ ] Cmd+Shift+N still creates a new window (intentional behavior preserved)

Fixes #872, #616
Related: #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent spurious new macOS windows on sidebar "+", notifications, and dock clicks; tabs now open in the existing window and the app focuses it instead, preserving Cmd+Shift+N behavior. Fixes #872, #616.

- **Bug Fixes**
  - Restrict external events on the window scene and content view with `.handlesExternalEvents` to stop SwiftUI from auto-creating windows.
  - Update bringToFront() to drop `.activateAllWindows` and use `.activateIgnoringOtherApps` only.
  - Implement `applicationShouldHandleReopen` to focus the existing window on dock clicks instead of creating a new one.

<sup>Written for commit c581d3e8160c018d46512249b79c21872805be59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window activation behavior when reopening the app to prevent unintended window creation.
  * Improved dock interaction: Dock clicks now properly detect existing windows instead of triggering duplicate window creation.
  * Enhanced event handling configuration for more predictable external event routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->