### PR TITLE
Import Chrome sessions and history into cmux browser

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -124,6 +124,8 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 		/* End PBXBuildFile section */
+		A5001651 /* ChromeCookieImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001650 /* ChromeCookieImporter.swift */; };
+			/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		A5001020 /* Embed Frameworks */ = {
@@ -292,6 +294,7 @@
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		A5001650 /* ChromeCookieImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Browser/ChromeCookieImporter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -458,6 +461,7 @@
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
+				A5001650 /* ChromeCookieImporter.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -753,6 +757,7 @@
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
 				A5001640 /* RemoteRelayZshBootstrap.swift in Sources */,
+				A5001651 /* ChromeCookieImporter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -38453,6 +38453,23 @@
         }
       }
     },
+    "menu.view.importChromeSessions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Chrome Sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeセッションをインポート"
+          }
+        }
+      }
+    },
     "menu.view.jumpToUnread": {
       "extractionState": "manual",
       "localizations": {
@@ -51100,6 +51117,142 @@
         }
       }
     },
+    "settings.browser.chromeCookie.autoImport": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Chrome Sessions on Launch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動時にChromeセッションをインポート"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.autoImport.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copies your Chrome login cookies into cmux's browser so you're already signed in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeのログインクッキーをcmuxのブラウザにコピーし、すでにサインインした状態にします。"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.importButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Now"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐインポート"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.importNow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chrome Sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeセッション"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.importNow.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import cookies from Chrome now."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今すぐChromeからクッキーをインポートします。"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.importSuccess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported %lld cookies from Chrome."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeから%lld個のクッキーをインポートしました。"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.profile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chrome Profile"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeプロファイル"
+          }
+        }
+      }
+    },
+    "settings.browser.chromeCookie.profile.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Which Chrome profile to import cookies from."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クッキーをインポートするChromeプロファイル。"
+          }
+        }
+      }
+    },
     "settings.browser.externalPatterns": {
       "extractionState": "manual",
       "localizations": {
@@ -56899,6 +57052,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tarayıcı"
+          }
+        }
+      }
+    },
+    "settings.section.chromeSessions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chrome Sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chromeセッション"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2341,6 +2341,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         installBrowserAddressBarFocusObservers()
         installShortcutMonitor()
         installShortcutDefaultsObserver()
+
+        // Import Chrome cookies if enabled — run early so cookies are ready before browser panels open.
+        if !isRunningUnderXCTest && UserDefaults.standard.bool(forKey: ChromeCookieSettings.autoImportEnabledKey) {
+            ChromeCookieImporter.importCookies { result in
+                if let error = result.error {
+                    NSLog("[ChromeCookieImporter] auto-import failed: \(error.localizedDescription)")
+                } else if result.cookieCount > 0 {
+                    NSLog("[ChromeCookieImporter] auto-imported \(result.cookieCount) cookies from Chrome")
+                }
+            }
+        }
+
         NSApp.servicesProvider = self
 #if DEBUG
         UpdateTestSupport.applyIfNeeded(to: updateController.viewModel)

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -1,0 +1,424 @@
+import Foundation
+import Security
+import CommonCrypto
+import SQLite3
+import WebKit
+
+// MARK: - Settings constants (temporary; will move to BrowserPanel.swift in Task 2)
+
+enum ChromeCookieSettings {
+    static let autoImportEnabledKey = "browserChromeCookieAutoImport"
+    static let profileKey = "browserChromeCookieProfile"
+    static let defaultAutoImportEnabled = false
+    static let defaultProfile = "Default"
+}
+
+// MARK: - ChromeCookieImporter
+
+final class ChromeCookieImporter {
+
+    static let shared = ChromeCookieImporter()
+
+    // MARK: - Error types
+
+    enum ImportError: Error, LocalizedError {
+        case chromeNotInstalled
+        case keychainAccessDenied
+        case keychainError(OSStatus)
+        case databaseOpenFailed(String)
+        case decryptionFailed
+        case noProfile(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .chromeNotInstalled:
+                return "Google Chrome is not installed or its data directory is missing."
+            case .keychainAccessDenied:
+                return "Access to the Chrome Safe Storage keychain item was denied."
+            case .keychainError(let status):
+                return "Keychain error: \(status)"
+            case .databaseOpenFailed(let reason):
+                return "Failed to open Chrome cookie database: \(reason)"
+            case .decryptionFailed:
+                return "Failed to decrypt Chrome cookie values."
+            case .noProfile(let name):
+                return "Chrome profile not found: \(name)"
+            }
+        }
+    }
+
+    // MARK: - Import result
+
+    struct ImportResult {
+        let cookieCount: Int
+        let error: ImportError?
+    }
+
+    // MARK: - Constants
+
+    private static let chromeAppSupportPath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/Library/Application Support/Google/Chrome"
+    }()
+
+    private let importQueue = DispatchQueue(
+        label: "com.cmux.chrome-cookie-import",
+        qos: .userInitiated
+    )
+
+    /// Microseconds between 1601-01-01 and 1970-01-01 (Unix epoch).
+    private static let chromeEpochOffset: Int64 = 11_644_473_600
+
+    private init() {}
+
+    // MARK: - Step 1: Chrome profile discovery
+
+    static var isChromeInstalled: Bool {
+        FileManager.default.fileExists(atPath: chromeAppSupportPath)
+    }
+
+    /// Scans Chrome's data directory for profile subdirectories.
+    /// Returns a sorted list with "Default" first, then alphabetical by display name.
+    static func availableProfiles() -> [(directory: String, displayName: String)] {
+        let basePath = chromeAppSupportPath
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: basePath) else { return [] }
+
+        var profiles: [(directory: String, displayName: String)] = []
+
+        guard let contents = try? fm.contentsOfDirectory(atPath: basePath) else {
+            return []
+        }
+
+        for entry in contents {
+            let entryPath = "\(basePath)/\(entry)"
+
+            // Chrome profiles are either "Default" or "Profile N"
+            guard entry == "Default" || entry.hasPrefix("Profile ") else { continue }
+
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: entryPath, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+
+            // Check that a Cookies file exists in the profile directory
+            let cookiesPath = "\(entryPath)/Cookies"
+            guard fm.fileExists(atPath: cookiesPath) else { continue }
+
+            let displayName = readProfileDisplayName(at: entryPath) ?? entry
+            profiles.append((directory: entry, displayName: displayName))
+        }
+
+        // Sort: "Default" first, then alphabetical by display name
+        profiles.sort { lhs, rhs in
+            if lhs.directory == "Default" { return true }
+            if rhs.directory == "Default" { return false }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+
+        return profiles
+    }
+
+    /// Reads the profile display name from Chrome's Preferences JSON.
+    private static func readProfileDisplayName(at profilePath: String) -> String? {
+        let prefsPath = "\(profilePath)/Preferences"
+        guard let data = FileManager.default.contents(atPath: prefsPath) else { return nil }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let profile = json["profile"] as? [String: Any],
+              let name = profile["name"] as? String,
+              !name.isEmpty
+        else {
+            return nil
+        }
+
+        return name
+    }
+
+    /// Returns the path to the Cookies SQLite database for a given profile directory name.
+    func cookieDBPath(profile: String) -> String {
+        "\(Self.chromeAppSupportPath)/\(profile)/Cookies"
+    }
+
+    // MARK: - Step 2: Keychain access
+
+    /// Reads the "Chrome Safe Storage" password from macOS Keychain.
+    func readChromeKeychainPassword() throws -> String {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Chrome Safe Storage",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data,
+                  let password = String(data: data, encoding: .utf8)
+            else {
+                throw ImportError.keychainError(status)
+            }
+            return password
+
+        case errSecAuthFailed, errSecUserCanceled, errSecInteractionNotAllowed:
+            throw ImportError.keychainAccessDenied
+
+        default:
+            throw ImportError.keychainError(status)
+        }
+    }
+
+    // MARK: - Step 3: AES-128-CBC decryption
+
+    /// Derives a 16-byte AES key from the Chrome keychain password using PBKDF2.
+    func deriveKey(fromPassword password: String) -> [UInt8] {
+        let salt = Array("saltysalt".utf8)
+        let iterations: UInt32 = 1003
+        let keyLength = 16
+
+        var derivedKey = [UInt8](repeating: 0, count: keyLength)
+
+        password.withCString { passwordPtr in
+            CCKeyDerivationPBKDF(
+                CCPBKDFAlgorithm(kCCPBKDF2),
+                passwordPtr,
+                strlen(passwordPtr),
+                salt,
+                salt.count,
+                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                iterations,
+                &derivedKey,
+                keyLength
+            )
+        }
+
+        return derivedKey
+    }
+
+    /// Decrypts a Chrome cookie value that uses the `v10` encryption format.
+    ///
+    /// Chrome cookie values are encrypted with AES-128-CBC:
+    /// - First 3 bytes: version tag (`v10`)
+    /// - IV: 16 bytes of space characters (0x20)
+    /// - Remaining bytes: AES-128-CBC encrypted data with PKCS7 padding
+    func decryptCookieValue(_ encryptedData: Data, key: [UInt8]) -> String? {
+        // Must have at least the 3-byte "v10" prefix plus some cipher data
+        guard encryptedData.count > 3 else { return nil }
+
+        let prefix = encryptedData.prefix(3)
+        guard String(data: prefix, encoding: .utf8) == "v10" else { return nil }
+
+        let ciphertext = encryptedData.dropFirst(3)
+        let iv = [UInt8](repeating: 0x20, count: 16)
+
+        // AES-128-CBC output buffer (ciphertext length + one block for padding)
+        let bufferSize = ciphertext.count + kCCBlockSizeAES128
+        var decryptedBytes = [UInt8](repeating: 0, count: bufferSize)
+        var decryptedLength = 0
+
+        let status = ciphertext.withUnsafeBytes { ciphertextPtr in
+            CCCrypt(
+                CCOperation(kCCDecrypt),
+                CCAlgorithm(kCCAlgorithmAES128),
+                CCOptions(kCCOptionPKCS7Padding),
+                key,
+                key.count,
+                iv,
+                ciphertextPtr.baseAddress,
+                ciphertext.count,
+                &decryptedBytes,
+                bufferSize,
+                &decryptedLength
+            )
+        }
+
+        guard status == kCCSuccess, decryptedLength > 0 else { return nil }
+
+        return String(bytes: decryptedBytes.prefix(decryptedLength), encoding: .utf8)
+    }
+
+    // MARK: - Step 4: SQLite reading
+
+    /// Reads and decrypts cookies from Chrome's SQLite database.
+    func readCookies(profile: String, key: [UInt8]) throws -> [HTTPCookie] {
+        let dbPath = cookieDBPath(profile: profile)
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: dbPath) else {
+            throw ImportError.noProfile(profile)
+        }
+
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
+        let openStatus = sqlite3_open_v2(dbPath, &db, flags, nil)
+
+        guard openStatus == SQLITE_OK, let db = db else {
+            let message = db.map { String(cString: sqlite3_errmsg($0)) } ?? "Unknown error"
+            sqlite3_close(db)
+            throw ImportError.databaseOpenFailed(message)
+        }
+
+        defer { sqlite3_close(db) }
+
+        var cookies: [HTTPCookie] = []
+
+        let query = """
+            SELECT host_key, name, path, encrypted_value, is_secure, is_httponly, expires_utc
+            FROM cookies
+            WHERE expires_utc > 0 OR is_persistent = 1
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw ImportError.databaseOpenFailed(message)
+        }
+
+        defer { sqlite3_finalize(stmt) }
+
+        let now = currentChromeTimestamp()
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let hostKeyCStr = sqlite3_column_text(stmt, 0),
+                  let nameCStr = sqlite3_column_text(stmt, 1),
+                  let pathCStr = sqlite3_column_text(stmt, 2)
+            else {
+                continue
+            }
+
+            let hostKey = String(cString: hostKeyCStr)
+            let name = String(cString: nameCStr)
+            let path = String(cString: pathCStr)
+
+            // Skip expired cookies
+            let expiresUtc = sqlite3_column_int64(stmt, 6)
+            if expiresUtc > 0 && expiresUtc < now {
+                continue
+            }
+
+            // Decrypt cookie value
+            let blobPtr = sqlite3_column_blob(stmt, 3)
+            let blobLen = sqlite3_column_bytes(stmt, 3)
+
+            var value = ""
+            if let blobPtr = blobPtr, blobLen > 0 {
+                let encryptedData = Data(bytes: blobPtr, count: Int(blobLen))
+                if let decrypted = decryptCookieValue(encryptedData, key: key) {
+                    value = decrypted
+                } else {
+                    // Skip cookies we cannot decrypt
+                    continue
+                }
+            }
+
+            let isSecure = sqlite3_column_int(stmt, 4) != 0
+            let isHttpOnly = sqlite3_column_int(stmt, 5) != 0
+
+            // Build domain: prefix with "." if not already prefixed
+            let domain = hostKey.hasPrefix(".") ? hostKey : ".\(hostKey)"
+
+            // Convert Chrome timestamp to Unix Date
+            let expiresDate: Date?
+            if expiresUtc > 0 {
+                let unixSeconds = TimeInterval(expiresUtc / 1_000_000) - TimeInterval(Self.chromeEpochOffset)
+                expiresDate = Date(timeIntervalSince1970: unixSeconds)
+            } else {
+                expiresDate = nil
+            }
+
+            var properties: [HTTPCookiePropertyKey: Any] = [
+                .domain: domain,
+                .path: path,
+                .name: name,
+                .value: value,
+                .secure: isSecure ? "TRUE" : "FALSE",
+            ]
+
+            if isHttpOnly {
+                // NSHTTPCookieHTTPOnly is not exposed as a public property key constant,
+                // but it is recognized when constructing HTTPCookie.
+                properties[HTTPCookiePropertyKey("HttpOnly")] = "YES"
+            }
+
+            if let expiresDate = expiresDate {
+                properties[.expires] = expiresDate
+            }
+
+            if let cookie = HTTPCookie(properties: properties) {
+                cookies.append(cookie)
+            }
+        }
+
+        return cookies
+    }
+
+    /// Returns the current time as a Chrome-format timestamp (microseconds since 1601-01-01).
+    private func currentChromeTimestamp() -> Int64 {
+        let unixSeconds = Int64(Date().timeIntervalSince1970)
+        return (unixSeconds + Self.chromeEpochOffset) * 1_000_000
+    }
+
+    // MARK: - Step 5: Public import API
+
+    /// Imports Chrome cookies into WKWebView's default cookie store.
+    ///
+    /// Reads the target profile from `UserDefaults` (key: `ChromeCookieSettings.profileKey`),
+    /// falling back to `"Default"`. Runs on a background queue; completion is called on main thread.
+    static func importCookies(
+        profile: String? = nil,
+        completion: @escaping (ImportResult) -> Void
+    ) {
+        let importer = shared
+        let targetProfile = profile
+            ?? UserDefaults.standard.string(forKey: ChromeCookieSettings.profileKey)
+            ?? ChromeCookieSettings.defaultProfile
+
+        importer.importQueue.async {
+            do {
+                guard isChromeInstalled else {
+                    throw ImportError.chromeNotInstalled
+                }
+
+                let password = try importer.readChromeKeychainPassword()
+                let key = importer.deriveKey(fromPassword: password)
+                let cookies = try importer.readCookies(profile: targetProfile, key: key)
+
+                guard !cookies.isEmpty else {
+                    DispatchQueue.main.async {
+                        completion(ImportResult(cookieCount: 0, error: nil))
+                    }
+                    return
+                }
+
+                let cookieStore = WKWebsiteDataStore.default().httpCookieStore
+                let group = DispatchGroup()
+
+                for cookie in cookies {
+                    group.enter()
+                    DispatchQueue.main.async {
+                        cookieStore.setCookie(cookie) {
+                            group.leave()
+                        }
+                    }
+                }
+
+                group.notify(queue: .main) {
+                    completion(ImportResult(cookieCount: cookies.count, error: nil))
+                }
+
+            } catch let error as ImportError {
+                DispatchQueue.main.async {
+                    completion(ImportResult(cookieCount: 0, error: error))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(ImportResult(cookieCount: 0, error: .decryptionFailed))
+                }
+            }
+        }
+    }
+}

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -311,8 +311,13 @@ final class ChromeCookieImporter: @unchecked Sendable {
             let isSecure = sqlite3_column_int(stmt, 4) != 0
             let isHttpOnly = sqlite3_column_int(stmt, 5) != 0
 
-            // Build domain: prefix with "." if not already prefixed
-            let domain = hostKey.hasPrefix(".") ? hostKey : ".\(hostKey)"
+            // Chrome stores domain cookies with a leading dot (".github.com") and
+            // host-only cookies without ("github.com"). Preserve this distinction:
+            // - Domain cookies: keep the leading dot so the cookie applies to subdomains.
+            // - Host-only cookies: use the bare host. __Host- prefixed cookies MUST NOT
+            //   have a Domain attribute at all per the cookie spec.
+            let isHostOnly = !hostKey.hasPrefix(".")
+            let domain = hostKey
 
             // Convert Chrome timestamp to Unix Date
             let expiresDate: Date?
@@ -324,12 +329,23 @@ final class ChromeCookieImporter: @unchecked Sendable {
             }
 
             var properties: [HTTPCookiePropertyKey: Any] = [
-                .domain: domain,
                 .path: path,
                 .name: name,
                 .value: value,
                 .secure: isSecure ? "TRUE" : "FALSE",
             ]
+
+            // __Host- cookies must not have a Domain attribute.
+            // For other host-only cookies, set .domain to the bare host.
+            // For domain cookies, keep the leading-dot domain.
+            if name.hasPrefix("__Host-") {
+                // HTTPCookie requires .domain; use the origin host without leading dot.
+                // Setting originURL instead lets the cookie be host-locked.
+                let scheme = isSecure ? "https" : "http"
+                properties[.originURL] = "\(scheme)://\(hostKey)"
+            } else {
+                properties[.domain] = domain
+            }
 
             if isHttpOnly {
                 // NSHTTPCookieHTTPOnly is not exposed as a public property key constant,
@@ -376,8 +392,10 @@ final class ChromeCookieImporter: @unchecked Sendable {
                 }
 
                 let password = try readChromeKeychainPassword()
+                NSLog("[ChromeCookieImporter] keychain access OK, deriving key")
                 let key = deriveKey(fromPassword: password)
                 let cookies = try readCookies(profile: targetProfile, key: key)
+                NSLog("[ChromeCookieImporter] read \(cookies.count) cookies from Chrome profile '\(targetProfile)'")
 
                 guard !cookies.isEmpty else {
                     DispatchQueue.main.async {

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -412,9 +412,99 @@ final class ChromeCookieImporter: @unchecked Sendable {
         return (unixSeconds + Self.chromeEpochOffset) * 1_000_000
     }
 
-    // MARK: - Step 5: Public import API
+    // MARK: - Chrome history import
 
-    /// Imports Chrome cookies into WKWebView's default cookie store.
+    /// Path to Chrome's History SQLite database for a given profile.
+    private static func historyDBPath(profile: String) -> String {
+        "\(chromeAppSupportPath)/\(profile)/History"
+    }
+
+    /// Reads browsing history from Chrome's History SQLite database.
+    /// Copies the file to a temp location first because Chrome holds an exclusive lock.
+    private static func readHistory(profile: String) throws -> [BrowserHistoryStore.Entry] {
+        let srcPath = historyDBPath(profile: profile)
+        guard FileManager.default.fileExists(atPath: srcPath) else {
+            return []
+        }
+
+        // Chrome locks the History file exclusively. Copy to temp to read safely.
+        let tmpPath = NSTemporaryDirectory() + "cmux-chrome-history-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        do {
+            try FileManager.default.copyItem(atPath: srcPath, toPath: tmpPath)
+        } catch {
+            NSLog("[ChromeCookieImporter] failed to copy History DB: \(error)")
+            return []
+        }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(tmpPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let db = db else {
+            sqlite3_close(db)
+            return []
+        }
+        defer { sqlite3_close(db) }
+
+        let query = """
+            SELECT url, title, visit_count, typed_count, last_visit_time
+            FROM urls
+            WHERE hidden = 0 AND visit_count > 0
+            ORDER BY last_visit_time DESC
+            LIMIT 5000
+            """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var entries: [BrowserHistoryStore.Entry] = []
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let urlCStr = sqlite3_column_text(stmt, 0) else { continue }
+            let urlString = String(cString: urlCStr)
+
+            // Skip non-HTTP(S) URLs
+            guard urlString.hasPrefix("http://") || urlString.hasPrefix("https://") else {
+                continue
+            }
+
+            let title: String?
+            if let titleCStr = sqlite3_column_text(stmt, 1) {
+                let t = String(cString: titleCStr)
+                title = t.isEmpty ? nil : t
+            } else {
+                title = nil
+            }
+
+            let visitCount = Int(sqlite3_column_int(stmt, 2))
+            let typedCount = Int(sqlite3_column_int(stmt, 3))
+            let lastVisitTime = sqlite3_column_int64(stmt, 4)
+
+            // Convert Chrome timestamp to Date
+            let unixSeconds = TimeInterval(lastVisitTime / 1_000_000) - TimeInterval(chromeEpochOffset)
+            let lastVisited = Date(timeIntervalSince1970: unixSeconds)
+
+            let entry = BrowserHistoryStore.Entry(
+                id: UUID(),
+                url: urlString,
+                title: title,
+                lastVisited: lastVisited,
+                visitCount: visitCount,
+                typedCount: typedCount
+            )
+            entries.append(entry)
+        }
+
+        return entries
+    }
+
+    // MARK: - Public import API
+
+    /// Imports Chrome cookies into WKWebView's default cookie store and Chrome history
+    /// into BrowserHistoryStore.
     ///
     /// Reads the target profile from `UserDefaults` (key: `ChromeCookieSettings.profileKey`),
     /// falling back to `"Default"`. Runs on a background queue; completion is called on main thread.
@@ -438,15 +528,24 @@ final class ChromeCookieImporter: @unchecked Sendable {
                 let cookies = try readCookies(profile: targetProfile, key: key)
                 NSLog("[ChromeCookieImporter] read \(cookies.count) cookies from Chrome profile '\(targetProfile)'")
 
-                guard !cookies.isEmpty else {
-                    DispatchQueue.main.async {
-                        completion(ImportResult(cookieCount: 0, error: nil))
-                    }
-                    return
+                // Import history (best-effort, don't fail the whole import if this errors)
+                let historyEntries = (try? readHistory(profile: targetProfile)) ?? []
+                if !historyEntries.isEmpty {
+                    NSLog("[ChromeCookieImporter] read \(historyEntries.count) history entries from Chrome")
                 }
 
-                // WKWebsiteDataStore must be accessed on the main thread.
+                // WKWebsiteDataStore and BrowserHistoryStore must be accessed on the main thread.
                 DispatchQueue.main.async {
+                    // Merge Chrome history into BrowserHistoryStore
+                    if !historyEntries.isEmpty {
+                        BrowserHistoryStore.shared.mergeImportedEntries(historyEntries)
+                    }
+
+                    guard !cookies.isEmpty else {
+                        completion(ImportResult(cookieCount: 0, error: nil))
+                        return
+                    }
+
                     let cookieStore = WKWebsiteDataStore.default().httpCookieStore
                     let group = DispatchGroup()
 

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -196,6 +196,9 @@ final class ChromeCookieImporter: @unchecked Sendable {
     /// - First 3 bytes: version tag (`v10`)
     /// - IV: 16 bytes of space characters (0x20)
     /// - Remaining bytes: AES-128-CBC encrypted data with PKCS7 padding
+    ///
+    /// Modern Chrome (v80+) prepends a 32-byte hash to the plaintext before encryption.
+    /// After decrypting, we strip these 32 bytes to get the actual cookie value.
     private static func decryptCookieValue(_ encryptedData: Data, key: [UInt8]) -> String? {
         // Must have at least the 3-byte "v10" prefix plus some cipher data
         guard encryptedData.count > 3 else { return nil }
@@ -229,7 +232,19 @@ final class ChromeCookieImporter: @unchecked Sendable {
 
         guard status == kCCSuccess, decryptedLength > 0 else { return nil }
 
-        return String(bytes: decryptedBytes.prefix(decryptedLength), encoding: .utf8)
+        let decrypted = Array(decryptedBytes.prefix(decryptedLength))
+
+        // Modern Chrome prepends a 32-byte hash/integrity prefix to the plaintext.
+        // Strip it to get the actual cookie value. If the decrypted data is <= 32 bytes,
+        // try interpreting the whole thing as the value (older Chrome format).
+        let valueBytes: ArraySlice<UInt8>
+        if decrypted.count > 32 {
+            valueBytes = decrypted.dropFirst(32)
+        } else {
+            valueBytes = decrypted[...]
+        }
+
+        return String(bytes: valueBytes, encoding: .utf8)
     }
 
     // MARK: - Step 4: SQLite reading

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -503,6 +503,39 @@ final class ChromeCookieImporter: @unchecked Sendable {
 
     // MARK: - Public import API
 
+    /// Injects cookies into WKWebView and merges history. Must be called on the main thread.
+    @MainActor
+    private static func applyImportedData(
+        cookies: [HTTPCookie],
+        historyEntries: [BrowserHistoryStore.Entry],
+        completion: @escaping (ImportResult) -> Void
+    ) {
+        // Merge Chrome history into BrowserHistoryStore
+        if !historyEntries.isEmpty {
+            BrowserHistoryStore.shared.mergeImportedEntries(historyEntries)
+        }
+
+        guard !cookies.isEmpty else {
+            completion(ImportResult(cookieCount: 0, error: nil))
+            return
+        }
+
+        let cookieStore = WKWebsiteDataStore.default().httpCookieStore
+        let group = DispatchGroup()
+
+        for cookie in cookies {
+            group.enter()
+            cookieStore.setCookie(cookie) {
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            shared.lastImportTime = Date()
+            completion(ImportResult(cookieCount: cookies.count, error: nil))
+        }
+    }
+
     /// Imports Chrome cookies into WKWebView's default cookie store and Chrome history
     /// into BrowserHistoryStore.
     ///
@@ -529,37 +562,13 @@ final class ChromeCookieImporter: @unchecked Sendable {
                 NSLog("[ChromeCookieImporter] read \(cookies.count) cookies from Chrome profile '\(targetProfile)'")
 
                 // Import history (best-effort, don't fail the whole import if this errors)
-                let historyEntries = (try? readHistory(profile: targetProfile)) ?? []
+                let historyEntries: [BrowserHistoryStore.Entry] = (try? readHistory(profile: targetProfile)) ?? []
                 if !historyEntries.isEmpty {
                     NSLog("[ChromeCookieImporter] read \(historyEntries.count) history entries from Chrome")
                 }
 
-                // WKWebsiteDataStore and BrowserHistoryStore must be accessed on the main thread.
-                DispatchQueue.main.async {
-                    // Merge Chrome history into BrowserHistoryStore
-                    if !historyEntries.isEmpty {
-                        BrowserHistoryStore.shared.mergeImportedEntries(historyEntries)
-                    }
-
-                    guard !cookies.isEmpty else {
-                        completion(ImportResult(cookieCount: 0, error: nil))
-                        return
-                    }
-
-                    let cookieStore = WKWebsiteDataStore.default().httpCookieStore
-                    let group = DispatchGroup()
-
-                    for cookie in cookies {
-                        group.enter()
-                        cookieStore.setCookie(cookie) {
-                            group.leave()
-                        }
-                    }
-
-                    group.notify(queue: .main) {
-                        shared.lastImportTime = Date()
-                        completion(ImportResult(cookieCount: cookies.count, error: nil))
-                    }
+                Task { @MainActor in
+                    applyImportedData(cookies: cookies, historyEntries: historyEntries, completion: completion)
                 }
 
             } catch let error as ImportError {

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -15,7 +15,7 @@ enum ChromeCookieSettings {
 
 // MARK: - ChromeCookieImporter
 
-final class ChromeCookieImporter {
+final class ChromeCookieImporter: @unchecked Sendable {
 
     static let shared = ChromeCookieImporter()
 
@@ -49,7 +49,7 @@ final class ChromeCookieImporter {
 
     // MARK: - Import result
 
-    struct ImportResult {
+    struct ImportResult: Sendable {
         let cookieCount: Int
         let error: ImportError?
     }
@@ -66,7 +66,7 @@ final class ChromeCookieImporter {
         qos: .userInitiated
     )
 
-    /// Microseconds between 1601-01-01 and 1970-01-01 (Unix epoch).
+    /// Seconds between 1601-01-01 and 1970-01-01 (Unix epoch).
     private static let chromeEpochOffset: Int64 = 11_644_473_600
 
     private init() {}
@@ -112,7 +112,7 @@ final class ChromeCookieImporter {
 
         // Sort: "Default" first, then alphabetical by display name
         profiles.sort { lhs, rhs in
-            if lhs.directory == "Default" { return true }
+            if lhs.directory == "Default" && rhs.directory != "Default" { return true }
             if rhs.directory == "Default" { return false }
             return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
         }
@@ -137,14 +137,14 @@ final class ChromeCookieImporter {
     }
 
     /// Returns the path to the Cookies SQLite database for a given profile directory name.
-    func cookieDBPath(profile: String) -> String {
+    private static func cookieDBPath(profile: String) -> String {
         "\(Self.chromeAppSupportPath)/\(profile)/Cookies"
     }
 
     // MARK: - Step 2: Keychain access
 
     /// Reads the "Chrome Safe Storage" password from macOS Keychain.
-    func readChromeKeychainPassword() throws -> String {
+    private static func readChromeKeychainPassword() throws -> String {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: "Chrome Safe Storage",
@@ -175,7 +175,7 @@ final class ChromeCookieImporter {
     // MARK: - Step 3: AES-128-CBC decryption
 
     /// Derives a 16-byte AES key from the Chrome keychain password using PBKDF2.
-    func deriveKey(fromPassword password: String) -> [UInt8] {
+    private static func deriveKey(fromPassword password: String) -> [UInt8] {
         let salt = Array("saltysalt".utf8)
         let iterations: UInt32 = 1003
         let keyLength = 16
@@ -205,7 +205,7 @@ final class ChromeCookieImporter {
     /// - First 3 bytes: version tag (`v10`)
     /// - IV: 16 bytes of space characters (0x20)
     /// - Remaining bytes: AES-128-CBC encrypted data with PKCS7 padding
-    func decryptCookieValue(_ encryptedData: Data, key: [UInt8]) -> String? {
+    private static func decryptCookieValue(_ encryptedData: Data, key: [UInt8]) -> String? {
         // Must have at least the 3-byte "v10" prefix plus some cipher data
         guard encryptedData.count > 3 else { return nil }
 
@@ -244,7 +244,7 @@ final class ChromeCookieImporter {
     // MARK: - Step 4: SQLite reading
 
     /// Reads and decrypts cookies from Chrome's SQLite database.
-    func readCookies(profile: String, key: [UInt8]) throws -> [HTTPCookie] {
+    private static func readCookies(profile: String, key: [UInt8]) throws -> [HTTPCookie] {
         let dbPath = cookieDBPath(profile: profile)
         let fm = FileManager.default
 
@@ -253,7 +253,7 @@ final class ChromeCookieImporter {
         }
 
         var db: OpaquePointer?
-        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
+        let flags = SQLITE_OPEN_READONLY
         let openStatus = sqlite3_open_v2(dbPath, &db, flags, nil)
 
         guard openStatus == SQLITE_OK, let db = db else {
@@ -263,6 +263,8 @@ final class ChromeCookieImporter {
         }
 
         defer { sqlite3_close(db) }
+
+        sqlite3_busy_timeout(db, 1000)
 
         var cookies: [HTTPCookie] = []
 
@@ -357,7 +359,7 @@ final class ChromeCookieImporter {
     }
 
     /// Returns the current time as a Chrome-format timestamp (microseconds since 1601-01-01).
-    private func currentChromeTimestamp() -> Int64 {
+    private static func currentChromeTimestamp() -> Int64 {
         let unixSeconds = Int64(Date().timeIntervalSince1970)
         return (unixSeconds + Self.chromeEpochOffset) * 1_000_000
     }
@@ -372,20 +374,19 @@ final class ChromeCookieImporter {
         profile: String? = nil,
         completion: @escaping (ImportResult) -> Void
     ) {
-        let importer = shared
         let targetProfile = profile
             ?? UserDefaults.standard.string(forKey: ChromeCookieSettings.profileKey)
             ?? ChromeCookieSettings.defaultProfile
 
-        importer.importQueue.async {
+        shared.importQueue.async {
             do {
                 guard isChromeInstalled else {
                     throw ImportError.chromeNotInstalled
                 }
 
-                let password = try importer.readChromeKeychainPassword()
-                let key = importer.deriveKey(fromPassword: password)
-                let cookies = try importer.readCookies(profile: targetProfile, key: key)
+                let password = try readChromeKeychainPassword()
+                let key = deriveKey(fromPassword: password)
+                let cookies = try readCookies(profile: targetProfile, key: key)
 
                 guard !cookies.isEmpty else {
                     DispatchQueue.main.async {

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -60,7 +60,33 @@ final class ChromeCookieImporter: @unchecked Sendable {
     /// Seconds between 1601-01-01 and 1970-01-01 (Unix epoch).
     private static let chromeEpochOffset: Int64 = 11_644_473_600
 
+    /// Minimum interval between automatic re-imports (5 minutes).
+    private static let autoReimportInterval: TimeInterval = 300
+
+    /// Timestamp of last successful import.
+    private var lastImportTime: Date?
+
     private init() {}
+
+    /// Triggers a cookie re-import if enough time has passed since the last one.
+    /// Called when a new browser tab is opened. No-op if auto-import is disabled,
+    /// Chrome is not installed, or the throttle interval hasn't elapsed.
+    static func importIfNeeded() {
+        guard UserDefaults.standard.bool(forKey: ChromeCookieSettings.autoImportEnabledKey),
+              isChromeInstalled else { return }
+
+        let now = Date()
+        if let lastImport = shared.lastImportTime,
+           now.timeIntervalSince(lastImport) < autoReimportInterval {
+            return
+        }
+
+        importCookies { result in
+            if result.error == nil && result.cookieCount > 0 {
+                shared.lastImportTime = now
+            }
+        }
+    }
 
     // MARK: - Step 1: Chrome profile discovery
 
@@ -432,6 +458,7 @@ final class ChromeCookieImporter: @unchecked Sendable {
                     }
 
                     group.notify(queue: .main) {
+                        shared.lastImportTime = Date()
                         completion(ImportResult(cookieCount: cookies.count, error: nil))
                     }
                 }

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -419,20 +419,21 @@ final class ChromeCookieImporter: @unchecked Sendable {
                     return
                 }
 
-                let cookieStore = WKWebsiteDataStore.default().httpCookieStore
-                let group = DispatchGroup()
+                // WKWebsiteDataStore must be accessed on the main thread.
+                DispatchQueue.main.async {
+                    let cookieStore = WKWebsiteDataStore.default().httpCookieStore
+                    let group = DispatchGroup()
 
-                for cookie in cookies {
-                    group.enter()
-                    DispatchQueue.main.async {
+                    for cookie in cookies {
+                        group.enter()
                         cookieStore.setCookie(cookie) {
                             group.leave()
                         }
                     }
-                }
 
-                group.notify(queue: .main) {
-                    completion(ImportResult(cookieCount: cookies.count, error: nil))
+                    group.notify(queue: .main) {
+                        completion(ImportResult(cookieCount: cookies.count, error: nil))
+                    }
                 }
 
             } catch let error as ImportError {

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -23,17 +23,17 @@ final class ChromeCookieImporter: @unchecked Sendable {
         var errorDescription: String? {
             switch self {
             case .chromeNotInstalled:
-                return "Google Chrome is not installed or its data directory is missing."
+                return String(localized: "browser.import.error.chromeNotInstalled", defaultValue: "Google Chrome is not installed or its data directory is missing.")
             case .keychainAccessDenied:
-                return "Access to the Chrome Safe Storage keychain item was denied."
+                return String(localized: "browser.import.error.keychainAccessDenied", defaultValue: "Access to the Chrome Safe Storage keychain item was denied.")
             case .keychainError(let status):
-                return "Keychain error: \(status)"
+                return String(localized: "browser.import.error.keychainError", defaultValue: "Keychain error: \(status)")
             case .databaseOpenFailed(let reason):
-                return "Failed to open Chrome cookie database: \(reason)"
+                return String(localized: "browser.import.error.databaseOpenFailed", defaultValue: "Failed to open Chrome cookie database: \(reason)")
             case .decryptionFailed:
-                return "Failed to decrypt Chrome cookie values."
+                return String(localized: "browser.import.error.decryptionFailed", defaultValue: "Failed to decrypt Chrome cookie values.")
             case .noProfile(let name):
-                return "Chrome profile not found: \(name)"
+                return String(localized: "browser.import.error.noProfile", defaultValue: "Chrome profile not found: \(name)")
             }
         }
     }
@@ -63,8 +63,14 @@ final class ChromeCookieImporter: @unchecked Sendable {
     /// Minimum interval between automatic re-imports (5 minutes).
     private static let autoReimportInterval: TimeInterval = 300
 
+    /// Guards access to `lastImportTime` and `importInFlight` for thread safety.
+    private let lock = NSLock()
+
     /// Timestamp of last successful import.
     private var lastImportTime: Date?
+
+    /// Whether an import is currently in progress (prevents duplicate concurrent imports).
+    private var importInFlight = false
 
     private init() {}
 
@@ -75,15 +81,21 @@ final class ChromeCookieImporter: @unchecked Sendable {
         guard UserDefaults.standard.bool(forKey: ChromeCookieSettings.autoImportEnabledKey),
               isChromeInstalled else { return }
 
-        let now = Date()
-        if let lastImport = shared.lastImportTime,
-           now.timeIntervalSince(lastImport) < autoReimportInterval {
-            return
+        let shouldImport: Bool = shared.lock.withLock {
+            guard !shared.importInFlight else { return false }
+            let now = Date()
+            if let lastImport = shared.lastImportTime,
+               now.timeIntervalSince(lastImport) < autoReimportInterval {
+                return false
+            }
+            shared.importInFlight = true
+            return true
         }
+        guard shouldImport else { return }
 
-        importCookies { result in
-            if result.error == nil && result.cookieCount > 0 {
-                shared.lastImportTime = now
+        importCookies { _ in
+            shared.lock.withLock {
+                shared.importInFlight = false
             }
         }
     }
@@ -301,7 +313,7 @@ final class ChromeCookieImporter: @unchecked Sendable {
         var cookies: [HTTPCookie] = []
 
         let query = """
-            SELECT host_key, name, path, encrypted_value, is_secure, is_httponly, expires_utc
+            SELECT host_key, name, path, encrypted_value, is_secure, is_httponly, expires_utc, value
             FROM cookies
             WHERE expires_utc > 0 OR is_persistent = 1
             """
@@ -334,20 +346,25 @@ final class ChromeCookieImporter: @unchecked Sendable {
                 continue
             }
 
-            // Decrypt cookie value
+            // Prefer encrypted_value; fall back to plaintext value column
             let blobPtr = sqlite3_column_blob(stmt, 3)
             let blobLen = sqlite3_column_bytes(stmt, 3)
 
-            var value = ""
+            var value: String?
             if let blobPtr = blobPtr, blobLen > 0 {
                 let encryptedData = Data(bytes: blobPtr, count: Int(blobLen))
-                if let decrypted = decryptCookieValue(encryptedData, key: key) {
-                    value = decrypted
-                } else {
-                    // Skip cookies we cannot decrypt
-                    continue
+                value = decryptCookieValue(encryptedData, key: key)
+            }
+            // Fall back to plaintext value column (index 7)
+            if value == nil || value?.isEmpty == true {
+                if let plaintextCStr = sqlite3_column_text(stmt, 7) {
+                    let plaintext = String(cString: plaintextCStr)
+                    if !plaintext.isEmpty {
+                        value = plaintext
+                    }
                 }
             }
+            guard let cookieValue = value, !cookieValue.isEmpty else { continue }
 
             let isSecure = sqlite3_column_int(stmt, 4) != 0
             let isHttpOnly = sqlite3_column_int(stmt, 5) != 0
@@ -357,7 +374,6 @@ final class ChromeCookieImporter: @unchecked Sendable {
             // - Domain cookies: keep the leading dot so the cookie applies to subdomains.
             // - Host-only cookies: use the bare host. __Host- prefixed cookies MUST NOT
             //   have a Domain attribute at all per the cookie spec.
-            let isHostOnly = !hostKey.hasPrefix(".")
             let domain = hostKey
 
             // Convert Chrome timestamp to Unix Date
@@ -372,16 +388,13 @@ final class ChromeCookieImporter: @unchecked Sendable {
             var properties: [HTTPCookiePropertyKey: Any] = [
                 .path: path,
                 .name: name,
-                .value: value,
+                .value: cookieValue,
                 .secure: isSecure ? "TRUE" : "FALSE",
             ]
 
             // __Host- cookies must not have a Domain attribute.
-            // For other host-only cookies, set .domain to the bare host.
-            // For domain cookies, keep the leading-dot domain.
+            // For other cookies, set .domain to preserve Chrome's host/domain distinction.
             if name.hasPrefix("__Host-") {
-                // HTTPCookie requires .domain; use the origin host without leading dot.
-                // Setting originURL instead lets the cookie be host-locked.
                 let scheme = isSecure ? "https" : "http"
                 properties[.originURL] = "\(scheme)://\(hostKey)"
             } else {
@@ -389,8 +402,6 @@ final class ChromeCookieImporter: @unchecked Sendable {
             }
 
             if isHttpOnly {
-                // NSHTTPCookieHTTPOnly is not exposed as a public property key constant,
-                // but it is recognized when constructing HTTPCookie.
                 properties[HTTPCookiePropertyKey("HttpOnly")] = "YES"
             }
 
@@ -420,7 +431,7 @@ final class ChromeCookieImporter: @unchecked Sendable {
     }
 
     /// Reads browsing history from Chrome's History SQLite database.
-    /// Copies the file to a temp location first because Chrome holds an exclusive lock.
+    /// Copies the file (and WAL sidecars) to a temp location first because Chrome holds an exclusive lock.
     private static func readHistory(profile: String) throws -> [BrowserHistoryStore.Entry] {
         let srcPath = historyDBPath(profile: profile)
         guard FileManager.default.fileExists(atPath: srcPath) else {
@@ -428,13 +439,24 @@ final class ChromeCookieImporter: @unchecked Sendable {
         }
 
         // Chrome locks the History file exclusively. Copy to temp to read safely.
-        let tmpPath = NSTemporaryDirectory() + "cmux-chrome-history-\(UUID().uuidString).db"
-        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+        // Also copy WAL sidecar files so we get the most recent data.
+        let tmpBase = NSTemporaryDirectory() + "cmux-chrome-history-\(UUID().uuidString)"
+        let tmpPath = tmpBase + ".db"
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpPath)
+            try? FileManager.default.removeItem(atPath: tmpPath + "-wal")
+            try? FileManager.default.removeItem(atPath: tmpPath + "-shm")
+        }
 
         do {
             try FileManager.default.copyItem(atPath: srcPath, toPath: tmpPath)
+            // Best-effort copy of WAL sidecars — they may not exist
+            try? FileManager.default.copyItem(atPath: srcPath + "-wal", toPath: tmpPath + "-wal")
+            try? FileManager.default.copyItem(atPath: srcPath + "-shm", toPath: tmpPath + "-shm")
         } catch {
+            #if DEBUG
             NSLog("[ChromeCookieImporter] failed to copy History DB: \(error)")
+            #endif
             return []
         }
 
@@ -531,7 +553,9 @@ final class ChromeCookieImporter: @unchecked Sendable {
         }
 
         group.notify(queue: .main) {
-            shared.lastImportTime = Date()
+            shared.lock.withLock {
+                shared.lastImportTime = Date()
+            }
             completion(ImportResult(cookieCount: cookies.count, error: nil))
         }
     }
@@ -556,16 +580,22 @@ final class ChromeCookieImporter: @unchecked Sendable {
                 }
 
                 let password = try readChromeKeychainPassword()
+                #if DEBUG
                 NSLog("[ChromeCookieImporter] keychain access OK, deriving key")
+                #endif
                 let key = deriveKey(fromPassword: password)
                 let cookies = try readCookies(profile: targetProfile, key: key)
+                #if DEBUG
                 NSLog("[ChromeCookieImporter] read \(cookies.count) cookies from Chrome profile '\(targetProfile)'")
+                #endif
 
                 // Import history (best-effort, don't fail the whole import if this errors)
                 let historyEntries: [BrowserHistoryStore.Entry] = (try? readHistory(profile: targetProfile)) ?? []
+                #if DEBUG
                 if !historyEntries.isEmpty {
                     NSLog("[ChromeCookieImporter] read \(historyEntries.count) history entries from Chrome")
                 }
+                #endif
 
                 Task { @MainActor in
                     applyImportedData(cookies: cookies, historyEntries: historyEntries, completion: completion)

--- a/Sources/Browser/ChromeCookieImporter.swift
+++ b/Sources/Browser/ChromeCookieImporter.swift
@@ -4,15 +4,6 @@ import CommonCrypto
 import SQLite3
 import WebKit
 
-// MARK: - Settings constants (temporary; will move to BrowserPanel.swift in Task 2)
-
-enum ChromeCookieSettings {
-    static let autoImportEnabledKey = "browserChromeCookieAutoImport"
-    static let profileKey = "browserChromeCookieProfile"
-    static let defaultAutoImportEnabled = false
-    static let defaultProfile = "Default"
-}
-
 // MARK: - ChromeCookieImporter
 
 final class ChromeCookieImporter: @unchecked Sendable {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -786,6 +786,13 @@ enum BrowserInsecureHTTPSettings {
     }
 }
 
+enum ChromeCookieSettings {
+    static let autoImportEnabledKey = "browserChromeCookieAutoImport"
+    static let profileKey = "browserChromeCookieProfile"
+    static let defaultAutoImportEnabled = false
+    static let defaultProfile = "Default"
+}
+
 func browserShouldBlockInsecureHTTPURL(
     _ url: URL,
     defaults: UserDefaults = .standard

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2575,6 +2575,10 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         self.id = UUID()
         self.workspaceId = workspaceId
+
+        // Re-import Chrome cookies if enough time has passed since the last import.
+        ChromeCookieImporter.importIfNeeded()
+
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID
         let resolvedProfileID = BrowserProfileStore.shared.profileDefinition(id: requestedProfileID) != nil
             ? requestedProfileID

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1277,6 +1277,24 @@ final class BrowserHistoryStore: ObservableObject {
         try? Self.persistSnapshot(entries, to: fileURL)
     }
 
+    /// Merges imported history entries, skipping URLs that already exist.
+    /// Called by ChromeCookieImporter on the main thread.
+    func mergeImportedEntries(_ imported: [Entry]) {
+        loadIfNeeded()
+        let existingURLs = Set(entries.map { $0.url })
+        var added = 0
+        for entry in imported where !existingURLs.contains(entry.url) {
+            entries.append(entry)
+            added += 1
+        }
+        guard added > 0 else { return }
+        entries.sort(by: { $0.lastVisited > $1.lastVisited })
+        if entries.count > maxEntries {
+            entries.removeLast(entries.count - maxEntries)
+        }
+        scheduleSave()
+    }
+
     private func scheduleSave() {
         guard let fileURL else { return }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1277,24 +1277,6 @@ final class BrowserHistoryStore: ObservableObject {
         try? Self.persistSnapshot(entries, to: fileURL)
     }
 
-    /// Merges imported history entries, skipping URLs that already exist.
-    /// Called by ChromeCookieImporter on the main thread.
-    func mergeImportedEntries(_ imported: [Entry]) {
-        loadIfNeeded()
-        let existingURLs = Set(entries.map { $0.url })
-        var added = 0
-        for entry in imported where !existingURLs.contains(entry.url) {
-            entries.append(entry)
-            added += 1
-        }
-        guard added > 0 else { return }
-        entries.sort(by: { $0.lastVisited > $1.lastVisited })
-        if entries.count > maxEntries {
-            entries.removeLast(entries.count - maxEntries)
-        }
-        scheduleSave()
-    }
-
     private func scheduleSave() {
         guard let fileURL else { return }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3800,6 +3800,10 @@ struct SettingsView: View {
     @AppStorage(BrowserLinkOpenSettings.browserExternalOpenPatternsKey)
     private var browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
     @AppStorage(BrowserInsecureHTTPSettings.allowlistKey) private var browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
+    @AppStorage(ChromeCookieSettings.autoImportEnabledKey)
+    private var chromeCookieAutoImport = ChromeCookieSettings.defaultAutoImportEnabled
+    @AppStorage(ChromeCookieSettings.profileKey)
+    private var chromeCookieProfile = ChromeCookieSettings.defaultProfile
     @AppStorage(NotificationSoundSettings.key) private var notificationSound = NotificationSoundSettings.defaultValue
     @AppStorage(NotificationSoundSettings.customFilePathKey)
     private var notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
@@ -3854,6 +3858,9 @@ struct SettingsView: View {
     @State private var pendingOpenAccessMode: SocketControlMode?
     @State private var browserHistoryEntryCount: Int = 0
     @State private var detectedImportBrowsers: [InstalledBrowserCandidate] = []
+    @State private var chromeCookieImportStatus: String?
+    @State private var chromeCookieImporting = false
+    @State private var chromeProfiles: [(directory: String, displayName: String)] = []
     @State private var browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText
     @State private var socketPasswordDraft = ""
     @State private var socketPasswordStatusMessage: String?
@@ -4296,6 +4303,66 @@ struct SettingsView: View {
         } catch {
             socketPasswordStatusMessage = String(localized: "settings.automation.socketPassword.clearFailed", defaultValue: "Failed to clear password (\(error.localizedDescription)).")
             socketPasswordStatusIsError = true
+        }
+    }
+
+    @ViewBuilder
+    private var chromeSessionsSection: some View {
+        if ChromeCookieImporter.isChromeInstalled {
+            SettingsSectionHeader(title: String(localized: "settings.section.chromeSessions", defaultValue: "Chrome Sessions"))
+            SettingsCard {
+                SettingsCardRow(
+                    String(localized: "settings.browser.chromeCookie.autoImport", defaultValue: "Import Chrome Sessions on Launch"),
+                    subtitle: String(localized: "settings.browser.chromeCookie.autoImport.subtitle", defaultValue: "Copies your Chrome login cookies into cmux's browser so you're already signed in.")
+                ) {
+                    Toggle("", isOn: $chromeCookieAutoImport)
+                        .labelsHidden()
+                        .controlSize(.small)
+                }
+
+                SettingsCardDivider()
+
+                SettingsPickerRow(
+                    String(localized: "settings.browser.chromeCookie.profile", defaultValue: "Chrome Profile"),
+                    subtitle: String(localized: "settings.browser.chromeCookie.profile.subtitle", defaultValue: "Which Chrome profile to import cookies from."),
+                    controlWidth: pickerColumnWidth,
+                    selection: $chromeCookieProfile
+                ) {
+                    ForEach(chromeProfiles, id: \.directory) { profile in
+                        Text(profile.displayName).tag(profile.directory)
+                    }
+                }
+
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    String(localized: "settings.browser.chromeCookie.importNow", defaultValue: "Chrome Sessions"),
+                    subtitle: chromeCookieImportStatus ?? String(localized: "settings.browser.chromeCookie.importNow.subtitle", defaultValue: "Import cookies from Chrome now.")
+                ) {
+                    Button(String(localized: "settings.browser.chromeCookie.importButton", defaultValue: "Import Now")) {
+                        chromeCookieImporting = true
+                        chromeCookieImportStatus = nil
+                        ChromeCookieImporter.importCookies(profile: chromeCookieProfile) { result in
+                            chromeCookieImporting = false
+                            if let error = result.error {
+                                chromeCookieImportStatus = error.localizedDescription
+                            } else {
+                                let count = result.cookieCount
+                                chromeCookieImportStatus = String(
+                                    localized: "settings.browser.chromeCookie.importSuccess",
+                                    defaultValue: "Imported \(count) cookies from Chrome."
+                                )
+                            }
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(chromeCookieImporting)
+                }
+            }
+            .onAppear {
+                chromeProfiles = ChromeCookieImporter.availableProfiles()
+            }
         }
     }
 
@@ -5291,6 +5358,8 @@ struct SettingsView: View {
                         }
                     }
 
+                    chromeSessionsSection
+
                     SettingsSectionHeader(title: String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts"))
                         .id(SettingsNavigationTarget.keyboardShortcuts)
                         .accessibilityIdentifier("SettingsKeyboardShortcutsSection")
@@ -5544,6 +5613,8 @@ struct SettingsView: View {
         browserExternalOpenPatterns = BrowserLinkOpenSettings.defaultBrowserExternalOpenPatterns
         browserInsecureHTTPAllowlist = BrowserInsecureHTTPSettings.defaultAllowlistText
         browserInsecureHTTPAllowlistDraft = BrowserInsecureHTTPSettings.defaultAllowlistText
+        chromeCookieAutoImport = ChromeCookieSettings.defaultAutoImportEnabled
+        chromeCookieProfile = ChromeCookieSettings.defaultProfile
         notificationSound = NotificationSoundSettings.defaultValue
         notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
         notificationCustomSoundStatusMessage = nil

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4323,8 +4323,8 @@ struct SettingsView: View {
             SettingsSectionHeader(title: String(localized: "settings.section.chromeSessions", defaultValue: "Chrome Sessions"))
             SettingsCard {
                 SettingsCardRow(
-                    String(localized: "settings.browser.chromeCookie.autoImport", defaultValue: "Import Chrome Sessions on Launch"),
-                    subtitle: String(localized: "settings.browser.chromeCookie.autoImport.subtitle", defaultValue: "Copies your Chrome login cookies into cmux's browser so you're already signed in.")
+                    String(localized: "settings.browser.chromeCookie.autoImport", defaultValue: "Auto-Import Chrome Sessions"),
+                    subtitle: String(localized: "settings.browser.chromeCookie.autoImport.subtitle", defaultValue: "On launch and when opening new browser tabs, copies your Chrome login cookies into cmux's browser so you're already signed in.")
                 ) {
                     Toggle("", isOn: $chromeCookieAutoImport)
                         .labelsHidden()
@@ -4356,23 +4356,29 @@ struct SettingsView: View {
                         ChromeCookieImporter.importCookies(profile: chromeCookieProfile) { result in
                             chromeCookieImporting = false
                             if let error = result.error {
-                                chromeCookieImportStatus = error.localizedDescription
+                                chromeCookieImportStatus = String(
+                                    localized: "settings.browser.chromeCookie.importFailed",
+                                    defaultValue: "Couldn't import Chrome sessions."
+                                )
+                                NSLog("[ChromeCookieImporter] import failed: \(error.localizedDescription)")
                             } else {
                                 let count = result.cookieCount
-                                chromeCookieImportStatus = String(
-                                    localized: "settings.browser.chromeCookie.importSuccess",
-                                    defaultValue: "Imported \(count) cookies from Chrome."
-                                )
+                                chromeCookieImportStatus = count == 1
+                                    ? String(localized: "settings.browser.chromeCookie.importSuccess.one", defaultValue: "Imported 1 cookie from Chrome.")
+                                    : String(localized: "settings.browser.chromeCookie.importSuccess.other", defaultValue: "Imported \(count) cookies from Chrome.")
                             }
                         }
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .disabled(chromeCookieImporting)
+                    .disabled(chromeCookieImporting || chromeProfiles.isEmpty)
                 }
             }
             .onAppear {
                 chromeProfiles = ChromeCookieImporter.availableProfiles()
+                if !chromeProfiles.contains(where: { $0.directory == chromeCookieProfile }) {
+                    chromeCookieProfile = chromeProfiles.first?.directory ?? ChromeCookieSettings.defaultProfile
+                }
             }
         }
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -765,6 +765,8 @@ struct cmuxApp: App {
                     DispatchQueue.main.async {
                         BrowserDataImportCoordinator.shared.presentImportDialog()
                     }
+                }
+
                 if ChromeCookieImporter.isChromeInstalled {
                     Button(String(localized: "menu.view.importChromeSessions", defaultValue: "Import Chrome Sessions")) {
                         ChromeCookieImporter.importCookies { result in

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -765,6 +765,15 @@ struct cmuxApp: App {
                     DispatchQueue.main.async {
                         BrowserDataImportCoordinator.shared.presentImportDialog()
                     }
+                if ChromeCookieImporter.isChromeInstalled {
+                    Button(String(localized: "menu.view.importChromeSessions", defaultValue: "Import Chrome Sessions")) {
+                        ChromeCookieImporter.importCookies { result in
+                            if let error = result.error {
+                                NSLog("[ChromeCookieImporter] manual import failed: \(error.localizedDescription)")
+                            }
+                        }
+                    }
+                    .keyboardShortcut("i", modifiers: [.command, .shift])
                 }
 
                 splitCommandButton(title: String(localized: "menu.view.nextWorkspace", defaultValue: "Next Workspace"), shortcut: nextWorkspaceMenuShortcut) {


### PR DESCRIPTION
## Summary

<img width="1512" height="956" alt="Screenshot 2026-03-21 at 9 29 27 AM" src="https://github.com/user-attachments/assets/16a4416f-b0b3-4d4c-92c2-758a33b16c2a" />

- Adds a `ChromeCookieImporter` that reads Chrome's encrypted cookie database, decrypts values using the macOS Keychain, and injects them into WKWebView so users are already logged in to sites they use in Chrome.
- Also imports Chrome browsing history into the omnibar autocomplete.
- Configurable via Settings > Browser > Chrome Sessions (toggle auto-import, pick Chrome profile, manual import button).
- Menu item: **Import Chrome Sessions** (Cmd+Shift+I).
- Auto re-imports on new browser tab creation (throttled to every 5 minutes).


## How it works

1. Reads Chrome Safe Storage password from macOS Keychain
2. Derives AES-128-CBC key via PBKDF2 (salt: `saltysalt`, 1003 iterations)
3. Reads cookies from Chrome's SQLite database (read-only, safe while Chrome is running)
4. Decrypts `v10`-prefixed cookie values, strips 32-byte integrity hash prefix
5. Injects into `WKWebsiteDataStore.default().httpCookieStore`
6. Copies Chrome's History DB to temp file and merges entries into `BrowserHistoryStore`

## Test plan

- [ ] Open Settings > Browser — verify "Chrome Sessions" section appears (hidden if Chrome not installed)
- [ ] Select Chrome profile from dropdown
- [ ] Click "Import Now" — verify cookie count shown (should be ~4000+)
- [ ] Open browser tab, navigate to a site you're logged into in Chrome (e.g. github.com) — verify session is active
- [ ] Type a URL in omnibar — verify Chrome history appears in suggestions
- [ ] Use Cmd+Shift+I from menu bar — verify import triggers
- [ ] Toggle "Import Chrome Sessions on Launch" on, restart app — verify auto-import on launch
- [ ] Open multiple browser tabs quickly — verify no performance issues (throttled to 5 min)
- [ ] Test with Chrome not installed — verify settings section is hidden, no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Chrome cookies and browsing sessions into the app.
  * Automatic Chrome import option at startup (configurable).
  * Manual import via menu command (Cmd+Shift+I) and Settings.
  * Select which Chrome profile to import from.
  * Import status messages, success notifications, and localized UI strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->