### PR TITLE
feat: add arrow keys, shift+tab, home/end/delete/pageup/pagedown to sendNamedKey

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13146,6 +13146,36 @@ class TerminalController {
         case "backspace":
             sendKeyEvent(surface: surface, keycode: UInt32(kVK_Delete))
             return true
+        case "up", "arrow_up", "arrowup":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_UpArrow))
+            return true
+        case "down", "arrow_down", "arrowdown":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_DownArrow))
+            return true
+        case "left", "arrow_left", "arrowleft":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_LeftArrow))
+            return true
+        case "right", "arrow_right", "arrowright":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_RightArrow))
+            return true
+        case "shift+tab", "shift-tab", "backtab":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Tab), mods: GHOSTTY_MODS_SHIFT)
+            return true
+        case "home":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Home))
+            return true
+        case "end":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_End))
+            return true
+        case "delete", "del", "forward_delete":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_ForwardDelete))
+            return true
+        case "pageup", "page_up":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_PageUp))
+            return true
+        case "pagedown", "page_down":
+            sendKeyEvent(surface: surface, keycode: UInt32(kVK_PageDown))
+            return true
         default:
             if keyName.lowercased().hasPrefix("ctrl-") || keyName.lowercased().hasPrefix("ctrl+") {
                 let letter = keyName.dropFirst(5)


### PR DESCRIPTION
## Problem

The socket API's `send-key` command only supports `enter`, `escape`, `tab`, `backspace`, and `ctrl+letter`. Arrow keys, Shift+Tab, and navigation keys are not supported.

Attempts to send these as raw escape sequences via `send_text` fail because `socketTextChunks` filters out `0x1B` (ESC) and converts it to a standalone Escape key event in `handleControlScalar`. This breaks multi-byte sequences like `\x1b[A` (ArrowUp) — the ESC is sent as a bare Escape key event, and the remaining `[A` arrives as literal text.

## Fix

Extend `sendNamedKey` in `TerminalController.swift` to handle:

| Key name(s) | Action |
|---|---|
| `up`, `arrow_up`, `arrowup` | UpArrow |
| `down`, `arrow_down`, `arrowdown` | DownArrow |
| `left`, `arrow_left`, `arrowleft` | LeftArrow |
| `right`, `arrow_right`, `arrowright` | RightArrow |
| `shift+tab`, `shift-tab`, `backtab` | Shift+Tab |
| `home` | Home |
| `end` | End |
| `delete`, `del`, `forward_delete` | ForwardDelete |
| `pageup`, `page_up` | PageUp |
| `pagedown`, `page_down` | PageDown |

These map directly to the existing `sendKeyEvent` infrastructure using the appropriate `kVK_*` keycodes and modifier flags — no new infrastructure needed.

## Usage (after this fix)

```
cmux send-key --workspace workspace:1 --surface surface:1 --key up
cmux send-key --workspace workspace:1 --surface surface:1 --key shift+tab
cmux send-key --workspace workspace:1 --surface surface:1 --key pagedown
```

Or via the socket API:
```json
{"method": "surface.send_key", "params": {"workspace_id": "workspace:1", "surface_id": "surface:1", "key": "up"}}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for arrow keys, Shift+Tab, Home/End, Delete, and PageUp/PageDown in sendNamedKey for the socket/CLI send-key API. This removes reliance on escape sequences and makes navigation keys work reliably.

- **New Features**
  - Arrow keys: up/down/left/right (+ aliases like `arrow_up`, `arrowup`).
  - Shift+Tab: `shift+tab`, `shift-tab`, `backtab`.
  - Navigation keys: Home, End, Forward Delete (`delete`, `del`, `forward_delete`), PageUp/PageDown (`pageup`/`page_down`, `pagedown`/`page_down`).
  - Uses existing sendKeyEvent with `kVK_*` keycodes and modifiers; no new infrastructure.

<sup>Written for commit 49d114d0e0dd1eb86a7fb1fa10ec691fd7266f5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard support for terminal navigation and editing, including arrow keys, Home/End, Page Up/Down, Delete, and Shift+Tab shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->