### PR TITLE
Open relative file links in default app using terminal CWD

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -560,6 +560,20 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     return .external(fallback)
 }
 
+/// Resolves a relative file path against a working directory.
+/// Returns a file URL if the path is relative (no scheme, not absolute) and the resolved file exists.
+func resolveRelativeFileLink(_ rawValue: String, workingDirectory: String) -> URL? {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    guard !NSString(string: trimmed).isAbsolutePath else { return nil }
+    guard URL(string: trimmed)?.scheme == nil else { return nil }
+    guard !workingDirectory.isEmpty else { return nil }
+    let cwdURL = URL(fileURLWithPath: workingDirectory, isDirectory: true)
+    let resolved = cwdURL.appendingPathComponent(trimmed).standardized
+    guard FileManager.default.fileExists(atPath: resolved.path) else { return nil }
+    return resolved
+}
+
 enum TerminalKeyboardCopyModeSelectionMove: String, Equatable {
     case left
     case right
@@ -2445,36 +2459,24 @@ class GhosttyApp {
             // Ghostty emits bare relative paths (e.g. "src/main.swift", "./foo.txt")
             // which have no URL scheme and are not absolute — resolve them against the
             // panel's reported CWD and open in the default app if the file exists.
-            let trimmedForRelative = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmedForRelative.isEmpty,
-               !NSString(string: trimmedForRelative).isAbsolutePath,
-               URL(string: trimmedForRelative)?.scheme == nil {
-                let panelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
-                let tabId = callbackTabId ?? surfaceView.tabId
-                if let panelId, let tabId {
-                    let resolvedFileURL: URL? = performOnMain {
-                        guard let app = AppDelegate.shared,
-                              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
-                              let workspace = manager.tabs.first(where: { $0.id == tabId }),
-                              let cwd = workspace.panelDirectories[panelId],
-                              !cwd.isEmpty else {
-                            return nil
-                        }
-                        let cwdURL = URL(fileURLWithPath: cwd, isDirectory: true)
-                        let resolved = cwdURL.appendingPathComponent(trimmedForRelative)
-                            .standardized
-                        guard FileManager.default.fileExists(atPath: resolved.path) else {
-                            return nil
-                        }
-                        return resolved
+            let panelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
+            let tabId = callbackTabId ?? surfaceView.tabId
+            if let panelId, let tabId {
+                let resolvedFileURL: URL? = performOnMain {
+                    guard let app = AppDelegate.shared,
+                          let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+                          let workspace = manager.tabs.first(where: { $0.id == tabId }),
+                          let cwd = workspace.panelDirectories[panelId] else {
+                        return nil
                     }
-                    if let fileURL = resolvedFileURL {
-                        #if DEBUG
-                        dlog("link.openURL resolved relative path to file=\(fileURL.path)")
-                        #endif
-                        return performOnMain {
-                            NSWorkspace.shared.open(fileURL)
-                        }
+                    return resolveRelativeFileLink(urlString, workingDirectory: cwd)
+                }
+                if let fileURL = resolvedFileURL {
+                    #if DEBUG
+                    dlog("link.openURL resolved relative path to file=\(fileURL.path)")
+                    #endif
+                    return performOnMain {
+                        NSWorkspace.shared.open(fileURL)
                     }
                 }
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2440,6 +2440,45 @@ class GhosttyApp {
             #if DEBUG
             dlog("link.openURL raw=\(urlString)")
             #endif
+
+            // Resolve relative file paths against the terminal's working directory.
+            // Ghostty emits bare relative paths (e.g. "src/main.swift", "./foo.txt")
+            // which have no URL scheme and are not absolute — resolve them against the
+            // panel's reported CWD and open in the default app if the file exists.
+            let trimmedForRelative = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedForRelative.isEmpty,
+               !NSString(string: trimmedForRelative).isAbsolutePath,
+               URL(string: trimmedForRelative)?.scheme == nil {
+                let panelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
+                let tabId = callbackTabId ?? surfaceView.tabId
+                if let panelId, let tabId {
+                    let resolvedFileURL: URL? = performOnMain {
+                        guard let app = AppDelegate.shared,
+                              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+                              let workspace = manager.tabs.first(where: { $0.id == tabId }),
+                              let cwd = workspace.panelDirectories[panelId],
+                              !cwd.isEmpty else {
+                            return nil
+                        }
+                        let cwdURL = URL(fileURLWithPath: cwd, isDirectory: true)
+                        let resolved = cwdURL.appendingPathComponent(trimmedForRelative)
+                            .standardized
+                        guard FileManager.default.fileExists(atPath: resolved.path) else {
+                            return nil
+                        }
+                        return resolved
+                    }
+                    if let fileURL = resolvedFileURL {
+                        #if DEBUG
+                        dlog("link.openURL resolved relative path to file=\(fileURL.path)")
+                        #endif
+                        return performOnMain {
+                            NSWorkspace.shared.open(fileURL)
+                        }
+                    }
+                }
+            }
+
             guard let target = resolveTerminalOpenURLTarget(urlString) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3013,6 +3013,83 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
 }
 
 
+final class ResolveRelativeFileLinkTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("cmux-relative-link-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
+    }
+
+    func testResolvesExistingRelativeFile() throws {
+        let file = tempDir.appendingPathComponent("hello.txt")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let result = try XCTUnwrap(resolveRelativeFileLink("hello.txt", workingDirectory: tempDir.path))
+        XCTAssertEqual(result.path, file.path)
+    }
+
+    func testResolvesNestedRelativePath() throws {
+        let subdir = tempDir.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        let file = subdir.appendingPathComponent("main.swift")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let result = try XCTUnwrap(resolveRelativeFileLink("src/main.swift", workingDirectory: tempDir.path))
+        XCTAssertEqual(result.path, file.path)
+    }
+
+    func testResolvesDotSlashPrefix() throws {
+        let file = tempDir.appendingPathComponent("readme.md")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let result = try XCTUnwrap(resolveRelativeFileLink("./readme.md", workingDirectory: tempDir.path))
+        XCTAssertEqual(result.path, file.path)
+    }
+
+    func testResolvesParentTraversal() throws {
+        let subdir = tempDir.appendingPathComponent("deep")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        let file = tempDir.appendingPathComponent("root.txt")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        let result = try XCTUnwrap(resolveRelativeFileLink("../root.txt", workingDirectory: subdir.path))
+        XCTAssertEqual(result.standardized.path, file.standardized.path)
+    }
+
+    func testReturnsNilForNonexistentFile() {
+        XCTAssertNil(resolveRelativeFileLink("does-not-exist.txt", workingDirectory: tempDir.path))
+    }
+
+    func testReturnsNilForAbsolutePath() {
+        XCTAssertNil(resolveRelativeFileLink("/tmp/some-file", workingDirectory: tempDir.path))
+    }
+
+    func testReturnsNilForURLWithScheme() {
+        XCTAssertNil(resolveRelativeFileLink("https://example.com", workingDirectory: tempDir.path))
+    }
+
+    func testReturnsNilForEmptyString() {
+        XCTAssertNil(resolveRelativeFileLink("", workingDirectory: tempDir.path))
+    }
+
+    func testReturnsNilForEmptyWorkingDirectory() throws {
+        let file = tempDir.appendingPathComponent("file.txt")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+        XCTAssertNil(resolveRelativeFileLink("file.txt", workingDirectory: ""))
+    }
+
+    func testReturnsNilForWhitespaceOnly() {
+        XCTAssertNil(resolveRelativeFileLink("   ", workingDirectory: tempDir.path))
+    }
+}
+
+
 final class TerminalControllerSocketTextChunkTests: XCTestCase {
     func testSocketTextChunksReturnsSingleChunkForPlainText() {
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

- Clicking a relative file path in the terminal (e.g. `src/main.swift`, `./foo.txt`) now resolves it against the terminal panel's reported working directory and opens it in the default application
- Previously, relative paths fell through to URL resolution which either prepended `https://` (bogus web URL) or failed entirely
- Extracted `resolveRelativeFileLink(_:workingDirectory:)` as a testable pure function

## Testing

- Built Debug app with tagged derivedDataPath — compiles clean
- Unit tests compile (`cmux-unit` scheme) — 10 new tests for `resolveRelativeFileLink`
- Manual test: launched tagged debug build (`reload.sh --tag relative-links`), clicked relative file path in terminal → opened in default app

## Demo Video

- Video URL or attachment: _(TODO: record and attach)_

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening files from terminal commands using relative file paths, with automatic resolution against the current working directory.

* **Tests**
  * Added tests validating relative file path resolution, including nested paths, parent directory references, non-existent files, and invalid path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->