### PR TITLE
Create shared script path helper and harden repo path resolution

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4010,15 +4010,19 @@ final class WorkspaceRemoteSessionController {
                 NSLocalizedDescriptionKey: "cannot locate cmux repo root for dev-only cmuxd-remote build fallback",
             ])
         }
-        let daemonRoot = repoRoot.appendingPathComponent("daemon/remote", isDirectory: true)
+        guard let daemonRoot = Self.remoteDaemonSourceRoot(repoRoot: repoRoot) else {
+            throw NSError(domain: "cmux.remote.daemon", code: 21, userInfo: [
+                NSLocalizedDescriptionKey: "cannot locate local cmuxd-remote source directory from \(repoRoot.path)",
+            ])
+        }
         let goModPath = daemonRoot.appendingPathComponent("go.mod").path
         guard FileManager.default.fileExists(atPath: goModPath) else {
-            throw NSError(domain: "cmux.remote.daemon", code: 21, userInfo: [
+            throw NSError(domain: "cmux.remote.daemon", code: 22, userInfo: [
                 NSLocalizedDescriptionKey: "missing daemon module at \(goModPath)",
             ])
         }
         guard let goBinary = Self.which("go") else {
-            throw NSError(domain: "cmux.remote.daemon", code: 22, userInfo: [
+            throw NSError(domain: "cmux.remote.daemon", code: 23, userInfo: [
                 NSLocalizedDescriptionKey: "go is required for the dev-only cmuxd-remote build fallback",
             ])
         }
@@ -4041,12 +4045,12 @@ final class WorkspaceRemoteSessionController {
         )
         guard result.status == 0 else {
             let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ?? "go build failed with status \(result.status)"
-            throw NSError(domain: "cmux.remote.daemon", code: 23, userInfo: [
+            throw NSError(domain: "cmux.remote.daemon", code: 24, userInfo: [
                 NSLocalizedDescriptionKey: "failed to build cmuxd-remote: \(detail)",
             ])
         }
         guard FileManager.default.isExecutableFile(atPath: output.path) else {
-            throw NSError(domain: "cmux.remote.daemon", code: 24, userInfo: [
+            throw NSError(domain: "cmux.remote.daemon", code: 25, userInfo: [
                 NSLocalizedDescriptionKey: "cmuxd-remote build output is not executable",
             ])
         }
@@ -4377,6 +4381,16 @@ final class WorkspaceRemoteSessionController {
         return "\(baseVersion)-dev-\(sourceFingerprint)"
     }
 
+    private static let repoRootMarkers = [
+        "daemon/remote/go.mod",
+        "Tools/daemon-remote/go.mod",
+        "GhosttyTabs.xcodeproj/project.pbxproj",
+        "Apps/cmux-macOS/cmux.xcodeproj/project.pbxproj",
+    ]
+    private static let remoteDaemonRelativePaths = [
+        "daemon/remote",
+        "Tools/daemon-remote",
+    ]
     private static let cachedRemoteDaemonSourceFingerprint: String? = computeRemoteDaemonSourceFingerprint()
 
     private static func remoteDaemonSourceFingerprint() -> String? {
@@ -4384,8 +4398,7 @@ final class WorkspaceRemoteSessionController {
     }
 
     private static func computeRemoteDaemonSourceFingerprint(fileManager: FileManager = .default) -> String? {
-        guard let repoRoot = findRepoRoot() else { return nil }
-        let daemonRoot = repoRoot.appendingPathComponent("daemon/remote", isDirectory: true)
+        guard let daemonRoot = remoteDaemonSourceRoot(fileManager: fileManager) else { return nil }
         guard let enumerator = fileManager.enumerator(
             at: daemonRoot,
             includingPropertiesForKeys: [.isRegularFileKey],
@@ -4452,12 +4465,16 @@ final class WorkspaceRemoteSessionController {
 
     private static func findRepoRoot() -> URL? {
         var candidates: [URL] = []
-        let compileTimeRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Sources
-            .deletingLastPathComponent() // repo root
-        candidates.append(compileTimeRoot)
+        let compileTimePath = URL(fileURLWithPath: #filePath)
+        candidates.append(compileTimePath.deletingLastPathComponent())
+        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent())
+        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent())
         let environment = ProcessInfo.processInfo.environment
         if let envRoot = environment["CMUX_REMOTE_DAEMON_SOURCE_ROOT"],
+           !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            candidates.append(URL(fileURLWithPath: envRoot, isDirectory: true))
+        }
+        if let envRoot = environment["CMUX_REPO_ROOT"],
            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             candidates.append(URL(fileURLWithPath: envRoot, isDirectory: true))
         }
@@ -4476,8 +4493,9 @@ final class WorkspaceRemoteSessionController {
         for base in candidates {
             var cursor = base.standardizedFileURL
             for _ in 0..<10 {
-                let marker = cursor.appendingPathComponent("daemon/remote/go.mod").path
-                if fm.fileExists(atPath: marker) {
+                if Self.repoRootMarkers.contains(where: { marker in
+                    fm.fileExists(atPath: cursor.appendingPathComponent(marker).path)
+                }) {
                     return cursor
                 }
                 let parent = cursor.deletingLastPathComponent()
@@ -4485,6 +4503,29 @@ final class WorkspaceRemoteSessionController {
                     break
                 }
                 cursor = parent
+            }
+        }
+        return nil
+    }
+
+    private static func remoteDaemonSourceRoot(fileManager: FileManager = .default) -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        if let explicitPath = environment["CMUX_REMOTE_DAEMON_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicitPath.isEmpty {
+            let explicitURL = URL(fileURLWithPath: explicitPath, isDirectory: true)
+            if fileManager.fileExists(atPath: explicitURL.appendingPathComponent("go.mod").path) {
+                return explicitURL
+            }
+        }
+        guard let repoRoot = findRepoRoot() else { return nil }
+        return remoteDaemonSourceRoot(repoRoot: repoRoot, fileManager: fileManager)
+    }
+
+    private static func remoteDaemonSourceRoot(repoRoot: URL, fileManager: FileManager = .default) -> URL? {
+        for relativePath in remoteDaemonRelativePaths {
+            let candidate = repoRoot.appendingPathComponent(relativePath, isDirectory: true)
+            if fileManager.fileExists(atPath: candidate.appendingPathComponent("go.mod").path) {
+                return candidate
             }
         }
         return nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4005,14 +4005,15 @@ final class WorkspaceRemoteSessionController {
             ])
         }
 
-        guard let repoRoot = Self.findRepoRoot() else {
+        let repoRoot = Self.findRepoRoot()
+        guard let daemonRoot = Self.remoteDaemonSourceRoot() else {
+            if let repoRoot {
+                throw NSError(domain: "cmux.remote.daemon", code: 21, userInfo: [
+                    NSLocalizedDescriptionKey: "cannot locate local cmuxd-remote source directory from \(repoRoot.path)",
+                ])
+            }
             throw NSError(domain: "cmux.remote.daemon", code: 20, userInfo: [
                 NSLocalizedDescriptionKey: "cannot locate cmux repo root for dev-only cmuxd-remote build fallback",
-            ])
-        }
-        guard let daemonRoot = Self.remoteDaemonSourceRoot(repoRoot: repoRoot) else {
-            throw NSError(domain: "cmux.remote.daemon", code: 21, userInfo: [
-                NSLocalizedDescriptionKey: "cannot locate local cmuxd-remote source directory from \(repoRoot.path)",
             ])
         }
         let goModPath = daemonRoot.appendingPathComponent("go.mod").path
@@ -4465,10 +4466,6 @@ final class WorkspaceRemoteSessionController {
 
     private static func findRepoRoot() -> URL? {
         var candidates: [URL] = []
-        let compileTimePath = URL(fileURLWithPath: #filePath)
-        candidates.append(compileTimePath.deletingLastPathComponent())
-        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent())
-        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent())
         let environment = ProcessInfo.processInfo.environment
         if let envRoot = environment["CMUX_REMOTE_DAEMON_SOURCE_ROOT"],
            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -4482,6 +4479,10 @@ final class WorkspaceRemoteSessionController {
            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             candidates.append(URL(fileURLWithPath: envRoot, isDirectory: true))
         }
+        let compileTimePath = URL(fileURLWithPath: #filePath)
+        candidates.append(compileTimePath.deletingLastPathComponent())
+        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent())
+        candidates.append(compileTimePath.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent())
         candidates.append(URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true))
         if let executable = Bundle.main.executableURL?.deletingLastPathComponent() {
             candidates.append(executable)

--- a/scripts/build-ghostty-cli-helper.sh
+++ b/scripts/build-ghostty-cli-helper.sh
@@ -14,8 +14,9 @@ EOF
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-GHOSTTY_DIR="$REPO_ROOT/ghostty"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+GHOSTTY_DIR="$CMUX_GHOSTTY_DIR"
 
 OUTPUT_PATH=""
 TARGET_TRIPLE=""

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -204,7 +204,7 @@ cask "cmux" do
   ]
 end
 CASKEOF
-    cd "$CMUX_HOMEBREW_TAP_DIR"
+    pushd "$CMUX_HOMEBREW_TAP_DIR" >/dev/null
     git add Casks/cmux.rb
     if git diff --staged --quiet; then
       echo "Homebrew cask already up to date"
@@ -213,7 +213,7 @@ CASKEOF
       git push
       echo "Homebrew cask updated"
     fi
-    cd ..
+    popd >/dev/null
   else
     echo "WARNING: homebrew tap submodule not found at $CMUX_HOMEBREW_TAP_DIR, skipping cask update"
   fi

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # Usage: ./scripts/build-sign-upload.sh <tag> [--allow-overwrite]
 # Requires: source ~/.secrets/cmuxterm.env && export SPARKLE_PRIVATE_KEY
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
 usage() {
   cat <<'EOF'
 Usage: ./scripts/build-sign-upload.sh <tag> [--allow-overwrite]
@@ -47,8 +51,10 @@ fi
 
 TAG="$1"
 SIGN_HASH="A050CC7E193C8221BDBA204E731B046CDCCC1B30"
-ENTITLEMENTS="cmux.entitlements"
+ENTITLEMENTS="$CMUX_APP_ROOT/cmux.entitlements"
 APP_PATH="build/Build/Products/Release/cmux.app"
+
+cd "$CMUX_REPO_ROOT"
 
 # --- Pre-flight ---
 source ~/.secrets/cmuxterm.env
@@ -59,11 +65,14 @@ done
 echo "Pre-flight checks passed"
 
 # --- Build GhosttyKit (if needed) ---
-if [ ! -d "GhosttyKit.xcframework" ]; then
+if [ ! -d "$CMUX_GHOSTTYKIT_PATH" ]; then
   echo "Building GhosttyKit..."
-  cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast && cd ..
-  rm -rf GhosttyKit.xcframework
-  cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
+  (
+    cd "$CMUX_GHOSTTY_DIR"
+    zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
+  )
+  rm -rf "$CMUX_GHOSTTYKIT_PATH"
+  cp -R "$CMUX_GHOSTTY_DIR/macos/GhosttyKit.xcframework" "$CMUX_GHOSTTYKIT_PATH"
 else
   echo "GhosttyKit.xcframework exists, skipping build"
 fi
@@ -71,7 +80,7 @@ fi
 # --- Build app (Release, unsigned) ---
 echo "Building app..."
 rm -rf build/
-xcodebuild -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO build 2>&1 | tail -5
+xcodebuild -project "$CMUX_XCODE_PROJECT_PATH" -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO build 2>&1 | tail -5
 echo "Build succeeded"
 
 HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
@@ -82,7 +91,7 @@ fi
 
 # --- Inject Sparkle keys ---
 echo "Injecting Sparkle keys..."
-SPARKLE_PUBLIC_KEY_DERIVED=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+SPARKLE_PUBLIC_KEY_DERIVED=$(swift "$CMUX_TOOLS_SCRIPTS_DIR/derive_sparkle_public_key.swift" "$SPARKLE_PRIVATE_KEY")
 APP_PLIST="$APP_PATH/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_PLIST" 2>/dev/null || true
@@ -126,7 +135,7 @@ echo "DMG notarized"
 
 # --- Generate Sparkle appcast ---
 echo "Generating appcast..."
-./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$TAG" appcast.xml
+"$CMUX_TOOLS_SCRIPTS_DIR/sparkle_generate_appcast.sh" cmux-macos.dmg "$TAG" appcast.xml
 
 # --- Create GitHub release (if needed) and upload ---
 if gh release view "$TAG" >/dev/null 2>&1; then
@@ -166,7 +175,7 @@ if [[ "$TAG" != *"-nightly"* ]]; then
   VERSION="${TAG#v}"
   DMG_SHA256=$(shasum -a 256 cmux-macos.dmg | cut -d' ' -f1)
   echo "Updating homebrew cask to $VERSION (SHA: $DMG_SHA256)..."
-  CASK_FILE="homebrew-cmux/Casks/cmux.rb"
+  CASK_FILE="$CMUX_HOMEBREW_TAP_DIR/Casks/cmux.rb"
   if [ -f "$CASK_FILE" ]; then
     cat > "$CASK_FILE" << CASKEOF
 cask "cmux" do
@@ -195,7 +204,7 @@ cask "cmux" do
   ]
 end
 CASKEOF
-    cd homebrew-cmux
+    cd "$CMUX_HOMEBREW_TAP_DIR"
     git add Casks/cmux.rb
     if git diff --staged --quiet; then
       echo "Homebrew cask already up to date"
@@ -206,7 +215,7 @@ CASKEOF
     fi
     cd ..
   else
-    echo "WARNING: homebrew-cmux submodule not found, skipping cask update"
+    echo "WARNING: homebrew tap submodule not found at $CMUX_HOMEBREW_TAP_DIR, skipping cask update"
   fi
 fi
 

--- a/scripts/build_remote_daemon_release_assets.sh
+++ b/scripts/build_remote_daemon_release_assets.sh
@@ -63,8 +63,9 @@ if ! command -v go >/dev/null 2>&1; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DAEMON_ROOT="${REPO_ROOT}/daemon/remote"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+DAEMON_ROOT="$CMUX_REMOTE_DAEMON_DIR"
 mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 rm -f "$OUTPUT_DIR"/cmuxd-remote-* "$OUTPUT_DIR"/cmuxd-remote-checksums.txt "$OUTPUT_DIR"/cmuxd-remote-manifest.json

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,10 +8,14 @@ set -euo pipefail
 #   ./scripts/bump-version.sh patch     # Bump patch (0.15.0 -> 0.15.1)
 #   ./scripts/bump-version.sh major     # Bump major (0.15.0 -> 1.0.0)
 
-PROJECT_FILE="GhosttyTabs.xcodeproj/project.pbxproj"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
+PROJECT_FILE="${CMUX_XCODE_PROJECT_PATH}/project.pbxproj"
 
 if [[ ! -f "$PROJECT_FILE" ]]; then
-  echo "Error: $PROJECT_FILE not found. Run from repo root." >&2
+  echo "Error: Xcode project file not found at $PROJECT_FILE" >&2
   exit 1
 fi
 

--- a/scripts/download-prebuilt-ghosttykit.sh
+++ b/scripts/download-prebuilt-ghosttykit.sh
@@ -2,21 +2,22 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
 
 if [ -n "${GHOSTTY_SHA:-}" ]; then
   GHOSTTY_SHA="$GHOSTTY_SHA"
 else
-  if [ ! -d "$REPO_ROOT/ghostty" ] || ! git -C "$REPO_ROOT/ghostty" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ ! -d "$CMUX_GHOSTTY_DIR" ] || ! git -C "$CMUX_GHOSTTY_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "Missing ghostty submodule. Run ./scripts/setup.sh or git submodule update --init --recursive first." >&2
     exit 1
   fi
-  GHOSTTY_SHA="$(git -C "$REPO_ROOT/ghostty" rev-parse HEAD)"
+  GHOSTTY_SHA="$(git -C "$CMUX_GHOSTTY_DIR" rev-parse HEAD)"
 fi
 
 TAG="xcframework-$GHOSTTY_SHA"
 ARCHIVE_NAME="${GHOSTTYKIT_ARCHIVE_NAME:-GhosttyKit.xcframework.tar.gz}"
-OUTPUT_DIR="${GHOSTTYKIT_OUTPUT_DIR:-GhosttyKit.xcframework}"
+OUTPUT_DIR="${GHOSTTYKIT_OUTPUT_DIR:-$CMUX_GHOSTTYKIT_PATH}"
 CHECKSUMS_FILE="${GHOSTTYKIT_CHECKSUMS_FILE:-$SCRIPT_DIR/ghosttykit-checksums.txt}"
 DOWNLOAD_URL="${GHOSTTYKIT_URL:-https://github.com/manaflow-ai/ghostty/releases/download/$TAG/$ARCHIVE_NAME}"
 DOWNLOAD_RETRIES="${GHOSTTYKIT_DOWNLOAD_RETRIES:-30}"

--- a/scripts/download-prebuilt-ghosttykit.sh
+++ b/scripts/download-prebuilt-ghosttykit.sh
@@ -18,6 +18,7 @@ fi
 TAG="xcframework-$GHOSTTY_SHA"
 ARCHIVE_NAME="${GHOSTTYKIT_ARCHIVE_NAME:-GhosttyKit.xcframework.tar.gz}"
 OUTPUT_DIR="${GHOSTTYKIT_OUTPUT_DIR:-$CMUX_GHOSTTYKIT_PATH}"
+OUTPUT_PARENT_DIR="$(dirname "$OUTPUT_DIR")"
 CHECKSUMS_FILE="${GHOSTTYKIT_CHECKSUMS_FILE:-$SCRIPT_DIR/ghosttykit-checksums.txt}"
 DOWNLOAD_URL="${GHOSTTYKIT_URL:-https://github.com/manaflow-ai/ghostty/releases/download/$TAG/$ARCHIVE_NAME}"
 DOWNLOAD_RETRIES="${GHOSTTYKIT_DOWNLOAD_RETRIES:-30}"
@@ -49,14 +50,15 @@ if [ -z "$EXPECTED_SHA256" ]; then
 fi
 
 echo "Downloading $ARCHIVE_NAME for ghostty $GHOSTTY_SHA"
+mkdir -p "$OUTPUT_PARENT_DIR"
 curl --fail --show-error --location \
   --retry "$DOWNLOAD_RETRIES" \
   --retry-delay "$DOWNLOAD_RETRY_DELAY" \
   --retry-all-errors \
-  -o "$ARCHIVE_NAME" \
+  -o "$OUTPUT_PARENT_DIR/$ARCHIVE_NAME" \
   "$DOWNLOAD_URL"
 
-ACTUAL_SHA256="$(shasum -a 256 "$ARCHIVE_NAME" | awk '{print $1}')"
+ACTUAL_SHA256="$(shasum -a 256 "$OUTPUT_PARENT_DIR/$ARCHIVE_NAME" | awk '{print $1}')"
 if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
   echo "$ARCHIVE_NAME checksum mismatch" >&2
   echo "Expected: $EXPECTED_SHA256" >&2
@@ -65,8 +67,8 @@ if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
 fi
 
 rm -rf "$OUTPUT_DIR"
-tar xzf "$ARCHIVE_NAME"
-rm "$ARCHIVE_NAME"
+tar -C "$OUTPUT_PARENT_DIR" -xzf "$OUTPUT_PARENT_DIR/$ARCHIVE_NAME"
+rm "$OUTPUT_PARENT_DIR/$ARCHIVE_NAME"
 test -d "$OUTPUT_DIR"
 
 echo "Verified and extracted $OUTPUT_DIR"

--- a/scripts/lib/cmux-paths.sh
+++ b/scripts/lib/cmux-paths.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Shared repo path contract for local scripts.
+# Keep this narrowly focused on path resolution so directory moves can update
+# one place without adding broader build orchestration layers.
+
+cmux_paths_init() {
+  local caller_path="${1:-${BASH_SOURCE[0]}}"
+  local caller_dir script_dir
+
+  caller_dir="$(cd "$(dirname "$caller_path")" && pwd)"
+  if [[ "$(basename "$caller_dir")" == "lib" ]]; then
+    script_dir="$(cd "$caller_dir/.." && pwd)"
+  else
+    script_dir="$caller_dir"
+  fi
+
+  if [[ -z "${CMUX_REPO_ROOT:-}" ]]; then
+    CMUX_REPO_ROOT="$(cd "$script_dir/.." && pwd)"
+  fi
+
+  if [[ -z "${CMUX_TOOLS_SCRIPTS_DIR:-}" ]]; then
+    CMUX_TOOLS_SCRIPTS_DIR="$CMUX_REPO_ROOT/scripts"
+  fi
+  if [[ -z "${CMUX_APP_ROOT:-}" ]]; then
+    CMUX_APP_ROOT="$CMUX_REPO_ROOT"
+  fi
+  if [[ -z "${CMUX_XCODE_PROJECT_PATH:-}" ]]; then
+    CMUX_XCODE_PROJECT_PATH="$CMUX_APP_ROOT/GhosttyTabs.xcodeproj"
+  fi
+  if [[ -z "${CMUX_GHOSTTY_DIR:-}" ]]; then
+    CMUX_GHOSTTY_DIR="$CMUX_REPO_ROOT/ghostty"
+  fi
+  if [[ -z "${CMUX_REMOTE_DAEMON_DIR:-}" ]]; then
+    CMUX_REMOTE_DAEMON_DIR="$CMUX_REPO_ROOT/daemon/remote"
+  fi
+  if [[ -z "${CMUX_LOCAL_DAEMON_DIR:-}" ]]; then
+    CMUX_LOCAL_DAEMON_DIR="$CMUX_REPO_ROOT/cmuxd"
+  fi
+  if [[ -z "${CMUX_GHOSTTYKIT_PATH:-}" ]]; then
+    CMUX_GHOSTTYKIT_PATH="$CMUX_APP_ROOT/GhosttyKit.xcframework"
+  fi
+  if [[ -z "${CMUX_APP_SUPPORT_DIR:-}" ]]; then
+    CMUX_APP_SUPPORT_DIR="$HOME/Library/Application Support/cmux"
+  fi
+  if [[ -z "${CMUX_HOMEBREW_TAP_DIR:-}" ]]; then
+    CMUX_HOMEBREW_TAP_DIR="$CMUX_REPO_ROOT/homebrew-cmux"
+  fi
+}

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -3,7 +3,11 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
+cd "$CMUX_REPO_ROOT"
 
 # Kill existing app if running
 pkill -9 -f "cmux" 2>/dev/null || true

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
 APP_NAME="cmux DEV"
 BUNDLE_ID="com.cmuxterm.app.debug"
 BASE_APP_NAME="cmux DEV"
@@ -11,7 +15,7 @@ DERIVED_SET=0
 TAG=""
 CMUX_DEBUG_LOG=""
 CLI_PATH=""
-LAST_SOCKET_PATH_DIR="$HOME/Library/Application Support/cmux"
+LAST_SOCKET_PATH_DIR="$CMUX_APP_SUPPORT_DIR"
 LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
 write_dev_cli_shim() {
@@ -266,7 +270,7 @@ if [[ -n "$TAG" ]]; then
 fi
 
 XCODEBUILD_ARGS=(
-  -project GhosttyTabs.xcodeproj
+  -project "$CMUX_XCODE_PROJECT_PATH"
   -scheme cmux
   -configuration Debug
   -destination 'platform=macOS'
@@ -354,7 +358,7 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
     /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$INFO_PLIST" 2>/dev/null \
       || /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string $BUNDLE_ID" "$INFO_PLIST"
     if [[ -n "${TAG_SLUG:-}" ]]; then
-      APP_SUPPORT_DIR="$HOME/Library/Application Support/cmux"
+      APP_SUPPORT_DIR="$CMUX_APP_SUPPORT_DIR"
       CMUXD_SOCKET="${APP_SUPPORT_DIR}/cmuxd-dev-${TAG_SLUG}.sock"
       CMUX_SOCKET="/tmp/cmux-debug-${TAG_SLUG}.sock"
       CMUX_DEBUG_LOG="/tmp/cmux-debug-${TAG_SLUG}.log"
@@ -373,8 +377,8 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
         || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:CMUX_SOCKET_MODE string automation" "$INFO_PLIST"
       /usr/libexec/PlistBuddy -c "Set :LSEnvironment:CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD 1" "$INFO_PLIST" 2>/dev/null \
         || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD string 1" "$INFO_PLIST"
-      /usr/libexec/PlistBuddy -c "Set :LSEnvironment:CMUXTERM_REPO_ROOT \"${PWD}\"" "$INFO_PLIST" 2>/dev/null \
-        || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:CMUXTERM_REPO_ROOT string \"${PWD}\"" "$INFO_PLIST"
+      /usr/libexec/PlistBuddy -c "Set :LSEnvironment:CMUXTERM_REPO_ROOT \"${CMUX_REPO_ROOT}\"" "$INFO_PLIST" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:CMUXTERM_REPO_ROOT string \"${CMUX_REPO_ROOT}\"" "$INFO_PLIST"
       if [[ -S "$CMUXD_SOCKET" ]]; then
         for PID in $(lsof -t "$CMUXD_SOCKET" 2>/dev/null); do
           kill "$PID" 2>/dev/null || true
@@ -416,13 +420,13 @@ else
   pkill -f "${APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
 fi
 sleep 0.3
-CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
-GHOSTTY_HELPER_SRC="$PWD/ghostty/zig-out/bin/ghostty"
-if [[ -d "$PWD/cmuxd" ]]; then
-  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+CMUXD_SRC="$CMUX_LOCAL_DAEMON_DIR/zig-out/bin/cmuxd"
+GHOSTTY_HELPER_SRC="$CMUX_GHOSTTY_DIR/zig-out/bin/ghostty"
+if [[ -d "$CMUX_LOCAL_DAEMON_DIR" ]]; then
+  (cd "$CMUX_LOCAL_DAEMON_DIR" && zig build -Doptimize=ReleaseFast)
 fi
-if [[ -d "$PWD/ghostty" ]]; then
-  (cd "$PWD/ghostty" && zig build cli-helper -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Doptimize=ReleaseFast)
+if [[ -d "$CMUX_GHOSTTY_DIR" ]]; then
+  (cd "$CMUX_GHOSTTY_DIR" && zig build cli-helper -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Doptimize=ReleaseFast)
 fi
 if [[ -x "$CMUXD_SRC" ]]; then
   BIN_DIR="$APP_PATH/Contents/Resources/bin"
@@ -468,9 +472,9 @@ OPEN_CLEAN_ENV=(
 
 if [[ -n "${TAG_SLUG:-}" && -n "${CMUX_SOCKET:-}" ]]; then
   # Ensure tag-specific socket paths win even if the caller has CMUX_* overrides.
-  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_ENABLE=1 CMUX_SOCKET_MODE=automation CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD=1 CMUXTERM_REPO_ROOT="$PWD" open -g "$APP_PATH"
+  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_ENABLE=1 CMUX_SOCKET_MODE=automation CMUX_SOCKET_PATH="$CMUX_SOCKET" CMUXD_UNIX_PATH="$CMUXD_SOCKET" CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD=1 CMUXTERM_REPO_ROOT="$CMUX_REPO_ROOT" open -g "$APP_PATH"
 elif [[ -n "${TAG_SLUG:-}" ]]; then
-  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_ENABLE=1 CMUX_SOCKET_MODE=automation CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD=1 CMUXTERM_REPO_ROOT="$PWD" open -g "$APP_PATH"
+  "${OPEN_CLEAN_ENV[@]}" CMUX_TAG="$TAG_SLUG" CMUX_SOCKET_ENABLE=1 CMUX_SOCKET_MODE=automation CMUX_DEBUG_LOG="$CMUX_DEBUG_LOG" CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD=1 CMUXTERM_REPO_ROOT="$CMUX_REPO_ROOT" open -g "$APP_PATH"
 else
   echo "/tmp/cmux-debug.sock" > /tmp/cmux-last-socket-path || true
   echo "/tmp/cmux-debug.log" > /tmp/cmux-last-debug-log-path || true

--- a/scripts/reloadp.sh
+++ b/scripts/reloadp.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -destination 'platform=macOS' build
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
+xcodebuild -project "$CMUX_XCODE_PROJECT_PATH" -scheme cmux -configuration Release -destination 'platform=macOS' build
 pkill -x cmux || true
 sleep 0.2
 APP_PATH="$(

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -229,9 +229,9 @@ sleep 0.3
 # Kill any running staging instance; allow side-by-side with the main and dev apps.
 pkill -f "${APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
 sleep 0.3
-CMUXD_SRC="$PWD/cmuxd/zig-out/bin/cmuxd"
-if [[ -d "$PWD/cmuxd" ]]; then
-  (cd "$PWD/cmuxd" && zig build -Doptimize=ReleaseFast)
+CMUXD_SRC="$CMUX_LOCAL_DAEMON_DIR/zig-out/bin/cmuxd"
+if [[ -d "$CMUX_LOCAL_DAEMON_DIR" ]]; then
+  (cd "$CMUX_LOCAL_DAEMON_DIR" && zig build -Doptimize=ReleaseFast)
 fi
 if [[ -x "$CMUXD_SRC" ]]; then
   BIN_DIR="$APP_PATH/Contents/Resources/bin"

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -201,7 +201,7 @@ if [[ -f "$INFO_PLIST" ]]; then
   # Inject staging socket paths via LSEnvironment so the Release binary
   # (which defaults to the per-user stable socket) uses isolated sockets instead.
   STAGING_SLUG="${TAG_SLUG:-staging}"
-  APP_SUPPORT_DIR="$HOME/Library/Application Support/cmux"
+  APP_SUPPORT_DIR="$CMUX_APP_SUPPORT_DIR"
   CMUXD_SOCKET="${APP_SUPPORT_DIR}/cmuxd-${STAGING_SLUG}.sock"
   CMUX_SOCKET="/tmp/cmux-${STAGING_SLUG}.sock"
   write_last_socket_path "$CMUX_SOCKET"

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
 APP_NAME="cmux STAGING"
 BUNDLE_ID="com.cmuxterm.app.staging"
 BASE_APP_NAME="cmux"
@@ -9,7 +13,7 @@ NAME_SET=0
 BUNDLE_SET=0
 DERIVED_SET=0
 TAG=""
-LAST_SOCKET_PATH_DIR="$HOME/Library/Application Support/cmux"
+LAST_SOCKET_PATH_DIR="$CMUX_APP_SUPPORT_DIR"
 LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
 write_last_socket_path() {
@@ -120,7 +124,7 @@ if [[ -n "$TAG" ]]; then
 fi
 
 XCODEBUILD_ARGS=(
-  -project GhosttyTabs.xcodeproj
+  -project "$CMUX_XCODE_PROJECT_PATH"
   -scheme cmux
   -configuration Release
   -destination 'platform=macOS'

--- a/scripts/run-tests-v1.sh
+++ b/scripts/run-tests-v1.sh
@@ -9,7 +9,11 @@ if [ "$(id -un)" != "cmux" ]; then
   exit 2
 fi
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
+cd "$CMUX_REPO_ROOT"
 
 DERIVED_DATA_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-tests-v1"
 APP="$DERIVED_DATA_PATH/Build/Products/Debug/cmux DEV.app"
@@ -21,7 +25,7 @@ echo "== build =="
 # module file ... was built".
 rm -rf "$DERIVED_DATA_PATH/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules" || true
 xcodebuild \
-  -project GhosttyTabs.xcodeproj \
+  -project "$CMUX_XCODE_PROJECT_PATH" \
   -scheme cmux \
   -configuration Debug \
   -destination "platform=macOS" \

--- a/scripts/run-tests-v2.sh
+++ b/scripts/run-tests-v2.sh
@@ -9,7 +9,11 @@ if [ "$(id -un)" != "cmux" ]; then
   exit 2
 fi
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
+
+cd "$CMUX_REPO_ROOT"
 
 DERIVED_DATA_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-tests-v2"
 APP="$DERIVED_DATA_PATH/Build/Products/Debug/cmux DEV.app"
@@ -21,7 +25,7 @@ echo "== build =="
 # module file ... was built".
 rm -rf "$DERIVED_DATA_PATH/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules" || true
 xcodebuild \
-  -project GhosttyTabs.xcodeproj \
+  -project "$CMUX_XCODE_PROJECT_PATH" \
   -scheme cmux \
   -configuration Debug \
   -destination "platform=macOS" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
 
-cd "$PROJECT_DIR"
+cd "$CMUX_REPO_ROOT"
 
 echo "==> Initializing submodules..."
 git submodule update --init --recursive
@@ -16,11 +17,11 @@ if ! command -v zig &> /dev/null; then
     exit 1
 fi
 
-GHOSTTY_SHA="$(git -C ghostty rev-parse HEAD)"
+GHOSTTY_SHA="$(git -C "$CMUX_GHOSTTY_DIR" rev-parse HEAD)"
 CACHE_ROOT="${CMUX_GHOSTTYKIT_CACHE_DIR:-$HOME/.cache/cmux/ghosttykit}"
 CACHE_DIR="$CACHE_ROOT/$GHOSTTY_SHA"
 CACHE_XCFRAMEWORK="$CACHE_DIR/GhosttyKit.xcframework"
-LOCAL_XCFRAMEWORK="$PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
+LOCAL_XCFRAMEWORK="$CMUX_GHOSTTY_DIR/macos/GhosttyKit.xcframework"
 LOCAL_SHA_STAMP="$LOCAL_XCFRAMEWORK/.ghostty_sha"
 LOCK_DIR="$CACHE_ROOT/$GHOSTTY_SHA.lock"
 
@@ -57,7 +58,7 @@ else
     else
         echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
         (
-            cd ghostty
+            cd "$CMUX_GHOSTTY_DIR"
             zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
         )
         # Stamp the build output with the SHA it was built from
@@ -79,7 +80,7 @@ else
 fi
 
 echo "==> Creating symlink for GhosttyKit.xcframework..."
-ln -sfn "$CACHE_XCFRAMEWORK" GhosttyKit.xcframework
+ln -sfn "$CACHE_XCFRAMEWORK" "$CMUX_GHOSTTYKIT_PATH"
 
 echo "==> Setup complete!"
 echo ""

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/cmux-paths.sh"
+cmux_paths_init "${BASH_SOURCE[0]}"
 
-PROJECT="GhosttyTabs.xcodeproj"
+cd "$CMUX_REPO_ROOT"
+
+PROJECT="$CMUX_XCODE_PROJECT_PATH"
 SCHEME="cmux-unit"
 CONFIGURATION="${CMUX_TEST_CONFIGURATION:-Debug}"
 DESTINATION="${CMUX_TEST_DESTINATION:-platform=macOS}"


### PR DESCRIPTION
## Summary

Series context: PR 1 of 6 in the repo reorganization plan. This stage creates the shared shell path helper and hardens repo-root / local `cmuxd-remote` source resolution without moving directories yet. Moved-layout-only repairs are intentionally deferred to later PRs in the series so Stage 1 stays correct for the current repo layout.

Reviewer note: please review this PR as a bounded Stage 1 path-contract pass. Do not expect moved-layout path adoption, CLI path-probing cleanup, workflow rewrites, broad test-path repair, or Xcode project restructuring in this stage; those are intentionally deferred to later PRs in the series.

- Create `scripts/lib/cmux-paths.sh` and rewire the bounded Stage 1 script surface to resolve shared repo paths from one helper instead of repeating per-script path math.
- Harden `Workspace.swift` repo-root and local `cmuxd-remote` source resolution so the dev-only remote daemon fallback works against the current layout and remains compatible with the planned later move.
- Keep Stage 1 intentionally narrow: no filesystem moves, no CLI path-probing sweep, no workflow rewrites, no test-path repair sweep, and no Xcode project churn.

## Testing

- Ran `bash -n` on the new helper and all touched Stage 1 shell scripts.
- Ran `git diff --check`.
- Ran `./scripts/setup.sh` to completion before the first debug build in this worktree.
- Ran `./scripts/reload.sh --tag stage1-paths`, verified the tagged app build and CLI shim pointed at commit `5d2f4f779`.
- Ran `./scripts/reload.sh --tag stage1-paths-build2` after installing local Go and used the tagged build to validate the `Workspace.swift` remote-daemon fallback end to end.
- Verified `cmux-dev ping`, `cmux-dev current-workspace`, `cmux-dev --version`, and `cmux-dev ssh galem@gmm4.lan` against the tagged app.
- Verified remote SSH connect still worked after quitting and relaunching the tagged app.
- Ran `bash -n` on the follow-up touched scripts: `scripts/build-sign-upload.sh`, `scripts/download-prebuilt-ghosttykit.sh`, and `scripts/lib/cmux-paths.sh`.
- Ran `./scripts/reload.sh --tag stage1-paths-fixes`, verified the CLI shim pointed at commit `2cceffa16`, and re-verified `cmux-dev ping` plus `cmux-dev ssh galem@gmm4.lan` against the fixup build.
- Ran `bash /Users/galew/Workspace/manaflow-ai/wt-cmux-add-sharedPathResolutionForScripts/scripts/download-prebuilt-ghosttykit.sh` from `/tmp` and verified it still extracted to the intended absolute `GhosttyKit.xcframework` path.

## AI Review Snapshot

- Codex: no major issues found. [Comment](https://github.com/manaflow-ai/cmux/pull/1926#issuecomment-4104728236)
- Greptile: summarized this as a clean Stage 1 path-centralization refactor, called out the new shared `cmux-paths.sh` helper plus the hardened `Workspace.swift` repo-root and daemon-source probing, and noted one future-layout asymmetry to keep in mind: shell defaults still point to `daemon/remote` while Swift already dual-probes `daemon/remote` and `Tools/daemon-remote`. [Comment](https://github.com/manaflow-ai/cmux/pull/1926#issuecomment-4104732281)
- CodeRabbit: review still in progress. [Comment](https://github.com/manaflow-ai/cmux/pull/1926#issuecomment-4104715997)
- Cubic: review still in progress. [Comment](https://github.com/manaflow-ai/cmux/pull/1926#issuecomment-4104719503)

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

## Summary by cubic

Adds a shared script path helper and hardens repo/daemon path detection so dev builds and scripts work reliably across current and future repo layouts.

- Refactors
  - Introduced `scripts/lib/cmux-paths.sh` to centralize path resolution and `CMUX_*` env vars.
  - Updated Stage 1 scripts to source the helper and use vars like `CMUX_REPO_ROOT`, `CMUX_GHOSTTY_DIR`, `CMUX_XCODE_PROJECT_PATH`, `CMUX_GHOSTTYKIT_PATH`, `CMUX_HOMEBREW_TAP_DIR`, and `CMUX_APP_SUPPORT_DIR`.
  - Standardized Xcode project, GhosttyKit, and Homebrew tap paths across build/reload/test scripts.
- Bug Fixes
  - `Workspace.swift`: made repo-root and local `cmuxd-remote` source detection more robust with multiple repo markers and env overrides (`CMUX_REMOTE_DAEMON_DIR`, `CMUX_REPO_ROOT`, `CMUXTERM_REPO_ROOT`); supports `daemon/remote` and `Tools/daemon-remote`.
  - Improved dev-only `cmuxd-remote` build fallback with clearer errors, stricter Go checks, and executable verification.

Written for commit `5d2f4f779ba8fcb4ab1bcda3d4cd0f86fd0eac06`. Summary will update on new commits.

## Summary by CodeRabbit

### Chores

- Refactored build system path resolution to support centralized configuration through environment variables (`CMUX_REMOTE_DAEMON_DIR`, `CMUX_REPO_ROOT`).
- Enhanced repository root detection with improved validation across multiple project markers.

### Bug Fixes

- Updated error codes and messages for clearer local source discovery diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized path and build configuration into a shared helper used by many scripts for consistent behavior.
  * Scripts and builds now honor environment overrides for local daemon, ghostty, and repo locations.
  * Improved repository-root detection and more robust local daemon discovery with cleaner, more actionable error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->