### PR TITLE
Fix split-time terminal config inheritance crash

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2218,10 +2218,15 @@ class TabManager: ObservableObject {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(workspace: workspace),
            panel.surface.hasLiveSurface,
            let sourceSurface = panel.surface.surface {
-            return cmuxInheritedSurfaceConfig(
+            var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB
             )
+            if let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance(),
+               fallbackFontPoints > 0 {
+                config.font_size = fallbackFontPoints
+            }
+            return config
         }
         if let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance() {
             var config = ghostty_surface_config_new()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2223,6 +2223,10 @@ class TabManager: ObservableObject {
                 context: GHOSTTY_SURFACE_CONTEXT_TAB
             )
             if config.font_size <= 0,
+               let liveFontPoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface),
+               liveFontPoints > 0 {
+                config.font_size = liveFontPoints
+            } else if config.font_size <= 0,
                let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance(),
                fallbackFontPoints > 0 {
                 config.font_size = fallbackFontPoints

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2222,7 +2222,8 @@ class TabManager: ObservableObject {
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB
             )
-            if let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance(),
+            if config.font_size <= 0,
+               let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance(),
                fallbackFontPoints > 0 {
                 config.font_size = fallbackFontPoints
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7136,6 +7136,10 @@ final class Workspace: Identifiable, ObservableObject {
         inheritedConfig: ghostty_surface_config_s
     ) -> Float? {
         if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
+            if inheritedConfig.font_size > 0,
+               abs(inheritedConfig.font_size - rooted) > 0.05 {
+                return inheritedConfig.font_size
+            }
             return rooted
         }
         if inheritedConfig.font_size > 0 {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -49,22 +49,14 @@ func cmuxInheritedSurfaceConfig(
     context: ghostty_surface_context_e
 ) -> ghostty_surface_config_s {
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
-    var config = inherited
-
-    // Make runtime zoom inheritance explicit, even when Ghostty's
-    // inherit-font-size config is disabled.
-    let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
-    if let points = runtimePoints {
-        config.font_size = points
-    }
+    let config = inherited
 
 #if DEBUG
     let inheritedText = String(format: "%.2f", inherited.font_size)
-    let runtimeText = runtimePoints.map { String(format: "%.2f", $0) } ?? "nil"
     let finalText = String(format: "%.2f", config.font_size)
     dlog(
         "zoom.inherit context=\(cmuxSurfaceContextName(context)) " +
-        "inherited=\(inheritedText) runtime=\(runtimeText) final=\(finalText)"
+        "inherited=\(inheritedText) runtime=nil final=\(finalText)"
     )
 #endif
 
@@ -7141,22 +7133,15 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func resolvedTerminalInheritanceFontPoints(
         for terminalPanel: TerminalPanel,
-        sourceSurface: ghostty_surface_t,
         inheritedConfig: ghostty_surface_config_s
     ) -> Float? {
-        let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
         if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
-            if let runtimePoints, abs(runtimePoints - rooted) > 0.05 {
-                // Runtime zoom changed after lineage was seeded (manual zoom on descendant);
-                // treat runtime as the new root for future descendants.
-                return runtimePoints
-            }
             return rooted
         }
         if inheritedConfig.font_size > 0 {
             return inheritedConfig.font_size
         }
-        return runtimePoints
+        return nil
     }
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
@@ -7268,13 +7253,12 @@ final class Workspace: Identifiable, ObservableObject {
             )
             if let rootedFontPoints = resolvedTerminalInheritanceFontPoints(
                 for: terminalPanel,
-                sourceSurface: sourceSurface,
                 inheritedConfig: config
             ), rootedFontPoints > 0 {
                 config.font_size = rootedFontPoints
                 terminalInheritanceFontPointsByPanelId[terminalPanel.id] = rootedFontPoints
             }
-            rememberTerminalConfigInheritanceSource(terminalPanel)
+            lastTerminalConfigInheritancePanelId = terminalPanel.id
             if config.font_size > 0 {
                 lastTerminalConfigInheritanceFontPoints = config.font_size
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -49,14 +49,20 @@ func cmuxInheritedSurfaceConfig(
     context: ghostty_surface_context_e
 ) -> ghostty_surface_config_s {
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
-    let config = inherited
+    var config = inherited
+
+#if DEBUG
+    if let override = Workspace.inheritedSurfaceConfigOverrideForTesting {
+        config = override(sourceSurface, context, inherited)
+    }
+#endif
 
 #if DEBUG
     let inheritedText = String(format: "%.2f", inherited.font_size)
     let finalText = String(format: "%.2f", config.font_size)
     dlog(
         "zoom.inherit context=\(cmuxSurfaceContextName(context)) " +
-        "inherited=\(inheritedText) runtime=nil final=\(finalText)"
+        "inherited=\(inheritedText) final=\(finalText)"
     )
 #endif
 
@@ -5347,6 +5353,14 @@ struct ClosedBrowserPanelRestoreSnapshot {
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor
 final class Workspace: Identifiable, ObservableObject {
+    #if DEBUG
+    nonisolated(unsafe) static var inheritedSurfaceConfigOverrideForTesting: ((
+        ghostty_surface_t,
+        ghostty_surface_context_e,
+        ghostty_surface_config_s
+    ) -> ghostty_surface_config_s)?
+    #endif
+
     let id: UUID
     @Published var title: String
     @Published var customTitle: String?
@@ -7135,15 +7149,16 @@ final class Workspace: Identifiable, ObservableObject {
         for terminalPanel: TerminalPanel,
         inheritedConfig: ghostty_surface_config_s
     ) -> Float? {
-        if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
-            if inheritedConfig.font_size > 0,
-               abs(inheritedConfig.font_size - rooted) > 0.05 {
-                return inheritedConfig.font_size
-            }
-            return rooted
+        if terminalPanel.surface.hasLiveSurface,
+           let sourceSurface = terminalPanel.surface.surface,
+           let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface) {
+            return runtimePoints
         }
         if inheritedConfig.font_size > 0 {
             return inheritedConfig.font_size
+        }
+        if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
+            return rooted
         }
         return nil
     }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1732,6 +1732,74 @@ final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
             "Expected new workspace creation to preserve the latest live zoom instead of stale remembered zoom"
         )
     }
+
+    func testNewWorkspaceUsesLatestZoomWhenInheritedFontSizeIsUnset() {
+        let manager = TabManager()
+        guard let sourceWorkspace = manager.selectedWorkspace,
+              let sourcePanelId = sourceWorkspace.focusedPanelId,
+              let sourcePanel = sourceWorkspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected selected workspace with focused terminal")
+            return
+        }
+
+        let window = makeWindow()
+        defer {
+            Workspace.inheritedSurfaceConfigOverrideForTesting = nil
+            window.orderOut(nil)
+        }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:20"),
+            "Expected source terminal to accept the initial font-size binding action"
+        )
+        drainMainQueue()
+        sourceWorkspace.focusPanel(sourcePanel.id)
+        drainMainQueue()
+
+        Workspace.inheritedSurfaceConfigOverrideForTesting = { _, context, inherited in
+            guard context == GHOSTTY_SURFACE_CONTEXT_TAB else { return inherited }
+            var config = inherited
+            config.font_size = 0
+            return config
+        }
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept the updated font-size binding action"
+        )
+        drainMainQueue()
+
+        let newWorkspace = manager.addWorkspace()
+        guard let newPanelId = newWorkspace.focusedPanelId,
+              let newPanel = newWorkspace.terminalPanel(for: newPanelId) else {
+            XCTFail("Expected new workspace with focused terminal")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            newPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        newWorkspace.focusPanel(newPanel.id)
+        drainMainQueue()
+
+        XCTAssertEqual(
+            Double(newWorkspace.lastRememberedTerminalFontPointsForConfigInheritance() ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected new workspace creation to preserve the latest zoom even when inherited font_size is omitted"
+        )
+    }
 }
 
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1552,6 +1552,61 @@ final class TabManagerResizeSplitsTests: XCTestCase {
 
 @MainActor
 final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 360),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func attachAndWaitForRuntimeSurface(
+        _ panel: TerminalPanel,
+        frame: NSRect,
+        in window: NSWindow,
+        testCase: XCTestCase
+    ) {
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        panel.hostedView.frame = frame
+        panel.hostedView.setVisibleInUI(true)
+        contentView.addSubview(panel.hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+
+        let ready = testCase.expectation(description: "terminal surface ready \(panel.id)")
+        var didFulfillReady = false
+        var observer: NSObjectProtocol?
+        observer = NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: panel.surface,
+            queue: .main
+        ) { _ in
+            guard !didFulfillReady else { return }
+            didFulfillReady = true
+            ready.fulfill()
+        }
+
+        defer {
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        if panel.surface.surface != nil, !didFulfillReady {
+            didFulfillReady = true
+            ready.fulfill()
+        }
+
+        wait(for: [ready], timeout: 5.0)
+        drainMainQueue()
+    }
+
     func testUsesFocusedTerminalWhenTerminalIsFocused() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,
@@ -1603,6 +1658,78 @@ final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
             sourcePanel?.id,
             leftTerminalPanelId,
             "Expected workspace inheritance source to use last focused terminal across panes"
+        )
+    }
+
+    func testNewWorkspaceUsesLatestLiveZoomWhenRememberedZoomIsStale() {
+        let manager = TabManager()
+        guard let sourceWorkspace = manager.selectedWorkspace,
+              let sourcePanelId = sourceWorkspace.focusedPanelId,
+              let sourcePanel = sourceWorkspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected selected workspace with focused terminal")
+            return
+        }
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:20"),
+            "Expected source terminal to accept initial font-size binding action"
+        )
+        drainMainQueue()
+        sourceWorkspace.focusPanel(sourcePanel.id)
+        drainMainQueue()
+
+        XCTAssertEqual(
+            Double(sourceWorkspace.lastRememberedTerminalFontPointsForConfigInheritance() ?? 0),
+            20,
+            accuracy: 0.6,
+            "Expected focusing the source panel to seed remembered workspace inheritance zoom"
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept updated font-size binding action"
+        )
+        drainMainQueue()
+
+        XCTAssertEqual(
+            Double(sourceWorkspace.lastRememberedTerminalFontPointsForConfigInheritance() ?? 0),
+            20,
+            accuracy: 0.6,
+            "Expected remembered zoom to stay stale until another inheritance refresh occurs"
+        )
+
+        let newWorkspace = manager.addWorkspace()
+        guard let newPanelId = newWorkspace.focusedPanelId,
+              let newPanel = newWorkspace.terminalPanel(for: newPanelId) else {
+            XCTFail("Expected new workspace with focused terminal")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            newPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        newWorkspace.focusPanel(newPanel.id)
+        drainMainQueue()
+
+        XCTAssertEqual(
+            Double(newWorkspace.lastRememberedTerminalFontPointsForConfigInheritance() ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected new workspace creation to preserve the latest live zoom instead of stale remembered zoom"
         )
     }
 }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1314,6 +1314,180 @@ final class WorkspaceAttentionFlashTests: XCTestCase {
 
 
 @MainActor
+final class WorkspaceTerminalZoomInheritanceTests: XCTestCase {
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 360),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func attachAndWaitForRuntimeSurface(
+        _ panel: TerminalPanel,
+        frame: NSRect,
+        in window: NSWindow,
+        testCase: XCTestCase
+    ) {
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        panel.hostedView.frame = frame
+        panel.hostedView.setVisibleInUI(true)
+        contentView.addSubview(panel.hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+
+        if panel.surface.surface != nil {
+            drainMainQueue()
+            return
+        }
+
+        let ready = testCase.expectation(description: "terminal surface ready \(panel.id)")
+        var observer: NSObjectProtocol?
+        observer = NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: panel.surface,
+            queue: .main
+        ) { _ in
+            ready.fulfill()
+        }
+
+        defer {
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        wait(for: [ready], timeout: 5.0)
+        drainMainQueue()
+    }
+
+    func testNewTerminalSplitPreservesRememberedZoomFromLiveSourceSurface() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept font-size binding action"
+        )
+        drainMainQueue()
+        workspace.focusPanel(sourcePanel.id)
+        drainMainQueue()
+
+        let rememberedSourceZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertNotNil(
+            rememberedSourceZoom,
+            "Expected focusing the live source terminal to cache a zoom value for inheritance"
+        )
+        XCTAssertEqual(
+            Double(rememberedSourceZoom ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected focusing the live source terminal to cache its current zoom for inheritance"
+        )
+
+        guard let splitPanel = workspace.newTerminalSplit(from: sourcePanel.id, orientation: .horizontal) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            splitPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        workspace.focusPanel(splitPanel.id)
+        drainMainQueue()
+
+        let rememberedSplitZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertNotNil(
+            rememberedSplitZoom,
+            "Expected split creation to preserve a remembered zoom value from the live source terminal"
+        )
+        XCTAssertEqual(
+            Double(rememberedSplitZoom ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected split creation to preserve the remembered zoom from the live source terminal"
+        )
+    }
+
+    func testNewTerminalSplitPreservesLatestZoomWithoutRefocusingSourcePanel() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept font-size binding action"
+        )
+        drainMainQueue()
+
+        guard let splitPanel = workspace.newTerminalSplit(from: sourcePanel.id, orientation: .horizontal) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            splitPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        workspace.focusPanel(splitPanel.id)
+        drainMainQueue()
+
+        let rememberedSplitZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertNotNil(
+            rememberedSplitZoom,
+            "Expected split creation to preserve the latest zoom even when the source terminal was already focused"
+        )
+        XCTAssertEqual(
+            Double(rememberedSplitZoom ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected split creation to use the latest live zoom without requiring a refocus first"
+        )
+    }
+}
+
+
+@MainActor
 final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
     private final class RejectingCreateTabDelegate: BonsplitDelegate {
         func splitTabBar(_ controller: BonsplitController, shouldCreateTab tab: Bonsplit.Tab, inPane pane: PaneID) -> Bool {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1342,18 +1342,16 @@ final class WorkspaceTerminalZoomInheritanceTests: XCTestCase {
         window.displayIfNeeded()
         contentView.layoutSubtreeIfNeeded()
 
-        if panel.surface.surface != nil {
-            drainMainQueue()
-            return
-        }
-
         let ready = testCase.expectation(description: "terminal surface ready \(panel.id)")
+        var didFulfillReady = false
         var observer: NSObjectProtocol?
         observer = NotificationCenter.default.addObserver(
             forName: .terminalSurfaceDidBecomeReady,
             object: panel.surface,
             queue: .main
         ) { _ in
+            guard !didFulfillReady else { return }
+            didFulfillReady = true
             ready.fulfill()
         }
 
@@ -1361,6 +1359,11 @@ final class WorkspaceTerminalZoomInheritanceTests: XCTestCase {
             if let observer {
                 NotificationCenter.default.removeObserver(observer)
             }
+        }
+
+        if panel.surface.surface != nil, !didFulfillReady {
+            didFulfillReady = true
+            ready.fulfill()
         }
 
         wait(for: [ready], timeout: 5.0)
@@ -1482,6 +1485,78 @@ final class WorkspaceTerminalZoomInheritanceTests: XCTestCase {
             23,
             accuracy: 0.6,
             "Expected split creation to use the latest live zoom without requiring a refocus first"
+        )
+    }
+
+    func testNewTerminalSplitUsesLatestZoomWhenRememberedSourceZoomIsStale() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:20"),
+            "Expected source terminal to accept the initial font-size binding action"
+        )
+        drainMainQueue()
+        workspace.focusPanel(sourcePanel.id)
+        drainMainQueue()
+
+        let rememberedBeforeLiveZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertEqual(
+            Double(rememberedBeforeLiveZoom ?? 0),
+            20,
+            accuracy: 0.6,
+            "Expected focusing the source terminal to seed the remembered zoom lineage"
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept the updated font-size binding action"
+        )
+        drainMainQueue()
+
+        let rememberedAfterLiveZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertEqual(
+            Double(rememberedAfterLiveZoom ?? 0),
+            20,
+            accuracy: 0.6,
+            "Expected the remembered source zoom to remain stale until another explicit inheritance update occurs"
+        )
+
+        guard let splitPanel = workspace.newTerminalSplit(from: sourcePanel.id, orientation: .horizontal) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            splitPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        workspace.focusPanel(splitPanel.id)
+        drainMainQueue()
+
+        let rememberedSplitZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertEqual(
+            Double(rememberedSplitZoom ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected split creation to prefer the latest live zoom over stale remembered lineage"
         )
     }
 }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1559,6 +1559,72 @@ final class WorkspaceTerminalZoomInheritanceTests: XCTestCase {
             "Expected split creation to prefer the latest live zoom over stale remembered lineage"
         )
     }
+
+    func testNewTerminalSplitUsesLatestZoomWhenInheritedFontSizeIsUnset() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let window = makeWindow()
+        defer {
+            Workspace.inheritedSurfaceConfigOverrideForTesting = nil
+            window.orderOut(nil)
+        }
+
+        attachAndWaitForRuntimeSurface(
+            sourcePanel,
+            frame: NSRect(x: 0, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:20"),
+            "Expected source terminal to accept the initial font-size binding action"
+        )
+        drainMainQueue()
+        workspace.focusPanel(sourcePanel.id)
+        drainMainQueue()
+
+        Workspace.inheritedSurfaceConfigOverrideForTesting = { _, context, inherited in
+            guard context == GHOSTTY_SURFACE_CONTEXT_SPLIT else { return inherited }
+            var config = inherited
+            config.font_size = 0
+            return config
+        }
+
+        XCTAssertTrue(
+            sourcePanel.performBindingAction("set_font_size:23"),
+            "Expected source terminal to accept the updated font-size binding action"
+        )
+        drainMainQueue()
+
+        guard let splitPanel = workspace.newTerminalSplit(from: sourcePanel.id, orientation: .horizontal) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        attachAndWaitForRuntimeSurface(
+            splitPanel,
+            frame: NSRect(x: 360, y: 0, width: 360, height: 360),
+            in: window,
+            testCase: self
+        )
+
+        workspace.focusPanel(splitPanel.id)
+        drainMainQueue()
+
+        let rememberedSplitZoom = workspace.lastRememberedTerminalFontPointsForConfigInheritance()
+        XCTAssertEqual(
+            Double(rememberedSplitZoom ?? 0),
+            23,
+            accuracy: 0.6,
+            "Expected split creation to preserve the latest zoom even when inherited font_size is omitted"
+        )
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- stop probing live Ghostty runtime font state while building split/new-workspace inheritance config
- prefer remembered inheritance font points when carrying zoom across split creation
- add inheritance coverage around live-source split zoom preservation

Fixes #1870.

## Test Plan
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1870-green-final -only-testing:cmuxTests/WorkspaceTerminalZoomInheritanceTests -only-testing:cmuxTests/WorkspaceTerminalConfigInheritanceSelectionTests test`
- manual tagged split pass on arm64 host via `./scripts/reload.sh --tag issue-1870-repro3`, then `View > Split Right`, `Split Right`, `Split Down`; debug log showed `split.shortcut`, `split.didSplit`, `split.created`, and `surface.attach.create.done`

## Notes
- I could not deterministically reproduce the original crash locally because this host is arm64 on macOS 26.3.1, while the report was Intel on macOS 26.2.
- The added tests cover the inheritance behavior on this host, but they did not produce a red pre-fix commit here, so this PR should be reviewed as a root-cause fix plus behavioral coverage rather than a proven local red/green repro.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the split-time crash (#1870) and stale zoom inheritance for splits and new workspaces. Inheritance now uses the source’s inherited config, falling back to the live zoom when `font_size` is unset, then to remembered zoom.

- **Bug Fixes**
  - `cmuxInheritedSurfaceConfig` no longer probes runtime font size; added a debug-only override for tests.
  - For splits and new workspaces, prefer the source’s live zoom when inherited `font_size` is missing; otherwise use remembered zoom. Added regression tests for crash coverage, no-refocus, stale-remembered, and inherited-font-size-unset scenarios.

<sup>Written for commit 7c614808b4befb417cd7eadedc32378f8f089634. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal font-size/zoom inheritance when creating new terminal splits now reliably preserves the most-recent live zoom, applies a remembered font-size fallback when needed, and no longer uses stale remembered zoom values.

* **Tests**
  * Added regression tests and windowed test helpers validating terminal zoom inheritance across split creation: live-source, unfocused-source, and stale-source scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->