### PR TITLE
Fix dock icon not auto-switching with system dark mode

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3703,12 +3703,15 @@ final class AppIconAppearanceObserver: NSObject {
     static let shared = AppIconAppearanceObserver()
     private var observation: NSKeyValueObservation?
 
+    private override init() { super.init() }
+
     func startObserving() {
         applyIconForCurrentAppearance()
         guard observation == nil else { return }
-        observation = NSApp.observe(\.effectiveAppearance, options: [.new]) { [weak self] _, _ in
+        observation = NSApp.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
             DispatchQueue.main.async {
-                self?.applyIconForCurrentAppearance()
+                guard let self, self.observation != nil else { return }
+                self.applyIconForCurrentAppearance()
             }
         }
     }


### PR DESCRIPTION
## Summary
- The automatic dock icon mode sets `applicationIconImage = nil`, expecting the asset catalog to handle dark/light switching — but the compiled `Assets.car` doesn't include dark variant renditions for `AppIcon`, so the icon stays light regardless of system appearance
- Replaced the nil-reset approach with a KVO observer on `NSApp.effectiveAppearance` that programmatically swaps between `AppIconDark` and `AppIconLight` images when in automatic mode
- Observer is started/stopped cleanly when switching between icon modes

## Root Cause
The `AppIcon.appiconset/Contents.json` correctly defines dark variants with `luminosity: dark` appearance, but the compiled `Assets.car` strips these — all `AppIcon` entries have `Appearance: none`. The `AppIconDark` and `AppIconLight` imagesets exist separately but aren't linked as appearance variants of the main `AppIcon`.

## Test plan
- [ ] Set icon mode to "Automatic" in cmux settings
- [ ] Switch macOS appearance to dark mode → dock icon should change to dark variant
- [ ] Switch macOS appearance to light mode → dock icon should change to light variant
- [ ] Set icon mode to "Light" or "Dark" → icon should stay fixed regardless of system appearance
- [ ] Restart app in automatic mode → icon should match current system appearance on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dock icon not switching with macOS dark mode by observing system appearance and swapping between `AppIconDark` and `AppIconLight` in Automatic mode. The observer starts/stops with icon mode changes, avoids stale async updates, and applies the correct icon on launch while keeping manual Light/Dark fixed.

- **Bug Fixes**
  - Use KVO on `NSApp.effectiveAppearance` to swap `AppIconDark`/`AppIconLight` in Automatic mode.
  - Apply the right icon at startup and on appearance changes; start/stop the observer when switching modes so Light/Dark stay fixed.
  - Hardened observer: ignore stale async callbacks after `stopObserving()`, enforce a singleton with a private init, and remove the unused KVO option.

<sup>Written for commit fb5b763bd3e72cc2910d8c0791d118a2e13443ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic app icon now responds immediately to system light/dark appearance changes.
  * Icon updates occur in real time when switching themes without needing manual action or app restart.
  * Improved reliability in selecting the appropriate light or dark icon for the current appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->