### PR TITLE
Replace deprecated NSFileHandle APIs to prevent ObjC exception crash

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1040,8 +1040,9 @@ class GhosttyApp {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: initLogPath) {
             defer { try? handle.close() }
-            try? handle.seekToEnd()
-            try? handle.write(contentsOf: line.data(using: .utf8)!)
+            if let _ = try? handle.seekToEnd() {
+                try? handle.write(contentsOf: line.data(using: .utf8)!)
+            }
         } else {
             FileManager.default.createFile(atPath: initLogPath, contents: line.data(using: .utf8))
         }
@@ -3127,8 +3128,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: surfaceLogPath) {
             defer { try? handle.close() }
-            try? handle.seekToEnd()
-            try? handle.write(contentsOf: line.data(using: .utf8)!)
+            if let _ = try? handle.seekToEnd() {
+                try? handle.write(contentsOf: line.data(using: .utf8)!)
+            }
         } else {
             FileManager.default.createFile(atPath: surfaceLogPath, contents: line.data(using: .utf8))
         }
@@ -3141,8 +3143,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: sizeLogPath) {
             defer { try? handle.close() }
-            try? handle.seekToEnd()
-            try? handle.write(contentsOf: line.data(using: .utf8)!)
+            if let _ = try? handle.seekToEnd() {
+                try? handle.write(contentsOf: line.data(using: .utf8)!)
+            }
         } else {
             FileManager.default.createFile(atPath: sizeLogPath, contents: line.data(using: .utf8))
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1039,9 +1039,9 @@ class GhosttyApp {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: initLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
-            handle.closeFile()
+            defer { try? handle.close() }
+            try? handle.seekToEnd()
+            try? handle.write(contentsOf: line.data(using: .utf8)!)
         } else {
             FileManager.default.createFile(atPath: initLogPath, contents: line.data(using: .utf8))
         }
@@ -3126,9 +3126,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: surfaceLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
-            handle.closeFile()
+            defer { try? handle.close() }
+            try? handle.seekToEnd()
+            try? handle.write(contentsOf: line.data(using: .utf8)!)
         } else {
             FileManager.default.createFile(atPath: surfaceLogPath, contents: line.data(using: .utf8))
         }
@@ -3140,9 +3140,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: sizeLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(line.data(using: .utf8)!)
-            handle.closeFile()
+            defer { try? handle.close() }
+            try? handle.seekToEnd()
+            try? handle.write(contentsOf: line.data(using: .utf8)!)
         } else {
             FileManager.default.createFile(atPath: sizeLogPath, contents: line.data(using: .utf8))
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -304,9 +304,9 @@ extension WorkspaceContentView {
             let line = "[\(ts)] PANEL NOT FOUND for tabId=\(tab.id) ws=\(workspace.id) panelCount=\(workspace.panels.count)\n"
             let logPath = "/tmp/cmux-panel-debug.log"
             if let handle = FileHandle(forWritingAtPath: logPath) {
-                handle.seekToEndOfFile()
-                handle.write(line.data(using: .utf8)!)
-                handle.closeFile()
+                defer { try? handle.close() }
+                try? handle.seekToEnd()
+                try? handle.write(contentsOf: line.data(using: .utf8)!)
             } else {
                 FileManager.default.createFile(atPath: logPath, contents: line.data(using: .utf8))
             }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -305,8 +305,9 @@ extension WorkspaceContentView {
             let logPath = "/tmp/cmux-panel-debug.log"
             if let handle = FileHandle(forWritingAtPath: logPath) {
                 defer { try? handle.close() }
-                try? handle.seekToEnd()
-                try? handle.write(contentsOf: line.data(using: .utf8)!)
+                if let _ = try? handle.seekToEnd() {
+                    try? handle.write(contentsOf: line.data(using: .utf8)!)
+                }
             } else {
                 FileManager.default.createFile(atPath: logPath, contents: line.data(using: .utf8))
             }


### PR DESCRIPTION
## Summary
- Legacy `seekToEndOfFile()`, `write(_:)`, and `closeFile()` throw ObjC `NSFileHandleOperationException` on I/O errors — Swift's `do-catch` cannot catch these, causing an unhandled crash
- Replaced all debug logging call sites with modern Swift-throwing equivalents: `seekToEnd()`, `write(contentsOf:)`, and `close()`
- The same fix is needed in `vendor/bonsplit` submodule (`DebugEventLog.swift:67-70`) — the original crash site from the issue

## Files changed
- `Sources/GhosttyTerminalView.swift` — 3 call sites (init log, surface log, size log)
- `Sources/WorkspaceContentView.swift` — 1 call site (panel debug log)

## Note
The root crash from #1924 originates in `vendor/bonsplit/Sources/Bonsplit/Public/DebugEventLog.swift` which is a submodule. The same `seekToEndOfFile()` → `seekToEnd()` fix needs to be applied there as well.

## Test plan
- [ ] Run debug build for extended period (14+ hours) with debug logging active
- [ ] Verify no crash when log file is deleted/moved while app is running
- [ ] Verify debug logs still append correctly under normal operation

Fixes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated `NSFileHandle` logging calls with Swift-throwing equivalents and now skip writes if `seekToEnd()` fails. Prevents crashes and avoids corrupting logs when files rotate, are deleted, or handles go stale.

- **Bug Fixes**
  - Swapped `seekToEndOfFile()`, `write(_:)`, `closeFile()` → `seekToEnd()`, `write(contentsOf:)`, `close()` (using `try?`, `defer`), and guard writes behind a successful seek.
  - Updated: `Sources/GhosttyTerminalView.swift` (init/surface/size logs) and `Sources/WorkspaceContentView.swift` (panel debug log). Follow-up needed in `vendor/bonsplit/Sources/Bonsplit/Public/DebugEventLog.swift` to cover the original crash path (#1924).

<sup>Written for commit 1f79ce38d4383f6b5c395a4fe02fef6234cc4a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal debug logging robustness so log operations fail silently on write/seek errors, reducing risk of disruptions during debug sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->