### PR TITLE
Allow macOS window arrangement shortcuts (Fn+Ctrl+Arrow) to pass through

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5025,6 +5025,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
               fr === self || fr.isDescendant(of: self) else { return false }
         guard let surface = ensureSurfaceReadyForInput() else { return false }
 
+        // Allow macOS system window arrangement shortcuts (e.g. Fn+Ctrl+Arrow
+        // for window tiling in macOS Sequoia+) to pass through to the system.
+        // The .function modifier indicates a Fn-key combination intended for the
+        // OS, not terminal input.
+        let systemModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if systemModifiers.contains(.function) && systemModifiers.contains(.control)
+            && !systemModifiers.contains(.command) {
+            return false
+        }
+
         // If the IME is composing (marked text present) and the key has no Cmd
         // modifier, don't intercept — let it flow through to keyDown so the input
         // method can process it normally. Cmd-based shortcuts should still work

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5027,11 +5027,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Allow macOS system window arrangement shortcuts (e.g. Fn+Ctrl+Arrow
         // for window tiling in macOS Sequoia+) to pass through to the system.
-        // The .function modifier indicates a Fn-key combination intended for the
-        // OS, not terminal input.
-        let systemModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if systemModifiers.contains(.function) && systemModifiers.contains(.control)
-            && !systemModifiers.contains(.command) {
+        // Fn+Arrow produces Home/End/PageUp/PageDown key codes (115/119/121/116)
+        // which differ from plain arrow key codes (123/124/125/126). We only pass
+        // through the Fn-translated key codes with Control, so plain Ctrl+Arrow
+        // (terminal word navigation) continues to work.
+        let fnNavKeyCodes: Set<UInt16> = [115, 119, 121, 116, 105] // Home, End, PgDn, PgUp, F13(Fn+F)
+        if fnNavKeyCodes.contains(event.keyCode)
+            && event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.control)
+            && !event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) {
             return false
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5031,8 +5031,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // which differ from plain arrow key codes (123/124/125/126). We only pass
         // through the Fn-translated key codes with Control, so plain Ctrl+Arrow
         // (terminal word navigation) continues to work.
-        let fnNavKeyCodes: Set<UInt16> = [115, 119, 121, 116, 105] // Home, End, PgDn, PgUp, F13(Fn+F)
-        if fnNavKeyCodes.contains(event.keyCode)
+        if Self.fnNavKeyCodes.contains(event.keyCode)
             && event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.control)
             && !event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) {
             return false
@@ -6526,6 +6525,10 @@ final class GhosttySurfaceScrollView: NSView {
         case standardFocus
         case notificationDismiss
     }
+
+    // Key codes produced by Fn+Arrow (Home/End/PgUp/PgDn) and Fn+F (F13),
+    // used to detect macOS system window arrangement shortcuts.
+    private static let fnNavKeyCodes: Set<UInt16> = [115, 119, 121, 116, 105]
 
     private enum NotificationRingMetrics {
         static let inset: CGFloat = 2


### PR DESCRIPTION
## Summary
- macOS Sequoia introduced Fn+Ctrl+Arrow shortcuts for window tiling (tile left/right, maximize, etc.)
- `performKeyEquivalent` was not distinguishing Fn-key system combinations from terminal input
- Events with `.function` + `.control` modifiers would match Ghostty keybindings (e.g., Ctrl+Arrow for word navigation) or fall through to `keyDown`, preventing the system from processing them
- Added early check: when `.function` and `.control` are both present without `.command`, return `false` to let macOS handle the event

## Behavior
| Shortcut | Before | After |
|----------|--------|-------|
| Ctrl+Arrow | Terminal word nav | Terminal word nav (unchanged) |
| Fn+Ctrl+Arrow | Nothing / garbage input | macOS window tiling |
| Fn+Ctrl+F | Nothing | macOS fullscreen |

## Test plan
- [ ] Fn+Ctrl+← tiles window left
- [ ] Fn+Ctrl+→ tiles window right
- [ ] Fn+Ctrl+↑ maximizes window
- [ ] Fn+Ctrl+↓ restores window
- [ ] Fn+Ctrl+F toggles fullscreen
- [ ] Ctrl+← / Ctrl+→ still does word navigation in terminal
- [ ] Regular Fn+F1-F12 keys still work in terminal

Fixes #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow macOS window arrangement shortcuts to pass through so Sequoia’s tiling and fullscreen work as expected. Fixes Ghostty consuming Fn+Ctrl system combos while keeping existing terminal shortcuts intact.

- **Bug Fixes**
  - Detect Fn+Ctrl system combos by key codes (Home=115, End=119, PgUp=116, PgDn=121, F13=105) with Control and no Command in `performKeyEquivalent`, and return false so macOS handles them; replaces the `.function` + `.control` check that matched plain arrows; hoists `fnNavKeyCodes` to a static Set to avoid per-keystroke allocation.
  - Terminal shortcuts remain unchanged (Ctrl+Arrow word nav, Fn+F1–F12).

<sup>Written for commit 19c51a241d98cccef8ede802b3d1232554b63bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS window-tiling and arrangement keyboard shortcuts invoked with Control (and without Command) now bypass the terminal and reach the OS as expected.
  * Restores expected behavior for arranging and managing windows via keyboard, preventing the app from intercepting those system shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->