### PR TITLE
fix: gracefully handle TabManager unavailable in claude-hook stop

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10198,26 +10198,32 @@ struct CMUXCLI {
                 )
             }
 
-            if let completion {
-                let resolvedSurface = try resolveSurfaceIdForClaudeHook(
-                    surfaceId,
-                    workspaceId: workspaceId,
-                    client: client
-                )
-                let title = "Claude Code"
-                let subtitle = sanitizeNotificationField(completion.subtitle)
-                let body = sanitizeNotificationField(completion.body)
-                let payload = "\(title)|\(subtitle)|\(body)"
-                _ = try? sendV1Command("notify_target \(workspaceId) \(resolvedSurface) \(payload)", client: client)
-            }
+            // Stop is a cleanup operation — errors (e.g. TabManager already
+            // disposed during session shutdown) are logged but must not propagate.
+            do {
+                if let completion {
+                    let resolvedSurface = try resolveSurfaceIdForClaudeHook(
+                        surfaceId,
+                        workspaceId: workspaceId,
+                        client: client
+                    )
+                    let title = "Claude Code"
+                    let subtitle = sanitizeNotificationField(completion.subtitle)
+                    let body = sanitizeNotificationField(completion.body)
+                    let payload = "\(title)|\(subtitle)|\(body)"
+                    _ = try? sendV1Command("notify_target \(workspaceId) \(resolvedSurface) \(payload)", client: client)
+                }
 
-            try setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Idle",
-                icon: "pause.circle.fill",
-                color: "#8E8E93"
-            )
+                try setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Idle",
+                    icon: "pause.circle.fill",
+                    color: "#8E8E93"
+                )
+            } catch {
+                Logger.shared.log("claude-hook stop: ignoring cleanup error: \(error.localizedDescription)")
+            }
             print("OK")
 
         case "prompt-submit":


### PR DESCRIPTION
## Summary
- The `claude-hook stop` command fails with "TabManager not available" when the session's TabManager is disposed before the stop hook fires
- This is a timing issue during session cleanup — the stop hook should not fail since it's a cleanup operation

## Root Cause
`TerminalController.tabManager` is set to `nil` via `setActiveTabManager(nil)` during window/tab close. If `claude-hook stop` fires after this, the V1/V2 command handlers return an error.

## Fix
Catch errors from `sendV1Command` and `setClaudeStatus` in the stop handler and log them instead of propagating. Stop hooks are cleanup operations and should always succeed.

Fixes #1905

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `claude-hook stop` resilient when the session `TabManager` is already disposed during cleanup. We now catch and log errors from notification/status updates so the stop hook always exits successfully.

<sup>Written for commit c6809190bd20501594377d1da79e007546b8bfde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shutdown sequence resilience by catching and logging cleanup errors instead of propagating them, ensuring graceful transitions to idle state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->