### PR TITLE
cmux ssh: add --no-focus flag to suppress auto-focus on connect

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3510,7 +3510,7 @@ struct CMUXCLI {
         }
     }
 
-    private func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
+    func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
         var destination: String?
         var port: Int?
         var identityFile: String?

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3294,6 +3294,7 @@ struct CMUXCLI {
         let port: Int?
         let identityFile: String?
         let workspaceName: String?
+        let noFocus: Bool
         let sshOptions: [String]
         let extraArguments: [String]
         let localSocketPath: String
@@ -3464,7 +3465,9 @@ struct CMUXCLI {
             if let workspaceWindowId, !workspaceWindowId.isEmpty {
                 selectParams["window_id"] = workspaceWindowId
             }
-            _ = try client.sendV2(method: "workspace.select", params: selectParams)
+            if !sshOptions.noFocus {
+                _ = try client.sendV2(method: "workspace.select", params: selectParams)
+            }
             let remoteState = ((configuredPayload["remote"] as? [String: Any])?["state"] as? String) ?? "unknown"
             cliDebugLog(
                 "cli.ssh.remote.configure.ok workspace=\(String(workspaceId.prefix(8))) state=\(remoteState)"
@@ -3512,6 +3515,7 @@ struct CMUXCLI {
         var port: Int?
         var identityFile: String?
         var workspaceName: String?
+        var noFocus = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
 
@@ -3550,6 +3554,9 @@ struct CMUXCLI {
                 }
                 workspaceName = commandArgs[index + 1]
                 index += 2
+            case "--no-focus":
+                noFocus = true
+                index += 1
             case "--ssh-option":
                 guard index + 1 < commandArgs.count else {
                     throw CLIError(message: "ssh: --ssh-option requires a value")
@@ -3585,6 +3592,7 @@ struct CMUXCLI {
             port: port,
             identityFile: identityFile,
             workspaceName: workspaceName,
+            noFocus: noFocus,
             sshOptions: sshOptions,
             extraArguments: extraArguments,
             localSocketPath: localSocketPath,
@@ -6012,6 +6020,7 @@ struct CMUXCLI {
               --port <n>              SSH port
               --identity <path>       SSH identity file path
               --ssh-option <opt>      Extra SSH -o option (repeatable)
+              --no-focus              Create workspace without switching to it
 
             Example:
               cmux ssh dev@my-host

--- a/cmuxTests/CLIProcessRunnerTests.swift
+++ b/cmuxTests/CLIProcessRunnerTests.swift
@@ -340,6 +340,7 @@ final class CLIProcessRunnerTests: XCTestCase {
                 port: nil,
                 identityFile: nil,
                 workspaceName: nil,
+                noFocus: false,
                 sshOptions: [],
                 extraArguments: [],
                 localSocketPath: "",
@@ -409,6 +410,24 @@ print(out.decode("utf-8", "replace"), end="")
         let remoteCommand = try String(contentsOf: remoteCommandURL, encoding: .utf8)
         XCTAssertFalse(remoteCommand.contains("%{255}"), remoteCommand)
         XCTAssertTrue(remoteCommand.contains("base64"), remoteCommand)
+    }
+
+    func testParseSSHCommandOptionsNoFocusFlag() throws {
+        let cli = CMUXCLI(args: [])
+
+        let withFlag = try cli.parseSSHCommandOptions(["user@host", "--no-focus"])
+        XCTAssertTrue(withFlag.noFocus)
+        XCTAssertEqual(withFlag.destination, "user@host")
+
+        let withoutFlag = try cli.parseSSHCommandOptions(["user@host"])
+        XCTAssertFalse(withoutFlag.noFocus)
+
+        let withOtherFlags = try cli.parseSSHCommandOptions([
+            "user@host", "--name", "mybox", "--no-focus", "--port", "2222",
+        ])
+        XCTAssertTrue(withOtherFlags.noFocus)
+        XCTAssertEqual(withOtherFlags.workspaceName, "mybox")
+        XCTAssertEqual(withOtherFlags.port, 2222)
     }
 
     func testEncodedRemoteBootstrapCommandEscapesPercentsForSSHRemoteCommand() throws {


### PR DESCRIPTION
## Summary

Add `--no-focus` flag to `cmux ssh` so scripted/background SSH workspace creation does not steal the user's active workspace focus.

Without this flag, `workspace.select` is called immediately after `workspace.remote.configure` returns, switching the user away from their current workspace before SSH is even established. With `--no-focus`, the workspace is created and configured but the caller's workspace retains focus. The caller can then redirect to the new workspace later via `cmux select-workspace`.

## Usage

```
cmux ssh dev@my-host --no-focus
cmux ssh dev@my-host --name "gpu-box" --no-focus
```

## Consistency

Follows the same pattern as `break-pane --no-focus` and `join-pane --no-focus`.

## Changes

- `SSHCommandOptions`: add `noFocus: Bool` field
- `parseSSHCommandOptions`: parse `--no-focus` flag (also made `internal` for testability)
- `runSSH`: guard `workspace.select` call with `if !sshOptions.noFocus`
- Help text: document `--no-focus` flag
- Tests: fix existing `SSHCommandOptions` initializer call; add `testParseSSHCommandOptionsNoFocusFlag`

## Testing

![cmux_ssh_no_focus](https://github.com/user-attachments/assets/1c6d4e8e-4695-4681-b008-df41fe462c98)

Tested locally by compiling the CLI directly and running against a live cmux socket:

```
/tmp/cmux-test-cli ssh devbox --name "no focus" --no-focus
# → OK workspace=workspace:N target=devbox state=connecting
# active workspace did not change
```

Also verified:
- `--no-focus` alongside other flags (`--name`, `--port`) parses correctly
- unknown flags still error as expected
- unit test `testParseSSHCommandOptionsNoFocusFlag` added to `CLIProcessRunnerTests`

## Issues

Addresses the `cmux ssh` case of #140 ("CLI commands should not change focus state") and is complementary to #1418 (`new-surface: add --no-focus flag`).