### PR TITLE
feat: add markdown relay command to cmuxd-remote

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4039,6 +4039,7 @@ struct CMUXCLI {
         if !trimmedShellFeatures.isEmpty {
             exports.append("export GHOSTTY_SHELL_FEATURES=\(shellQuote(trimmedShellFeatures))")
         }
+        exports.append("export CMUX_LOCAL_HOME=\(shellQuote(NSHomeDirectory()))")
         return exports
     }
 

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -382,8 +382,21 @@ func runMarkdownRelay(socketPath string, args []string, jsonOutput bool, refresh
 		return 2
 	}
 
+	filePath := parsed.positional[0]
+	// If the file exists locally (devbox) and CMUX_LOCAL_HOME is set, translate
+	// the path to the Mac-side equivalent so markdown.open can find it.
+	if localHome := os.Getenv("HOME"); localHome != "" {
+		if macHome := os.Getenv("CMUX_LOCAL_HOME"); macHome != "" {
+			if _, err := os.Stat(filePath); err == nil {
+				if strings.HasPrefix(filePath, localHome+"/") {
+					filePath = macHome + filePath[len(localHome):]
+				}
+			}
+		}
+	}
+
 	params := make(map[string]any)
-	params["path"] = parsed.positional[0]
+	params["path"] = filePath
 	for _, key := range flagKeys {
 		if val, ok := parsed.flags[key]; ok {
 			params[flagToParamKey(key)] = val

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -945,6 +945,41 @@ func TestCLIMarkdownNoArgs(t *testing.T) {
 	}
 }
 
+func TestCLIMarkdownPathTranslation(t *testing.T) {
+	// Create a real temp file so os.Stat succeeds (simulating a local devbox file).
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.md")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	tmpFile.Close()
+	localPath := tmpFile.Name()
+
+	// Simulate: HOME=/home/ubuntu, CMUX_LOCAL_HOME=/Users/mac
+	fakeHome := filepath.Dir(localPath) // use tmp dir as fake HOME
+	macHome := "/Users/mac"
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("CMUX_LOCAL_HOME", macHome)
+
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	// Path starts with fakeHome — should be rewritten to macHome prefix.
+	code := runCLI([]string{"--socket", sockPath, "--json", "markdown", "open", localPath})
+	if code != 0 {
+		t.Fatalf("markdown open should return 0, got %d", code)
+	}
+
+	select {
+	case req := <-requests:
+		params, _ := req["params"].(map[string]any)
+		got, _ := params["path"].(string)
+		want := macHome + localPath[len(fakeHome):]
+		if got != want {
+			t.Fatalf("expected translated path %q, got %q", want, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for markdown open request")
+	}
+}
+
 func TestCLIEnvVarDefaults(t *testing.T) {
 	// Test that CMUX_WORKSPACE_ID and CMUX_SURFACE_ID are used as defaults
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

`cmux markdown open <path>` works on macOS (added in #883, `--direction` in #1763). On devbox, `cmux` is `cmuxd-remote` — the Go relay daemon installed via `cmux ssh`. It was missing the `markdown` subcommand, so users got `unknown command "markdown"` when trying to open markdown files from a remote host.

## Solution

Add `runMarkdownRelay` to `daemon/remote/cmd/cmuxd-remote/cli.go`, modeled on the existing `runBrowserRelay` pattern. It relays to the `markdown.open` V2 JSON-RPC method on the macOS host.

**Supported forms:**
```
cmux markdown open <path>                          # explicit subcommand
cmux markdown <path>                               # shorthand (matches macOS CLI)
cmux markdown open <path> --direction right        # split direction
cmux markdown open <path> --workspace <id>         # target workspace
cmux markdown open <path> --surface <id>           # target surface
```

Env vars `CMUX_WORKSPACE_ID` / `CMUX_SURFACE_ID` are applied as fallbacks, consistent with other commands.

## Tests

Five new tests in `cli_test.go`:
- `TestCLIMarkdownOpen` — verifies `markdown.open` RPC with correct `path`
- `TestCLIMarkdownOpenShorthand` — verifies bare-path shorthand form
- `TestCLIMarkdownOpenWithDirection` — verifies `--direction` param
- `TestCLIMarkdownOpenMissingPath` — verifies exit 2 on missing path
- `TestCLIMarkdownNoArgs` — verifies exit 2 with no arguments

```
ok  github.com/manaflow-ai/cmux/daemon/remote/cmd/cmuxd-remote  0.447s
```

Closes #533

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a markdown relay command to `cmuxd-remote` to open Markdown files on the Mac via V2 JSON-RPC. Also translates devbox paths to Mac paths so `cmux markdown open ~/...` works over SSH.

- **New Features**
  - Add `markdown` relay mapped to `markdown.open` (V2 JSON-RPC).
  - Support `cmux markdown open <path>` and shorthand `cmux markdown <path>`.
  - Flags: `--direction`, `--workspace`, `--surface`; falls back to `CMUX_WORKSPACE_ID` and `CMUX_SURFACE_ID`.
  - Translate paths from `$HOME` (devbox) to `$CMUX_LOCAL_HOME` (Mac) when the file exists; export `CMUX_LOCAL_HOME` from the macOS CLI; update CLI usage text.

<sup>Written for commit 4da38eab6a2bbe5c02714ec697609642264d8064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `markdown` command to CLI for opening markdown files with flexible syntax (`markdown open <path>` or `markdown <path>`)
  * Supports optional configuration flags for workspace, surface, and direction settings
  * Updated CLI documentation

* **Tests**
  * Added comprehensive test coverage for the new markdown command, including positive and negative validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->