### PR TITLE
fix: backport Korean Hangul font-family fix to v0.62.2

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1287,9 +1287,6 @@ class GhosttyApp {
             if lower.hasPrefix("ja") {
                 font = "Hiragino Sans"
                 langRanges = japaneseRanges
-            } else if lower.hasPrefix("ko") {
-                font = "Apple SD Gothic Neo"
-                langRanges = koreanRanges
             } else if lower.hasPrefix("zh-hant") || lower.hasPrefix("zh-tw") || lower.hasPrefix("zh-hk") {
                 font = "PingFang TC"
             } else if lower.hasPrefix("zh") {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1417,16 +1417,10 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsAppleSDGothicNeoWithHangulForKorean() {
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"])!
-        let fonts = Set(mappings.map(\.1))
-        let ranges = mappings.map(\.0)
-
-        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
-        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"), "Should include Hangul Syllables")
-        XCTAssertTrue(ranges.contains("U+1100-U+11FF"), "Should include Hangul Jamo")
-        XCTAssertTrue(ranges.contains("U+4E00-U+9FFF"), "Should include CJK Ideographs")
-        XCTAssertFalse(ranges.contains("U+3040-U+309F"), "Should NOT include Hiragana")
+    func testCJKFontMappingsReturnsNilForKoreanOnly() {
+        // Korean is not auto-mapped — Ghostty's native CTFontCreateForString
+        // fallback selects a better-matching font for Hangul.
+        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -1445,15 +1439,16 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: []))
     }
 
-    func testCJKFontMappingsMultiLanguageMapsScriptSpecificRanges() {
+    func testCJKFontMappingsMultiLanguageSkipsKorean() {
+        // When both ja and ko are preferred, only Japanese mappings are generated.
+        // Korean is left to Ghostty's native CTFontCreateForString fallback.
         let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
 
         let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
-        let sdGothicRanges = mappings.filter { $0.1 == "Apple SD Gothic Neo" }.map(\.0)
 
         XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
         XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
-        XCTAssertTrue(sdGothicRanges.contains("U+AC00-U+D7AF"), "Hangul → Apple SD Gothic Neo")
+        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
         XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
     }
 


### PR DESCRIPTION
## Summary
- backport the Korean CJK fallback fix to the `v0.62.2` release line
- stop auto-injecting `font-codepoint-map` entries for Korean so Hangul uses Ghostty's native CoreText fallback instead of forcing `Apple SD Gothic Neo`
- keep the existing regression coverage updated so Korean-only preferred languages return no injected mappings

## Context
`main` already contains the equivalent fix from #1700, but the released `v0.62.2` tag predates it. This PR backports that change for users hitting #1946 on the 0.62.x release line.

Refs #1946

## Verification
- built and launched with `./scripts/reload.sh --tag issue-1946-hangul`
- xcodebuild completed successfully
- did not run the local test suite per repo policy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the Hangul fallback fix to `v0.62.2` by removing Korean CJK auto-mappings so CoreText chooses the font instead of forcing `Apple SD Gothic Neo`. Fixes incorrect Korean rendering for 0.62.x users (addresses #1946).

- **Bug Fixes**
  - Stop injecting Korean `font-codepoint-map`; rely on CoreText fallback for Hangul.
  - Keep Japanese and Chinese mappings unchanged.
  - Update tests to expect nil for Korean-only prefs and no `Apple SD Gothic Neo` in mixed ja+ko.

<sup>Written for commit 7dfd1afe41d020229d43293888d3d4f0b7a322ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

