### PR TITLE
Fix Escape key not working in terminal panels (e.g. lazygit)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4452,9 +4452,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               commandPaletteEscapeSuppressionByWindowId.contains(windowId) else {
             return false
         }
-        if event.isARepeat {
-            return true
-        }
         let startedAt = commandPaletteEscapeSuppressionStartedAtByWindowId[windowId] ?? 0
         if ProcessInfo.processInfo.systemUptime - startedAt <= 0.35 {
             return true


### PR DESCRIPTION
## Summary
- `shouldConsumeSuppressedEscape` had an `isARepeat` early return that unconditionally swallowed all repeated Escape key events, with no time limit
- This caused Escape to stop working in TUI apps (lazygit, vim, etc.) running in panels after the command palette was dismissed
- Removed the `isARepeat` guard so repeated Escapes fall through to the existing 0.35s time-based check, which correctly expires

## Root Cause
```swift
// Before: repeat Escapes consumed forever until keyUp
if event.isARepeat {
    return true  // BUG: no time limit
}

// After: removed — falls through to 0.35s grace period check
```

## Test plan
- [ ] Open lazygit in a panel, press `?` to open help, press Esc → dialog closes
- [ ] Open command palette (Cmd+K), press Esc to dismiss, then press Esc in terminal → Esc works
- [ ] Hold Esc key → first 0.35s suppressed (prevents palette re-trigger), then passes through
- [ ] Rapid Esc taps in vim/neovim → all register correctly

Fixes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Escape not working in terminal panels and TUIs after dismissing the command palette. Repeated Escapes are no longer consumed indefinitely and now respect the 0.35s suppression window. Fixes #1610.

- **Bug Fixes**
  - Removed `isARepeat` early return in `shouldConsumeSuppressedEscape`, letting repeats pass the 0.35s time-based check.
  - Esc works again in TUI apps in panels (e.g., lazygit, vim), including rapid taps and key repeat.

<sup>Written for commit 5de59cd4ed736efa5219cf8849a645cff5de0c9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined escape key suppression logic to use elapsed time-based detection instead of repeat event consumption, providing more consistent and predictable suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->