### PR TITLE
Fix tab bar staying dark in light mode

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5332,21 +5332,34 @@ final class Workspace: Identifiable, ObservableObject {
         .init(backgroundHex: backgroundColor.hexString())
     }
 
+    private static var isSystemDarkMode: Bool {
+        NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    /// Returns the chrome hex for the current appearance. In light mode, returns
+    /// nil so Bonsplit falls back to the system window background color.
+    private static func resolvedChromeHex(
+        backgroundColor: NSColor,
+        backgroundOpacity: Double
+    ) -> String? {
+        guard isSystemDarkMode else { return nil }
+        return bonsplitChromeHex(
+            backgroundColor: backgroundColor,
+            backgroundOpacity: backgroundOpacity
+        )
+    }
+
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
         backgroundOpacity: Double
     ) -> BonsplitConfiguration.Appearance {
-        // In light mode, leave backgroundHex nil so the tab bar uses the
-        // system window background color, which respects appearance changes.
-        let isDarkMode = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let chromeHex: String? = isDarkMode ? Self.bonsplitChromeHex(
-            backgroundColor: backgroundColor,
-            backgroundOpacity: backgroundOpacity
-        ) : nil
-        return BonsplitConfiguration.Appearance(
+        BonsplitConfiguration.Appearance(
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
-            chromeColors: .init(backgroundHex: chromeHex)
+            chromeColors: .init(backgroundHex: resolvedChromeHex(
+                backgroundColor: backgroundColor,
+                backgroundOpacity: backgroundOpacity
+            ))
         )
     }
 
@@ -5359,14 +5372,10 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func applyGhosttyChrome(backgroundColor: NSColor, backgroundOpacity: Double, reason: String = "unspecified") {
-        // In light mode, use nil to fall back to system window background color
-        // which automatically respects appearance changes. Only apply the custom
-        // Ghostty theme color in dark mode.
-        let isDarkMode = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let nextHex: String? = isDarkMode ? Self.bonsplitChromeHex(
+        let nextHex: String? = Self.resolvedChromeHex(
             backgroundColor: backgroundColor,
             backgroundOpacity: backgroundOpacity
-        ) : nil
+        )
         let currentChromeColors = bonsplitController.configuration.appearance.chromeColors
         let isNoOp = currentChromeColors.backgroundHex == nextHex
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5336,15 +5336,17 @@ final class Workspace: Identifiable, ObservableObject {
         from backgroundColor: NSColor,
         backgroundOpacity: Double
     ) -> BonsplitConfiguration.Appearance {
-        BonsplitConfiguration.Appearance(
+        // In light mode, leave backgroundHex nil so the tab bar uses the
+        // system window background color, which respects appearance changes.
+        let isDarkMode = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let chromeHex: String? = isDarkMode ? Self.bonsplitChromeHex(
+            backgroundColor: backgroundColor,
+            backgroundOpacity: backgroundOpacity
+        ) : nil
+        return BonsplitConfiguration.Appearance(
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
-            chromeColors: .init(
-                backgroundHex: Self.bonsplitChromeHex(
-                    backgroundColor: backgroundColor,
-                    backgroundOpacity: backgroundOpacity
-                )
-            )
+            chromeColors: .init(backgroundHex: chromeHex)
         )
     }
 
@@ -5357,17 +5359,21 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func applyGhosttyChrome(backgroundColor: NSColor, backgroundOpacity: Double, reason: String = "unspecified") {
-        let nextHex = Self.bonsplitChromeHex(
+        // In light mode, use nil to fall back to system window background color
+        // which automatically respects appearance changes. Only apply the custom
+        // Ghostty theme color in dark mode.
+        let isDarkMode = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let nextHex: String? = isDarkMode ? Self.bonsplitChromeHex(
             backgroundColor: backgroundColor,
             backgroundOpacity: backgroundOpacity
-        )
+        ) : nil
         let currentChromeColors = bonsplitController.configuration.appearance.chromeColors
         let isNoOp = currentChromeColors.backgroundHex == nextHex
 
         if GhosttyApp.shared.backgroundLogEnabled {
             let currentBackgroundHex = currentChromeColors.backgroundHex ?? "nil"
             GhosttyApp.shared.logBackground(
-                "theme apply workspace=\(id.uuidString) reason=\(reason) currentBg=\(currentBackgroundHex) nextBg=\(nextHex) noop=\(isNoOp)"
+                "theme apply workspace=\(id.uuidString) reason=\(reason) currentBg=\(currentBackgroundHex) nextBg=\(nextHex ?? "nil") noop=\(isNoOp)"
             )
         }
 


### PR DESCRIPTION
## Summary
- The horizontal tab bar used a single fixed `chromeColors.backgroundHex` from the Ghostty theme, set once at initialization
- Unlike the sidebar (which has dual light/dark handling), the tab bar never adapted to macOS appearance changes
- In light mode, now passes `nil` for `backgroundHex` so Bonsplit falls back to system `windowBackgroundColor`, which automatically respects appearance

## Root Cause
`bonsplitAppearance` and `applyGhosttyChrome` in `Workspace.swift` always set a hardcoded hex color regardless of appearance mode. The sidebar works because it has separate `sidebarBackgroundLight`/`sidebarBackgroundDark` resolution.

## Test plan
- [ ] Switch to light mode → tab bar background matches light theme
- [ ] Switch to dark mode → tab bar uses Ghostty theme color (unchanged)
- [ ] Auto appearance switching → tab bar updates correctly
- [ ] Custom Ghostty theme in dark mode → tab bar respects theme color

Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tab bar staying dark in light mode by deferring to the system window background in light appearance and using the Ghostty theme color in dark mode. The tab bar now updates correctly when macOS appearance changes.

- **Bug Fixes**
  - In light mode, pass nil for `chromeColors.backgroundHex` so `Bonsplit` uses `windowBackgroundColor` and auto-updates with appearance.
  - In dark mode, keep the Ghostty theme color.
  - Extracted shared `resolvedChromeHex` with `isSystemDarkMode` and used in `bonsplitAppearance` and `applyGhosttyChrome` to remove duplicate checks and improve nil logging.

Fixes #395

<sup>Written for commit 45d5226c43a3c0a62518d4f7f2f6cbd9a5bdfcea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection of system dark mode so appearance matches OS settings more reliably.
  * Chrome background now only uses computed accent in dark mode; in light mode it falls back to the system window background for consistent visuals.
  * Improved background-color logging to show explicit nil vs value for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->