### PR TITLE
Fix unbound Cmd+Shift+key combos being silently swallowed

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5110,7 +5110,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if let lastPerformKeyEvent {
                 self.lastPerformKeyEvent = nil
                 if lastPerformKeyEvent == event.timestamp {
-                    equivalent = event.characters ?? ""
+                    equivalent = event.charactersIgnoringModifiers ?? ""
                     break
                 }
             }


### PR DESCRIPTION
## Summary
- Unbound `Cmd+Shift+key` combos (e.g. Cmd+Shift+K with no binding) were silently consumed and never reached the terminal via kitty keyboard protocol
- Root cause: the `performKeyEquivalent` redispatch path used `event.characters` which returns empty string for Cmd-modified keys
- Changed to `event.charactersIgnoringModifiers` which returns the actual key character (e.g. "k"), while modifiers are preserved in `modifierFlags`

## Why bound keys worked
Bound Cmd+Shift keys go directly through `keyDown` (line ~5077), bypassing the redispatch path entirely. Only unbound keys hit the two-pass redispatch where `event.characters` was used.

## Test plan
- [ ] Press Cmd+Shift+K (unbound) in Neovim with kitty protocol → key event received
- [ ] Press Cmd+Shift+J (bound to write_screen_file) → still works as before
- [ ] Press Cmd+N, Cmd+D, etc. (bound cmux shortcuts) → unchanged
- [ ] Test on non-US keyboard layout (AZERTY, etc.) → correct character sent

Fixes #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unbound Cmd+Shift+key combos being swallowed on macOS so the keys reach the terminal via the kitty keyboard protocol. Fixes #1718 while leaving existing keybindings unchanged.

- **Bug Fixes**
  - Root cause: `event.characters` returns an empty string for Cmd‑modified keys in the `performKeyEquivalent` redispatch path.
  - Change: use `event.charactersIgnoringModifiers` to get the base character while preserving `modifierFlags`.

<sup>Written for commit 1ce751fbc6a74dcb2446bdc89c6d277ac7b2cce7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard event routing to correctly handle modifier key combinations, improving input consistency when processing complex key sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->