### PR TITLE
Fix Sparkle signing and installer fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 
+      - name: Validate app signing helper
+        run: ./tests/test_ci_codesign_app_bundle.sh
+
       - name: Validate current GhosttyKit checksum pin
         run: ./tests/test_ci_ghosttykit_checksum_present.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -368,16 +368,7 @@ jobs:
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
-            CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-            HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-            if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-            fi
-            if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-            fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-            /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+            ./scripts/codesign_app_bundle.sh "$APP_PATH" "$APPLE_SIGNING_IDENTITY" "$ENTITLEMENTS"
           done
 
       - name: Notarize apps and dmgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,16 +235,7 @@ jobs:
           fi
           APP_PATH="build/Build/Products/Release/cmux.app"
           ENTITLEMENTS="cmux.entitlements"
-          CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-          HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-          if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-          fi
-          if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-          fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-          /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          ./scripts/codesign_app_bundle.sh "$APP_PATH" "$APPLE_SIGNING_IDENTITY" "$ENTITLEMENTS"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -77797,6 +77797,57 @@
           }
         }
       }
+    },
+    "update.downloadLatestDmg": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download Latest DMG"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新のDMGをダウンロード"
+          }
+        }
+      }
+    },
+    "update.error.installationFailed.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux couldn't install the downloaded update. Download the latest DMG to update manually."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux はダウンロード済みのアップデートをインストールできませんでした。手動で更新するには最新のDMGをダウンロードしてください。"
+          }
+        }
+      }
+    },
+    "update.error.installationFailed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update Installation Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートのインストールに失敗しました"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/Update/UpdateDriver.swift
+++ b/Sources/Update/UpdateDriver.swift
@@ -117,6 +117,20 @@ class UpdateDriver: NSObject, SPUUserDriver {
                           acknowledgement: @escaping () -> Void) {
         let details = formatErrorForLog(error)
         UpdateLogStore.shared.append("show updater error: \(details)")
+        if usesStandardPresentation,
+           let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error) {
+            clearCustomStateForStandardPresentation()
+            presentManualDownloadAlert(for: error, manualDownloadURL: manualDownloadURL) { [weak self] shouldRetry in
+                self?.finishUserInitiatedCheckPresentation()
+                acknowledgement()
+                guard shouldRetry else { return }
+                DispatchQueue.main.async {
+                    guard let delegate = NSApp.delegate as? AppDelegate else { return }
+                    delegate.checkForUpdates(nil)
+                }
+            }
+            return
+        }
         if usesStandardPresentation {
             clearCustomStateForStandardPresentation()
             standard.showUpdaterError(error) { [weak self] in
@@ -454,6 +468,40 @@ class UpdateDriver: NSObject, SPUUserDriver {
                 return
             }
             applyState(.idle)
+        }
+    }
+
+    private func presentManualDownloadAlert(
+        for error: any Error,
+        manualDownloadURL: URL,
+        completion: @escaping (Bool) -> Void
+    ) {
+        runOnMain {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = UpdateViewModel.userFacingErrorTitle(for: error)
+            alert.informativeText = UpdateViewModel.userFacingErrorMessage(for: error)
+            alert.addButton(withTitle: String(localized: "update.downloadLatestDmg", defaultValue: "Download Latest DMG"))
+            alert.addButton(withTitle: String(localized: "common.retry", defaultValue: "Retry"))
+            alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+
+            let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+                switch response {
+                case .alertFirstButtonReturn:
+                    NSWorkspace.shared.open(manualDownloadURL)
+                    completion(false)
+                case .alertSecondButtonReturn:
+                    completion(true)
+                default:
+                    completion(false)
+                }
+            }
+
+            if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+                alert.beginSheetModal(for: window, completionHandler: handleResponse)
+            } else {
+                handleResponse(alert.runModal())
+            }
         }
     }
 

--- a/Sources/Update/UpdateDriver.swift
+++ b/Sources/Update/UpdateDriver.swift
@@ -118,7 +118,7 @@ class UpdateDriver: NSObject, SPUUserDriver {
         let details = formatErrorForLog(error)
         UpdateLogStore.shared.append("show updater error: \(details)")
         if usesStandardPresentation,
-           let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error) {
+           let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error, infoFeedURLString: lastFeedURLString) {
             clearCustomStateForStandardPresentation()
             presentManualDownloadAlert(for: error, manualDownloadURL: manualDownloadURL) { [weak self] shouldRetry in
                 self?.finishUserInitiatedCheckPresentation()

--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -345,7 +345,7 @@ fileprivate struct UpdateErrorView: View {
             technicalDetails: error.technicalDetails,
             feedURLString: error.feedURLString
         )
-        let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error.error)
+        let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error)
 
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {

--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -345,6 +345,7 @@ fileprivate struct UpdateErrorView: View {
             technicalDetails: error.technicalDetails,
             feedURLString: error.feedURLString
         )
+        let manualDownloadURL = UpdateViewModel.manualDownloadURL(for: error.error)
 
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
@@ -388,6 +389,15 @@ fileprivate struct UpdateErrorView: View {
                 .controlSize(.small)
 
                 Spacer()
+
+                if let manualDownloadURL {
+                    Button(String(localized: "update.downloadLatestDmg", defaultValue: "Download Latest DMG")) {
+                        error.dismiss()
+                        dismiss()
+                        NSWorkspace.shared.open(manualDownloadURL)
+                    }
+                    .controlSize(.small)
+                }
 
                 Button(String(localized: "common.retry", defaultValue: "Retry")) {
                     error.retry()

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -4,6 +4,8 @@ import SwiftUI
 import Sparkle
 
 class UpdateViewModel: ObservableObject {
+    static let manualDownloadDMGURLString = "https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg"
+
     @Published var state: UpdateState = .idle
     @Published var overrideState: UpdateState?
     @Published var detectedUpdateVersion: String?
@@ -235,8 +237,8 @@ class UpdateViewModel: ObservableObject {
         }
         if nsError.domain == SUSparkleErrorDomain {
             switch nsError.code {
-            case 4005:
-                return String(localized: "update.error.permissionError.title", defaultValue: "Updater Permission Error")
+            case 4000, 4001, 4002, 4003, 4004, 4005, 4010, 4012:
+                return String(localized: "update.error.installationFailed.title", defaultValue: "Update Installation Failed")
             case 2001:
                 return String(localized: "update.error.downloadFailed.title", defaultValue: "Couldn't Download Update")
             case 1000, 1002:
@@ -282,6 +284,8 @@ class UpdateViewModel: ObservableObject {
         }
         if nsError.domain == SUSparkleErrorDomain {
             switch nsError.code {
+            case 4000, 4001, 4002, 4003, 4004, 4005, 4010, 4012:
+                return String(localized: "update.error.installationFailed.message", defaultValue: "cmux couldn't install the downloaded update. Download the latest DMG to update manually.")
             case 2001:
                 return String(localized: "update.error.feedDownload.message", defaultValue: "cmux couldn't download the update feed. Check your connection and try again.")
             case 1000, 1002:
@@ -292,7 +296,7 @@ class UpdateViewModel: ObservableObject {
                 return String(localized: "update.error.insecureFeed.message", defaultValue: "The update feed is insecure. Please contact support.")
             case 1, 2, 3001, 3002:
                 return String(localized: "update.error.signatureError.message", defaultValue: "The update's signature could not be verified. Please try again later.")
-            case 1003, 1005, 4005:
+            case 1003, 1005:
                 return String(localized: "update.error.permissionError.message", defaultValue: "Move cmux into Applications and relaunch to enable updates.")
             default:
                 break
@@ -340,6 +344,12 @@ class UpdateViewModel: ObservableObject {
         return lines.joined(separator: "\n")
     }
 
+    static func manualDownloadURL(for error: Swift.Error) -> URL? {
+        let nsError = error as NSError
+        guard shouldOfferManualDownload(for: nsError) else { return nil }
+        return URL(string: manualDownloadDMGURLString)
+    }
+
     private static func networkError(from error: NSError) -> NSError? {
         if error.domain == NSURLErrorDomain {
             return error
@@ -367,6 +377,19 @@ class UpdateViewModel: ObservableObject {
         case 3002: return "SUValidationError"
         default:
             return nil
+        }
+    }
+
+    private static func shouldOfferManualDownload(for error: NSError) -> Bool {
+        guard error.domain == SUSparkleErrorDomain else {
+            return false
+        }
+
+        switch error.code {
+        case 4000, 4001, 4002, 4003, 4004, 4005, 4010, 4012:
+            return true
+        default:
+            return false
         }
     }
 

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -353,6 +353,10 @@ class UpdateViewModel: ObservableObject {
         return URL(string: isNightly ? manualDownloadNightlyDMGURLString : manualDownloadDMGURLString)
     }
 
+    static func manualDownloadURL(for updateError: UpdateState.Error) -> URL? {
+        manualDownloadURL(for: updateError.error, infoFeedURLString: updateError.feedURLString)
+    }
+
     private static func networkError(from error: NSError) -> NSError? {
         if error.domain == NSURLErrorDomain {
             return error

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -345,10 +345,10 @@ class UpdateViewModel: ObservableObject {
         return lines.joined(separator: "\n")
     }
 
-    static func manualDownloadURL(for error: Swift.Error) -> URL? {
+    static func manualDownloadURL(for error: Swift.Error, infoFeedURLString: String? = nil) -> URL? {
         let nsError = error as NSError
         guard shouldOfferManualDownload(for: nsError) else { return nil }
-        let infoFeedURL = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String
+        let infoFeedURL = infoFeedURLString ?? (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String)
         let isNightly = UpdateFeedResolver.resolvedFeedURLString(infoFeedURL: infoFeedURL).isNightly
         return URL(string: isNightly ? manualDownloadNightlyDMGURLString : manualDownloadDMGURLString)
     }

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -5,6 +5,7 @@ import Sparkle
 
 class UpdateViewModel: ObservableObject {
     static let manualDownloadDMGURLString = "https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg"
+    static let manualDownloadNightlyDMGURLString = "https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg"
 
     @Published var state: UpdateState = .idle
     @Published var overrideState: UpdateState?
@@ -347,7 +348,9 @@ class UpdateViewModel: ObservableObject {
     static func manualDownloadURL(for error: Swift.Error) -> URL? {
         let nsError = error as NSError
         guard shouldOfferManualDownload(for: nsError) else { return nil }
-        return URL(string: manualDownloadDMGURLString)
+        let infoFeedURL = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String
+        let isNightly = UpdateFeedResolver.resolvedFeedURLString(infoFeedURL: infoFeedURL).isNightly
+        return URL(string: isNightly ? manualDownloadNightlyDMGURLString : manualDownloadDMGURLString)
     }
 
     private static func networkError(from error: NSError) -> NSError? {
@@ -367,6 +370,14 @@ class UpdateViewModel: ObservableObject {
         case 2: return "SUInsufficientSigningError"
         case 3: return "SUInsecureFeedURLError"
         case 4: return "SUInvalidFeedURLError"
+        case 4000: return "SUFileCopyFailure"
+        case 4001: return "SUAuthenticationFailure"
+        case 4002: return "SUMissingUpdateError"
+        case 4003: return "SUMissingInstallerToolError"
+        case 4004: return "SURelaunchError"
+        case 4005: return "SUInstallationError"
+        case 4010: return "SUAgentInvalidationError"
+        case 4012: return "SUInstallationWriteNoPermissionError"
         case 1000: return "SUAppcastParseError"
         case 1001: return "SUNoUpdateError"
         case 1002: return "SUAppcastError"

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -997,6 +997,24 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         )
     }
 
+    func testUpdateStateErrorManualDownloadURLUsesFeedURLString() {
+        let updateError = UpdateState.Error(
+            error: NSError(
+                domain: SUSparkleErrorDomain,
+                code: 4005,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create installation cache directory"]
+            ),
+            retry: {},
+            dismiss: {},
+            feedURLString: "https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast.xml"
+        )
+
+        XCTAssertEqual(
+            UpdateViewModel.manualDownloadURL(for: updateError)?.absoluteString,
+            "https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg"
+        )
+    }
+
     func testSparkleInstallationErrorDetailsUseSparkleCodeName() {
         let error = NSError(
             domain: SUSparkleErrorDomain,

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -978,6 +978,22 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         )
     }
 
+    func testSparkleInstallationErrorDetailsUseSparkleCodeName() {
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 4005,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create installation cache directory"]
+        )
+
+        let details = UpdateViewModel.errorDetails(
+            for: error,
+            technicalDetails: nil,
+            feedURLString: nil
+        )
+
+        XCTAssertTrue(details.contains("Code: SUInstallationError (4005)"))
+    }
+
     func testNetworkErrorDoesNotOfferManualDownloadURL() {
         let error = NSError(
             domain: NSURLErrorDomain,

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -6,6 +6,7 @@ import WebKit
 import ObjectiveC.runtime
 import Bonsplit
 import UserNotifications
+import Sparkle
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -948,6 +949,43 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         XCTAssertTrue(viewModel.showsPill)
         XCTAssertFalse(viewModel.showsDetectedBackgroundUpdate)
         XCTAssertEqual(viewModel.text, "Checking for Updates…")
+    }
+
+    func testSparkleInstallationErrorUsesManualInstallCopy() {
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 4005,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create installation cache directory"]
+        )
+
+        XCTAssertEqual(UpdateViewModel.userFacingErrorTitle(for: error), "Update Installation Failed")
+        XCTAssertEqual(
+            UpdateViewModel.userFacingErrorMessage(for: error),
+            "cmux couldn't install the downloaded update. Download the latest DMG to update manually."
+        )
+    }
+
+    func testSparkleInstallationErrorOffersManualDownloadURL() {
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 4005,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create installation cache directory"]
+        )
+
+        XCTAssertEqual(
+            UpdateViewModel.manualDownloadURL(for: error)?.absoluteString,
+            "https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg"
+        )
+    }
+
+    func testNetworkErrorDoesNotOfferManualDownloadURL() {
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out"]
+        )
+
+        XCTAssertNil(UpdateViewModel.manualDownloadURL(for: error))
     }
 }
 

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -973,8 +973,27 @@ final class UpdateViewModelPresentationTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            UpdateViewModel.manualDownloadURL(for: error)?.absoluteString,
+            UpdateViewModel.manualDownloadURL(
+                for: error,
+                infoFeedURLString: UpdateFeedResolver.fallbackFeedURL
+            )?.absoluteString,
             "https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg"
+        )
+    }
+
+    func testSparkleInstallationErrorOffersNightlyManualDownloadURL() {
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 4005,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to create installation cache directory"]
+        )
+
+        XCTAssertEqual(
+            UpdateViewModel.manualDownloadURL(
+                for: error,
+                infoFeedURLString: "https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast.xml"
+            )?.absoluteString,
+            "https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg"
         )
     }
 

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -92,15 +92,7 @@ echo "Sparkle keys injected"
 
 # --- Codesign ---
 echo "Codesigning..."
-CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-if [ -f "$CLI_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-fi
-if [ -f "$HELPER_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-fi
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+./scripts/codesign_app_bundle.sh "$APP_PATH" "$SIGN_HASH" "$ENTITLEMENTS"
 echo "Codesign verified"
 
 # --- Notarize app ---

--- a/scripts/codesign_app_bundle.sh
+++ b/scripts/codesign_app_bundle.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/codesign_app_bundle.sh <app-path> <signing-identity> <entitlements-path>
+
+Signs a built cmux app bundle inside-out so Sparkle helpers keep their own entitlements.
+Set CMUX_CODESIGN_DRY_RUN=1 to print the signing plan instead of executing codesign.
+EOF
+}
+
+if [ "$#" -ne 3 ]; then
+  usage >&2
+  exit 1
+fi
+
+APP_PATH="$1"
+SIGNING_IDENTITY="$2"
+ENTITLEMENTS_PATH="$3"
+CODESIGN_BIN="/usr/bin/codesign"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "App bundle not found: $APP_PATH" >&2
+  exit 1
+fi
+
+emit_or_run() {
+  if [ "${CMUX_CODESIGN_DRY_RUN:-0}" = "1" ]; then
+    printf '%q' "$CODESIGN_BIN"
+    for arg in "$@"; do
+      printf ' %q' "$arg"
+    done
+    printf '\n'
+    return 0
+  fi
+
+  "$CODESIGN_BIN" "$@"
+}
+
+sign_without_entitlements() {
+  local path="$1"
+  [ -e "$path" ] || return 0
+  emit_or_run --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$path"
+}
+
+sign_with_entitlements() {
+  local path="$1"
+  [ -e "$path" ] || return 0
+  emit_or_run --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS_PATH" "$path"
+}
+
+resolve_sparkle_version_dir() {
+  local sparkle_framework="$1"
+  local current_dir="$sparkle_framework/Versions/Current"
+
+  if [ -d "$current_dir" ]; then
+    printf '%s\n' "$current_dir"
+    return 0
+  fi
+
+  find "$sparkle_framework/Versions" -mindepth 1 -maxdepth 1 -type d ! -name Current -print | LC_ALL=C sort | head -n 1
+}
+
+FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
+SPARKLE_FRAMEWORK="$FRAMEWORKS_DIR/Sparkle.framework"
+SPARKLE_VERSION_DIR=""
+
+if [ -d "$SPARKLE_FRAMEWORK/Versions" ]; then
+  SPARKLE_VERSION_DIR="$(resolve_sparkle_version_dir "$SPARKLE_FRAMEWORK")"
+fi
+
+if [ -n "$SPARKLE_VERSION_DIR" ]; then
+  sign_without_entitlements "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc"
+  sign_without_entitlements "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc"
+  sign_without_entitlements "$SPARKLE_VERSION_DIR/Autoupdate"
+  sign_without_entitlements "$SPARKLE_VERSION_DIR/Updater.app"
+fi
+
+sign_without_entitlements "$SPARKLE_FRAMEWORK"
+
+if [ -d "$FRAMEWORKS_DIR" ]; then
+  while IFS= read -r dependency; do
+    [ "$dependency" = "$SPARKLE_FRAMEWORK" ] && continue
+    sign_without_entitlements "$dependency"
+  done < <(
+    find "$FRAMEWORKS_DIR" -mindepth 1 -maxdepth 1 \
+      \( -name '*.framework' -o -name '*.bundle' -o -name '*.dylib' \) \
+      -print | LC_ALL=C sort
+  )
+fi
+
+sign_with_entitlements "$APP_PATH/Contents/Resources/bin/cmux"
+sign_with_entitlements "$APP_PATH/Contents/Resources/bin/ghostty"
+sign_with_entitlements "$APP_PATH"
+
+emit_or_run --verify --deep --strict --verbose=2 "$APP_PATH"

--- a/scripts/codesign_app_bundle.sh
+++ b/scripts/codesign_app_bundle.sh
@@ -67,12 +67,9 @@ resolve_sparkle_version_dir() {
 
 code_paths_by_depth() {
   local root="$1"
-  find "$root" -mindepth 1 \
-    \( -name '*.framework' -o -name '*.xpc' -o -name '*.app' -o -name '*.dylib' \) \
-    -print |
-    awk -F/ '{print NF ":" $0}' |
-    LC_ALL=C sort -t: -k1,1nr -k2,2 |
-    cut -d: -f2-
+  find "$root" -depth -mindepth 1 \
+    \( -name '*.framework' -o -name '*.xpc' -o -name '*.app' -o -name '*.bundle' -o -name '*.dylib' \) \
+    -print
 }
 
 FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
@@ -85,16 +82,9 @@ fi
 
 if [ -n "$SPARKLE_VERSION_DIR" ]; then
   sign_without_entitlements "$SPARKLE_VERSION_DIR/Autoupdate"
-  if [ -d "$SPARKLE_VERSION_DIR/XPCServices" ]; then
-    while IFS= read -r dependency; do
-      sign_without_entitlements "$dependency"
-    done < <(code_paths_by_depth "$SPARKLE_VERSION_DIR/XPCServices")
-  fi
   while IFS= read -r dependency; do
     sign_without_entitlements "$dependency"
-  done < <(
-    find "$SPARKLE_VERSION_DIR" -mindepth 1 -maxdepth 1 -name '*.app' -print | LC_ALL=C sort
-  )
+  done < <(code_paths_by_depth "$SPARKLE_VERSION_DIR")
 fi
 
 sign_without_entitlements "$SPARKLE_FRAMEWORK"
@@ -106,12 +96,6 @@ if [ -d "$FRAMEWORKS_DIR" ]; then
     esac
     sign_without_entitlements "$dependency"
   done < <(code_paths_by_depth "$FRAMEWORKS_DIR")
-  while IFS= read -r dependency; do
-    [ "$dependency" = "$SPARKLE_FRAMEWORK" ] && continue
-    sign_without_entitlements "$dependency"
-  done < <(
-    find "$FRAMEWORKS_DIR" -mindepth 1 -maxdepth 1 -name '*.bundle' -print | LC_ALL=C sort
-  )
 fi
 
 sign_with_entitlements "$APP_PATH/Contents/Resources/bin/cmux"

--- a/scripts/codesign_app_bundle.sh
+++ b/scripts/codesign_app_bundle.sh
@@ -54,12 +54,25 @@ resolve_sparkle_version_dir() {
   local sparkle_framework="$1"
   local current_dir="$sparkle_framework/Versions/Current"
 
-  if [ -d "$current_dir" ]; then
-    printf '%s\n' "$current_dir"
+  if [ -e "$current_dir" ]; then
+    (
+      cd "$current_dir" >/dev/null 2>&1
+      pwd -P
+    )
     return 0
   fi
 
   find "$sparkle_framework/Versions" -mindepth 1 -maxdepth 1 -type d ! -name Current -print | LC_ALL=C sort | head -n 1
+}
+
+code_paths_by_depth() {
+  local root="$1"
+  find "$root" -mindepth 1 \
+    \( -name '*.framework' -o -name '*.xpc' -o -name '*.app' -o -name '*.dylib' \) \
+    -print |
+    awk -F/ '{print NF ":" $0}' |
+    LC_ALL=C sort -t: -k1,1nr -k2,2 |
+    cut -d: -f2-
 }
 
 FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
@@ -71,22 +84,33 @@ if [ -d "$SPARKLE_FRAMEWORK/Versions" ]; then
 fi
 
 if [ -n "$SPARKLE_VERSION_DIR" ]; then
-  sign_without_entitlements "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc"
-  sign_without_entitlements "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc"
   sign_without_entitlements "$SPARKLE_VERSION_DIR/Autoupdate"
-  sign_without_entitlements "$SPARKLE_VERSION_DIR/Updater.app"
+  if [ -d "$SPARKLE_VERSION_DIR/XPCServices" ]; then
+    while IFS= read -r dependency; do
+      sign_without_entitlements "$dependency"
+    done < <(code_paths_by_depth "$SPARKLE_VERSION_DIR/XPCServices")
+  fi
+  while IFS= read -r dependency; do
+    sign_without_entitlements "$dependency"
+  done < <(
+    find "$SPARKLE_VERSION_DIR" -mindepth 1 -maxdepth 1 -name '*.app' -print | LC_ALL=C sort
+  )
 fi
 
 sign_without_entitlements "$SPARKLE_FRAMEWORK"
 
 if [ -d "$FRAMEWORKS_DIR" ]; then
   while IFS= read -r dependency; do
+    case "$dependency" in
+      "$SPARKLE_FRAMEWORK"|"$SPARKLE_FRAMEWORK"/*) continue ;;
+    esac
+    sign_without_entitlements "$dependency"
+  done < <(code_paths_by_depth "$FRAMEWORKS_DIR")
+  while IFS= read -r dependency; do
     [ "$dependency" = "$SPARKLE_FRAMEWORK" ] && continue
     sign_without_entitlements "$dependency"
   done < <(
-    find "$FRAMEWORKS_DIR" -mindepth 1 -maxdepth 1 \
-      \( -name '*.framework' -o -name '*.bundle' -o -name '*.dylib' \) \
-      -print | LC_ALL=C sort
+    find "$FRAMEWORKS_DIR" -mindepth 1 -maxdepth 1 -name '*.bundle' -print | LC_ALL=C sort
   )
 fi
 

--- a/tests/test_ci_codesign_app_bundle.sh
+++ b/tests/test_ci_codesign_app_bundle.sh
@@ -11,8 +11,10 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 APP_PATH="$TMP_DIR/cmux.app"
 SPARKLE_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sparkle.framework"
 SPARKLE_VERSION_DIR="$SPARKLE_FRAMEWORK/Versions/B"
-EXTRA_SPARKLE_XPC="$SPARKLE_VERSION_DIR/XPCServices/InstallerStatus.xpc"
+NESTED_SPARKLE_XPC="$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc/Contents/XPCServices/InstallerStatus.xpc"
+NESTED_SPARKLE_FRAMEWORK="$SPARKLE_VERSION_DIR/Updater.app/Contents/Frameworks/UpdaterSupport.framework"
 OTHER_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sentry.framework"
+NESTED_SENTRY_BUNDLE="$OTHER_FRAMEWORK/Resources/Crashpad.bundle"
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
 HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
 ENTITLEMENTS="cmux.entitlements"
@@ -25,9 +27,10 @@ fi
 mkdir -p \
   "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc" \
   "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc" \
-  "$EXTRA_SPARKLE_XPC" \
+  "$NESTED_SPARKLE_XPC" \
+  "$NESTED_SPARKLE_FRAMEWORK" \
   "$SPARKLE_VERSION_DIR/Updater.app" \
-  "$OTHER_FRAMEWORK" \
+  "$NESTED_SENTRY_BUNDLE" \
   "$(dirname "$CLI_PATH")"
 ln -s B "$SPARKLE_FRAMEWORK/Versions/Current"
 touch \
@@ -47,17 +50,19 @@ line_number_regex() {
 
 installer_line="$(line_number_regex 'Installer\.xpc$')"
 downloader_line="$(line_number_regex 'Downloader\.xpc$')"
-extra_xpc_line="$(line_number_regex 'InstallerStatus\.xpc$')"
+nested_xpc_line="$(line_number_regex 'InstallerStatus\.xpc$')"
 autoupdate_line="$(line_number_regex '/Autoupdate$')"
+updater_support_line="$(line_number_regex 'UpdaterSupport\.framework$')"
 updater_line="$(line_number_regex 'Updater\.app$')"
 sparkle_line="$(line_number_regex 'Sparkle\.framework$')"
+nested_bundle_line="$(line_number_regex 'Crashpad\.bundle$')"
 sentry_line="$(line_number_regex 'Sentry\.framework$')"
 cli_line="$(line_number_regex '/Resources/bin/cmux$')"
 helper_line="$(line_number_regex '/Resources/bin/ghostty$')"
 app_line="$(line_number_regex '--entitlements cmux\.entitlements .*/cmux\.app$')"
 verify_line="$(line_number_regex '--verify --deep --strict --verbose=2 .*/cmux\.app$')"
 
-for value_name in installer_line downloader_line extra_xpc_line autoupdate_line updater_line sparkle_line sentry_line cli_line helper_line app_line verify_line; do
+for value_name in installer_line downloader_line nested_xpc_line autoupdate_line updater_support_line updater_line sparkle_line nested_bundle_line sentry_line cli_line helper_line app_line verify_line; do
   if [ -z "${!value_name}" ]; then
     echo "FAIL: expected $value_name in signing plan"
     printf '%s\n' "$OUTPUT"
@@ -65,17 +70,17 @@ for value_name in installer_line downloader_line extra_xpc_line autoupdate_line 
   fi
 done
 
-if [ "$installer_line" -ge "$sparkle_line" ] || [ "$downloader_line" -ge "$sparkle_line" ] || [ "$extra_xpc_line" -ge "$sparkle_line" ] || [ "$autoupdate_line" -ge "$sparkle_line" ] || [ "$updater_line" -ge "$sparkle_line" ]; then
+if [ "$nested_xpc_line" -ge "$installer_line" ] || [ "$installer_line" -ge "$sparkle_line" ] || [ "$downloader_line" -ge "$sparkle_line" ] || [ "$autoupdate_line" -ge "$sparkle_line" ] || [ "$updater_support_line" -ge "$updater_line" ] || [ "$updater_line" -ge "$sparkle_line" ]; then
   echo "FAIL: Sparkle nested components must be signed before Sparkle.framework"
   exit 1
 fi
 
-if [ "$sparkle_line" -ge "$sentry_line" ] || [ "$sentry_line" -ge "$cli_line" ] || [ "$helper_line" -ge "$app_line" ] || [ "$app_line" -ge "$verify_line" ]; then
+if [ "$nested_bundle_line" -ge "$sentry_line" ] || [ "$sparkle_line" -ge "$sentry_line" ] || [ "$sentry_line" -ge "$cli_line" ] || [ "$helper_line" -ge "$app_line" ] || [ "$app_line" -ge "$verify_line" ]; then
   echo "FAIL: signing order is incorrect"
   exit 1
 fi
 
-for sparkle_component in Installer.xpc Downloader.xpc InstallerStatus.xpc /Autoupdate Updater.app Sparkle.framework Sentry.framework; do
+for sparkle_component in Installer.xpc Downloader.xpc InstallerStatus.xpc /Autoupdate UpdaterSupport.framework Updater.app Crashpad.bundle Sparkle.framework Sentry.framework; do
   if printf '%s\n' "$OUTPUT" | grep -F "$sparkle_component" | grep -Fq -- '--entitlements'; then
     echo "FAIL: $sparkle_component must not be signed with app entitlements"
     exit 1

--- a/tests/test_ci_codesign_app_bundle.sh
+++ b/tests/test_ci_codesign_app_bundle.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/manaflow-ai/cmux/issues/1960.
+# Ensures cmux signs Sparkle inside-out without --deep and without app entitlements on Sparkle helpers.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/codesign_app_bundle.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+APP_PATH="$TMP_DIR/cmux.app"
+SPARKLE_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sparkle.framework"
+SPARKLE_VERSION_DIR="$SPARKLE_FRAMEWORK/Versions/B"
+OTHER_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sentry.framework"
+CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
+HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+ENTITLEMENTS="cmux.entitlements"
+
+WORKFLOWS=(
+  "$ROOT_DIR/.github/workflows/release.yml"
+  "$ROOT_DIR/.github/workflows/nightly.yml"
+  "$ROOT_DIR/scripts/build-sign-upload.sh"
+)
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: missing signing helper at $SCRIPT"
+  exit 1
+fi
+
+mkdir -p \
+  "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc" \
+  "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc" \
+  "$SPARKLE_VERSION_DIR/Updater.app" \
+  "$OTHER_FRAMEWORK" \
+  "$(dirname "$CLI_PATH")"
+ln -s B "$SPARKLE_FRAMEWORK/Versions/Current"
+touch \
+  "$SPARKLE_VERSION_DIR/Autoupdate" \
+  "$CLI_PATH" \
+  "$HELPER_PATH"
+
+for workflow in "${WORKFLOWS[@]}"; do
+  if ! grep -Fq './scripts/codesign_app_bundle.sh' "$workflow"; then
+    echo "FAIL: $workflow must use scripts/codesign_app_bundle.sh"
+    exit 1
+  fi
+done
+
+OUTPUT="$(
+  CMUX_CODESIGN_DRY_RUN=1 \
+  "$SCRIPT" "$APP_PATH" "Developer ID Application: Example" "$ENTITLEMENTS"
+)"
+
+line_number_regex() {
+  local pattern="$1"
+  printf '%s\n' "$OUTPUT" | nl -ba | grep -E -- "$pattern" | awk 'NR==1 {print $1}'
+}
+
+installer_line="$(line_number_regex 'Installer\.xpc$')"
+downloader_line="$(line_number_regex 'Downloader\.xpc$')"
+autoupdate_line="$(line_number_regex '/Autoupdate$')"
+updater_line="$(line_number_regex 'Updater\.app$')"
+sparkle_line="$(line_number_regex 'Sparkle\.framework$')"
+sentry_line="$(line_number_regex 'Sentry\.framework$')"
+cli_line="$(line_number_regex '/Resources/bin/cmux$')"
+helper_line="$(line_number_regex '/Resources/bin/ghostty$')"
+app_line="$(line_number_regex '--entitlements cmux\.entitlements .*/cmux\.app$')"
+verify_line="$(line_number_regex '--verify --deep --strict --verbose=2 .*/cmux\.app$')"
+
+for value_name in installer_line downloader_line autoupdate_line updater_line sparkle_line sentry_line cli_line helper_line app_line verify_line; do
+  if [ -z "${!value_name}" ]; then
+    echo "FAIL: expected $value_name in signing plan"
+    printf '%s\n' "$OUTPUT"
+    exit 1
+  fi
+done
+
+if [ "$installer_line" -ge "$sparkle_line" ] || [ "$downloader_line" -ge "$sparkle_line" ] || [ "$autoupdate_line" -ge "$sparkle_line" ] || [ "$updater_line" -ge "$sparkle_line" ]; then
+  echo "FAIL: Sparkle nested components must be signed before Sparkle.framework"
+  exit 1
+fi
+
+if [ "$sparkle_line" -ge "$sentry_line" ] || [ "$sentry_line" -ge "$cli_line" ] || [ "$helper_line" -ge "$app_line" ] || [ "$app_line" -ge "$verify_line" ]; then
+  echo "FAIL: signing order is incorrect"
+  exit 1
+fi
+
+for sparkle_component in Installer.xpc Downloader.xpc /Autoupdate Updater.app Sparkle.framework Sentry.framework; do
+  if printf '%s\n' "$OUTPUT" | grep -F "$sparkle_component" | grep -Fq -- '--entitlements'; then
+    echo "FAIL: $sparkle_component must not be signed with app entitlements"
+    exit 1
+  fi
+done
+
+for entitled_component in /Resources/bin/cmux /Resources/bin/ghostty /cmux.app; do
+  if ! printf '%s\n' "$OUTPUT" | grep -F "$entitled_component" | grep -Fv -- '--verify' | grep -Fq -- "--entitlements $ENTITLEMENTS"; then
+    echo "FAIL: $entitled_component must be signed with app entitlements"
+    exit 1
+  fi
+done
+
+if printf '%s\n' "$OUTPUT" | grep -F '/cmux.app' | grep -Fv -- '--verify' | grep -Fq -- '--deep'; then
+  echo "FAIL: app signing must not use --deep"
+  exit 1
+fi
+
+echo "PASS: app signing plan signs Sparkle inside-out without --deep"

--- a/tests/test_ci_codesign_app_bundle.sh
+++ b/tests/test_ci_codesign_app_bundle.sh
@@ -11,6 +11,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 APP_PATH="$TMP_DIR/cmux.app"
 SPARKLE_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sparkle.framework"
 SPARKLE_VERSION_DIR="$SPARKLE_FRAMEWORK/Versions/B"
+EXTRA_SPARKLE_XPC="$SPARKLE_VERSION_DIR/XPCServices/InstallerStatus.xpc"
 OTHER_FRAMEWORK="$APP_PATH/Contents/Frameworks/Sentry.framework"
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
 HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
@@ -24,6 +25,7 @@ fi
 mkdir -p \
   "$SPARKLE_VERSION_DIR/XPCServices/Installer.xpc" \
   "$SPARKLE_VERSION_DIR/XPCServices/Downloader.xpc" \
+  "$EXTRA_SPARKLE_XPC" \
   "$SPARKLE_VERSION_DIR/Updater.app" \
   "$OTHER_FRAMEWORK" \
   "$(dirname "$CLI_PATH")"
@@ -45,6 +47,7 @@ line_number_regex() {
 
 installer_line="$(line_number_regex 'Installer\.xpc$')"
 downloader_line="$(line_number_regex 'Downloader\.xpc$')"
+extra_xpc_line="$(line_number_regex 'InstallerStatus\.xpc$')"
 autoupdate_line="$(line_number_regex '/Autoupdate$')"
 updater_line="$(line_number_regex 'Updater\.app$')"
 sparkle_line="$(line_number_regex 'Sparkle\.framework$')"
@@ -54,7 +57,7 @@ helper_line="$(line_number_regex '/Resources/bin/ghostty$')"
 app_line="$(line_number_regex '--entitlements cmux\.entitlements .*/cmux\.app$')"
 verify_line="$(line_number_regex '--verify --deep --strict --verbose=2 .*/cmux\.app$')"
 
-for value_name in installer_line downloader_line autoupdate_line updater_line sparkle_line sentry_line cli_line helper_line app_line verify_line; do
+for value_name in installer_line downloader_line extra_xpc_line autoupdate_line updater_line sparkle_line sentry_line cli_line helper_line app_line verify_line; do
   if [ -z "${!value_name}" ]; then
     echo "FAIL: expected $value_name in signing plan"
     printf '%s\n' "$OUTPUT"
@@ -62,7 +65,7 @@ for value_name in installer_line downloader_line autoupdate_line updater_line sp
   fi
 done
 
-if [ "$installer_line" -ge "$sparkle_line" ] || [ "$downloader_line" -ge "$sparkle_line" ] || [ "$autoupdate_line" -ge "$sparkle_line" ] || [ "$updater_line" -ge "$sparkle_line" ]; then
+if [ "$installer_line" -ge "$sparkle_line" ] || [ "$downloader_line" -ge "$sparkle_line" ] || [ "$extra_xpc_line" -ge "$sparkle_line" ] || [ "$autoupdate_line" -ge "$sparkle_line" ] || [ "$updater_line" -ge "$sparkle_line" ]; then
   echo "FAIL: Sparkle nested components must be signed before Sparkle.framework"
   exit 1
 fi
@@ -72,7 +75,7 @@ if [ "$sparkle_line" -ge "$sentry_line" ] || [ "$sentry_line" -ge "$cli_line" ] 
   exit 1
 fi
 
-for sparkle_component in Installer.xpc Downloader.xpc /Autoupdate Updater.app Sparkle.framework Sentry.framework; do
+for sparkle_component in Installer.xpc Downloader.xpc InstallerStatus.xpc /Autoupdate Updater.app Sparkle.framework Sentry.framework; do
   if printf '%s\n' "$OUTPUT" | grep -F "$sparkle_component" | grep -Fq -- '--entitlements'; then
     echo "FAIL: $sparkle_component must not be signed with app entitlements"
     exit 1

--- a/tests/test_ci_codesign_app_bundle.sh
+++ b/tests/test_ci_codesign_app_bundle.sh
@@ -16,12 +16,6 @@ CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
 HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
 ENTITLEMENTS="cmux.entitlements"
 
-WORKFLOWS=(
-  "$ROOT_DIR/.github/workflows/release.yml"
-  "$ROOT_DIR/.github/workflows/nightly.yml"
-  "$ROOT_DIR/scripts/build-sign-upload.sh"
-)
-
 if [ ! -x "$SCRIPT" ]; then
   echo "FAIL: missing signing helper at $SCRIPT"
   exit 1
@@ -38,13 +32,6 @@ touch \
   "$SPARKLE_VERSION_DIR/Autoupdate" \
   "$CLI_PATH" \
   "$HELPER_PATH"
-
-for workflow in "${WORKFLOWS[@]}"; do
-  if ! grep -Fq './scripts/codesign_app_bundle.sh' "$workflow"; then
-    echo "FAIL: $workflow must use scripts/codesign_app_bundle.sh"
-    exit 1
-  fi
-done
 
 OUTPUT="$(
   CMUX_CODESIGN_DRY_RUN=1 \


### PR DESCRIPTION
## Summary
- sign Sparkle and bundled helpers inside-out without `--deep`, using a shared codesign helper for nightly and release builds
- show a manual latest-DMG fallback when Sparkle install errors block in-app updates
- add regression coverage for both the signing workflow and the update error presentation

## Testing
- ./tests/test_ci_codesign_app_bundle.sh
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-1960-sparkle-update-hardening-tests -only-testing:cmuxTests/UpdateViewModelPresentationTests test
- ./scripts/reload.sh --tag issue-1960-sparkle-update-hardening

Closes https://github.com/manaflow-ai/cmux/issues/1960
Closes https://github.com/manaflow-ai/cmux/issues/1961

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens macOS update flow by signing the app bundle inside‑out (no --deep) and adding a manual “Download Latest DMG” path when Sparkle install fails.

- **Bug Fixes**
  - Hardened `scripts/codesign_app_bundle.sh`: resolves `Sparkle.framework` `Versions/Current`, signs XPCs/Autoupdate/`Updater.app` first, then other frameworks, then the app and bundled CLIs; avoids `--deep` and keeps app entitlements off Sparkle components.
  - Replaced ad‑hoc signing in `release.yml`, `nightly.yml`, and `build-sign-upload.sh`; CI runs `tests/test_ci_codesign_app_bundle.sh` (dry‑run) to verify signing order and flags.

- **New Features**
  - On Sparkle installation errors, show “Download Latest DMG” in both the standard alert and the update popover; opens the correct stable or nightly DMG based on the resolved feed. Updated titles/messages and added tests for error mapping, URL selection (including nightly), code‑name details, and suppressing the link for network errors.

<sup>Written for commit f77e7d8302ffdf3d3b4d7c3609c76d450289d046. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update UI now offers a "Download Latest DMG" flow when installation fails; popovers and updater prompts present the option plus retry/dismiss choices.

* **Localization**
  * Added English and Japanese strings for the download action and installation-failed title/message.

* **CI**
  * CI now runs an additional signing-validation step and delegates app-bundle signing to a centralized signing helper.

* **Tests**
  * Added a CI regression test that validates the signing plan in dry-run mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->