### PR TITLE
Fix blank terminal renders after workspace switches

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4015,7 +4015,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return true
     }
 
-        // Visibility is used for focus gating, not for libghostty occlusion.
+        // Visibility is used for focus gating. Explicit portal visibility transitions
+        // also drive Ghostty occlusion so hidden workspace/split surfaces pause and
+        // queue a redraw when they become visible again.
         fileprivate var isVisibleInUI: Bool { visibleInUI }
         fileprivate func setVisibleInUI(_ visible: Bool) {
             visibleInUI = visible
@@ -6590,6 +6592,7 @@ final class GhosttySurfaceScrollView: NSView {
     private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
+    private var lastRequestedPortalOcclusionVisible: Bool?
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
@@ -7909,6 +7912,10 @@ final class GhosttySurfaceScrollView: NSView {
         let wasVisible = surfaceView.isVisibleInUI
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
+        if wasVisible != visible, lastRequestedPortalOcclusionVisible != visible {
+            lastRequestedPortalOcclusionVisible = visible
+            surfaceView.terminalSurface?.setOcclusion(visible)
+        }
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"


### PR DESCRIPTION
Closes #1789

## Summary

- Drive Ghostty occlusion from terminal portal visibility transitions during workspace hide/show.
- Use Ghostty's native hidden/visible render resume path instead of forcing ad hoc surface refreshes when a workspace comes back.
- Fix the stale blank/white terminal surfaces that could appear after switching away from and back to a workspace.

## Testing

- Built and launched the tagged Debug app with `./scripts/reload.sh --tag issue-1789-v2`.
- Used the tagged `cmux` CLI to switch workspaces back and forth to exercise the workspace handoff path.
- Did not run local automated tests per repo policy.
- Did not add an automated test because this is a portal-hosted macOS rendering lifecycle bug and there is no meaningful existing executable seam for it; source-shape tests would violate the repo's test policy.

## Demo Video

- Video URL or attachment: none

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank/white terminal surfaces after switching workspaces by driving Ghostty occlusion from portal visibility transitions and relying on the native pause/resume render path. This removes the need for forced surface refreshes and ensures a redraw when a workspace becomes visible.

- **Bug Fixes**
  - Trigger `terminalSurface?.setOcclusion(visible)` on portal visibility changes so hidden surfaces pause and resume with a redraw.
  - Prevent redundant occlusion toggles by tracking `lastRequestedPortalOcclusionVisible`; keep view visibility for focus gating only.

<sup>Written for commit aa24f1239b80437c177e45a41912438219d07834. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal visibility state management to ensure proper synchronization when the application window visibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->