### PR TITLE
Fix crash in newTabInsertIndex when creating workspace

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -800,8 +800,23 @@ class TabManager: ObservableObject {
     private var sidebarSelectedWorkspaceIds: Set<UUID> = []
     var confirmCloseHandler: ((String, String, Bool) -> Bool)?
     private struct WorkspaceCreationSnapshot {
+        struct TabMeta {
+            let id: UUID
+            let isPinned: Bool
+        }
         let tabs: [Workspace]
         let selectedTabId: UUID?
+        /// Value-type tab metadata extracted eagerly at snapshot creation
+        /// time so that newTabInsertIndex never dereferences Workspace
+        /// class references after intermediate operations (config
+        /// inheritance, tracking wiring) that may invalidate them.
+        let tabMetas: [TabMeta]
+
+        init(tabs: [Workspace], selectedTabId: UUID?) {
+            self.tabs = tabs
+            self.selectedTabId = selectedTabId
+            self.tabMetas = tabs.map { TabMeta(id: $0.id, isPinned: $0.isPinned) }
+        }
 
         var selectedWorkspace: Workspace? {
             guard let selectedTabId else { return nil }
@@ -2003,17 +2018,18 @@ class TabManager: ObservableObject {
         placementOverride: NewWorkspacePlacement? = nil
     ) -> Int {
         let placement = placementOverride ?? WorkspacePlacementSettings.current()
-        let pinnedCount = snapshot.tabs.filter { $0.isPinned }.count
+        let metas = snapshot.tabMetas
+        let pinnedCount = metas.filter { $0.isPinned }.count
         let selectedIndex = snapshot.selectedTabId.flatMap { tabId in
-            snapshot.tabs.firstIndex(where: { $0.id == tabId })
+            metas.firstIndex(where: { $0.id == tabId })
         }
-        let selectedIsPinned = selectedIndex.map { snapshot.tabs[$0].isPinned } ?? false
+        let selectedIsPinned = selectedIndex.map { metas[$0].isPinned } ?? false
         return WorkspacePlacementSettings.insertionIndex(
             placement: placement,
             selectedIndex: selectedIndex,
             selectedIsPinned: selectedIsPinned,
             pinnedCount: pinnedCount,
-            totalCount: snapshot.tabs.count
+            totalCount: metas.count
         )
     }
 


### PR DESCRIPTION
## Summary

- Extract `id` and `isPinned` as value-type `TabMeta` structs eagerly at `WorkspaceCreationSnapshot` creation time
- `newTabInsertIndex` now iterates over `[TabMeta]` instead of `[Workspace]` class references, eliminating the deref window where references can become invalid

## Problem

`newTabInsertIndex` crashes with `EXC_BAD_ACCESS (SIGSEGV)` at address `0x0` when iterating `snapshot.tabs` to access `Workspace.isPinned`. Between snapshot creation (line 1067) and `newTabInsertIndex` (line 1085), intermediate operations (`inheritedTerminalConfigForNewWorkspace`, `wireClosedBrowserTracking`) traverse Ghostty surfaces and Combine-backed state, which can invalidate `Workspace` references held in the snapshot.

Register state from crash: `x19=3` (3 tabs), `x20=1` (index 1), `x21=0` (null Workspace pointer).

Same stale-pointer pattern as #1870 and #1496.

## Scope

Only `TabManager.swift` changed. Only the `WorkspaceCreationSnapshot` struct and `newTabInsertIndex` function are modified. No other features or code paths affected.

## Test plan

- [ ] Verify workspace creation via Cmd+N works with 0, 1, and multiple existing tabs
- [ ] Verify workspace creation with pinned tabs preserves correct insertion order
- [ ] Verify "after current" placement still works correctly
- [ ] No behavioral or API changes. `WorkspacePlacementSettings.insertionIndex` inputs unchanged

Fixes #1966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal tab metadata handling to enhance the robustness of tab insertion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->