### PR TITLE
Fix shell integration not loading on Finder launch

### DIFF
--- a/Resources/shell-integration/.zlogin
+++ b/Resources/shell-integration/.zlogin
@@ -1,19 +1,8 @@
 # vim:ft=zsh
 #
-# Compatibility shim: with the current integration model, cmux restores
-# ZDOTDIR in .zshenv so this file should never be reached. If it is, restore
-# ZDOTDIR and behave like vanilla zsh by sourcing the user's .zlogin.
+# cmux ZDOTDIR wrapper for .zlogin.
+# Sources the user's real .zlogin from _CMUX_ORIG_ZDOTDIR.
 
-if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
-    builtin unset GHOSTTY_ZSH_ZDOTDIR
-elif [[ -n "${CMUX_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$CMUX_ZSH_ZDOTDIR"
-    builtin unset CMUX_ZSH_ZDOTDIR
-else
-    builtin unset ZDOTDIR
-fi
-
-builtin typeset _cmux_file="${ZDOTDIR-$HOME}/.zlogin"
+builtin typeset _cmux_file="${_CMUX_ORIG_ZDOTDIR-$HOME}/.zlogin"
 [[ ! -r "$_cmux_file" ]] || builtin source -- "$_cmux_file"
 builtin unset _cmux_file

--- a/Resources/shell-integration/.zprofile
+++ b/Resources/shell-integration/.zprofile
@@ -1,19 +1,8 @@
 # vim:ft=zsh
 #
-# Compatibility shim: with the current integration model, cmux restores
-# ZDOTDIR in .zshenv so this file should never be reached. If it is, restore
-# ZDOTDIR and behave like vanilla zsh by sourcing the user's .zprofile.
+# cmux ZDOTDIR wrapper for .zprofile.
+# Sources the user's real .zprofile from _CMUX_ORIG_ZDOTDIR.
 
-if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
-    builtin unset GHOSTTY_ZSH_ZDOTDIR
-elif [[ -n "${CMUX_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$CMUX_ZSH_ZDOTDIR"
-    builtin unset CMUX_ZSH_ZDOTDIR
-else
-    builtin unset ZDOTDIR
-fi
-
-builtin typeset _cmux_file="${ZDOTDIR-$HOME}/.zprofile"
+builtin typeset _cmux_file="${_CMUX_ORIG_ZDOTDIR-$HOME}/.zprofile"
 [[ ! -r "$_cmux_file" ]] || builtin source -- "$_cmux_file"
 builtin unset _cmux_file

--- a/Resources/shell-integration/.zshenv
+++ b/Resources/shell-integration/.zshenv
@@ -2,54 +2,29 @@
 #
 # cmux ZDOTDIR bootstrap for zsh.
 #
-# GhosttyKit already uses a ZDOTDIR injection mechanism for zsh (setting ZDOTDIR
-# to Ghostty's integration dir). cmux also needs to run its integration, but
-# we must restore the user's real ZDOTDIR immediately so that:
-# - /etc/zshrc sets HISTFILE relative to the real ZDOTDIR/HOME (shared history)
-# - zsh loads the user's real .zprofile/.zshrc normally (no wrapper recursion)
+# GhosttyKit sets ZDOTDIR to this integration directory so zsh loads this file
+# first.  We keep ZDOTDIR pointing here through the full startup sequence
+# (.zshenv → .zprofile → .zshrc → .zlogin) so that our wrapper files control
+# the loading order.  Each wrapper sources the user's real file, and .zshrc
+# loads cmux/Ghostty shell integration AFTER the user's .zshrc — ensuring
+# tools like Kiro CLI or Amazon Q that reset precmd_functions in .zprofile
+# cannot clobber cmux's hooks.
 #
-# We restore ZDOTDIR from (in priority order):
-# - GHOSTTY_ZSH_ZDOTDIR (set by GhosttyKit when it overwrote ZDOTDIR)
-# - CMUX_ZSH_ZDOTDIR (set by cmux when it overwrote a user-provided ZDOTDIR)
-# - unset (zsh treats unset ZDOTDIR as $HOME)
+# The user's original ZDOTDIR is preserved in _CMUX_ORIG_ZDOTDIR and restored
+# in .zshrc after integration loading completes.
 
+# Save the user's original ZDOTDIR so wrappers can find user files.
 if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
+    builtin export _CMUX_ORIG_ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
     builtin unset GHOSTTY_ZSH_ZDOTDIR
 elif [[ -n "${CMUX_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$CMUX_ZSH_ZDOTDIR"
+    builtin export _CMUX_ORIG_ZDOTDIR="$CMUX_ZSH_ZDOTDIR"
     builtin unset CMUX_ZSH_ZDOTDIR
 else
-    builtin unset ZDOTDIR
+    builtin export _CMUX_ORIG_ZDOTDIR="${HOME}"
 fi
 
-{
-    # zsh treats unset ZDOTDIR as if it were HOME. We do the same.
-    builtin typeset _cmux_file="${ZDOTDIR-$HOME}/.zshenv"
-    [[ ! -r "$_cmux_file" ]] || builtin source -- "$_cmux_file"
-} always {
-    if [[ -o interactive ]]; then
-        # We overwrote GhosttyKit's injected ZDOTDIR, so manually load Ghostty's
-        # zsh integration if available.
-        #
-        # We can't rely on GHOSTTY_ZSH_ZDOTDIR here because Ghostty's own zsh
-        # bootstrap unsets it before chaining into this cmux wrapper.
-        if [[ "${CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION:-0}" == "1" ]]; then
-            if [[ -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
-                builtin typeset _cmux_ghostty="$CMUX_SHELL_INTEGRATION_DIR/ghostty-integration.zsh"
-            fi
-            if [[ ! -r "${_cmux_ghostty:-}" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then
-                builtin typeset _cmux_ghostty="$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"
-            fi
-            [[ -r "$_cmux_ghostty" ]] && builtin source -- "$_cmux_ghostty"
-        fi
-
-        # Load cmux integration (unless disabled)
-        if [[ "${CMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
-            builtin typeset _cmux_integ="$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh"
-            [[ -r "$_cmux_integ" ]] && builtin source -- "$_cmux_integ"
-        fi
-    fi
-
-    builtin unset _cmux_file _cmux_ghostty _cmux_integ
-}
+# Source the user's .zshenv (runs for all shells, interactive or not).
+builtin typeset _cmux_file="${_CMUX_ORIG_ZDOTDIR}/.zshenv"
+[[ ! -r "$_cmux_file" ]] || builtin source -- "$_cmux_file"
+builtin unset _cmux_file

--- a/Resources/shell-integration/.zshrc
+++ b/Resources/shell-integration/.zshrc
@@ -1,19 +1,44 @@
 # vim:ft=zsh
 #
-# Compatibility shim: with the current integration model, cmux restores
-# ZDOTDIR in .zshenv so this file should never be reached. If it is, restore
-# ZDOTDIR and behave like vanilla zsh by sourcing the user's .zshrc.
+# cmux ZDOTDIR wrapper for .zshrc.
+# Sources the user's real .zshrc, then loads Ghostty and cmux shell
+# integration.  Loading integration HERE (after .zshrc) ensures it runs
+# after tools like Kiro CLI / Amazon Q that may reset precmd_functions
+# in .zprofile or .zshrc.
 
-if [[ -n "${GHOSTTY_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$GHOSTTY_ZSH_ZDOTDIR"
-    builtin unset GHOSTTY_ZSH_ZDOTDIR
-elif [[ -n "${CMUX_ZSH_ZDOTDIR+X}" ]]; then
-    builtin export ZDOTDIR="$CMUX_ZSH_ZDOTDIR"
-    builtin unset CMUX_ZSH_ZDOTDIR
-else
-    builtin unset ZDOTDIR
-fi
-
-builtin typeset _cmux_file="${ZDOTDIR-$HOME}/.zshrc"
+# Source the user's real .zshrc.
+builtin typeset _cmux_file="${_CMUX_ORIG_ZDOTDIR-$HOME}/.zshrc"
 [[ ! -r "$_cmux_file" ]] || builtin source -- "$_cmux_file"
 builtin unset _cmux_file
+
+# Fix HISTFILE: /etc/zshrc sets HISTFILE based on ZDOTDIR which currently
+# points to our integration dir.  Only fix if it still points there;
+# if the user's .zshrc set a custom HISTFILE, respect it.
+if [[ "$HISTFILE" == "${ZDOTDIR}"/* ]]; then
+    HISTFILE="${_CMUX_ORIG_ZDOTDIR-$HOME}/.zsh_history"
+fi
+
+# Load Ghostty shell integration (if requested by cmux).
+if [[ "${CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION:-0}" == "1" ]]; then
+    if [[ -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+        builtin typeset _cmux_ghostty="$CMUX_SHELL_INTEGRATION_DIR/ghostty-integration.zsh"
+    fi
+    if [[ ! -r "${_cmux_ghostty:-}" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then
+        builtin typeset _cmux_ghostty="$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"
+    fi
+    [[ -r "$_cmux_ghostty" ]] && builtin source -- "$_cmux_ghostty"
+fi
+
+# Load cmux shell integration.
+if [[ "${CMUX_SHELL_INTEGRATION:-1}" != "0" && -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ]]; then
+    builtin typeset _cmux_integ="$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh"
+    [[ -r "$_cmux_integ" ]] && builtin source -- "$_cmux_integ"
+fi
+
+# Restore the user's original ZDOTDIR now that all startup files are done.
+if [[ "${_CMUX_ORIG_ZDOTDIR}" == "${HOME}" ]]; then
+    builtin unset ZDOTDIR
+else
+    builtin export ZDOTDIR="${_CMUX_ORIG_ZDOTDIR}"
+fi
+builtin unset _CMUX_ORIG_ZDOTDIR _cmux_ghostty _cmux_integ


### PR DESCRIPTION
## Summary

- **Fix shell integration not loading when cmux is launched from Finder** (double-click / Dock / Spotlight).
- Root cause: the previous design loaded cmux integration in `.zshenv`, but tools that reset `precmd_functions` in `.zprofile` or `.zshrc` clobbered the hooks before the first prompt.
- Fix: keep ZDOTDIR pointing to the integration directory through the full zsh startup sequence and load integration in the `.zshrc` wrapper — after all user startup files have been processed.
- Fixes #1165 

### Affected tools

Confirmed with **Kiro CLI** (formerly Amazon Q / Fig), which resets `precmd_functions` in `.zprofile` during full initialization. Any other tool that resets (rather than appends to) `precmd_functions` during `.zprofile` or `.zshrc` processing could cause the same issue. The new design is immune because integration loads **after** all user startup files.

### Why Finder-only?

When launched via `reload.sh` or `open` from a terminal, the app inherits environment variables (e.g. `Q_TERM`) from the parent shell. Some tools skip their full initialization when these variables are present, preserving `precmd_functions`. From Finder, these variables are absent, triggering a full init that resets the array.

### What changed

| File | Before | After |
|---|---|---|
| `.zshenv` | Restored ZDOTDIR immediately, loaded Ghostty + cmux integration in `always` block | Saves original ZDOTDIR to `_CMUX_ORIG_ZDOTDIR`, sources user's `.zshenv`, keeps ZDOTDIR set to integration dir |
| `.zprofile` | Fallback shim (never reached) | Sources user's `.zprofile` via `_CMUX_ORIG_ZDOTDIR` |
| `.zshrc` | Fallback shim (never reached) | Sources user's `.zshrc`, fixes HISTFILE if still pointing to integration dir (respects custom HISTFILE), loads Ghostty + cmux integration, restores ZDOTDIR |
| `.zlogin` | Fallback shim (never reached) | Not reached — ZDOTDIR is restored in .zshrc so zsh loads the user's .zlogin directly. Wrapper exists as a safety fallback. |  

## Testing

- Verified on macOS 26.3.1(a) (Build 25D771280a) with Kiro CLI installed.
- **Finder launch**: `type _cmux_precmd` → shell function found. Workspace sidebar updates on `cd`.
- **`reload.sh --tag` launch**: same result, no regression.
- **`open` from terminal launch**: same result, no regression.
- Verified `HISTFILE` points to `~/.zsh_history` (not the integration dir).
- Verified custom `HISTFILE` (set in user's `.zshrc`) is preserved after shell startup.
- Verified `ZDOTDIR` is unset (or restored to user's original) after shell startup.

## Known limitation

During the user's `.zshrc` execution, `$ZDOTDIR` still points to the integration directory. If a user's `.zshrc` references `$ZDOTDIR` (e.g. `source "$ZDOTDIR/.zsh_aliases"`), it will resolve to the wrong path. Affected users are likely rare, but the issue would be hard to diagnose. Please consider addressing this separately.

- **Possible fix**: temporarily restore `ZDOTDIR` before sourcing the user's `.zshrc`, then re-set it afterward.


## Demo Video

### Kiro is not installed
Directory changes are properly reflected in the workspace.

https://github.com/user-attachments/assets/3a84bfd0-3725-42a8-93dc-69abb5a1ad9f

### Kiro is installed
#### This is cmux built from the latest main branch

- Open from Finder
Directory changes are not reflected in the workspace.

https://github.com/user-attachments/assets/04581e62-03e0-49ac-acf7-02a1153f168b

- Open from the command
Directory changes are properly reflected in the workspace.

https://github.com/user-attachments/assets/0488d5fa-2d87-4562-903f-d8c518ef2ed4

#### The version with this fix
Directory changes are properly reflected in the workspace.

https://github.com/user-attachments/assets/d57b0410-82e2-4e92-82d1-501798cbb3c5



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux` zsh integration not loading when launched from Finder by keeping `ZDOTDIR` pinned during startup and moving integration load to the `.zshrc` wrapper. Prevents tools that reset `precmd_functions` from clobbering `cmux` hooks, then restores the user's `ZDOTDIR`.

- **Bug Fixes**
  - `.zshenv` saves the original `ZDOTDIR` to `_CMUX_ORIG_ZDOTDIR`, sources the user’s `.zshenv`, and defers integration to `.zshrc`.
  - `.zshrc` sources the user’s file, loads Ghostty and `cmux` integration, fixes `HISTFILE` if it points to the integration dir, then restores `ZDOTDIR`.
  - `.zprofile` and `.zlogin` wrappers source the user’s files from `_CMUX_ORIG_ZDOTDIR`.

<sup>Written for commit ccf948f31282e6be339e3b46382df6e62814b2d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved shell startup handling to consistently source users' shell startup files and better preserve their history location.
  * Reduced unexpected environment variable side effects during startup.
  * Made integration modules load only when explicitly enabled, with safer fallback resolution for integration scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->