### PR TITLE
feat: add browser element picker via Option+Click

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -34,13 +34,20 @@ import Security
 /// - The `__cmuxPointedElement` global is defined as non-enumerable to
 ///   reduce CAPTCHA/bot-detection fingerprinting surface.
 final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
-    private let workspaceId: UUID
+    private var workspaceId: UUID
+
+    func updateWorkspaceId(_ newId: UUID) {
+        workspaceId = newId
+    }
 
     /// Timestamp of last native Option+Click detected via NSEvent monitor.
     /// Used to validate that postMessage was triggered by a real user click,
     /// not by malicious page JS calling postMessage directly.
     private var lastNativeOptionClickTime: TimeInterval = 0
     private var eventMonitor: Any?
+    /// Weak reference to the associated webView for source validation.
+    /// Ensures clicks in other windows/panels cannot authorize this handler.
+    weak var associatedWebView: WKWebView?
 
     /// Maximum allowed delay between native click and postMessage arrival.
     private static let nativeEventWindowSeconds: TimeInterval = 1.0
@@ -48,10 +55,18 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     init(workspaceId: UUID) {
         self.workspaceId = workspaceId
         super.init()
-        // Monitor native mouse clicks with Option modifier
+        // Monitor native mouse clicks with Option modifier.
+        // Only accept clicks that hit our associated webView (checked via hitTest).
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
-            if event.modifierFlags.contains(.option) {
-                self?.lastNativeOptionClickTime = ProcessInfo.processInfo.systemUptime
+            guard let self, event.modifierFlags.contains(.option) else { return event }
+            // Verify the click targets our webView's window and hit-tests within it
+            if let webView = self.associatedWebView,
+               let window = webView.window,
+               event.window === window {
+                let pointInWebView = webView.convert(event.locationInWindow, from: nil)
+                if webView.bounds.contains(pointInWebView) {
+                    self.lastNativeOptionClickTime = ProcessInfo.processInfo.systemUptime
+                }
             }
             return event
         }
@@ -67,9 +82,17 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     /// This is critical for security: web content is untrusted and is
     /// injected into terminal stdin. Without sanitization, a malicious
     /// page could embed shell commands via newlines or ANSI sequences.
+    /// Dangerous Unicode scalars: BiDi overrides, zero-width chars
+    private static let dangerousScalars: Set<UInt32> = [
+        0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0xFEFF,  // zero-width
+        0x202A, 0x202B, 0x202C, 0x202D, 0x202E,            // BiDi overrides
+        0x2066, 0x2067, 0x2068, 0x2069                      // BiDi isolates
+    ]
+
     private func sanitize(_ text: String) -> String {
         let cleaned = text.unicodeScalars.filter { s in
-            (s.value >= 0x20 && s.value <= 0x7E) || s.value > 0x9F
+            ((s.value >= 0x20 && s.value <= 0x7E) || s.value > 0x9F)
+            && !Self.dangerousScalars.contains(s.value)
         }
         return String(String.UnicodeScalarView(cleaned)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -2721,15 +2744,16 @@ final class BrowserPanel: Panel, ObservableObject {
     private var pickerMessageHandler: BrowserPickerMessageHandler?
 
     private func bindWebView(_ webView: CmuxWebView) {
-        // Clean up previous picker handler to prevent NSEvent monitor leaks
+        // Clean up previous picker handler from the OLD webView to prevent NSEvent monitor leaks
         // when bindWebView is called multiple times (profile change, context reset, etc.)
         if pickerMessageHandler != nil {
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxPointer")
+            // Remove from the previous webView (self.webView), not the new one being bound
+            self.webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxPointer")
             pickerMessageHandler = nil
         }
-        // Register Option+Click element picker message handler.
-        // Use a separate handler object to avoid retain cycles with WKUserContentController.
+        // Register Option+Click element picker message handler on the NEW webView.
         let handler = BrowserPickerMessageHandler(workspaceId: workspaceId)
+        handler.associatedWebView = webView  // Link for source validation
         pickerMessageHandler = handler
         webView.configuration.userContentController.add(handler, name: "cmuxPointer")
 
@@ -2977,6 +3001,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func updateWorkspaceId(_ newWorkspaceId: UUID) {
         workspaceId = newWorkspaceId
+        pickerMessageHandler?.updateWorkspaceId(newWorkspaceId)
     }
 
     func reattachToWorkspace(
@@ -2987,6 +3012,7 @@ final class BrowserPanel: Panel, ObservableObject {
         remoteStatus: BrowserRemoteWorkspaceStatus?
     ) {
         workspaceId = newWorkspaceId
+        pickerMessageHandler?.updateWorkspaceId(newWorkspaceId)
         usesRemoteWorkspaceProxy = isRemoteWorkspace
         let targetStore = isRemoteWorkspace
             ? WKWebsiteDataStore(forIdentifier: remoteWebsiteDataStoreIdentifier ?? newWorkspaceId)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -17,8 +17,19 @@ import Security
 // MARK: - Element Picker Message Handler
 
 /// Receives Option+Click element selection from the browser JS and sends
-/// sanitized summary to the first terminal in the workspace.
-/// Text is sanitized: control chars, newlines, ANSI escapes are stripped.
+/// sanitized summary to the focused terminal in the workspace.
+///
+/// Security notes (terminal stdin injection):
+/// - All text from web content is sanitized before terminal injection.
+/// - Control characters (U+0000–U+001F, U+007F–U+009F) are stripped to
+///   prevent ANSI escape sequence attacks and terminal command injection.
+/// - Newlines are removed so injected text cannot execute shell commands.
+/// - Text is truncated to 200 chars to prevent buffer overflow attempts.
+/// - Sanitization is applied on both the JS side (first pass) and the
+///   Swift side (defense in depth), since page JS can call postMessage
+///   directly with arbitrary payloads.
+/// - The `__cmuxPointedElement` global is defined as non-enumerable to
+///   reduce CAPTCHA/bot-detection fingerprinting surface.
 final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     private let workspaceId: UUID
 
@@ -27,7 +38,10 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
         super.init()
     }
 
-    /// Strip control characters, newlines, and ANSI escape sequences
+    /// Strip control characters, newlines, and ANSI escape sequences.
+    /// This is critical for security: web content is untrusted and is
+    /// injected into terminal stdin. Without sanitization, a malicious
+    /// page could embed shell commands via newlines or ANSI sequences.
     private func sanitize(_ text: String) -> String {
         let cleaned = text.unicodeScalars.filter { s in
             (s.value >= 0x20 && s.value <= 0x7E) || s.value > 0x9F
@@ -1878,7 +1892,12 @@ final class BrowserPanel: Panel, ObservableObject {
             }
             return '/' + parts.join('/');
           };
-          // Sanitize text: strip control chars, newlines, escape sequences
+          // Security: sanitize text before sending to terminal stdin.
+          // Strip control chars (U+0000-U+001F, U+007F-U+009F) to prevent:
+          // - Terminal command injection via embedded newlines
+          // - ANSI escape sequence attacks (cursor movement, title change)
+          // - Terminal control character exploitation
+          // This is the first pass; Swift side applies a second sanitization.
           const __sanitize = (str) => {
             return str.replace(/[\\u0000-\\u001f\\u007f-\\u009f]/g, '').slice(0, 200).trim();
           };

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -89,12 +89,22 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
         0x2066, 0x2067, 0x2068, 0x2069                      // BiDi isolates
     ]
 
-    private func sanitize(_ text: String) -> String {
-        let cleaned = text.unicodeScalars.filter { s in
+    private func filtered(_ value: String) -> String {
+        let cleaned = value.unicodeScalars.filter { s in
             ((s.value >= 0x20 && s.value <= 0x7E) || s.value > 0x9F)
             && !Self.dangerousScalars.contains(s.value)
         }
-        return String(String.UnicodeScalarView(cleaned)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(String.UnicodeScalarView(cleaned))
+    }
+
+    /// Sanitize display text: strip control chars + BiDi/zero-width, cap at 200 chars
+    private func sanitizeWebText(_ text: String) -> String {
+        String(filtered(text).prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Sanitize xpath: strip control chars + BiDi/zero-width, cap at 2000 chars (preserve selector fidelity)
+    private func sanitizeXPath(_ xpath: String) -> String {
+        String(filtered(xpath).prefix(2000)).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func userContentController(
@@ -114,8 +124,8 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
         // Invalidate the timestamp so each native click can only be used once
         lastNativeOptionClickTime = 0
 
-        let xpath = sanitize(body["xpath"] as? String ?? "")
-        let rawText = sanitize(body["text"] as? String ?? "")
+        let xpath = sanitizeXPath(body["xpath"] as? String ?? "")
+        let rawText = sanitizeWebText(body["text"] as? String ?? "")
 
         var summary = "[picked] \(xpath)"
         if !rawText.isEmpty {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -16,18 +16,48 @@ import Security
 
 // MARK: - Element Picker Message Handler
 
-/// Receives Option+Click element selection from the browser JS.
-/// Data is stored and read via the socket API (browser.picked / browser.picked.wait).
-/// No data is injected into terminal stdin — the agent reads it explicitly.
+/// Receives Option+Click element selection from the browser JS and sends
+/// sanitized summary to the first terminal in the workspace.
+/// Text is sanitized: control chars, newlines, ANSI escapes are stripped.
 final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
+    private let workspaceId: UUID
+
+    init(workspaceId: UUID) {
+        self.workspaceId = workspaceId
+        super.init()
+    }
+
+    /// Strip control characters, newlines, and ANSI escape sequences
+    private func sanitize(_ text: String) -> String {
+        let cleaned = text.unicodeScalars.filter { s in
+            (s.value >= 0x20 && s.value <= 0x7E) || s.value > 0x9F
+        }
+        return String(String.UnicodeScalarView(cleaned)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceive message: WKScriptMessage
     ) {
-        // Data is stored in window.__cmuxPointedElement on the JS side.
-        // The Swift side reads it via browser.pointed / browser.picked.wait eval.
-        // This handler exists only to validate the message bridge is active.
-        // No action needed — the JS already stored the data before calling postMessage.
+        guard message.name == "cmuxPointer" else { return }
+        guard let body = message.body as? [String: Any] else { return }
+
+        let xpath = sanitize(body["xpath"] as? String ?? "")
+        let rawText = sanitize(body["text"] as? String ?? "")
+
+        var summary = "[picked] \(xpath)"
+        if !rawText.isEmpty {
+            summary += " \"\(rawText)\""
+        }
+
+        NotificationCenter.default.post(
+            name: .browserElementPicked,
+            object: nil,
+            userInfo: [
+                "workspaceId": workspaceId,
+                "summary": summary
+            ]
+        )
     }
 }
 
@@ -2639,7 +2669,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private func bindWebView(_ webView: CmuxWebView) {
         // Register Option+Click element picker message handler.
         // Use a separate handler object to avoid retain cycles with WKUserContentController.
-        let handler = BrowserPickerMessageHandler()
+        let handler = BrowserPickerMessageHandler(workspaceId: workspaceId)
         pickerMessageHandler = handler
         webView.configuration.userContentController.add(handler, name: "cmuxPointer")
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -14,6 +14,46 @@ import CommonCrypto
 import Security
 #endif
 
+// MARK: - Element Pointer Message Handler
+
+/// Receives Option+Click element selection from the browser JS and forwards via NotificationCenter
+final class BrowserPointerMessageHandler: NSObject, WKScriptMessageHandler {
+    private let panelId: UUID
+    private let workspaceId: UUID
+
+    init(panelId: UUID, workspaceId: UUID) {
+        self.panelId = panelId
+        self.workspaceId = workspaceId
+        super.init()
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == "cmuxPointer" else { return }
+        guard let body = message.body as? [String: Any] else { return }
+
+        let xpath = body["xpath"] as? String ?? ""
+        let text = ((body["text"] as? String) ?? "").prefix(80).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var summary = "[pointed] \(xpath)"
+        if !text.isEmpty {
+            summary += " \"\(text)\""
+        }
+
+        NotificationCenter.default.post(
+            name: .browserElementPointed,
+            object: nil,
+            userInfo: [
+                "surfaceId": panelId,
+                "workspaceId": workspaceId,
+                "summary": summary
+            ]
+        )
+    }
+}
+
 fileprivate func dedupedCanonicalURLs(_ urls: [URL]) -> [URL] {
     var seen = Set<String>()
     var result: [URL] = []
@@ -1775,6 +1815,91 @@ final class BrowserPanel: Panel, ObservableObject {
         } catch (_) {}
       });
 
+      // --- Element Pointer (Option+Click) ---
+      window.__cmuxPointedElement = null;
+      (() => {
+        let __altDown = false;
+        let __overlay = null;
+        const __ensureOverlay = () => {
+          if (__overlay) return __overlay;
+          __overlay = document.createElement('div');
+          __overlay.id = '__cmux_pointer_overlay';
+          __overlay.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483647;border:2px solid #4F46E5;background:rgba(79,70,229,0.1);display:none;transition:all 0.05s;border-radius:3px;';
+          (document.body || document.documentElement).appendChild(__overlay);
+          return __overlay;
+        };
+        document.addEventListener('keydown', (e) => {
+          if (e.key === 'Alt' && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
+            __altDown = true;
+            document.documentElement.style.cursor = 'crosshair';
+          }
+        }, true);
+        document.addEventListener('keyup', (e) => {
+          if (e.key === 'Alt') {
+            __altDown = false;
+            document.documentElement.style.cursor = '';
+            const ov = __ensureOverlay();
+            ov.style.display = 'none';
+          }
+        }, true);
+        document.addEventListener('mouseover', (e) => {
+          if (!__altDown) return;
+          const r = e.target.getBoundingClientRect();
+          const ov = __ensureOverlay();
+          ov.style.display = 'block';
+          ov.style.top = r.top + 'px';
+          ov.style.left = r.left + 'px';
+          ov.style.width = r.width + 'px';
+          ov.style.height = r.height + 'px';
+        }, true);
+        document.addEventListener('click', (e) => {
+          if (!__altDown) return;
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          const el = e.target;
+          const cs = window.getComputedStyle(el);
+          const ov = __ensureOverlay();
+          ov.style.borderColor = '#16A34A';
+          ov.style.background = 'rgba(22,163,74,0.15)';
+          // Build xpath for the element
+          const __xpath = (node) => {
+            const parts = [];
+            let cur = node;
+            while (cur && cur !== document.documentElement) {
+              if (cur === document.body) { parts.unshift('/html/body'); break; }
+              const tag = cur.tagName.toLowerCase();
+              const parent = cur.parentElement;
+              if (parent) {
+                const siblings = Array.from(parent.children).filter(s => s.tagName === cur.tagName);
+                if (siblings.length > 1) {
+                  parts.unshift(tag + '[' + (siblings.indexOf(cur) + 1) + ']');
+                } else {
+                  parts.unshift(tag);
+                }
+              } else {
+                parts.unshift(tag);
+              }
+              cur = parent;
+            }
+            return '/' + parts.join('/');
+          };
+          const xpath = __xpath(el);
+          const text = (el.textContent || '').slice(0, 80).trim();
+          const data = {
+            xpath: xpath,
+            text: text,
+            tag: el.tagName,
+            timestamp_ms: Date.now()
+          };
+          window.__cmuxPointedElement = data;
+          try {
+            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.cmuxPointer) {
+              window.webkit.messageHandlers.cmuxPointer.postMessage(data);
+            }
+          } catch (_) {}
+        }, true);
+      })();
+
       return true;
     })()
     """
@@ -2506,7 +2631,14 @@ final class BrowserPanel: Panel, ObservableObject {
         )
     }
 
+    private var pointerMessageHandler: BrowserPointerMessageHandler?
+
     private func bindWebView(_ webView: CmuxWebView) {
+        // Register Option+Click element pointer message handler
+        let handler = BrowserPointerMessageHandler(panelId: id, workspaceId: workspaceId)
+        pointerMessageHandler = handler
+        webView.configuration.userContentController.add(handler, name: "cmuxPointer")
+
         webView.onContextMenuDownloadStateChanged = { [weak self] downloading in
             if downloading {
                 self?.beginDownloadActivity()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -14,43 +14,20 @@ import CommonCrypto
 import Security
 #endif
 
-// MARK: - Element Pointer Message Handler
+// MARK: - Element Picker Message Handler
 
-/// Receives Option+Click element selection from the browser JS and forwards via NotificationCenter
-final class BrowserPointerMessageHandler: NSObject, WKScriptMessageHandler {
-    private let panelId: UUID
-    private let workspaceId: UUID
-
-    init(panelId: UUID, workspaceId: UUID) {
-        self.panelId = panelId
-        self.workspaceId = workspaceId
-        super.init()
-    }
-
+/// Receives Option+Click element selection from the browser JS.
+/// Data is stored and read via the socket API (browser.picked / browser.picked.wait).
+/// No data is injected into terminal stdin — the agent reads it explicitly.
+final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceive message: WKScriptMessage
     ) {
-        guard message.name == "cmuxPointer" else { return }
-        guard let body = message.body as? [String: Any] else { return }
-
-        let xpath = body["xpath"] as? String ?? ""
-        let text = ((body["text"] as? String) ?? "").prefix(80).trimmingCharacters(in: .whitespacesAndNewlines)
-
-        var summary = "[pointed] \(xpath)"
-        if !text.isEmpty {
-            summary += " \"\(text)\""
-        }
-
-        NotificationCenter.default.post(
-            name: .browserElementPointed,
-            object: nil,
-            userInfo: [
-                "surfaceId": panelId,
-                "workspaceId": workspaceId,
-                "summary": summary
-            ]
-        )
+        // Data is stored in window.__cmuxPointedElement on the JS side.
+        // The Swift side reads it via browser.pointed / browser.picked.wait eval.
+        // This handler exists only to validate the message bridge is active.
+        // No action needed — the JS already stored the data before calling postMessage.
     }
 }
 
@@ -1815,90 +1792,116 @@ final class BrowserPanel: Panel, ObservableObject {
         } catch (_) {}
       });
 
-      // --- Element Pointer (Option+Click) ---
-      window.__cmuxPointedElement = null;
-      (() => {
-        let __altDown = false;
-        let __overlay = null;
-        const __ensureOverlay = () => {
-          if (__overlay) return __overlay;
-          __overlay = document.createElement('div');
-          __overlay.id = '__cmux_pointer_overlay';
-          __overlay.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483647;border:2px solid #4F46E5;background:rgba(79,70,229,0.1);display:none;transition:all 0.05s;border-radius:3px;';
-          (document.body || document.documentElement).appendChild(__overlay);
-          return __overlay;
-        };
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Alt' && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
-            __altDown = true;
-            document.documentElement.style.cursor = 'crosshair';
-          }
-        }, true);
-        document.addEventListener('keyup', (e) => {
-          if (e.key === 'Alt') {
-            __altDown = false;
-            document.documentElement.style.cursor = '';
-            const ov = __ensureOverlay();
-            ov.style.display = 'none';
-          }
-        }, true);
-        document.addEventListener('mouseover', (e) => {
-          if (!__altDown) return;
-          const r = e.target.getBoundingClientRect();
-          const ov = __ensureOverlay();
-          ov.style.display = 'block';
-          ov.style.top = r.top + 'px';
-          ov.style.left = r.left + 'px';
-          ov.style.width = r.width + 'px';
-          ov.style.height = r.height + 'px';
-        }, true);
-        document.addEventListener('click', (e) => {
-          if (!__altDown) return;
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          const el = e.target;
-          const cs = window.getComputedStyle(el);
-          const ov = __ensureOverlay();
-          ov.style.borderColor = '#16A34A';
-          ov.style.background = 'rgba(22,163,74,0.15)';
-          // Build xpath for the element
+      // --- Element Picker (Option+Click) ---
+      // Guard against double-injection on SPA navigation
+      if (!window.__cmuxPickerInstalled) {
+        Object.defineProperty(window, '__cmuxPickerInstalled', { value: true, enumerable: false });
+        // Store picked element as non-enumerable to reduce CAPTCHA fingerprinting
+        Object.defineProperty(window, '__cmuxPointedElement', { value: null, writable: true, enumerable: false, configurable: true });
+        (() => {
+          let __overlay = null;
+          const __ensureOverlay = () => {
+            if (__overlay) return __overlay;
+            __overlay = document.createElement('div');
+            __overlay.setAttribute('aria-hidden', 'true');
+            __overlay.setAttribute('role', 'presentation');
+            const s = __overlay.style;
+            s.cssText = 'position:fixed;pointer-events:none;z-index:2147483647;border:2px solid #4F46E5;background:rgba(79,70,229,0.1);display:none;border-radius:3px;';
+            // Respect prefers-reduced-motion
+            if (!window.matchMedia || !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+              s.transition = 'all 0.05s';
+            }
+            (document.body || document.documentElement).appendChild(__overlay);
+            return __overlay;
+          };
+          // Build xpath using previousElementSibling (avoids Array.from allocation)
+          const __siblingIndex = (el) => {
+            let idx = 1;
+            let sib = el.previousElementSibling;
+            while (sib) {
+              if (sib.tagName === el.tagName) idx++;
+              sib = sib.previousElementSibling;
+            }
+            return idx;
+          };
+          const __hasSameTagSibling = (el) => {
+            let sib = el.parentElement ? el.parentElement.firstElementChild : null;
+            while (sib) {
+              if (sib !== el && sib.tagName === el.tagName) return true;
+              sib = sib.nextElementSibling;
+            }
+            return false;
+          };
           const __xpath = (node) => {
             const parts = [];
             let cur = node;
-            while (cur && cur !== document.documentElement) {
-              if (cur === document.body) { parts.unshift('/html/body'); break; }
+            while (cur && cur.nodeType === 1) {
+              if (cur === document.body) { parts.unshift('body'); break; }
+              if (cur === document.documentElement) { parts.unshift('html'); break; }
               const tag = cur.tagName.toLowerCase();
-              const parent = cur.parentElement;
-              if (parent) {
-                const siblings = Array.from(parent.children).filter(s => s.tagName === cur.tagName);
-                if (siblings.length > 1) {
-                  parts.unshift(tag + '[' + (siblings.indexOf(cur) + 1) + ']');
-                } else {
-                  parts.unshift(tag);
-                }
+              if (__hasSameTagSibling(cur)) {
+                parts.unshift(tag + '[' + __siblingIndex(cur) + ']');
               } else {
                 parts.unshift(tag);
               }
-              cur = parent;
+              cur = cur.parentElement;
             }
             return '/' + parts.join('/');
           };
-          const xpath = __xpath(el);
-          const text = (el.textContent || '').slice(0, 80).trim();
-          const data = {
-            xpath: xpath,
-            text: text,
-            tag: el.tagName,
-            timestamp_ms: Date.now()
+          // Sanitize text: strip control chars, newlines, escape sequences
+          const __sanitize = (str) => {
+            return str.replace(/[\\u0000-\\u001f\\u007f-\\u009f]/g, '').slice(0, 200).trim();
           };
-          window.__cmuxPointedElement = data;
-          try {
-            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.cmuxPointer) {
-              window.webkit.messageHandlers.cmuxPointer.postMessage(data);
+          // Use e.altKey directly instead of tracking keydown/keyup state
+          // This avoids stuck-Alt issues from blur, tab-away, IME, etc.
+          document.addEventListener('mouseover', (e) => {
+            if (!e.altKey) {
+              if (__overlay && __overlay.style.display !== 'none') {
+                __overlay.style.display = 'none';
+              }
+              return;
             }
-          } catch (_) {}
-        }, true);
-      })();
+            // Use composedPath for shadow DOM support
+            const target = (e.composedPath && e.composedPath()[0]) || e.target;
+            const r = target.getBoundingClientRect();
+            const ov = __ensureOverlay();
+            ov.style.display = 'block';
+            // Reset color to default on each hover (fix: green stuck after click)
+            ov.style.borderColor = '#4F46E5';
+            ov.style.background = 'rgba(79,70,229,0.1)';
+            ov.style.top = r.top + 'px';
+            ov.style.left = r.left + 'px';
+            ov.style.width = r.width + 'px';
+            ov.style.height = r.height + 'px';
+          }, true);
+          document.addEventListener('click', (e) => {
+            if (!e.altKey) return;
+            e.preventDefault();
+            // Use stopPropagation instead of stopImmediatePropagation to avoid breaking page handlers
+            e.stopPropagation();
+            const el = (e.composedPath && e.composedPath()[0]) || e.target;
+            const ov = __ensureOverlay();
+            ov.style.borderColor = '#16A34A';
+            ov.style.background = 'rgba(22,163,74,0.15)';
+            const xpath = __xpath(el);
+            const text = __sanitize(el.textContent || '');
+            const data = { xpath: xpath, text: text, tag: el.tagName, timestamp_ms: Date.now() };
+            window.__cmuxPointedElement = data;
+            try {
+              if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.cmuxPointer) {
+                window.webkit.messageHandlers.cmuxPointer.postMessage(data);
+              }
+            } catch (_) {}
+          }, true);
+          // Reset overlay on blur/visibility change (prevents stuck state)
+          window.addEventListener('blur', () => {
+            if (__overlay) __overlay.style.display = 'none';
+          });
+          document.addEventListener('visibilitychange', () => {
+            if (document.hidden && __overlay) __overlay.style.display = 'none';
+          });
+        })();
+      }
 
       return true;
     })()
@@ -2631,12 +2634,13 @@ final class BrowserPanel: Panel, ObservableObject {
         )
     }
 
-    private var pointerMessageHandler: BrowserPointerMessageHandler?
+    private var pickerMessageHandler: BrowserPickerMessageHandler?
 
     private func bindWebView(_ webView: CmuxWebView) {
-        // Register Option+Click element pointer message handler
-        let handler = BrowserPointerMessageHandler(panelId: id, workspaceId: workspaceId)
-        pointerMessageHandler = handler
+        // Register Option+Click element picker message handler.
+        // Use a separate handler object to avoid retain cycles with WKUserContentController.
+        let handler = BrowserPickerMessageHandler()
+        pickerMessageHandler = handler
         webView.configuration.userContentController.add(handler, name: "cmuxPointer")
 
         webView.onContextMenuDownloadStateChanged = { [weak self] downloading in
@@ -3996,6 +4000,9 @@ final class BrowserPanel: Panel, ObservableObject {
         if let detachedDeveloperToolsWindowCloseObserver {
             NotificationCenter.default.removeObserver(detachedDeveloperToolsWindowCloseObserver)
         }
+        // Remove picker message handler to break WKUserContentController retain cycle
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxPointer")
+        pickerMessageHandler = nil
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
         let webView = webView

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -20,6 +20,9 @@ import Security
 /// sanitized summary to the focused terminal in the workspace.
 ///
 /// Security notes (terminal stdin injection):
+/// - A native NSEvent Option+Click must have occurred within 1 second
+///   of receiving the postMessage. This prevents page JS from calling
+///   postMessage directly without a real user click (zero-click attack).
 /// - All text from web content is sanitized before terminal injection.
 /// - Control characters (U+0000–U+001F, U+007F–U+009F) are stripped to
 ///   prevent ANSI escape sequence attacks and terminal command injection.
@@ -33,9 +36,31 @@ import Security
 final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     private let workspaceId: UUID
 
+    /// Timestamp of last native Option+Click detected via NSEvent monitor.
+    /// Used to validate that postMessage was triggered by a real user click,
+    /// not by malicious page JS calling postMessage directly.
+    private var lastNativeOptionClickTime: TimeInterval = 0
+    private var eventMonitor: Any?
+
+    /// Maximum allowed delay between native click and postMessage arrival.
+    private static let nativeEventWindowSeconds: TimeInterval = 1.0
+
     init(workspaceId: UUID) {
         self.workspaceId = workspaceId
         super.init()
+        // Monitor native mouse clicks with Option modifier
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
+            if event.modifierFlags.contains(.option) {
+                self?.lastNativeOptionClickTime = ProcessInfo.processInfo.systemUptime
+            }
+            return event
+        }
+    }
+
+    deinit {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
     }
 
     /// Strip control characters, newlines, and ANSI escape sequences.
@@ -55,6 +80,16 @@ final class BrowserPickerMessageHandler: NSObject, WKScriptMessageHandler {
     ) {
         guard message.name == "cmuxPointer" else { return }
         guard let body = message.body as? [String: Any] else { return }
+
+        // Security: verify a real native Option+Click occurred recently.
+        // Reject postMessage calls from page JS without a corresponding native event.
+        let now = ProcessInfo.processInfo.systemUptime
+        let elapsed = now - lastNativeOptionClickTime
+        guard elapsed < Self.nativeEventWindowSeconds else {
+            return  // No recent native Option+Click — likely a spoofed postMessage
+        }
+        // Invalidate the timestamp so each native click can only be used once
+        lastNativeOptionClickTime = 0
 
         let xpath = sanitize(body["xpath"] as? String ?? "")
         let rawText = sanitize(body["text"] as? String ?? "")
@@ -2686,6 +2721,12 @@ final class BrowserPanel: Panel, ObservableObject {
     private var pickerMessageHandler: BrowserPickerMessageHandler?
 
     private func bindWebView(_ webView: CmuxWebView) {
+        // Clean up previous picker handler to prevent NSEvent monitor leaks
+        // when bindWebView is called multiple times (profile change, context reset, etc.)
+        if pickerMessageHandler != nil {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxPointer")
+            pickerMessageHandler = nil
+        }
         // Register Option+Click element picker message handler.
         // Use a separate handler object to avoid retain cycles with WKUserContentController.
         let handler = BrowserPickerMessageHandler(workspaceId: workspaceId)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -239,11 +239,15 @@ class TerminalController {
     /// sequences. This prevents terminal command injection even if a malicious
     /// page crafts element text containing shell commands. The text is also
     /// truncated to 200 chars. Sanitization happens on both the JS side and
-    /// the Swift side (defense in depth) since `postMessage` can be called
-    /// directly by page scripts without a user click.
+    /// the Swift side (defense in depth). Additionally, the postMessage is
+    /// only accepted if a native NSEvent Option+Click occurred within 1 second
+    /// (see BrowserPickerMessageHandler).
+    ///
+    /// Multi-window: resolves the workspace via AppDelegate.workspaceFor(tabId:)
+    /// which searches across all windows, not just the active one.
     private func sendPickedElementToTerminal(workspaceId: UUID, summary: String) {
-        guard let tabManager = self.tabManager else { return }
-        guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+        // Resolve workspace across all windows (not just self.tabManager which is active-window only)
+        guard let ws = AppDelegate.shared?.workspaceFor(tabId: workspaceId) else { return }
         // Prefer the focused panel if it's a terminal
         if let focusedId = ws.focusedPanelId,
            let terminalPanel = ws.terminalPanel(for: focusedId),

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10,6 +10,7 @@ extension Notification.Name {
     static let terminalSurfaceHostedViewDidMoveToWindow = Notification.Name("cmux.terminalSurfaceHostedViewDidMoveToWindow")
     static let mainWindowContextsDidChange = Notification.Name("cmux.mainWindowContextsDidChange")
     static let browserDownloadEventDidArrive = Notification.Name("cmux.browserDownloadEventDidArrive")
+    static let browserElementPointed = Notification.Name("cmux.browserElementPointed")
 }
 
 /// Unix socket-based controller for programmatic terminal control
@@ -198,6 +199,7 @@ class TerminalController {
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
     private var browserDownloadObserver: NSObjectProtocol?
+    private var browserElementPointedObserver: NSObjectProtocol?
 
     private init() {
         browserDownloadObserver = NotificationCenter.default.addObserver(
@@ -212,6 +214,34 @@ class TerminalController {
                 var queue = self.v2BrowserDownloadEventsBySurface[surfaceId] ?? []
                 queue.append(event)
                 self.v2BrowserDownloadEventsBySurface[surfaceId] = queue
+            }
+        }
+
+        browserElementPointedObserver = NotificationCenter.default.addObserver(
+            forName: .browserElementPointed,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
+                  let summary = note.userInfo?["summary"] as? String else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.sendPointedElementToTerminal(workspaceId: workspaceId, summary: summary)
+            }
+        }
+    }
+
+    /// Find the first terminal surface in the workspace and send pointed element text to it
+    private func sendPointedElementToTerminal(workspaceId: UUID, summary: String) {
+        guard let tabManager = self.tabManager else { return }
+        guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+        // Find the first terminal panel in this workspace
+        for (panelId, _) in ws.panels {
+            if let terminalPanel = ws.terminalPanel(for: panelId),
+               let surface = terminalPanel.surface.surface {
+                sendSocketText(summary, surface: surface)
+                terminalPanel.surface.forceRefresh(reason: "browserElementPointed")
+                return
             }
         }
     }
@@ -2302,6 +2332,10 @@ class TerminalController {
             return v2Result(id: id, self.v2BrowserConsoleClear(params: params))
         case "browser.errors.list":
             return v2Result(id: id, self.v2BrowserErrorsList(params: params))
+        case "browser.pointed":
+            return v2Result(id: id, self.v2BrowserPointed(params: params))
+        case "browser.pointed.clear":
+            return v2Result(id: id, self.v2BrowserPointedClear(params: params))
         case "browser.highlight":
             return v2Result(id: id, self.v2BrowserHighlight(params: params))
         case "browser.state.save":
@@ -2554,6 +2588,8 @@ class TerminalController {
             "browser.console.list",
             "browser.console.clear",
             "browser.errors.list",
+            "browser.pointed",
+            "browser.pointed.clear",
             "browser.highlight",
             "browser.state.save",
             "browser.state.load",
@@ -9960,6 +9996,64 @@ class TerminalController {
                     "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
                     "errors": items.map(v2NormalizeJSValue),
                     "count": items.count
+                ])
+            }
+        }
+    }
+
+    private func v2BrowserPointed(params: [String: Any]) -> V2CallResult {
+        return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
+            v2BrowserEnsureTelemetryHooks(surfaceId: surfaceId, browserPanel: browserPanel)
+            let script = """
+            (() => {
+              const el = window.__cmuxPointedElement;
+              if (!el) return { ok: true, pointed: false, element: null };
+              return { ok: true, pointed: true, element: el };
+            })()
+            """
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
+            case .failure(let message):
+                return .err(code: "js_error", message: message, data: nil)
+            case .success(let value):
+                let dict = value as? [String: Any]
+                let pointed = (dict?["pointed"] as? Bool) ?? false
+                let element = dict?["element"]
+                if pointed, let element {
+                    return .ok([
+                        "workspace_id": ws.id.uuidString,
+                        "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                        "surface_id": surfaceId.uuidString,
+                        "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                        "pointed": true,
+                        "element": v2NormalizeJSValue(element)
+                    ])
+                } else {
+                    return .ok([
+                        "workspace_id": ws.id.uuidString,
+                        "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                        "surface_id": surfaceId.uuidString,
+                        "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                        "pointed": false,
+                        "message": "No element pointed. Use Option+Click in the browser to select an element."
+                    ])
+                }
+            }
+        }
+    }
+
+    private func v2BrowserPointedClear(params: [String: Any]) -> V2CallResult {
+        return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
+            let script = "window.__cmuxPointedElement = null; true"
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
+            case .failure(let message):
+                return .err(code: "js_error", message: message, data: nil)
+            case .success:
+                return .ok([
+                    "workspace_id": ws.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                    "surface_id": surfaceId.uuidString,
+                    "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                    "cleared": true
                 ])
             }
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10,7 +10,6 @@ extension Notification.Name {
     static let terminalSurfaceHostedViewDidMoveToWindow = Notification.Name("cmux.terminalSurfaceHostedViewDidMoveToWindow")
     static let mainWindowContextsDidChange = Notification.Name("cmux.mainWindowContextsDidChange")
     static let browserDownloadEventDidArrive = Notification.Name("cmux.browserDownloadEventDidArrive")
-    static let browserElementPointed = Notification.Name("cmux.browserElementPointed")
 }
 
 /// Unix socket-based controller for programmatic terminal control
@@ -199,8 +198,6 @@ class TerminalController {
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
     private var browserDownloadObserver: NSObjectProtocol?
-    private var browserElementPointedObserver: NSObjectProtocol?
-
     private init() {
         browserDownloadObserver = NotificationCenter.default.addObserver(
             forName: .browserDownloadEventDidArrive,
@@ -217,33 +214,6 @@ class TerminalController {
             }
         }
 
-        browserElementPointedObserver = NotificationCenter.default.addObserver(
-            forName: .browserElementPointed,
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
-            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
-                  let summary = note.userInfo?["summary"] as? String else { return }
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.sendPointedElementToTerminal(workspaceId: workspaceId, summary: summary)
-            }
-        }
-    }
-
-    /// Find the first terminal surface in the workspace and send pointed element text to it
-    private func sendPointedElementToTerminal(workspaceId: UUID, summary: String) {
-        guard let tabManager = self.tabManager else { return }
-        guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
-        // Find the first terminal panel in this workspace
-        for (panelId, _) in ws.panels {
-            if let terminalPanel = ws.terminalPanel(for: panelId),
-               let surface = terminalPanel.surface.surface {
-                sendSocketText(summary, surface: surface)
-                terminalPanel.surface.forceRefresh(reason: "browserElementPointed")
-                return
-            }
-        }
     }
 
     private nonisolated func withListenerState<T>(_ body: () -> T) -> T {
@@ -2336,6 +2306,8 @@ class TerminalController {
             return v2Result(id: id, self.v2BrowserPointed(params: params))
         case "browser.pointed.clear":
             return v2Result(id: id, self.v2BrowserPointedClear(params: params))
+        case "browser.picked.wait":
+            return v2Result(id: id, self.v2BrowserPickedWait(params: params))
         case "browser.highlight":
             return v2Result(id: id, self.v2BrowserHighlight(params: params))
         case "browser.state.save":
@@ -2590,6 +2562,7 @@ class TerminalController {
             "browser.errors.list",
             "browser.pointed",
             "browser.pointed.clear",
+            "browser.picked.wait",
             "browser.highlight",
             "browser.state.save",
             "browser.state.load",
@@ -10001,6 +9974,15 @@ class TerminalController {
         }
     }
 
+    /// Sanitize string from web content: strip control chars, newlines, ANSI escapes
+    private func v2SanitizeWebText(_ text: String) -> String {
+        let sanitized = text.unicodeScalars.filter { scalar in
+            // Allow printable ASCII (space through tilde) and non-ASCII unicode (emoji, CJK, etc.)
+            (scalar.value >= 0x20 && scalar.value <= 0x7E) || scalar.value > 0x9F
+        }
+        return String(String.UnicodeScalarView(sanitized)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func v2BrowserPointed(params: [String: Any]) -> V2CallResult {
         return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
             v2BrowserEnsureTelemetryHooks(surfaceId: surfaceId, browserPanel: browserPanel)
@@ -10008,6 +9990,8 @@ class TerminalController {
             (() => {
               const el = window.__cmuxPointedElement;
               if (!el) return { ok: true, pointed: false, element: null };
+              // Sanitize text on read (defense in depth)
+              if (el.text) el.text = el.text.replace(/[\\u0000-\\u001f\\u007f-\\u009f]/g, '').slice(0, 200).trim();
               return { ok: true, pointed: true, element: el };
             })()
             """
@@ -10039,6 +10023,98 @@ class TerminalController {
                 }
             }
         }
+    }
+
+    private func v2BrowserPickedWait(params: [String: Any]) -> V2CallResult {
+        let timeoutMs = max(1, v2Int(params, "timeout_ms") ?? 30_000)
+
+        var setupResult: V2CallResult?
+        var workspaceId: UUID?
+        var surfaceIdOut: UUID?
+        var webView: WKWebView?
+
+        v2MainSync {
+            guard let tabManager = self.v2ResolveTabManager(params: params) else {
+                setupResult = .err(code: "unavailable", message: "TabManager not available", data: nil)
+                return
+            }
+            guard let ws = self.v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                setupResult = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            let surfaceId = self.v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let surfaceId else {
+                setupResult = .err(code: "not_found", message: "No focused browser surface", data: nil)
+                return
+            }
+            guard let browserPanel = ws.browserPanel(for: surfaceId) else {
+                setupResult = .err(code: "invalid_params", message: "Surface is not a browser", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+            workspaceId = ws.id
+            surfaceIdOut = surfaceId
+            webView = browserPanel.webView
+
+            // Clear any previous selection before waiting
+            browserPanel.webView.evaluateJavaScript("window.__cmuxPointedElement = null; true") { _, _ in }
+        }
+
+        if let setupResult { return setupResult }
+        guard let workspaceId, let surfaceIdOut, let webView else {
+            return .err(code: "internal_error", message: "Failed to resolve browser surface", data: nil)
+        }
+
+        // Wait for user to Option+Click an element
+        let conditionScript = "window.__cmuxPointedElement !== null"
+        guard v2WaitForBrowserCondition(
+            webView,
+            surfaceId: surfaceIdOut,
+            conditionScript: conditionScript,
+            timeoutMs: timeoutMs
+        ) else {
+            return .err(code: "timeout", message: "No element picked before timeout", data: ["timeout_ms": timeoutMs])
+        }
+
+        // Element was picked — read the data
+        let readScript = """
+        (() => {
+          const el = window.__cmuxPointedElement;
+          if (!el) return { ok: true, picked: false, element: null };
+          window.__cmuxPointedElement = null;
+          return { ok: true, picked: true, element: el };
+        })()
+        """
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to read picked element", data: nil)
+        v2MainSync {
+            switch self.v2RunJavaScript(webView, script: readScript, timeout: 5.0, contentWorld: .page) {
+            case .failure(let message):
+                result = .err(code: "js_error", message: message, data: nil)
+            case .success(let value):
+                let dict = value as? [String: Any]
+                let picked = (dict?["picked"] as? Bool) ?? false
+                let element = dict?["element"]
+                if picked, let element {
+                    result = .ok([
+                        "workspace_id": workspaceId.uuidString,
+                        "workspace_ref": self.v2Ref(kind: .workspace, uuid: workspaceId),
+                        "surface_id": surfaceIdOut.uuidString,
+                        "surface_ref": self.v2Ref(kind: .surface, uuid: surfaceIdOut),
+                        "picked": true,
+                        "element": self.v2NormalizeJSValue(element)
+                    ])
+                } else {
+                    result = .ok([
+                        "workspace_id": workspaceId.uuidString,
+                        "workspace_ref": self.v2Ref(kind: .workspace, uuid: workspaceId),
+                        "surface_id": surfaceIdOut.uuidString,
+                        "surface_ref": self.v2Ref(kind: .surface, uuid: surfaceIdOut),
+                        "picked": false,
+                        "message": "Element was cleared before it could be read"
+                    ])
+                }
+            }
+        }
+        return result
     }
 
     private func v2BrowserPointedClear(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10,6 +10,7 @@ extension Notification.Name {
     static let terminalSurfaceHostedViewDidMoveToWindow = Notification.Name("cmux.terminalSurfaceHostedViewDidMoveToWindow")
     static let mainWindowContextsDidChange = Notification.Name("cmux.mainWindowContextsDidChange")
     static let browserDownloadEventDidArrive = Notification.Name("cmux.browserDownloadEventDidArrive")
+    static let browserElementPicked = Notification.Name("cmux.browserElementPicked")
 }
 
 /// Unix socket-based controller for programmatic terminal control
@@ -198,6 +199,8 @@ class TerminalController {
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
     private var browserDownloadObserver: NSObjectProtocol?
+    private var browserElementPickedObserver: NSObjectProtocol?
+
     private init() {
         browserDownloadObserver = NotificationCenter.default.addObserver(
             forName: .browserDownloadEventDidArrive,
@@ -214,6 +217,42 @@ class TerminalController {
             }
         }
 
+        browserElementPickedObserver = NotificationCenter.default.addObserver(
+            forName: .browserElementPicked,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
+                  let summary = note.userInfo?["summary"] as? String else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.sendPickedElementToTerminal(workspaceId: workspaceId, summary: summary)
+            }
+        }
+    }
+
+    /// Send picked element summary to the focused terminal in the workspace.
+    /// The summary is already sanitized (no control chars, newlines, or escape sequences).
+    private func sendPickedElementToTerminal(workspaceId: UUID, summary: String) {
+        guard let tabManager = self.tabManager else { return }
+        guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+        // Prefer the focused panel if it's a terminal
+        if let focusedId = ws.focusedPanelId,
+           let terminalPanel = ws.terminalPanel(for: focusedId),
+           let surface = terminalPanel.surface.surface {
+            sendSocketText(summary, surface: surface)
+            terminalPanel.surface.forceRefresh(reason: "browserElementPicked")
+            return
+        }
+        // Fallback: find any terminal panel in the workspace
+        for (panelId, _) in ws.panels {
+            if let terminalPanel = ws.terminalPanel(for: panelId),
+               let surface = terminalPanel.surface.surface {
+                sendSocketText(summary, surface: surface)
+                terminalPanel.surface.forceRefresh(reason: "browserElementPicked")
+                return
+            }
+        }
     }
 
     private nonisolated func withListenerState<T>(_ body: () -> T) -> T {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10048,8 +10048,14 @@ class TerminalController {
             case .success(let value):
                 let dict = value as? [String: Any]
                 let picked = (dict?["picked"] as? Bool) ?? false
-                let element = dict?["element"]
-                if picked, let element {
+                if picked, var element = dict?["element"] as? [String: Any] {
+                    // Swift-side sanitization (defense in depth)
+                    if let text = element["text"] as? String {
+                        element["text"] = v2SanitizeWebText(text)
+                    }
+                    if let xpath = element["xpath"] as? String {
+                        element["xpath"] = v2SanitizeWebText(xpath)
+                    }
                     return .ok([
                         "workspace_id": ws.id.uuidString,
                         "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
@@ -10140,8 +10146,14 @@ class TerminalController {
             case .success(let value):
                 let dict = value as? [String: Any]
                 let picked = (dict?["picked"] as? Bool) ?? false
-                let element = dict?["element"]
-                if picked, let element {
+                if picked, var element = dict?["element"] as? [String: Any] {
+                    // Swift-side sanitization (defense in depth)
+                    if let text = element["text"] as? String {
+                        element["text"] = self.v2SanitizeWebText(text)
+                    }
+                    if let xpath = element["xpath"] as? String {
+                        element["xpath"] = self.v2SanitizeWebText(xpath)
+                    }
                     result = .ok([
                         "workspace_id": workspaceId.uuidString,
                         "workspace_ref": self.v2Ref(kind: .workspace, uuid: workspaceId),

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2349,10 +2349,10 @@ class TerminalController {
             return v2Result(id: id, self.v2BrowserConsoleClear(params: params))
         case "browser.errors.list":
             return v2Result(id: id, self.v2BrowserErrorsList(params: params))
-        case "browser.pointed":
-            return v2Result(id: id, self.v2BrowserPointed(params: params))
-        case "browser.pointed.clear":
-            return v2Result(id: id, self.v2BrowserPointedClear(params: params))
+        case "browser.picked":
+            return v2Result(id: id, self.v2BrowserPicked(params: params))
+        case "browser.picked.clear":
+            return v2Result(id: id, self.v2BrowserPickedClear(params: params))
         case "browser.picked.wait":
             return v2Result(id: id, self.v2BrowserPickedWait(params: params))
         case "browser.highlight":
@@ -2607,8 +2607,8 @@ class TerminalController {
             "browser.console.list",
             "browser.console.clear",
             "browser.errors.list",
-            "browser.pointed",
-            "browser.pointed.clear",
+            "browser.picked",
+            "browser.picked.clear",
             "browser.picked.wait",
             "browser.highlight",
             "browser.state.save",
@@ -10030,16 +10030,16 @@ class TerminalController {
         return String(String.UnicodeScalarView(sanitized)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func v2BrowserPointed(params: [String: Any]) -> V2CallResult {
+    private func v2BrowserPicked(params: [String: Any]) -> V2CallResult {
         return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
             v2BrowserEnsureTelemetryHooks(surfaceId: surfaceId, browserPanel: browserPanel)
             let script = """
             (() => {
               const el = window.__cmuxPointedElement;
-              if (!el) return { ok: true, pointed: false, element: null };
+              if (!el) return { ok: true, picked: false, element: null };
               // Sanitize text on read (defense in depth)
               if (el.text) el.text = el.text.replace(/[\\u0000-\\u001f\\u007f-\\u009f]/g, '').slice(0, 200).trim();
-              return { ok: true, pointed: true, element: el };
+              return { ok: true, picked: true, element: el };
             })()
             """
             switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
@@ -10047,15 +10047,15 @@ class TerminalController {
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
                 let dict = value as? [String: Any]
-                let pointed = (dict?["pointed"] as? Bool) ?? false
+                let picked = (dict?["picked"] as? Bool) ?? false
                 let element = dict?["element"]
-                if pointed, let element {
+                if picked, let element {
                     return .ok([
                         "workspace_id": ws.id.uuidString,
                         "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
                         "surface_id": surfaceId.uuidString,
                         "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
-                        "pointed": true,
+                        "picked": true,
                         "element": v2NormalizeJSValue(element)
                     ])
                 } else {
@@ -10064,8 +10064,8 @@ class TerminalController {
                         "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
                         "surface_id": surfaceId.uuidString,
                         "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
-                        "pointed": false,
-                        "message": "No element pointed. Use Option+Click in the browser to select an element."
+                        "picked": false,
+                        "message": "No element picked. Use Option+Click in the browser to select an element."
                     ])
                 }
             }
@@ -10122,11 +10122,12 @@ class TerminalController {
             return .err(code: "timeout", message: "No element picked before timeout", data: ["timeout_ms": timeoutMs])
         }
 
-        // Element was picked — read the data
+        // Element was picked — read the data with JS-side re-sanitization (defense in depth)
         let readScript = """
         (() => {
           const el = window.__cmuxPointedElement;
           if (!el) return { ok: true, picked: false, element: null };
+          if (el.text) el.text = el.text.replace(/[\\u0000-\\u001f\\u007f-\\u009f]/g, '').slice(0, 200).trim();
           window.__cmuxPointedElement = null;
           return { ok: true, picked: true, element: el };
         })()
@@ -10164,7 +10165,7 @@ class TerminalController {
         return result
     }
 
-    private func v2BrowserPointedClear(params: [String: Any]) -> V2CallResult {
+    private func v2BrowserPickedClear(params: [String: Any]) -> V2CallResult {
         return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
             let script = "window.__cmuxPointedElement = null; true"
             switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10025,13 +10025,28 @@ class TerminalController {
         }
     }
 
-    /// Sanitize string from web content: strip control chars, newlines, ANSI escapes
+    /// Dangerous Unicode scalars: BiDi overrides, zero-width chars
+    private static let dangerousScalars: Set<UInt32> = [
+        0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0xFEFF,
+        0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+        0x2066, 0x2067, 0x2068, 0x2069
+    ]
+
+    private func v2SanitizeScalar(_ scalar: Unicode.Scalar) -> Bool {
+        ((scalar.value >= 0x20 && scalar.value <= 0x7E) || scalar.value > 0x9F)
+        && !Self.dangerousScalars.contains(scalar.value)
+    }
+
+    /// Sanitize text from web content: strip control chars + BiDi/zero-width, truncate to 200 chars
     private func v2SanitizeWebText(_ text: String) -> String {
-        let sanitized = text.unicodeScalars.filter { scalar in
-            // Allow printable ASCII (space through tilde) and non-ASCII unicode (emoji, CJK, etc.)
-            (scalar.value >= 0x20 && scalar.value <= 0x7E) || scalar.value > 0x9F
-        }
+        let sanitized = text.unicodeScalars.filter { v2SanitizeScalar($0) }
         return String(String.UnicodeScalarView(sanitized)).prefix(200).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Sanitize xpath from web content: strip control chars + BiDi/zero-width, cap at 2000 chars
+    private func v2SanitizeXPath(_ xpath: String) -> String {
+        let sanitized = xpath.unicodeScalars.filter { v2SanitizeScalar($0) }
+        return String(String.UnicodeScalarView(sanitized)).prefix(2000).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func v2BrowserPicked(params: [String: Any]) -> V2CallResult {
@@ -10052,21 +10067,21 @@ class TerminalController {
             case .success(let value):
                 let dict = value as? [String: Any]
                 let picked = (dict?["picked"] as? Bool) ?? false
-                if picked, var element = dict?["element"] as? [String: Any] {
-                    // Swift-side sanitization (defense in depth)
-                    if let text = element["text"] as? String {
-                        element["text"] = v2SanitizeWebText(text)
-                    }
-                    if let xpath = element["xpath"] as? String {
-                        element["xpath"] = v2SanitizeWebText(xpath)
-                    }
+                if picked, let raw = dict?["element"] as? [String: Any] {
+                    // Whitelist-based sanitization: only return known safe fields
+                    let element: [String: Any] = [
+                        "xpath": v2SanitizeXPath(raw["xpath"] as? String ?? ""),
+                        "text": v2SanitizeWebText(raw["text"] as? String ?? ""),
+                        "tag": v2SanitizeWebText(raw["tag"] as? String ?? ""),
+                        "timestamp_ms": (raw["timestamp_ms"] as? NSNumber) ?? 0
+                    ]
                     return .ok([
                         "workspace_id": ws.id.uuidString,
                         "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
                         "surface_id": surfaceId.uuidString,
                         "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
                         "picked": true,
-                        "element": v2NormalizeJSValue(element)
+                        "element": element
                     ])
                 } else {
                     return .ok([
@@ -10112,8 +10127,20 @@ class TerminalController {
             surfaceIdOut = surfaceId
             webView = browserPanel.webView
 
-            // Clear any previous selection before waiting
-            browserPanel.webView.evaluateJavaScript("window.__cmuxPointedElement = null; true") { _, _ in }
+            // Clear any previous selection synchronously before waiting
+            // (fire-and-forget evaluateJavaScript would race with v2WaitForBrowserCondition)
+            switch self.v2RunJavaScript(
+                browserPanel.webView,
+                script: "window.__cmuxPointedElement = null; true",
+                timeout: 5.0,
+                contentWorld: .page
+            ) {
+            case .failure(let message):
+                setupResult = .err(code: "js_error", message: message, data: nil)
+                return
+            case .success:
+                break
+            }
         }
 
         if let setupResult { return setupResult }
@@ -10150,21 +10177,21 @@ class TerminalController {
             case .success(let value):
                 let dict = value as? [String: Any]
                 let picked = (dict?["picked"] as? Bool) ?? false
-                if picked, var element = dict?["element"] as? [String: Any] {
-                    // Swift-side sanitization (defense in depth)
-                    if let text = element["text"] as? String {
-                        element["text"] = self.v2SanitizeWebText(text)
-                    }
-                    if let xpath = element["xpath"] as? String {
-                        element["xpath"] = self.v2SanitizeWebText(xpath)
-                    }
+                if picked, let raw = dict?["element"] as? [String: Any] {
+                    // Whitelist-based sanitization: only return known safe fields
+                    let element: [String: Any] = [
+                        "xpath": self.v2SanitizeXPath(raw["xpath"] as? String ?? ""),
+                        "text": self.v2SanitizeWebText(raw["text"] as? String ?? ""),
+                        "tag": self.v2SanitizeWebText(raw["tag"] as? String ?? ""),
+                        "timestamp_ms": (raw["timestamp_ms"] as? NSNumber) ?? 0
+                    ]
                     result = .ok([
                         "workspace_id": workspaceId.uuidString,
                         "workspace_ref": self.v2Ref(kind: .workspace, uuid: workspaceId),
                         "surface_id": surfaceIdOut.uuidString,
                         "surface_ref": self.v2Ref(kind: .surface, uuid: surfaceIdOut),
                         "picked": true,
-                        "element": self.v2NormalizeJSValue(element)
+                        "element": element
                     ])
                 } else {
                     result = .ok([

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -232,7 +232,15 @@ class TerminalController {
     }
 
     /// Send picked element summary to the focused terminal in the workspace.
-    /// The summary is already sanitized (no control chars, newlines, or escape sequences).
+    ///
+    /// Security: the `summary` string has already been sanitized by
+    /// `BrowserPickerMessageHandler.sanitize()` which strips all control
+    /// characters (U+0000–U+001F, U+007F–U+009F), newlines, and ANSI escape
+    /// sequences. This prevents terminal command injection even if a malicious
+    /// page crafts element text containing shell commands. The text is also
+    /// truncated to 200 chars. Sanitization happens on both the JS side and
+    /// the Swift side (defense in depth) since `postMessage` can be called
+    /// directly by page scripts without a user click.
     private func sendPickedElementToTerminal(workspaceId: UUID, summary: String) {
         guard let tabManager = self.tabManager else { return }
         guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1130,6 +1130,10 @@ final class WindowTerminalPortal: NSObject {
 
         synchronizeHostedView(withId: hostedId)
         scheduleDeferredFullSynchronizeAll()
+        // Session/window restore can queue additional ancestor layout shifts (sidebar width,
+        // split positions) after the initial bind tick. Queue a later external sync so the
+        // portal catches that settled geometry instead of staying at the seeded frame.
+        scheduleExternalGeometrySynchronize()
         pruneDeadEntries()
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2939,6 +2939,83 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testBindQueuesExternalGeometrySyncForQueuedLayoutShift() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let shiftedContainer = NSView(frame: NSRect(x: 40, y: 60, width: 260, height: 180))
+        contentView.addSubview(shiftedContainer)
+        let anchor = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 180))
+        shiftedContainer.addSubview(anchor)
+        let hosted = surface.hostedView
+        TerminalWindowPortalRegistry.bind(
+            hostedView: hosted,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+
+        let anchorCenter = NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY)
+        let originalWindowPoint = anchor.convert(anchorCenter, to: nil)
+        let originalAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(originalWindowPoint, in: window),
+            "Initial hit-testing should resolve the portal-hosted terminal at its original window position"
+        )
+
+        DispatchQueue.main.async {
+            shiftedContainer.frame.origin.x += 72
+            contentView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+        }
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        let shiftedAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertGreaterThan(
+            shiftedAnchorFrameInWindow.minX,
+            originalAnchorFrameInWindow.minX + 1,
+            "The queued layout shift should move the anchor to the right"
+        )
+        let retiredStaleWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.minX + shiftedAnchorFrameInWindow.minX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        let shiftedWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.maxX + shiftedAnchorFrameInWindow.maxX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        XCTAssertNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(retiredStaleWindowPoint, in: window),
+            "Bind should queue a later external sync so restore-like ancestor shifts do not leave a stale portal in the sidebar region"
+        )
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
+            "Bind should refresh the portal after queued ancestor layout settles"
+        )
+    }
+
     func testScheduledExternalGeometrySyncKeepsDragDrivenResizeResponsive() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),


### PR DESCRIPTION
## Summary

Adds native element selection in the built-in browser via Option+Click, enabling AI coding agents to receive element context directly from user interaction.

- **Option+Click** on any DOM element → sanitized `[picked] /xpath "text"` sent to focused terminal
- **Socket API**: `browser.pointed` (read), `browser.pointed.clear` (reset), `browser.picked.wait` (blocking wait with timeout)
- **Hover overlay**: blue highlight on mouseover while Alt is held, green on selection
- **Security**: all web content sanitized on both JS and Swift sides — control chars, newlines, ANSI escapes stripped; text truncated to 200 chars

Resolves #1975

### Architecture

```
Option+Click → JS (xpath + sanitized text)
  → webkit.messageHandlers.cmuxPointer
  → BrowserPickerMessageHandler (Swift sanitization)
  → NotificationCenter
  → TerminalController.sendPickedElementToTerminal()
```

### Security measures

- Dual sanitization (JS + Swift defense in depth)
- `stopPropagation` instead of `stopImmediatePropagation` (avoids breaking page handlers)
- `e.altKey` check instead of keydown/keyup tracking (avoids stuck-Alt issues)
- Non-enumerable globals (reduces CAPTCHA fingerprinting)
- `removeScriptMessageHandler` in deinit (prevents WKUserContentController retain cycle)
- `composedPath()[0]` for shadow DOM support
- `aria-hidden` + `role="presentation"` on overlay element
- `prefers-reduced-motion` support

## Testing

- Built and tested locally on macOS with Naver, GitHub, example.com
- Option+Click correctly captures xpath + text and sends to terminal
- Socket API (`browser.pointed`, `browser.picked.wait`) returns structured JSON
- Overlay highlights on hover, resets on blur/visibility change
- Existing unit tests pass (test runner env issue unrelated to changes)

## Demo Video

<!-- GIF will be added as a comment -->

## Review Trigger

@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review

## Checklist

- [x] Tested locally
- [x] Security review conducted (10 reviewers, all findings addressed)
- [ ] Added tests (pending — will add based on maintainer feedback on scope)
- [ ] Updated docs
- [x] Requested bot reviews
- [ ] Resolved review comments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Option+Click element picker to the built-in browser. It sends a sanitized element summary to the focused terminal and exposes socket APIs so agents can read picks programmatically.

- **New Features**
  - Option+Click on any DOM element sends `[picked] /xpath "text"` to the focused terminal, with fallback to any terminal in the workspace.
  - Socket API: `browser.picked` (read), `browser.picked.clear` (reset), `browser.picked.wait` (blocking wait with timeout).
  - Hover overlay highlights elements (blue on hover, green on pick), supports shadow DOM, and resets on blur/visibility change.
  - Security: native Option+Click gate (1s window) with source validation (window + hit-test) before accepting `postMessage`; dual JS + Swift sanitization (strips control chars, newlines, ANSI, zero‑width/BiDi), 200‑char text and 2000‑char XPath caps; non‑enumerable globals; message handler cleanup.

- **Bug Fixes**
  - Unified API naming from `browser.pointed*` to `browser.picked*`; both `browser.picked` and `browser.picked.wait` sanitize via `v2SanitizeWebText`/`v2SanitizeXPath` and return only whitelisted fields: `xpath`, `text`, `tag`, `timestamp_ms`.
  - Fixed multi‑window routing to find the focused terminal across windows; kept `workspaceId` in sync; removed previous handler on re‑bind to avoid NSEvent monitor leaks and called `removeScriptMessageHandler` on the old web view.
  - `browser.picked.wait` clears previous picks synchronously to avoid races before waiting.
  - Split `BrowserPickerMessageHandler` sanitizers: 200‑char cap for text and 2000‑char cap for XPath to prevent XPath truncation on deep DOMs.

<sup>Written for commit 3b2129d5bd3ef3fe5d9463381eec7e5d1dc678a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option+Click element picker with hover overlay to visually select and capture text from web pages.
  * Picked elements can be injected into terminal input (focused surface or first available).
  * New operations: read current pick, wait-for-pick with timeout, and clear pick; captured text/xpath/tag are sanitized and truncated.

* **Bug Fixes**
  * Improved reliability across workspace changes and when opening/closing web views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->