### PR TITLE
docs: Claude Code hooks for tab auto-naming and /rename sync

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -732,6 +732,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupMultiWindowNotificationsUITest = false
     private var didSetupDisplayResolutionUITestDiagnostics = false
     private var displayResolutionUITestObservers: [NSObjectProtocol] = []
+    private var didRequestFallbackUITestWindow = false
     private struct UITestRenderDiagnosticsSnapshot {
         let panelId: UUID
         let drawCount: Int
@@ -1109,18 +1110,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-                guard let self else { return }
-                if NSApp.windows.isEmpty {
-                    self.openNewMainWindow(nil)
-                }
-                self.moveUITestWindowToTargetDisplayIfNeeded()
-                NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
-                // On headless CI runners, activate() silently fails (no GUI session).
-                // Force windows visible so the terminal surface starts rendering.
-                for window in NSApp.windows {
-                    window.orderFrontRegardless()
-                }
-                self.writeUITestDiagnosticsIfNeeded(stage: "afterForceWindow")
+                self?.stabilizeUITestLaunchWindowAndForeground()
             }
             if env["CMUX_UI_TEST_BROWSER_IMPORT_HINT_OPEN_BLANK_BROWSER"] == "1" {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) { [weak self] in
@@ -1146,6 +1136,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
 #if DEBUG
+    // Retry launch stabilization until a delayed WindowGroup materialization produces
+    // a visible key window that XCUITest can bring to the foreground on the shared VM.
+    private func stabilizeUITestLaunchWindowAndForeground(attempt: Int = 0) {
+        let env = ProcessInfo.processInfo.environment
+        guard isRunningUnderXCTest(env) else { return }
+
+        if NSApp.windows.isEmpty, !didRequestFallbackUITestWindow {
+            didRequestFallbackUITestWindow = true
+            openNewMainWindow(nil)
+        }
+
+        moveUITestWindowToTargetDisplayIfNeeded()
+        activateUITestAppIfNeeded()
+
+        let hasWindow = !NSApp.windows.isEmpty
+        let hasVisibleWindow = NSApp.windows.contains { $0.isVisible }
+        let hasKeyWindow = NSApp.keyWindow != nil
+        let stage = attempt == 0 ? "afterForceWindow" : "afterForceWindow.retry\(attempt)"
+        writeUITestDiagnosticsIfNeeded(stage: stage)
+
+        guard attempt < 20 else { return }
+        if !hasWindow || !hasVisibleWindow || !hasKeyWindow || !NSRunningApplication.current.isActive {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.stabilizeUITestLaunchWindowAndForeground(attempt: attempt + 1)
+            }
+        }
+    }
+
+    private func activateUITestAppIfNeeded() {
+        if let window = NSApp.windows.first {
+            window.makeKeyAndOrderFront(nil)
+            window.orderFrontRegardless()
+        }
+        if #available(macOS 14.0, *) {
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
+        } else {
+            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        }
+    }
+
     private func writeUITestDiagnosticsIfNeeded(stage: String) {
         let env = ProcessInfo.processInfo.environment
         guard let path = env["CMUX_UI_TEST_DIAGNOSTICS_PATH"], !path.isEmpty else { return }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -732,7 +732,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupMultiWindowNotificationsUITest = false
     private var didSetupDisplayResolutionUITestDiagnostics = false
     private var displayResolutionUITestObservers: [NSObjectProtocol] = []
-    private var didRequestFallbackUITestWindow = false
+    private weak var fallbackUITestWindow: NSWindow?
     private struct UITestRenderDiagnosticsSnapshot {
         let panelId: UUID
         let drawCount: Int
@@ -1142,12 +1142,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let env = ProcessInfo.processInfo.environment
         guard isRunningUnderXCTest(env) else { return }
 
-        if NSApp.windows.isEmpty, !didRequestFallbackUITestWindow {
-            didRequestFallbackUITestWindow = true
+        if NSApp.windows.isEmpty, fallbackUITestWindow == nil {
+            // WindowGroup hasn't materialized yet — force-create a fallback window.
+            // Store a weak reference so we can close it if the real window appears later.
             openNewMainWindow(nil)
+            fallbackUITestWindow = NSApp.windows.first
         }
 
-        moveUITestWindowToTargetDisplayIfNeeded()
+        // Only start the display-move retry chain on the first attempt.
+        // moveUITestWindowToTargetDisplayIfNeeded() schedules its own 20-step retry;
+        // calling it on every pass of this outer loop would fan out into overlapping timers.
+        if attempt == 0 {
+            moveUITestWindowToTargetDisplayIfNeeded()
+        }
         activateUITestAppIfNeeded()
 
         let hasWindow = !NSApp.windows.isEmpty
@@ -3456,6 +3463,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if window.isKeyWindow {
             setActiveMainWindow(window)
         }
+
+        #if DEBUG
+        // If a forced fallback window was created during UI test launch stabilization,
+        // close it once a real WindowGroup window registers to avoid two main windows.
+        if let fallback = fallbackUITestWindow, fallback !== window, mainWindowContexts.count > 1 {
+            fallbackUITestWindow = nil
+            fallback.close()
+        }
+        #endif
 
         attemptStartupSessionRestoreIfNeeded(primaryWindow: window)
         if !isTerminatingApp {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1165,6 +1165,10 @@ final class WindowTerminalPortal: NSObject {
 
         synchronizeHostedView(withId: hostedId)
         scheduleDeferredFullSynchronizeAll()
+        // Session/window restore can queue additional ancestor layout shifts (sidebar width,
+        // split positions) after the initial bind tick. Queue a later external sync so the
+        // portal catches that settled geometry instead of staying at the seeded frame.
+        scheduleExternalGeometrySynchronize()
         pruneDeadEntries()
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3590,6 +3590,83 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testBindQueuesExternalGeometrySyncForQueuedLayoutShift() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let shiftedContainer = NSView(frame: NSRect(x: 40, y: 60, width: 260, height: 180))
+        contentView.addSubview(shiftedContainer)
+        let anchor = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 180))
+        shiftedContainer.addSubview(anchor)
+        let hosted = surface.hostedView
+        TerminalWindowPortalRegistry.bind(
+            hostedView: hosted,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+
+        let anchorCenter = NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY)
+        let originalWindowPoint = anchor.convert(anchorCenter, to: nil)
+        let originalAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(originalWindowPoint, in: window),
+            "Initial hit-testing should resolve the portal-hosted terminal at its original window position"
+        )
+
+        DispatchQueue.main.async {
+            shiftedContainer.frame.origin.x += 72
+            contentView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+        }
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        let shiftedAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertGreaterThan(
+            shiftedAnchorFrameInWindow.minX,
+            originalAnchorFrameInWindow.minX + 1,
+            "The queued layout shift should move the anchor to the right"
+        )
+        let retiredStaleWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.minX + shiftedAnchorFrameInWindow.minX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        let shiftedWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.maxX + shiftedAnchorFrameInWindow.maxX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        XCTAssertNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(retiredStaleWindowPoint, in: window),
+            "Bind should queue a later external sync so restore-like ancestor shifts do not leave a stale portal in the sidebar region"
+        )
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
+            "Bind should refresh the portal after queued ancestor layout settles"
+        )
+    }
+
     func testScheduledExternalGeometrySyncKeepsDragDrivenResizeResponsive() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),

--- a/docs/claude-code-hooks-integration.md
+++ b/docs/claude-code-hooks-integration.md
@@ -1,0 +1,123 @@
+# Claude Code Hooks Integration
+
+cmux includes built-in Claude Code integration via `cmux claude-hook`, which manages workspace status indicators (`✳`/`⠂` prefixes) and session lifecycle. This document describes additional Claude Code hooks that enhance the experience with **auto-generated tab names** and **instant `/rename` sync**.
+
+## Overview
+
+cmux natively names workspaces from Claude Code's terminal title (OSC 2). These hooks add two capabilities:
+
+| Hook | Event | Purpose |
+|------|-------|---------|
+| `cmux-tab-sync.sh` | `Stop` | Auto-summarize session focus → tab name |
+| `cmux-rename-sync.sh` | `UserPromptSubmit` | Sync `/rename` → workspace name instantly |
+| `cmux-session-start.sh` | `SessionStart` | Reset workspace name for new sessions |
+
+### Why tab names matter
+
+In a workspace with multiple tabs (e.g., one Claude session + helper terminals), all tabs default to mirroring the workspace name. These hooks give each tab a concise, auto-generated summary of its current conversation focus — making it easy to distinguish tabs at a glance.
+
+## Setup
+
+### 1. Install hook scripts
+
+Copy the three scripts to your Claude Code hooks directory:
+
+```bash
+mkdir -p ~/.claude/hooks
+cp docs/examples/cmux-tab-sync.sh ~/.claude/hooks/
+cp docs/examples/cmux-rename-sync.sh ~/.claude/hooks/
+cp docs/examples/cmux-session-start.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/cmux-tab-sync.sh
+chmod +x ~/.claude/hooks/cmux-rename-sync.sh
+chmod +x ~/.claude/hooks/cmux-session-start.sh
+```
+
+### 2. Register hooks in Claude Code settings
+
+Add the following to `~/.claude/settings.json` under `"hooks"`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cmux-rename-sync.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cmux-tab-sync.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cmux-session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **Note:** If you already have hooks configured for these events, add the cmux hooks to the existing arrays.
+
+## How it works
+
+### Tab name auto-summary (`cmux-tab-sync.sh`)
+
+Fires on the `Stop` event (after each Claude response). Reads the session transcript JSONL:
+
+- **First 3 user messages** — captures the session's original goal
+- **Last 5 messages** (user + assistant) — captures the current focus
+
+Extracts the most frequent meaningful keywords (2-5 words, mixed Chinese/English), and calls `cmux rename-tab --surface $CMUX_SURFACE_ID`.
+
+Examples of generated tab names:
+- `Fix auth bug login` (from "fix the authentication bug in login.py")
+- `cmux skill rename` (from a session about building cmux integration)
+- `Add unit tests API` (from "add unit tests for the API endpoints")
+
+### `/rename` workspace sync (`cmux-rename-sync.sh`)
+
+Fires on `UserPromptSubmit`. Checks the transcript for `custom-title` entries (written by `/rename`). If found, immediately syncs to `cmux rename-workspace`.
+
+### Session start reset (`cmux-session-start.sh`)
+
+Fires on `SessionStart`. Resets the workspace name to the working directory basename, clearing any stale `/rename` from a previous session. cmux's native OSC 2 integration then takes over with the new session's auto-generated title.
+
+## Architecture
+
+```
+Workspace name (sidebar):
+  Priority 1: /rename → cmux-rename-sync.sh (UserPromptSubmit) → rename-workspace
+  Priority 2: Claude Code auto-title → OSC 2 → cmux native (ghosttyDidSetTitle)
+  Priority 3: cwd basename → cmux-session-start.sh (SessionStart)
+
+Tab name (tab bar):
+  Always: transcript summary → cmux-tab-sync.sh (Stop) → rename-tab
+```
+
+All hooks are guarded by `[ -z "$CMUX_WORKSPACE_ID" ] && exit 0` — they no-op outside cmux.
+
+## Performance
+
+- `cmux-tab-sync.sh`: ~0.35s (reads head/tail of transcript, not full scan)
+- `cmux-rename-sync.sh`: ~0.35s (tail + grep for custom-title)
+- `cmux-session-start.sh`: ~0.05s (single rename-workspace call)

--- a/docs/examples/cmux-rename-sync.sh
+++ b/docs/examples/cmux-rename-sync.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Hook: Immediately sync /rename to cmux workspace name
+# Triggered on: UserPromptSubmit
+# Lightweight — no Python, no summarization. Just tail + grep.
+set -e
+
+INPUT=$(cat)
+
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+# Extract transcript path
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+[ -z "$TRANSCRIPT" ] && exit 0
+[ -f "$TRANSCRIPT" ] || exit 0
+
+# Fast: grep last custom-title from transcript tail
+TITLE=$(tail -500 "$TRANSCRIPT" | grep '"custom-title"' | tail -1 | python3 -c "
+import sys,json
+try:
+    print(json.loads(sys.stdin.readline()).get('customTitle',''))
+except: pass
+" 2>/dev/null)
+
+[ -z "$TITLE" ] && exit 0
+
+# Only rename if workspace name differs (avoid unnecessary calls)
+CURRENT=$(cmux list-workspaces 2>/dev/null | grep '\[selected\]' | sed 's/.*  //;s/  \[selected\]//')
+if [ "$CURRENT" != "$TITLE" ]; then
+  cmux rename-workspace "$TITLE" 2>/dev/null || true
+fi

--- a/docs/examples/cmux-rename-sync.sh
+++ b/docs/examples/cmux-rename-sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Hook: Immediately sync /rename to cmux workspace name
 # Triggered on: UserPromptSubmit
-# Lightweight — no Python, no summarization. Just tail + grep.
+# Lightweight — minimal Python for JSON parsing only. Just tail + grep.
 set -e
 
 INPUT=$(cat)
@@ -10,7 +10,7 @@ INPUT=$(cat)
 command -v cmux &>/dev/null || exit 0
 
 # Extract transcript path
-TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
 [ -z "$TRANSCRIPT" ] && exit 0
 [ -f "$TRANSCRIPT" ] || exit 0
 

--- a/docs/examples/cmux-session-start.sh
+++ b/docs/examples/cmux-session-start.sh
@@ -11,7 +11,7 @@ INPUT=$(cat)
 command -v cmux &>/dev/null || exit 0
 
 # Extract session cwd for a reasonable default workspace name
-CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null)
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)
 
 if [ -n "$CWD" ]; then
   # Use basename of cwd as temporary workspace name

--- a/docs/examples/cmux-session-start.sh
+++ b/docs/examples/cmux-session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Hook: Reset cmux workspace name on new Claude Code session
+# Triggered on: SessionStart
+# Clears any previous /rename workspace override so cmux's native
+# auto-title (via OSC 2) can take effect for the new session.
+set -e
+
+INPUT=$(cat)
+
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+# Extract session cwd for a reasonable default workspace name
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null)
+
+if [ -n "$CWD" ]; then
+  # Use basename of cwd as temporary workspace name
+  # cmux's native auto-title will override this once Claude generates a session title
+  BASENAME=$(basename "$CWD")
+  cmux rename-workspace "$BASENAME" 2>/dev/null || true
+fi

--- a/docs/examples/cmux-tab-sync.sh
+++ b/docs/examples/cmux-tab-sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Hook: Sync Claude Code session focus to cmux tab/workspace name
 # Triggered on: Stop (after Claude finishes each response)
-# Reads transcript JSONL efficiently (head+tail, not full scan)
+# Reads transcript JSONL (first 300 + last 200 lines, not full parse)
 # Global hook — no-ops outside cmux.
 set -e
 
@@ -10,7 +10,7 @@ INPUT=$(cat)
 [ -z "$CMUX_WORKSPACE_ID" ] && exit 0
 command -v cmux &>/dev/null || exit 0
 
-TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
 [ -z "$TRANSCRIPT" ] && exit 0
 [ -f "$TRANSCRIPT" ] || exit 0
 
@@ -93,24 +93,28 @@ def summarize(texts):
         if w.lower() not in seen:
             seen.add(w.lower())
             deduped.append(w)
-    # Build label: 2-4 words, max 25 chars
-    for n in (4, 3, 2):
+    # Build label: 2-5 words, max 25 chars
+    for n in (5, 4, 3, 2):
         label = ' '.join(deduped[:n])
         if len(label) <= 25:
             return label
     return deduped[0][:25] if deduped else ''
 
-# --- Read transcript efficiently: only parse what we need ---
-lines = []
-with open(TRANSCRIPT, 'r') as f:
-    lines = f.readlines()
+# --- Read transcript efficiently: head (first 300) + tail (last 200) ---
+import subprocess
+head_lines = subprocess.run(
+    ['head', '-300', TRANSCRIPT], capture_output=True, text=True
+).stdout.splitlines()
+tail_lines = subprocess.run(
+    ['tail', '-200', TRANSCRIPT], capture_output=True, text=True
+).stdout.splitlines()
 
-if not lines:
+if not head_lines and not tail_lines:
     sys.exit(0)
 
-# First 3 user messages — scan from start, stop early
+# First 3 user messages — scan from head
 first_user = []
-for raw in lines[:300]:  # first 300 lines is enough to find 3 user msgs
+for raw in head_lines:
     try:
         e = json.loads(raw)
         if e.get('type') == 'user':
@@ -120,9 +124,9 @@ for raw in lines[:300]:  # first 300 lines is enough to find 3 user msgs
                 if len(first_user) >= 3: break
     except: pass
 
-# Last 5 user+assistant messages — scan from end
+# Last 5 user+assistant messages — scan from tail (reversed)
 last_msgs = []
-for raw in reversed(lines[-200:]):
+for raw in reversed(tail_lines):
     try:
         e = json.loads(raw)
         if e.get('type') in ('user', 'assistant'):

--- a/docs/examples/cmux-tab-sync.sh
+++ b/docs/examples/cmux-tab-sync.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Hook: Sync Claude Code session focus to cmux tab/workspace name
+# Triggered on: Stop (after Claude finishes each response)
+# Reads transcript JSONL efficiently (head+tail, not full scan)
+# Global hook — no-ops outside cmux.
+set -e
+
+INPUT=$(cat)
+
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null)
+[ -z "$TRANSCRIPT" ] && exit 0
+[ -f "$TRANSCRIPT" ] || exit 0
+
+LABEL=$(_TRANSCRIPT="$TRANSCRIPT" python3 -c "
+import json, re, os, sys, collections
+
+TRANSCRIPT = os.environ['_TRANSCRIPT']
+
+STOP_WORDS = frozenset({
+    'please','can','you','the','a','an','i','want','to','me',
+    'need','help','with','this','that','for','in','on','it',
+    'is','my','do','let','lets','make','also','and','or','but',
+    'would','should','could','just','some','all','any','be',
+    'have','has','had','will','shall','may','might','must',
+    'so','very','really','from','into','about','how','what',
+    'when','where','which','who','why','if','then','there',
+    'here','these','those','them','their','its','our','your',
+    'we','they','he','she','of','at','by','up','out','look',
+    'go','see','know','get','give','take','put','tell','say',
+    'try','use','way','new','now','one','two','not','no','yes',
+    'ok','sure','done','thanks','right','well','think','like',
+    'good','great','yeah','code','file','run','first','using',
+    'option','based','hook','session','current','already',
+    'def','return','import','json','sys','os','re','none',
+    'true','false','print','elif','else','except','pass','break',
+    'class','self','entry','entries','label','text','content',
+    'isinstance','dict','list','str','int','len','type','line',
+    'msg','get','set','split','replace','join','lower','pyeof',
+    'collections','counter','frozenset','append','strip',
+    '请','帮我','帮','我','你','能','能不能','可以','一下','看看',
+    '这个','那个','的','了','吗','呢','啊','是','在','有','和','与',
+    '把','给','让','对','到','从','用','被','着','过','得','地',
+    '也','都','就','还','又','再','很','太','不','没','怎么','什么',
+    '如何','是否','已经','然后','现在','一些','所有','还是','比较',
+    '应该','可能','需要','想','要','会','去','来','做','看','或者',
+})
+
+def extract_text(entry):
+    msg = entry.get('message', {})
+    if isinstance(msg, dict):
+        c = msg.get('content', '')
+        if isinstance(c, str): return c
+        if isinstance(c, list):
+            return ' '.join(b.get('text','') for b in c if isinstance(b,dict) and b.get('type')=='text')
+    return ''
+
+def tokenize(text):
+    # Clean markup/code
+    text = re.sub(r'https?://\S+', '', text)
+    text = re.sub(r'\x60{3}.*?\x60{3}', '', text, flags=re.S)
+    text = re.sub(r'\x60[^\x60]+\x60', '', text)
+    text = re.sub(r'[#*_>\[\]\(\){}|\":]', ' ', text)
+    text = re.sub(r'^\d+[.)]\s*', '', text, flags=re.M)
+    # Split CJK and Latin into separate tokens
+    return re.findall(r'[\u4e00-\u9fff]{2,}|[a-zA-Z][a-zA-Z0-9]*', text)
+
+def summarize(texts):
+    tokens = []
+    for t in texts:
+        tokens.extend(tokenize(t))
+    freq = collections.Counter()
+    for w in tokens:
+        low = w.lower()
+        if low in STOP_WORDS or len(low) < 2:
+            continue
+        freq[low] += 1
+    if not freq:
+        return ''
+    # Deduplicate, prefer original casing
+    casing = {}
+    for w in tokens:
+        low = w.lower()
+        if low not in casing and low in freq:
+            casing[low] = w
+    top = [casing.get(w, w) for w, _ in freq.most_common(6)]
+    # Remove duplicates preserving order
+    seen = set()
+    deduped = []
+    for w in top:
+        if w.lower() not in seen:
+            seen.add(w.lower())
+            deduped.append(w)
+    # Build label: 2-4 words, max 25 chars
+    for n in (4, 3, 2):
+        label = ' '.join(deduped[:n])
+        if len(label) <= 25:
+            return label
+    return deduped[0][:25] if deduped else ''
+
+# --- Read transcript efficiently: only parse what we need ---
+lines = []
+with open(TRANSCRIPT, 'r') as f:
+    lines = f.readlines()
+
+if not lines:
+    sys.exit(0)
+
+# First 3 user messages — scan from start, stop early
+first_user = []
+for raw in lines[:300]:  # first 300 lines is enough to find 3 user msgs
+    try:
+        e = json.loads(raw)
+        if e.get('type') == 'user':
+            t = extract_text(e)
+            if t.strip():
+                first_user.append(t[:300])
+                if len(first_user) >= 3: break
+    except: pass
+
+# Last 5 user+assistant messages — scan from end
+last_msgs = []
+for raw in reversed(lines[-200:]):
+    try:
+        e = json.loads(raw)
+        if e.get('type') in ('user', 'assistant'):
+            t = extract_text(e)
+            if t.strip():
+                last_msgs.append(t[:300])
+                if len(last_msgs) >= 5: break
+    except: pass
+last_msgs.reverse()
+
+all_texts = first_user + last_msgs
+if not all_texts:
+    sys.exit(0)
+
+label = summarize(all_texts)
+if label:
+    print(label)
+" 2>/dev/null)
+
+# Tab: always our focus summary
+# Workspace sync is handled by cmux-rename-sync.sh on UserPromptSubmit
+if [ -n "$LABEL" ]; then
+  cmux rename-tab --surface "$CMUX_SURFACE_ID" "$LABEL" 2>/dev/null || true
+fi

--- a/docs/examples/cmux-tab-sync.sh
+++ b/docs/examples/cmux-tab-sync.sh
@@ -58,6 +58,12 @@ def extract_text(entry):
     return ''
 
 def tokenize(text):
+    # Redact sensitive spans before tokenization to prevent leaking into tab names
+    text = re.sub(r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', '', text)  # UUIDs
+    text = re.sub(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}', '', text)  # emails
+    text = re.sub(r'(/[a-zA-Z0-9._-]+){2,}', '', text)  # file paths
+    text = re.sub(r'[A-Z_]{2,}=[^\s]+', '', text)  # ENV_VAR=value
+    text = re.sub(r'\b[0-9]{6,}\b', '', text)  # long numeric sequences
     # Clean markup/code
     text = re.sub(r'https?://\S+', '', text)
     text = re.sub(r'\x60{3}.*?\x60{3}', '', text, flags=re.S)


### PR DESCRIPTION
## Summary

- Add documentation and example hook scripts for enhanced Claude Code integration
- **Tab auto-naming**: `Stop` hook reads session transcript (first 3 user msgs + last 5 msgs), extracts 2-5 keyword summary, sets tab name via `cmux rename-tab` — gives each tab a distinct focus label instead of mirroring the workspace name
- **/rename sync**: `UserPromptSubmit` hook instantly propagates Claude Code `/rename` to cmux workspace name
- **Session reset**: `SessionStart` hook clears stale workspace names when starting a new session

### Motivation

cmux's native `claude-hook` integration handles workspace naming well via OSC 2, but tab names default to mirroring the workspace name. In multi-tab workspaces (Claude session + helper terminals), this makes tabs indistinguishable. These hooks solve that by auto-generating concise tab summaries from the conversation transcript.

### Files added

| File | Purpose |
|------|---------|
| `docs/claude-code-hooks-integration.md` | Setup guide and architecture overview |
| `docs/examples/cmux-tab-sync.sh` | Stop hook — transcript → tab name (~0.35s) |
| `docs/examples/cmux-rename-sync.sh` | UserPromptSubmit hook — /rename → workspace (~0.35s) |
| `docs/examples/cmux-session-start.sh` | SessionStart hook — reset workspace name (~0.05s) |

### How it works

```
Workspace name (sidebar):
  1. /rename → cmux-rename-sync.sh (UserPromptSubmit) → rename-workspace
  2. Claude Code auto-title → OSC 2 → cmux native
  3. cwd basename → cmux-session-start.sh (SessionStart)

Tab name (tab bar):
  Always: transcript summary → cmux-tab-sync.sh (Stop) → rename-tab
```

All hooks are guarded by `[ -z "$CMUX_WORKSPACE_ID" ] && exit 0` — they no-op outside cmux.

## Test plan

- [ ] Install hooks in `~/.claude/hooks/` and register in `~/.claude/settings.json`
- [ ] Start a Claude Code session in cmux — verify tab name auto-updates after first response
- [ ] Use `/rename foo` — verify workspace name changes to "foo" immediately
- [ ] Exit session and start a new one in same workspace — verify workspace name resets
- [ ] Test in non-cmux terminal — verify hooks exit silently (no errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Code hook docs and example scripts to auto-name tabs (with privacy-safe tokenization) and instantly sync `/rename` to `cmux` workspaces. Also resyncs portal geometry after restore-time bind and stabilizes UI test launch by using a fallback window and avoiding overlapping timers.

- **New Features**
  - Added `docs/claude-code-hooks-integration.md` and example hooks:
    - `cmux-tab-sync.sh` (`Stop`): summarizes transcript to rename the tab.
    - `cmux-rename-sync.sh` (`UserPromptSubmit`): syncs `/rename` to workspace name.
    - `cmux-session-start.sh` (`SessionStart`): resets workspace name on new session.
  - Hooks no-op outside `cmux`.
  - Hardening: read transcript via `head`/`tail`, guard `python3` with `|| true`, cap tab labels to 2–5 words, and redact UUIDs/emails/paths/ENV assignments/long numbers before tokenization.

- **Bug Fixes**
  - Terminal portal: queue an external geometry sync after restore-time bind; added a test covering hit-testing after queued layout shifts.
  - UI tests: stabilize launch and foregrounding with a retry loop; track a weak fallback window and close it when a real WindowGroup window appears; start display-move retries only once to prevent overlapping timers.
  - CI: retry the display-resolution UI test once on the known activation flake.

<sup>Written for commit ea3287864f74c140ffa4eae86594ae9988c4d8b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claude Code hooks integration with example scripts for workspace and tab management

* **Bug Fixes**
  * Improved UI-test launch stability with adaptive retry mechanism
  * Enhanced window geometry synchronization for portal-hosted views during layout changes

* **Documentation**
  * Added comprehensive Claude Code hooks integration guide with working example scripts

* **Tests**
  * Added regression test for portal lifecycle and geometry synchronization behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->