### PR TITLE
Make View menu zoom items context-aware for terminal font size

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2737,6 +2737,21 @@ class TabManager: ObservableObject {
     }
 
     @discardableResult
+    func increaseFontSizeFocusedTerminal() -> Bool {
+        selectedTerminalPanel?.performBindingAction("increase_font_size:1") ?? false
+    }
+
+    @discardableResult
+    func decreaseFontSizeFocusedTerminal() -> Bool {
+        selectedTerminalPanel?.performBindingAction("decrease_font_size:1") ?? false
+    }
+
+    @discardableResult
+    func resetFontSizeFocusedTerminal() -> Bool {
+        selectedTerminalPanel?.performBindingAction("reset_font_size") ?? false
+    }
+
+    @discardableResult
     func toggleDeveloperToolsFocusedBrowser() -> Bool {
         focusedBrowserPanel?.toggleDeveloperTools() ?? false
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -747,7 +747,7 @@ struct cmuxApp: App {
                     if manager.selectedTerminalPanel != nil {
                         if !manager.increaseFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        if !manager.zoomInFocusedBrowser() { NSSound.beep() }
+                        _ = manager.zoomInFocusedBrowser()
                     }
                 }
                 .keyboardShortcut("=", modifiers: .command)
@@ -757,7 +757,7 @@ struct cmuxApp: App {
                     if manager.selectedTerminalPanel != nil {
                         if !manager.decreaseFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        if !manager.zoomOutFocusedBrowser() { NSSound.beep() }
+                        _ = manager.zoomOutFocusedBrowser()
                     }
                 }
                 .keyboardShortcut("-", modifiers: .command)
@@ -767,7 +767,7 @@ struct cmuxApp: App {
                     if manager.selectedTerminalPanel != nil {
                         if !manager.resetFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        if !manager.resetZoomFocusedBrowser() { NSSound.beep() }
+                        _ = manager.resetZoomFocusedBrowser()
                     }
                 }
                 .keyboardShortcut("0", modifiers: .command)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -744,31 +744,28 @@ struct cmuxApp: App {
 
                 Button(String(localized: "menu.view.zoomIn", defaultValue: "Zoom In")) {
                     let manager = activeTabManager
-                    if manager.selectedTerminalPanel != nil {
-                        if !manager.increaseFontSizeFocusedTerminal() { NSSound.beep() }
-                    } else {
-                        _ = manager.zoomInFocusedBrowser()
-                    }
+                    let success = manager.selectedTerminalPanel != nil
+                        ? manager.increaseFontSizeFocusedTerminal()
+                        : manager.zoomInFocusedBrowser()
+                    if !success { NSSound.beep() }
                 }
                 .keyboardShortcut("=", modifiers: .command)
 
                 Button(String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out")) {
                     let manager = activeTabManager
-                    if manager.selectedTerminalPanel != nil {
-                        if !manager.decreaseFontSizeFocusedTerminal() { NSSound.beep() }
-                    } else {
-                        _ = manager.zoomOutFocusedBrowser()
-                    }
+                    let success = manager.selectedTerminalPanel != nil
+                        ? manager.decreaseFontSizeFocusedTerminal()
+                        : manager.zoomOutFocusedBrowser()
+                    if !success { NSSound.beep() }
                 }
                 .keyboardShortcut("-", modifiers: .command)
 
                 Button(String(localized: "menu.view.actualSize", defaultValue: "Actual Size")) {
                     let manager = activeTabManager
-                    if manager.selectedTerminalPanel != nil {
-                        if !manager.resetFontSizeFocusedTerminal() { NSSound.beep() }
-                    } else {
-                        _ = manager.resetZoomFocusedBrowser()
-                    }
+                    let success = manager.selectedTerminalPanel != nil
+                        ? manager.resetFontSizeFocusedTerminal()
+                        : manager.resetZoomFocusedBrowser()
+                    if !success { NSSound.beep() }
                 }
                 .keyboardShortcut("0", modifiers: .command)
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -743,17 +743,32 @@ struct cmuxApp: App {
                 }
 
                 Button(String(localized: "menu.view.zoomIn", defaultValue: "Zoom In")) {
-                    _ = activeTabManager.zoomInFocusedBrowser()
+                    let manager = activeTabManager
+                    if manager.selectedTerminalPanel != nil {
+                        _ = manager.increaseFontSizeFocusedTerminal()
+                    } else {
+                        _ = manager.zoomInFocusedBrowser()
+                    }
                 }
                 .keyboardShortcut("=", modifiers: .command)
 
                 Button(String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out")) {
-                    _ = activeTabManager.zoomOutFocusedBrowser()
+                    let manager = activeTabManager
+                    if manager.selectedTerminalPanel != nil {
+                        _ = manager.decreaseFontSizeFocusedTerminal()
+                    } else {
+                        _ = manager.zoomOutFocusedBrowser()
+                    }
                 }
                 .keyboardShortcut("-", modifiers: .command)
 
                 Button(String(localized: "menu.view.actualSize", defaultValue: "Actual Size")) {
-                    _ = activeTabManager.resetZoomFocusedBrowser()
+                    let manager = activeTabManager
+                    if manager.selectedTerminalPanel != nil {
+                        _ = manager.resetFontSizeFocusedTerminal()
+                    } else {
+                        _ = manager.resetZoomFocusedBrowser()
+                    }
                 }
                 .keyboardShortcut("0", modifiers: .command)
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -745,9 +745,9 @@ struct cmuxApp: App {
                 Button(String(localized: "menu.view.zoomIn", defaultValue: "Zoom In")) {
                     let manager = activeTabManager
                     if manager.selectedTerminalPanel != nil {
-                        _ = manager.increaseFontSizeFocusedTerminal()
+                        if !manager.increaseFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        _ = manager.zoomInFocusedBrowser()
+                        if !manager.zoomInFocusedBrowser() { NSSound.beep() }
                     }
                 }
                 .keyboardShortcut("=", modifiers: .command)
@@ -755,9 +755,9 @@ struct cmuxApp: App {
                 Button(String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out")) {
                     let manager = activeTabManager
                     if manager.selectedTerminalPanel != nil {
-                        _ = manager.decreaseFontSizeFocusedTerminal()
+                        if !manager.decreaseFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        _ = manager.zoomOutFocusedBrowser()
+                        if !manager.zoomOutFocusedBrowser() { NSSound.beep() }
                     }
                 }
                 .keyboardShortcut("-", modifiers: .command)
@@ -765,9 +765,9 @@ struct cmuxApp: App {
                 Button(String(localized: "menu.view.actualSize", defaultValue: "Actual Size")) {
                     let manager = activeTabManager
                     if manager.selectedTerminalPanel != nil {
-                        _ = manager.resetFontSizeFocusedTerminal()
+                        if !manager.resetFontSizeFocusedTerminal() { NSSound.beep() }
                     } else {
-                        _ = manager.resetZoomFocusedBrowser()
+                        if !manager.resetZoomFocusedBrowser() { NSSound.beep() }
                     }
                 }
                 .keyboardShortcut("0", modifiers: .command)


### PR DESCRIPTION
## Summary
- View > Zoom In/Out/Actual Size menu items now dispatch to terminal font size control when a terminal panel is focused, and to browser zoom when a browser panel is focused
- Added `increaseFontSizeFocusedTerminal()`, `decreaseFontSizeFocusedTerminal()`, `resetFontSizeFocusedTerminal()` methods to `TabManager` (parallel to existing browser zoom methods)
- Keyboard shortcut behavior (Cmd+=/−/0) is unchanged — still routed to Ghostty at the key event level via `AppDelegate`

## Test plan
- [ ] Build with `./scripts/reload.sh --tag font-zoom`
- [ ] Focus a terminal panel → click View > Zoom In → font size increases
- [ ] Focus a terminal panel → click View > Zoom Out → font size decreases
- [ ] Focus a terminal panel → click View > Actual Size → font size resets
- [ ] Focus a browser panel → same menu items control browser zoom (existing behavior preserved)
- [ ] Cmd+=/−/0 keyboard shortcuts continue to work as before in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the View > Zoom menu context-aware: Zoom In/Out/Actual Size change terminal font size when a terminal is focused, or browser zoom when a browser is focused. All Zoom menu actions now beep on failure; keyboard shortcuts (Cmd+=, Cmd−, Cmd+0) are unchanged.

- **New Features**
  - Route menu actions based on focused panel (terminal font size vs. browser zoom).
  - Added `TabManager` methods: `increaseFontSizeFocusedTerminal`, `decreaseFontSizeFocusedTerminal`, `resetFontSizeFocusedTerminal`.

- **Bug Fixes**
  - Consistent error feedback: both terminal and browser zoom beep on failure.

<sup>Written for commit 3ea6c5d747e107e9d68c16f9ae6f85b0d32a26fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom In/Out and Actual Size now adjust terminal font size when a terminal is focused.
  * Zoom commands automatically target the active terminal or the browser as appropriate.

* **Bug Fixes**
  * Menu commands produce an audible alert if a terminal font-size change cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->