### PR TITLE
Add default browser zoom level setting

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53434,6 +53434,40 @@
         }
       }
     },
+    "settings.browser.defaultZoom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Browser Zoom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトのブラウザズーム"
+          }
+        }
+      }
+    },
+    "settings.browser.defaultZoom.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applied when opening new browser panes. Use Actual Size to reset an existing pane."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブラウザパネルを開くときに適用されます。既存のパネルをリセットするには「実際のサイズ」を使用してください。"
+          }
+        }
+      }
+    },
     "settings.browser.openTerminalLinks": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4721,7 +4721,7 @@ extension BrowserPanel {
 
     @discardableResult
     func resetZoom() -> Bool {
-        applyPageZoom(BrowserDefaultZoomSettings.zoomLevel())
+        applyPageZoom(1.0)
     }
 
     func currentPageZoomFactor() -> CGFloat {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -520,6 +520,16 @@ final class BrowserProfileStore: ObservableObject {
     }
 }
 
+enum BrowserDefaultZoomSettings {
+    static let key = "browserDefaultZoomLevel"
+    static let defaultValue: Double = 1.0
+
+    static func zoomLevel() -> CGFloat {
+        let raw = UserDefaults.standard.double(forKey: key)
+        return raw > 0 ? CGFloat(raw) : CGFloat(defaultValue)
+    }
+}
+
 enum BrowserLinkOpenSettings {
     static let openTerminalLinksInCmuxBrowserKey = "browserOpenTerminalLinksInCmuxBrowser"
     static let defaultOpenTerminalLinksInCmuxBrowser: Bool = true
@@ -2463,6 +2473,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.underPageBackgroundColor = GhosttyBackgroundTheme.currentColor()
         // Always present as Safari.
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
+        webView.pageZoom = BrowserDefaultZoomSettings.zoomLevel()
         return webView
     }
 
@@ -4710,7 +4721,7 @@ extension BrowserPanel {
 
     @discardableResult
     func resetZoom() -> Bool {
-        applyPageZoom(1.0)
+        applyPageZoom(BrowserDefaultZoomSettings.zoomLevel())
     }
 
     func currentPageZoomFactor() -> CGFloat {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -524,9 +524,12 @@ enum BrowserDefaultZoomSettings {
     static let key = "browserDefaultZoomLevel"
     static let defaultValue: Double = 1.0
 
-    static func zoomLevel() -> CGFloat {
-        let raw = UserDefaults.standard.double(forKey: key)
-        return raw > 0 ? CGFloat(raw) : CGFloat(defaultValue)
+    static func zoomLevel(defaults: UserDefaults = .standard) -> CGFloat {
+        if defaults.object(forKey: key) == nil {
+            return CGFloat(defaultValue)
+        }
+        let raw = defaults.double(forKey: key)
+        return CGFloat(max(0.5, min(3.0, raw)))
     }
 }
 
@@ -4721,7 +4724,7 @@ extension BrowserPanel {
 
     @discardableResult
     func resetZoom() -> Bool {
-        applyPageZoom(1.0)
+        applyPageZoom(BrowserDefaultZoomSettings.zoomLevel())
     }
 
     func currentPageZoomFactor() -> CGFloat {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3801,6 +3801,7 @@ struct SettingsView: View {
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
     @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
     @AppStorage(BrowserThemeSettings.modeKey) private var browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
+    @AppStorage(BrowserDefaultZoomSettings.key) private var browserDefaultZoom = BrowserDefaultZoomSettings.defaultValue
     @AppStorage(BrowserImportHintSettings.variantKey) private var browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
     @AppStorage(BrowserImportHintSettings.showOnBlankTabsKey) private var showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
     @AppStorage(BrowserImportHintSettings.dismissedKey) private var isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed
@@ -5081,6 +5082,25 @@ struct SettingsView: View {
                             ForEach(BrowserThemeMode.allCases) { mode in
                                 Text(mode.displayName).tag(mode.rawValue)
                             }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.browser.defaultZoom", defaultValue: "Default Browser Zoom"),
+                            subtitle: String(localized: "settings.browser.defaultZoom.subtitle", defaultValue: "Applied when opening new browser panes. Use Actual Size to reset an existing pane."),
+                            controlWidth: pickerColumnWidth,
+                            selection: $browserDefaultZoom
+                        ) {
+                            Text("75%").tag(0.75)
+                            Text("80%").tag(0.8)
+                            Text("90%").tag(0.9)
+                            Text("100%").tag(1.0)
+                            Text("110%").tag(1.1)
+                            Text("125%").tag(1.25)
+                            Text("150%").tag(1.5)
+                            Text("175%").tag(1.75)
+                            Text("200%").tag(2.0)
                         }
 
                         SettingsCardDivider()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5092,15 +5092,15 @@ struct SettingsView: View {
                             controlWidth: pickerColumnWidth,
                             selection: $browserDefaultZoom
                         ) {
-                            Text("75%").tag(0.75)
-                            Text("80%").tag(0.8)
-                            Text("90%").tag(0.9)
-                            Text("100%").tag(1.0)
-                            Text("110%").tag(1.1)
-                            Text("125%").tag(1.25)
-                            Text("150%").tag(1.5)
-                            Text("175%").tag(1.75)
-                            Text("200%").tag(2.0)
+                            Text(verbatim: "75%").tag(0.75)
+                            Text(verbatim: "80%").tag(0.8)
+                            Text(verbatim: "90%").tag(0.9)
+                            Text(verbatim: "100%").tag(1.0)
+                            Text(verbatim: "110%").tag(1.1)
+                            Text(verbatim: "125%").tag(1.25)
+                            Text(verbatim: "150%").tag(1.5)
+                            Text(verbatim: "175%").tag(1.75)
+                            Text(verbatim: "200%").tag(2.0)
                         }
 
                         SettingsCardDivider()
@@ -5566,6 +5566,7 @@ struct SettingsView: View {
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
+        browserDefaultZoom = BrowserDefaultZoomSettings.defaultValue
         browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
         showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
         isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed


### PR DESCRIPTION
## Summary
- Added `BrowserDefaultZoomSettings` enum in `BrowserPanel.swift` with UserDefaults-backed zoom level (default 100%)
- New browser panes apply the configured default zoom via `webView.pageZoom` at creation time
- View > Actual Size now resets to the configured default instead of hardcoded 1.0
- Settings UI: added "Default Browser Zoom" picker (75%–200%) in the Browser section, between Browser Theme and Open Terminal Links

## Test plan
- [ ] Build with `./scripts/reload.sh --tag default-zoom`
- [ ] Open Settings > Browser — "Default Browser Zoom" picker should appear with 100% selected
- [ ] Change to 125%, open a new browser pane — it should load at 125% zoom
- [ ] Press View > Actual Size — should reset to 125% (the configured default), not 100%
- [ ] Change setting back to 100% — new panes should open at 100%
- [ ] Existing panes should retain their current zoom level (no retroactive changes)

Closes #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a default browser zoom setting so new panes open at your preferred zoom. View > Actual Size now resets to your configured default. Closes #1934.

- **New Features**
  - Added “Default Browser Zoom” picker in Settings > Browser (75%–200%, default 100%, EN/JA). New panes use `webView.pageZoom` from `BrowserDefaultZoomSettings`; existing panes keep their current zoom.

- **Bug Fixes**
  - Clamped stored zoom to 0.5–3.0; Reset All Settings now resets this value; percentage labels use verbatim text to avoid unwanted localization.

<sup>Written for commit a2343ab589b81bea2f8210ac6ec27a2ea2d90a19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Default Browser Zoom" setting (choices 0.75x–2.0x); new browser panes open at the selected zoom.
  * Resetting an existing pane now returns to the chosen default zoom (not always 1.0).

* **Documentation**
  * Added localized label and explanatory subtitle for the new setting (English and Japanese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->