### PR TITLE
Support modifier+key combinations in send-key (ctrl+enter, shift+tab, etc.)

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13198,10 +13198,24 @@ class TerminalController {
             sendKeyEvent(surface: surface, keycode: UInt32(kVK_Delete))
             return true
         default:
-            // Parse generic modifier+key combinations (e.g. "ctrl+enter", "shift+tab",
-            // "ctrl+shift+a"). Separators: '+' or '-'.
+            // Parse modifier+key combinations (e.g. "ctrl+enter", "shift+tab",
+            // "ctrl+shift+a") or standalone named keys (e.g. "space", "up").
+            // Separators: '+' or '-'.
             let parts = keyName.lowercased().split(separator: "+").flatMap { $0.split(separator: "-") }.map(String.init).filter { !$0.isEmpty }
-            guard parts.count >= 2 else { return false }
+            guard let baseKey = parts.last else { return false }
+
+            // Single named key without modifiers (e.g. "space", "up", "delete")
+            if parts.count == 1 {
+                if let keycode = keycodeForNamedKey(baseKey) {
+                    sendKeyEvent(surface: surface, keycode: keycode)
+                    return true
+                }
+                if baseKey.count == 1, let char = baseKey.first, let keycode = keycodeForLetter(char) {
+                    sendKeyEvent(surface: surface, keycode: keycode)
+                    return true
+                }
+                return false
+            }
 
             var mods = GHOSTTY_MODS_NONE
             for mod in parts.dropLast() {
@@ -13214,7 +13228,6 @@ class TerminalController {
                 }
             }
 
-            let baseKey = parts.last!
             if let keycode = keycodeForNamedKey(baseKey) {
                 sendKeyEvent(surface: surface, keycode: keycode, mods: mods)
                 return true

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13159,7 +13159,8 @@ class TerminalController {
         case "enter", "return": return UInt32(kVK_Return)
         case "tab": return UInt32(kVK_Tab)
         case "escape", "esc": return UInt32(kVK_Escape)
-        case "backspace", "delete": return UInt32(kVK_Delete)
+        case "backspace": return UInt32(kVK_Delete)
+        case "delete": return UInt32(kVK_ForwardDelete)
         case "space": return UInt32(kVK_Space)
         case "up": return UInt32(kVK_UpArrow)
         case "down": return UInt32(kVK_DownArrow)
@@ -13199,7 +13200,7 @@ class TerminalController {
         default:
             // Parse generic modifier+key combinations (e.g. "ctrl+enter", "shift+tab",
             // "ctrl+shift+a"). Separators: '+' or '-'.
-            let parts = keyName.lowercased().split(separator: "+").flatMap { $0.split(separator: "-") }.map(String.init)
+            let parts = keyName.lowercased().split(separator: "+").flatMap { $0.split(separator: "-") }.map(String.init).filter { !$0.isEmpty }
             guard parts.count >= 2 else { return false }
 
             var mods = GHOSTTY_MODS_NONE

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13154,6 +13154,22 @@ class TerminalController {
         }
     }
 
+    private func keycodeForNamedKey(_ name: String) -> UInt32? {
+        switch name {
+        case "enter", "return": return UInt32(kVK_Return)
+        case "tab": return UInt32(kVK_Tab)
+        case "escape", "esc": return UInt32(kVK_Escape)
+        case "backspace", "delete": return UInt32(kVK_Delete)
+        case "space": return UInt32(kVK_Space)
+        case "up": return UInt32(kVK_UpArrow)
+        case "down": return UInt32(kVK_DownArrow)
+        case "left": return UInt32(kVK_LeftArrow)
+        case "right": return UInt32(kVK_RightArrow)
+        case "\\": return UInt32(kVK_ANSI_Backslash)
+        default: return nil
+        }
+    }
+
     private func sendNamedKey(_ surface: ghostty_surface_t, keyName: String) -> Bool {
         switch keyName.lowercased() {
         case "ctrl-c", "ctrl+c", "sigint":
@@ -13181,12 +13197,30 @@ class TerminalController {
             sendKeyEvent(surface: surface, keycode: UInt32(kVK_Delete))
             return true
         default:
-            if keyName.lowercased().hasPrefix("ctrl-") || keyName.lowercased().hasPrefix("ctrl+") {
-                let letter = keyName.dropFirst(5)
-                if letter.count == 1, let char = letter.first, let keycode = keycodeForLetter(char) {
-                    sendKeyEvent(surface: surface, keycode: keycode, mods: GHOSTTY_MODS_CTRL)
-                    return true
+            // Parse generic modifier+key combinations (e.g. "ctrl+enter", "shift+tab",
+            // "ctrl+shift+a"). Separators: '+' or '-'.
+            let parts = keyName.lowercased().split(separator: "+").flatMap { $0.split(separator: "-") }.map(String.init)
+            guard parts.count >= 2 else { return false }
+
+            var mods = GHOSTTY_MODS_NONE
+            for mod in parts.dropLast() {
+                switch mod {
+                case "ctrl", "control": mods = ghostty_input_mods_e(rawValue: mods.rawValue | GHOSTTY_MODS_CTRL.rawValue)
+                case "shift": mods = ghostty_input_mods_e(rawValue: mods.rawValue | GHOSTTY_MODS_SHIFT.rawValue)
+                case "alt", "opt", "option": mods = ghostty_input_mods_e(rawValue: mods.rawValue | GHOSTTY_MODS_ALT.rawValue)
+                case "cmd", "command", "super": mods = ghostty_input_mods_e(rawValue: mods.rawValue | GHOSTTY_MODS_SUPER.rawValue)
+                default: return false
                 }
+            }
+
+            let baseKey = parts.last!
+            if let keycode = keycodeForNamedKey(baseKey) {
+                sendKeyEvent(surface: surface, keycode: keycode, mods: mods)
+                return true
+            }
+            if baseKey.count == 1, let char = baseKey.first, let keycode = keycodeForLetter(char) {
+                sendKeyEvent(surface: surface, keycode: keycode, mods: mods)
+                return true
             }
             return false
         }


### PR DESCRIPTION
## Summary
- `send-key` now supports generic modifier+key combinations like `ctrl+enter`, `shift+tab`, `ctrl+shift+a`, `alt+backspace`
- Added `keycodeForNamedKey()` helper mapping named keys (enter, tab, escape, backspace, space, arrow keys) to virtual keycodes
- The default branch in `sendNamedKey()` now parses `+` / `-` separated modifier+key strings, accumulates modifier flags, and resolves the base key
- Supported modifiers: `ctrl`/`control`, `shift`, `alt`/`opt`/`option`, `cmd`/`command`/`super`
- Existing hardcoded shortcuts (`ctrl+c`, `ctrl+d`, etc.) still work via the fast-path switch cases

## Test plan
- [ ] Build with `./scripts/reload.sh --tag send-key-mods`
- [ ] `cmux send-key ctrl+enter` — should send Ctrl+Enter (needed for GitHub Copilot CLI agent mode submission)
- [ ] `cmux send-key shift+tab` — should send Shift+Tab
- [ ] `cmux send-key ctrl+shift+a` — should send Ctrl+Shift+A
- [ ] `cmux send-key alt+backspace` — should send Alt+Backspace
- [ ] `cmux send-key enter` — should still work (bare key, no modifier)
- [ ] `cmux send-key ctrl+c` — should still work (existing fast path)
- [ ] `cmux send-key ctrl+enter` in a surface running GitHub Copilot CLI agent mode — should submit the message

Closes #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generic modifier+key support to `send-key` (ctrl+enter, shift+tab, ctrl+shift+a) and fixes named key handling so bare keys like "space" or "up" work reliably. Closes #1990.

- **New Features**
  - Parse '+' or '-' separated modifier+key combos; accumulate ctrl/control, shift, alt/opt/option, cmd/command/super; keep existing fast-path shortcuts.
  - Add `keycodeForNamedKey()` for enter/return, tab, escape/esc, backspace, delete, space, arrow keys, and "\".

- **Bug Fixes**
  - Map "delete" (forward delete) vs "backspace" correctly and reject malformed inputs like "+shift+a".
  - Handle standalone named keys (e.g., "space", "up", "delete") and use safe unwrapping to avoid silent failures.

<sup>Written for commit a71b6aac2fcbbe7baa7975744833407ffef467e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved keyboard input handling: common named keys (Enter/Return, Tab, Escape, Backspace/Delete, Space, arrows, Backslash) are recognized and mapped to system keycodes.
  * Shortcut parsing now accepts modifier+base-key combinations (Ctrl/Control, Shift, Alt/Option, Cmd/Command) with flexible separators.
  * Invalid or unresolvable key specifications are rejected to avoid unintended behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->