### PR TITLE
feat: add quick Terminal panel, CLI/socket controls, and automation-safe focus behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to cmux are documented here.
 ## [Unreleased]
 
 ### Added
-- Quick Terminal panel with configurable position, size, auto-hide, keyboard shortcut (default: Option+Command+`), command palette action, and CLI/socket controls (`cmux quick-terminal [toggle|show|hide|status]`, `quick_terminal.*`) ([#327](https://github.com/manaflow-ai/cmux/issues/327))
+- Quick Terminal panel with configurable position, size, auto-hide, keyboard shortcut (default: Option+Command+\`), command palette action, and CLI/socket controls (`cmux quick-terminal [toggle|show|hide|status]`, `quick_terminal.*`) ([#327](https://github.com/manaflow-ai/cmux/issues/327))
 
 ## [0.63.2] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to cmux are documented here.
 
+## [Unreleased]
+
+### Added
+- Quick Terminal panel with configurable position, size, auto-hide, keyboard shortcut (default: Option+Command+`), command palette action, and CLI/socket controls (`cmux quick-terminal [toggle|show|hide|status]`, `quick_terminal.*`) ([#327](https://github.com/manaflow-ai/cmux/issues/327))
+
 ## [0.63.2] - 2026-04-06
 
 ### Added

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2845,6 +2845,13 @@ struct CMUXCLI {
             let response = try sendV1Command("simulate_app_active", client: client)
             print(response)
 
+        case "quick-terminal":
+            try runQuickTerminal(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput
+            )
+
         case "__tmux-compat":
             try runClaudeTeamsTmuxCompat(
                 commandArgs: commandArgs,
@@ -3216,6 +3223,62 @@ struct CMUXCLI {
         } else {
             print("OK")
         }
+    }
+
+    private func runQuickTerminal(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool
+    ) throws {
+        let subcommand = commandArgs.first?.lowercased() ?? "toggle"
+        let remaining = Array(commandArgs.dropFirst()).filter { $0 != "--" }
+        if let unknown = remaining.first {
+            throw CLIError(message: "quick-terminal \(subcommand): unexpected argument '\(unknown)'")
+        }
+
+        let method: String
+        switch subcommand {
+        case "toggle":
+            method = "quick_terminal.toggle"
+        case "show":
+            method = "quick_terminal.show"
+        case "hide":
+            method = "quick_terminal.hide"
+        case "status":
+            method = "quick_terminal.status"
+        default:
+            throw CLIError(message: "quick-terminal requires one of: toggle, show, hide, status")
+        }
+
+        let payload = try client.sendV2(method: method)
+        if jsonOutput {
+            print(jsonString(payload))
+            return
+        }
+
+        if subcommand == "status" {
+            print(formatQuickTerminalStatusPayload(payload))
+        } else {
+            print("OK")
+        }
+    }
+
+    private func formatQuickTerminalStatusPayload(_ payload: [String: Any]) -> String {
+        let available = (payload["available"] as? Bool) ?? true
+        let visible = (payload["visible"] as? Bool) ?? false
+        let position = (payload["position"] as? String) ?? "unknown"
+        let autoHide = (payload["auto_hide"] as? Bool) ?? false
+        let primarySizeRatio = (payload["primary_size_ratio"] as? Double) ?? 0
+        let secondarySizeRatio = (payload["secondary_size_ratio"] as? Double) ?? 0
+
+        return """
+        available: \(available ? "yes" : "no")
+        visible: \(visible ? "yes" : "no")
+        position: \(position)
+        auto_hide: \(autoHide ? "yes" : "no")
+        primary_size_ratio: \(String(format: "%.2f", primarySizeRatio))
+        secondary_size_ratio: \(String(format: "%.2f", secondarySizeRatio))
+        """
     }
 
     private func connectClient(
@@ -6919,6 +6982,23 @@ struct CMUXCLI {
             Usage: cmux shortcuts
 
             Open the Settings window to Keyboard Shortcuts.
+            """
+        case "quick-terminal":
+            return """
+            Usage: cmux quick-terminal [toggle|show|hide|status]
+
+            Control the floating quick terminal panel.
+
+            Subcommands:
+              toggle    Toggle quick terminal visibility (default)
+              show      Show quick terminal
+              hide      Hide quick terminal
+              status    Print quick terminal status
+
+            Examples:
+              cmux quick-terminal
+              cmux quick-terminal show
+              cmux --json quick-terminal status
             """
         case "feedback":
             return """
@@ -14497,6 +14577,7 @@ struct CMUXCLI {
           claude-hook <session-start|stop|notification> [--workspace <id|ref>] [--surface <id|ref>]
           set-app-focus <active|inactive|clear>
           simulate-app-active
+          quick-terminal [toggle|show|hide|status]
 
           # tmux compatibility commands
           capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3264,7 +3264,7 @@ struct CMUXCLI {
     }
 
     private func formatQuickTerminalStatusPayload(_ payload: [String: Any]) -> String {
-        let available = (payload["available"] as? Bool) ?? true
+        let available = (payload["available"] as? Bool) ?? false
         let visible = (payload["visible"] as? Bool) ?? false
         let position = (payload["position"] as? String) ?? "unknown"
         let autoHide = (payload["auto_hide"] as? Bool) ?? false

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3230,8 +3230,9 @@ struct CMUXCLI {
         client: SocketClient,
         jsonOutput: Bool
     ) throws {
-        let subcommand = commandArgs.first?.lowercased() ?? "toggle"
-        let remaining = Array(commandArgs.dropFirst()).filter { $0 != "--" }
+        let normalizedArgs = Array(commandArgs.drop(while: { $0 == "--" }))
+        let subcommand = normalizedArgs.first?.lowercased() ?? "toggle"
+        let remaining = Array(normalizedArgs.dropFirst()).filter { $0 != "--" }
         if let unknown = remaining.first {
             throw CLIError(message: "quick-terminal \(subcommand): unexpected argument '\(unknown)'")
         }

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For more info on how to configure cmux, [head over to our docs](https://cmux.com
 | ⌘ ⇧ W | Close workspace |
 | ⌘ ⇧ R | Rename workspace |
 | ⌘ B | Toggle sidebar |
+| ⌥ ⌘ ` | Toggle quick terminal |
 
 ### Surfaces
 
@@ -218,6 +219,15 @@ Browser developer-tool shortcuts follow Safari defaults and are customizable in 
 | ⌘ V | Paste |
 | ⌘ + / ⌘ - | Increase / decrease font size |
 | ⌘ 0 | Reset font size |
+
+### Quick Terminal CLI
+
+```bash
+cmux quick-terminal [toggle|show|hide|status]
+cmux --json quick-terminal status
+```
+
+Control the floating quick terminal from scripts and check its visibility and settings state.
 
 ### Window
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For more info on how to configure cmux, [head over to our docs](https://cmux.com
 | ⌘ ⇧ W | Close workspace |
 | ⌘ ⇧ R | Rename workspace |
 | ⌘ B | Toggle sidebar |
-| ⌥ ⌘ ` | Toggle quick terminal |
+| ⌥ ⌘ \` | Toggle quick terminal |
 
 ### Surfaces
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -91057,6 +91057,312 @@
           }
         }
       }
+    },
+    "shortcut.toggleQuickTerminal.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Quick Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルを切替"
+          }
+        }
+      }
+    },
+    "menu.view.toggleQuickTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Quick Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルの切り替え"
+          }
+        }
+      }
+    },
+    "command.toggleQuickTerminal.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Quick Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルの切り替え"
+          }
+        }
+      }
+    },
+    "command.toggleQuickTerminal.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Terminal Position"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルの位置"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose which edge the quick terminal slides from."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルをどの端から表示するかを選択します。"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.top": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.bottom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.left": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.right": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.position.center": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Center"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.primarySize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Terminal Primary Size"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルの主サイズ"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.primarySize.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size along the deployment axis."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開方向のサイズです。"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.secondarySize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Terminal Secondary Size"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナルの副サイズ"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.secondarySize.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size on the opposite axis."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反対軸のサイズです。"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.autoHide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Terminal Auto-Hide"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイックターミナル自動非表示"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.autoHide.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide automatically when it loses focus."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーカスを失うと自動的に非表示にします。"
+          }
+        }
+      }
+    },
+    "settings.quickTerminal.autoHide.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep visible when focus moves to another app/window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "他のアプリやウインドウにフォーカスが移っても表示したままにします。"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11396,6 +11396,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Preserve native macOS window cycling for Cmd+` and Cmd+Shift+`.
+        if event.keyCode == 50,
+           normalizedFlags.contains(.command),
+           normalizedFlags.isSubset(of: [.command, .shift]) {
+            return false
+        }
+
         // Allow quick-terminal toggle even when the key event comes from the quick
         // panel itself (which is not a main terminal window context).
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleQuickTerminal)) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2190,6 +2190,412 @@ func shouldSuppressWindowMoveForFolderDrag(window: NSWindow, event: NSEvent) -> 
     return shouldSuppressWindowMoveForFolderDrag(hitView: hitView)
 }
 
+enum QuickTerminalSettings {
+    static let positionKey = "quickTerminal.position"
+    static let primarySizeRatioKey = "quickTerminal.primarySizeRatio"
+    static let secondarySizeRatioKey = "quickTerminal.secondarySizeRatio"
+    static let autoHideKey = "quickTerminal.autoHide"
+
+    static let defaultPosition: QuickTerminalPosition = .top
+    static let defaultPrimarySizeRatio: Double = 0.38
+    static let defaultSecondarySizeRatio: Double = 1.0
+    static let defaultAutoHide = true
+    static let defaultAnimationDuration: TimeInterval = 0.16
+
+    static func resolved(defaults: UserDefaults = .standard) -> QuickTerminalResolvedSettings {
+        let rawPosition = defaults.string(forKey: positionKey)
+        let position = QuickTerminalPosition(rawValue: rawPosition ?? "") ?? defaultPosition
+
+        let rawPrimary = defaults.double(forKey: primarySizeRatioKey)
+        let primarySizeRatio = clampRatio(
+            defaults.object(forKey: primarySizeRatioKey) == nil ? defaultPrimarySizeRatio : rawPrimary
+        )
+
+        let rawSecondary = defaults.double(forKey: secondarySizeRatioKey)
+        let secondarySizeRatio = clampRatio(
+            defaults.object(forKey: secondarySizeRatioKey) == nil ? defaultSecondarySizeRatio : rawSecondary
+        )
+
+        let autoHide = defaults.object(forKey: autoHideKey) == nil
+            ? defaultAutoHide
+            : defaults.bool(forKey: autoHideKey)
+
+        return QuickTerminalResolvedSettings(
+            position: position,
+            primarySizeRatio: primarySizeRatio,
+            secondarySizeRatio: secondarySizeRatio,
+            autoHide: autoHide,
+            animationDuration: defaultAnimationDuration
+        )
+    }
+
+    static func clampRatio(_ value: Double) -> Double {
+        min(max(value, 0.2), 1.0)
+    }
+}
+
+struct QuickTerminalResolvedSettings {
+    let position: QuickTerminalPosition
+    let primarySizeRatio: Double
+    let secondarySizeRatio: Double
+    let autoHide: Bool
+    let animationDuration: TimeInterval
+}
+
+enum QuickTerminalPosition: String, CaseIterable, Identifiable {
+    case top
+    case bottom
+    case left
+    case right
+    case center
+
+    var id: String { rawValue }
+
+    func finalFrame(
+        in visibleFrame: NSRect,
+        primarySizeRatio: Double,
+        secondarySizeRatio: Double
+    ) -> NSRect {
+        let primary = CGFloat(QuickTerminalSettings.clampRatio(primarySizeRatio))
+        let secondary = CGFloat(QuickTerminalSettings.clampRatio(secondarySizeRatio))
+        let minWidth: CGFloat = 420
+        let minHeight: CGFloat = 220
+
+        let size: NSSize = {
+            switch self {
+            case .top, .bottom:
+                return NSSize(
+                    width: max(minWidth, visibleFrame.width * secondary),
+                    height: max(minHeight, visibleFrame.height * primary)
+                )
+            case .left, .right:
+                return NSSize(
+                    width: max(minWidth, visibleFrame.width * primary),
+                    height: max(minHeight, visibleFrame.height * secondary)
+                )
+            case .center:
+                return NSSize(
+                    width: max(minWidth, visibleFrame.width * primary),
+                    height: max(minHeight, visibleFrame.height * secondary)
+                )
+            }
+        }()
+
+        let clamped = NSSize(
+            width: min(size.width, visibleFrame.width),
+            height: min(size.height, visibleFrame.height)
+        )
+
+        switch self {
+        case .top:
+            return NSRect(
+                x: round(visibleFrame.midX - clamped.width / 2),
+                y: visibleFrame.maxY - clamped.height,
+                width: clamped.width,
+                height: clamped.height
+            )
+        case .bottom:
+            return NSRect(
+                x: round(visibleFrame.midX - clamped.width / 2),
+                y: visibleFrame.minY,
+                width: clamped.width,
+                height: clamped.height
+            )
+        case .left:
+            return NSRect(
+                x: visibleFrame.minX,
+                y: round(visibleFrame.midY - clamped.height / 2),
+                width: clamped.width,
+                height: clamped.height
+            )
+        case .right:
+            return NSRect(
+                x: visibleFrame.maxX - clamped.width,
+                y: round(visibleFrame.midY - clamped.height / 2),
+                width: clamped.width,
+                height: clamped.height
+            )
+        case .center:
+            return NSRect(
+                x: round(visibleFrame.midX - clamped.width / 2),
+                y: round(visibleFrame.midY - clamped.height / 2),
+                width: clamped.width,
+                height: clamped.height
+            )
+        }
+    }
+
+    func hiddenFrame(from finalFrame: NSRect, visibleFrame: NSRect) -> NSRect {
+        switch self {
+        case .top:
+            return NSRect(
+                x: finalFrame.origin.x,
+                y: visibleFrame.maxY,
+                width: finalFrame.width,
+                height: finalFrame.height
+            )
+        case .bottom:
+            return NSRect(
+                x: finalFrame.origin.x,
+                y: visibleFrame.minY - finalFrame.height,
+                width: finalFrame.width,
+                height: finalFrame.height
+            )
+        case .left:
+            return NSRect(
+                x: visibleFrame.minX - finalFrame.width,
+                y: finalFrame.origin.y,
+                width: finalFrame.width,
+                height: finalFrame.height
+            )
+        case .right:
+            return NSRect(
+                x: visibleFrame.maxX,
+                y: finalFrame.origin.y,
+                width: finalFrame.width,
+                height: finalFrame.height
+            )
+        case .center:
+            return NSRect(
+                x: finalFrame.origin.x,
+                y: visibleFrame.maxY + 18,
+                width: finalFrame.width,
+                height: finalFrame.height
+            )
+        }
+    }
+}
+
+private final class QuickTerminalPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+@MainActor
+private final class QuickTerminalController: NSObject, NSWindowDelegate {
+    private weak var appDelegate: AppDelegate?
+    private var panel: QuickTerminalPanel?
+    private var terminalSurface: TerminalSurface?
+    private var previousFrontmostApp: NSRunningApplication?
+    private let workspaceId = UUID()
+    private var isTransitioning = false
+
+    private(set) var isVisible = false
+
+    init(appDelegate: AppDelegate) {
+        self.appDelegate = appDelegate
+        super.init()
+    }
+
+    func toggle(activateApp: Bool = true) {
+        if isVisible {
+            hide(restorePreviousApp: activateApp)
+        } else {
+            show(activateApp: activateApp)
+        }
+    }
+
+    func show(activateApp: Bool = true) {
+        guard !isVisible, !isTransitioning else { return }
+        let settings = QuickTerminalSettings.resolved()
+        guard let panel = ensurePanel() else { return }
+        let targetScreen = screen(for: panel)
+        let visibleFrame = targetScreen.visibleFrame
+        let finalFrame = settings.position.finalFrame(
+            in: visibleFrame,
+            primarySizeRatio: settings.primarySizeRatio,
+            secondarySizeRatio: settings.secondarySizeRatio
+        )
+        let hiddenFrame = settings.position.hiddenFrame(from: finalFrame, visibleFrame: visibleFrame)
+
+          if activateApp,
+              !NSApp.isActive,
+           let frontmost = NSWorkspace.shared.frontmostApplication,
+           frontmost.bundleIdentifier != Bundle.main.bundleIdentifier {
+            previousFrontmostApp = frontmost
+        }
+
+        isVisible = true
+        isTransitioning = true
+        panel.alphaValue = 0
+        panel.setFrame(hiddenFrame, display: false)
+        panel.level = .popUpMenu
+        if activateApp {
+            panel.orderFrontRegardless()
+            panel.makeKeyAndOrderFront(nil)
+        } else {
+            panel.orderFront(nil)
+        }
+
+        if let terminalSurface {
+            terminalSurface.hostedView.setVisibleInUI(true)
+            terminalSurface.hostedView.setActive(activateApp)
+        }
+
+        if activateApp, !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = settings.animationDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            panel.animator().alphaValue = 1
+            panel.animator().setFrame(finalFrame, display: true)
+        } completionHandler: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isTransitioning = false
+                panel.level = .floating
+                if activateApp {
+                    panel.makeKeyAndOrderFront(nil)
+                    panel.makeFirstResponder(self.terminalSurface?.hostedView)
+                    self.terminalSurface?.hostedView.setActive(true)
+                    self.terminalSurface?.hostedView.moveFocus()
+                } else {
+                    panel.orderFront(nil)
+                    self.terminalSurface?.hostedView.setActive(false)
+                }
+            }
+        }
+    }
+
+    func hide(restorePreviousApp: Bool) {
+        guard isVisible, !isTransitioning else { return }
+        let settings = QuickTerminalSettings.resolved()
+        guard let panel else {
+            isVisible = false
+            previousFrontmostApp = nil
+            return
+        }
+
+        let targetScreen = screen(for: panel)
+        let visibleFrame = targetScreen.visibleFrame
+        let finalFrame = panel.frame
+        let hiddenFrame = settings.position.hiddenFrame(from: finalFrame, visibleFrame: visibleFrame)
+
+        isVisible = false
+        isTransitioning = true
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = settings.animationDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            panel.animator().alphaValue = 0
+            panel.animator().setFrame(hiddenFrame, display: false)
+        } completionHandler: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isTransitioning = false
+                panel.orderOut(nil)
+                self.terminalSurface?.hostedView.setActive(false)
+                self.terminalSurface?.hostedView.setVisibleInUI(false)
+                if restorePreviousApp,
+                   let previousFrontmostApp = self.previousFrontmostApp,
+                   !previousFrontmostApp.isTerminated {
+                    _ = previousFrontmostApp.activate(options: [])
+                }
+                self.previousFrontmostApp = nil
+            }
+        }
+    }
+
+    func statusPayload() -> [String: Any] {
+        let settings = QuickTerminalSettings.resolved()
+        return [
+            "visible": isVisible,
+            "position": settings.position.rawValue,
+            "auto_hide": settings.autoHide,
+            "primary_size_ratio": settings.primarySizeRatio,
+            "secondary_size_ratio": settings.secondarySizeRatio
+        ]
+    }
+
+    func teardown() {
+        panel?.orderOut(nil)
+        terminalSurface?.hostedView.setActive(false)
+        terminalSurface?.hostedView.setVisibleInUI(false)
+        panel = nil
+        terminalSurface = nil
+        isVisible = false
+        previousFrontmostApp = nil
+        isTransitioning = false
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        let settings = QuickTerminalSettings.resolved()
+        guard settings.autoHide else { return }
+        guard isVisible, !isTransitioning else { return }
+        guard let panel = notification.object as? NSWindow, panel === self.panel else { return }
+        guard panel.attachedSheet == nil else { return }
+        hide(restorePreviousApp: false)
+    }
+
+    private func ensurePanel() -> QuickTerminalPanel? {
+        if let panel {
+            return panel
+        }
+
+        let settings = QuickTerminalSettings.resolved()
+        let targetScreen = screen(for: nil)
+        let visibleFrame = targetScreen.visibleFrame
+        let initialFrame = settings.position.finalFrame(
+            in: visibleFrame,
+            primarySizeRatio: settings.primarySizeRatio,
+            secondarySizeRatio: settings.secondarySizeRatio
+        )
+        let panel = QuickTerminalPanel(
+            contentRect: initialFrame,
+            styleMask: [.borderless, .resizable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.identifier = NSUserInterfaceItemIdentifier("cmux.quick-terminal")
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.collectionBehavior = [.moveToActiveSpace, .fullScreenAuxiliary, .ignoresCycle]
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.level = .floating
+        panel.delegate = self
+
+        if terminalSurface == nil {
+            terminalSurface = TerminalSurface(
+                tabId: workspaceId,
+                context: GHOSTTY_SURFACE_CONTEXT_WINDOW,
+                configTemplate: nil,
+                initialEnvironmentOverrides: ["CMUX_QUICK_TERMINAL": "1"]
+            )
+        }
+
+        if let terminalSurface {
+            terminalSurface.hostedView.frame = NSRect(origin: .zero, size: initialFrame.size)
+            terminalSurface.hostedView.autoresizingMask = [.width, .height]
+            terminalSurface.hostedView.setVisibleInUI(false)
+            terminalSurface.hostedView.setActive(false)
+            panel.contentView = terminalSurface.hostedView
+        }
+
+        self.panel = panel
+        return panel
+    }
+
+    private func screen(for panel: NSWindow?) -> NSScreen {
+        if let panel, let panelScreen = panel.screen {
+            return panelScreen
+        }
+        if let keyScreen = NSApp.keyWindow?.screen {
+            return keyScreen
+        }
+        if let main = NSScreen.main {
+            return main
+        }
+        if let first = NSScreen.screens.first {
+            return first
+        }
+        preconditionFailure("No available NSScreen for quick terminal")
+    }
+}
+
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate, NSMenuItemValidation {
     nonisolated(unsafe) static var shared: AppDelegate?
@@ -2463,6 +2869,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private static let commandPaletteRequestGraceInterval: TimeInterval = 1.25
     private static let commandPalettePendingOpenMaxAge: TimeInterval = 8.0
     private static let sessionAutosaveTypingQuietPeriod: TimeInterval = 0.65
+    private lazy var quickTerminalController = QuickTerminalController(appDelegate: self)
 
     var updateViewModel: UpdateViewModel {
         updateController.viewModel
@@ -3015,6 +3422,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
+        quickTerminalController.teardown()
         TerminalController.shared.stop()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
@@ -6561,6 +6969,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
         return false
+    }
+
+    @discardableResult
+    func toggleQuickTerminalVisibility(activateApp: Bool = true) -> Bool {
+        quickTerminalController.toggle(activateApp: activateApp)
+        return true
+    }
+
+    @discardableResult
+    func showQuickTerminal(activateApp: Bool = true) -> Bool {
+        quickTerminalController.show(activateApp: activateApp)
+        return true
+    }
+
+    @discardableResult
+    func hideQuickTerminal(restorePreviousApp: Bool = true) -> Bool {
+        quickTerminalController.hide(restorePreviousApp: restorePreviousApp)
+        return true
+    }
+
+    func quickTerminalStatusPayload() -> [String: Any] {
+        quickTerminalController.statusPayload()
+    }
+
+    @objc func toggleQuickTerminal(_ sender: Any?) {
+        _ = sender
+        _ = toggleQuickTerminalVisibility()
     }
 
     func sidebarVisibility(windowId: UUID) -> Bool? {
@@ -10958,6 +11393,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if flags.isDisjoint(with: [.command, .control, .option]),
            titlebarAccessoryController.isNotificationsPopoverShown(),
            (notificationStore?.notifications.isEmpty ?? false) {
+            return true
+        }
+
+        // Allow quick-terminal toggle even when the key event comes from the quick
+        // panel itself (which is not a main terminal window context).
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleQuickTerminal)) {
+            _ = toggleQuickTerminalVisibility()
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2408,8 +2408,8 @@ private final class QuickTerminalController: NSObject, NSWindowDelegate {
         )
         let hiddenFrame = settings.position.hiddenFrame(from: finalFrame, visibleFrame: visibleFrame)
 
-          if activateApp,
-              !NSApp.isActive,
+        if activateApp,
+           !NSApp.isActive,
            let frontmost = NSWorkspace.shared.frontmostApplication,
            frontmost.bundleIdentifier != Bundle.main.bundleIdentifier {
             previousFrontmostApp = frontmost

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2373,12 +2373,18 @@ private final class QuickTerminalPanel: NSPanel {
 
 @MainActor
 private final class QuickTerminalController: NSObject, NSWindowDelegate {
+    private enum PendingTransitionAction {
+        case show(activateApp: Bool)
+        case hide(restorePreviousApp: Bool)
+    }
+
     private weak var appDelegate: AppDelegate?
     private var panel: QuickTerminalPanel?
     private var terminalSurface: TerminalSurface?
     private var previousFrontmostApp: NSRunningApplication?
     private let workspaceId = UUID()
     private var isTransitioning = false
+    private var pendingTransitionAction: PendingTransitionAction?
 
     private(set) var isVisible = false
 
@@ -2396,7 +2402,11 @@ private final class QuickTerminalController: NSObject, NSWindowDelegate {
     }
 
     func show(activateApp: Bool = true) {
-        guard !isVisible, !isTransitioning else { return }
+        if isTransitioning {
+            pendingTransitionAction = .show(activateApp: activateApp)
+            return
+        }
+        guard !isVisible else { return }
         let settings = QuickTerminalSettings.resolved()
         guard let panel = ensurePanel() else { return }
         let targetScreen = screen(for: panel)
@@ -2455,12 +2465,17 @@ private final class QuickTerminalController: NSObject, NSWindowDelegate {
                     panel.orderFront(nil)
                     self.terminalSurface?.hostedView.setActive(false)
                 }
+                self.replayPendingTransitionActionIfNeeded()
             }
         }
     }
 
     func hide(restorePreviousApp: Bool) {
-        guard isVisible, !isTransitioning else { return }
+        if isTransitioning {
+            pendingTransitionAction = .hide(restorePreviousApp: restorePreviousApp)
+            return
+        }
+        guard isVisible else { return }
         let settings = QuickTerminalSettings.resolved()
         guard let panel else {
             isVisible = false
@@ -2494,6 +2509,7 @@ private final class QuickTerminalController: NSObject, NSWindowDelegate {
                     _ = previousFrontmostApp.activate(options: [])
                 }
                 self.previousFrontmostApp = nil
+                self.replayPendingTransitionActionIfNeeded()
             }
         }
     }
@@ -2518,15 +2534,27 @@ private final class QuickTerminalController: NSObject, NSWindowDelegate {
         isVisible = false
         previousFrontmostApp = nil
         isTransitioning = false
+        pendingTransitionAction = nil
     }
 
     func windowDidResignKey(_ notification: Notification) {
         let settings = QuickTerminalSettings.resolved()
         guard settings.autoHide else { return }
-        guard isVisible, !isTransitioning else { return }
+        guard isVisible else { return }
         guard let panel = notification.object as? NSWindow, panel === self.panel else { return }
         guard panel.attachedSheet == nil else { return }
         hide(restorePreviousApp: false)
+    }
+
+    private func replayPendingTransitionActionIfNeeded() {
+        guard !isTransitioning, let action = pendingTransitionAction else { return }
+        pendingTransitionAction = nil
+        switch action {
+        case .show(let activateApp):
+            show(activateApp: activateApp)
+        case .hide(let restorePreviousApp):
+            hide(restorePreviousApp: restorePreviousApp)
+        }
     }
 
     private func ensurePanel() -> QuickTerminalPanel? {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6619,6 +6619,8 @@ struct ContentView: View {
             return .closeWindow
         case "palette.toggleSidebar":
             return .toggleSidebar
+        case "palette.toggleQuickTerminal":
+            return .toggleQuickTerminal
         case "palette.showNotifications":
             return .showNotifications
         case "palette.jumpUnread":
@@ -6936,6 +6938,14 @@ struct ContentView: View {
                 title: constant(String(localized: "command.toggleSidebar.title", defaultValue: "Toggle Sidebar")),
                 subtitle: constant(String(localized: "command.toggleSidebar.subtitle", defaultValue: "Layout")),
                 keywords: ["toggle", "sidebar", "layout"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.toggleQuickTerminal",
+                title: constant(String(localized: "command.toggleQuickTerminal.title", defaultValue: "Toggle Quick Terminal")),
+                subtitle: constant(String(localized: "command.toggleQuickTerminal.subtitle", defaultValue: "Terminal")),
+                keywords: ["quick", "terminal", "toggle", "dropdown", "quake"]
             )
         )
         contributions.append(
@@ -7638,6 +7648,9 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.toggleSidebar") {
             sidebarState.toggle()
+        }
+        registry.register(commandId: "palette.toggleQuickTerminal") {
+            AppDelegate.shared?.toggleQuickTerminal(nil)
         }
         registry.register(commandId: "palette.enableMinimalMode") {
             workspacePresentationMode = WorkspacePresentationModeSettings.Mode.minimal.rawValue

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -39,6 +39,7 @@ enum KeyboardShortcutSettings {
 
         // Titlebar / primary UI
         case toggleSidebar
+        case toggleQuickTerminal
         case newTab
         case openFolder
         case goToWorkspace
@@ -109,6 +110,7 @@ enum KeyboardShortcutSettings {
             case .toggleFullScreen: return String(localized: "command.toggleFullScreen.title", defaultValue: "Toggle Full Screen")
             case .quit: return String(localized: "menu.quitCmux", defaultValue: "Quit cmux")
             case .toggleSidebar: return String(localized: "shortcut.toggleSidebar.label", defaultValue: "Toggle Sidebar")
+            case .toggleQuickTerminal: return String(localized: "shortcut.toggleQuickTerminal.label", defaultValue: "Toggle Quick Terminal")
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
             case .openFolder: return String(localized: "shortcut.openFolder.label", defaultValue: "Open Folder")
             case .goToWorkspace: return String(localized: "menu.file.goToWorkspace", defaultValue: "Go to Workspace…")
@@ -185,6 +187,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "q", command: true, shift: false, option: false, control: false)
             case .toggleSidebar:
                 return StoredShortcut(key: "b", command: true, shift: false, option: false, control: false)
+            case .toggleQuickTerminal:
+                return StoredShortcut(key: "`", command: true, shift: false, option: true, control: false)
             case .newTab:
                 return StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
             case .openFolder:
@@ -715,6 +719,7 @@ enum KeyboardShortcutSettings {
     static func splitRightShortcut() -> StoredShortcut { shortcut(for: .splitRight) }
     static func splitDownShortcut() -> StoredShortcut { shortcut(for: .splitDown) }
     static func toggleSplitZoomShortcut() -> StoredShortcut { shortcut(for: .toggleSplitZoom) }
+    static func toggleQuickTerminalShortcut() -> StoredShortcut { shortcut(for: .toggleQuickTerminal) }
     static func splitBrowserRightShortcut() -> StoredShortcut { shortcut(for: .splitBrowserRight) }
     static func splitBrowserDownShortcut() -> StoredShortcut { shortcut(for: .splitBrowserDown) }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -139,9 +139,6 @@ class TerminalController {
         "browser.focus_webview",
         "browser.focus",
         "browser.tab.switch",
-        "quick_terminal.toggle",
-        "quick_terminal.show",
-        "quick_terminal.hide",
         "debug.command_palette.toggle",
         "debug.notification.focus",
         "debug.app.activate"

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -139,6 +139,9 @@ class TerminalController {
         "browser.focus_webview",
         "browser.focus",
         "browser.tab.switch",
+        "quick_terminal.toggle",
+        "quick_terminal.show",
+        "quick_terminal.hide",
         "debug.command_palette.toggle",
         "debug.notification.focus",
         "debug.app.activate"
@@ -2226,6 +2229,14 @@ class TerminalController {
             return v2Result(id: id, self.v2AppFocusOverride(params: params))
         case "app.simulate_active":
             return v2Result(id: id, self.v2AppSimulateActive())
+        case "quick_terminal.toggle":
+            return v2Result(id: id, self.v2QuickTerminalToggle())
+        case "quick_terminal.show":
+            return v2Result(id: id, self.v2QuickTerminalShow())
+        case "quick_terminal.hide":
+            return v2Result(id: id, self.v2QuickTerminalHide())
+        case "quick_terminal.status":
+            return v2Ok(id: id, result: self.v2QuickTerminalStatus())
 
         // Browser
         case "browser.open_split":
@@ -2551,6 +2562,10 @@ class TerminalController {
             "notification.clear",
             "app.focus_override.set",
             "app.simulate_active",
+            "quick_terminal.toggle",
+            "quick_terminal.show",
+            "quick_terminal.hide",
+            "quick_terminal.status",
             "markdown.open",
             "browser.open_split",
             "browser.navigate",
@@ -7132,6 +7147,56 @@ class TerminalController {
             )
         }
         return .ok([:])
+    }
+
+    private func v2QuickTerminalToggle() -> V2CallResult {
+        var didToggle = false
+        v2MainSync {
+            didToggle = AppDelegate.shared?.toggleQuickTerminalVisibility(activateApp: false) == true
+        }
+        guard didToggle else {
+            return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
+        }
+        return .ok(v2QuickTerminalStatus())
+    }
+
+    private func v2QuickTerminalShow() -> V2CallResult {
+        var didShow = false
+        v2MainSync {
+            didShow = AppDelegate.shared?.showQuickTerminal(activateApp: false) == true
+        }
+        guard didShow else {
+            return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
+        }
+        return .ok(v2QuickTerminalStatus())
+    }
+
+    private func v2QuickTerminalHide() -> V2CallResult {
+        var didHide = false
+        v2MainSync {
+            didHide = AppDelegate.shared?.hideQuickTerminal(restorePreviousApp: false) == true
+        }
+        guard didHide else {
+            return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
+        }
+        return .ok(v2QuickTerminalStatus())
+    }
+
+    private func v2QuickTerminalStatus() -> [String: Any] {
+        var payload: [String: Any]?
+        v2MainSync {
+            payload = AppDelegate.shared?.quickTerminalStatusPayload()
+        }
+
+        guard var payload else {
+            return [
+                "available": false,
+                "visible": false
+            ]
+        }
+
+        payload["available"] = true
+        return payload
     }
 
     // MARK: - V2 Browser Methods

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4630,6 +4630,73 @@ struct SettingsView: View {
         "\(Int((QuickTerminalSettings.clampRatio(ratio) * 100).rounded()))%"
     }
 
+    private var quickTerminalSettingsRows: AnyView {
+        AnyView(Group {
+            SettingsPickerRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.quickTerminal.position", defaultValue: "Quick Terminal Position"),
+                subtitle: String(localized: "settings.quickTerminal.position.subtitle", defaultValue: "Choose which edge the quick terminal slides from."),
+                controlWidth: pickerColumnWidth,
+                selection: quickTerminalPositionSelection
+            ) {
+                ForEach(Array(QuickTerminalPosition.allCases), id: \.rawValue) { position in
+                    Text(verbatim: quickTerminalPositionDisplayName(position))
+                        .tag(position.rawValue)
+                }
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.quickTerminal.primarySize", defaultValue: "Quick Terminal Primary Size"),
+                subtitle: String(localized: "settings.quickTerminal.primarySize.subtitle", defaultValue: "Size along the deployment axis.")
+            ) {
+                HStack(spacing: 8) {
+                    Slider(value: quickTerminalPrimarySizeBinding, in: 0.2...1.0)
+                        .frame(width: 132)
+                    Text(quickTerminalRatioPercentLabel(quickTerminalPrimarySizeRatio))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .trailing)
+                }
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.quickTerminal.secondarySize", defaultValue: "Quick Terminal Secondary Size"),
+                subtitle: String(localized: "settings.quickTerminal.secondarySize.subtitle", defaultValue: "Size on the opposite axis.")
+            ) {
+                HStack(spacing: 8) {
+                    Slider(value: quickTerminalSecondarySizeBinding, in: 0.2...1.0)
+                        .frame(width: 132)
+                    Text(quickTerminalRatioPercentLabel(quickTerminalSecondarySizeRatio))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 42, alignment: .trailing)
+                }
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.quickTerminal.autoHide", defaultValue: "Quick Terminal Auto-Hide"),
+                subtitle: quickTerminalAutoHide
+                    ? String(localized: "settings.quickTerminal.autoHide.subtitleOn", defaultValue: "Hide automatically when it loses focus.")
+                    : String(localized: "settings.quickTerminal.autoHide.subtitleOff", defaultValue: "Keep visible when focus moves to another app/window.")
+            ) {
+                Toggle("", isOn: $quickTerminalAutoHide)
+                    .labelsHidden()
+                    .controlSize(.small)
+            }
+
+            SettingsCardDivider()
+        })
+    }
+
     private var sidebarIndicatorStyleSelection: Binding<String> {
         Binding(
             get: { selectedSidebarActiveTabIndicatorStyle.rawValue },
@@ -5134,63 +5201,7 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
-                        SettingsPickerRow(
-                            String(localized: "settings.quickTerminal.position", defaultValue: "Quick Terminal Position"),
-                            subtitle: String(localized: "settings.quickTerminal.position.subtitle", defaultValue: "Choose which edge the quick terminal slides from."),
-                            controlWidth: pickerColumnWidth,
-                            selection: quickTerminalPositionSelection
-                        ) {
-                            ForEach(QuickTerminalPosition.allCases) { position in
-                                Text(quickTerminalPositionDisplayName(position)).tag(position.rawValue)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            String(localized: "settings.quickTerminal.primarySize", defaultValue: "Quick Terminal Primary Size"),
-                            subtitle: String(localized: "settings.quickTerminal.primarySize.subtitle", defaultValue: "Size along the deployment axis.")
-                        ) {
-                            HStack(spacing: 8) {
-                                Slider(value: quickTerminalPrimarySizeBinding, in: 0.2...1.0)
-                                    .frame(width: 132)
-                                Text(quickTerminalRatioPercentLabel(quickTerminalPrimarySizeRatio))
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 42, alignment: .trailing)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            String(localized: "settings.quickTerminal.secondarySize", defaultValue: "Quick Terminal Secondary Size"),
-                            subtitle: String(localized: "settings.quickTerminal.secondarySize.subtitle", defaultValue: "Size on the opposite axis.")
-                        ) {
-                            HStack(spacing: 8) {
-                                Slider(value: quickTerminalSecondarySizeBinding, in: 0.2...1.0)
-                                    .frame(width: 132)
-                                Text(quickTerminalRatioPercentLabel(quickTerminalSecondarySizeRatio))
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 42, alignment: .trailing)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            String(localized: "settings.quickTerminal.autoHide", defaultValue: "Quick Terminal Auto-Hide"),
-                            subtitle: quickTerminalAutoHide
-                                ? String(localized: "settings.quickTerminal.autoHide.subtitleOn", defaultValue: "Hide automatically when it loses focus.")
-                                : String(localized: "settings.quickTerminal.autoHide.subtitleOff", defaultValue: "Keep visible when focus moves to another app/window.")
-                        ) {
-                            Toggle("", isOn: $quickTerminalAutoHide)
-                                .labelsHidden()
-                                .controlSize(.small)
-                        }
-
-                        SettingsCardDivider()
+                        quickTerminalSettingsRows
 
                         SettingsCardRow(
                             configurationReview: .json("app.keepWorkspaceOpenWhenClosingLastSurface"),

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -697,6 +697,13 @@ struct cmuxApp: App {
                     }
                 }
 
+                splitCommandButton(
+                    title: String(localized: "menu.view.toggleQuickTerminal", defaultValue: "Toggle Quick Terminal"),
+                    shortcut: menuShortcut(for: .toggleQuickTerminal)
+                ) {
+                    AppDelegate.shared?.toggleQuickTerminal(nil)
+                }
+
                 Divider()
 
                 splitCommandButton(title: String(localized: "menu.view.nextSurface", defaultValue: "Next Surface"), shortcut: menuShortcut(for: .nextSurface)) {
@@ -4468,6 +4475,14 @@ struct SettingsView: View {
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarMatchTerminalBackground") private var sidebarMatchTerminalBackground = false
+    @AppStorage(QuickTerminalSettings.positionKey)
+    private var quickTerminalPosition = QuickTerminalSettings.defaultPosition.rawValue
+    @AppStorage(QuickTerminalSettings.primarySizeRatioKey)
+    private var quickTerminalPrimarySizeRatio = QuickTerminalSettings.defaultPrimarySizeRatio
+    @AppStorage(QuickTerminalSettings.secondarySizeRatioKey)
+    private var quickTerminalSecondarySizeRatio = QuickTerminalSettings.defaultSecondarySizeRatio
+    @AppStorage(QuickTerminalSettings.autoHideKey)
+    private var quickTerminalAutoHide = QuickTerminalSettings.defaultAutoHide
 
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @ObservedObject private var authManager = AuthManager.shared
@@ -4566,6 +4581,53 @@ struct SettingsView: View {
 
     private var selectedSidebarActiveTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
         SidebarActiveTabIndicatorSettings.resolvedStyle(rawValue: sidebarActiveTabIndicatorStyle)
+    }
+
+    private var selectedQuickTerminalPosition: QuickTerminalPosition {
+        QuickTerminalPosition(rawValue: quickTerminalPosition) ?? QuickTerminalSettings.defaultPosition
+    }
+
+    private var quickTerminalPositionSelection: Binding<String> {
+        Binding(
+            get: { selectedQuickTerminalPosition.rawValue },
+            set: { newValue in
+                quickTerminalPosition = QuickTerminalPosition(rawValue: newValue)?.rawValue
+                    ?? QuickTerminalSettings.defaultPosition.rawValue
+            }
+        )
+    }
+
+    private var quickTerminalPrimarySizeBinding: Binding<Double> {
+        Binding(
+            get: { QuickTerminalSettings.clampRatio(quickTerminalPrimarySizeRatio) },
+            set: { quickTerminalPrimarySizeRatio = QuickTerminalSettings.clampRatio($0) }
+        )
+    }
+
+    private var quickTerminalSecondarySizeBinding: Binding<Double> {
+        Binding(
+            get: { QuickTerminalSettings.clampRatio(quickTerminalSecondarySizeRatio) },
+            set: { quickTerminalSecondarySizeRatio = QuickTerminalSettings.clampRatio($0) }
+        )
+    }
+
+    private func quickTerminalPositionDisplayName(_ position: QuickTerminalPosition) -> String {
+        switch position {
+        case .top:
+            return String(localized: "settings.quickTerminal.position.top", defaultValue: "Top")
+        case .bottom:
+            return String(localized: "settings.quickTerminal.position.bottom", defaultValue: "Bottom")
+        case .left:
+            return String(localized: "settings.quickTerminal.position.left", defaultValue: "Left")
+        case .right:
+            return String(localized: "settings.quickTerminal.position.right", defaultValue: "Right")
+        case .center:
+            return String(localized: "settings.quickTerminal.position.center", defaultValue: "Center")
+        }
+    }
+
+    private func quickTerminalRatioPercentLabel(_ ratio: Double) -> String {
+        "\(Int((QuickTerminalSettings.clampRatio(ratio) * 100).rounded()))%"
     }
 
     private var sidebarIndicatorStyleSelection: Binding<String> {
@@ -5068,6 +5130,64 @@ struct SettingsView: View {
                                 .accessibilityLabel(
                                     String(localized: "settings.app.minimalMode", defaultValue: "Minimal Mode")
                                 )
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.quickTerminal.position", defaultValue: "Quick Terminal Position"),
+                            subtitle: String(localized: "settings.quickTerminal.position.subtitle", defaultValue: "Choose which edge the quick terminal slides from."),
+                            controlWidth: pickerColumnWidth,
+                            selection: quickTerminalPositionSelection
+                        ) {
+                            ForEach(QuickTerminalPosition.allCases) { position in
+                                Text(quickTerminalPositionDisplayName(position)).tag(position.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.quickTerminal.primarySize", defaultValue: "Quick Terminal Primary Size"),
+                            subtitle: String(localized: "settings.quickTerminal.primarySize.subtitle", defaultValue: "Size along the deployment axis.")
+                        ) {
+                            HStack(spacing: 8) {
+                                Slider(value: quickTerminalPrimarySizeBinding, in: 0.2...1.0)
+                                    .frame(width: 132)
+                                Text(quickTerminalRatioPercentLabel(quickTerminalPrimarySizeRatio))
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 42, alignment: .trailing)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.quickTerminal.secondarySize", defaultValue: "Quick Terminal Secondary Size"),
+                            subtitle: String(localized: "settings.quickTerminal.secondarySize.subtitle", defaultValue: "Size on the opposite axis.")
+                        ) {
+                            HStack(spacing: 8) {
+                                Slider(value: quickTerminalSecondarySizeBinding, in: 0.2...1.0)
+                                    .frame(width: 132)
+                                Text(quickTerminalRatioPercentLabel(quickTerminalSecondarySizeRatio))
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 42, alignment: .trailing)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.quickTerminal.autoHide", defaultValue: "Quick Terminal Auto-Hide"),
+                            subtitle: quickTerminalAutoHide
+                                ? String(localized: "settings.quickTerminal.autoHide.subtitleOn", defaultValue: "Hide automatically when it loses focus.")
+                                : String(localized: "settings.quickTerminal.autoHide.subtitleOff", defaultValue: "Keep visible when focus moves to another app/window.")
+                        ) {
+                            Toggle("", isOn: $quickTerminalAutoHide)
+                                .labelsHidden()
+                                .controlSize(.small)
                         }
 
                         SettingsCardDivider()
@@ -6622,6 +6742,10 @@ struct SettingsView: View {
         openSidebarPortLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
         showShortcutHintsOnControlHold = ShortcutHintDebugSettings.defaultShowHintsOnControlHold
+        quickTerminalPosition = QuickTerminalSettings.defaultPosition.rawValue
+        quickTerminalPrimarySizeRatio = QuickTerminalSettings.defaultPrimarySizeRatio
+        quickTerminalSecondarySizeRatio = QuickTerminalSettings.defaultSecondarySizeRatio
+        quickTerminalAutoHide = QuickTerminalSettings.defaultAutoHide
         sidebarShowSSH = true
         sidebarShowPorts = true
         sidebarShowLog = true

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1933,10 +1933,15 @@ final class StoredShortcutMatchingTests: XCTestCase {
 
         let shortcut = KeyboardShortcutSettings.Action.toggleQuickTerminal.defaultShortcut
         XCTAssertEqual(shortcut.key, "`")
+        XCTAssertEqual(shortcut.keyEquivalent, KeyEquivalent("`"))
+        XCTAssertEqual(shortcut.menuItemKeyEquivalent, "`")
         XCTAssertTrue(shortcut.command)
         XCTAssertFalse(shortcut.shift)
         XCTAssertTrue(shortcut.option)
         XCTAssertFalse(shortcut.control)
+        XCTAssertEqual(shortcut.eventModifiers, [.command, .option])
+        XCTAssertFalse(shortcut.eventModifiers.contains(.shift))
+        XCTAssertFalse(shortcut.eventModifiers.contains(.control))
     }
 
     func testShortcutRecorderValidationPresentationUsesNumberedDisplayOnlyForNumberedConflicts() {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1924,6 +1924,21 @@ final class StoredShortcutMatchingTests: XCTestCase {
         XCTAssertEqual(presentation?.undoButtonTitle, "Undo")
     }
 
+    func testToggleQuickTerminalShortcutDefaultsAndMetadata() {
+        XCTAssertEqual(KeyboardShortcutSettings.Action.toggleQuickTerminal.label, "Toggle Quick Terminal")
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.toggleQuickTerminal.defaultsKey,
+            "shortcut.toggleQuickTerminal"
+        )
+
+        let shortcut = KeyboardShortcutSettings.Action.toggleQuickTerminal.defaultShortcut
+        XCTAssertEqual(shortcut.key, "`")
+        XCTAssertTrue(shortcut.command)
+        XCTAssertFalse(shortcut.shift)
+        XCTAssertTrue(shortcut.option)
+        XCTAssertFalse(shortcut.control)
+    }
+
     func testShortcutRecorderValidationPresentationUsesNumberedDisplayOnlyForNumberedConflicts() {
         let presentation = ShortcutRecorderValidationPresentation(
             attempt: ShortcutRecorderRejectedAttempt(

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -532,6 +532,7 @@
               "toggleFullScreen",
               "quit",
               "toggleSidebar",
+              "toggleQuickTerminal",
               "newTab",
               "openFolder",
               "goToWorkspace",

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -45,6 +45,7 @@ export const shortcutCategories: ShortcutCategory[] = [
     blurbKey: "workspacesBlurb",
     shortcuts: [
       { id: "toggleSidebar", combos: [["⌘", "B"]], description: { en: "Toggle sidebar", ja: "サイドバーを切り替え" } },
+      { id: "toggleQuickTerminal", combos: [["⌥", "⌘", "`"]], description: { en: "Toggle quick terminal", ja: "クイックターミナルを切り替え" } },
       { id: "newTab", combos: [["⌘", "N"]], description: { en: "New workspace", ja: "新規ワークスペース" } },
       { id: "openFolder", combos: [["⌘", "O"]], description: { en: "Open folder", ja: "フォルダを開く" } },
       {


### PR DESCRIPTION
Implements Quick Terminal across app shortcut/menu/settings, command palette, socket v2, and CLI (cmux quick-terminal).

Also ensures socket/CLI quick terminal commands do not steal macOS focus and wraps animation completion state updates on MainActor.

Adds README and CHANGELOG notes.

Closes #327

## Summary

- Added Quick Terminal end-to-end integration:
  - Keyboard shortcut (default: Option+Command+`)
  - View menu action
  - Command Palette action
  - Settings controls (position, primary/secondary size, auto-hide)
  - Socket v2 methods:
    - quick_terminal.toggle
    - quick_terminal.show
    - quick_terminal.hide
    - quick_terminal.status
  - CLI commands:
    - cmux quick-terminal [toggle|show|hide|status]
    - cmux --json quick-terminal status
- Added localization strings for new Quick Terminal labels and settings.
- Added/updated test coverage for shortcut metadata defaults.
- Updated docs:
  - CHANGELOG (Unreleased)
  - README shortcut table and Quick Terminal CLI section.

## Why

- Provide a fast “drop-down style” terminal surface for quick interactions.
- Make Quick Terminal scriptable for automation workflows.
- Preserve user context by preventing socket/CLI calls from stealing macOS app focus.
- Improve concurrency safety in Quick Terminal animation completion paths.

## Testing

- Local build/run:
  - ./scripts/reload.sh --tag quick-terminal
- CLI smoke tests:
  - cmux-dev quick-terminal status
  - cmux-dev quick-terminal show
  - cmux-dev quick-terminal status
  - cmux-dev quick-terminal hide
  - cmux-dev --json quick-terminal status
- Manual verification:
  - Shortcut Option+Command+` toggles Quick Terminal.
  - View menu action toggles Quick Terminal.
  - Command Palette action toggles Quick Terminal.
  - Settings values apply (position, primary size, secondary size, auto-hide).
  - Socket/CLI automation path does not steal frontmost app focus.
- Notes:
  - No full local test suite run (repo policy favors CI for heavier suites).

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a drop-down Quick Terminal panel with keyboard/menu/palette controls and scriptable CLI/socket APIs. Automation-safe: CLI/socket calls don’t steal macOS focus; supports configurable position, size, auto-hide, and restores the previous app when hiding.

- **New Features**
  - Toggle via Option+Command+`, View menu, and Command Palette.
  - Settings: position (top/bottom/left/right/center), primary/secondary size, auto-hide on blur.
  - CLI: `cmux quick-terminal [toggle|show|hide|status]` and `cmux --json quick-terminal status` (prints availability, visibility, position, auto-hide, and size ratios).
  - Socket v2: `quick_terminal.toggle`, `quick_terminal.show`, `quick_terminal.hide`, `quick_terminal.status`.

- **Bug Fixes**
  - Queue show/hide actions during animations to avoid missed toggles and flicker.
  - Preserve native Cmd+` window cycling; allow toggle from within the Quick Terminal.

<sup>Written for commit 7a9b5282de8dc7ef40dfec870104c560a2a76bad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Terminal panel with default shortcut Option+Command+`
  * Configurable position, primary/secondary size ratios, and auto-hide in Preferences
  * Toggle via menu/command palette and CLI commands (toggle | show | hide | status)
* **Documentation**
  * Added README and changelog entries describing Quick Terminal, shortcut, and CLI usage
* **Localization**
  * Added English and Japanese strings for Quick Terminal UI and settings
* **Tests**
  * Added unit test validating Quick Terminal shortcut defaults and metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->