### PR TITLE
Add native macOS color picker to workspace color dialog

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2497,109 +2497,109 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter a hex color in the format #RRGGBB."
+            "value": "Enter a hex color or use the color picker."
           }
         },
         "ja": {
           "stringUnit": {
-            "state": "translated",
-            "value": "#RRGGBB形式で16進カラーコードを入力してください。"
+            "state": "needs_review",
+            "value": "16進カラーコードを入力するか、カラーピッカーを使用してください。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
-            "state": "translated",
-            "value": "请输入 #RRGGBB 格式的十六进制颜色。"
+            "state": "needs_review",
+            "value": "输入十六进制颜色或使用颜色选择器。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
-            "state": "translated",
-            "value": "請輸入 #RRGGBB 格式的十六進位色碼。"
+            "state": "needs_review",
+            "value": "輸入十六進位色碼或使用顏色選擇器。"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "translated",
-            "value": "#RRGGBB 형식으로 16진수 색상을 입력하세요."
+            "state": "needs_review",
+            "value": "16진수 색상을 입력하거나 색상 선택기를 사용하세요."
           }
         },
         "de": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Geben Sie eine Hex-Farbe im Format #RRGGBB ein."
+            "state": "needs_review",
+            "value": "Geben Sie eine Hex-Farbe ein oder verwenden Sie die Farbauswahl."
           }
         },
         "es": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Introduce un color hexadecimal con el formato #RRGGBB."
+            "state": "needs_review",
+            "value": "Introduce un color hexadecimal o usa el selector de color."
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Saisissez une couleur hexadécimale au format #RRVVBB."
+            "state": "needs_review",
+            "value": "Saisissez une couleur hexadécimale ou utilisez le sélecteur de couleurs."
           }
         },
         "it": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Inserisci un colore esadecimale nel formato #RRGGBB."
+            "state": "needs_review",
+            "value": "Inserisci un colore esadecimale o usa il selettore colori."
           }
         },
         "da": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Indtast en hex-farve i formatet #RRGGBB."
+            "state": "needs_review",
+            "value": "Indtast en hex-farve eller brug farvevælgeren."
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Wprowadź kolor szesnastkowy w formacie #RRGGBB."
+            "state": "needs_review",
+            "value": "Wprowadź kolor szesnastkowy lub użyj selektora kolorów."
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Введите цвет в формате #RRGGBB."
+            "state": "needs_review",
+            "value": "Введите цвет в формате hex или используйте палитру цветов."
           }
         },
         "bs": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Unesite heksadecimalnu boju u formatu #RRGGBB."
+            "state": "needs_review",
+            "value": "Unesite heksadecimalnu boju ili koristite birač boja."
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "translated",
-            "value": "أدخل لونًا سداسيًا بالتنسيق #RRGGBB."
+            "state": "needs_review",
+            "value": "أدخل لونًا سداسيًا أو استخدم منتقي الألوان."
           }
         },
         "nb": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Skriv inn en heksadesimal farge i formatet #RRGGBB."
+            "state": "needs_review",
+            "value": "Skriv inn en heksadesimal farge eller bruk fargevelgeren."
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Insira uma cor hexadecimal no formato #RRGGBB."
+            "state": "needs_review",
+            "value": "Insira uma cor hexadecimal ou use o seletor de cores."
           }
         },
         "th": {
           "stringUnit": {
-            "state": "translated",
-            "value": "ป้อนรหัสสี hex ในรูปแบบ #RRGGBB"
+            "state": "needs_review",
+            "value": "ป้อนรหัสสี hex หรือใช้ตัวเลือกสี"
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "#RRGGBB biçiminde bir onaltılık renk girin."
+            "state": "needs_review",
+            "value": "Onaltılık renk girin veya renk seçiciyi kullanın."
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12293,13 +12293,29 @@ private struct TabItemView: View, Equatable {
     private func promptCustomColor(targetIds: [UUID]) {
         let alert = NSAlert()
         alert.messageText = String(localized: "alert.customColor.title", defaultValue: "Custom Workspace Color")
-        alert.informativeText = String(localized: "alert.customColor.message", defaultValue: "Enter a hex color in the format #RRGGBB.")
+        alert.informativeText = String(localized: "alert.customColor.message", defaultValue: "Enter a hex color or use the color picker.")
 
         let seed = tab.customColor ?? WorkspaceTabColorSettings.customColors().first ?? ""
-        let input = NSTextField(string: seed)
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+
+        let colorWell = NSColorWell(frame: NSRect(x: 0, y: 0, width: 40, height: 24))
+        if #available(macOS 13.0, *) {
+            colorWell.colorWellStyle = .minimal
+        }
+        colorWell.color = NSColor(hex: seed) ?? .systemBlue
+        container.addSubview(colorWell)
+
+        let input = NSTextField(frame: NSRect(x: 48, y: 1, width: 192, height: 22))
+        input.stringValue = seed
         input.placeholderString = "#1565C0"
-        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
-        alert.accessoryView = input
+        container.addSubview(input)
+
+        let coordinator = ColorPanelCoordinator(colorWell: colorWell, textField: input)
+        // Keep coordinator alive for the duration of the alert
+        objc_setAssociatedObject(alert, &ColorPanelCoordinator.associatedKey, coordinator, .OBJC_ASSOCIATION_RETAIN)
+
+        alert.accessoryView = container
         alert.addButton(withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply"))
         alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
 
@@ -13885,6 +13901,45 @@ enum SidebarPresetOption: String, CaseIterable, Identifiable {
         case .hudGlass: return 0.98
         case .underWindow: return 0.9
         }
+    }
+}
+
+private class ColorPanelCoordinator: NSObject, NSTextFieldDelegate {
+    static var associatedKey: UInt8 = 0
+    private weak var colorWell: NSColorWell?
+    private weak var textField: NSTextField?
+    private var isSyncing = false
+
+    init(colorWell: NSColorWell, textField: NSTextField) {
+        self.colorWell = colorWell
+        self.textField = textField
+        super.init()
+        colorWell.target = self
+        colorWell.action = #selector(colorWellChanged(_:))
+        textField.delegate = self
+    }
+
+    @objc private func colorWellChanged(_ sender: NSColorWell) {
+        guard !isSyncing, let textField else { return }
+        isSyncing = true
+        textField.stringValue = sender.color.hexString()
+        textField.backgroundColor = .controlBackgroundColor
+        isSyncing = false
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        guard !isSyncing, let textField, let colorWell else { return }
+        isSyncing = true
+        let trimmed = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let color = NSColor(hex: trimmed) {
+            colorWell.color = color
+            textField.backgroundColor = .controlBackgroundColor
+        } else if !trimmed.isEmpty {
+            textField.backgroundColor = NSColor.systemRed.withAlphaComponent(0.15)
+        } else {
+            textField.backgroundColor = .controlBackgroundColor
+        }
+        isSyncing = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds an `NSColorWell` alongside the existing hex text field in the "Custom Workspace Color" dialog
- Bidirectional sync: picking from the system color panel updates the hex field, typing a valid hex updates the swatch
- Invalid hex input gives immediate visual feedback (red-tinted text field background)
- Existing hex-only workflow preserved for power users

## Test plan
- [ ] Right-click workspace tab → Workspace Color → Choose Custom Color…
- [ ] Verify color swatch appears to the left of the hex text field
- [ ] Click the swatch → system color picker opens → pick a color → hex field updates
- [ ] Type a valid hex in the text field → swatch updates to match
- [ ] Type an invalid hex → text field background tints red
- [ ] Clear the text field → red tint disappears
- [ ] Click Apply with a valid color → workspace color updates
- [ ] Click Apply with invalid hex → existing "Invalid Color" alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native macOS color picker to the Custom Workspace Color dialog alongside the hex field, with bidirectional sync and inline validation to make color selection faster and clearer.

- **New Features**
  - System color panel opens from the swatch; chosen color updates the hex field.
  - Typing a valid hex updates the swatch; invalid input tints the field red until corrected.
  - Updated helper text to “Enter a hex color or use the color picker.” (non‑English locales marked needs_review).

<sup>Written for commit d806b96a9cfc74d01137cf4a6c29ceec942c3056. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an integrated color picker alongside the hex color input field for easier color selection.

* **UI/UX Improvements**
  * Updated color input instructions to clarify users can enter hex values or use the color picker.
  * Added visual feedback (red tint) for invalid hex color entries.

* **Localization**
  * Updated localized strings across multiple languages with revised color input instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->