### PR TITLE
Fix browser portal leaking to other tabs on Bonsplit tab switch

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9386,6 +9386,16 @@ extension Workspace: BonsplitDelegate {
         }
     }
 
+    /// Hide browser portals for tabs that are no longer selected in the given pane.
+    private func hideBrowserPortalsForDeselectedTabs(inPane pane: PaneID, selectedTabId: TabID) {
+        for tab in bonsplitController.tabs(inPane: pane) {
+            guard tab.id != selectedTabId else { continue }
+            guard let panelId = panelIdFromSurfaceId(tab.id),
+                  let browserPanel = panels[panelId] as? BrowserPanel else { continue }
+            browserPanel.hideBrowserPortalView(source: "tabDeselected")
+        }
+    }
+
     private func applyTabSelectionNow(
         tabId: TabID,
         inPane pane: PaneID,
@@ -9464,6 +9474,13 @@ extension Workspace: BonsplitDelegate {
         for (id, p) in panels where id != effectiveFocusedPanelId {
             p.unfocus()
         }
+
+        // Explicitly hide browser portals for deselected tabs in this pane.
+        // Bonsplit's keepAllAlive mode hides non-selected tabs via SwiftUI .opacity(0),
+        // but portal-hosted WKWebViews render at the window level in AppKit and are not
+        // affected by SwiftUI opacity. Without an explicit hide, the deselected browser's
+        // portal layer can remain visible above the newly selected tab.
+        hideBrowserPortalsForDeselectedTabs(inPane: focusedPane, selectedTabId: selectedTabId)
 
         if let focusWindow = activationWindow(for: panel) {
             yieldForeignOwnedFocusIfNeeded(


### PR DESCRIPTION
## Summary

- When switching between Bonsplit tabs within a workspace, portal-hosted WKWebViews from deselected browser panels could remain visible above the newly selected tab
- Root cause: Bonsplit's `keepAllAlive` mode hides non-selected tabs via SwiftUI `.opacity(0)`, but portal-hosted WKWebViews render at the AppKit window level and are not affected by SwiftUI opacity changes
- Fix: explicitly hide browser portals for deselected tabs in the pane during `applyTabSelectionNow`, ensuring portal visibility is always in sync regardless of SwiftUI re-render timing

## Test plan

- [ ] Open a workspace with multiple tabs, including at least one browser tab
- [ ] Switch from the browser tab to a terminal tab — the browser content should disappear immediately
- [ ] Switch back to the browser tab — it should reappear correctly
- [ ] Test with split panes: browser in one pane should not be affected when switching tabs in another pane
- [ ] Test rapid tab switching to verify no flicker or stale portal frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops browser portal layers from showing over other tabs when switching within a Bonsplit pane by explicitly hiding portals for deselected tabs. Keeps portal-hosted web views in sync with tab selection even when `keepAllAlive` uses SwiftUI opacity.

- **Bug Fixes**
  - Hide browser portals for non-selected tabs in a pane during tab selection.
  - Resolves SwiftUI `.opacity(0)` vs AppKit window-level rendering mismatch.
  - Scopes the update to the active pane; other panes are unaffected.

<sup>Written for commit 91440f065fb691ba7e1163db0fc9f053e286ba17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab switching behavior to ensure browser content is properly hidden when switching between tabs, providing a more consistent experience when navigating multiple browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->