### PR TITLE
Add built-in Amp integration for agent status in tabs

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
+		A1E500000002D4E5F60A0072 /* amp in Copy CLI */ = {isa = PBXBuildFile; fileRef = A1E500000001D4E5F60A0071 /* amp */; };
+		A1E500000004D4E5F60A0074 /* cmux-status.ts in Copy Amp Plugins */ = {isa = PBXBuildFile; fileRef = A1E500000003D4E5F60A0073 /* cmux-status.ts */; };
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
@@ -252,6 +254,7 @@
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
+				A1E500000002D4E5F60A0072 /* amp in Copy CLI */,
 			);
 			name = "Copy CLI";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -265,6 +268,17 @@
 				D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */,
 			);
 			name = "Copy Dock Tile Plugin";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1E500000005D4E5F60A0075 /* Copy Amp Plugins */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "amp-plugins";
+			dstSubfolderSpec = 7;
+			files = (
+				A1E500000004D4E5F60A0074 /* cmux-status.ts in Copy Amp Plugins */,
+			);
+			name = "Copy Amp Plugins";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -424,6 +438,8 @@
 		C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
 		E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigNamedColorTests.swift; sourceTree = "<group>"; };
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
+		A1E500000001D4E5F60A0071 /* amp */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/amp; sourceTree = SOURCE_ROOT; };
+		A1E500000003D4E5F60A0073 /* cmux-status.ts */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.typescript; path = "Resources/amp-plugins/cmux-status.ts"; sourceTree = SOURCE_ROOT; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
@@ -515,6 +531,8 @@
 				B2E7294509CC42FE9191870E /* xterm-ghostty */,
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 				C1ADE00001A1B2C3D4E5F719 /* claude */,
+				A1E500000001D4E5F60A0071 /* amp */,
+				A1E500000003D4E5F60A0073 /* cmux-status.ts */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,
 				FEED0000000000000000F006 /* opencode-plugin.js */,
@@ -791,6 +809,7 @@
 				D1320AA0D1320AA0D1320AA6 /* Copy Dock Tile Plugin */,
 				A5001020 /* Embed Frameworks */,
 				B900000AA1B2C3D4E5F60719 /* Copy CLI */,
+				A1E500000005D4E5F60A0075 /* Copy Amp Plugins */,
 				A5001300A1B2C3D4E5F60719 /* ShellScript */,
 			);
 			buildRules = (

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -58145,6 +58145,458 @@
         }
       }
     },
+    "settings.automation.amp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp Integration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp連携"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp 集成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp 整合"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp 연동"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp-Integration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integración con Amp"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intégration Amp"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integrazione Amp"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp-integration"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integracja z Amp"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Интеграция с Amp"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp integracija"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكامل Amp"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp-integrering"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integração com Amp"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การผสานรวม Amp"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp Entegrasyonu"
+          }
+        }
+      }
+    },
+    "settings.automation.amp.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When enabled, cmux wraps the amp command to install a status plugin and enable agent tracking. Disable if you prefer to manage Amp plugins yourself."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にすると、cmuxはampコマンドをラップしてステータスプラグインをインストールし、エージェント追跡を有効にします。Ampのプラグインを自分で管理する場合は無効にしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用后，cmux 会包装 amp 命令以安装状态插件并启用代理跟踪。如果您希望自行管理 Amp 插件，请禁用此选项。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後，cmux 會包裝 amp 指令以安裝狀態外掛程式並啟用代理追蹤。如果您偏好自行管理 Amp 外掛程式，請停用此選項。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성화하면 cmux가 amp 명령을 래핑하여 상태 플러그인을 설치하고 에이전트 추적을 활성화합니다. Amp 플러그인을 직접 관리하려면 비활성화하세요."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn aktiviert, umhüllt cmux den amp-Befehl, um ein Status-Plugin zu installieren und die Agentenverfolgung zu aktivieren. Deaktivieren Sie dies, wenn Sie Amp-Plugins selbst verwalten möchten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está activado, cmux envuelve el comando amp para instalar un plugin de estado y habilitar el seguimiento del agente. Desactiva si prefieres gestionar los plugins de Amp tú mismo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsque cette option est activée, cmux encapsule la commande amp pour installer un plugin de statut et activer le suivi de l'agent. Désactivez si vous préférez gérer les plugins Amp vous-même."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quando abilitato, cmux avvolge il comando amp per installare un plugin di stato e abilitare il tracciamento dell'agente. Disabilita se preferisci gestire i plugin di Amp manualmente."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Når aktiveret, wrapper cmux amp-kommandoen for at installere et statusplugin og aktivere agentsporing. Deaktiver, hvis du foretrækker at administrere Amp-plugins selv."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Po włączeniu cmux opakowuje polecenie amp, aby zainstalować wtyczkę statusu i włączyć śledzenie agenta. Wyłącz, jeśli wolisz samodzielnie zarządzać wtyczkami Amp."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "При включении cmux оборачивает команду amp для установки плагина статуса и отслеживания агента. Отключите, если предпочитаете управлять плагинами Amp самостоятельно."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kada je omogućeno, cmux omotava naredbu amp kako bi instalirao statusni dodatak i omogućio praćenje agenta. Onemogućite ako preferirate sami upravljati Amp dodacima."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عند التفعيل، يغلّف cmux أمر amp لتثبيت إضافة الحالة وتفعيل تتبع الوكيل. قم بالتعطيل إذا كنت تفضل إدارة إضافات Amp بنفسك."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Når aktivert, pakker cmux inn amp-kommandoen for å installere et statustillegg og aktivere agentsporing. Deaktiver hvis du foretrekker å håndtere Amp-tillegg selv."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quando ativado, o cmux encapsula o comando amp para instalar um plugin de status e habilitar o rastreamento do agente. Desative se preferir gerenciar os plugins do Amp você mesmo."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เมื่อเปิดใช้งาน cmux จะห่อคำสั่ง amp เพื่อติดตั้งปลั๊กอินสถานะและเปิดใช้งานการติดตามเอเจนต์ ปิดใช้งานหากคุณต้องการจัดการปลั๊กอิน Amp ด้วยตัวเอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etkinleştirildiğinde, cmux durum eklentisi yüklemek ve ajan takibini etkinleştirmek için amp komutunu sarar. Amp eklentilerini kendiniz yönetmeyi tercih ediyorsanız devre dışı bırakın."
+          }
+        }
+      }
+    },
+    "settings.automation.amp.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp runs without cmux integration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ampはcmux連携なしで実行されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp 在没有 cmux 集成的情况下运行。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp 在不使用 cmux 整合的情況下運行。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp가 cmux 연동 없이 실행됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp wird ohne cmux-Integration ausgeführt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp se ejecuta sin integración con cmux."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp s'exécute sans intégration cmux."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp viene eseguito senza integrazione cmux."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp kører uden cmux-integration."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp działa bez integracji z cmux."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp работает без интеграции с cmux."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp radi bez cmux integracije."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعمل Amp بدون تكامل cmux."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp kjører uten cmux-integrering."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Amp é executado sem integração com o cmux."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp ทำงานโดยไม่มีการผสานรวม cmux"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amp cmux entegrasyonu olmadan çalışır."
+          }
+        }
+      }
+    },
+    "settings.automation.amp.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar shows Amp agent status and notifications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーにAmpエージェントのステータスと通知が表示されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧边栏显示 Amp 代理状态和通知。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "側邊欄顯示 Amp 代理狀態和通知。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바에 Amp 에이전트 상태와 알림이 표시됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Seitenleiste zeigt den Amp-Agentenstatus und Benachrichtigungen an."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La barra lateral muestra el estado del agente Amp y las notificaciones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La barre latérale affiche le statut de l'agent Amp et les notifications."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La barra laterale mostra lo stato dell'agente Amp e le notifiche."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælken viser Amp-agentstatus og notifikationer."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasek boczny pokazuje status agenta Amp i powiadomienia."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Боковая панель показывает статус агента Amp и уведомления."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bočna traka prikazuje status Amp agenta i obavještenja."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يعرض الشريط الجانبي حالة وكيل Amp والإشعارات."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidepanelet viser Amp-agentstatus og varsler."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A barra lateral mostra o status do agente Amp e notificações."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แถบด้านข้างแสดงสถานะเอเจนต์ Amp และการแจ้งเตือน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar çubuğu Amp ajan durumunu ve bildirimlerini gösterir."
+          }
+        }
+      }
+    },
     "settings.automation.openAccess.dialog.cancel": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/amp-plugins/cmux-status.ts
+++ b/Resources/amp-plugins/cmux-status.ts
@@ -1,0 +1,133 @@
+// @i-know-the-amp-plugin-api-is-wip-and-very-experimental-right-now
+import type { PluginAPI } from "@ampcode/plugin";
+
+const STATUS_KEY = "amp";
+const LOG_SOURCE = "amp";
+
+function toolLabel(tool: string): string {
+  switch (tool) {
+    case "Read":
+      return "reading";
+    case "edit_file":
+    case "create_file":
+      return "editing";
+    case "Bash":
+      return "running cmd";
+    case "Grep":
+    case "finder":
+    case "glob":
+      return "searching";
+    case "Task":
+      return "subagent";
+    case "oracle":
+      return "consulting oracle";
+    case "web_search":
+    case "read_web_page":
+      return "browsing";
+    case "mermaid":
+      return "diagramming";
+    case "handoff":
+      return "handing off";
+    case "skill":
+      return "loading skill";
+    default:
+      return tool;
+  }
+}
+
+function toolIcon(tool: string): string {
+  switch (tool) {
+    case "Read":
+      return "eye";
+    case "edit_file":
+    case "create_file":
+      return "pencil";
+    case "Bash":
+      return "terminal";
+    case "Grep":
+    case "finder":
+    case "glob":
+      return "magnifyingglass";
+    case "Task":
+      return "person.2";
+    case "oracle":
+      return "sparkles";
+    case "web_search":
+    case "read_web_page":
+      return "globe";
+    default:
+      return "hammer";
+  }
+}
+
+export default function (amp: PluginAPI) {
+  const pid = process.env.CMUX_AMP_PID;
+
+  const setStatus = async (label: string, icon: string, color: string) => {
+    try {
+      if (pid) {
+        await amp.$`cmux set-status ${STATUS_KEY} ${label} --icon ${icon} --color ${color} --pid ${pid}`;
+      } else {
+        await amp.$`cmux set-status ${STATUS_KEY} ${label} --icon ${icon} --color ${color}`;
+      }
+    } catch {}
+  };
+
+  const clearStatus = async () => {
+    try {
+      await amp.$`cmux clear-status ${STATUS_KEY}`;
+    } catch {}
+  };
+
+  const log = async (message: string, level: string = "info") => {
+    try {
+      await amp.$`cmux log --level ${level} --source ${LOG_SOURCE} -- ${message}`;
+    } catch {}
+  };
+
+  const cleanup = () => {
+    clearStatus();
+  };
+
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+
+  amp.on("session.start", async () => {
+    await setStatus("idle", "circle", "adb5bd");
+  });
+
+  amp.on("agent.start", async () => {
+    await setStatus("thinking", "brain", "ffffff");
+    await log("prompt received", "info");
+  });
+
+  amp.on("tool.call", async (event) => {
+    const label = toolLabel(event.tool);
+    const icon = toolIcon(event.tool);
+    await setStatus(label, icon, "ffd700");
+    return { action: "allow" as const };
+  });
+
+  amp.on("tool.result", async (event) => {
+    if (event.status === "error") {
+      await log(`${event.tool} failed`, "error");
+    }
+  });
+
+  amp.on("agent.end", async (event) => {
+    switch (event.status) {
+      case "done":
+        await setStatus("done", "checkmark.circle", "50fa7b");
+        await log("turn complete", "success");
+        break;
+      case "error":
+        await setStatus("error", "xmark.circle", "ff5555");
+        await log("turn errored", "error");
+        break;
+      case "interrupted":
+        await setStatus("interrupted", "pause.circle", "ffb86c");
+        await log("turn interrupted", "warning");
+        break;
+    }
+  });
+}

--- a/Resources/bin/amp
+++ b/Resources/bin/amp
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# cmux amp wrapper - injects plugin and session tracking
+#
+# When running inside a cmux terminal (CMUX_SURFACE_ID is set), this wrapper
+# intercepts `amp` invocations to auto-install the cmux-status plugin and
+# export env vars so the plugin can communicate back to cmux.
+# Outside cmux, it passes through to the real amp binary unchanged.
+
+# Find the real amp binary, skipping our own directory.
+find_real_amp() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/amp" ]] && printf '%s' "$d/amp" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
+cmux_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir cmux_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    cmux_bin="$self_dir/cmux"
+    [[ -x "$cmux_bin" ]] || cmux_bin="$(command -v cmux || true)"
+    [[ -n "$cmux_bin" ]] || return 1
+
+    # Keep stale/hung socket checks bounded so amp startup does not block
+    # behind the CLI default timeout (15s).
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in a cmux terminal, hooks are disabled, or the cmux
+# socket is unavailable (stale env / app not running).
+IN_CMUX=0
+if [[ -n "$CMUX_SURFACE_ID" ]]; then
+    IN_CMUX=1
+fi
+
+if [[ "$IN_CMUX" == "0" || "$CMUX_AMP_HOOKS_DISABLED" == "1" ]] || ! cmux_socket_available; then
+    REAL_AMP="$(find_real_amp)" || { echo "Error: amp not found in PATH" >&2; exit 127; }
+    exec "$REAL_AMP" "$@"
+fi
+
+# Find real amp.
+REAL_AMP="$(find_real_amp)" || { echo "Error: amp not found in PATH" >&2; exit 127; }
+
+# Auto-install the bundled cmux-status plugin if the source is newer or
+# the destination doesn't exist.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_SRC="$SCRIPT_DIR/../amp-plugins/cmux-status.ts"
+PLUGIN_DST="$HOME/.config/amp/plugins/cmux-status.ts"
+
+if [[ -f "$PLUGIN_SRC" ]]; then
+    mkdir -p "$(dirname "$PLUGIN_DST")"
+    if [[ ! -f "$PLUGIN_DST" ]] || ! cmp -s "$PLUGIN_SRC" "$PLUGIN_DST"; then
+        cp "$PLUGIN_SRC" "$PLUGIN_DST"
+    fi
+fi
+
+# Export the wrapper's PID. Because we exec amp below, this PID becomes
+# the actual amp process PID, which the plugin uses for stale-session detection.
+export CMUX_AMP_PID=$$
+
+# Enable Amp's plugin system.
+export PLUGINS=all
+
+exec "$REAL_AMP" "$@"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3327,12 +3327,12 @@ class GhosttyApp {
                           let tabId = tabManager.selectedTabId else {
                         return false
                     }
-                    // Suppress OSC notifications for workspaces with active Claude hook sessions.
+                    // Suppress OSC notifications for workspaces with active agent hook sessions.
                     // The hook system manages notifications with proper lifecycle tracking;
                     // raw OSC notifications would duplicate or outlive the structured hooks.
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
                     if let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
-                       workspace.agentPIDs["claude_code"] != nil {
+                       !workspace.agentPIDs.isEmpty {
                         return true
                     }
                     let tabTitle = owningManager.titleForTab(tabId) ?? "Terminal"
@@ -3607,10 +3607,10 @@ class GhosttyApp {
             let actionBody = action.action.desktop_notification.body
                 .flatMap { String(cString: $0) } ?? ""
             performOnMain {
-                // Suppress OSC notifications for workspaces with active Claude hook sessions.
+                // Suppress OSC notifications for workspaces with active agent hook sessions.
                 let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? AppDelegate.shared?.tabManager
                 if let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
-                   workspace.agentPIDs["claude_code"] != nil {
+                   !workspace.agentPIDs.isEmpty {
                     return
                 }
                 let tabTitle = owningManager?.titleForTab(tabId) ?? "Terminal"
@@ -4846,6 +4846,11 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
         if !GeminiIntegrationSettings.hooksEnabled() {
             setManagedEnvironmentValue("CMUX_GEMINI_HOOKS_DISABLED", "1")
+        }
+
+        let ampHooksEnabled = AmpIntegrationSettings.hooksEnabled()
+        if !ampHooksEnabled {
+            setManagedEnvironmentValue("CMUX_AMP_HOOKS_DISABLED", "1")
         }
 
         if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1825,7 +1825,7 @@ class TabManager: ObservableObject {
                 let remainingAgentPIDs = Set(tab.agentPIDs.values.compactMap { $0 > 0 ? Int($0) : nil })
                 PortScanner.shared.refreshAgentPorts(workspaceId: tab.id, agentPIDs: remainingAgentPIDs)
                 // Also clear stale notifications (e.g. "Doing well, thanks!")
-                // left behind when Claude was killed without SessionEnd firing.
+                // left behind when an agent was killed without cleanup firing.
                 AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id)
             }
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4916,6 +4916,18 @@ enum GeminiIntegrationSettings {
     }
 }
 
+enum AmpIntegrationSettings {
+    static let hooksEnabledKey = "ampHooksEnabled"
+    static let defaultHooksEnabled = true
+
+    static func hooksEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: hooksEnabledKey) == nil {
+            return defaultHooksEnabled
+        }
+        return defaults.bool(forKey: hooksEnabledKey)
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }
@@ -5193,6 +5205,8 @@ struct SettingsView: View {
     private var cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
     @AppStorage(GeminiIntegrationSettings.hooksEnabledKey)
     private var geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
+    @AppStorage(AmpIntegrationSettings.hooksEnabledKey)
+    private var ampHooksEnabled = AmpIntegrationSettings.defaultHooksEnabled
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
@@ -5806,6 +5820,28 @@ struct SettingsView: View {
         } catch {
             socketPasswordStatusMessage = String(localized: "settings.automation.socketPassword.clearFailed", defaultValue: "Failed to clear password (\(error.localizedDescription)).")
             socketPasswordStatusIsError = true
+        }
+    }
+
+    @ViewBuilder
+    private var ampIntegrationCard: some View {
+        SettingsCard {
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.automation.amp", defaultValue: "Amp Integration"),
+                subtitle: ampHooksEnabled
+                    ? String(localized: "settings.automation.amp.subtitleOn", defaultValue: "Sidebar shows Amp agent status and notifications.")
+                    : String(localized: "settings.automation.amp.subtitleOff", defaultValue: "Amp runs without cmux integration.")
+            ) {
+                Toggle("", isOn: $ampHooksEnabled)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityIdentifier("SettingsAmpHooksToggle")
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardNote(String(localized: "settings.automation.amp.note", defaultValue: "When enabled, cmux wraps the amp command to install a status plugin and enable agent tracking. Disable if you prefer to manage Amp plugins yourself."))
         }
     }
 
@@ -6652,6 +6688,8 @@ struct SettingsView: View {
                         SettingsCardNote(String(localized: "settings.automation.gemini.note", defaultValue: "Hooks must be installed with `cmux gemini install-hooks`. They no-op outside cmux terminals."))
                     }
 
+                    ampIntegrationCard
+
                     SettingsCard {
                         SettingsCardRow(configurationReview: .json("automation.portBase"), String(localized: "settings.automation.portBase", defaultValue: "Port Base"), subtitle: String(localized: "settings.automation.portBase.subtitle", defaultValue: "Starting port for CMUX_PORT env var."), controlWidth: pickerColumnWidth) {
                             TextField("", value: $cmuxPortBase, format: .number)
@@ -7389,6 +7427,7 @@ struct SettingsView: View {
         customClaudePath = ""
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
+        ampHooksEnabled = AmpIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         preferredEditorCommand = ""
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue


### PR DESCRIPTION
## Summary

Adds zero-config Amp agent status tracking in cmux tabs, mirroring the existing Claude Code integration.

### How it works

When a user types `amp` inside a cmux terminal, the shell wrapper transparently:
1. Auto-installs the bundled status plugin into `~/.config/amp/plugins/`
2. Enables Amp's plugin system (`PLUGINS=all`)
3. Exports `CMUX_AMP_PID` for stale-session detection

The plugin hooks into Amp's lifecycle events (`session.start`, `agent.start/end`, `tool.call/result`) and sends status updates back to cmux via `set-status`/`clear-status` socket commands.

### Changes

| File | What |
|---|---|
| `Resources/bin/amp` | Shell wrapper — detects cmux, auto-installs plugin, sets env vars, execs real amp |
| `Resources/amp-plugins/cmux-status.ts` | Bundled Amp plugin with PID tracking for stale-session detection |
| `Sources/cmuxApp.swift` | `AmpIntegrationSettings` enum + settings toggle UI (mirrors Claude's card) |
| `Sources/GhosttyTerminalView.swift` | Sets `CMUX_AMP_HOOKS_DISABLED=1` env var when toggle is off |
| `Sources/TabManager.swift` | Comment update (logic was already generic) |

### Also generalized

- OSC notification suppression now checks `!workspace.agentPIDs.isEmpty` instead of hardcoded `"claude_code"` — works for any agent
- Stale-session sweeper was already generic; updated comment to reflect that

### User experience

Type `amp` in a cmux terminal → tab instantly shows live status (thinking, reading, editing, searching, done, error). Zero config. ✨

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds built-in Amp integration to show live agent status and sidebar notifications in cmux tabs with zero config. Run `amp` in a cmux terminal to see thinking/reading/editing/searching/done/error in real time; a settings toggle can disable it.

- **New Features**
  - `Resources/bin/amp` wrapper: detects cmux, pings the socket with a short timeout, auto-installs the bundled plugin if contents differ, sets `PLUGINS=all` and `CMUX_AMP_PID`, and passes through outside cmux or when `CMUX_AMP_HOOKS_DISABLED=1`.
  - Bundled plugin `Resources/amp-plugins/cmux-status.ts`: uses `@ampcode/plugin` events to send `set-status`/`clear-status` and `log` to cmux, with tool→label/icon mapping and `--pid` for stale-session cleanup; handles SIGINT/SIGTERM.
  - Amp Integration toggle (18 locales). Injects `CMUX_AMP_HOOKS_DISABLED` when off. Wrapper and plugin are included in packaged builds.

- **Refactors**
  - Suppress OSC notifications when any `workspace.agentPIDs` is present; updated stale-notification comment.
  - Removed async `process.on('exit')` cleanup; plugin update check now compares file contents (`cmp -s`); “Reset All Settings” resets the Amp toggle.

<sup>Written for commit 14261ce569c6431d05730ae7facfc45072beb0c1. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/2007?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Amp agent integration: surfaces real-time agent statuses (idle, thinking, tool calls, completion/error) and lifecycle logs.
  * CLI wrapper: activates Amp integration when available and auto-provisions the helper plugin for launched sessions.

* **Improvements**
  * New "Amp Integration" toggle in Automation settings (persisted).
  * Improved desktop notification suppression for active agent sessions.

* **Documentation**
  * Added localization strings and UI text for the Amp Integration setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->