### PR TITLE
docs(notifications): remove outdated Claude Code hooks section

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,37 +54,6 @@ cmux notify --title "Done" --tab 0 --panel 1
 
 ## Integration Examples
 
-### Claude Code Hooks
-
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --body 'Waiting for input' || osascript -e 'display notification \"Waiting for input\" with title \"Claude Code\"'"
-          }
-        ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --subtitle 'Permission' --body 'Approval needed' || osascript -e 'display notification \"Approval needed\" with title \"Claude Code\"'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 ### OpenAI Codex
 
 Add to `~/.codex/config.toml`:


### PR DESCRIPTION
Remove the pre-0.60 Claude Code hooks section from the Notifications docs as it became irrelevant after PR #247 (released in 0.60.0). Fixes #2009.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated “Claude Code Hooks” integration example from `docs/notifications.md` that only applied to pre-0.60; aligns the Notifications docs with changes shipped in 0.60.0 (PR #247). Fixes #2009.

<sup>Written for commit e68933495882a0cc322f7f313034b39f63889dc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a notification integration example from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->