### PR TITLE
docs(notifications): remove outdated Claude Code hooks section

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,37 +54,6 @@ cmux notify --title "Done" --tab 0 --panel 1
 
 ## Integration Examples
 
-### Claude Code Hooks
-
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --body 'Waiting for input' || osascript -e 'display notification \"Waiting for input\" with title \"Claude Code\"'"
-          }
-        ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --subtitle 'Permission' --body 'Approval needed' || osascript -e 'display notification \"Approval needed\" with title \"Claude Code\"'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 ### OpenAI Codex
 
 Add to `~/.codex/config.toml`:


### PR DESCRIPTION
The Notifications docs had an outdated "Claude Code hooks" section from pre-0.60 that no longer applies. Removed the stale section. Fixes #2009

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated "Claude Code hooks" section from `docs/notifications.md`. This pre-0.60 content no longer applies and was misleading.

<sup>Written for commit 1090a46a9637e895bbf6de657c2ba79bf7329d62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Claude Code Hooks integration section from the notifications documentation, including related configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->