### PR TITLE
fix: increase contentSideHitWidth to prevent accidental window resize

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -339,7 +339,10 @@ enum SidebarResizeInteraction {
     // Keep a generous drag target inside the sidebar itself, but make the
     // terminal-side overlap very small so column-0 text selection still wins.
     static let sidebarSideHitWidth: CGFloat = 6
-    static let contentSideHitWidth: CGFloat = 2
+    // 4 pt matches the 4 pt padding used in GhosttySurfaceScrollView drop zone overlays
+    // (dropZoneOverlayFrame). This prevents column-0 text near the leading edge from
+    // accidentally triggering the sidebar resize when interacting with leftmost content.
+    static let contentSideHitWidth: CGFloat = 4
 
     static var totalHitWidth: CGFloat {
         sidebarSideHitWidth + contentSideHitWidth


### PR DESCRIPTION
Column-0 text near the leading edge of the terminal triggers the sidebar resize handle
because contentSideHitWidth was only 2 pt — too narrow to distinguish intentional
drag from text interaction.

Changed contentSideHitWidth from 2 to 4 pt, matching the 4 pt padding already used in
GhosttySurfaceScrollView drop zone overlays. This gives users 4 pt of breathing room
before the resize region activates, preventing accidental window resize while preserving
the sidebar drag target.

Fixes #1979

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased `SidebarResizeInteraction.contentSideHitWidth` from 2 pt to 4 pt to prevent accidental sidebar/window resize when interacting with column-0 text, matching existing 4 pt overlay padding and preserving the sidebar drag handle. Fixes #1979.

<sup>Written for commit ee9a7f2a8020a395730d0544baa304ac86fff78f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar resize interaction by enlarging the clickable hit area for sidebar resizing, making it easier to initiate resize operations at the sidebar edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->