### PR TITLE
fix(openFolder): set NSOpenPanel directoryURL to focused pane's working directory

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5975,8 +5975,11 @@ struct ContentView: View {
                 panel.allowsMultipleSelection = false
                 panel.title = String(localized: "panel.openFolder.title", defaultValue: "Open Folder")
                 panel.prompt = String(localized: "panel.openFolder.prompt", defaultValue: "Open")
+                if let preferredDir = self.tabManager.selectedWorkspace?.focusedPanelId.flatMap({ self.tabManager.selectedWorkspace?.panelDirectories[$0] }), !preferredDir.isEmpty {
+                    panel.directoryURL = URL(fileURLWithPath: preferredDir)
+                }
                 if panel.runModal() == .OK, let url = panel.url {
-                    tabManager.addWorkspace(workingDirectory: url.path)
+                    self.tabManager.addWorkspace(workingDirectory: url.path)
                 }
             }
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -593,6 +593,9 @@ struct cmuxApp: App {
                     panel.allowsMultipleSelection = false
                     panel.title = String(localized: "menu.file.openFolder.panelTitle", defaultValue: "Open Folder")
                     panel.prompt = String(localized: "menu.file.openFolder.panelPrompt", defaultValue: "Open")
+                    if let preferredDir = self.activeTabManager.selectedWorkspace?.focusedPanelId.flatMap({ self.activeTabManager.selectedWorkspace?.panelDirectories[$0] }), !preferredDir.isEmpty {
+                        panel.directoryURL = URL(fileURLWithPath: preferredDir)
+                    }
                     if panel.runModal() == .OK, let url = panel.url {
                         if let appDelegate = AppDelegate.shared {
                             if appDelegate.addWorkspaceInPreferredMainWindow(
@@ -602,7 +605,7 @@ struct cmuxApp: App {
                                 appDelegate.openNewMainWindow(nil)
                             }
                         } else {
-                            activeTabManager.addWorkspace(workingDirectory: url.path)
+                            self.activeTabManager.addWorkspace(workingDirectory: url.path)
                         }
                     }
                 }


### PR DESCRIPTION
Before: ⌘O always opened the file picker at ~/Documents (NSOpenPanel default).
After: ⌘O now opens the picker at the focused pane's current working directory when available, falling back to ~/Documents otherwise.\n\nRoot cause: Both the menu bar and command palette Open Folder handlers created NSOpenPanel without setting `directoryURL`, so macOS defaulted to ~/Documents.\n\nFixes: #2010

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
⌘O now opens the folder picker at the focused pane’s working directory, falling back to ~/Documents when no directory is available. Applies to both the menu bar and command palette.

- **Bug Fixes**
  - Set NSOpenPanel.directoryURL using the focused pane’s working directory in both ContentView and cmuxApp handlers.

<sup>Written for commit 140349190a40f67dec3d31bebbeaa4e49ff9cb05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Open Folder…" command now remembers the last directory you accessed, streamlining folder selection for frequently used locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->