### PR TITLE
docs(notifications): remove outdated Claude Code hooks section

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,37 +54,6 @@ cmux notify --title "Done" --tab 0 --panel 1
 
 ## Integration Examples
 
-### Claude Code Hooks
-
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --body 'Waiting for input' || osascript -e 'display notification \"Waiting for input\" with title \"Claude Code\"'"
-          }
-        ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --subtitle 'Permission' --body 'Approval needed' || osascript -e 'display notification \"Approval needed\" with title \"Claude Code\"'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 ### OpenAI Codex
 
 Add to `~/.codex/config.toml`:


### PR DESCRIPTION
The pre-0.60 'Claude Code hooks' section in the Notifications docs is outdated after PR #247. Removed as suggested. Fixes #2009

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated "Claude Code hooks" section from the Notifications docs (pre-0.60). This removes incorrect guidance and aligns the page with current notification integrations.

<sup>Written for commit a5e5a04979cc3f57d403926ff550d0ff4e7cdc1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed integration documentation for Claude Code Hooks from notification settings guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->