### PR TITLE
Add configurable inline VS Code placement

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54112,6 +54112,125 @@
         }
       }
     },
+    "settings.browser.vscodeInlineSplitDirection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inline VS Code Placement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インライン VS Code の配置"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.bottom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.left": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.right": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose whether inline VS Code opens as a split or a tab, and where the split appears."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インライン VS Code を分割またはタブのどちらで開くかと、分割位置を選びます。"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.tab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ"
+          }
+        }
+      }
+    },
+    "settings.browser.vscodeInlineSplitDirection.top": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上"
+          }
+        }
+      }
+    },
     "settings.browser.theme.subtitleForced": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7362,12 +7362,12 @@ struct ContentView: View {
     private func openFocusedDirectoryInInlineVSCode(_ directoryURL: URL) -> Bool {
         guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL(),
               let workspace = tabManager.selectedWorkspace,
-              let sourcePanelId = workspace.focusedPanelId,
-              let sourcePaneId = workspace.paneId(forPanelId: sourcePanelId) else {
+              let sourcePanelId = workspace.focusedPanelId else {
             return false
         }
         let sourceTabId = workspace.id
         let openDirection = vscodeInlineSplitDirection
+        let fallbackPaneId = workspace.bonsplitController.focusedPaneId
         let tabManager = tabManager
         VSCodeServeWebController.shared.ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
             guard let serveWebURL,
@@ -7388,6 +7388,9 @@ struct ContentView: View {
                         url: openFolderURL,
                         focus: true
                     )
+                }
+                guard let sourcePaneId = workspace.paneId(forPanelId: sourcePanelId) ?? fallbackPaneId else {
+                    return nil
                 }
                 return tabManager.newBrowserSurface(
                     tabId: sourceTabId,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1612,6 +1612,8 @@ struct ContentView: View {
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
     @AppStorage(CommandPaletteSwitcherSearchSettings.searchAllSurfacesKey)
     private var commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces
+    @AppStorage(VSCodeInlineSplitDirectionSettings.key)
+    private var vscodeInlineSplitDirectionRaw = VSCodeInlineSplitDirectionSettings.defaultDirection.rawValue
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
     @FocusState private var isCommandPaletteSearchFocused: Bool
@@ -7337,6 +7339,11 @@ struct ContentView: View {
         return openFocusedDirectory(directoryURL, in: target)
     }
 
+    private var vscodeInlineSplitDirection: VSCodeInlineSplitDirection {
+        VSCodeInlineSplitDirectionSettings.parse(rawValue: vscodeInlineSplitDirectionRaw)
+            ?? VSCodeInlineSplitDirectionSettings.defaultDirection
+    }
+
     private func openFocusedDirectory(_ directoryURL: URL, in target: TerminalDirectoryOpenTarget) -> Bool {
         switch target {
         case .finder:
@@ -7355,10 +7362,12 @@ struct ContentView: View {
     private func openFocusedDirectoryInInlineVSCode(_ directoryURL: URL) -> Bool {
         guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL(),
               let workspace = tabManager.selectedWorkspace,
-              let sourcePanelId = workspace.focusedPanelId else {
+              let sourcePanelId = workspace.focusedPanelId,
+              let sourcePaneId = workspace.paneId(forPanelId: sourcePanelId) else {
             return false
         }
         let sourceTabId = workspace.id
+        let openDirection = vscodeInlineSplitDirection
         let tabManager = tabManager
         VSCodeServeWebController.shared.ensureServeWebURL(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
             guard let serveWebURL,
@@ -7369,14 +7378,25 @@ struct ContentView: View {
                 NSSound.beep()
                 return
             }
-            guard tabManager.newBrowserSplit(
-                tabId: sourceTabId,
-                fromPanelId: sourcePanelId,
-                orientation: SplitDirection.right.orientation,
-                insertFirst: SplitDirection.right.insertFirst,
-                url: openFolderURL,
-                focus: true
-            ) != nil else {
+            let createdPanelId: UUID? = {
+                if let splitDirection = openDirection.splitDirection {
+                    return tabManager.newBrowserSplit(
+                        tabId: sourceTabId,
+                        fromPanelId: sourcePanelId,
+                        orientation: splitDirection.orientation,
+                        insertFirst: splitDirection.insertFirst,
+                        url: openFolderURL,
+                        focus: true
+                    )
+                }
+                return tabManager.newBrowserSurface(
+                    tabId: sourceTabId,
+                    inPane: sourcePaneId,
+                    url: openFolderURL,
+                    focus: true
+                )
+            }()
+            guard createdPanelId != nil else {
                 NSSound.beep()
                 return
             }

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -35,6 +35,7 @@ struct GhosttyConfig {
     var sidebarBackgroundLight: NSColor?
     var sidebarBackgroundDark: NSColor?
     var sidebarTintOpacity: Double?
+    var vscodeInlineSplitDirection: VSCodeInlineSplitDirection?
 
     // Palette colors (0-15)
     var palette: [Int: NSColor] = [:]
@@ -189,6 +190,11 @@ struct GhosttyConfig {
         }
     }
 
+    func applyVSCodeInlineSplitDirectionToUserDefaults(defaults: UserDefaults = .standard) {
+        guard let vscodeInlineSplitDirection else { return }
+        defaults.set(vscodeInlineSplitDirection.rawValue, forKey: VSCodeInlineSplitDirectionSettings.key)
+    }
+
     private static func loadFromDisk(preferredColorScheme: ColorSchemePreference) -> GhosttyConfig {
         var config = GhosttyConfig()
 
@@ -218,6 +224,7 @@ struct GhosttyConfig {
 
         config.resolveSidebarBackground(preferredColorScheme: preferredColorScheme)
         config.applySidebarAppearanceToUserDefaults()
+        config.applyVSCodeInlineSplitDirectionToUserDefaults()
 
         return config
     }
@@ -303,6 +310,10 @@ struct GhosttyConfig {
                 case "sidebar-tint-opacity":
                     if let opacity = Double(value) {
                         sidebarTintOpacity = min(max(opacity, 0), 1)
+                    }
+                case VSCodeInlineSplitDirectionSettings.configKey:
+                    if let direction = VSCodeInlineSplitDirectionSettings.parse(rawValue: value) {
+                        vscodeInlineSplitDirection = direction
                     }
                 default:
                     break

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -212,6 +212,80 @@ enum BrowserThemeSettings {
     }
 }
 
+enum VSCodeInlineSplitDirection: String, CaseIterable, Identifiable {
+    case right
+    case left
+    case bottom
+    case top
+    case tab
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .right:
+            return String(localized: "settings.browser.vscodeInlineSplitDirection.right", defaultValue: "Right")
+        case .left:
+            return String(localized: "settings.browser.vscodeInlineSplitDirection.left", defaultValue: "Left")
+        case .bottom:
+            return String(localized: "settings.browser.vscodeInlineSplitDirection.bottom", defaultValue: "Bottom")
+        case .top:
+            return String(localized: "settings.browser.vscodeInlineSplitDirection.top", defaultValue: "Top")
+        case .tab:
+            return String(localized: "settings.browser.vscodeInlineSplitDirection.tab", defaultValue: "Tab")
+        }
+    }
+
+    var splitDirection: SplitDirection? {
+        switch self {
+        case .right:
+            return .right
+        case .left:
+            return .left
+        case .bottom:
+            return .down
+        case .top:
+            return .up
+        case .tab:
+            return nil
+        }
+    }
+}
+
+enum VSCodeInlineSplitDirectionSettings {
+    static let key = "vscodeInlineSplitDirection"
+    static let configKey = "vscode-inline-split-direction"
+    static let defaultDirection: VSCodeInlineSplitDirection = .right
+
+    static func parse(rawValue: String?) -> VSCodeInlineSplitDirection? {
+        guard let rawValue = rawValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !rawValue.isEmpty else {
+            return nil
+        }
+
+        switch rawValue {
+        case VSCodeInlineSplitDirection.right.rawValue:
+            return .right
+        case VSCodeInlineSplitDirection.left.rawValue:
+            return .left
+        case VSCodeInlineSplitDirection.bottom.rawValue, "down":
+            return .bottom
+        case VSCodeInlineSplitDirection.top.rawValue, "up":
+            return .top
+        case VSCodeInlineSplitDirection.tab.rawValue:
+            return .tab
+        default:
+            return nil
+        }
+    }
+
+    static func current(defaults: UserDefaults = .standard) -> VSCodeInlineSplitDirection {
+        parse(rawValue: defaults.string(forKey: key)) ?? defaultDirection
+    }
+}
+
 enum BrowserImportHintVariant: String, CaseIterable, Identifiable {
     case inlineStrip
     case floatingCard

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3502,12 +3502,14 @@ class TabManager: ObservableObject {
         tabId: UUID,
         inPane paneId: PaneID,
         url: URL? = nil,
-        preferredProfileID: UUID? = nil
+        preferredProfileID: UUID? = nil,
+        focus: Bool? = nil
     ) -> UUID? {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return nil }
         return tab.newBrowserSurface(
             inPane: paneId,
             url: url,
+            focus: focus,
             preferredProfileID: preferredProfileID
         )?.id
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3801,6 +3801,8 @@ struct SettingsView: View {
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
     @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
     @AppStorage(BrowserThemeSettings.modeKey) private var browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
+    @AppStorage(VSCodeInlineSplitDirectionSettings.key)
+    private var vscodeInlineSplitDirection = VSCodeInlineSplitDirectionSettings.defaultDirection.rawValue
     @AppStorage(BrowserImportHintSettings.variantKey) private var browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
     @AppStorage(BrowserImportHintSettings.showOnBlankTabsKey) private var showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
     @AppStorage(BrowserImportHintSettings.dismissedKey) private var isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed
@@ -3961,6 +3963,22 @@ struct SettingsView: View {
             get: { browserThemeMode },
             set: { newValue in
                 browserThemeMode = BrowserThemeSettings.mode(for: newValue).rawValue
+            }
+        )
+    }
+
+    private var selectedVSCodeInlineSplitDirection: VSCodeInlineSplitDirection {
+        VSCodeInlineSplitDirectionSettings.parse(rawValue: vscodeInlineSplitDirection)
+            ?? VSCodeInlineSplitDirectionSettings.defaultDirection
+    }
+
+    private var vscodeInlineSplitDirectionSelection: Binding<String> {
+        Binding(
+            get: { selectedVSCodeInlineSplitDirection.rawValue },
+            set: { newValue in
+                vscodeInlineSplitDirection =
+                    (VSCodeInlineSplitDirectionSettings.parse(rawValue: newValue)
+                     ?? VSCodeInlineSplitDirectionSettings.defaultDirection).rawValue
             }
         )
     }
@@ -5085,6 +5103,19 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsPickerRow(
+                            String(localized: "settings.browser.vscodeInlineSplitDirection", defaultValue: "Inline VS Code Placement"),
+                            subtitle: String(localized: "settings.browser.vscodeInlineSplitDirection.subtitle", defaultValue: "Choose whether inline VS Code opens as a split or a tab, and where the split appears."),
+                            controlWidth: pickerColumnWidth,
+                            selection: vscodeInlineSplitDirectionSelection
+                        ) {
+                            ForEach(VSCodeInlineSplitDirection.allCases) { direction in
+                                Text(direction.displayName).tag(direction.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsCardRow(
                             String(localized: "settings.browser.openTerminalLinks", defaultValue: "Open Terminal Links in cmux Browser"),
                             subtitle: String(localized: "settings.browser.openTerminalLinks.subtitle", defaultValue: "When off, links clicked in terminal output open in your default browser.")
@@ -5432,6 +5463,7 @@ struct SettingsView: View {
             BrowserHistoryStore.shared.loadIfNeeded()
             notificationStore.refreshAuthorizationStatus()
             browserThemeMode = BrowserThemeSettings.mode(defaults: .standard).rawValue
+            vscodeInlineSplitDirection = VSCodeInlineSplitDirectionSettings.current(defaults: .standard).rawValue
             browserImportHintVariantRaw = BrowserImportHintSettings.variant(for: browserImportHintVariantRaw).rawValue
             browserHistoryEntryCount = BrowserHistoryStore.shared.entries.count
             browserInsecureHTTPAllowlistDraft = browserInsecureHTTPAllowlist
@@ -5546,6 +5578,7 @@ struct SettingsView: View {
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue
+        vscodeInlineSplitDirection = VSCodeInlineSplitDirectionSettings.defaultDirection.rawValue
         browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
         showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
         isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1074,6 +1074,63 @@ final class BrowserThemeSettingsTests: XCTestCase {
 }
 
 
+final class VSCodeInlineSplitDirectionSettingsTests: XCTestCase {
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "VSCodeInlineSplitDirectionSettingsTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+
+    func testDefaultsToRightWhenUnsetOrInvalid() {
+        let defaults = makeIsolatedDefaults()
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .right
+        )
+
+        defaults.set("diagonal", forKey: VSCodeInlineSplitDirectionSettings.key)
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .right
+        )
+    }
+
+    func testCurrentReadsStoredValuesAndNormalizesAliases() {
+        let defaults = makeIsolatedDefaults()
+
+        defaults.set(VSCodeInlineSplitDirection.left.rawValue, forKey: VSCodeInlineSplitDirectionSettings.key)
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .left
+        )
+
+        defaults.set("down", forKey: VSCodeInlineSplitDirectionSettings.key)
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .bottom
+        )
+
+        defaults.set("up", forKey: VSCodeInlineSplitDirectionSettings.key)
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .top
+        )
+
+        defaults.set(VSCodeInlineSplitDirection.tab.rawValue, forKey: VSCodeInlineSplitDirectionSettings.key)
+        XCTAssertEqual(
+            VSCodeInlineSplitDirectionSettings.current(defaults: defaults),
+            .tab
+        )
+    }
+}
+
+
 final class BrowserDeveloperToolsShortcutDefaultsTests: XCTestCase {
     func testSafariDefaultShortcutForToggleDeveloperTools() {
         let shortcut = KeyboardShortcutSettings.Action.toggleBrowserDeveloperTools.defaultShortcut

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2340,6 +2340,53 @@ final class SidebarBackgroundConfigTests: XCTestCase {
     }
 }
 
+final class VSCodeInlineSplitDirectionConfigTests: XCTestCase {
+    func testParseVSCodeInlineSplitDirection() {
+        var config = GhosttyConfig()
+        config.parse("vscode-inline-split-direction = bottom")
+
+        XCTAssertEqual(config.vscodeInlineSplitDirection, .bottom)
+    }
+
+    func testApplyVSCodeInlineSplitDirectionToUserDefaultsWritesCanonicalValue() {
+        let suiteName = "VSCodeInlineSplitDirectionConfigTests.Write.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var config = GhosttyConfig()
+        config.parse("vscode-inline-split-direction = down")
+        config.applyVSCodeInlineSplitDirectionToUserDefaults(defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.string(forKey: VSCodeInlineSplitDirectionSettings.key),
+            VSCodeInlineSplitDirection.bottom.rawValue
+        )
+    }
+
+    func testApplyVSCodeInlineSplitDirectionToUserDefaultsSkipsInvalidValues() {
+        let suiteName = "VSCodeInlineSplitDirectionConfigTests.Invalid.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(VSCodeInlineSplitDirection.tab.rawValue, forKey: VSCodeInlineSplitDirectionSettings.key)
+
+        var config = GhosttyConfig()
+        config.parse("vscode-inline-split-direction = diagonal")
+        config.applyVSCodeInlineSplitDirectionToUserDefaults(defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.string(forKey: VSCodeInlineSplitDirectionSettings.key),
+            VSCodeInlineSplitDirection.tab.rawValue
+        )
+    }
+}
+
 final class ZshShellIntegrationHandoffTests: XCTestCase {
     func testGhosttyPromptHooksLoadWhenCmuxRequestsZshIntegration() throws {
         let output = try runInteractiveZsh(cmuxLoadGhosttyIntegration: true)


### PR DESCRIPTION
## Summary
- add a typed `vscode-inline-split-direction` setting with `right`, `left`, `bottom`, `top`, and `tab` values
- mirror config-file values into defaults, expose the setting in Browser Settings, and localize the new labels
- use the configured placement when opening inline VS Code, including opening in the current pane as a tab
- add unit coverage for settings normalization and config parsing

Closes #1977

## Verification
- `./scripts/reload.sh --tag issue-1977-vscode-split-direction`
- tests not run locally per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make inline VS Code placement configurable: open as a split (right/left/top/bottom) or as a tab. Defaults to right; configurable in Browser Settings and via `vscode-inline-split-direction` (closes #1977).

- **New Features**
  - Added `vscode-inline-split-direction` with `right`, `left`, `bottom` (`down`), `top` (`up`), `tab`.
  - Setting in Browser Settings with localized labels and help text.
  - Placement applied when opening inline VS Code; `tab` opens in the current pane.
  - Config parsed and normalized from the config file, synced to `UserDefaults` on load; tests added for parsing, aliases, defaults, and canonical writes.

- **Bug Fixes**
  - Deferred pane lookup for `tab` placement to reliably find the source pane.

<sup>Written for commit 2919545446ece8301e91a9c49f0464d7c02e395a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable VS Code inline split direction setting (left, right, top, bottom, tab) in Settings > Browser.
  * Added English and Japanese localizations for the new setting and related UI labels.

* **Behavior**
  * Updated how inline VS Code opens to respect the chosen split/tab preference and fallback behavior when needed.

* **Tests**
  * Added unit tests covering parsing, persistence, normalization, and defaults for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->