### PR TITLE
Add Intel Cmd+D smoke test on GitHub Actions

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,10 +17,17 @@ jobs:
           - os: warp-macos-15-arm64-6x
             timeout: 30
             smoke: true
+            ui_smoke_test: ""
+            skip_zig: false
+          - os: macos-15-intel
+            timeout: 35
+            smoke: false
+            ui_smoke_test: IntelCmdDSmokeUITests
             skip_zig: false
           - os: warp-macos-26-arm64-6x
             timeout: 30
             smoke: false
+            ui_smoke_test: ""
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
@@ -74,12 +81,22 @@ jobs:
           if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
             echo "zig ${ZIG_REQUIRED} already installed"
           else
+            ARCH="$(uname -m)"
+            case "$ARCH" in
+              arm64) ZIG_ARCH="aarch64" ;;
+              x86_64) ZIG_ARCH="x86_64" ;;
+              *)
+                echo "Unsupported macOS runner architecture: $ARCH" >&2
+                exit 1
+                ;;
+            esac
+            ARCHIVE="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
             echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
+            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/${ARCHIVE}.tar.xz" -o /tmp/zig.tar.xz
             tar xf /tmp/zig.tar.xz -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
+            sudo cp -f "/tmp/${ARCHIVE}/zig" /usr/local/bin/zig
+            sudo cp -rf "/tmp/${ARCHIVE}/lib" /usr/local/lib/zig
             export PATH="/usr/local/bin:$PATH"
             zig version
           fi
@@ -166,7 +183,7 @@ jobs:
           fi
 
       - name: Create virtual display
-        if: matrix.smoke
+        if: matrix.smoke || matrix.ui_smoke_test != ''
         run: |
           set -euo pipefail
           echo "=== Display before ==="
@@ -197,3 +214,16 @@ jobs:
           set -euo pipefail
           chmod +x scripts/smoke-test-ci.sh
           scripts/smoke-test-ci.sh
+
+      - name: Run Intel Cmd+D smoke UI test
+        if: matrix.ui_smoke_test != ''
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            -maximum-test-execution-time-allowance 120 \
+            -only-testing:cmuxUITests/${{ matrix.ui_smoke_test }} \
+            test

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,11 @@ on:
         options:
           - depot-macos-latest
           - depot-macos-14
+          - macos-14-large
           - macos-15-intel
+          - macos-15-large
+          - macos-26-intel
+          - macos-26-large
 
 jobs:
   e2e:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,13 +20,14 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS (Depot runners for GUI activation support)"
+        description: "Runner OS"
         required: false
         default: "depot-macos-latest"
         type: choice
         options:
           - depot-macos-latest
           - depot-macos-14
+          - macos-15-intel
 
 jobs:
   e2e:
@@ -97,12 +98,22 @@ jobs:
           if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
             echo "zig ${ZIG_REQUIRED} already installed"
           else
+            ARCH="$(uname -m)"
+            case "$ARCH" in
+              arm64) ZIG_ARCH="aarch64" ;;
+              x86_64) ZIG_ARCH="x86_64" ;;
+              *)
+                echo "Unsupported macOS runner architecture: $ARCH" >&2
+                exit 1
+                ;;
+            esac
+            ARCHIVE="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
             echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
+            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/${ARCHIVE}.tar.xz" -o /tmp/zig.tar.xz
             tar xf /tmp/zig.tar.xz -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
+            sudo cp -f "/tmp/${ARCHIVE}/zig" /usr/local/bin/zig
+            sudo cp -rf "/tmp/${ARCHIVE}/lib" /usr/local/lib/zig
             export PATH="/usr/local/bin:$PATH"
             zig version
           fi

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 		A5002000 /* THIRD_PARTY_LICENSES.md in Resources */ = {isa = PBXBuildFile; fileRef = A5002001 /* THIRD_PARTY_LICENSES.md */; };
 			B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
+			C9100000A1B2C3D4E5F60718 /* IntelCmdDSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9100001A1B2C3D4E5F60718 /* IntelCmdDSmokeUITests.swift */; };
 			B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
@@ -251,6 +252,7 @@
 		B9000001A1B2C3D4E5F60719 /* cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmux.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
+				C9100001A1B2C3D4E5F60718 /* IntelCmdDSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelCmdDSmokeUITests.swift; sourceTree = "<group>"; };
 					B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
 					B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 					B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceConfirmDialogUITests.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				isa = PBXGroup;
 						children = (
 							B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */,
+							C9100001A1B2C3D4E5F60718 /* IntelCmdDSmokeUITests.swift */,
 							B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 							B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
 							B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */,
@@ -761,6 +764,7 @@
 				buildActionMask = 2147483647;
 						files = (
 							B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
+							C9100000A1B2C3D4E5F60718 /* IntelCmdDSmokeUITests.swift in Sources */,
 							B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 							B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
 							B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */,

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -254,17 +254,29 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertTrue(manager.tabs.contains(where: { $0.id == pinnedWorkspace.id }))
     }
 
-    private func waitForSocket(at path: String, timeout: TimeInterval = 2.0) throws {
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in
-                FileManager.default.fileExists(atPath: path)
-            },
-            object: NSObject()
-        )
-        if XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed {
-            return
+    private func waitForSocket(at path: String, timeout: TimeInterval = 5.0) throws {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+
+        // File-system predicate expectations proved flaky on Intel runners even
+        // after the listener had already bound and started accepting.
+        while true {
+            let health = TerminalController.shared.socketListenerHealth(expectedSocketPath: path)
+            if health.socketPathExists {
+                return
+            }
+            if Date() >= deadline {
+                XCTFail(
+                    "Timed out waiting for socket at \(path), " +
+                    "isRunning=\(health.isRunning), " +
+                    "acceptLoopAlive=\(health.acceptLoopAlive), " +
+                    "socketPathMatches=\(health.socketPathMatches), " +
+                    "socketPathExists=\(health.socketPathExists)"
+                )
+                break
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         }
-        XCTFail("Timed out waiting for socket at \(path)")
+
         throw NSError(domain: NSPOSIXErrorDomain, code: Int(ETIMEDOUT))
     }
 

--- a/cmuxUITests/IntelCmdDSmokeUITests.swift
+++ b/cmuxUITests/IntelCmdDSmokeUITests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+final class IntelCmdDSmokeUITests: XCTestCase {
+    private let launchTag = "ui-tests-intel-cmd-d-smoke"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testLaunchAndCmdDDoesNotCrash() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        launchAndEnsureStarted(app)
+
+        XCTAssertTrue(
+            waitForWindowCount(app: app, atLeast: 1, timeout: 12.0),
+            "Expected app to open a window before Cmd+D. state=\(app.state.rawValue)"
+        )
+
+        app.typeKey("d", modifierFlags: [.command])
+
+        XCTAssertTrue(
+            waitForWindowCount(app: app, atLeast: 1, timeout: 5.0),
+            "Expected app window to stay open after Cmd+D. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(
+            waitForAppToKeepRunning(app: app, timeout: 5.0),
+            "Expected app to keep running after Cmd+D. state=\(app.state.rawValue)"
+        )
+    }
+
+    private func launchAndEnsureStarted(_ app: XCUIApplication) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground || app.state == .runningBackground {
+            return
+        }
+
+        XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func waitForWindowCount(app: XCUIApplication, atLeast count: Int, timeout: TimeInterval) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                app.windows.count >= count
+            },
+            object: NSObject()
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func waitForAppToKeepRunning(app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                app.state != .notRunning
+            },
+            object: NSObject()
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+}

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -16,6 +16,7 @@ REF=""
 WAIT=false
 RECORD_VIDEO=true
 TIMEOUT=120
+RUNNER=""
 
 usage() {
   cat <<EOF
@@ -28,6 +29,7 @@ Options:
   --ref <ref>      Branch or SHA to test (default: current branch)
   --wait           Wait for the run to complete and print result
   --no-video       Disable video recording
+  --runner <name>  Runner label (e.g. macos-15-intel)
   --timeout <sec>  Per-test timeout in seconds (default: 120)
   -h, --help       Show this help
 EOF
@@ -55,6 +57,10 @@ while [ $# -gt 0 ]; do
       RECORD_VIDEO=false
       shift
       ;;
+    --runner)
+      RUNNER="$2"
+      shift 2
+      ;;
     --timeout)
       TIMEOUT="$2"
       shift 2
@@ -71,8 +77,11 @@ FIELDS=(-f "test_filter=$TEST_FILTER" -f "record_video=$RECORD_VIDEO" -f "test_t
 if [ -n "$REF" ]; then
   FIELDS+=(-f "ref=$REF")
 fi
+if [ -n "$RUNNER" ]; then
+  FIELDS+=(-f "runner=$RUNNER")
+fi
 
-echo "Triggering $WORKFLOW with test_filter=$TEST_FILTER ref=${REF:-<default>} video=$RECORD_VIDEO timeout=$TIMEOUT"
+echo "Triggering $WORKFLOW with test_filter=$TEST_FILTER ref=${REF:-<default>} runner=${RUNNER:-<default>} video=$RECORD_VIDEO timeout=$TIMEOUT"
 gh workflow run "$WORKFLOW" --repo "$REPO" "${FIELDS[@]}"
 
 # Wait a moment for the run to register


### PR DESCRIPTION
## Summary
- add an Intel-only XCUITest that launches cmux, sends Cmd+D, and asserts the app stays alive
- run that smoke test automatically in macOS Compatibility on GitHub-hosted `macos-15-intel`
- make `test-e2e.yml` and `scripts/run-e2e.sh` accept Intel runners, including architecture-aware Zig install

## Testing
- `ruby -e 'require "yaml"; [".github/workflows/test-e2e.yml", ".github/workflows/ci-macos-compat.yml"].each { |p| YAML.load_file(p); puts "OK #{p}" }'`
- `xcodebuild -list -project GhosttyTabs.xcodeproj`
- `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=task-intel-mac-cmd-d-smoke-test -f test_filter=IntelCmdDSmokeUITests -f runner=macos-15-intel -f record_video=false -f test_timeout=120`

## Issues
- Task: Intel Mac GitHub Actions smoke test that launches the app, sends Cmd+D, and ensures it does not crash

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Intel-only macOS UI smoke test that launches cmux, sends Cmd+D, and checks the app keeps running. Updates CI to run it on GitHub Actions `macos-15-intel` and expands E2E runner selection, satisfying the Linear task.

- **New Features**
  - Added XCUITest `IntelCmdDSmokeUITests` and wired it to run on `macos-15-intel` with a virtual display.
  - E2E workflows/scripts accept a `runner` and add GitHub-hosted choices (`macos-15-intel`, `macos-14-large`, `macos-15-large`, `macos-26-intel`, `macos-26-large`); `zig` install is arch-aware for `aarch64`/`x86_64`.

- **Bug Fixes**
  - Stabilized `TerminalControllerSocketSecurityTests` on Intel by polling `socketListenerHealth` and increasing the wait timeout.

<sup>Written for commit 1024d906208f4fbaeaef20db42f3dbf2abc25182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an Intel macOS UI smoke test to verify app stability and Cmd+D behavior.
  * Increased socket wait timeout and improved failure diagnostics for socket readiness.

* **Chores**
  * CI updated for Intel macOS: expanded runner options, conditional UI test execution, and architecture-aware tooling installation.
  * E2E dispatch script gained a runner selection option for targeted workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->