### PR TITLE
Shift titlebar folder icon 7px left

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2465,7 +2465,7 @@ struct ContentView: View {
                 // Draggable folder icon + focused command name
                 if let directory = focusedDirectory {
                     DraggableFolderIcon(directory: directory)
-                        .padding(.leading, -7)
+                        .padding(.leading, -6)
                 }
 
                 Text(titlebarText)


### PR DESCRIPTION
## Summary
- Move the titlebar draggable folder icon 7 points left by adding a negative leading padding in the custom titlebar row.

## Testing
- `./scripts/download-prebuilt-ghosttykit.sh`
- `./scripts/reload.sh --tag task-titlebar-folder-icon-left`

## Issues
- Task summary: move titlebar folder icon left by 7px

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the draggable folder icon in the custom titlebar 6px to the left to match the task’s visual alignment. Achieved with negative leading padding (`.padding(.leading, -6)`), after nudging right by 1px from the initial 7px shift.

<sup>Written for commit 7f1e8835fe51624ad756cdc4974c003cfc72c637. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the folder icon positioning in the app title bar when a directory is focused, shifting it slightly left for improved visual alignment and a more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->