### PR TITLE
Consume Cmd+number shortcuts when workspace index is out of bounds

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9481,18 +9481,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         // Numeric shortcuts for specific workspaces (9 = last workspace)
-        if let manager = tabManager,
-           let digit = numberedShortcutDigit(
-               event: event,
-               shortcut: KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
-           ),
-           let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
+        // Always consume the event when the digit matches to prevent Ghostty's
+        // goto_tab fallback from creating a new window when the index is out of bounds.
+        if let digit = numberedShortcutDigit(
+            event: event,
+            shortcut: KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
+        ) {
+            if let manager = tabManager,
+               let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
-            dlog(
-                "shortcut.action name=workspaceDigit digit=\(digit) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
-            )
+                dlog(
+                    "shortcut.action name=workspaceDigit digit=\(digit) targetIndex=\(targetIndex) manager=\(debugManagerToken(manager)) \(debugShortcutRouteSnapshot(event: event))"
+                )
 #endif
-            manager.selectTab(at: targetIndex)
+                manager.selectTab(at: targetIndex)
+            }
             return true
         }
 


### PR DESCRIPTION
## Summary
- When pressing Cmd+N (N=1-9) for a workspace index that doesn't exist, the shortcut event was not consumed and fell through to Ghostty's `goto_tab` binding, which could create a new window
- Fix: always consume the event when the digit shortcut matches, regardless of whether a valid workspace exists at that index

Fixes #1970

## Test plan
- [ ] Open cmux with 2 workspaces, press Cmd+5 — should do nothing (no new window)
- [ ] Press Cmd+1 / Cmd+2 — should switch workspaces normally
- [ ] Press Cmd+9 — should switch to last workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)