### PR TITLE
Normalize keyboard event for menu dispatch under non-Latin IME

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12611,9 +12611,10 @@ private extension NSWindow {
             // non-ASCII characters (e.g. "ㅅ" instead of "t"), causing menu
             // shortcut matching to fail.
             var menuEvent = event
-            if let chars = event.charactersIgnoringModifiers,
-               !chars.allSatisfy({ $0.isASCII }),
-               let normalized = KeyboardLayout.character(forKeyCode: event.keyCode, modifierFlags: event.modifierFlags) {
+            let rawChars = event.charactersIgnoringModifiers ?? ""
+            if (rawChars.isEmpty || !rawChars.allSatisfy(\.isASCII)),
+               let normalized = KeyboardLayout.character(forKeyCode: event.keyCode, modifierFlags: event.modifierFlags),
+               !normalized.isEmpty {
                 menuEvent = NSEvent.keyEvent(
                     with: event.type,
                     location: event.locationInWindow,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12613,7 +12613,7 @@ private extension NSWindow {
             var menuEvent = event
             if let chars = event.charactersIgnoringModifiers,
                !chars.allSatisfy({ $0.isASCII }),
-               let normalized = KeyboardLayout.character(forKeyCode: event.keyCode) {
+               let normalized = KeyboardLayout.character(forKeyCode: event.keyCode, modifierFlags: event.modifierFlags) {
                 menuEvent = NSEvent.keyEvent(
                     with: event.type,
                     location: event.locationInWindow,
@@ -12621,7 +12621,7 @@ private extension NSWindow {
                     timestamp: event.timestamp,
                     windowNumber: event.windowNumber,
                     context: nil,
-                    characters: normalized,
+                    characters: event.characters ?? normalized,
                     charactersIgnoringModifiers: normalized,
                     isARepeat: event.isARepeat,
                     keyCode: event.keyCode

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12605,7 +12605,34 @@ private extension NSWindow {
         if firstResponderGhosttyView != nil,
            shouldRouteCommandEquivalentDirectlyToMainMenu(event),
            let mainMenu = NSApp.mainMenu {
-            let consumedByMenu = mainMenu.performKeyEquivalent(with: event)
+            // Normalize event characters for non-Latin IME (Korean, Russian, etc.)
+            // so NSMenu.performKeyEquivalent can match ASCII-based shortcuts.
+            // When IME is active, event.charactersIgnoringModifiers may return
+            // non-ASCII characters (e.g. "ㅅ" instead of "t"), causing menu
+            // shortcut matching to fail.
+            var menuEvent = event
+            if let chars = event.charactersIgnoringModifiers,
+               !chars.allSatisfy({ $0.isASCII }),
+               let normalized = KeyboardLayout.character(forKeyCode: event.keyCode) {
+                menuEvent = NSEvent.keyEvent(
+                    with: event.type,
+                    location: event.locationInWindow,
+                    modifierFlags: event.modifierFlags,
+                    timestamp: event.timestamp,
+                    windowNumber: event.windowNumber,
+                    context: nil,
+                    characters: normalized,
+                    charactersIgnoringModifiers: normalized,
+                    isARepeat: event.isARepeat,
+                    keyCode: event.keyCode
+                ) ?? event
+            }
+#if DEBUG
+            if menuEvent !== event {
+                dlog("  → normalized menu event chars: \(event.charactersIgnoringModifiers ?? "nil") → \(menuEvent.charactersIgnoringModifiers ?? "nil")")
+            }
+#endif
+            let consumedByMenu = mainMenu.performKeyEquivalent(with: menuEvent)
 #if DEBUG
             if browserZoomShortcutTraceCandidate(
                 flags: event.modifierFlags,

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2103,13 +2103,10 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsKoreanMappings() {
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"])
-        XCTAssertNotNil(mappings)
-        let fonts = Set(mappings!.map { $0.1 })
-        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
-        let ranges = mappings!.map { $0.0 }
-        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"))
+    func testCJKFontMappingsReturnsNilForKoreanOnly() {
+        // Korean is not auto-mapped — Ghostty's native CTFontCreateForString
+        // fallback selects a better-matching font for Hangul.
+        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2128,12 +2125,17 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: []))
     }
 
-    func testCJKFontMappingsMultiLanguageIncludesKorean() {
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja", "ko-KR"])
-        XCTAssertNotNil(mappings)
-        let fonts = Set(mappings!.map { $0.1 })
-        XCTAssertTrue(fonts.contains("Hiragino Sans"))
-        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
+    func testCJKFontMappingsMultiLanguageSkipsKorean() {
+        // When both ja and ko are preferred, only Japanese mappings are generated.
+        // Korean is left to Ghostty's native CTFontCreateForString fallback.
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
+
+        let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
+
+        XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
+        XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
+        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
+        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
     }
 
     // MARK: userConfigContainsCJKCodepointMap

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2103,10 +2103,13 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsNilForKoreanOnly() {
-        // Korean is not auto-mapped — Ghostty's native CTFontCreateForString
-        // fallback selects a better-matching font for Hangul.
-        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
+    func testCJKFontMappingsReturnsKoreanMappings() {
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"])
+        XCTAssertNotNil(mappings)
+        let fonts = Set(mappings!.map { $0.1 })
+        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
+        let ranges = mappings!.map { $0.0 }
+        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"))
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2125,17 +2128,12 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: []))
     }
 
-    func testCJKFontMappingsMultiLanguageSkipsKorean() {
-        // When both ja and ko are preferred, only Japanese mappings are generated.
-        // Korean is left to Ghostty's native CTFontCreateForString fallback.
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
-
-        let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
-
-        XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
-        XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
-        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
-        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
+    func testCJKFontMappingsMultiLanguageIncludesKorean() {
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja", "ko-KR"])
+        XCTAssertNotNil(mappings)
+        let fonts = Set(mappings!.map { $0.1 })
+        XCTAssertTrue(fonts.contains("Hiragino Sans"))
+        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
     }
 
     // MARK: userConfigContainsCJKCodepointMap


### PR DESCRIPTION
## Summary
- When Korean or Russian IME is active (even without active composition), `event.charactersIgnoringModifiers` returns non-ASCII characters (e.g. "ㅅ" instead of "t")
- `handleCustomShortcut` already handles this via `KeyboardLayout.normalizedCharacters` multi-layer fallback
- But `mainMenu.performKeyEquivalent(with: event)` in `cmux_performKeyEquivalent` uses the raw event, so AppKit's NSMenu fails to match ASCII-based keyboard shortcuts
- Fix: synthesize a normalized NSEvent with ASCII `charactersIgnoringModifiers` derived from the physical key code before dispatching to the menu

Fixes #1945

## Test plan
- [ ] Activate Korean IME (2-Set Korean), press Cmd+T — should open new tab
- [ ] Activate Korean IME, press Cmd+W — should close tab
- [ ] Activate Russian IME, press Cmd+C / Cmd+V — should copy/paste
- [ ] Verify normal (English) keyboard still works correctly
- [ ] Verify IME composition (typing Korean/Russian text) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command shortcuts under non‑Latin IMEs by normalizing menu key events, including Shift combos. Also adds Korean Hangul font fallback and routes Cmd+O to Open Folder to avoid AppKit’s default.

- **Bug Fixes**
  - Before `NSMenu.performKeyEquivalent`, synthesize an `NSEvent` with ASCII `charactersIgnoringModifiers` from the physical `keyCode` and current `modifierFlags`; preserve original `characters`, normalize when `charactersIgnoringModifiers` is nil/empty, and ignore empty normalization results. Restores Cmd+T/W/C/V and Cmd+Shift+[/? under Korean/Russian IMEs.
  - Route Cmd+O to `showOpenFolderPanel()` to prevent `NSDocumentController` from opening the Documents folder when SwiftUI focus breaks menu dispatch.
  - Map Hangul (U+AC00–U+D7AF) to “Apple SD Gothic Neo” when Korean is preferred, and include it alongside Japanese in mixed‑language prefs.

<sup>Written for commit 10088a03d4083eb5457007085a9d905b82b1965e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard shortcut handling when the Ghostty terminal window is active, improving support for various keyboard layouts and ensuring Command-key shortcuts function correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->