### PR TITLE
docs(notifications): remove outdated pre-0.60 Claude Code hooks section

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,37 +54,6 @@ cmux notify --title "Done" --tab 0 --panel 1
 
 ## Integration Examples
 
-### Claude Code Hooks
-
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --body 'Waiting for input' || osascript -e 'display notification \"Waiting for input\" with title \"Claude Code\"'"
-          }
-        ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --subtitle 'Permission' --body 'Approval needed' || osascript -e 'display notification \"Approval needed\" with title \"Claude Code\"'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 ### OpenAI Codex
 
 Add to `~/.codex/config.toml`:


### PR DESCRIPTION
The Claude Code hooks section in the notifications docs documented manual JSON hook configuration for idle and permission prompts. This was relevant before 0.60.0.

Since PR #247 (released in 0.60.0), Claude Code integration is enabled by default — cmux automatically wraps the claude command to inject notification hooks. Users on 0.60+ no longer need this manual configuration, so the section is misleading and has been removed.

Fixes #2009.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated pre-0.60 Claude Code hooks section from the notifications docs to avoid misleading setup steps. Since 0.60.0, `cmux` auto-wraps the `claude` command to inject notification hooks, so manual JSON config is unnecessary—fixes #2009.

<sup>Written for commit d57f7cb6c294bb062bb51c09edc4f1f35ee35c92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Claude Code Hooks integration section from the notifications documentation, including configuration guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->