### PR TITLE
Add Korean font mapping to CJK font fallback system

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1406,6 +1406,13 @@ class GhosttyApp {
         "U+30A0-U+30FF",  // Katakana
     ]
 
+    /// Unicode ranges specific to Korean (Hangul).
+    private static let koreanRanges = [
+        "U+AC00-U+D7AF",  // Hangul Syllables
+        "U+1100-U+11FF",  // Hangul Jamo
+        "U+3130-U+318F",  // Hangul Compatibility Jamo
+    ]
+
     private struct UserFontConfigSummary {
         var containsCodepointMap = false
         var effectiveFontFamilies: [String] = []
@@ -1463,6 +1470,9 @@ class GhosttyApp {
                 font = "PingFang TC"
             } else if lower.hasPrefix("zh") {
                 font = "PingFang SC"
+            } else if lower.hasPrefix("ko") {
+                font = "Apple SD Gothic Neo"
+                langRanges = koreanRanges
             } else {
                 continue
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1470,7 +1470,7 @@ class GhosttyApp {
                 font = "PingFang TC"
             } else if lower.hasPrefix("zh") {
                 font = "PingFang SC"
-            } else if lower.hasPrefix("ko") {
+            } else if lower == "ko" || lower.hasPrefix("ko-") {
                 font = "Apple SD Gothic Neo"
                 langRanges = koreanRanges
             } else {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2109,8 +2109,9 @@ final class GhosttyMouseFocusTests: XCTestCase {
         let fonts = Set(mappings!.map { $0.1 })
         XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
         let ranges = mappings!.map { $0.0 }
-        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"))
+        XCTAssertTrue(ranges.contains("U+1100-U+11FF"), "Should include Hangul Jamo")
         XCTAssertTrue(ranges.contains("U+3130-U+318F"), "Should include Hangul Compatibility Jamo")
+        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"), "Should include Hangul Syllables")
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2137,8 +2138,9 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
         // Regression: Korean ranges must not leak into the Japanese (Hiragino) font entries
         let hiraginoRanges = mappings!.filter { $0.1 == "Hiragino Sans" }.map(\.0)
-        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul Syllables must not bleed into Hiragino")
+        XCTAssertFalse(hiraginoRanges.contains("U+1100-U+11FF"), "Hangul Jamo must not bleed into Hiragino")
         XCTAssertFalse(hiraginoRanges.contains("U+3130-U+318F"), "Hangul Compat Jamo must not bleed into Hiragino")
+        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul Syllables must not bleed into Hiragino")
     }
 
     // MARK: userConfigContainsCJKCodepointMap

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2110,6 +2110,7 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
         let ranges = mappings!.map { $0.0 }
         XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"))
+        XCTAssertTrue(ranges.contains("U+3130-U+318F"), "Should include Hangul Compatibility Jamo")
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2134,6 +2135,10 @@ final class GhosttyMouseFocusTests: XCTestCase {
         let fonts = Set(mappings!.map { $0.1 })
         XCTAssertTrue(fonts.contains("Hiragino Sans"))
         XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
+        // Regression: Korean ranges must not leak into the Japanese (Hiragino) font entries
+        let hiraginoRanges = mappings!.filter { $0.1 == "Hiragino Sans" }.map(\.0)
+        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul Syllables must not bleed into Hiragino")
+        XCTAssertFalse(hiraginoRanges.contains("U+3130-U+318F"), "Hangul Compat Jamo must not bleed into Hiragino")
     }
 
     // MARK: userConfigContainsCJKCodepointMap

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2103,10 +2103,13 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsNilForKoreanOnly() {
-        // Korean is not auto-mapped — Ghostty's native CTFontCreateForString
-        // fallback selects a better-matching font for Hangul.
-        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
+    func testCJKFontMappingsReturnsKoreanMappings() {
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"])
+        XCTAssertNotNil(mappings)
+        let fonts = Set(mappings!.map { $0.1 })
+        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
+        let ranges = mappings!.map { $0.0 }
+        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"))
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -2125,17 +2128,12 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: []))
     }
 
-    func testCJKFontMappingsMultiLanguageSkipsKorean() {
-        // When both ja and ko are preferred, only Japanese mappings are generated.
-        // Korean is left to Ghostty's native CTFontCreateForString fallback.
-        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
-
-        let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
-
-        XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
-        XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
-        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
-        XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
+    func testCJKFontMappingsMultiLanguageIncludesKorean() {
+        let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja", "ko-KR"])
+        XCTAssertNotNil(mappings)
+        let fonts = Set(mappings!.map { $0.1 })
+        XCTAssertTrue(fonts.contains("Hiragino Sans"))
+        XCTAssertTrue(fonts.contains("Apple SD Gothic Neo"))
     }
 
     // MARK: userConfigContainsCJKCodepointMap


### PR DESCRIPTION
## Summary
- Korean (Hangul) characters were excluded from the automatic CJK font mapping in `cjkFontMappings()`
- Ghostty's native `CTFontCreateForString` fallback ignores user `font-family` settings, causing Korean text to render in system fonts
- Add `ko` language prefix handling that maps Hangul ranges (Syllables, Jamo, Compatibility Jamo) to "Apple SD Gothic Neo"
- Add Hangul Compatibility Jamo range `U+3130-U+318F` to `koreanRanges`
- Update unit tests to verify Korean font mappings are generated

Fixes #1946

## Test plan
- [ ] Set system language to Korean, verify Hangul renders with configured font
- [ ] Run `GhosttyConfigTests` — all CJK font mapping tests pass
- [ ] Verify Japanese/Chinese font mappings still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Korean Hangul to the CJK font fallback so Korean text uses the configured font instead of the system default. Adds strict `ko` locale mapping and prevents Hangul ranges from bleeding into Japanese when both are preferred. Fixes #1946.

- **Bug Fixes**
  - Map `ko` and `ko-*` to "Apple SD Gothic Neo" and apply Hangul ranges (U+1100–U+11FF, U+3130–U+318F, U+AC00–U+D7AF) in `cjkFontMappings()`.
  - Update tests: Korean-only returns mappings; `ja` + `ko` includes both fonts and asserts Hangul ranges (incl. U+1100–U+11FF) do not bleed into "Hiragino Sans".

<sup>Written for commit 3510353a5d4d71e37c5f0087dfe0ba8f7168e9f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Korean font fallback/detection: when preferred language is `ko` (or starts with `ko-`), the app selects Apple SD Gothic Neo and applies Hangul codepoint ranges so Korean text renders with the correct font, including mixed CJK scenarios.

* **Tests**
  * Updated tests to require Korean mappings when Korean is present and to assert Hangul ranges are associated only with the Korean font, not with other CJK fonts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->