### PR TITLE
fix(openFolder): set NSOpenPanel directoryURL to focused pane's working directory

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5975,6 +5975,9 @@ struct ContentView: View {
                 panel.allowsMultipleSelection = false
                 panel.title = String(localized: "panel.openFolder.title", defaultValue: "Open Folder")
                 panel.prompt = String(localized: "panel.openFolder.prompt", defaultValue: "Open")
+                if let cwd = tabManager.selectedWorkspace?.currentDirectory, !cwd.isEmpty {
+                    panel.directoryURL = URL(fileURLWithPath: cwd)
+                }
                 if panel.runModal() == .OK, let url = panel.url {
                     tabManager.addWorkspace(workingDirectory: url.path)
                 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -593,6 +593,9 @@ struct cmuxApp: App {
                     panel.allowsMultipleSelection = false
                     panel.title = String(localized: "menu.file.openFolder.panelTitle", defaultValue: "Open Folder")
                     panel.prompt = String(localized: "menu.file.openFolder.panelPrompt", defaultValue: "Open")
+                    if let cwd = activeTabManager.selectedWorkspace?.currentDirectory, !cwd.isEmpty {
+                        panel.directoryURL = URL(fileURLWithPath: cwd)
+                    }
                     if panel.runModal() == .OK, let url = panel.url {
                         if let appDelegate = AppDelegate.shared {
                             if appDelegate.addWorkspaceInPreferredMainWindow(


### PR DESCRIPTION
## Summary

- **What changed?** Set the `directoryURL` property on `NSOpenPanel` before presenting it for the `⌘O` Open Folder action, so the file picker opens at the selected workspace's working directory instead of the macOS default ~/Documents.

- **Why?** `NSOpenPanel` defaults to ~/Documents when `directoryURL` is not set. By reading `activeTabManager.selectedWorkspace?.currentDirectory` (or `tabManager.selectedWorkspace?.currentDirectory` in the command palette path), the panel now opens at a contextually relevant location.

## Testing

- **How did you test this change?** Code review + verified the two NSOpenPanel call sites now set `directoryURL` from the workspace's current directory before calling `runModal()`.
- **What did you verify manually?** Confirmed `currentDirectory` is populated from the focused pane's shell integration and used as the fallback when set.

## Files changed

- `Sources/cmuxApp.swift`: menu File → Open Folder (⌘O) path
- `Sources/ContentView.swift`: command palette `palette.openFolder` path

## Review Trigger

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open Folder now starts in the focused workspace’s working directory instead of ~/Documents. We set NSOpenPanel.directoryURL from the selected workspace’s currentDirectory in both the File → Open Folder (⌘O) and command palette actions.

<sup>Written for commit 27beb345422a3853bf6c38ae02e1d4adf3be8d6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File → Open Folder dialog now opens to the current workspace directory, improving navigation efficiency and preserving workspace context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->