### PR TITLE
feat: expose per-surface TTY in tree output

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8565,6 +8565,9 @@ struct CMUXCLI {
         if (surface["here"] as? Bool) == true {
             parts.append("◀ here")
         }
+        if let tty = surface["tty"] as? String, !tty.isEmpty {
+            parts.append("tty=\(tty)")
+        }
         if surfaceType.lowercased() == "browser",
            let url = surface["url"] as? String,
            !url.isEmpty {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2849,7 +2849,8 @@ class TerminalController {
                 "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
                 "pane_id": v2OrNull(paneUUID?.uuidString),
                 "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
-                "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id])
+                "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
+                "tty": v2OrNull(workspace.surfaceTTYNames[panel.id])
             ]
 
             if panel.panelType == .browser, let browserPanel = panel as? BrowserPanel {


### PR DESCRIPTION
## Summary

Expose per-surface TTY name in the `system.tree` response. Reads from the existing `surfaceTTYNames` dictionary — no new data collection, just surfacing what's already tracked internally.

### Changes

**TerminalController.swift** — add `tty` field to surface items in `v2TreeWorkspaceNode`:
```swift
"tty": v2OrNull(workspace.surfaceTTYNames[panel.id])
```

**CLI/cmux.swift** — show `tty=<value>` in text tree output for surfaces with a registered TTY.

### Before / After

**Before:**
```
└── surface surface:1 [terminal] "session title" [selected] ◀ active
```

**After:**
```
└── surface surface:1 [terminal] "session title" [selected] ◀ active tty=ttys010
```

### Use case

Enables external tools to cross-reference process TTYs (`ps -o tty=`) with cmux surfaces for identifying which terminal tab a specific process is running in. This is the cmux equivalent of iTerm2's `tty of session` AppleScript property.

### Test proof

Dev build (`reload.sh --tag codev-tty`), running `tree --all`:

```
window window:1 [current] ◀ active
├── workspace workspace:3 "grimmer@MacBookAirK15:~/git/codev" [selected] ◀ active
│   └── pane pane:3 [focused] ◀ active
│       └── surface surface:3 [terminal] "grimmer@MacBookAirK15:~/git/codev" [selected] ◀ active tty=ttys006
├── workspace workspace:4 "✳ hi codev 16"
│   └── pane pane:4 [focused]
│       └── surface surface:5 [terminal] "✳ hi codev 16" [selected] tty=ttys010
└── workspace workspace:5 "grimmer@MacBookAirK15:~/git/codev"
    └── pane pane:5 [focused]
        └── surface surface:6 [terminal] "grimmer@MacBookAirK15:~/git/codev" [selected] tty=ttys020
```

Surfaces without registered TTY (e.g. newly created, no shell integration) show no `tty=` field — same output as before.

_🤖 On behalf of @grimmerk — generated with Claude Code_
