### PR TITLE
feat: AI-powered tab & workspace auto-naming for Claude Code

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -253,6 +253,9 @@ if GUARD_PATH="$(ensure_node_options_restore_module)"; then
     export NODE_OPTIONS="$(merge_node_options "$GUARD_PATH")"
 fi
 
+# Resolve the directory containing this wrapper (for sibling scripts).
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Build hooks settings JSON.
 # Claude Code merges --settings additively with the user's own settings.json.
 # - SessionStart/Stop/Notification: existing lifecycle hooks
@@ -263,7 +266,19 @@ fi
 #   This is Claude Code's native blocking decision hook. It covers
 #   permissions, ExitPlanMode, and AskUserQuestion without using
 #   PreToolUse denial as a side channel.
-HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":125}]}]}}'
+# - Tab/workspace naming hooks: AI-powered auto-naming from conversation content
+BASE_HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":125}]}]}}'
+
+# $SELF_DIR is interpolated into JSON command strings, so validate it contains
+# no characters that would break JSON or the shell command string.
+# If unsafe, fall back to BASE_HOOKS_JSON — existing lifecycle hooks still work,
+# but AI tab/workspace naming won't run.
+if printf '%s' "$SELF_DIR" | grep -qE "[\"\\\\' \$\`!;|&<>()*?\[\]]"; then
+    echo "cmux: warning: wrapper path has JSON/shell-unsafe characters — AI tab naming disabled: $SELF_DIR" >&2
+    HOOKS_JSON="$BASE_HOOKS_JSON"
+else
+    HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10},{"type":"command","command":"'"$SELF_DIR"'/cmux-session-namer.sh","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10},{"type":"command","command":"'"$SELF_DIR"'/cmux-tab-namer.sh","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10},{"type":"command","command":"'"$SELF_DIR"'/cmux-rename-namer.sh","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":125}]}]}}'
+fi
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" "${CMUX_BYPASS_AVAILABILITY_ARGS[@]}" --settings "$HOOKS_JSON" "$@"

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -256,12 +256,13 @@ fi
 # Resolve the directory containing this wrapper (for sibling scripts).
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Guard: $SELF_DIR is interpolated directly into a JSON string literal.
-# A path containing '"' or '\' would produce malformed JSON and silently
-# disable all hooks. This is extremely unlikely in practice but worth catching.
-if [[ "$SELF_DIR" =~ [\"\\] ]]; then
-    echo "cmux: warning: wrapper directory path contains JSON-unsafe characters: $SELF_DIR" >&2
-    echo "cmux: hooks disabled — move cmux to a path without '\"' or '\\'" >&2
+# Guard: $SELF_DIR is interpolated directly into JSON command strings.
+# Characters that break JSON (" \) or shell command tokenization (space and
+# other metacharacters: $`!;|&<>()) would silently disable hooks or enable
+# injection. Validate and fail safe rather than proceed with a broken config.
+if printf '%s' "$SELF_DIR" | grep -qE '["\\ $`!;|&<>()]'; then
+    echo "cmux: warning: wrapper directory path contains JSON/shell-unsafe characters: $SELF_DIR" >&2
+    echo "cmux: hooks disabled — move cmux to a path without special characters" >&2
     exec "$REAL_CLAUDE" "$@"
 fi
 

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -256,16 +256,6 @@ fi
 # Resolve the directory containing this wrapper (for sibling scripts).
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Guard: $SELF_DIR is interpolated directly into JSON command strings.
-# Characters that break JSON (" \) or shell command tokenization (space and
-# other metacharacters: $`!;|&<>()) would silently disable hooks or enable
-# injection. Validate and fail safe rather than proceed with a broken config.
-if printf '%s' "$SELF_DIR" | grep -qE '["\\ $`!;|&<>()]'; then
-    echo "cmux: warning: wrapper directory path contains JSON/shell-unsafe characters: $SELF_DIR" >&2
-    echo "cmux: hooks disabled — move cmux to a path without special characters" >&2
-    exec "$REAL_CLAUDE" "$@"
-fi
-
 # Build hooks settings JSON.
 # Claude Code merges --settings additively with the user's own settings.json.
 # - SessionStart/Stop/Notification: existing lifecycle hooks

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -256,6 +256,15 @@ fi
 # Resolve the directory containing this wrapper (for sibling scripts).
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Guard: $SELF_DIR is interpolated directly into a JSON string literal.
+# A path containing '"' or '\' would produce malformed JSON and silently
+# disable all hooks. This is extremely unlikely in practice but worth catching.
+if [[ "$SELF_DIR" =~ [\"\\] ]]; then
+    echo "cmux: warning: wrapper directory path contains JSON-unsafe characters: $SELF_DIR" >&2
+    echo "cmux: hooks disabled — move cmux to a path without '\"' or '\\'" >&2
+    exec "$REAL_CLAUDE" "$@"
+fi
+
 # Build hooks settings JSON.
 # Claude Code merges --settings additively with the user's own settings.json.
 # - SessionStart/Stop/Notification: existing lifecycle hooks

--- a/Resources/bin/cmux-rename-namer.sh
+++ b/Resources/bin/cmux-rename-namer.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# cmux-rename-namer.sh — Sync /rename custom title to cmux tab name
+# cmux-rename-namer.sh — Apply pending AI labels + sync /rename custom title to cmux tab
 #
 # Invoked by the cmux claude wrapper as a UserPromptSubmit hook.
-# When a user /renames their Claude Code session, this hook syncs the
-# custom title to the cmux tab. Workspace name is only updated if this
-# tab is the workspace owner (first session).
+#
+# Phase 1: Apply pending AI label from previous Stop (moved here from the Stop hook
+#          so the tab name updates the moment the user sends their next message,
+#          rather than waiting for Claude's full response to complete).
+#
+# Phase 2: Sync /rename custom title to tab and workspace (owner only).
+#          Writes a marker file so the custom title persists even in long transcripts
+#          where tail-500 would miss an early /rename entry.
 #
 # Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
 # Stdin: JSON with session_id, transcript_path, etc.
@@ -17,6 +22,38 @@ INPUT=$(cat)
 [ -z "$CMUX_WORKSPACE_ID" ] && exit 0
 [ -z "$CMUX_SURFACE_ID" ] && exit 0
 command -v cmux &>/dev/null || exit 0
+
+# ============================================================
+# PHASE 1: Apply pending AI label from previous Stop (fast path)
+# Tab name updates on next user prompt, not on next Claude response.
+# ============================================================
+TAB_PENDING="/tmp/cmux-tab-pending-${CMUX_SURFACE_ID}"
+TAB_CACHE="/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}"
+if [ -f "$TAB_PENDING" ]; then
+  LABEL=$(head -1 "$TAB_PENDING" 2>/dev/null)
+  P_LINE_COUNT=$(sed -n '2p' "$TAB_PENDING" 2>/dev/null)
+  P_HAS_CUSTOM=$(sed -n '3p' "$TAB_PENDING" 2>/dev/null)
+  rm -f "$TAB_PENDING" 2>/dev/null
+
+  if [ -n "$LABEL" ]; then
+    # Update tab cache
+    printf '%s\n%s\n' "${P_LINE_COUNT:-0}" "$LABEL" > "$TAB_CACHE" 2>/dev/null
+
+    # Rename this tab
+    cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$LABEL" 2>/dev/null || true
+
+    # Rename workspace only if: (a) no custom-title, AND (b) this tab is the workspace owner
+    WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
+    WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
+    if [ "${P_HAS_CUSTOM:-0}" -eq 0 ] 2>/dev/null && [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
+      cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$LABEL" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# ============================================================
+# PHASE 2: Sync /rename custom title
+# ============================================================
 
 # Extract transcript path
 TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
@@ -32,6 +69,10 @@ except: pass
 " 2>/dev/null)
 
 [ -z "$TITLE" ] && exit 0
+
+# Write marker file — ensures custom-title suppresses AI summary even in very long
+# transcripts where the /rename entry falls outside the tail-500 window
+echo "$TITLE" > "/tmp/cmux-custom-title-${CMUX_SURFACE_ID}" 2>/dev/null
 
 # Always rename this tab
 cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$TITLE" 2>/dev/null || true

--- a/Resources/bin/cmux-rename-namer.sh
+++ b/Resources/bin/cmux-rename-namer.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# cmux-rename-namer.sh — Sync /rename custom title to cmux tab name
+#
+# Invoked by the cmux claude wrapper as a UserPromptSubmit hook.
+# When a user /renames their Claude Code session, this hook syncs the
+# custom title to the cmux tab. Workspace name is only updated if this
+# tab is the workspace owner (first session).
+#
+# Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
+# Stdin: JSON with session_id, transcript_path, etc.
+
+set -e
+
+INPUT=$(cat)
+
+[ "$CMUX_TAB_NAMER_DISABLED" = "1" ] && exit 0
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+[ -z "$CMUX_SURFACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+# Extract transcript path
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
+[ -z "$TRANSCRIPT" ] && exit 0
+[ -f "$TRANSCRIPT" ] || exit 0
+
+# Fast: grep last custom-title from transcript tail
+TITLE=$(tail -500 "$TRANSCRIPT" | grep '"custom-title"' | tail -1 | python3 -c "
+import sys,json
+try:
+    print(json.loads(sys.stdin.readline()).get('customTitle',''))
+except: pass
+" 2>/dev/null)
+
+[ -z "$TITLE" ] && exit 0
+
+# Always rename this tab
+cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$TITLE" 2>/dev/null || true
+
+# Only rename workspace if this tab is the owner (first session)
+WS_OWNER=$(cat "/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}" 2>/dev/null || true)
+if [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
+  cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$TITLE" 2>/dev/null || true
+fi

--- a/Resources/bin/cmux-rename-namer.sh
+++ b/Resources/bin/cmux-rename-namer.sh
@@ -61,7 +61,7 @@ TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.st
 [ -f "$TRANSCRIPT" ] || exit 0
 
 # Fast: grep last custom-title from transcript tail
-TITLE=$(tail -500 "$TRANSCRIPT" | grep '"custom-title"' | tail -1 | python3 -c "
+TITLE=$(tail -500 "$TRANSCRIPT" | grep '"type":"custom-title"' | tail -1 | python3 -c "
 import sys,json
 try:
     print(json.loads(sys.stdin.readline()).get('customTitle',''))

--- a/Resources/bin/cmux-rename-namer.sh
+++ b/Resources/bin/cmux-rename-namer.sh
@@ -71,8 +71,9 @@ except: pass
 [ -z "$TITLE" ] && exit 0
 
 # Write marker file — ensures custom-title suppresses AI summary even in very long
-# transcripts where the /rename entry falls outside the tail-500 window
-echo "$TITLE" > "/tmp/cmux-custom-title-${CMUX_SURFACE_ID}" 2>/dev/null
+# transcripts where the /rename entry falls outside the tail-500 window.
+# umask 077 → 0600: marker contains conversation-derived text.
+(umask 077; printf '%s\n' "$TITLE" > "/tmp/cmux-custom-title-${CMUX_SURFACE_ID}") 2>/dev/null
 
 # Always rename this tab
 cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$TITLE" 2>/dev/null || true

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # cmux-session-namer.sh — Initialize tab/workspace naming on new Claude Code session
 #
-# Invoked by the cmux claude wrapper as a SessionStart hook.
-# - Clears tab-naming cache so first Stop triggers a fresh AI summary
-# - Registers this surface as the workspace "owner" (first session wins)
-# - Sets project basename as initial workspace name
+# Invoked by the cmux claude wrapper as a SessionStart hook (both new and resume).
+#
+# New session:    clear cache for fresh AI summary, set project basename
+# Resume session: scan entire transcript for custom-title and sync it immediately,
+#                 write marker file so AI summary is suppressed (fixes the bug where
+#                 /rename early in a long transcript was invisible to tail-500 checks)
 #
 # Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
-# Stdin: JSON with session_id, cwd, etc.
+# Stdin: JSON with session_id, cwd, transcript_path, etc.
 
 set -e
 
@@ -18,15 +20,41 @@ INPUT=$(cat)
 [ -z "$CMUX_SURFACE_ID" ] && exit 0
 command -v cmux &>/dev/null || exit 0
 
-# Clear this tab's cache so first Stop triggers a fresh AI summary
-rm -f "/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}" 2>/dev/null
-
 # Register as workspace owner if no owner exists yet (first session wins).
-# The workspace owner's AI summary controls the workspace name.
+# The workspace owner's AI summary / custom-title controls the workspace name.
 WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
 if [ ! -f "$WS_OWNER_FILE" ]; then
   echo "$CMUX_SURFACE_ID" > "$WS_OWNER_FILE"
 fi
+
+# Check entire transcript for an existing custom-title (handles resumed sessions
+# where /rename was issued earlier in a long transcript, beyond tail-500 reach)
+CUSTOM_MARKER="/tmp/cmux-custom-title-${CMUX_SURFACE_ID}"
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
+
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  TITLE=$(grep '"custom-title"' "$TRANSCRIPT" 2>/dev/null | tail -1 | python3 -c "
+import sys,json
+try:
+    print(json.loads(sys.stdin.readline()).get('customTitle',''))
+except: pass
+" 2>/dev/null)
+
+  if [ -n "$TITLE" ]; then
+    # Resumed session with custom-title: sync immediately and suppress AI summary
+    echo "$TITLE" > "$CUSTOM_MARKER"
+    cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$TITLE" 2>/dev/null || true
+    WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
+    if [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
+      cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$TITLE" 2>/dev/null || true
+    fi
+    exit 0
+  fi
+fi
+
+# No custom-title: clear marker and cache so the first Stop triggers a fresh AI summary
+rm -f "$CUSTOM_MARKER" 2>/dev/null
+rm -f "/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}" 2>/dev/null
 
 # Set project basename as initial workspace name (overridden by AI summary after first response)
 CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -23,9 +23,12 @@ command -v cmux &>/dev/null || exit 0
 # Register as workspace owner if no owner exists yet (first session wins).
 # The workspace owner's AI summary / custom-title controls the workspace name.
 WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
-if [ ! -f "$WS_OWNER_FILE" ]; then
-  echo "$CMUX_SURFACE_ID" > "$WS_OWNER_FILE"
-fi
+# Use noclobber for atomic owner claim — shell's O_EXCL equivalent.
+# Two concurrent SessionStart hooks both seeing a missing file: only one
+# write succeeds; the other gets EEXIST and silently skips.
+( set -o noclobber
+  printf '%s\n' "$CMUX_SURFACE_ID" > "$WS_OWNER_FILE"
+) 2>/dev/null || true
 
 # Check entire transcript for an existing custom-title (handles resumed sessions
 # where /rename was issued earlier in a long transcript, beyond tail-500 reach)

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -23,9 +23,23 @@ command -v cmux &>/dev/null || exit 0
 # Register as workspace owner if no owner exists yet (first session wins).
 # The workspace owner's AI summary / custom-title controls the workspace name.
 WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
-# Use noclobber for atomic owner claim — shell's O_EXCL equivalent.
-# Two concurrent SessionStart hooks both seeing a missing file: only one
-# write succeeds; the other gets EEXIST and silently skips.
+
+# Stale-owner recovery: if an owner file exists but that surface is no longer
+# active in this workspace, clear the file so a live session can claim ownership.
+# This prevents the workspace name from freezing after the original owner exits.
+if [ -f "$WS_OWNER_FILE" ]; then
+  STALE_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
+  if [ -n "$STALE_OWNER" ] && [ "$STALE_OWNER" != "$CMUX_SURFACE_ID" ]; then
+    # Check if the owner surface is still active in this workspace
+    if ! cmux list-surfaces --workspace "$CMUX_WORKSPACE_ID" --id-format uuids 2>/dev/null \
+        | grep -qF "$STALE_OWNER"; then
+      rm -f "$WS_OWNER_FILE" 2>/dev/null
+    fi
+  fi
+fi
+
+# Atomic owner claim via noclobber (O_EXCL): only the first concurrent
+# SessionStart wins; others silently skip.
 ( set -o noclobber
   printf '%s\n' "$CMUX_SURFACE_ID" > "$WS_OWNER_FILE"
 ) 2>/dev/null || true

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -33,7 +33,7 @@ CUSTOM_MARKER="/tmp/cmux-custom-title-${CMUX_SURFACE_ID}"
 TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
 
 if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
-  TITLE=$(grep '"custom-title"' "$TRANSCRIPT" 2>/dev/null | tail -1 | python3 -c "
+  TITLE=$(grep '"type":"custom-title"' "$TRANSCRIPT" 2>/dev/null | tail -1 | python3 -c "
 import sys,json
 try:
     print(json.loads(sys.stdin.readline()).get('customTitle',''))

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# cmux-session-namer.sh — Initialize tab/workspace naming on new Claude Code session
+#
+# Invoked by the cmux claude wrapper as a SessionStart hook.
+# - Clears tab-naming cache so first Stop triggers a fresh AI summary
+# - Registers this surface as the workspace "owner" (first session wins)
+# - Sets project basename as initial workspace name
+#
+# Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
+# Stdin: JSON with session_id, cwd, etc.
+
+set -e
+
+INPUT=$(cat)
+
+[ "$CMUX_TAB_NAMER_DISABLED" = "1" ] && exit 0
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+[ -z "$CMUX_SURFACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+# Clear this tab's cache so first Stop triggers a fresh AI summary
+rm -f "/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}" 2>/dev/null
+
+# Register as workspace owner if no owner exists yet (first session wins).
+# The workspace owner's AI summary controls the workspace name.
+WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
+if [ ! -f "$WS_OWNER_FILE" ]; then
+  echo "$CMUX_SURFACE_ID" > "$WS_OWNER_FILE"
+fi
+
+# Set project basename as initial workspace name (overridden by AI summary after first response)
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)
+if [ -n "$CWD" ]; then
+  BASENAME=$(basename "$CWD")
+  cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$BASENAME" 2>/dev/null || true
+fi

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -56,9 +56,13 @@ fi
 rm -f "$CUSTOM_MARKER" 2>/dev/null
 rm -f "/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}" 2>/dev/null
 
-# Set project basename as initial workspace name (overridden by AI summary after first response)
-CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)
-if [ -n "$CWD" ]; then
-  BASENAME=$(basename "$CWD")
-  cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$BASENAME" 2>/dev/null || true
+# Set project basename as initial workspace name — only if this tab owns the workspace.
+# Non-owner sessions must not overwrite an already-established workspace name.
+WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
+if [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
+  CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || true)
+  if [ -n "$CWD" ]; then
+    BASENAME=$(basename "$CWD")
+    cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$BASENAME" 2>/dev/null || true
+  fi
 fi

--- a/Resources/bin/cmux-session-namer.sh
+++ b/Resources/bin/cmux-session-namer.sh
@@ -30,9 +30,12 @@ WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
 if [ -f "$WS_OWNER_FILE" ]; then
   STALE_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
   if [ -n "$STALE_OWNER" ] && [ "$STALE_OWNER" != "$CMUX_SURFACE_ID" ]; then
-    # Check if the owner surface is still active in this workspace
-    if ! cmux list-surfaces --workspace "$CMUX_WORKSPACE_ID" --id-format uuids 2>/dev/null \
-        | grep -qF "$STALE_OWNER"; then
+    # Check if the owner surface is still active in this workspace.
+    # Capture output first so a transient cmux error (empty output) is
+    # not mistaken for "owner not present" — only delete if the command
+    # succeeded AND the owner ID is absent from the listing.
+    LIVE_SURFACES=$(cmux list-surfaces --workspace "$CMUX_WORKSPACE_ID" --id-format uuids 2>/dev/null || true)
+    if [ -n "$LIVE_SURFACES" ] && ! printf '%s' "$LIVE_SURFACES" | grep -qF "$STALE_OWNER"; then
       rm -f "$WS_OWNER_FILE" 2>/dev/null
     fi
   fi
@@ -58,8 +61,9 @@ except: pass
 " 2>/dev/null)
 
   if [ -n "$TITLE" ]; then
-    # Resumed session with custom-title: sync immediately and suppress AI summary
-    echo "$TITLE" > "$CUSTOM_MARKER"
+    # Resumed session with custom-title: sync immediately and suppress AI summary.
+    # Write with umask 077 (0600) — marker contains conversation-derived text.
+    (umask 077; printf '%s\n' "$TITLE" > "$CUSTOM_MARKER")
     cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$TITLE" 2>/dev/null || true
     WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
     if [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then

--- a/Resources/bin/cmux-tab-namer.sh
+++ b/Resources/bin/cmux-tab-namer.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# cmux-tab-namer.sh — AI-powered tab & workspace auto-naming for Claude Code
+#
+# Invoked by the cmux claude wrapper as a Stop hook. Uses a two-phase design:
+#   Phase 1 (foreground): Apply a pending AI-generated label from the previous Stop
+#   Phase 2 (background): Spawn `claude -p --model haiku` to generate a label for next Stop
+#
+# Two-phase avoids: (a) blocking the hook with slow AI calls,
+#                   (b) cmux socket errors from detached background processes.
+#
+# Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
+# Stdin: JSON with session_id, transcript_path, cwd, etc.
+
+set -e
+
+INPUT=$(cat)
+
+[ "$CMUX_TAB_NAMER_DISABLED" = "1" ] && exit 0
+[ -z "$CMUX_WORKSPACE_ID" ] && exit 0
+[ -z "$CMUX_SURFACE_ID" ] && exit 0
+command -v cmux &>/dev/null || exit 0
+
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null || true)
+[ -z "$TRANSCRIPT" ] && exit 0
+[ -f "$TRANSCRIPT" ] || exit 0
+
+# Per-tab (surface) files — each tab tracks its own label independently
+TAB_PENDING="/tmp/cmux-tab-pending-${CMUX_SURFACE_ID}"
+TAB_CACHE="/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}"
+
+# ============================================================
+# PHASE 1: Apply pending label from previous run (foreground)
+# ============================================================
+if [ -f "$TAB_PENDING" ]; then
+  LABEL=$(head -1 "$TAB_PENDING" 2>/dev/null)
+  P_LINE_COUNT=$(sed -n '2p' "$TAB_PENDING" 2>/dev/null)
+  P_HAS_CUSTOM=$(sed -n '3p' "$TAB_PENDING" 2>/dev/null)
+  rm -f "$TAB_PENDING" 2>/dev/null
+
+  if [ -n "$LABEL" ]; then
+    # Update tab cache
+    printf '%s\n%s\n' "${P_LINE_COUNT:-0}" "$LABEL" > "$TAB_CACHE" 2>/dev/null
+
+    # Rename this tab
+    cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$LABEL" 2>/dev/null || true
+
+    # Rename workspace if no custom-title and this tab is the workspace owner
+    WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
+    WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
+    if [ "${P_HAS_CUSTOM:-0}" -eq 0 ] 2>/dev/null && [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
+      cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$LABEL" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# ============================================================
+# PHASE 2: Check if we need a new AI summary, spawn background
+# ============================================================
+LINE_COUNT=$(wc -l < "$TRANSCRIPT" 2>/dev/null | tr -d ' ')
+# Skip tiny transcripts (subagent sessions)
+[ "$LINE_COUNT" -lt 50 ] 2>/dev/null && exit 0
+
+# Skip if user has /renamed this session
+HAS_CUSTOM_TITLE=$(tail -500 "$TRANSCRIPT" | grep -c '"custom-title"' 2>/dev/null; true)
+[ "${HAS_CUSTOM_TITLE:-0}" -gt 0 ] 2>/dev/null && exit 0
+
+if [ -f "$TAB_CACHE" ]; then
+  PREV_COUNT=$(head -1 "$TAB_CACHE" 2>/dev/null || echo 0)
+  DIFF=$((LINE_COUNT - PREV_COUNT))
+  if [ "$DIFF" -lt 6 ]; then
+    exit 0
+  fi
+fi
+
+# Extract recent conversation context
+CONTEXT=$(_TRANSCRIPT="$TRANSCRIPT" python3 -c "
+import json, os, subprocess, sys
+
+TRANSCRIPT = os.environ['_TRANSCRIPT']
+
+tail_lines = subprocess.run(
+    ['tail', '-300', TRANSCRIPT], capture_output=True, text=True
+).stdout.splitlines()
+
+head_lines = subprocess.run(
+    ['head', '-100', TRANSCRIPT], capture_output=True, text=True
+).stdout.splitlines()
+
+def extract_text(entry):
+    msg = entry.get('message', {})
+    if isinstance(msg, dict):
+        c = msg.get('content', '')
+        if isinstance(c, str): return c
+        if isinstance(c, list):
+            return ' '.join(b.get('text','') for b in c if isinstance(b, dict) and b.get('type') == 'text')
+    return ''
+
+first_user = []
+for raw in head_lines:
+    try:
+        e = json.loads(raw)
+        if e.get('type') == 'user':
+            t = extract_text(e)
+            if t.strip():
+                first_user.append(f'user: {t[:200]}')
+                if len(first_user) >= 2: break
+    except: pass
+
+last_msgs = []
+for raw in reversed(tail_lines):
+    try:
+        e = json.loads(raw)
+        if e.get('type') in ('user', 'assistant'):
+            t = extract_text(e)
+            if t.strip():
+                last_msgs.append(f'{e[\"type\"]}: {t[:200]}')
+                if len(last_msgs) >= 4: break
+    except: pass
+last_msgs.reverse()
+
+all_msgs = first_user + last_msgs
+if all_msgs:
+    print('\n'.join(all_msgs))
+" 2>/dev/null)
+
+[ -z "$CONTEXT" ] && exit 0
+
+# Build prompt file (per-surface to avoid collisions)
+PROMPT_FILE="/tmp/cmux-tab-prompt-${CMUX_SURFACE_ID}"
+cat > "$PROMPT_FILE" << PYEOF
+Summarize this conversation in 2-5 words, using the SAME language as the conversation. Output ONLY the summary, nothing else.
+
+$CONTEXT
+PYEOF
+
+# Spawn background: generate AI label → write to pending file for next Stop
+(
+  set +e
+  LABEL=$(perl -e 'alarm 15; exec @ARGV' claude -p --model haiku < "$PROMPT_FILE" 2>/dev/null | head -1 | cut -c1-30)
+  rm -f "$PROMPT_FILE" 2>/dev/null
+  if [ -n "$LABEL" ]; then
+    printf '%s\n%s\n%s\n' "$LABEL" "$LINE_COUNT" "$HAS_CUSTOM_TITLE" > "$TAB_PENDING"
+  fi
+) &>/dev/null &
+disown
+
+exit 0

--- a/Resources/bin/cmux-tab-namer.sh
+++ b/Resources/bin/cmux-tab-namer.sh
@@ -40,7 +40,7 @@ LINE_COUNT=$(wc -l < "$TRANSCRIPT" 2>/dev/null | tr -d ' ')
 # then fall back to tail-500 scan for /rename done in the current session.
 CUSTOM_MARKER="/tmp/cmux-custom-title-${CMUX_SURFACE_ID}"
 [ -f "$CUSTOM_MARKER" ] && exit 0
-HAS_CUSTOM_TITLE=$(tail -500 "$TRANSCRIPT" | grep -c '"custom-title"' 2>/dev/null; true)
+HAS_CUSTOM_TITLE=$(tail -500 "$TRANSCRIPT" | grep -c '"type":"custom-title"' 2>/dev/null; true)
 [ "${HAS_CUSTOM_TITLE:-0}" -gt 0 ] 2>/dev/null && exit 0
 
 if [ -f "$TAB_CACHE" ]; then
@@ -114,8 +114,12 @@ PYEOF
 
 # Spawn background: generate AI label → write to pending file
 # (applied on next UserPromptSubmit by cmux-rename-namer.sh for faster tab updates)
+# Unset cmux env vars so the `claude -p` subprocess does not inherit them and
+# re-trigger the naming hooks recursively (would corrupt cache/pending state).
 (
   set +e
+  unset CMUX_WORKSPACE_ID CMUX_SURFACE_ID CMUX_TAB_ID
+  # Timeout after 15s using perl alarm (POSIX-compatible, no external deps)
   LABEL=$(perl -e 'alarm 15; exec @ARGV' claude -p --model haiku < "$PROMPT_FILE" 2>/dev/null | head -1 | cut -c1-30)
   rm -f "$PROMPT_FILE" 2>/dev/null
   if [ -n "$LABEL" ]; then

--- a/Resources/bin/cmux-tab-namer.sh
+++ b/Resources/bin/cmux-tab-namer.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # cmux-tab-namer.sh — AI-powered tab & workspace auto-naming for Claude Code
 #
-# Invoked by the cmux claude wrapper as a Stop hook. Uses a two-phase design:
-#   Phase 1 (foreground): Apply a pending AI-generated label from the previous Stop
-#   Phase 2 (background): Spawn `claude -p --model haiku` to generate a label for next Stop
+# Invoked by the cmux claude wrapper as a Stop hook.
+# Generates an AI summary in background → writes to pending file.
+# The pending label is applied in cmux-rename-namer.sh (UserPromptSubmit)
+# for faster tab name updates (user sees new name on next prompt, not next response).
 #
-# Two-phase avoids: (a) blocking the hook with slow AI calls,
-#                   (b) cmux socket errors from detached background processes.
+# custom-title detection uses a marker file so long transcripts (e.g. resumed
+# sessions with /rename early in history) are handled correctly.
 #
 # Environment: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID (set by cmux shell integration)
 # Stdin: JSON with session_id, transcript_path, cwd, etc.
@@ -29,38 +30,16 @@ TAB_PENDING="/tmp/cmux-tab-pending-${CMUX_SURFACE_ID}"
 TAB_CACHE="/tmp/cmux-tab-cache-${CMUX_SURFACE_ID}"
 
 # ============================================================
-# PHASE 1: Apply pending label from previous run (foreground)
-# ============================================================
-if [ -f "$TAB_PENDING" ]; then
-  LABEL=$(head -1 "$TAB_PENDING" 2>/dev/null)
-  P_LINE_COUNT=$(sed -n '2p' "$TAB_PENDING" 2>/dev/null)
-  P_HAS_CUSTOM=$(sed -n '3p' "$TAB_PENDING" 2>/dev/null)
-  rm -f "$TAB_PENDING" 2>/dev/null
-
-  if [ -n "$LABEL" ]; then
-    # Update tab cache
-    printf '%s\n%s\n' "${P_LINE_COUNT:-0}" "$LABEL" > "$TAB_CACHE" 2>/dev/null
-
-    # Rename this tab
-    cmux rename-tab --workspace "$CMUX_WORKSPACE_ID" --surface "$CMUX_SURFACE_ID" "$LABEL" 2>/dev/null || true
-
-    # Rename workspace if no custom-title and this tab is the workspace owner
-    WS_OWNER_FILE="/tmp/cmux-ws-owner-${CMUX_WORKSPACE_ID}"
-    WS_OWNER=$(cat "$WS_OWNER_FILE" 2>/dev/null || true)
-    if [ "${P_HAS_CUSTOM:-0}" -eq 0 ] 2>/dev/null && [ "$WS_OWNER" = "$CMUX_SURFACE_ID" ]; then
-      cmux rename-workspace --workspace "$CMUX_WORKSPACE_ID" "$LABEL" 2>/dev/null || true
-    fi
-  fi
-fi
-
-# ============================================================
-# PHASE 2: Check if we need a new AI summary, spawn background
+# Generate AI summary if needed, spawn background
 # ============================================================
 LINE_COUNT=$(wc -l < "$TRANSCRIPT" 2>/dev/null | tr -d ' ')
 # Skip tiny transcripts (subagent sessions)
 [ "$LINE_COUNT" -lt 50 ] 2>/dev/null && exit 0
 
-# Skip if user has /renamed this session
+# Skip if custom-title exists — check marker file first (handles long/resumed transcripts),
+# then fall back to tail-500 scan for /rename done in the current session.
+CUSTOM_MARKER="/tmp/cmux-custom-title-${CMUX_SURFACE_ID}"
+[ -f "$CUSTOM_MARKER" ] && exit 0
 HAS_CUSTOM_TITLE=$(tail -500 "$TRANSCRIPT" | grep -c '"custom-title"' 2>/dev/null; true)
 [ "${HAS_CUSTOM_TITLE:-0}" -gt 0 ] 2>/dev/null && exit 0
 
@@ -133,13 +112,14 @@ Summarize this conversation in 2-5 words, using the SAME language as the convers
 $CONTEXT
 PYEOF
 
-# Spawn background: generate AI label → write to pending file for next Stop
+# Spawn background: generate AI label → write to pending file
+# (applied on next UserPromptSubmit by cmux-rename-namer.sh for faster tab updates)
 (
   set +e
   LABEL=$(perl -e 'alarm 15; exec @ARGV' claude -p --model haiku < "$PROMPT_FILE" 2>/dev/null | head -1 | cut -c1-30)
   rm -f "$PROMPT_FILE" 2>/dev/null
   if [ -n "$LABEL" ]; then
-    printf '%s\n%s\n%s\n' "$LABEL" "$LINE_COUNT" "$HAS_CUSTOM_TITLE" > "$TAB_PENDING"
+    printf '%s\n%s\n%s\n' "$LABEL" "$LINE_COUNT" "${HAS_CUSTOM_TITLE:-0}" > "$TAB_PENDING"
   fi
 ) &>/dev/null &
 disown

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -732,6 +732,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupMultiWindowNotificationsUITest = false
     private var didSetupDisplayResolutionUITestDiagnostics = false
     private var displayResolutionUITestObservers: [NSObjectProtocol] = []
+    private var didRequestFallbackUITestWindow = false
     private struct UITestRenderDiagnosticsSnapshot {
         let panelId: UUID
         let drawCount: Int
@@ -1146,6 +1147,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
 #if DEBUG
+    // Retry launch stabilization until a delayed WindowGroup materialization produces
+    // a visible key window that XCUITest can bring to the foreground on the shared VM.
+    private func stabilizeUITestLaunchWindowAndForeground(attempt: Int = 0) {
+        let env = ProcessInfo.processInfo.environment
+        guard isRunningUnderXCTest(env) else { return }
+
+        if NSApp.windows.isEmpty, !didRequestFallbackUITestWindow {
+            didRequestFallbackUITestWindow = true
+            openNewMainWindow(nil)
+        }
+
+        moveUITestWindowToTargetDisplayIfNeeded()
+        activateUITestAppIfNeeded()
+
+        let hasWindow = !NSApp.windows.isEmpty
+        let hasVisibleWindow = NSApp.windows.contains { $0.isVisible }
+        let hasKeyWindow = NSApp.keyWindow != nil
+        let stage = attempt == 0 ? "afterForceWindow" : "afterForceWindow.retry\(attempt)"
+        writeUITestDiagnosticsIfNeeded(stage: stage)
+
+        guard attempt < 20 else { return }
+        if !hasWindow || !hasVisibleWindow || !hasKeyWindow || !NSRunningApplication.current.isActive {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.stabilizeUITestLaunchWindowAndForeground(attempt: attempt + 1)
+            }
+        }
+    }
+
+    private func activateUITestAppIfNeeded() {
+        if let window = NSApp.windows.first {
+            window.makeKeyAndOrderFront(nil)
+            window.orderFrontRegardless()
+        }
+        if #available(macOS 14.0, *) {
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
+        } else {
+            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        }
+    }
+
     private func writeUITestDiagnosticsIfNeeded(stage: String) {
         let env = ProcessInfo.processInfo.environment
         guard let path = env["CMUX_UI_TEST_DIAGNOSTICS_PATH"], !path.isEmpty else { return }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1165,6 +1165,10 @@ final class WindowTerminalPortal: NSObject {
 
         synchronizeHostedView(withId: hostedId)
         scheduleDeferredFullSynchronizeAll()
+        // Session/window restore can queue additional ancestor layout shifts (sidebar width,
+        // split positions) after the initial bind tick. Queue a later external sync so the
+        // portal catches that settled geometry instead of staying at the seeded frame.
+        scheduleExternalGeometrySynchronize()
         pruneDeadEntries()
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3590,6 +3590,83 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testBindQueuesExternalGeometrySyncForQueuedLayoutShift() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let shiftedContainer = NSView(frame: NSRect(x: 40, y: 60, width: 260, height: 180))
+        contentView.addSubview(shiftedContainer)
+        let anchor = NSView(frame: NSRect(x: 0, y: 0, width: 260, height: 180))
+        shiftedContainer.addSubview(anchor)
+        let hosted = surface.hostedView
+        TerminalWindowPortalRegistry.bind(
+            hostedView: hosted,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+
+        let anchorCenter = NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY)
+        let originalWindowPoint = anchor.convert(anchorCenter, to: nil)
+        let originalAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(originalWindowPoint, in: window),
+            "Initial hit-testing should resolve the portal-hosted terminal at its original window position"
+        )
+
+        DispatchQueue.main.async {
+            shiftedContainer.frame.origin.x += 72
+            contentView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+        }
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        let shiftedAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        XCTAssertGreaterThan(
+            shiftedAnchorFrameInWindow.minX,
+            originalAnchorFrameInWindow.minX + 1,
+            "The queued layout shift should move the anchor to the right"
+        )
+        let retiredStaleWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.minX + shiftedAnchorFrameInWindow.minX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        let shiftedWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.maxX + shiftedAnchorFrameInWindow.maxX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        XCTAssertNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(retiredStaleWindowPoint, in: window),
+            "Bind should queue a later external sync so restore-like ancestor shifts do not leave a stale portal in the sidebar region"
+        )
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
+            "Bind should refresh the portal after queued ancestor layout settles"
+        )
+    }
+
     func testScheduledExternalGeometrySyncKeepsDragDrivenResizeResponsive() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),

--- a/docs/ai-tab-naming.md
+++ b/docs/ai-tab-naming.md
@@ -1,0 +1,69 @@
+# AI-Powered Tab & Workspace Naming
+
+cmux automatically names tabs and workspaces based on Claude Code conversation content using AI-generated summaries.
+
+## How it works
+
+Three shell hooks are injected by the `claude` wrapper alongside the existing lifecycle hooks:
+
+### 1. Session Start (`cmux-session-namer.sh`)
+
+On new Claude Code session:
+- Sets project directory basename as initial workspace name
+- Registers this tab as the "workspace owner" (first session wins)
+- Clears naming cache so first response triggers a fresh AI summary
+
+### 2. Stop / Turn End (`cmux-tab-namer.sh`)
+
+After each Claude Code response, uses a **two-phase design**:
+
+**Phase 1 (foreground):** If a pending AI label exists from the previous turn, apply it immediately via `cmux rename-tab` and `cmux rename-workspace`. This runs in the hook's main process which has full cmux socket access.
+
+**Phase 2 (background):** Extract conversation context from the transcript, then spawn `claude -p --model haiku` in a detached background process to generate a 2-5 word summary in the conversation's language. The result is written to a pending file for the next Stop to pick up.
+
+Two-phase avoids:
+- Blocking the hook with slow AI calls (~5-10s for Haiku)
+- cmux socket errors from detached background processes (socket is only accessible from the hook's foreground process)
+
+### 3. User Rename (`cmux-rename-namer.sh`)
+
+When a user `/rename`s their session:
+- Always updates the tab name to the custom title
+- Only updates workspace name if this tab is the workspace owner
+
+## Naming priority
+
+| Priority | Workspace name source | Tab name source |
+|----------|----------------------|-----------------|
+| 1 (highest) | `/rename` by owner tab | `/rename` custom title |
+| 2 | AI summary from owner tab | AI summary (per-tab) |
+| 3 (initial) | Project directory basename | (none) |
+
+## Workspace owner model
+
+The first Claude Code session started in a workspace becomes the "owner". Only the owner's AI summary and `/rename` affect the workspace name. Other tabs in the same workspace manage their own tab names independently.
+
+Owner is tracked via `/tmp/cmux-ws-owner-{WORKSPACE_ID}` and resets when all sessions in the workspace end.
+
+## Custom title behavior
+
+When a user `/rename`s a session:
+- The custom title immediately becomes the tab name
+- AI auto-naming stops for that tab (detected via `custom-title` entries in the transcript)
+- If the tab is the workspace owner, the workspace name also updates to the custom title
+
+## Configuration
+
+Tab naming is enabled by default. To disable it, set:
+
+```bash
+export CMUX_TAB_NAMER_DISABLED=1
+```
+
+## Cache and temp files
+
+All temporary files are in `/tmp/` and scoped by surface/workspace ID:
+- `/tmp/cmux-tab-pending-{SURFACE_ID}` — pending AI label
+- `/tmp/cmux-tab-cache-{SURFACE_ID}` — last applied label + line count
+- `/tmp/cmux-tab-prompt-{SURFACE_ID}` — prompt file for `claude -p`
+- `/tmp/cmux-ws-owner-{WORKSPACE_ID}` — workspace owner surface ID

--- a/docs/ai-tab-naming.md
+++ b/docs/ai-tab-naming.md
@@ -15,21 +15,22 @@ On new Claude Code session:
 
 ### 2. Stop / Turn End (`cmux-tab-namer.sh`)
 
-After each Claude Code response, uses a **two-phase design**:
+After each Claude Code response, spawns `claude -p --model haiku` in a detached background process to generate a 2-5 word summary in the conversation's language. The result is written to a pending file.
 
-**Phase 1 (foreground):** If a pending AI label exists from the previous turn, apply it immediately via `cmux rename-tab` and `cmux rename-workspace`. This runs in the hook's main process which has full cmux socket access.
+The background process unsets `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`, and `CMUX_TAB_ID` before calling `claude -p`, preventing the naming hooks from triggering recursively inside the subprocess.
 
-**Phase 2 (background):** Extract conversation context from the transcript, then spawn `claude -p --model haiku` in a detached background process to generate a 2-5 word summary in the conversation's language. The result is written to a pending file for the next Stop to pick up.
+The pending label is applied in `cmux-rename-namer.sh` (UserPromptSubmit hook), so the tab name updates the moment the user sends their next message — not after waiting for Claude's full response.
 
-Two-phase avoids:
+Background design avoids:
 - Blocking the hook with slow AI calls (~5-10s for Haiku)
 - cmux socket errors from detached background processes (socket is only accessible from the hook's foreground process)
 
-### 3. User Rename (`cmux-rename-namer.sh`)
+### 3. User Prompt Submit (`cmux-rename-namer.sh`)
 
-When a user `/rename`s their session:
-- Always updates the tab name to the custom title
-- Only updates workspace name if this tab is the workspace owner
+On every user message:
+- Applies any pending AI label from the previous Stop (faster than waiting for Claude's next response)
+- If a `/rename` custom title exists in the transcript, syncs it to the tab name and workspace (owner only)
+- Writes a marker file so the custom title suppresses AI naming even in long transcripts
 
 ## Naming priority
 
@@ -43,7 +44,7 @@ When a user `/rename`s their session:
 
 The first Claude Code session started in a workspace becomes the "owner". Only the owner's AI summary and `/rename` affect the workspace name. Other tabs in the same workspace manage their own tab names independently.
 
-Owner is tracked via `/tmp/cmux-ws-owner-{WORKSPACE_ID}` and resets when all sessions in the workspace end.
+Owner is tracked via `/tmp/cmux-ws-owner-{WORKSPACE_ID}`. This file persists in `/tmp/` until the OS clears it (typically on reboot); it is not removed when sessions end. The first session to start in a workspace wins ownership for the lifetime of that file.
 
 ## Custom title behavior
 


### PR DESCRIPTION
## Summary

Adds three shell hooks that auto-name cmux tabs and workspaces from Claude Code conversation content using AI summaries (`claude -p --model haiku`). Integrates into the existing `Resources/bin/claude` wrapper alongside current lifecycle hooks.

- Multilingual support (generates summary in the conversation's language)
- `/rename` custom titles take absolute precedence — AI naming stops immediately
- Opt-out via `CMUX_TAB_NAMER_DISABLED=1`

## Problem

When running multiple Claude Code sessions across cmux tabs, all tabs show generic names (directory basename or shell command). With 5+ concurrent sessions, it's impossible to tell which tab is doing what without manually `/rename`-ing each one.

## Solution

Three hooks injected by the claude wrapper:

| Hook | Event | What it does |
|------|-------|-------------|
| `cmux-session-namer.sh` | SessionStart | Register workspace owner, set basename; on resume, sync existing custom-title immediately |
| `cmux-tab-namer.sh` | Stop | Generate AI summary in background → write to pending file |
| `cmux-rename-namer.sh` | UserPromptSubmit | Apply pending AI label + sync `/rename` custom title |

### Design decisions

#### Decoupled generate/apply for non-blocking, fast updates

`claude -p --model haiku` takes ~5-10s and detached background processes lose cmux socket access. The original two-phase design (generate in background, apply at next Stop) has been improved:

```
Stop N:
  Background: claude -p haiku → write pending file

UserPromptSubmit N+1:  ← FASTER: apply on user's next prompt, not Claude's next response
  Apply pending label → cmux rename-tab/workspace

Stop N+1:
  Background: generate new label
```

This means tab names update the moment the user sends their next message — typically the entire Claude response time sooner than the original design.

#### Custom-title marker file (fix for long/resumed sessions)

The original `tail -500` approach to detect `/rename` fails when a session is resumed and the custom-title entry is more than 500 lines back in the transcript. Fix: a marker file `/tmp/cmux-custom-title-{SURFACE_ID}` that is independent of transcript length.

```
Written by: cmux-session-namer.sh (detected existing custom-title on resume)
            cmux-rename-namer.sh (user just /renamed)
Checked by: cmux-tab-namer.sh (before generating AI summary — marker = skip)
Cleared by: cmux-session-namer.sh (new session with no custom-title)
```

#### Workspace owner model

```
Tab A starts first → registered as workspace owner (/tmp/cmux-ws-owner-{WS_ID})
Tab B starts later → manages its own tab name only

Tab A AI summary → updates tab A name AND workspace name
Tab B AI summary → updates tab B name only
Tab A /rename    → updates tab A name AND workspace name
Tab B /rename    → updates tab B name only
```

### Naming priority

| Priority | Workspace name | Tab name |
|----------|---------------|----------|
| 1 (highest) | Owner's `/rename` | `/rename` custom title |
| 2 | Owner's AI summary | AI summary (per-tab) |
| 3 (initial) | Project basename | — |

## Files changed

- `Resources/bin/claude` — inject naming hooks into the settings JSON
- `Resources/bin/cmux-tab-namer.sh` — Stop hook: generate AI summary in background
- `Resources/bin/cmux-session-namer.sh` — SessionStart hook: init + resume custom-title sync
- `Resources/bin/cmux-rename-namer.sh` — UserPromptSubmit hook: apply pending label + /rename sync
- `docs/ai-tab-naming.md` — documentation

## Test plan

- [ ] New Claude Code session in cmux → tab shows AI summary after 2nd prompt submit
- [ ] AI label appears on **prompt submit** (not at end of Claude response)
- [ ] Multiple tabs in same workspace → each tab has independent name, only owner updates workspace
- [ ] `/rename "custom name"` → tab and workspace (if owner) show custom name, AI stops
- [ ] Resume a session that had `/rename` → custom title syncs immediately on SessionStart
- [ ] Resume a very long session (1000+ lines) where /rename is beyond tail-500 → custom title still respected
- [ ] Chinese conversation → Chinese AI summary
- [ ] `CMUX_TAB_NAMER_DISABLED=1` → no auto-naming
- [ ] Subagent sessions (short transcripts <50 lines) → skipped, no naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-driven automatic tab and workspace naming triggered at session start, stop, and on user-submit events.
  * Respects user `/rename` custom titles and workspace ownership rules.
  * New background summarization that generates short (2–5 word) labels.

* **Bug Fixes**
  * Wrapper includes a JSON-safety guard that skips hook-based naming for unsafe install paths (emits a warning).
  * Improved UI-test window stabilization and terminal geometry sync for queued layout shifts.

* **Tests**
  * Added test coverage for bind-path external geometry synchronization.

* **Documentation**
  * New guide for AI-driven tab and workspace naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->