### PR TITLE
docs: remove outdated Claude Code hooks section from notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,36 +54,9 @@ cmux notify --title "Done" --tab 0 --panel 1
 
 ## Integration Examples
 
-### Claude Code Hooks
+### Claude Code
 
-Add to `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "idle_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --body 'Waiting for input' || osascript -e 'display notification \"Waiting for input\" with title \"Claude Code\"'"
-          }
-        ]
-      },
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "command -v cmux &>/dev/null && cmux notify --title 'Claude Code' --subtitle 'Permission' --body 'Approval needed' || osascript -e 'display notification \"Approval needed\" with title \"Claude Code\"'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for hook configuration.
 
 ### OpenAI Codex
 


### PR DESCRIPTION
The Claude Code hooks section in the Notifications docs referenced pre-0.60 configuration using matchers (`idle_prompt`, `permission_prompt`) that are no longer valid in current Claude Code versions.

This removes the outdated section and replaces it with a link to the official Claude Code documentation.

Fixes #2009

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated Claude Code hooks section from the notifications docs that referenced pre-0.60 matchers (`idle_prompt`, `permission_prompt`). Replaced it with a link to the official Claude Code docs to avoid invalid configurations.

<sup>Written for commit 26ebda547d82ca811313ffd87473363e866b99dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated notifications documentation. Removed specific hook configuration examples, detailed setup instructions, and implementation details previously included. The documentation now directs users to the official Anthropic documentation for comprehensive hook configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->