### PR TITLE
Add arrow-key shortcuts for workspace/tab switching

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9261,10 +9261,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        // When the browser address bar is focused, let Cmd+Shift+Arrow through for
-        // text selection (select-to-beginning/end-of-line) instead of consuming it
+        // When a browser text input (address bar or in-page <input>/<textarea>/
+        // contentEditable) has focus, let Cmd+Shift+Arrow through for text
+        // selection (select-to-beginning/end-of-line) instead of consuming it
         // for surface switching.
-        if focusedBrowserAddressBarPanelIdForShortcutEvent(event) != nil {
+        if focusedBrowserAddressBarPanelIdForShortcutEvent(event) != nil
+            || browserWebViewIsFirstResponderForShortcutEvent(event) {
             let arrowNormalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
             let isHorizontalArrow = event.keyCode == 123 || event.keyCode == 124
             if isHorizontalArrow && arrowNormalizedFlags == [.command, .shift] {
@@ -10022,6 +10024,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         return panelId
+    }
+
+    /// Returns true when the first responder for the shortcut event's window
+    /// is a `CmuxWebView` or one of its WebKit-internal subviews (i.e., web
+    /// page content has keyboard focus). This is a lightweight AppKit responder
+    /// chain walk — no JavaScript execution — so it is safe on the typing hot
+    /// path.
+    private func browserWebViewIsFirstResponderForShortcutEvent(_ event: NSEvent) -> Bool {
+        let window = event.window ?? NSApp.keyWindow
+        guard let firstResponder = window?.firstResponder else { return false }
+
+        // Walk the responder chain looking for CmuxWebView.
+        if firstResponder is CmuxWebView { return true }
+        var current: NSResponder? = firstResponder
+        while let next = current?.nextResponder {
+            if next is CmuxWebView { return true }
+            current = next
+        }
+
+        return false
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10757,9 +10757,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     /// Match arrow key shortcuts using keyCode
     /// Arrow keys include .numericPad and .function in their modifierFlags, so strip those before comparing.
+    /// Also strip .capsLock to match matchShortcut behavior so CapsLock-on does not silently break these shortcuts.
     private func matchArrowShortcut(event: NSEvent, shortcut: StoredShortcut, keyCode: UInt16) -> Bool {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            .subtracting([.numericPad, .function])
+            .subtracting([.numericPad, .function, .capsLock])
         return event.keyCode == keyCode && flags == shortcut.modifierFlags
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9261,6 +9261,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
+        // When the browser address bar is focused, let Cmd+Shift+Arrow through for
+        // text selection (select-to-beginning/end-of-line) instead of consuming it
+        // for surface switching.
+        if browserAddressBarFocusedPanelId != nil {
+            let arrowNormalizedFlags = flags.intersection(.deviceIndependentFlagsMask)
+                .subtracting([.numericPad, .function, .capsLock])
+            let isHorizontalArrow = event.keyCode == 123 || event.keyCode == 124
+            if isHorizontalArrow && arrowNormalizedFlags == [.command, .shift] {
+                return false
+            }
+        }
+
         // Primary UI shortcuts
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleSidebar)) {
             _ = toggleSidebarInActiveMainWindow()
@@ -9353,6 +9365,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Surface navigation (arrow-key alternatives): Cmd+Shift+→ / Cmd+Shift+←
+        if matchArrowShortcut(
+            event: event,
+            shortcut: StoredShortcut(key: "→", command: true, shift: true, option: false, control: false),
+            keyCode: 124
+        ) {
+            tabManager?.selectNextSurface()
+            return true
+        }
+        if matchArrowShortcut(
+            event: event,
+            shortcut: StoredShortcut(key: "←", command: true, shift: true, option: false, control: false),
+            keyCode: 123
+        ) {
+            tabManager?.selectPreviousSurface()
+            return true
+        }
+
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleTerminalCopyMode)) {
             let handled = tabManager?.toggleFocusedTerminalCopyMode() ?? false
 #if DEBUG
@@ -9385,6 +9415,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "ws.shortcut dir=prev repeat=\(event.isARepeat ? 1 : 0) keyCode=\(event.keyCode) selected=\(selected)"
             )
 #endif
+            tabManager?.selectPreviousTab()
+            return true
+        }
+
+        // Workspace navigation (arrow-key alternatives): Cmd+Ctrl+→ / Cmd+Ctrl+←
+        if matchArrowShortcut(
+            event: event,
+            shortcut: StoredShortcut(key: "→", command: true, shift: false, option: false, control: true),
+            keyCode: 124
+        ) {
+            tabManager?.selectNextTab()
+            return true
+        }
+        if matchArrowShortcut(
+            event: event,
+            shortcut: StoredShortcut(key: "←", command: true, shift: false, option: false, control: true),
+            keyCode: 123
+        ) {
             tabManager?.selectPreviousTab()
             return true
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9264,9 +9264,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // When the browser address bar is focused, let Cmd+Shift+Arrow through for
         // text selection (select-to-beginning/end-of-line) instead of consuming it
         // for surface switching.
-        if browserAddressBarFocusedPanelId != nil {
-            let arrowNormalizedFlags = flags.intersection(.deviceIndependentFlagsMask)
-                .subtracting([.numericPad, .function, .capsLock])
+        if focusedBrowserAddressBarPanelIdForShortcutEvent(event) != nil {
+            let arrowNormalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
             let isHorizontalArrow = event.keyCode == 123 || event.keyCode == 124
             if isHorizontalArrow && arrowNormalizedFlags == [.command, .shift] {
                 return false


### PR DESCRIPTION
## Summary

- Add `Cmd+Shift+←/→` as alternative shortcuts for switching between surfaces (tabs within a pane)
- Add `Cmd+Ctrl+←/→` as alternative shortcuts for switching between workspaces
- Existing bracket-based shortcuts (`Cmd+Shift+]/[` and `Cmd+Ctrl+]/[`) are fully preserved
- When browser address bar is focused, `Cmd+Shift+Arrow` is passed through to text selection instead of triggering surface switching

## New Shortcuts

| Action | New Shortcut | Existing (preserved) |
|--------|-------------|---------------------|
| Next Surface | `Cmd+Shift+→` | `Cmd+Shift+]` |
| Previous Surface | `Cmd+Shift+←` | `Cmd+Shift+[` |
| Next Workspace | `Cmd+Ctrl+→` | `Cmd+Ctrl+]` |
| Previous Workspace | `Cmd+Ctrl+←` | `Cmd+Ctrl+[` |

## Test plan

- [ ] `Cmd+Shift+→/←` switches surfaces
- [ ] `Cmd+Ctrl+→/←` switches workspaces
- [ ] Original `Cmd+Shift+]/[` and `Cmd+Ctrl+]/[` still work
- [ ] `Cmd+Option+Arrow` pane focus navigation is unaffected
- [ ] Arrow keys in browser address bar are unaffected
- [ ] `Cmd+Shift+Arrow` in browser address bar selects text (not switching surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds arrow-key shortcuts for faster navigation: Cmd+Shift+→/← switches surfaces, and Cmd+Ctrl+→/← switches workspaces. Existing bracket shortcuts still work, and text selection in the address bar and in-page inputs is preserved.

- **New Features**
  - Surfaces: Cmd+Shift+→/← (alternative to Cmd+Shift+]/[)
  - Workspaces: Cmd+Ctrl+→/← (alternative to Cmd+Ctrl+]/[)
  - Address bar and in-page inputs: Cmd+Shift+Arrow selects text; we don’t intercept it
  - Pane focus (Cmd+Option+Arrow) remains unchanged

- **Bug Fixes**
  - More robust detection: address bar via `focusedBrowserAddressBarPanelIdForShortcutEvent`; in-page inputs via `browserWebViewIsFirstResponderForShortcutEvent`
  - Arrow-key shortcuts work with Caps Lock on by stripping `.capsLock` from modifier flags

<sup>Written for commit a0f123ce3ba482296d1d8241b1fc9a0146b38081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to move between surfaces (Cmd+Shift+← / →).
  * Added keyboard shortcuts to move between tabs (Cmd+Ctrl+← / →).

* **Bug Fixes**
  * Arrow-key shortcuts no longer interfere with text selection or navigation when browser address bar or web view is focused.
  * Caps Lock no longer prevents arrow-key shortcuts from matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->