### PR TITLE
fix(browser): use native value setter for React compatibility

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8076,18 +8076,20 @@ class TerminalController {
     }
 
     /// JavaScript snippet that sets an input element's value using the native
-    /// HTMLInputElement/HTMLTextAreaElement/HTMLSelectElement prototype setter.
-    /// Frameworks like React, Vue, and Angular override the value property on
-    /// instances, so a plain `el.value = x` assignment only updates the DOM
-    /// without notifying the framework's internal state. Calling the native
-    /// setter from the prototype bypasses the override and triggers the
-    /// framework's change-detection when followed by an `input` event.
+    /// prototype setter. Frameworks like React, Vue, and Angular override the
+    /// value property on instances, so a plain `el.value = x` assignment only
+    /// updates the DOM without notifying the framework's internal state.
+    /// Calling the native setter from the prototype bypasses the override and
+    /// triggers the framework's change-detection when followed by an `input`
+    /// event. Walks the prototype chain instead of using instanceof so it
+    /// works with cross-realm elements (iframes) and custom web components.
     /// Expects `el` and `newValue` to be in scope.
     private static let reactCompatibleSetValue = """
-        const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype
-                    : el instanceof HTMLSelectElement  ? HTMLSelectElement.prototype
-                    : HTMLInputElement.prototype;
-        const nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+        let nativeSetter = null;
+        for (let proto = Object.getPrototypeOf(el); proto; proto = Object.getPrototypeOf(proto)) {
+          const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+          if (desc && desc.set) { nativeSetter = desc.set; break; }
+        }
         if (nativeSetter) {
           nativeSetter.call(el, newValue);
         } else {


### PR DESCRIPTION
Fixes #2058

fill, type, and select use `el.value = x` which doesn't trigger state updates in React (or Vue/Angular). This uses the native setter from the prototype instead, same approach as Playwright and Puppeteer.

Falls back to direct assignment if the native setter isn't available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the native value setter so `browser.fill`, `browser.type`, and `browser.select` trigger React/Vue/Angular state updates. Supports cross‑realm elements and web components.

- **Bug Fixes**
  - Walk the prototype chain to call the native `value` setter; fallback to direct assignment. Works across realms and custom elements.
  - Dispatch `input` and `change` events after setting the value for proper framework updates.

<sup>Written for commit 0dbc2881b99675579be26f46d2ee907e84306b01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling to use native browser mechanisms when updating values for inputs, textareas, and selects, ensuring value changes are applied more reliably.
  * Ensured `input` and `change` events are consistently dispatched after value updates; adjusted fill/type/select paths to compute and apply the final value before event dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->