### PR TITLE
fix(openFolder): default NSOpenPanel to focused workspace directory

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5976,6 +5976,9 @@ struct ContentView: View {
                 panel.allowsMultipleSelection = false
                 panel.title = String(localized: "panel.openFolder.title", defaultValue: "Open Folder")
                 panel.prompt = String(localized: "panel.openFolder.prompt", defaultValue: "Open")
+                if let currentDir = tabManager.selectedTab?.currentDirectory {
+                    panel.directoryURL = URL(fileURLWithPath: currentDir)
+                }
                 if panel.runModal() == .OK, let url = panel.url {
                     tabManager.addWorkspace(workingDirectory: url.path)
                 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -593,6 +593,9 @@ struct cmuxApp: App {
                     panel.allowsMultipleSelection = false
                     panel.title = String(localized: "menu.file.openFolder.panelTitle", defaultValue: "Open Folder")
                     panel.prompt = String(localized: "menu.file.openFolder.panelPrompt", defaultValue: "Open")
+                    if let currentDir = activeTabManager.selectedTab?.currentDirectory {
+                        panel.directoryURL = URL(fileURLWithPath: currentDir)
+                    }
                     if panel.runModal() == .OK, let url = panel.url {
                         if let appDelegate = AppDelegate.shared {
                             if appDelegate.addWorkspaceInPreferredMainWindow(


### PR DESCRIPTION
NSOpenPanel was created without a directoryURL, causing the ⌘O file picker to always open at ~/Documents instead of the focused workspace's working directory.

Fix by setting panel.directoryURL to the selected tab's currentDirectory before running the modal in both the menu bar File → Open Folder action and the command palette openFolder handler.

Fixes #2010.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the Open Folder (`NSOpenPanel`) to the focused workspace’s working directory (menu File → Open Folder and command palette), instead of always opening at ~/Documents; falls back to the system default when no workspace is open. Fixes #2010.

<sup>Written for commit 0a17725dd1f5466508e5524e6f3c613de2d958d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Open Folder" dialog now intelligently pre-selects your current working directory from the active tab, eliminating the need to manually navigate to commonly used folders. This streamlines your workflow and provides a more intuitive folder selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->