### PR TITLE
Fix workspace state loss after macOS relaunch

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1989,10 +1989,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let visibleFrame: CGRect
     }
 
-    private struct PersistedWindowGeometry: Codable, Sendable {
-        let frame: SessionRectSnapshot
-        let display: SessionDisplaySnapshot?
-    }
+    private typealias PersistedWindowGeometry = SessionWindowGeometrySnapshot
 
     private static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v1"
 
@@ -2776,10 +2773,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func persistedWindowGeometry(
         defaults: UserDefaults = .standard
     ) -> PersistedWindowGeometry? {
-        guard let data = defaults.data(forKey: Self.persistedWindowGeometryDefaultsKey) else {
+        if let persisted = SessionWindowGeometryStore.load() {
+            return persisted
+        }
+
+        guard let data = defaults.data(forKey: Self.persistedWindowGeometryDefaultsKey),
+              let persisted = try? JSONDecoder().decode(PersistedWindowGeometry.self, from: data) else {
             return nil
         }
-        return try? JSONDecoder().decode(PersistedWindowGeometry.self, from: data)
+
+        if SessionWindowGeometryStore.save(persisted) {
+            defaults.removeObject(forKey: Self.persistedWindowGeometryDefaultsKey)
+        }
+        return persisted
     }
 
     private func persistWindowGeometry(
@@ -2787,19 +2793,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         display: SessionDisplaySnapshot?,
         defaults: UserDefaults = .standard
     ) {
-        guard let data = Self.encodedPersistedWindowGeometryData(frame: frame, display: display) else {
+        guard let frame else {
             return
         }
-        defaults.set(data, forKey: Self.persistedWindowGeometryDefaultsKey)
-    }
 
-    private nonisolated static func encodedPersistedWindowGeometryData(
-        frame: SessionRectSnapshot?,
-        display: SessionDisplaySnapshot?
-    ) -> Data? {
-        guard let frame else { return nil }
-        let payload = PersistedWindowGeometry(frame: frame, display: display)
-        return try? JSONEncoder().encode(payload)
+        let persisted = PersistedWindowGeometry(frame: frame, display: display)
+        if SessionWindowGeometryStore.save(persisted) {
+            defaults.removeObject(forKey: Self.persistedWindowGeometryDefaultsKey)
+            return
+        }
+
+        guard let data = try? JSONEncoder().encode(persisted) else { return }
+        defaults.set(data, forKey: Self.persistedWindowGeometryDefaultsKey)
     }
 
     private func persistWindowGeometry(from window: NSWindow?) {
@@ -3410,17 +3415,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             persistSessionSnapshot(
                 nil,
                 removeWhenEmpty: removeWhenEmpty,
-                persistedGeometryData: nil,
+                persistedGeometry: nil,
                 synchronously: writeSynchronously
             )
             return false
         }
 
-        let persistedGeometryData = snapshot.windows.first.flatMap { primaryWindow in
-            Self.encodedPersistedWindowGeometryData(
-                frame: primaryWindow.frame,
-                display: primaryWindow.display
-            )
+        let persistedGeometry = snapshot.windows.first.flatMap { primaryWindow in
+            primaryWindow.frame.map { frame in
+                PersistedWindowGeometry(frame: frame, display: primaryWindow.display)
+            }
         }
 
 #if DEBUG
@@ -3429,7 +3433,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         persistSessionSnapshot(
             snapshot,
             removeWhenEmpty: false,
-            persistedGeometryData: persistedGeometryData,
+            persistedGeometry: persistedGeometry,
             synchronously: writeSynchronously
         )
         return true
@@ -3614,17 +3618,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func persistSessionSnapshot(
         _ snapshot: AppSessionSnapshot?,
         removeWhenEmpty: Bool,
-        persistedGeometryData: Data?,
+        persistedGeometry: PersistedWindowGeometry?,
         synchronously: Bool
     ) {
-        guard snapshot != nil || removeWhenEmpty || persistedGeometryData != nil else { return }
+        guard snapshot != nil || removeWhenEmpty || persistedGeometry != nil else { return }
 
         let writeBlock = {
-            if let persistedGeometryData {
-                UserDefaults.standard.set(
-                    persistedGeometryData,
-                    forKey: Self.persistedWindowGeometryDefaultsKey
-                )
+            if let persistedGeometry {
+                if SessionWindowGeometryStore.save(persistedGeometry) {
+                    UserDefaults.standard.removeObject(forKey: Self.persistedWindowGeometryDefaultsKey)
+                } else if let persistedGeometryData = try? JSONEncoder().encode(persistedGeometry) {
+                    UserDefaults.standard.set(
+                        persistedGeometryData,
+                        forKey: Self.persistedWindowGeometryDefaultsKey
+                    )
+                }
             }
             if let snapshot {
                 _ = SessionPersistenceStore.save(snapshot)

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -127,12 +127,52 @@ enum SessionRestorePolicy {
             return false
         }
 
-        let extraArgs = arguments
-            .dropFirst()
-            .filter { !$0.hasPrefix("-psn_") }
+        return explicitOpenArguments(from: Array(arguments.dropFirst())).isEmpty
+    }
 
-        // Any explicit launch argument is treated as an explicit open intent.
-        return extraArgs.isEmpty
+    private static func explicitOpenArguments(from extraArgs: [String]) -> [String] {
+        var explicitArgs: [String] = []
+        var index = 0
+
+        while index < extraArgs.count {
+            let argument = extraArgs[index]
+            if argument.hasPrefix("-psn_") {
+                index += 1
+                continue
+            }
+
+            // macOS relaunches apps after restart/system update with LaunchServices /
+            // Cocoa arguments such as -ApplePersistenceIgnoreState YES. These are
+            // not user open intents and should not suppress cmux's own session restore.
+            if isSystemManagedLaunchArgument(argument) {
+                index = nextArgumentIndex(afterSystemManagedArgumentAt: index, in: extraArgs)
+                continue
+            }
+
+            explicitArgs.append(argument)
+            index += 1
+        }
+
+        return explicitArgs
+    }
+
+    private static func isSystemManagedLaunchArgument(_ argument: String) -> Bool {
+        argument.hasPrefix("-Apple") || argument.hasPrefix("-NS")
+    }
+
+    private static func nextArgumentIndex(
+        afterSystemManagedArgumentAt index: Int,
+        in extraArgs: [String]
+    ) -> Int {
+        let nextIndex = index + 1
+        guard nextIndex < extraArgs.count else { return nextIndex }
+
+        // Treat the following token as the system flag's value only when it is not
+        // another option, so explicit app arguments still suppress restore.
+        if extraArgs[nextIndex].hasPrefix("-") {
+            return nextIndex
+        }
+        return nextIndex + 1
     }
 }
 
@@ -354,6 +394,11 @@ struct SessionWindowSnapshot: Codable, Sendable {
     var sidebar: SessionSidebarSnapshot
 }
 
+struct SessionWindowGeometrySnapshot: Codable, Sendable {
+    var frame: SessionRectSnapshot
+    var display: SessionDisplaySnapshot?
+}
+
 struct AppSessionSnapshot: Codable, Sendable {
     var version: Int
     var createdAt: TimeInterval
@@ -399,10 +444,7 @@ enum SessionPersistenceStore {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
-    static func defaultSnapshotFileURL(
-        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
-        appSupportDirectory: URL? = nil
-    ) -> URL? {
+    static func defaultStateDirectoryURL(appSupportDirectory: URL? = nil) -> URL? {
         let resolvedAppSupport: URL
         if let appSupportDirectory {
             resolvedAppSupport = appSupportDirectory
@@ -411,17 +453,72 @@ enum SessionPersistenceStore {
         } else {
             return nil
         }
+
+        return resolvedAppSupport.appendingPathComponent("cmux", isDirectory: true)
+    }
+
+    static func defaultSnapshotFileURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil
+    ) -> URL? {
+        guard let stateDirectory = defaultStateDirectoryURL(appSupportDirectory: appSupportDirectory) else {
+            return nil
+        }
+        let safeBundleId = safeBundleNamespace(bundleIdentifier: bundleIdentifier)
+        return stateDirectory
+            .appendingPathComponent("session-\(safeBundleId).json", isDirectory: false)
+    }
+
+    static func defaultWindowGeometryFileURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil
+    ) -> URL? {
+        guard let stateDirectory = defaultStateDirectoryURL(appSupportDirectory: appSupportDirectory) else {
+            return nil
+        }
+        let safeBundleId = safeBundleNamespace(bundleIdentifier: bundleIdentifier)
+        return stateDirectory
+            .appendingPathComponent("window-geometry-\(safeBundleId).json", isDirectory: false)
+    }
+
+    private static func safeBundleNamespace(bundleIdentifier: String?) -> String {
         let bundleId = (bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
             ? bundleIdentifier!
             : "com.cmuxterm.app"
-        let safeBundleId = bundleId.replacingOccurrences(
+        return bundleId.replacingOccurrences(
             of: "[^A-Za-z0-9._-]",
             with: "_",
             options: .regularExpression
         )
-        return resolvedAppSupport
-            .appendingPathComponent("cmux", isDirectory: true)
-            .appendingPathComponent("session-\(safeBundleId).json", isDirectory: false)
+    }
+}
+
+enum SessionWindowGeometryStore {
+    static func load(fileURL: URL? = nil) -> SessionWindowGeometrySnapshot? {
+        guard let fileURL = fileURL ?? SessionPersistenceStore.defaultWindowGeometryFileURL() else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode(SessionWindowGeometrySnapshot.self, from: data)
+    }
+
+    @discardableResult
+    static func save(_ snapshot: SessionWindowGeometrySnapshot, fileURL: URL? = nil) -> Bool {
+        guard let fileURL = fileURL ?? SessionPersistenceStore.defaultWindowGeometryFileURL() else {
+            return false
+        }
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+            let data = try JSONEncoder().encode(snapshot)
+            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                return true
+            }
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
     }
 }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -148,6 +148,49 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(path?.path.contains("com.example_unsafe_id") == true)
     }
 
+    func testDefaultWindowGeometryPathSanitizesBundleIdentifier() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let path = SessionPersistenceStore.defaultWindowGeometryFileURL(
+            bundleIdentifier: "com.example/unsafe id",
+            appSupportDirectory: tempDir
+        )
+
+        XCTAssertNotNil(path)
+        XCTAssertTrue(path?.path.contains("com.example_unsafe_id") == true)
+        XCTAssertTrue(path?.lastPathComponent.hasPrefix("window-geometry-") == true)
+    }
+
+    func testWindowGeometryStoreRoundTripWithCustomPath() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-window-geometry-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let fileURL = tempDir.appendingPathComponent("window-geometry.json", isDirectory: false)
+        let snapshot = SessionWindowGeometrySnapshot(
+            frame: SessionRectSnapshot(x: 10, y: 20, width: 900, height: 700),
+            display: SessionDisplaySnapshot(
+                displayID: 42,
+                frame: SessionRectSnapshot(x: 0, y: 0, width: 1440, height: 900),
+                visibleFrame: SessionRectSnapshot(x: 0, y: 25, width: 1440, height: 875)
+            )
+        )
+
+        XCTAssertTrue(SessionWindowGeometryStore.save(snapshot, fileURL: fileURL))
+
+        let loaded = SessionWindowGeometryStore.load(fileURL: fileURL)
+        XCTAssertEqual(loaded?.frame.x, 10, accuracy: 0.001)
+        XCTAssertEqual(loaded?.frame.y, 20, accuracy: 0.001)
+        XCTAssertEqual(loaded?.frame.width, 900, accuracy: 0.001)
+        XCTAssertEqual(loaded?.frame.height, 700, accuracy: 0.001)
+        XCTAssertEqual(loaded?.display?.displayID, 42)
+        XCTAssertEqual(loaded?.display?.visibleFrame?.y, 25, accuracy: 0.001)
+    }
+
     func testRestorePolicySkipsWhenLaunchHasExplicitArguments() {
         let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
             arguments: ["/Applications/cmux.app/Contents/MacOS/cmux", "--window", "window:1"],
@@ -178,6 +221,21 @@ final class SessionPersistenceTests: XCTestCase {
         )
 
         XCTAssertTrue(shouldRestore)
+    }
+
+    func testRestorePolicySkipsWhenExplicitArgumentsFollowMacOSRelaunchArguments() {
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: [
+                "/Applications/cmux.app/Contents/MacOS/cmux",
+                "-ApplePersistenceIgnoreState",
+                "YES",
+                "--window",
+                "window:1"
+            ],
+            environment: [:]
+        )
+
+        XCTAssertFalse(shouldRestore)
     }
 
     func testRestorePolicySkipsWhenRunningUnderXCTest() {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -166,6 +166,20 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(shouldRestore)
     }
 
+    func testRestorePolicyAllowsMacOSRelaunchArgumentsOnly() {
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: [
+                "/Applications/cmux.app/Contents/MacOS/cmux",
+                "-ApplePersistenceIgnoreState",
+                "YES",
+                "-psn_0_12345"
+            ],
+            environment: [:]
+        )
+
+        XCTAssertTrue(shouldRestore)
+    }
+
     func testRestorePolicySkipsWhenRunningUnderXCTest() {
         let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
             arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -164,7 +164,7 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(path?.lastPathComponent.hasPrefix("window-geometry-") == true)
     }
 
-    func testWindowGeometryStoreRoundTripWithCustomPath() {
+    func testWindowGeometryStoreRoundTripWithCustomPath() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-window-geometry-tests-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -182,13 +182,14 @@ final class SessionPersistenceTests: XCTestCase {
 
         XCTAssertTrue(SessionWindowGeometryStore.save(snapshot, fileURL: fileURL))
 
-        let loaded = SessionWindowGeometryStore.load(fileURL: fileURL)
-        XCTAssertEqual(loaded?.frame.x, 10, accuracy: 0.001)
-        XCTAssertEqual(loaded?.frame.y, 20, accuracy: 0.001)
-        XCTAssertEqual(loaded?.frame.width, 900, accuracy: 0.001)
-        XCTAssertEqual(loaded?.frame.height, 700, accuracy: 0.001)
-        XCTAssertEqual(loaded?.display?.displayID, 42)
-        XCTAssertEqual(loaded?.display?.visibleFrame?.y, 25, accuracy: 0.001)
+        let loaded = try XCTUnwrap(SessionWindowGeometryStore.load(fileURL: fileURL))
+        XCTAssertEqual(loaded.frame.x, 10, accuracy: 0.001)
+        XCTAssertEqual(loaded.frame.y, 20, accuracy: 0.001)
+        XCTAssertEqual(loaded.frame.width, 900, accuracy: 0.001)
+        XCTAssertEqual(loaded.frame.height, 700, accuracy: 0.001)
+        XCTAssertEqual(loaded.display?.displayID, 42)
+        let visibleFrame = try XCTUnwrap(loaded.display?.visibleFrame)
+        XCTAssertEqual(visibleFrame.y, 25, accuracy: 0.001)
     }
 
     func testRestorePolicySkipsWhenLaunchHasExplicitArguments() {


### PR DESCRIPTION
## Summary
- treat macOS relaunch arguments like `-ApplePersistenceIgnoreState YES` as system-managed startup metadata instead of explicit open intents, so session restore still runs after OS-driven relaunches
- move the last-window geometry fallback from `UserDefaults` into `~/Library/Application Support/cmux/` with migration from the legacy defaults key
- add regression coverage for the relaunch-argument restore path and the new file-backed geometry store

## Root Cause
cmux already stores full workspace/session snapshots in Application Support, but startup restore was gated on launch arguments. After a macOS relaunch/update, LaunchServices can inject system arguments that made cmux think the launch was an explicit open request, so restore was skipped and a fresh autosave could overwrite the good snapshot.

## Verification
- added a failing-first regression test commit for the macOS relaunch argument case
- tagged reload build succeeded: `./scripts/reload.sh --tag fix-2072-state`
- local tests were not run per repo policy

Closes #2072
Refs #480
Refs #1984

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session restore after macOS relaunch by ignoring system-managed launch args and persists last-window geometry to an Application Support file with automatic migration and tests.

- **Bug Fixes**
  - Ignore `-psn_*`, `-Apple*`, and `-NS*` (plus their value tokens) when deciding restore; explicit app args still suppress restore.
  - Prevent autosave from overwriting a good snapshot after OS-driven relaunch.

- **Migration**
  - Persist window geometry to `~/Library/Application Support/cmux/window-geometry-<bundle>.json` via `SessionWindowGeometryStore` and `SessionWindowGeometrySnapshot`.
  - Auto-migrate from `UserDefaults` on first successful save and remove the legacy key; fall back to `UserDefaults` if file save fails.
  - Atomic writes, skip redundant writes, sanitize bundle IDs; added round-trip, path, and relaunch-args tests.

<sup>Written for commit d8b64788cc23bbf6943e27b2ecdff8ce3fb649f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration logic to better distinguish user-initiated launches from system relaunches, reducing unwanted automatic restores.
* **New Features**
  * More robust window geometry persistence with safer on-disk storage, automatic migration from legacy data, and atomic saves to preserve window size/position across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->