### PR TITLE
Fix #2048: fall back to Claude Code app bundle

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -6,6 +6,24 @@
 # so that Claude Code hooks fire back into cmux for notifications/status.
 # Outside cmux, it passes through to the real claude binary unchanged.
 
+# Find the newest Claude Code app bundle install when the CLI is not on PATH.
+find_claude_app_bundle() {
+    local base_dir
+    local -a candidates=()
+    local had_nullglob=0
+
+    base_dir="${HOME}/Library/Application Support/Claude/claude-code"
+    [[ -d "$base_dir" ]] || return 1
+
+    shopt -q nullglob && had_nullglob=1
+    shopt -s nullglob
+    candidates=("$base_dir"/*/claude.app/Contents/MacOS/claude)
+    (( had_nullglob )) || shopt -u nullglob
+
+    ((${#candidates[@]})) || return 1
+    printf '%s\n' "${candidates[@]}" | LC_ALL=C sort -V | tail -n 1
+}
+
 # Find the real claude binary, skipping our own directory.
 find_real_claude() {
     local self_dir
@@ -15,7 +33,11 @@ find_real_claude() {
         [[ "$d" == "$self_dir" ]] && continue
         [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
     done
-    return 1
+    find_claude_app_bundle
+}
+
+resolve_real_claude() {
+    find_real_claude || find_claude_app_bundle
 }
 
 # Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
@@ -48,12 +70,18 @@ if [[ "$IN_CMUX" == "0" || "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]] || ! cmux_soc
     if [[ "$IN_CMUX" == "1" ]]; then
         unset CLAUDECODE
     fi
-    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    REAL_CLAUDE="$(resolve_real_claude)" || {
+        echo "Error: claude not found in PATH or in \$HOME/Library/Application Support/Claude/claude-code/*/claude.app" >&2
+        exit 127
+    }
     exec "$REAL_CLAUDE" "$@"
 fi
 
 # Find real claude.
-REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+REAL_CLAUDE="$(resolve_real_claude)" || {
+    echo "Error: claude not found in PATH or in \$HOME/Library/Application Support/Claude/claude-code/*/claude.app" >&2
+    exit 127
+}
 
 # Pass through subcommands that don't support session/hook flags.
 case "${1:-}" in

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -38,11 +38,19 @@ def parse_settings_arg(argv: list[str]) -> dict:
     return json.loads(argv[index + 1])
 
 
-def run_wrapper(*, socket_state: str, argv: list[str]) -> tuple[int, list[str], list[str], str, str]:
+def run_wrapper(
+    *,
+    socket_state: str,
+    argv: list[str],
+    use_path_claude: bool = True,
+    bundle_versions: list[str] | None = None,
+) -> tuple[int, list[str], list[str], str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
+        home = tmp / "home"
         wrapper_dir = tmp / "wrapper-bin"
         real_dir = tmp / "real-bin"
+        home.mkdir(parents=True, exist_ok=True)
         wrapper_dir.mkdir(parents=True, exist_ok=True)
         real_dir.mkdir(parents=True, exist_ok=True)
 
@@ -52,20 +60,28 @@ def run_wrapper(*, socket_state: str, argv: list[str]) -> tuple[int, list[str], 
 
         real_args_log = tmp / "real-args.log"
         real_claudecode_log = tmp / "real-claudecode.log"
+        real_path_log = tmp / "real-path.log"
         cmux_log = tmp / "cmux.log"
         socket_path = str(tmp / "cmux.sock")
 
-        make_executable(
-            real_dir / "claude",
-            """#!/usr/bin/env bash
+        fake_real_claude = """#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\\n' "$0" > "$FAKE_REAL_PATH_LOG"
 : > "$FAKE_REAL_ARGS_LOG"
 printf '%s\\n' "${CLAUDECODE-__UNSET__}" > "$FAKE_REAL_CLAUDECODE_LOG"
 for arg in "$@"; do
   printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
 done
-""",
-        )
+"""
+
+        if use_path_claude:
+            make_executable(real_dir / "claude", fake_real_claude)
+
+        for version in bundle_versions or []:
+            make_executable(
+                home / "Library" / "Application Support" / "Claude" / "claude-code" / version / "claude.app" / "Contents" / "MacOS" / "claude",
+                fake_real_claude,
+            )
 
         make_executable(
             wrapper_dir / "cmux",
@@ -91,11 +107,13 @@ exit 0
             test_socket.bind(socket_path)
 
         env = os.environ.copy()
+        env["HOME"] = str(home)
         env["PATH"] = f"{wrapper_dir}:{real_dir}:/usr/bin:/bin"
         env["CMUX_SURFACE_ID"] = "surface:test"
         env["CMUX_SOCKET_PATH"] = socket_path
         env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
         env["FAKE_REAL_CLAUDECODE_LOG"] = str(real_claudecode_log)
+        env["FAKE_REAL_PATH_LOG"] = str(real_path_log)
         env["FAKE_CMUX_LOG"] = str(cmux_log)
         env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
         env["CLAUDECODE"] = "nested-session-sentinel"
@@ -115,7 +133,16 @@ exit 0
 
         claudecode_lines = read_lines(real_claudecode_log)
         claudecode_value = claudecode_lines[0] if claudecode_lines else ""
-        return proc.returncode, read_lines(real_args_log), read_lines(cmux_log), proc.stderr.strip(), claudecode_value
+        real_path_lines = read_lines(real_path_log)
+        real_path_value = real_path_lines[0] if real_path_lines else ""
+        return (
+            proc.returncode,
+            read_lines(real_args_log),
+            read_lines(cmux_log),
+            proc.stderr.strip(),
+            claudecode_value,
+            real_path_value,
+        )
 
 
 def expect(condition: bool, message: str, failures: list[str]) -> None:
@@ -124,7 +151,7 @@ def expect(condition: bool, message: str, failures: list[str]) -> None:
 
 
 def test_live_socket_injects_supported_hooks(failures: list[str]) -> None:
-    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(socket_state="live", argv=["hello"])
+    code, real_argv, cmux_log, stderr, claudecode, _ = run_wrapper(socket_state="live", argv=["hello"])
     expect(code == 0, f"live socket: wrapper exited {code}: {stderr}", failures)
     expect("--settings" in real_argv, f"live socket: missing --settings in args: {real_argv}", failures)
     expect("--session-id" in real_argv, f"live socket: missing --session-id in args: {real_argv}", failures)
@@ -158,7 +185,7 @@ def test_live_socket_injects_supported_hooks(failures: list[str]) -> None:
 
 
 def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
-    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(socket_state="missing", argv=["hello"])
+    code, real_argv, cmux_log, stderr, claudecode, _ = run_wrapper(socket_state="missing", argv=["hello"])
     expect(code == 0, f"missing socket: wrapper exited {code}: {stderr}", failures)
     expect(real_argv == ["hello"], f"missing socket: expected passthrough args, got {real_argv}", failures)
     expect(cmux_log == [], f"missing socket: expected no cmux calls, got {cmux_log}", failures)
@@ -166,7 +193,7 @@ def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
 
 
 def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
-    code, real_argv, cmux_log, stderr, claudecode = run_wrapper(socket_state="stale", argv=["hello"])
+    code, real_argv, cmux_log, stderr, claudecode, _ = run_wrapper(socket_state="stale", argv=["hello"])
     expect(code == 0, f"stale socket: wrapper exited {code}: {stderr}", failures)
     expect(real_argv == ["hello"], f"stale socket: expected passthrough args, got {real_argv}", failures)
     expect(any(" ping" in line for line in cmux_log), f"stale socket: expected cmux ping probe, got {cmux_log}", failures)
@@ -178,11 +205,70 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
 
 
+def test_missing_socket_uses_newest_app_bundle_when_path_missing(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode, real_path = run_wrapper(
+        socket_state="missing",
+        argv=["hello"],
+        use_path_claude=False,
+        bundle_versions=["0.9.0", "0.10.2"],
+    )
+    expect(code == 0, f"missing socket fallback: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"missing socket fallback: expected passthrough args, got {real_argv}", failures)
+    expect(cmux_log == [], f"missing socket fallback: expected no cmux calls, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"missing socket fallback: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(
+        real_path.endswith("/0.10.2/claude.app/Contents/MacOS/claude"),
+        f"missing socket fallback: expected newest app bundle, got {real_path!r}",
+        failures,
+    )
+
+
+def test_live_socket_uses_app_bundle_when_path_missing(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode, real_path = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+        use_path_claude=False,
+        bundle_versions=["1.2.3"],
+    )
+    expect(code == 0, f"live socket fallback: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"live socket fallback: missing --settings in args: {real_argv}", failures)
+    expect("--session-id" in real_argv, f"live socket fallback: missing --session-id in args: {real_argv}", failures)
+    expect(real_argv[-1] == "hello", f"live socket fallback: expected original arg to pass through, got {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"live socket fallback: expected cmux ping, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"live socket fallback: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(
+        real_path.endswith("/1.2.3/claude.app/Contents/MacOS/claude"),
+        f"live socket fallback: expected app bundle path, got {real_path!r}",
+        failures,
+    )
+
+
+def test_path_claude_takes_priority_over_app_bundle(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode, real_path = run_wrapper(
+        socket_state="missing",
+        argv=["hello"],
+        use_path_claude=True,
+        bundle_versions=["99.0.0"],
+    )
+    expect(code == 0, f"PATH priority: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"PATH priority: expected passthrough args, got {real_argv}", failures)
+    expect(cmux_log == [], f"PATH priority: expected no cmux calls, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"PATH priority: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(
+        real_path.endswith("/real-bin/claude"),
+        f"PATH priority: expected PATH claude to win over app bundle, got {real_path!r}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_missing_socket_uses_newest_app_bundle_when_path_missing(failures)
+    test_live_socket_uses_app_bundle_when_path_missing(failures)
+    test_path_claude_takes_priority_over_app_bundle(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
## Summary
- keep `Resources/bin/claude` PATH-first, but fall back to the newest Claude Code app bundle under `$HOME/Library/Application Support/Claude/claude-code/*/claude.app/Contents/MacOS/claude`
- use the same fallback-aware resolver in both wrapper execution branches and update the not-found error to mention both lookup locations
- extend the wrapper regression harness to cover missing-PATH app bundle resolution in both branches and verify PATH still wins when both are present

## Verification
- `bash -n Resources/bin/claude`
- `python3 -m py_compile tests/test_claude_wrapper_hooks.py`
- `./scripts/reload.sh --tag issue-2048-claude-wrapper`

## Notes
- Local tests were not run per repo policy.

Closes #2048

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `Resources/bin/claude` wrapper fall back to the newest Claude Code app bundle when `claude` isn’t on PATH, while keeping PATH-first behavior. Fixes #2048 by preventing “claude not found” errors.

- **Bug Fixes**
  - Look up `$HOME/Library/Application Support/Claude/claude-code/*/claude.app/Contents/MacOS/claude` and pick the newest version.
  - Use one fallback-aware resolver in both hook and passthrough branches.
  - Update the not-found error to mention PATH and the app bundle.
  - Expand regression tests to cover missing-PATH fallback and confirm PATH wins.

<sup>Written for commit 82d4873a68bad1fc632d8a7e3cdf1b0d201c5e6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude binary resolution to automatically locate it from the Claude Code app bundle as a fallback when not found in PATH
  * Enhanced error messages to indicate the app bundle fallback location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->