### PR TITLE
Fix all split panes appearing focused after layout restoration

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2733,10 +2733,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private let maxPendingTextBytes = 1_048_576
     private var backgroundSurfaceStartQueued = false
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
-    /// Tracks the last focus state to avoid sending redundant focus events.
-    /// This prevents prompt redraw issues with zsh themes like Powerlevel10k.
+    /// The desired focus state for the Ghostty C surface. May be set before the
+    /// C surface exists (e.g. during layout restoration); `createSurface` syncs
+    /// it on creation. Also used as a dedup guard to avoid redundant
+    /// `ghostty_surface_set_focus` calls (prevents prompt redraws with P10k).
     /// Initialized to `true` to match Ghostty's default (Terminal.zig focused=true).
-    private var lastFocusState: Bool = true
+    private var desiredFocusState: Bool = true
 #if DEBUG
     private var needsConfirmCloseOverrideForTesting: Bool?
 #endif
@@ -3554,7 +3556,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // logically unfocused before the C surface existed (e.g. during layout
         // restoration). Always sync unconditionally so we don't couple to
         // Ghostty's default.
-        ghostty_surface_set_focus(createdSurface, lastFocusState)
+        ghostty_surface_set_focus(createdSurface, desiredFocusState)
 
         NotificationCenter.default.post(
             name: .terminalSurfaceDidBecomeReady,
@@ -3680,18 +3682,18 @@ final class TerminalSurface: Identifiable, ObservableObject {
         surfaceView.applyWindowBackgroundIfActive()
     }
 
-    /// Keep `lastFocusState` in sync when the hosted view's responder chain
+    /// Keep `desiredFocusState` in sync when the hosted view's responder chain
     /// calls `ghostty_surface_set_focus` directly (bypassing `setFocus`).
     /// Without this, `createSurface` would replay a stale state on recreation.
     func recordExternalFocusState(_ focused: Bool) {
-        lastFocusState = focused
+        desiredFocusState = focused
     }
 
     func setFocus(_ focused: Bool) {
         // Only send focus events when the state changes to avoid redundant
         // prompt redraws with zsh themes like Powerlevel10k.
-        guard focused != lastFocusState else { return }
-        lastFocusState = focused
+        guard focused != desiredFocusState else { return }
+        desiredFocusState = focused
         // Track desired state even before the C surface exists (e.g. during
         // layout restoration). createSurface syncs the state once created.
         guard let surface = surface else { return }


### PR DESCRIPTION
## Summary

After restarting cmux with layout restoration, all split panes appeared focused (blinking cursor in every pane) instead of only one. The root cause was a mismatch between Ghostty's default surface focus state (`true`) and the Swift-side tracking variable `lastFocusState` (initialized `false`), combined with unfocus calls being dropped when the C surface didn't exist yet during restoration.

Three changes:
- Initialize `lastFocusState = true` to match Ghostty's C default (`Terminal.zig:105 focused: bool = true`)
- In `setFocus()`, update `lastFocusState` before the surface-nil guard so the desired state is tracked even when the C surface doesn't exist yet
- In `createSurface()`, sync focus state after creation so panes that were logically unfocused before the C surface existed get `ghostty_surface_set_focus(false)` applied

## Testing

- Build succeeds with `xcodebuild -scheme cmux -configuration Debug`
- To verify: open cmux with multiple splits, quit, relaunch. Only the previously focused pane should show a focused cursor.

## Related

- https://github.com/manaflow-ai/cmux/issues/2080

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes split panes showing a focused cursor in every pane after layout restoration by aligning focus tracking with Ghostty defaults, syncing on surface creation, and keeping state in sync with AppKit-driven focus. Fixes #2080.

- **Bug Fixes**
  - Rename and initialize `desiredFocusState = true` to match Ghostty’s default.
  - In `setFocus()`, update `desiredFocusState` before the surface-nil guard to track unfocus even without a C surface.
  - In `createSurface()`, always sync the desired focus state to the new surface.
  - Add `recordExternalFocusState()` and call it from AppKit responder paths (`becomeFirstResponder`, `resignFirstResponder`, ctrl-key fast path) to mirror direct C focus calls.

<sup>Written for commit e3b74eb3e50a1ce144d3aeb6af9c468740a6411b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal pane focus handling during creation and restore: desired focus is now recorded earlier and reliably applied when a pane is initialized, preventing panes from briefly appearing focused or showing an active cursor when they should be unfocused.
  * Default initial focus behavior adjusted so newly created panes correctly reflect expected focus state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->