### PR TITLE
Fix command palette focus after terminal find

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4627,10 +4627,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         isCommandPaletteFocusStealingTerminalOrBrowserResponder(responder)
     }
 
-    private func isTerminalOrBrowserView(_ view: NSView) -> Bool {
-        isCommandPaletteFocusStealingTerminalOrBrowserView(view)
-    }
-
     private func isInsideCommandPaletteOverlay(_ view: NSView) -> Bool {
         var current: NSView? = view
         while let candidate = current {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -37,6 +37,38 @@ private enum CmuxThemeNotifications {
     static let reloadConfig = Notification.Name("com.cmuxterm.themes.reload-config")
 }
 
+func isCommandPaletteFocusStealingTerminalOrBrowserResponder(_ responder: NSResponder) -> Bool {
+    if responder is GhosttyNSView || responder is WKWebView {
+        return true
+    }
+
+    if let textView = responder as? NSTextView,
+       !textView.isFieldEditor,
+       let delegateView = textView.delegate as? NSView {
+        return isCommandPaletteFocusStealingTerminalOrBrowserView(delegateView)
+    }
+
+    if let view = responder as? NSView {
+        return isCommandPaletteFocusStealingTerminalOrBrowserView(view)
+    }
+
+    return false
+}
+
+func isCommandPaletteFocusStealingTerminalOrBrowserView(_ view: NSView) -> Bool {
+    if view is GhosttyNSView || view is WKWebView {
+        return true
+    }
+    var current: NSView? = view.superview
+    while let candidate = current {
+        if candidate is GhosttyNSView || candidate is WKWebView {
+            return true
+        }
+        current = candidate.superview
+    }
+    return false
+}
+
 #if DEBUG
 enum CmuxTypingTiming {
     static let isEnabled: Bool = {
@@ -4592,35 +4624,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func isFocusStealingResponderWhileCommandPaletteVisible(_ responder: NSResponder) -> Bool {
-        if responder is GhosttyNSView || responder is WKWebView {
-            return true
-        }
-
-        if let textView = responder as? NSTextView,
-           !textView.isFieldEditor,
-           let delegateView = textView.delegate as? NSView {
-            return isTerminalOrBrowserView(delegateView)
-        }
-
-        if let view = responder as? NSView {
-            return isTerminalOrBrowserView(view)
-        }
-
-        return false
+        isCommandPaletteFocusStealingTerminalOrBrowserResponder(responder)
     }
 
     private func isTerminalOrBrowserView(_ view: NSView) -> Bool {
-        if view is GhosttyNSView || view is WKWebView {
-            return true
-        }
-        var current: NSView? = view.superview
-        while let candidate = current {
-            if candidate is GhosttyNSView || candidate is WKWebView {
-                return true
-            }
-            current = candidate.superview
-        }
-        return false
+        isCommandPaletteFocusStealingTerminalOrBrowserView(view)
     }
 
     private func isInsideCommandPaletteOverlay(_ view: NSView) -> Bool {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -56,12 +56,12 @@ func isCommandPaletteFocusStealingTerminalOrBrowserResponder(_ responder: NSResp
 }
 
 func isCommandPaletteFocusStealingTerminalOrBrowserView(_ view: NSView) -> Bool {
-    if view is GhosttyNSView || view is WKWebView {
+    if view is GhosttyNSView || view is GhosttySurfaceScrollView || view is WKWebView {
         return true
     }
     var current: NSView? = view.superview
     while let candidate = current {
-        if candidate is GhosttyNSView || candidate is WKWebView {
+        if candidate is GhosttyNSView || candidate is GhosttySurfaceScrollView || candidate is WKWebView {
             return true
         }
         current = candidate.superview

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -222,6 +222,16 @@ private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
             }
         }
 
+        func focusField(_ field: BrowserSearchNativeTextField, in window: NSWindow) {
+            guard window.makeFirstResponder(field) else { return }
+            DispatchQueue.main.async { [weak field] in
+                guard let field,
+                      let editor = field.currentEditor() as? NSTextView else { return }
+                let end = field.stringValue.utf16.count
+                editor.setSelectedRange(NSRange(location: end, length: 0))
+            }
+        }
+
         func controlTextDidChange(_ obj: Notification) {
             guard !isProgrammaticMutation else { return }
             guard let field = obj.object as? NSTextField else { return }
@@ -294,7 +304,7 @@ private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
                 field.currentEditor() != nil ||
                 ((fr as? NSTextView)?.delegate as? NSTextField) === field
             guard !alreadyFocused else { return }
-            window.makeFirstResponder(field)
+            coordinator.focusField(field, in: window)
         }
         return field
     }
@@ -337,7 +347,7 @@ private struct BrowserSearchTextFieldRepresentable: NSViewRepresentable {
                         nsView.currentEditor() != nil ||
                         ((fr as? NSTextView)?.delegate as? NSTextField) === nsView
                     guard !alreadyFocused else { return }
-                    window.makeFirstResponder(nsView)
+                    coordinator.focusField(nsView, in: window)
                 }
             }
         }

--- a/Sources/Find/SurfaceSearchOverlay.swift
+++ b/Sources/Find/SurfaceSearchOverlay.swift
@@ -19,6 +19,7 @@ struct SurfaceSearchOverlay: View {
     let tabId: UUID
     let surfaceId: UUID
     @ObservedObject var searchState: TerminalSurface.SearchState
+    let canApplyFocusRequest: () -> Bool
     let onMoveFocusToTerminal: () -> Void
     let onNavigateSearch: (_ action: String) -> Void
     let onFieldDidFocus: () -> Void
@@ -37,6 +38,7 @@ struct SurfaceSearchOverlay: View {
                     text: $searchState.needle,
                     isFocused: $isSearchFieldFocused,
                     surfaceId: surfaceId,
+                    canApplyFocusRequest: canApplyFocusRequest,
                     onFieldDidFocus: onFieldDidFocus,
                     onEscape: {
                         #if DEBUG
@@ -227,6 +229,7 @@ private struct SearchTextFieldRepresentable: NSViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let surfaceId: UUID
+    let canApplyFocusRequest: () -> Bool
     let onFieldDidFocus: () -> Void
     let onEscape: () -> Void
     let onReturn: (_ isShift: Bool) -> Void
@@ -319,6 +322,7 @@ private struct SearchTextFieldRepresentable: NSViewRepresentable {
             guard let field, let coordinator else { return }
             guard let surface = notification.object as? TerminalSurface,
                   surface.id == coordinator.parent.surfaceId else { return }
+            guard coordinator.parent.canApplyFocusRequest() else { return }
             guard let window = field.window else { return }
             // Don't re-focus if already first responder. makeFirstResponder on an
             // already-editing NSTextField ends the editing session and restarts it
@@ -370,11 +374,16 @@ private struct SearchTextFieldRepresentable: NSViewRepresentable {
                 nsView.currentEditor() != nil ||
                 ((fr as? NSTextView)?.delegate as? NSTextField) === nsView
 
-            if isFocused, !isFirstResponder, context.coordinator.pendingFocusRequest != true {
+            if isFocused,
+               canApplyFocusRequest(),
+               !isFirstResponder,
+               context.coordinator.pendingFocusRequest != true {
                 context.coordinator.pendingFocusRequest = true
                 DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
                     coordinator?.pendingFocusRequest = nil
-                    guard let coordinator, coordinator.parent.isFocused else { return }
+                    guard let coordinator,
+                          coordinator.parent.isFocused,
+                          coordinator.parent.canApplyFocusRequest() else { return }
                     guard let nsView, let window = nsView.window else { return }
                     let fr = window.firstResponder
                     let alreadyFocused = fr === nsView ||

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7537,6 +7537,9 @@ final class GhosttySurfaceScrollView: NSView {
             tabId: terminalSurface.tabId,
             surfaceId: terminalSurface.id,
             searchState: searchState,
+            canApplyFocusRequest: { [weak self] in
+                self?.canApplyMountedSearchFieldFocusRequest() ?? false
+            },
             onMoveFocusToTerminal: { [weak self] in
                 self?.searchFocusTarget = .terminal
                 self?.moveFocus()
@@ -7568,6 +7571,17 @@ final class GhosttySurfaceScrollView: NSView {
         return nil
     }
 
+    private func canApplyMountedSearchFieldFocusRequest() -> Bool {
+        guard let terminalSurface = surfaceView.terminalSurface,
+              let app = AppDelegate.shared,
+              let manager = app.tabManagerFor(tabId: terminalSurface.tabId),
+              manager.selectedTabId == terminalSurface.tabId,
+              let workspace = manager.tabs.first(where: { $0.id == terminalSurface.tabId }) else {
+            return false
+        }
+        return workspace.focusedPanelId == terminalSurface.id
+    }
+
     private func requestMountedSearchFieldFocus(
         generation: UInt64,
         force: Bool,
@@ -7575,6 +7589,7 @@ final class GhosttySurfaceScrollView: NSView {
     ) {
         guard searchOverlayMutationGeneration == generation else { return }
         guard force || searchFocusTarget == .searchField else { return }
+        guard canApplyMountedSearchFieldFocusRequest() else { return }
         guard let overlay = searchOverlayHostingView,
               overlay.superview === self,
               let window,

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3914,7 +3914,7 @@ extension BrowserPanel {
 
         _ = hideDeveloperTools()
         cancelDeveloperToolsRestoreRetry()
-        preferredDeveloperToolsVisible = false
+        setPreferredDeveloperToolsVisible(false)
         preferredDeveloperToolsPresentation = .unknown
         forceDeveloperToolsRefreshOnNextAttach = false
         developerToolsDetachedOpenGraceDeadline = nil
@@ -4180,6 +4180,11 @@ extension BrowserPanel {
         }
     }
 
+    private func setPreferredDeveloperToolsVisible(_ next: Bool) {
+        guard preferredDeveloperToolsVisible != next else { return }
+        preferredDeveloperToolsVisible = next
+    }
+
     private func syncDeveloperToolsPresentationPreferenceFromUI() {
         if !detachedDeveloperToolsWindows().isEmpty {
             setPreferredDeveloperToolsPresentation(.detached)
@@ -4208,7 +4213,7 @@ extension BrowserPanel {
                 guard self.preferredDeveloperToolsVisible else { return }
                 guard !self.isDeveloperToolsVisible() else { return }
                 self.developerToolsDetachedOpenGraceDeadline = nil
-                self.preferredDeveloperToolsVisible = false
+                self.setPreferredDeveloperToolsVisible(false)
                 self.cancelDeveloperToolsRestoreRetry()
 #if DEBUG
                 dlog(
@@ -4344,7 +4349,7 @@ extension BrowserPanel {
     ) -> Bool {
         if isDeveloperToolsTransitionInFlight {
             pendingDeveloperToolsTransitionTargetVisible = targetVisible
-            preferredDeveloperToolsVisible = targetVisible
+            setPreferredDeveloperToolsVisible(targetVisible)
             if !targetVisible {
                 developerToolsDetachedOpenGraceDeadline = nil
                 forceDeveloperToolsRefreshOnNextAttach = false
@@ -4371,7 +4376,7 @@ extension BrowserPanel {
 
         let isVisibleSelector = NSSelectorFromString("isVisible")
         let visible = inspector.cmuxCallBool(selector: isVisibleSelector) ?? false
-        preferredDeveloperToolsVisible = targetVisible
+        setPreferredDeveloperToolsVisible(targetVisible)
         developerToolsTransitionTargetVisible = targetVisible
 
         if targetVisible {
@@ -4473,7 +4478,7 @@ extension BrowserPanel {
         guard let visible = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) else { return }
         if isDeveloperToolsTransitionInFlight {
             let targetVisible = pendingDeveloperToolsTransitionTargetVisible ?? developerToolsTransitionTargetVisible ?? visible
-            preferredDeveloperToolsVisible = targetVisible
+            setPreferredDeveloperToolsVisible(targetVisible)
             if targetVisible, visible {
                 developerToolsDetachedOpenGraceDeadline = nil
                 syncDeveloperToolsPresentationPreferenceFromUI()
@@ -4488,7 +4493,7 @@ extension BrowserPanel {
         if visible {
             developerToolsDetachedOpenGraceDeadline = nil
             syncDeveloperToolsPresentationPreferenceFromUI()
-            preferredDeveloperToolsVisible = true
+            setPreferredDeveloperToolsVisible(true)
             developerToolsLastKnownVisibleAt = Date()
             cancelDeveloperToolsRestoreRetry()
             return
@@ -4496,7 +4501,7 @@ extension BrowserPanel {
         if preserveVisibleIntent && preferredDeveloperToolsVisible {
             return
         }
-        preferredDeveloperToolsVisible = false
+        setPreferredDeveloperToolsVisible(false)
         developerToolsLastKnownVisibleAt = nil
         cancelDeveloperToolsRestoreRetry()
     }
@@ -4551,7 +4556,7 @@ extension BrowserPanel {
             return false
         }
 
-        preferredDeveloperToolsVisible = false
+        setPreferredDeveloperToolsVisible(false)
         developerToolsDetachedOpenGraceDeadline = nil
         developerToolsLastKnownVisibleAt = nil
         forceDeveloperToolsRefreshOnNextAttach = false
@@ -4597,7 +4602,7 @@ extension BrowserPanel {
 
         let detachedOpenStillSettling = developerToolsDetachedOpenGraceDeadline.map { $0 > Date() } ?? false
         if preferredDeveloperToolsPresentation == .detached && !detachedOpenStillSettling {
-            preferredDeveloperToolsVisible = false
+            setPreferredDeveloperToolsVisible(false)
             developerToolsDetachedOpenGraceDeadline = nil
             cancelDeveloperToolsRestoreRetry()
 #if DEBUG
@@ -4624,7 +4629,7 @@ extension BrowserPanel {
         cmuxWithWindowFirstResponderBypass {
             _ = revealDeveloperTools(inspector)
         }
-        preferredDeveloperToolsVisible = true
+        setPreferredDeveloperToolsVisible(true)
         let visibleAfterShow = inspector.cmuxCallBool(selector: NSSelectorFromString("isVisible")) ?? false
         if visibleAfterShow {
             syncDeveloperToolsPresentationPreferenceFromUI()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -460,7 +460,7 @@ struct BrowserPanelView: View {
                     searchState: searchState,
                     focusRequestGeneration: panel.searchFocusRequestGeneration,
                     canApplyFocusRequest: { generation in
-                        panel.canApplySearchFocusRequest(generation)
+                        canApplyBrowserFindFieldFocusRequest(generation)
                     },
                     onNext: { panel.findNext() },
                     onPrevious: { panel.findPrevious() },
@@ -1133,7 +1133,7 @@ struct BrowserPanelView: View {
                             searchState: searchState,
                             focusRequestGeneration: panel.searchFocusRequestGeneration,
                             canApplyFocusRequest: { generation in
-                                panel.canApplySearchFocusRequest(generation)
+                                canApplyBrowserFindFieldFocusRequest(generation)
                             },
                             onNext: { panel.findNext() },
                             onPrevious: { panel.findPrevious() },
@@ -1297,6 +1297,10 @@ struct BrowserPanelView: View {
             return false
         }
         return workspace.focusedPanelId == panel.id
+    }
+
+    private func canApplyBrowserFindFieldFocusRequest(_ generation: UInt64) -> Bool {
+        isPanelFocusedInModel() && panel.canApplySearchFocusRequest(generation)
     }
 
     private func shouldApplyAddressBarExitFallback(in window: NSWindow) -> Bool {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2895,16 +2895,16 @@ class TabManager: ObservableObject {
         guard let selectedTabId,
               let tab = tabs.first(where: { $0.id == selectedTabId }) else { return }
 
-        // Try to restore previous focus
+        let panelId: UUID
         if let restoredPanelId = lastFocusedPanelByTab[selectedTabId],
-           tab.panels[restoredPanelId] != nil,
-           tab.focusedPanelId != restoredPanelId {
-            tab.focusPanel(restoredPanelId)
+           tab.panels[restoredPanelId] != nil {
+            panelId = restoredPanelId
+        } else if let focusedPanelId = tab.focusedPanelId,
+                  tab.panels[focusedPanelId] != nil {
+            panelId = focusedPanelId
+        } else {
+            return
         }
-
-        // Focus the panel
-        guard let panelId = tab.focusedPanelId,
-              let panel = tab.panels[panelId] else { return }
 
         // Defer unfocusing the previous workspace's panel until ContentView confirms handoff
         // completion (new workspace has focus or timeout fallback), to avoid a visible freeze gap.
@@ -2917,12 +2917,9 @@ class TabManager: ObservableObject {
             )
         }
 
-        panel.focus()
-
-        // For terminal panels, ensure proper focus handling
-        if let terminalPanel = panel as? TerminalPanel {
-            terminalPanel.hostedView.ensureFocus(for: selectedTabId, surfaceId: panelId)
-        }
+        // Route workspace reactivation through the normal focus machinery so panel-local
+        // activation intents like browser find-field focus are restored on return.
+        tab.focusPanel(panelId)
     }
 
     func completePendingWorkspaceUnfocus(reason: String) {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Combine
 import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -1924,6 +1925,34 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
 
         XCTAssertTrue(panel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.showCount, 2)
+    }
+
+    func testSyncDoesNotRepublishHiddenDeveloperToolsIntentWhenInspectorAlreadyHidden() {
+        let (panel, inspector) = makePanelWithInspector(hideBehavior: .hides)
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        waitForDeveloperToolsTransitions()
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+
+        inspector.hide()
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+
+        panel.syncDeveloperToolsPreferenceFromInspector()
+        waitForDeveloperToolsTransitions()
+
+        var publishCount = 0
+        let cancellable = panel.objectWillChange.sink {
+            publishCount += 1
+        }
+        defer { _ = cancellable }
+
+        panel.syncDeveloperToolsPreferenceFromInspector()
+
+        XCTAssertEqual(
+            publishCount,
+            0,
+            "Repeated hidden-inspector syncs should not republish the same hidden DevTools intent"
+        )
     }
 
     func testForcedRefreshAfterAttachKeepsVisibleInspectorState() {

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -405,6 +405,8 @@ final class CommandPaletteOpenShortcutConsumptionTests: XCTestCase {
 
 
 final class CommandPaletteFocusStealerClassificationTests: XCTestCase {
+    private final class NonViewTextDelegate: NSObject, NSTextViewDelegate {}
+
     func testTreatsGhosttySurfaceViewAsFocusStealer() {
         let surfaceView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
 
@@ -428,6 +430,21 @@ final class CommandPaletteFocusStealerClassificationTests: XCTestCase {
         let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
 
         XCTAssertFalse(isCommandPaletteFocusStealingTerminalOrBrowserResponder(textField))
+    }
+
+    func testTreatsTextViewInsideTerminalHostedViewAsFocusStealerWhenDelegateIsNotAView() {
+        let hostedView = GhosttySurfaceScrollView(
+            surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+        )
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        let delegate = NonViewTextDelegate()
+        textView.delegate = delegate
+        hostedView.addSubview(textView)
+
+        XCTAssertTrue(
+            isCommandPaletteFocusStealingTerminalOrBrowserResponder(textView),
+            "NSTextView responders should still be blocked via the NSView hierarchy walk when the delegate is not a view"
+        )
     }
 }
 

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -404,6 +404,34 @@ final class CommandPaletteOpenShortcutConsumptionTests: XCTestCase {
 }
 
 
+final class CommandPaletteFocusStealerClassificationTests: XCTestCase {
+    func testTreatsGhosttySurfaceViewAsFocusStealer() {
+        let surfaceView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+
+        XCTAssertTrue(isCommandPaletteFocusStealingTerminalOrBrowserResponder(surfaceView))
+    }
+
+    func testTreatsTextFieldInsideTerminalHostedViewAsFocusStealer() {
+        let hostedView = GhosttySurfaceScrollView(
+            surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 120, height: 80))
+        )
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        hostedView.addSubview(textField)
+
+        XCTAssertTrue(
+            isCommandPaletteFocusStealingTerminalOrBrowserResponder(textField),
+            "Terminal-owned overlay text inputs should not be allowed to reclaim focus from the command palette"
+        )
+    }
+
+    func testDoesNotTreatUnrelatedTextFieldAsFocusStealer() {
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+
+        XCTAssertFalse(isCommandPaletteFocusStealingTerminalOrBrowserResponder(textField))
+    }
+}
+
+
 final class CommandPaletteRestoreFocusStateMachineTests: XCTestCase {
     func testRestoresBrowserAddressBarWhenPaletteOpenedFromFocusedAddressBar() {
         let panelId = UUID()

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -938,9 +938,31 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
     }
 
+    func testWorkspaceRoundTripPreservesFocusedTerminalFindWhenBrowserFindIsAlsoOpen() {
+        runSplitFindWorkspaceRoundTripScenario(restoredOwner: .terminal)
+    }
+
+    func testWorkspaceRoundTripPreservesFocusedBrowserFindWhenTerminalFindIsAlsoOpen() {
+        runSplitFindWorkspaceRoundTripScenario(restoredOwner: .browser)
+    }
+
     private enum FindFocusRoute {
         case cmdOptionArrows
         case cmdCtrlLetters
+    }
+
+    private enum SplitFindOwner {
+        case terminal
+        case browser
+
+        var focusedPanelKind: String {
+            switch self {
+            case .terminal:
+                return "terminal"
+            case .browser:
+                return "browser"
+            }
+        }
     }
 
     private func runFindFocusPersistenceScenario(route: FindFocusRoute, useAutofocusRacePage: Bool) {
@@ -1049,6 +1071,124 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
                     && data["browserFindNeedle"] == "amdo"
             },
             "Expected browser find query to stay focused and become 'amdo'. data=\(String(describing: loadData()))"
+        )
+    }
+
+    private func runSplitFindWorkspaceRoundTripScenario(restoredOwner: SplitFindOwner) {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        launchAndEnsureForeground(app)
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10.0), "Expected main window to exist")
+
+        app.typeKey("d", modifierFlags: [.command])
+        focusRightPaneForFindScenario(app, route: .cmdOptionArrows)
+
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
+        XCTAssertTrue(omnibar.waitForExistence(timeout: 8.0), "Expected browser omnibar after Cmd+Shift+L")
+
+        app.typeKey("a", modifierFlags: [.command])
+        app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
+        app.typeText("example.com")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForOmnibarToContainExampleDomain(omnibar, timeout: 8.0),
+            "Expected browser navigation to example domain before running workspace round trip. value=\(String(describing: omnibar.value))"
+        )
+
+        focusLeftPaneForFindScenario(app, route: .cmdOptionArrows)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == "terminal"
+            },
+            "Expected left terminal pane to be focused before opening terminal find. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        app.typeText("la")
+
+        focusRightPaneForFindScenario(app, route: .cmdOptionArrows)
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == "browser"
+                    && data["terminalFindNeedle"] == "la"
+            },
+            "Expected terminal find query to persist before opening browser find. data=\(String(describing: loadData()))"
+        )
+        app.typeKey("f", modifierFlags: [.command])
+        app.typeText("am")
+
+        switch restoredOwner {
+        case .terminal:
+            focusLeftPaneForFindScenario(app, route: .cmdOptionArrows)
+        case .browser:
+            break
+        }
+
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == restoredOwner.focusedPanelKind
+                    && data["terminalFindNeedle"] == "la"
+                    && data["browserFindNeedle"] == "am"
+            },
+            "Expected the intended find owner before leaving workspace 1. data=\(String(describing: loadData()))"
+        )
+
+        openCommandPaletteForNewWorkspace(app)
+        app.typeKey("1", modifierFlags: [.command])
+
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["focusedPanelKind"] == restoredOwner.focusedPanelKind
+                    && data["terminalFindNeedle"] == "la"
+                    && data["browserFindNeedle"] == "am"
+            },
+            "Expected the previously focused find owner to be restored after the workspace round trip. data=\(String(describing: loadData()))"
+        )
+
+        switch restoredOwner {
+        case .terminal:
+            app.typeText("foo")
+            XCTAssertTrue(
+                waitForDataMatch(timeout: 6.0) { data in
+                    data["focusedPanelKind"] == "terminal"
+                        && data["terminalFindNeedle"] == "lafoo"
+                        && data["browserFindNeedle"] == "am"
+                },
+                "Expected typing after returning to stay in terminal find. data=\(String(describing: loadData()))"
+            )
+        case .browser:
+            app.typeText("do")
+            XCTAssertTrue(
+                waitForDataMatch(timeout: 6.0) { data in
+                    data["focusedPanelKind"] == "browser"
+                        && data["terminalFindNeedle"] == "la"
+                        && data["browserFindNeedle"] == "amdo"
+                },
+                "Expected typing after returning to stay in browser find. data=\(String(describing: loadData()))"
+            )
+        }
+    }
+
+    private func openCommandPaletteForNewWorkspace(_ app: XCUIApplication) {
+        app.typeKey("p", modifierFlags: [.command, .shift])
+
+        let paletteSearchField = app.textFields["CommandPaletteSearchField"].firstMatch
+        XCTAssertTrue(paletteSearchField.waitForExistence(timeout: 5.0), "Expected command palette search field")
+        paletteSearchField.click()
+        paletteSearchField.typeText("New Workspace")
+
+        let firstResultRow = app.descendants(matching: .any).matching(identifier: "CommandPaletteResultRow.0").firstMatch
+        XCTAssertTrue(firstResultRow.waitForExistence(timeout: 5.0), "Expected command palette results for New Workspace")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(paletteSearchField, timeout: 5.0),
+            "Expected command palette to dismiss after creating a workspace"
         )
     }
 

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -853,6 +853,91 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
     }
 
+    func testBrowserFindFieldKeepsFocusAfterNewWorkspaceRoundTrip() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        launchAndEnsureForeground(app)
+
+        let window = app.windows.firstMatch
+        _ = window.waitForExistence(timeout: 2.0)
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2
+            },
+            "Expected Cmd+D to create a split before opening the browser. data=\(String(describing: loadData()))"
+        )
+
+        app.typeKey("l", modifierFlags: [.command])
+
+        let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
+        XCTAssertTrue(omnibar.waitForExistence(timeout: 8.0), "Expected browser omnibar after Cmd+L")
+
+        app.typeKey("a", modifierFlags: [.command])
+        app.typeKey(XCUIKeyboardKey.delete.rawValue, modifierFlags: [])
+        app.typeText("example.com")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForOmnibarToContainExampleDomain(omnibar, timeout: 8.0),
+            "Expected browser navigation to example domain before opening find. value=\(String(describing: omnibar.value))"
+        )
+
+        app.typeKey("f", modifierFlags: [.command])
+
+        let findField = app.textFields["BrowserFindSearchTextField"].firstMatch
+        XCTAssertTrue(findField.waitForExistence(timeout: 6.0), "Expected browser find field after Cmd+F")
+
+        app.typeText("seed")
+        XCTAssertTrue(
+            waitForCondition(timeout: 4.0) {
+                ((findField.value as? String) ?? "") == "seed"
+            },
+            "Expected browser find field to capture initial typing. value=\(String(describing: findField.value))"
+        )
+
+        app.typeKey("p", modifierFlags: [.command, .shift])
+
+        let paletteSearchField = app.textFields["CommandPaletteSearchField"].firstMatch
+        XCTAssertTrue(paletteSearchField.waitForExistence(timeout: 5.0), "Expected command palette search field")
+        paletteSearchField.click()
+        paletteSearchField.typeText("New Workspace")
+
+        let firstResultRow = app.descendants(matching: .any).matching(identifier: "CommandPaletteResultRow.0").firstMatch
+        XCTAssertTrue(firstResultRow.waitForExistence(timeout: 5.0), "Expected command palette results for New Workspace")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(paletteSearchField, timeout: 5.0),
+            "Expected command palette to dismiss after creating a workspace"
+        )
+
+        app.typeKey("1", modifierFlags: [.command])
+
+        let restoredFindField = app.textFields["BrowserFindSearchTextField"].firstMatch
+        XCTAssertTrue(restoredFindField.waitForExistence(timeout: 6.0), "Expected browser find field after returning to workspace 1")
+        XCTAssertTrue(
+            waitForCondition(timeout: 4.0) {
+                ((restoredFindField.value as? String) ?? "") == "seed"
+            },
+            "Expected existing browser find query to persist after returning. value=\(String(describing: restoredFindField.value))"
+        )
+
+        app.typeText("x")
+        XCTAssertTrue(
+            waitForCondition(timeout: 4.0) {
+                ((restoredFindField.value as? String) ?? "") == "seedx"
+            },
+            "Expected typing after returning from a new workspace to stay in the browser find field. " +
+                "findValue=\(String(describing: restoredFindField.value)) omnibarValue=\(String(describing: omnibar.value))"
+        )
+    }
+
     private enum FindFocusRoute {
         case cmdOptionArrows
         case cmdCtrlLetters


### PR DESCRIPTION
## Summary
- add regression coverage for command-palette focus-stealer classification
- treat terminal-owned inputs under `GhosttySurfaceScrollView` as blocked while the command palette is visible
- keep terminal find from reclaiming focus after `Cmd+F`, then `Cmd+P` or `Cmd+Shift+P`

## Testing
- `./scripts/reload.sh --tag task-find-command-palette-focus`
- Added targeted `cmux-unit` coverage in `cmuxTests/ShortcutAndCommandPaletteTests.swift`
- Local `xcodebuild -scheme cmux-unit` runs in this environment hit an existing SwiftUI/AppKit window-layout crash before the old window-based harness can complete, so rely on PR CI for the new regression

## Task
- after cmd+f, then cmd+p or cmd+shift+p the focus and typing is wrong

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents terminal and browser views from stealing focus when the command palette is open, and restores the browser find field (with caret) after a workspace round‑trip. Also avoids redundant DevTools visibility publishes when the inspector is already hidden.

- **Bug Fixes**
  - Treat `GhosttySurfaceScrollView`, `GhosttyNSView`, `WKWebView`, and terminal-owned text inputs as blocked while the palette is visible.
  - Centralize focus-stealer checks via `isCommandPaletteFocusStealingTerminalOrBrowserResponder` and `isCommandPaletteFocusStealingTerminalOrBrowserView`.
  - Restore browser find focus and caret after creating a new workspace and switching back by routing reactivation through `TabManager.focusPanel` and focusing the native field at the end of the query.
  - Add `cmux-unit` tests for focus classification (including `NSTextView` delegate-not-a-view fallback) and the Cmd+F → Cmd+P regression.
  - Avoid republishing hidden Developer Tools intent by gating changes through `setPreferredDeveloperToolsVisible`; add a regression test.
  - Add a UI test to ensure the browser find field keeps focus and its query across workspace changes.

<sup>Written for commit d6313ce8844811cff4343c62217b7f2a9385ff54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized detection of embedded browser/terminal responders and views that should steal focus; focus restoration now routes through normal panel/workspace focus machinery.

* **Stability**
  * Developer-tools visibility updates made idempotent to avoid state churn.
  * Search/find focus now reliably places the caret at the end and respects newly added gating so mounted search fields only focus when their workspace/panel is actually active.

* **Tests**
  * Added unit and UI tests covering focus classification, developer-tools sync, and find-field persistence across workspace round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->