### PR TITLE
Fix NIGHTLY crash after `cmux ssh cmux-macmini`

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1120,6 +1120,10 @@ class TabManager: ObservableObject {
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
         let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectoryForNewTab(snapshot: snapshot)
         let inheritedConfig = inheritedTerminalConfigForNewWorkspace(snapshot: snapshot)
+        // Resolve placement against the pre-creation snapshot before Workspace init
+        // boots terminal state. The ssh/new-workspace path can otherwise crash while
+        // reading @Published placement state from existing workspaces mid-creation.
+        let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
         let newWorkspace = Workspace(
@@ -1132,7 +1136,6 @@ class TabManager: ObservableObject {
         )
         newWorkspace.owningTabManager = self
         wireClosedBrowserTracking(for: newWorkspace)
-        let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
         if eagerLoadTerminal && !select {
             requestBackgroundWorkspaceLoad(for: newWorkspace.id)
         }


### PR DESCRIPTION
## Summary
- resolve workspace insertion before `Workspace(...)` initialization starts
- avoid reading existing workspaces' `@Published` placement state during the ssh/new-workspace create path

## Testing
- `./scripts/reload.sh --tag task-cmux-ssh-macmini-crash`
- `'/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-task-cmux-ssh-macmini-crash/Build/Products/Debug/cmux DEV task-cmux-ssh-macmini-crash.app/Contents/Resources/bin/cmux' --socket /tmp/cmux-debug-task-cmux-ssh-macmini-crash.sock new-workspace --command 'printf ready'` → `OK workspace:3`
- `CMUX_DEBUG_LOG=/tmp/cmux-debug-task-cmux-ssh-macmini-crash.log '/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-task-cmux-ssh-macmini-crash/Build/Products/Debug/cmux DEV task-cmux-ssh-macmini-crash.app/Contents/Resources/bin/cmux' --socket /tmp/cmux-debug-task-cmux-ssh-macmini-crash.sock ssh cmux-macmini` → `OK workspace=workspace:4 target=cmux-macmini state=connecting`
- `'/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-task-cmux-ssh-macmini-crash/Build/Products/Debug/cmux DEV task-cmux-ssh-macmini-crash.app/Contents/Resources/bin/cmux' --socket /tmp/cmux-debug-task-cmux-ssh-macmini-crash.sock tree --all` showed the new ssh workspace alive after the command

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/2098

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a crash when creating an SSH workspace (e.g., `cmux ssh cmux-macmini`) by resolving tab placement before `Workspace` init. This avoids reading `@Published` placement state mid-creation and fixes the NIGHTLY crash.

- **Bug Fixes**
  - Resolve insert index from the pre-creation snapshot before constructing `Workspace`.
  - Remove mid-creation reads of other workspaces’ placement state in the ssh/new-workspace path to eliminate the race.

<sup>Written for commit b55d5520b02835f4bf8ce88d183b32e4b3e081d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace tab insertion consistency by resolving insertion placement earlier in the creation sequence, eliminating potential dependency issues that could affect tab ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->