### PR TITLE
Add pane zoom/maximize command and focus-unzoom behavior

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1712,11 +1712,19 @@ struct CMUXCLI {
                 } else {
                     for pane in panes {
                         let focused = (pane["focused"] as? Bool) == true
+                        let zoomed = (pane["zoomed"] as? Bool) == true
                         let handle = textHandle(pane, idFormat: idFormat)
                         let count = pane["surface_count"] as? Int ?? 0
                         let prefix = focused ? "* " : "  "
-                        let focusTag = focused ? "  [focused]" : ""
-                        print("\(prefix)\(handle)  [\(count) surface\(count == 1 ? "" : "s")]\(focusTag)")
+                        var tags: [String] = []
+                        if focused {
+                            tags.append("focused")
+                        }
+                        if zoomed {
+                            tags.append("zoomed")
+                        }
+                        let suffix = tags.isEmpty ? "" : "  [" + tags.joined(separator: ", ") + "]"
+                        print("\(prefix)\(handle)  [\(count) surface\(count == 1 ? "" : "s")]\(suffix)")
                     }
                 }
             }
@@ -1753,7 +1761,7 @@ struct CMUXCLI {
 
         case "focus-pane":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
-            guard let paneRaw = optionValue(commandArgs, name: "--pane") ?? commandArgs.first else {
+            guard let paneRaw = optionValue(commandArgs, name: "--pane") ?? firstPositionalArgument(commandArgs) else {
                 throw CLIError(message: "focus-pane requires --pane <id|ref>")
             }
             var params: [String: Any] = [:]
@@ -1763,6 +1771,24 @@ struct CMUXCLI {
             if let paneId { params["pane_id"] = paneId }
             let payload = try client.sendV2(method: "pane.focus", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["pane", "workspace"]))
+
+        case "zoom-pane":
+            let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
+            let paneRaw = optionValue(commandArgs, name: "--pane") ?? firstPositionalArgument(commandArgs)
+            var params: [String: Any] = [:]
+            let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+            if let wsId { params["workspace_id"] = wsId }
+            if let paneRaw {
+                let paneId = try normalizePaneHandle(paneRaw, client: client, workspaceHandle: wsId)
+                if let paneId { params["pane_id"] = paneId }
+            }
+            let payload = try client.sendV2(method: "pane.zoom", params: params)
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2PaneZoomSummary(payload, idFormat: idFormat)
+            )
 
         case "new-pane":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
@@ -6423,6 +6449,21 @@ struct CMUXCLI {
               cmux focus-pane pane:1
               cmux focus-pane --pane pane:1 --workspace workspace:2
             """
+        case "zoom-pane":
+            return """
+            Usage: cmux zoom-pane [--pane <id|ref> | <id|ref>] [flags]
+
+            Toggle pane zoom for the focused pane or a specific pane.
+
+            Flags:
+              --pane <id|ref>          Pane to zoom (default: focused pane)
+              --workspace <id|ref>     Workspace context (default: $CMUX_WORKSPACE_ID)
+
+            Example:
+              cmux zoom-pane
+              cmux zoom-pane --pane pane:2
+              cmux zoom-pane pane:1 --workspace workspace:2
+            """
         case "new-pane":
             return """
             Usage: cmux new-pane [flags]
@@ -7947,6 +7988,19 @@ struct CMUXCLI {
         return args[index + 1]
     }
 
+    private func firstPositionalArgument(_ args: [String]) -> String? {
+        var index = 0
+        while index < args.count {
+            let arg = args[index]
+            if arg.hasPrefix("--") {
+                index += 2
+                continue
+            }
+            return arg
+        }
+        return nil
+    }
+
     private func hasFlag(_ args: [String], name: String) -> Bool {
         args.contains(name)
     }
@@ -8036,6 +8090,17 @@ struct CMUXCLI {
     private func v2OKSummary(_ payload: [String: Any], idFormat: CLIIDFormat, kinds: [String] = ["surface", "workspace"]) -> String {
         var parts = ["OK"]
         for kind in kinds {
+            if let handle = formatHandle(payload, kind: kind, idFormat: idFormat) {
+                parts.append(handle)
+            }
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private func v2PaneZoomSummary(_ payload: [String: Any], idFormat: CLIIDFormat) -> String {
+        let state = (payload["zoomed"] as? Bool) == true ? "Zoomed" : "Restored"
+        var parts = [state]
+        for kind in ["pane", "workspace"] {
             if let handle = formatHandle(payload, kind: kind, idFormat: idFormat) {
                 parts.append(handle)
             }
@@ -11382,6 +11447,7 @@ struct CMUXCLI {
           list-pane-surfaces [--workspace <id|ref>] [--pane <id|ref>]
           tree [--all] [--workspace <id|ref|index>]
           focus-pane --pane <id|ref> [--workspace <id|ref>]
+          zoom-pane [--pane <id|ref>] [--workspace <id|ref>]
           new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>]
           new-surface [--type <terminal|browser>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>]
           close-surface [--surface <id|ref>] [--workspace <id|ref>]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -134,6 +134,7 @@ class TerminalController {
         "workspace.last",
         "surface.focus",
         "pane.focus",
+        "pane.zoom",
         "pane.last",
         "browser.focus_webview",
         "browser.focus",
@@ -2138,6 +2139,8 @@ class TerminalController {
             return v2Result(id: id, self.v2PaneList(params: params))
         case "pane.focus":
             return v2Result(id: id, self.v2PaneFocus(params: params))
+        case "pane.zoom":
+            return v2Result(id: id, self.v2PaneZoom(params: params))
         case "pane.surfaces":
             return v2Result(id: id, self.v2PaneSurfaces(params: params))
         case "pane.create":
@@ -2474,6 +2477,7 @@ class TerminalController {
             "surface.trigger_flash",
             "pane.list",
             "pane.focus",
+            "pane.zoom",
             "pane.surfaces",
             "pane.create",
             "pane.resize",
@@ -5719,6 +5723,7 @@ class TerminalController {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
 
             let focusedPaneId = ws.bonsplitController.focusedPaneId
+            let zoomedPaneId = ws.bonsplitController.zoomedPaneId
             let panes: [[String: Any]] = ws.bonsplitController.allPaneIds.enumerated().map { index, paneId in
                 let tabs = ws.bonsplitController.tabs(inPane: paneId)
                 let surfaceUUIDs: [UUID] = tabs.compactMap { ws.panelIdFromSurfaceId($0.id) }
@@ -5729,6 +5734,7 @@ class TerminalController {
                     "ref": v2Ref(kind: .pane, uuid: paneId.id),
                     "index": index,
                     "focused": paneId == focusedPaneId,
+                    "zoomed": paneId == zoomedPaneId,
                     "surface_ids": surfaceUUIDs.map { $0.uuidString },
                     "surface_refs": surfaceUUIDs.map { v2Ref(kind: .surface, uuid: $0) },
                     "selected_surface_id": v2OrNull(selectedSurfaceUUID?.uuidString),
@@ -5741,6 +5747,8 @@ class TerminalController {
             payload = [
                 "workspace_id": ws.id.uuidString,
                 "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "zoomed_pane_id": v2OrNull(zoomedPaneId?.id.uuidString),
+                "zoomed_pane_ref": v2Ref(kind: .pane, uuid: zoomedPaneId?.id),
                 "panes": panes,
                 "window_id": v2OrNull(windowId?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: windowId)
@@ -5777,9 +5785,64 @@ class TerminalController {
             if tabManager.selectedTabId != ws.id {
                 tabManager.selectWorkspace(ws)
             }
-            ws.bonsplitController.focusPane(paneId)
+            guard ws.focusPane(paneId, reason: "socket.pane.focus") else {
+                result = .err(code: "internal_error", message: "Failed to focus pane", data: ["pane_id": paneUUID.uuidString])
+                return
+            }
             let windowId = v2ResolveWindowId(tabManager: tabManager)
             result = .ok(["window_id": v2OrNull(windowId?.uuidString), "window_ref": v2Ref(kind: .window, uuid: windowId), "workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "pane_id": paneId.id.uuidString, "pane_ref": v2Ref(kind: .pane, uuid: paneId.id)])
+        }
+        return result
+    }
+
+    private func v2PaneZoom(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "not_found", message: "Pane not found", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let paneId: PaneID? = {
+                if let paneUUID = v2UUID(params, "pane_id") {
+                    return ws.bonsplitController.allPaneIds.first(where: { $0.id == paneUUID })
+                }
+                return ws.bonsplitController.focusedPaneId
+            }()
+            guard let paneId else {
+                result = .err(code: "not_found", message: "Pane not found", data: nil)
+                return
+            }
+
+            guard ws.toggleSplitZoom(inPane: paneId) else {
+                result = .err(
+                    code: "invalid_state",
+                    message: "Pane zoom is unavailable",
+                    data: ["pane_id": paneId.id.uuidString]
+                )
+                return
+            }
+
+            let selectedSurfaceId = ws.effectiveSelectedPanelId(inPane: paneId)
+            let zoomedPaneId = ws.bonsplitController.zoomedPaneId
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "pane_id": paneId.id.uuidString,
+                "pane_ref": v2Ref(kind: .pane, uuid: paneId.id),
+                "surface_id": v2OrNull(selectedSurfaceId?.uuidString),
+                "surface_ref": v2Ref(kind: .surface, uuid: selectedSurfaceId),
+                "zoomed": zoomedPaneId == paneId,
+                "zoomed_pane_id": v2OrNull(zoomedPaneId?.id.uuidString),
+                "zoomed_pane_ref": v2Ref(kind: .pane, uuid: zoomedPaneId?.id)
+            ])
         }
         return result
     }
@@ -6154,7 +6217,7 @@ class TerminalController {
             }
 
             if focus {
-                workspace.bonsplitController.focusPane(targetPane)
+                _ = workspace.focusPane(targetPane, reason: "socket.pane.swap")
             }
             let windowId = located.windowId
             result = .ok([
@@ -6312,7 +6375,10 @@ class TerminalController {
                 return
             }
 
-            ws.bonsplitController.focusPane(target)
+            guard ws.focusPane(target, reason: "socket.pane.last") else {
+                result = .err(code: "internal_error", message: "Failed to focus pane", data: ["pane_id": target.id.uuidString])
+                return
+            }
             let selectedSurfaceId = ws.bonsplitController.selectedTab(inPane: target).flatMap { ws.panelIdFromSurfaceId($0.id) }
             let windowId = v2ResolveWindowId(tabManager: tabManager)
             result = .ok([
@@ -13745,10 +13811,10 @@ class TerminalController {
             // Try UUID first, then fall back to index
             if let uuid = UUID(uuidString: paneArg),
                let paneId = paneIds.first(where: { $0.id == uuid }) {
-                tab.bonsplitController.focusPane(paneId)
+                _ = tab.focusPane(paneId, reason: "socket.focusPane")
                 result = "OK"
             } else if let index = Int(paneArg), index >= 0, index < paneIds.count {
-                tab.bonsplitController.focusPane(paneIds[index])
+                _ = tab.focusPane(paneIds[index], reason: "socket.focusPane")
                 result = "OK"
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5202,6 +5202,56 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitController.selectedTab(inPane: paneId).flatMap { panelIdFromSurfaceId($0.id) }
     }
 
+    @discardableResult
+    private func exitSplitZoomIfNeeded(
+        whenFocusing targetPaneId: PaneID,
+        reason: String,
+        browserPanelId: UUID? = nil
+    ) -> Bool {
+        guard let zoomedPaneId = bonsplitController.zoomedPaneId,
+              zoomedPaneId != targetPaneId,
+              bonsplitController.clearPaneZoom() else {
+            return false
+        }
+
+        reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+        reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: reason)
+
+        if let browserPanelId,
+           let browserPanel = browserPanel(for: browserPanelId) {
+            browserPanel.preparePortalHostReplacementForNextDistinctClaim(
+                inPane: targetPaneId,
+                reason: reason
+            )
+        }
+
+        beginEventDrivenLayoutFollowUp(
+            reason: reason,
+            browserPanelId: browserPanelId,
+            includeGeometry: true
+        )
+        return true
+    }
+
+    @discardableResult
+    func focusPane(
+        _ paneId: PaneID,
+        reason: String = "workspace.focusPane"
+    ) -> Bool {
+        guard bonsplitController.allPaneIds.contains(paneId) else { return false }
+
+        let browserPanelId = effectiveSelectedPanelId(inPane: paneId).flatMap { panelId in
+            browserPanel(for: panelId) != nil ? panelId : nil
+        }
+        _ = exitSplitZoomIfNeeded(
+            whenFocusing: paneId,
+            reason: reason,
+            browserPanelId: browserPanelId
+        )
+        bonsplitController.focusPane(paneId)
+        return true
+    }
+
     enum FocusPanelTrigger {
         case standard
         case terminalFirstResponder
@@ -8172,6 +8222,12 @@ final class Workspace: Identifiable, ObservableObject {
 #endif
 
         if let targetPaneId, !selectionAlreadyConverged {
+            let browserPanelId = panels[panelId] is BrowserPanel ? panelId : nil
+            _ = exitSplitZoomIfNeeded(
+                whenFocusing: targetPaneId,
+                reason: "workspace.focusPanel",
+                browserPanelId: browserPanelId
+            )
 #if DEBUG
             dlog(
                 "focus.panel.focusPane workspace=\(id.uuidString.prefix(5)) " +
@@ -8250,6 +8306,11 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func moveFocus(direction: NavigationDirection) {
+        guard let currentPaneId = bonsplitController.focusedPaneId,
+              let targetPaneId = bonsplitController.adjacentPane(to: currentPaneId, direction: direction) else {
+            return
+        }
+
         let previousFocusedPanelId = focusedPanelId
 
         // Unfocus the currently-focused panel before navigating.
@@ -8257,7 +8318,15 @@ final class Workspace: Identifiable, ObservableObject {
             prev.unfocus()
         }
 
-        bonsplitController.navigateFocus(direction: direction)
+        let browserPanelId = effectiveSelectedPanelId(inPane: targetPaneId).flatMap { panelId in
+            browserPanel(for: panelId) != nil ? panelId : nil
+        }
+        _ = exitSplitZoomIfNeeded(
+            whenFocusing: targetPaneId,
+            reason: "workspace.moveFocus",
+            browserPanelId: browserPanelId
+        )
+        bonsplitController.focusPane(targetPaneId)
 
         // Always reconcile selection/focus after navigation so AppKit first-responder and
         // bonsplit's focused pane stay aligned, even through split tree mutations.
@@ -8327,14 +8396,39 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
+    func toggleSplitZoom(inPane paneId: PaneID) -> Bool {
+        toggleSplitZoom(
+            inPane: paneId,
+            preferredFocusPanelId: effectiveSelectedPanelId(inPane: paneId)
+        )
+    }
+
+    @discardableResult
     func toggleSplitZoom(panelId: UUID) -> Bool {
-        let wasSplitZoomed = bonsplitController.isSplitZoomed
         guard let paneId = paneId(forPanelId: panelId) else { return false }
+        return toggleSplitZoom(inPane: paneId, preferredFocusPanelId: panelId)
+    }
+
+    @discardableResult
+    private func toggleSplitZoom(
+        inPane paneId: PaneID,
+        preferredFocusPanelId: UUID?
+    ) -> Bool {
+        let wasSplitZoomed = bonsplitController.isSplitZoomed
         guard bonsplitController.togglePaneZoom(inPane: paneId) else { return false }
-        focusPanel(panelId)
+        let focusPanelId = preferredFocusPanelId ?? effectiveSelectedPanelId(inPane: paneId)
+        if let focusPanelId {
+            focusPanel(focusPanelId)
+        } else {
+            bonsplitController.focusPane(paneId)
+        }
         reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
         reconcileBrowserPortalVisibilityForCurrentRenderedLayout(reason: "workspace.toggleSplitZoom")
-        if let browserPanel = browserPanel(for: panelId) {
+        let browserPanelId = focusPanelId.flatMap { panelId in
+            browserPanel(for: panelId) != nil ? panelId : nil
+        }
+        if let browserPanelId,
+           let browserPanel = browserPanel(for: browserPanelId) {
             browserPanel.preparePortalHostReplacementForNextDistinctClaim(
                 inPane: paneId,
                 reason: "workspace.toggleSplitZoom"
@@ -8342,8 +8436,8 @@ final class Workspace: Identifiable, ObservableObject {
         }
         beginEventDrivenLayoutFollowUp(
             reason: "workspace.toggleSplitZoom",
-            browserPanelId: browserPanel(for: panelId) != nil ? panelId : nil,
-            browserExitFocusPanelId: (wasSplitZoomed && !bonsplitController.isSplitZoomed) ? panelId : nil,
+            browserPanelId: browserPanelId,
+            browserExitFocusPanelId: (wasSplitZoomed && !bonsplitController.isSplitZoomed) ? browserPanelId : nil,
             includeGeometry: true
         )
         return true

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -844,6 +844,32 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertEqual(workspace.focusedPanelId, rightPanel.id, "Expected notification target panel to be focused")
     }
 
+    func testFocusPaneClearsSplitZoomBeforeFocusingTargetPane() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let leftPanelId = workspace.focusedPanelId,
+              let rightPanel = workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal),
+              let rightPaneId = workspace.paneId(forPanelId: rightPanel.id) else {
+            XCTFail("Expected split setup to succeed")
+            return
+        }
+
+        workspace.focusPanel(leftPanelId)
+        XCTAssertTrue(workspace.toggleSplitZoom(panelId: leftPanelId), "Expected split zoom to enable")
+        XCTAssertTrue(workspace.bonsplitController.isSplitZoomed, "Expected workspace to start zoomed")
+
+        XCTAssertTrue(workspace.focusPane(rightPaneId, reason: "test.focusPane"))
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertFalse(
+            workspace.bonsplitController.isSplitZoomed,
+            "Expected pane focus to exit split zoom so the target pane becomes visible"
+        )
+        XCTAssertEqual(workspace.bonsplitController.focusedPaneId, rightPaneId, "Expected target pane to be focused")
+        XCTAssertEqual(workspace.focusedPanelId, rightPanel.id, "Expected target pane's panel to be focused")
+    }
+
     func testFocusTabFromNotificationReturnsFalseForMissingPanel() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace else {

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -67,6 +67,7 @@ var commands = []commandSpec{
 	{name: "focus-panel", proto: protoV2, v2Method: "surface.focus", flagKeys: []string{"panel", "workspace"}, paramKeyOverrides: map[string]string{"panel": "surface_id"}},
 	{name: "list-panes", proto: protoV2, v2Method: "pane.list", flagKeys: []string{"workspace"}},
 	{name: "list-pane-surfaces", proto: protoV2, v2Method: "pane.surfaces", flagKeys: []string{"pane"}},
+	{name: "zoom-pane", proto: protoV2, v2Method: "pane.zoom", flagKeys: []string{"workspace", "pane"}},
 	{name: "new-pane", proto: protoV2, v2Method: "pane.create", flagKeys: []string{"workspace", "direction", "type", "url"}, defaultParams: map[string]any{"direction": "right"}},
 	{name: "new-surface", proto: protoV2, v2Method: "surface.create", flagKeys: []string{"workspace", "pane", "type", "url"}},
 	{name: "new-split", proto: protoV2, v2Method: "surface.split", flagKeys: []string{"surface", "direction"}},
@@ -747,6 +748,7 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  new-workspace             Create a new workspace")
 	fmt.Fprintln(os.Stderr, "  new-surface               Create a new surface")
 	fmt.Fprintln(os.Stderr, "  new-split                 Split an existing surface")
+	fmt.Fprintln(os.Stderr, "  zoom-pane                 Toggle pane zoom")
 	fmt.Fprintln(os.Stderr, "  close-surface             Close a surface")
 	fmt.Fprintln(os.Stderr, "  close-workspace           Close a workspace")
 	fmt.Fprintln(os.Stderr, "  select-workspace          Select a workspace")

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -754,6 +754,30 @@ func TestCLIFocusPanelUsesSurfaceFocus(t *testing.T) {
 	}
 }
 
+func TestCLIZoomPaneUsesPaneZoom(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "zoom-pane", "--workspace", "ws-1", "--pane", "pane-2"})
+	if code != 0 {
+		t.Fatalf("zoom-pane should return 0, got %d", code)
+	}
+
+	select {
+	case req := <-requests:
+		if got := req["method"]; got != "pane.zoom" {
+			t.Fatalf("expected pane.zoom, got %v", got)
+		}
+		params, _ := req["params"].(map[string]any)
+		if got := params["workspace_id"]; got != "ws-1" {
+			t.Fatalf("expected workspace_id ws-1, got %v", got)
+		}
+		if got := params["pane_id"]; got != "pane-2" {
+			t.Fatalf("expected pane_id pane-2, got %v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for zoom-pane request")
+	}
+}
+
 func TestCLIBrowserOpenUsesOpenSplitAndWorkspaceEnv(t *testing.T) {
 	sockPath, requests := startMockV2SocketWithRequestCapture(t)
 	t.Setenv("CMUX_WORKSPACE_ID", "env-ws")


### PR DESCRIPTION
## Summary

- add a pane-scoped zoom/maximize flow with a new `pane.zoom` RPC and `cmux zoom-pane`
- exit split zoom when focus moves to another pane, including pane focus commands and pane navigation
- expose zoom state in `pane.list` / `cmux list-panes` and add regression coverage for focus-unzooms and CLI mapping

## Testing

- `go test ./cmd/cmuxd-remote -run 'TestCLI(NewPaneDefaultsDirectionAndForwardsExtraFlags|FocusPanelUsesSurfaceFocus|ZoomPaneUsesPaneZoom)$'`
- added/updated regression coverage in `cmuxTests/TabManagerUnitTests.swift` and `daemon/remote/cmd/cmuxd-remote/cli_test.go`
- manual GUI verification not run for this PR

## Demo Video

- Not included. This change was prepared without running the GUI app.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

Closes #937
Closes #1605
Closes #1594
Closes #1085


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pane zoom/maximize with a new `pane.zoom` RPC and `cmux zoom-pane` command. Zoom automatically clears when focus moves to another pane, and zoom state is shown in `pane.list` and `cmux list-panes`.

- **New Features**
  - Added `pane.zoom` RPC and `cmux zoom-pane` CLI; mapped in `cmuxd-remote`.
  - Focus-unzoom: leaving a zoomed pane via focus commands or navigation exits zoom.
  - `pane.list` now includes per-pane `zoomed` and workspace `zoomed_pane_*`; `cmux list-panes` tags zoomed panes.
  - Introduced `Workspace.focusPane` to centralize focus + unzoom; navigation uses it.
  - `cmux focus-pane` now accepts a positional pane argument.
  - Added tests for CLI mapping and focus-unzoom behavior.

Closes #937, #1605, #1594, #1085.

<sup>Written for commit 9b988c342b10b865e9a220f3de046c7def6d7542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `zoom-pane` command to toggle pane zoom state, supporting targeted pane selection via `--pane` flag or positional argument with optional `--workspace` parameter
  * Enhanced `list-panes` output to display pane zoom status alongside focus state indicators

* **Improvements**
  * Improved `focus-pane` argument fallback behavior for positional argument handling
  * Enhanced focus management when interacting with zoomed panes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->