### PR TITLE
feat: save and restore named workspace sessions

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1499,7 +1499,7 @@ struct CMUXCLI {
         let idFormat = try resolvedIDFormat(jsonOutput: jsonOutput, raw: idFormatArg)
 
         // If the user explicitly targets a window, focus it first so commands route correctly.
-        if let windowId {
+        if let windowId, command != "session" {
             let normalizedWindow = try normalizeWindowHandle(windowId, client: client) ?? windowId
             _ = try client.sendV2(method: "window.focus", params: ["window_id": normalizedWindow])
         }
@@ -2253,6 +2253,14 @@ struct CMUXCLI {
         case "simulate-app-active":
             let response = try sendV1Command("simulate_app_active", client: client)
             print(response)
+
+        case "session":
+            try runSessionCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                windowOverride: windowId
+            )
 
         case "__tmux-compat":
             try runClaudeTeamsTmuxCompat(
@@ -5971,6 +5979,138 @@ struct CMUXCLI {
         throw CLIError(message: "Unable to resolve surface ID")
     }
 
+    private func runSessionCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        windowOverride: String?
+    ) throws {
+        let subcommand = commandArgs.first?.lowercased() ?? "help"
+
+        switch subcommand {
+        case "save":
+            let name = try requiredSessionName(
+                Array(commandArgs.dropFirst()),
+                subcommand: "save"
+            )
+            var params: [String: Any] = ["name": name]
+            if let windowOverride {
+                let normalizedWindow = try normalizeWindowHandle(windowOverride, client: client) ?? windowOverride
+                params["window_id"] = normalizedWindow
+            }
+
+            let payload = try client.sendV2(method: "session.save", params: params)
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                let count = intFromAny(payload["workspace_count"]) ?? 0
+                print("Saved session '\(name)' (\(count) workspace\(count == 1 ? "" : "s"))")
+            }
+
+        case "restore":
+            let name = try requiredSessionName(
+                Array(commandArgs.dropFirst()),
+                subcommand: "restore"
+            )
+            var params: [String: Any] = ["name": name]
+            if let windowOverride {
+                let normalizedWindow = try normalizeWindowHandle(windowOverride, client: client) ?? windowOverride
+                params["window_id"] = normalizedWindow
+            }
+
+            let payload = try client.sendV2(method: "session.restore", params: params)
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                let count = intFromAny(payload["workspace_count"]) ?? 0
+                print("Restored session '\(name)' (\(count) workspace\(count == 1 ? "" : "s"))")
+            }
+
+        case "list":
+            let payload = try client.sendV2(method: "session.list")
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                let sessions = payload["sessions"] as? [[String: Any]] ?? []
+                printSessionList(sessions)
+            }
+
+        case "delete":
+            let name = try requiredSessionName(
+                Array(commandArgs.dropFirst()),
+                subcommand: "delete"
+            )
+            let payload = try client.sendV2(method: "session.delete", params: ["name": name])
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                print("Deleted session '\(name)'")
+            }
+
+        case "help", "--help", "-h":
+            if let text = subcommandUsage("session") {
+                print("cmux session")
+                print("")
+                print(text)
+            } else {
+                print(usage())
+            }
+
+        default:
+            throw CLIError(message: "Unknown session subcommand '\(subcommand)'. Run 'cmux session --help'.")
+        }
+    }
+
+    private func requiredSessionName(
+        _ args: [String],
+        subcommand: String
+    ) throws -> String {
+        let tokens = args.first == "--" ? Array(args.dropFirst()) : args
+        let rawName = tokens.joined(separator: " ")
+        guard let name = normalizedSessionName(rawName) else {
+            throw CLIError(message: "session \(subcommand) requires a valid <name>")
+        }
+        return name
+    }
+
+    private func normalizedSessionName(_ rawName: String) -> String? {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed != ".", trimmed != ".." else { return nil }
+
+        let invalidCharacters = CharacterSet(charactersIn: "/:\u{0000}")
+            .union(.newlines)
+            .union(.controlCharacters)
+        guard trimmed.rangeOfCharacter(from: invalidCharacters) == nil else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private func printSessionList(_ sessions: [[String: Any]]) {
+        guard !sessions.isEmpty else {
+            print("No saved sessions")
+            return
+        }
+
+        for session in sessions {
+            let name = (session["name"] as? String) ?? ""
+            let count = intFromAny(session["workspace_count"]) ?? 0
+            let savedAtText: String = {
+                guard let savedAt = doubleFromAny(session["saved_at"]) else { return "" }
+                return sessionTimestampText(savedAt)
+            }()
+            let savedAtSuffix = savedAtText.isEmpty ? "" : "  \(savedAtText)"
+            print("\(name)  [\(count) workspace\(count == 1 ? "" : "s")]\(savedAtSuffix)")
+        }
+    }
+
+    private func sessionTimestampText(_ timestamp: Double) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+
     /// Return the help/usage text for a subcommand, or nil if the command is unknown.
     private func subcommandUsage(_ command: String) -> String? {
         switch command {
@@ -6301,6 +6441,28 @@ struct CMUXCLI {
               cmux new-workspace
               cmux new-workspace --cwd ~/projects/myapp
               cmux new-workspace --cwd . --command "npm test"
+            """
+        case "session":
+            return """
+            Usage: cmux session save <name>
+                   cmux session restore <name>
+                   cmux session list
+                   cmux session delete <name>
+
+            Save and restore named workspace sets for the current window.
+            Sessions are stored in ~/Library/Application Support/cmux/sessions/.
+
+            Subcommands:
+              save <name>      Capture the current window's workspaces, CWDs, and split layouts
+              restore <name>   Replace the current window's workspaces with the saved session
+              list             List saved sessions
+              delete <name>    Delete a saved session
+
+            Examples:
+              cmux session save my-project
+              cmux session restore my-project
+              cmux session list
+              cmux session delete my-project
             """
         case "list-workspaces":
             return """
@@ -11378,6 +11540,7 @@ struct CMUXCLI {
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <#hex|name>]
           list-workspaces
           new-workspace [--cwd <path>] [--command <text>]
+          session <save|restore|list|delete> [name]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -360,6 +360,190 @@ struct AppSessionSnapshot: Codable, Sendable {
     var windows: [SessionWindowSnapshot]
 }
 
+enum NamedWorkspaceSessionSchema {
+    static let currentVersion = 1
+}
+
+struct NamedWorkspaceSessionRecord: Codable, Sendable {
+    var version: Int
+    var name: String
+    var savedAt: TimeInterval
+    var tabManager: SessionTabManagerSnapshot
+}
+
+struct NamedWorkspaceSessionListEntry: Sendable, Equatable {
+    var name: String
+    var savedAt: TimeInterval
+    var workspaceCount: Int
+    var fileURL: URL
+}
+
+enum NamedWorkspaceSessionStore {
+    enum DeleteResult: Equatable {
+        case deleted
+        case notFound
+        case failed
+    }
+
+    static func load(
+        named name: String,
+        appSupportDirectory: URL? = nil
+    ) -> NamedWorkspaceSessionRecord? {
+        guard let fileURL = fileURL(forSessionNamed: name, appSupportDirectory: appSupportDirectory) else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        guard let record = try? decoder.decode(NamedWorkspaceSessionRecord.self, from: data) else {
+            return nil
+        }
+        guard record.version == NamedWorkspaceSessionSchema.currentVersion else { return nil }
+        guard normalizedSessionName(record.name) != nil else { return nil }
+        return record
+    }
+
+    @discardableResult
+    static func save(
+        _ record: NamedWorkspaceSessionRecord,
+        appSupportDirectory: URL? = nil
+    ) -> Bool {
+        guard normalizedSessionName(record.name) != nil else { return false }
+        guard record.version == NamedWorkspaceSessionSchema.currentVersion else { return false }
+        guard let fileURL = fileURL(forSessionNamed: record.name, appSupportDirectory: appSupportDirectory) else {
+            return false
+        }
+
+        let directory = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+            let data = try encodedRecordData(record)
+            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+                return true
+            }
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func list(
+        appSupportDirectory: URL? = nil
+    ) -> [NamedWorkspaceSessionListEntry] {
+        guard let directoryURL = sessionsDirectoryURL(appSupportDirectory: appSupportDirectory) else {
+            return []
+        }
+        guard let fileURLs = try? FileManager.default.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return fileURLs
+            .filter { $0.pathExtension == "json" }
+            .compactMap { fileURL in
+                guard let record = loadRecord(from: fileURL) else { return nil }
+                return NamedWorkspaceSessionListEntry(
+                    name: record.name,
+                    savedAt: record.savedAt,
+                    workspaceCount: record.tabManager.workspaces.count,
+                    fileURL: fileURL
+                )
+            }
+            .sorted { lhs, rhs in
+                let lhsName = lhs.name.localizedLowercase
+                let rhsName = rhs.name.localizedLowercase
+                if lhsName != rhsName {
+                    return lhsName < rhsName
+                }
+                return lhs.savedAt > rhs.savedAt
+            }
+    }
+
+    static func delete(
+        named name: String,
+        appSupportDirectory: URL? = nil
+    ) -> DeleteResult {
+        guard let fileURL = fileURL(forSessionNamed: name, appSupportDirectory: appSupportDirectory) else {
+            return .failed
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .notFound
+        }
+
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            return .deleted
+        } catch {
+            return .failed
+        }
+    }
+
+    static func sessionsDirectoryURL(
+        appSupportDirectory: URL? = nil
+    ) -> URL? {
+        let resolvedAppSupport: URL
+        if let appSupportDirectory {
+            resolvedAppSupport = appSupportDirectory
+        } else if let discovered = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            resolvedAppSupport = discovered
+        } else {
+            return nil
+        }
+
+        return resolvedAppSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    static func fileURL(
+        forSessionNamed name: String,
+        appSupportDirectory: URL? = nil
+    ) -> URL? {
+        guard let normalizedName = normalizedSessionName(name) else { return nil }
+        guard let encodedName = encodedSessionFilenameComponent(for: normalizedName) else { return nil }
+        return sessionsDirectoryURL(appSupportDirectory: appSupportDirectory)?
+            .appendingPathComponent(encodedName, isDirectory: false)
+            .appendingPathExtension("json")
+    }
+
+    static func normalizedSessionName(_ rawName: String) -> String? {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard trimmed != ".", trimmed != ".." else { return nil }
+
+        let invalidCharacters = CharacterSet(charactersIn: "/:\u{0000}")
+            .union(.newlines)
+            .union(.controlCharacters)
+        guard trimmed.rangeOfCharacter(from: invalidCharacters) == nil else { return nil }
+        return trimmed
+    }
+
+    private static func loadRecord(from fileURL: URL) -> NamedWorkspaceSessionRecord? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        guard let record = try? decoder.decode(NamedWorkspaceSessionRecord.self, from: data) else {
+            return nil
+        }
+        guard record.version == NamedWorkspaceSessionSchema.currentVersion else { return nil }
+        guard normalizedSessionName(record.name) != nil else { return nil }
+        return record
+    }
+
+    private static func encodedRecordData(_ record: NamedWorkspaceSessionRecord) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(record)
+    }
+
+    private static func encodedSessionFilenameComponent(for name: String) -> String? {
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._"))
+        return name.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
+    }
+}
+
 enum SessionPersistenceStore {
     static func load(fileURL: URL? = nil) -> AppSessionSnapshot? {
         guard let fileURL = fileURL ?? defaultSnapshotFileURL() else { return nil }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2084,6 +2084,16 @@ class TerminalController {
         case "workspace.remote.terminal_session_end":
             return v2Result(id: id, self.v2WorkspaceRemoteTerminalSessionEnd(params: params))
 
+        // Named sessions
+        case "session.save":
+            return v2Result(id: id, self.v2SessionSave(params: params))
+        case "session.restore":
+            return v2Result(id: id, self.v2SessionRestore(params: params))
+        case "session.list":
+            return v2Result(id: id, self.v2SessionList(params: params))
+        case "session.delete":
+            return v2Result(id: id, self.v2SessionDelete(params: params))
+
         // Settings
         case "settings.open":
             return v2Result(id: id, self.v2SettingsOpen(params: params))
@@ -2450,6 +2460,10 @@ class TerminalController {
             "workspace.remote.disconnect",
             "workspace.remote.status",
             "workspace.remote.terminal_session_end",
+            "session.save",
+            "session.restore",
+            "session.list",
+            "session.delete",
             "settings.open",
             "feedback.open",
             "feedback.submit",
@@ -3943,6 +3957,113 @@ class TerminalController {
         }
 
         return result
+    }
+
+    // MARK: - V2 Named Session Methods
+
+    private func v2SessionSave(params: [String: Any]) -> V2CallResult {
+        guard let rawName = v2String(params, "name"),
+              let name = NamedWorkspaceSessionStore.normalizedSessionName(rawName) else {
+            return .err(code: "invalid_params", message: "Missing or invalid session name", data: nil)
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var snapshot: SessionTabManagerSnapshot?
+        v2MainSync {
+            snapshot = tabManager.sessionSnapshot(includeScrollback: false)
+        }
+        guard let snapshot else {
+            return .err(code: "internal_error", message: "Failed to capture session snapshot", data: [
+                "name": name
+            ])
+        }
+
+        let record = NamedWorkspaceSessionRecord(
+            version: NamedWorkspaceSessionSchema.currentVersion,
+            name: name,
+            savedAt: Date().timeIntervalSince1970,
+            tabManager: snapshot
+        )
+        guard NamedWorkspaceSessionStore.save(record) else {
+            return .err(code: "internal_error", message: "Failed to save session", data: [
+                "name": name
+            ])
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        let fileURL = NamedWorkspaceSessionStore.fileURL(forSessionNamed: name)
+        return .ok([
+            "name": name,
+            "saved_at": record.savedAt,
+            "workspace_count": snapshot.workspaces.count,
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "file_path": v2OrNull(fileURL?.path)
+        ])
+    }
+
+    private func v2SessionRestore(params: [String: Any]) -> V2CallResult {
+        guard let rawName = v2String(params, "name"),
+              let name = NamedWorkspaceSessionStore.normalizedSessionName(rawName) else {
+            return .err(code: "invalid_params", message: "Missing or invalid session name", data: nil)
+        }
+        guard let record = NamedWorkspaceSessionStore.load(named: name) else {
+            return .err(code: "not_found", message: "Saved session not found", data: [
+                "name": name
+            ])
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        v2MainSync {
+            tabManager.restoreSessionSnapshot(record.tabManager)
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "name": record.name,
+            "saved_at": record.savedAt,
+            "workspace_count": record.tabManager.workspaces.count,
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId)
+        ])
+    }
+
+    private func v2SessionList(params _: [String: Any]) -> V2CallResult {
+        let sessions = NamedWorkspaceSessionStore.list().map { entry in
+            [
+                "name": entry.name,
+                "saved_at": entry.savedAt,
+                "workspace_count": entry.workspaceCount,
+                "file_path": entry.fileURL.path
+            ]
+        }
+        return .ok([
+            "sessions": sessions
+        ])
+    }
+
+    private func v2SessionDelete(params: [String: Any]) -> V2CallResult {
+        guard let rawName = v2String(params, "name"),
+              let name = NamedWorkspaceSessionStore.normalizedSessionName(rawName) else {
+            return .err(code: "invalid_params", message: "Missing or invalid session name", data: nil)
+        }
+
+        switch NamedWorkspaceSessionStore.delete(named: name) {
+        case .deleted:
+            return .ok(["name": name])
+        case .notFound:
+            return .err(code: "not_found", message: "Saved session not found", data: [
+                "name": name
+            ])
+        case .failed:
+            return .err(code: "internal_error", message: "Failed to delete session", data: [
+                "name": name
+            ])
+        }
     }
 
     private func v2WorkspaceAction(params: [String: Any]) -> V2CallResult {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -148,6 +148,82 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(path?.path.contains("com.example_unsafe_id") == true)
     }
 
+    func testNamedWorkspaceSessionStoreRoundTripListAndDelete() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-named-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let workspace = SessionWorkspaceSnapshot(
+            processTitle: "Terminal",
+            customTitle: "Docs",
+            customColor: nil,
+            isPinned: false,
+            currentDirectory: "/tmp/project",
+            focusedPanelId: nil,
+            layout: .pane(SessionPaneLayoutSnapshot(panelIds: [], selectedPanelId: nil)),
+            panels: [],
+            statusEntries: [],
+            logEntries: [],
+            progress: nil,
+            gitBranch: nil
+        )
+        let record = NamedWorkspaceSessionRecord(
+            version: NamedWorkspaceSessionSchema.currentVersion,
+            name: "project alpha",
+            savedAt: 1_711_111_111,
+            tabManager: SessionTabManagerSnapshot(
+                selectedWorkspaceIndex: 0,
+                workspaces: [workspace]
+            )
+        )
+
+        XCTAssertTrue(NamedWorkspaceSessionStore.save(record, appSupportDirectory: tempDir))
+
+        let loaded = NamedWorkspaceSessionStore.load(
+            named: "project alpha",
+            appSupportDirectory: tempDir
+        )
+        XCTAssertEqual(loaded?.name, "project alpha")
+        XCTAssertEqual(loaded?.savedAt, record.savedAt)
+        XCTAssertEqual(loaded?.tabManager.workspaces.count, 1)
+        XCTAssertEqual(loaded?.tabManager.workspaces.first?.currentDirectory, "/tmp/project")
+
+        let entries = NamedWorkspaceSessionStore.list(appSupportDirectory: tempDir)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.name, "project alpha")
+        XCTAssertEqual(entries.first?.workspaceCount, 1)
+        XCTAssertTrue(entries.first?.fileURL.path.contains("/cmux/sessions/") == true)
+
+        XCTAssertEqual(
+            NamedWorkspaceSessionStore.delete(named: "project alpha", appSupportDirectory: tempDir),
+            .deleted
+        )
+        XCTAssertNil(
+            NamedWorkspaceSessionStore.load(named: "project alpha", appSupportDirectory: tempDir)
+        )
+    }
+
+    func testNamedWorkspaceSessionStoreRejectsInvalidNames() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-named-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let record = NamedWorkspaceSessionRecord(
+            version: NamedWorkspaceSessionSchema.currentVersion,
+            name: "../nope",
+            savedAt: 1,
+            tabManager: SessionTabManagerSnapshot(selectedWorkspaceIndex: nil, workspaces: [])
+        )
+
+        XCTAssertFalse(NamedWorkspaceSessionStore.save(record, appSupportDirectory: tempDir))
+        XCTAssertEqual(
+            NamedWorkspaceSessionStore.delete(named: "../nope", appSupportDirectory: tempDir),
+            .failed
+        )
+    }
+
     func testRestorePolicySkipsWhenLaunchHasExplicitArguments() {
         let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
             arguments: ["/Applications/cmux.app/Contents/MacOS/cmux", "--window", "window:1"],


### PR DESCRIPTION
## Summary
- add a durable named workspace session store under `~/Library/Application Support/cmux/sessions/`
- add `cmux session save <name>`, `restore <name>`, `list`, and `delete <name>`
- restore saved sessions through the existing `TabManager` snapshot path so CWDs and split layouts come back with the targeted/current window

## Notes
- sessions are window-scoped: save captures the targeted/current window's workspace set, and restore replaces that window's workspace set
- closes #2086
- related to #480 and #2072

## Verification
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-cli -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-2086-cli-rebase build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-2086-app-rebase build`
- `/tmp/cmux-issue-2086-cli-rebase/Build/Products/Debug/cmux session --help`

## Constraints
- did not run `xcodebuild test` because this repo's local test scheme launches the app host, and this task explicitly disallowed GUI/app launches


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add named workspace sessions that you can save, list, restore, and delete. Sessions persist to disk and bring back the current window’s workspaces, CWDs, and split layouts.

- **New Features**
  - CLI: `cmux session save <name>`, `restore <name>`, `list`, `delete <name>`; supports `--window` targeting and JSON output.
  - Persistent JSON store at `~/Library/Application Support/cmux/sessions/` with safe name validation and percent-encoded filenames.
  - Window-scoped restore via `TabManager` snapshots; replaces the targeted window’s workspace set.
  - New V2 RPCs: `session.save`, `session.restore`, `session.list`, `session.delete`.
  - Closes #2086.

<sup>Written for commit fc9cb4420ea595ca0429fe52a85f229f02f335d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `session` command with `save`, `restore`, `list`, and `delete` subcommands for managing named workspace sessions.
  * Session management now includes metadata such as saved timestamps and workspace counts.

* **Bug Fixes**
  * Updated window focus behavior: `--window` flag no longer forces focus when using session commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->