### PR TITLE
Reduce shell integration prompt latency

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -11,7 +11,7 @@ _cmux_detect_send_tool() {
         _CMUX_SEND_TOOL=nc
     fi
 }
-_cmux_detect_send_tool
+# Detection deferred to after _cmux_fix_path (end of file).
 
 _cmux_send() {
     local payload="$1"
@@ -280,9 +280,8 @@ _cmux_clear_pr_for_panel() {
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    {
-        _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    # Synchronous: must arrive before the next report_pr from the poll loop.
+    _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
 _cmux_pr_output_indicates_no_pull_request() {
@@ -456,9 +455,10 @@ _cmux_run_pr_probe_with_timeout() {
 
 _cmux_stop_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        # Direct kill avoids the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-        # Orphaned children (gh, sleep) finish on their own within seconds.
-        kill -KILL "$_CMUX_PR_POLL_PID" 2>/dev/null || true
+        # Process-group kill: background jobs are process-group leaders, so
+        # negative PID kills the loop + all descendants (gh, sleep) without
+        # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
+        kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
         _CMUX_PR_POLL_PID=""
     fi
 }
@@ -712,5 +712,7 @@ _cmux_fix_path() {
 }
 _cmux_fix_path
 unset -f _cmux_fix_path
+
+_cmux_detect_send_tool
 
 _cmux_install_prompt_command

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -579,9 +579,10 @@ _cmux_run_pr_probe_with_timeout() {
 
 _cmux_stop_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        # Direct kill avoids the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-        # Orphaned children (gh, sleep) finish on their own within seconds.
-        kill -KILL "$_CMUX_PR_POLL_PID" 2>/dev/null || true
+        # Process-group kill: background jobs are process-group leaders, so
+        # negative PID kills the loop + all descendants (gh, sleep) without
+        # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
+        kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
         _CMUX_PR_POLL_PID=""
     fi
 }


### PR DESCRIPTION
## Summary

- Use `zsh/net/unix` (zsocket) for socket sends, eliminating fork+exec of ncat/socat/nc per telemetry send (~3ms each, 3-4 per prompt cycle)
- Replace `_cmux_kill_process_tree` (synchronous `/bin/ps -ax | awk`) with direct `kill` in `_cmux_stop_pr_poll_loop`, removing ~5-13ms of synchronous process enumeration per command
- Guard `_cmux_patch_ghostty_semantic_redraw` after first success, make `_cmux_clear_pr_for_panel` async, cache bash send tool choice at init

Estimated savings: ~10-15ms per prompt cycle on zsh with zsocket, ~5-13ms on bash (from tree-kill removal).

## Testing

- `zsh -n` and `bash -n` syntax checks pass
- zsocket path: connect, write, close per send (same semantics as ncat `--send-only`)
- Fallback path: unchanged behavior when `zsh/net/unix` unavailable
- Direct kill: orphaned `gh` / `sleep` processes self-terminate within seconds

## Related

- Task: shell integration hotpath causing slightly slower prompt than vanilla Ghostty

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce shell prompt latency by ~10–15ms on zsh and ~5–13ms on bash with faster socket sends, cheaper poll shutdown, and fewer forks. Addresses the shell integration hotpath performance task.

- **Refactors**
  - zsh: Use `zsh/net/unix` (`zsocket`) for socket sends with fallback; add `_cmux_send_bg` (sync with zsocket, bg otherwise).
  - bash: Cache send tool once after `_cmux_fix_path`; keep `_cmux_clear_pr_for_panel` synchronous to avoid races.
  - Replace `_cmux_kill_process_tree` with process-group SIGKILL (`kill -KILL -- -$PID`) in `_cmux_stop_pr_poll_loop`; guard `_cmux_patch_ghostty_semantic_redraw` to run once.

<sup>Written for commit 84ef9e52c7920d9a26ac8843169c690c1ac4b521. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized shell integration startup by implementing caching for transport tool selection, reducing repeated detection overhead
  * Improved process cleanup and resource management across bash and zsh through refined termination mechanisms
  * Enhanced communication efficiency in zsh with faster socket handling for background operations
  * Refined transport tool detection to ensure reliable compatibility across diverse system configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->