### PR TITLE
Validate workspace color during cmux.json decode

### DIFF
--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -95,6 +95,33 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
     var cwd: String?
     var color: String?
     var layout: CmuxLayoutNode?
+
+    init(name: String? = nil, cwd: String? = nil, color: String? = nil, layout: CmuxLayoutNode? = nil) {
+        self.name = name
+        self.cwd = cwd
+        self.color = color
+        self.layout = layout
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+        cwd = try container.decodeIfPresent(String.self, forKey: .cwd)
+        layout = try container.decodeIfPresent(CmuxLayoutNode.self, forKey: .layout)
+
+        if let rawColor = try container.decodeIfPresent(String.self, forKey: .color) {
+            guard let normalized = WorkspaceTabColorSettings.normalizedHex(rawColor) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .color,
+                    in: container,
+                    debugDescription: "Invalid color \"\(rawColor)\". Expected 6-digit hex format: #RRGGBB"
+                )
+            }
+            color = normalized
+        } else {
+            color = nil
+        }
+    }
 }
 
 indirect enum CmuxLayoutNode: Codable, Sendable {


### PR DESCRIPTION
## Summary

- Reject invalid `color` values in `CmuxWorkspaceDefinition` at decode time with a `DecodingError` explaining the expected `#RRGGBB` format
- Normalize accepted colors via `WorkspaceTabColorSettings.normalizedHex` during decode so downstream code always receives valid hex

## Testing

- Build verified locally
- Existing test with `"#FF5733"` continues to pass (valid hex)
- Invalid values like `"red"`, `"#GGG"`, `"#FF573"` now throw a decode error with a clear message

## Related

- Follow-up from https://github.com/manaflow-ai/cmux/pull/2011 (CodeRabbit review comment on workspace color validation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate and normalize workspace color during cmux.json decode. Invalid values now fail with a clear error, and accepted colors are standardized to #RRGGBB.

- **Bug Fixes**
  - Throw a decode error when `color` is not in `#RRGGBB` format with a helpful message.
  - Normalize valid `color` values via `WorkspaceTabColorSettings.normalizedHex` for consistent downstream use.

<sup>Written for commit e751231e63bfb0d766cf8f0b48179e34847a4e97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

