### PR TITLE
Fix #2071: respect default editor for Ghostty settings

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8,6 +8,7 @@ import Darwin
 import Sentry
 import Bonsplit
 import IOSurface
+import CoreServices
 import UniformTypeIdentifiers
 
 #if os(macOS)
@@ -1768,14 +1769,35 @@ class GhosttyApp {
         reloadConfiguration(source: "appearanceSync:\(source)")
     }
 
-    func openConfigurationInTextEdit() {
+    static func preferredConfigurationEditorApplicationURL(
+        for fileURL: URL,
+        defaultApplicationURLForExtension: (String) -> URL? = {
+            NSWorkspace.shared.cmuxDefaultApplicationURL(forExtension: $0)
+        },
+        defaultTextEditorURL: () -> URL? = {
+            NSWorkspace.shared.cmuxDefaultTextEditor
+        }
+    ) -> URL? {
+        let pathExtension = fileURL.pathExtension
+        if !pathExtension.isEmpty,
+           let editorURL = defaultApplicationURLForExtension(pathExtension) {
+            return editorURL
+        }
+
+        return defaultTextEditorURL()
+    }
+
+    func openConfigurationInPreferredEditor() {
         #if os(macOS)
         let path = ghosttyStringValue(ghostty_config_open_path())
         guard !path.isEmpty else { return }
         let fileURL = URL(fileURLWithPath: path)
-        let editorURL = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
-        let configuration = NSWorkspace.OpenConfiguration()
-        NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: configuration)
+        if let editorURL = Self.preferredConfigurationEditorApplicationURL(for: fileURL) {
+            let configuration = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: configuration)
+        } else {
+            NSWorkspace.shared.open(fileURL)
+        }
         #endif
     }
 
@@ -2613,6 +2635,25 @@ class GhosttyApp {
                 try? handle.write(contentsOf: data)
             }
         }
+    }
+}
+
+private extension NSWorkspace {
+    var cmuxDefaultTextEditor: URL? {
+        cmuxDefaultApplicationURL(forContentType: UTType.plainText.identifier)
+    }
+
+    func cmuxDefaultApplicationURL(forContentType contentType: String) -> URL? {
+        LSCopyDefaultApplicationURLForContentType(
+            contentType as CFString,
+            .all,
+            nil
+        )?.takeRetainedValue() as? URL
+    }
+
+    func cmuxDefaultApplicationURL(forExtension ext: String) -> URL? {
+        guard let contentType = UTType(filenameExtension: ext) else { return nil }
+        return cmuxDefaultApplicationURL(forContentType: contentType.identifier)
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -374,7 +374,7 @@ struct cmuxApp: App {
                     showAboutPanel()
                 }
                 Button(String(localized: "menu.app.ghosttySettings", defaultValue: "Ghostty Settings…")) {
-                    GhosttyApp.shared.openConfigurationInTextEdit()
+                    GhosttyApp.shared.openConfigurationInPreferredEditor()
                 }
                 Button(String(localized: "menu.app.reloadConfiguration", defaultValue: "Reload Configuration")) {
                     GhosttyApp.shared.reloadConfiguration(source: "menu.reload_configuration")

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -311,6 +311,60 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
+    func testPreferredConfigurationEditorApplicationURLPrefersExtensionAssociation() {
+        let extensionEditorURL = URL(fileURLWithPath: "/Applications/Zed.app", isDirectory: true)
+        let defaultTextEditorURL = URL(fileURLWithPath: "/Applications/TextEdit.app", isDirectory: true)
+
+        let resolved = GhosttyApp.preferredConfigurationEditorApplicationURL(
+            for: URL(fileURLWithPath: "/tmp/config.ghostty"),
+            defaultApplicationURLForExtension: { ext in
+                XCTAssertEqual(ext, "ghostty")
+                return extensionEditorURL
+            },
+            defaultTextEditorURL: {
+                defaultTextEditorURL
+            }
+        )
+
+        XCTAssertEqual(resolved, extensionEditorURL)
+    }
+
+    func testPreferredConfigurationEditorApplicationURLFallsBackToDefaultTextEditorWhenExtensionHasNoAssociation() {
+        let defaultTextEditorURL = URL(fileURLWithPath: "/Applications/Zed.app", isDirectory: true)
+
+        let resolved = GhosttyApp.preferredConfigurationEditorApplicationURL(
+            for: URL(fileURLWithPath: "/tmp/config.ghostty"),
+            defaultApplicationURLForExtension: { ext in
+                XCTAssertEqual(ext, "ghostty")
+                return nil
+            },
+            defaultTextEditorURL: {
+                defaultTextEditorURL
+            }
+        )
+
+        XCTAssertEqual(resolved, defaultTextEditorURL)
+    }
+
+    func testPreferredConfigurationEditorApplicationURLFallsBackToDefaultTextEditorForLegacyExtensionlessConfig() {
+        let defaultTextEditorURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
+        var consultedExtensionLookup = false
+
+        let resolved = GhosttyApp.preferredConfigurationEditorApplicationURL(
+            for: URL(fileURLWithPath: "/tmp/config"),
+            defaultApplicationURLForExtension: { _ in
+                consultedExtensionLookup = true
+                return nil
+            },
+            defaultTextEditorURL: {
+                defaultTextEditorURL
+            }
+        )
+
+        XCTAssertFalse(consultedExtensionLookup)
+        XCTAssertEqual(resolved, defaultTextEditorURL)
+    }
+
     func testCmuxAppSupportConfigURLsUseReleaseConfigForDebugBundleWithoutCurrentConfig() throws {
         try withTemporaryAppSupportDirectory { appSupportDirectory in
             let releaseConfigURL = try writeAppSupportConfig(


### PR DESCRIPTION
## Summary

- stop hardcoding TextEdit for the Ghostty Settings menu action
- mirror Ghostty's macOS editor resolution by preferring the default app for the config file extension, then falling back to the default plain-text editor, then generic open
- add regression coverage for extension-associated and extensionless config paths

Closes #2071.

## Testing

- `./scripts/reload.sh --tag issue-2071-settings-default-editor`
- Verified the tagged Debug app built and launched successfully from DerivedData
- Added regression tests in `cmuxTests/GhosttyConfigTests.swift` for preferred editor resolution logic; not run locally per repo testing policy

## Demo Video

- Video URL or attachment: N/A (external editor handoff via menu action)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open Ghostty Settings with the user's default editor on macOS instead of hardcoded TextEdit. Mirrors Ghostty’s editor resolution and closes #2071.

- **Bug Fixes**
  - Prefer default app for the config file extension; fall back to the default plain‑text editor; then to a generic open.
  - Updated the Settings menu action to use the new resolver and added regression tests for extension-associated and extensionless config paths.

<sup>Written for commit 336b19f7d17965c7c901fe88bd7a86785b160e15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now open in your system's preferred editor based on file type, instead of always defaulting to TextEdit. Falls back to the default text editor if no specific preference is configured.

* **Tests**
  * Added tests to validate preferred editor resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->