### PR TITLE
Add Intel release split repro harness

### DIFF
--- a/.github/workflows/repro-intel-release-split-shortcuts.yml
+++ b/.github/workflows/repro-intel-release-split-shortcuts.yml
@@ -1,16 +1,14 @@
 name: Repro Intel release split shortcuts
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/repro-intel-release-split-shortcuts.yml
-      - scripts/repro-intel-release-split-shortcuts.sh
+  schedule:
+    - cron: '17 09 * * *'
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to test
+        description: Release tag to test, for example nightly or v0.62.2
         required: false
-        default: v0.62.2
+        default: nightly
       runner:
         description: Intel runner to use
         required: false
@@ -30,12 +28,13 @@ on:
 
 jobs:
   repro:
-    name: ${{ github.event_name == 'pull_request' && 'macos-15-intel cmd-d' || format('{0} {1}', inputs.runner, inputs.shortcut) }}
-    runs-on: ${{ github.event_name == 'pull_request' && 'macos-15-intel' || inputs.runner }}
+    name: ${{ format('{0} {1} {2}', github.event_name == 'schedule' && 'macos-15-intel' || inputs.runner || 'macos-15-intel', github.event_name == 'schedule' && 'cmd-d' || inputs.shortcut || 'cmd-d', github.event_name == 'schedule' && 'nightly' || inputs.release_tag || 'nightly') }}
+    runs-on: ${{ github.event_name == 'schedule' && 'macos-15-intel' || inputs.runner || 'macos-15-intel' }}
     timeout-minutes: 20
     env:
-      REPRO_RUNNER: ${{ github.event_name == 'pull_request' && 'macos-15-intel' || inputs.runner }}
-      REPRO_SHORTCUT: ${{ github.event_name == 'pull_request' && 'cmd-d' || inputs.shortcut }}
+      REPRO_RUNNER: ${{ github.event_name == 'schedule' && 'macos-15-intel' || inputs.runner || 'macos-15-intel' }}
+      REPRO_SHORTCUT: ${{ github.event_name == 'schedule' && 'cmd-d' || inputs.shortcut || 'cmd-d' }}
+      REPRO_RELEASE_TAG: ${{ github.event_name == 'schedule' && 'nightly' || inputs.release_tag || 'nightly' }}
 
     steps:
       - name: Checkout
@@ -70,7 +69,7 @@ jobs:
 
       - name: Reproduce release split failure
         env:
-          CMUX_RELEASE_TAG: ${{ inputs.release_tag || 'v0.62.2' }}
+          CMUX_RELEASE_TAG: ${{ env.REPRO_RELEASE_TAG }}
           CMUX_REPRO_SHORTCUT: ${{ env.REPRO_SHORTCUT }}
           CMUX_REPRO_DIR: ${{ runner.temp }}/cmux-intel-release-repro-${{ env.REPRO_RUNNER }}-${{ env.REPRO_SHORTCUT }}
         run: scripts/repro-intel-release-split-shortcuts.sh

--- a/.github/workflows/repro-intel-release-split-shortcuts.yml
+++ b/.github/workflows/repro-intel-release-split-shortcuts.yml
@@ -1,6 +1,10 @@
 name: Repro Intel release split shortcuts
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/repro-intel-release-split-shortcuts.yml
+      - scripts/repro-intel-release-split-shortcuts.sh
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/repro-intel-release-split-shortcuts.yml
+++ b/.github/workflows/repro-intel-release-split-shortcuts.yml
@@ -1,0 +1,70 @@
+name: Repro Intel release split shortcuts
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to test
+        required: false
+        default: v0.62.2
+
+jobs:
+  repro:
+    name: ${{ matrix.runner }} ${{ matrix.shortcut }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-15-intel
+          - macos-26-intel
+        shortcut:
+          - cmd-d
+          - cmd-shift-d
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+            if [ -z "$XCODE_APP" ]; then
+              echo "No Xcode installation found" >&2
+              exit 1
+            fi
+            XCODE_DIR="${XCODE_APP}/Contents/Developer"
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+
+      - name: Create virtual display
+        run: |
+          set -euo pipefail
+          clang -framework Foundation -framework CoreGraphics \
+            -o /tmp/create-virtual-display scripts/create-virtual-display.m
+          /tmp/create-virtual-display &
+          echo "VDISPLAY_PID=$!" >> "$GITHUB_ENV"
+          sleep 3
+          system_profiler SPDisplaysDataType 2>/dev/null || true
+
+      - name: Reproduce release split failure
+        env:
+          CMUX_RELEASE_TAG: ${{ inputs.release_tag || 'v0.62.2' }}
+          CMUX_REPRO_SHORTCUT: ${{ matrix.shortcut }}
+          CMUX_REPRO_DIR: ${{ runner.temp }}/cmux-intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}
+        run: scripts/repro-intel-release-split-shortcuts.sh
+
+      - name: Upload repro artifacts
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}
+          path: ${{ runner.temp }}/cmux-intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}/artifacts
+          if-no-files-found: warn

--- a/.github/workflows/repro-intel-release-split-shortcuts.yml
+++ b/.github/workflows/repro-intel-release-split-shortcuts.yml
@@ -62,9 +62,16 @@ jobs:
           set -euo pipefail
           clang -framework Foundation -framework CoreGraphics \
             -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
-          echo "VDISPLAY_PID=$!" >> "$GITHUB_ENV"
-          sleep 3
+          READY_FILE="$(mktemp)"
+          rm -f "$READY_FILE"
+          /tmp/create-virtual-display --ready-path "$READY_FILE" &
+          for _ in $(seq 1 60); do
+            if [[ -f "$READY_FILE" ]]; then
+              break
+            fi
+            sleep 0.5
+          done
+          [[ -f "$READY_FILE" ]] || { echo "Virtual display did not become ready" >&2; exit 1; }
           system_profiler SPDisplaysDataType 2>/dev/null || true
 
       - name: Reproduce release split failure

--- a/.github/workflows/repro-intel-release-split-shortcuts.yml
+++ b/.github/workflows/repro-intel-release-split-shortcuts.yml
@@ -11,21 +11,31 @@ on:
         description: Release tag to test
         required: false
         default: v0.62.2
+      runner:
+        description: Intel runner to use
+        required: false
+        default: macos-15-intel
+        type: choice
+        options:
+          - macos-15-intel
+          - macos-26-intel
+      shortcut:
+        description: Shortcut to send
+        required: false
+        default: cmd-d
+        type: choice
+        options:
+          - cmd-d
+          - cmd-shift-d
 
 jobs:
   repro:
-    name: ${{ matrix.runner }} ${{ matrix.shortcut }}
-    runs-on: ${{ matrix.runner }}
+    name: ${{ github.event_name == 'pull_request' && 'macos-15-intel cmd-d' || format('{0} {1}', inputs.runner, inputs.shortcut) }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'macos-15-intel' || inputs.runner }}
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - macos-15-intel
-          - macos-26-intel
-        shortcut:
-          - cmd-d
-          - cmd-shift-d
+    env:
+      REPRO_RUNNER: ${{ github.event_name == 'pull_request' && 'macos-15-intel' || inputs.runner }}
+      REPRO_SHORTCUT: ${{ github.event_name == 'pull_request' && 'cmd-d' || inputs.shortcut }}
 
     steps:
       - name: Checkout
@@ -61,14 +71,14 @@ jobs:
       - name: Reproduce release split failure
         env:
           CMUX_RELEASE_TAG: ${{ inputs.release_tag || 'v0.62.2' }}
-          CMUX_REPRO_SHORTCUT: ${{ matrix.shortcut }}
-          CMUX_REPRO_DIR: ${{ runner.temp }}/cmux-intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}
+          CMUX_REPRO_SHORTCUT: ${{ env.REPRO_SHORTCUT }}
+          CMUX_REPRO_DIR: ${{ runner.temp }}/cmux-intel-release-repro-${{ env.REPRO_RUNNER }}-${{ env.REPRO_SHORTCUT }}
         run: scripts/repro-intel-release-split-shortcuts.sh
 
       - name: Upload repro artifacts
         if: always()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
-          name: intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}
-          path: ${{ runner.temp }}/cmux-intel-release-repro-${{ matrix.runner }}-${{ matrix.shortcut }}/artifacts
+          name: intel-release-repro-${{ env.REPRO_RUNNER }}-${{ env.REPRO_SHORTCUT }}
+          path: ${{ runner.temp }}/cmux-intel-release-repro-${{ env.REPRO_RUNNER }}-${{ env.REPRO_SHORTCUT }}/artifacts
           if-no-files-found: warn

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,13 +20,14 @@ on:
         default: true
         type: boolean
       runner:
-        description: "Runner OS (Depot runners for GUI activation support)"
+        description: "Runner OS"
         required: false
         default: "depot-macos-latest"
         type: choice
         options:
           - depot-macos-latest
           - depot-macos-14
+          - macos-15-intel
 
 jobs:
   e2e:
@@ -97,12 +98,21 @@ jobs:
           if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
             echo "zig ${ZIG_REQUIRED} already installed"
           else
+            ARCH="$(uname -m)"
+            case "$ARCH" in
+              arm64) ZIG_ARCH="aarch64" ;;
+              x86_64) ZIG_ARCH="x86_64" ;;
+              *)
+                echo "Unsupported macOS architecture: $ARCH" >&2
+                exit 1
+                ;;
+            esac
             echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
+            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
             tar xf /tmp/zig.tar.xz -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
+            sudo cp -f "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/zig" /usr/local/bin/zig
+            sudo cp -rf "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/lib" /usr/local/lib/zig
             export PATH="/usr/local/bin:$PATH"
             zig version
           fi

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2093,8 +2093,7 @@ class TabManager: ObservableObject {
         snapshot: WorkspaceCreationSnapshot
     ) -> ghostty_surface_config_s? {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(snapshot: snapshot),
-           panel.surface.hasLiveSurface,
-           let sourceSurface = panel.surface.surface {
+           let sourceSurface = cmuxSurfaceForInheritance(panel) {
             return cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2094,10 +2094,16 @@ class TabManager: ObservableObject {
     ) -> ghostty_surface_config_s? {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(snapshot: snapshot),
            let sourceSurface = cmuxSurfaceForInheritance(panel) {
-            return cmuxInheritedSurfaceConfig(
+            var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB
             )
+            if config.font_size <= 0,
+               let fallbackFontPoints = snapshot.selectedWorkspace?.lastRememberedTerminalFontPointsForConfigInheritance(),
+               fallbackFontPoints > 0 {
+                config.font_size = fallbackFontPoints
+            }
+            return config
         }
         if let fallbackFontPoints = snapshot.selectedWorkspace?.lastRememberedTerminalFontPointsForConfigInheritance() {
             var config = ghostty_surface_config_new()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -22,6 +22,11 @@ func cmuxSurfaceContextName(_ context: ghostty_surface_context_e) -> String {
 }
 
 func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
+#if DEBUG
+    if let override = cmuxCurrentSurfaceFontSizePointsOverride {
+        return override(surface)
+    }
+#endif
     guard let quicklookFont = ghostty_surface_quicklook_font(surface) else {
         return nil
     }
@@ -44,11 +49,32 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
     return points
 }
 
+#if DEBUG
+var cmuxCurrentSurfaceFontSizePointsOverride: ((ghostty_surface_t) -> Float?)?
+var cmuxGhosttyInheritedSurfaceConfigOverride: ((ghostty_surface_t, ghostty_surface_context_e) -> ghostty_surface_config_s)?
+var cmuxSurfaceForInheritanceOverride: ((TerminalPanel) -> ghostty_surface_t?)?
+#endif
+
+func cmuxSurfaceForInheritance(_ terminalPanel: TerminalPanel) -> ghostty_surface_t? {
+#if DEBUG
+    if let override = cmuxSurfaceForInheritanceOverride {
+        return override(terminalPanel)
+    }
+#endif
+    guard terminalPanel.surface.hasLiveSurface else { return nil }
+    return terminalPanel.surface.surface
+}
+
 func cmuxInheritedSurfaceConfig(
     sourceSurface: ghostty_surface_t,
     context: ghostty_surface_context_e
 ) -> ghostty_surface_config_s {
+#if DEBUG
+    let inherited = cmuxGhosttyInheritedSurfaceConfigOverride?(sourceSurface, context)
+        ?? ghostty_surface_inherited_config(sourceSurface, context)
+#else
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
+#endif
     var config = inherited
 
     // Make runtime zoom inheritance explicit, even when Ghostty's
@@ -7172,8 +7198,7 @@ final class Workspace: Identifiable, ObservableObject {
             preferredPanelId: preferredPanelId,
             inPane: preferredPaneId
         ) {
-            guard terminalPanel.surface.hasLiveSurface,
-                  let sourceSurface = terminalPanel.surface.surface else { continue }
+            guard let sourceSurface = cmuxSurfaceForInheritance(terminalPanel) else { continue }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -69,6 +69,7 @@ var cmuxGhosttyInheritedSurfaceConfigOverride: ((ghostty_surface_t, ghostty_surf
 var cmuxSurfaceForInheritanceOverride: ((TerminalPanel) -> ghostty_surface_t?)?
 #endif
 
+@MainActor
 func cmuxSurfaceForInheritance(_ terminalPanel: TerminalPanel) -> ghostty_surface_t? {
 #if DEBUG
     if let override = cmuxSurfaceForInheritanceOverride {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -75,22 +75,14 @@ func cmuxInheritedSurfaceConfig(
 #else
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
 #endif
-    var config = inherited
-
-    // Make runtime zoom inheritance explicit, even when Ghostty's
-    // inherit-font-size config is disabled.
-    let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
-    if let points = runtimePoints {
-        config.font_size = points
-    }
+    let config = inherited
 
 #if DEBUG
     let inheritedText = String(format: "%.2f", inherited.font_size)
-    let runtimeText = runtimePoints.map { String(format: "%.2f", $0) } ?? "nil"
     let finalText = String(format: "%.2f", config.font_size)
     dlog(
         "zoom.inherit context=\(cmuxSurfaceContextName(context)) " +
-        "inherited=\(inheritedText) runtime=\(runtimeText) final=\(finalText)"
+        "inherited=\(inheritedText) runtime=nil final=\(finalText)"
     )
 #endif
 
@@ -7079,22 +7071,19 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func resolvedTerminalInheritanceFontPoints(
         for terminalPanel: TerminalPanel,
-        sourceSurface: ghostty_surface_t,
         inheritedConfig: ghostty_surface_config_s
     ) -> Float? {
-        let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
         if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
-            if let runtimePoints, abs(runtimePoints - rooted) > 0.05 {
-                // Runtime zoom changed after lineage was seeded (manual zoom on descendant);
-                // treat runtime as the new root for future descendants.
-                return runtimePoints
+            if inheritedConfig.font_size > 0,
+               abs(inheritedConfig.font_size - rooted) > 0.05 {
+                return inheritedConfig.font_size
             }
             return rooted
         }
         if inheritedConfig.font_size > 0 {
             return inheritedConfig.font_size
         }
-        return runtimePoints
+        return nil
     }
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
@@ -7205,13 +7194,12 @@ final class Workspace: Identifiable, ObservableObject {
             )
             if let rootedFontPoints = resolvedTerminalInheritanceFontPoints(
                 for: terminalPanel,
-                sourceSurface: sourceSurface,
                 inheritedConfig: config
             ), rootedFontPoints > 0 {
                 config.font_size = rootedFontPoints
                 terminalInheritanceFontPointsByPanelId[terminalPanel.id] = rootedFontPoints
             }
-            rememberTerminalConfigInheritanceSource(terminalPanel)
+            lastTerminalConfigInheritancePanelId = terminalPanel.id
             if config.font_size > 0 {
                 lastTerminalConfigInheritanceFontPoints = config.font_size
             }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1213,6 +1213,50 @@ final class TabManagerWorkspaceConfigInheritanceSourceTests: XCTestCase {
             "Expected workspace inheritance source to use last focused terminal across panes"
         )
     }
+
+    func testNewWorkspaceDoesNotProbeRuntimeFontOnSourceSurfaceDuringInheritance() {
+        let manager = TabManager()
+        guard let sourceWorkspace = manager.selectedWorkspace,
+              let sourcePanelId = sourceWorkspace.focusedPanelId,
+              let sourcePanel = sourceWorkspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected selected workspace with focused terminal")
+            return
+        }
+
+        let fakeSurfaceStorage = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        let fakeSurface = unsafeBitCast(fakeSurfaceStorage, to: ghostty_surface_t.self)
+        let originalFontOverride = cmuxCurrentSurfaceFontSizePointsOverride
+        let originalInheritedOverride = cmuxGhosttyInheritedSurfaceConfigOverride
+        let originalSurfaceOverride = cmuxSurfaceForInheritanceOverride
+        var runtimeProbeCount = 0
+        cmuxSurfaceForInheritanceOverride = { panel in
+            panel.id == sourcePanel.id ? fakeSurface : nil
+        }
+        cmuxGhosttyInheritedSurfaceConfigOverride = { _, _ in
+            var config = ghostty_surface_config_new()
+            config.font_size = 17
+            return config
+        }
+        cmuxCurrentSurfaceFontSizePointsOverride = { _ in
+            runtimeProbeCount += 1
+            return 23
+        }
+        defer {
+            cmuxCurrentSurfaceFontSizePointsOverride = originalFontOverride
+            cmuxGhosttyInheritedSurfaceConfigOverride = originalInheritedOverride
+            cmuxSurfaceForInheritanceOverride = originalSurfaceOverride
+            fakeSurfaceStorage.deallocate()
+        }
+
+        let newWorkspace = manager.addWorkspace()
+
+        XCTAssertNotNil(newWorkspace.focusedPanelId)
+        XCTAssertEqual(
+            runtimeProbeCount,
+            0,
+            "New workspace inheritance should not probe runtime font state from the source surface"
+        )
+    }
 }
 
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1086,6 +1086,56 @@ final class WorkspaceTerminalConfigInheritanceSelectionTests: XCTestCase {
             "Expected inheritance to prefer last focused terminal when browser is focused in another pane"
         )
     }
+
+    func testNewTerminalSplitDoesNotProbeRuntimeFontOnSourceSurfaceDuringInheritance() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let fakeSurfaceStorage = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        let fakeSurface = unsafeBitCast(fakeSurfaceStorage, to: ghostty_surface_t.self)
+        let originalFontOverride = cmuxCurrentSurfaceFontSizePointsOverride
+        let originalInheritedOverride = cmuxGhosttyInheritedSurfaceConfigOverride
+        let originalSurfaceOverride = cmuxSurfaceForInheritanceOverride
+        var runtimeProbeCount = 0
+        cmuxSurfaceForInheritanceOverride = { panel in
+            panel.id == sourcePanel.id ? fakeSurface : nil
+        }
+        cmuxGhosttyInheritedSurfaceConfigOverride = { _, _ in
+            var config = ghostty_surface_config_new()
+            config.font_size = 17
+            return config
+        }
+        cmuxCurrentSurfaceFontSizePointsOverride = { _ in
+            runtimeProbeCount += 1
+            return 23
+        }
+        defer {
+            cmuxCurrentSurfaceFontSizePointsOverride = originalFontOverride
+            cmuxGhosttyInheritedSurfaceConfigOverride = originalInheritedOverride
+            cmuxSurfaceForInheritanceOverride = originalSurfaceOverride
+            fakeSurfaceStorage.deallocate()
+        }
+
+        guard let splitPanel = workspace.newTerminalSplit(
+            from: sourcePanel.id,
+            orientation: .horizontal,
+            focus: false
+        ) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        XCTAssertNotNil(workspace.panels[splitPanel.id])
+        XCTAssertEqual(
+            runtimeProbeCount,
+            0,
+            "Split inheritance should not probe runtime font state from the source surface"
+        )
+    }
 }
 
 

--- a/scripts/repro-intel-release-split-shortcuts.sh
+++ b/scripts/repro-intel-release-split-shortcuts.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_TAG="${CMUX_RELEASE_TAG:-v0.62.2}"
+SHORTCUT="${CMUX_REPRO_SHORTCUT:-cmd-d}"
+REPRO_DIR="${CMUX_REPRO_DIR:-${RUNNER_TEMP:-/tmp}/cmux-intel-release-repro}"
+ARTIFACT_DIR="${REPRO_DIR}/artifacts"
+DMG_PATH="${REPRO_DIR}/cmux-macos.dmg"
+MOUNT_DIR="${REPRO_DIR}/mount"
+APP_PATH="${REPRO_DIR}/cmux.app"
+APP_BINARY="${APP_PATH}/Contents/MacOS/cmux"
+APP_LOG="${ARTIFACT_DIR}/app.log"
+CLI_LOG="${ARTIFACT_DIR}/cli.log"
+RESULT_LOG="${ARTIFACT_DIR}/result.txt"
+SHORTCUT_LOG="${ARTIFACT_DIR}/shortcut.log"
+SYSTEM_INFO_LOG="${ARTIFACT_DIR}/system-info.txt"
+BEFORE_JSON="${ARTIFACT_DIR}/before-list-panes.json"
+AFTER_JSON="${ARTIFACT_DIR}/after-list-panes.json"
+CRASH_DIR="${ARTIFACT_DIR}/crash-reports"
+SWIFT_HELPER_SRC="${REPRO_DIR}/send-shortcut.swift"
+SWIFT_HELPER_BIN="${REPRO_DIR}/send-shortcut"
+APP_PID=""
+BEFORE_CRASH_LIST="${REPRO_DIR}/before-crash-list.txt"
+
+mkdir -p "${ARTIFACT_DIR}" "${CRASH_DIR}" "${MOUNT_DIR}"
+: > "${APP_LOG}"
+: > "${CLI_LOG}"
+: > "${SHORTCUT_LOG}"
+: > "${RESULT_LOG}"
+
+cleanup() {
+  if [[ -n "${APP_PID}" ]] && kill -0 "${APP_PID}" 2>/dev/null; then
+    kill "${APP_PID}" 2>/dev/null || true
+    wait "${APP_PID}" 2>/dev/null || true
+  fi
+  if mount | grep -F "on ${MOUNT_DIR} " >/dev/null 2>&1; then
+    hdiutil detach "${MOUNT_DIR}" -quiet || true
+  fi
+}
+trap cleanup EXIT
+
+log() {
+  printf '%s\n' "$*" | tee -a "${RESULT_LOG}"
+}
+
+record_system_info() {
+  {
+    echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "release_tag=${RELEASE_TAG}"
+    echo "shortcut=${SHORTCUT}"
+    echo "uname=$(uname -a)"
+    echo "arch=$(uname -m)"
+    echo "sw_vers:"
+    sw_vers
+    echo "sysctl machdep.cpu.brand_string:"
+    sysctl machdep.cpu.brand_string 2>/dev/null || true
+  } > "${SYSTEM_INFO_LOG}"
+}
+
+copy_recent_crash_reports() {
+  local dest="${CRASH_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "${dest}"
+  local found=0
+  while IFS= read -r report_path; do
+    [[ -z "${report_path}" ]] && continue
+    cp "${report_path}" "${dest}/" 2>/dev/null || true
+    found=1
+  done < <(
+    python3 - <<'PY' "${BEFORE_CRASH_LIST}"
+from pathlib import Path
+import sys
+
+before = set()
+before_path = Path(sys.argv[1])
+if before_path.exists():
+    before = {line.strip() for line in before_path.read_text().splitlines() if line.strip()}
+
+diag = Path.home() / "Library/Logs/DiagnosticReports"
+if diag.exists():
+    candidates = sorted(
+        [p for p in diag.glob("*cmux*") if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for path in candidates:
+        if str(path) not in before:
+            print(path)
+PY
+  )
+  if [[ "${found}" -eq 0 ]]; then
+    echo "(none)" > "${dest}/none.txt"
+  fi
+}
+
+fail() {
+  log "FAIL: $*"
+  copy_recent_crash_reports
+  {
+    echo
+    echo "--- app.log ---"
+    tail -n 200 "${APP_LOG}" 2>/dev/null || true
+    echo
+    echo "--- cli.log ---"
+    tail -n 200 "${CLI_LOG}" 2>/dev/null || true
+    echo
+    echo "--- shortcut.log ---"
+    tail -n 200 "${SHORTCUT_LOG}" 2>/dev/null || true
+  } >> "${RESULT_LOG}"
+  exit 1
+}
+
+capture_existing_crash_list() {
+  : > "${BEFORE_CRASH_LIST}"
+  if [[ -d "${HOME}/Library/Logs/DiagnosticReports" ]]; then
+    find "${HOME}/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -name '*cmux*' -print | sort > "${BEFORE_CRASH_LIST}" || true
+  fi
+}
+
+download_release_dmg() {
+  local url="https://github.com/manaflow-ai/cmux/releases/download/${RELEASE_TAG}/cmux-macos.dmg"
+  log "Downloading ${url}"
+  curl -fL --retry 5 --retry-delay 2 --retry-all-errors "${url}" -o "${DMG_PATH}"
+}
+
+install_release_app() {
+  hdiutil attach "${DMG_PATH}" -mountpoint "${MOUNT_DIR}" -nobrowse -quiet
+  local mounted_app="${MOUNT_DIR}/cmux.app"
+  [[ -d "${mounted_app}" ]] || fail "Mounted DMG did not contain cmux.app"
+  rm -rf "${APP_PATH}"
+  ditto "${mounted_app}" "${APP_PATH}"
+  xattr -dr com.apple.quarantine "${APP_PATH}" 2>/dev/null || true
+  [[ -x "${APP_BINARY}" ]] || fail "Installed app binary not found at ${APP_BINARY}"
+  {
+    echo "app_binary=${APP_BINARY}"
+    echo "app_archs=$(lipo -archs "${APP_BINARY}" 2>/dev/null || file "${APP_BINARY}")"
+    echo "bundle_id=$(defaults read "${APP_PATH}/Contents/Info.plist" CFBundleIdentifier 2>/dev/null || echo unknown)"
+    echo "bundle_version=$(defaults read "${APP_PATH}/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo unknown)"
+    echo "bundle_build=$(defaults read "${APP_PATH}/Contents/Info.plist" CFBundleVersion 2>/dev/null || echo unknown)"
+  } >> "${SYSTEM_INFO_LOG}"
+}
+
+launch_release_app() {
+  pkill -f "/cmux.app/Contents/MacOS/cmux$" 2>/dev/null || true
+  sleep 1
+  "${APP_BINARY}" > "${APP_LOG}" 2>&1 &
+  APP_PID=$!
+  log "Launched ${APP_BINARY} pid=${APP_PID}"
+}
+
+wait_for_process_launch() {
+  for _ in $(seq 1 20); do
+    if kill -0 "${APP_PID}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+run_cli_json() {
+  local output_path="$1"
+  CMUX_CLI_SENTRY_DISABLED=1 "${APP_BINARY}" --json list-panes > "${output_path}" 2>> "${CLI_LOG}"
+}
+
+wait_for_cli_ready() {
+  local output_path="$1"
+  for _ in $(seq 1 60); do
+    if ! kill -0 "${APP_PID}" 2>/dev/null; then
+      return 2
+    fi
+    if run_cli_json "${output_path}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+pane_count() {
+  local json_path="$1"
+  python3 - <<'PY' "${json_path}"
+from pathlib import Path
+import json
+import sys
+
+payload = json.loads(Path(sys.argv[1]).read_text() or "{}")
+print(len(payload.get("panes", [])))
+PY
+}
+
+write_swift_shortcut_helper() {
+  cat > "${SWIFT_HELPER_SRC}" <<'EOF'
+import AppKit
+import CoreGraphics
+import Foundation
+
+let shortcut = CommandLine.arguments.dropFirst().first ?? "cmd-d"
+
+func shortcutSpec(_ raw: String) -> (CGKeyCode, CGEventFlags)? {
+    switch raw {
+    case "cmd-d":
+        return (2, .maskCommand)
+    case "cmd-shift-d":
+        return (2, [.maskCommand, .maskShift])
+    default:
+        return nil
+    }
+}
+
+guard let runningApp = NSWorkspace.shared.runningApplications.first(where: { ($0.localizedName ?? "") == "cmux" }) else {
+    fputs("No running cmux app found\n", stderr)
+    exit(1)
+}
+
+guard let (keyCode, flags) = shortcutSpec(shortcut) else {
+    fputs("Unsupported shortcut: \(shortcut)\n", stderr)
+    exit(1)
+}
+
+guard runningApp.activate(options: [.activateAllWindows, .activateIgnoringOtherApps]) else {
+    fputs("Failed to activate cmux\n", stderr)
+    exit(1)
+}
+
+RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+guard let source = CGEventSource(stateID: .combinedSessionState) else {
+    fputs("Could not create event source\n", stderr)
+    exit(1)
+}
+
+for keyDown in [true, false] {
+    guard let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: keyDown) else {
+        fputs("Could not create keyboard event\n", stderr)
+        exit(1)
+    }
+    event.flags = flags
+    event.post(tap: .cghidEventTap)
+    RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+}
+
+print("Sent \(shortcut) to cmux pid=\(runningApp.processIdentifier)")
+EOF
+  swiftc "${SWIFT_HELPER_SRC}" -o "${SWIFT_HELPER_BIN}"
+}
+
+send_shortcut_via_osascript() {
+  local keystroke_expr
+  case "${SHORTCUT}" in
+    cmd-d)
+      keystroke_expr='keystroke "d" using command down'
+      ;;
+    cmd-shift-d)
+      keystroke_expr='keystroke "d" using {command down, shift down}'
+      ;;
+    *)
+      fail "Unsupported shortcut ${SHORTCUT}"
+      ;;
+  esac
+
+  osascript > "${SHORTCUT_LOG}" 2>&1 <<EOF
+tell application "cmux" to activate
+delay 1
+tell application "System Events"
+  ${keystroke_expr}
+end tell
+EOF
+}
+
+send_shortcut_via_swift() {
+  write_swift_shortcut_helper
+  "${SWIFT_HELPER_BIN}" "${SHORTCUT}" > "${SHORTCUT_LOG}" 2>&1
+}
+
+wait_for_expected_result() {
+  local expected_count="$1"
+  local output_path="$2"
+  for _ in $(seq 1 12); do
+    if ! kill -0 "${APP_PID}" 2>/dev/null; then
+      return 2
+    fi
+    if run_cli_json "${output_path}"; then
+      local current_count
+      current_count="$(pane_count "${output_path}")"
+      if [[ "${current_count}" == "${expected_count}" ]]; then
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+attempt_shortcut() {
+  local method="$1"
+  local expected_count="$2"
+  : > "${SHORTCUT_LOG}"
+  log "Triggering ${SHORTCUT} via ${method}"
+  case "${method}" in
+    osascript)
+      if ! send_shortcut_via_osascript; then
+        log "Shortcut via osascript failed"
+        return 1
+      fi
+      ;;
+    swift)
+      if ! send_shortcut_via_swift; then
+        log "Shortcut via swift helper failed"
+        return 1
+      fi
+      ;;
+    *)
+      fail "Unknown shortcut method ${method}"
+      ;;
+  esac
+  if wait_for_expected_result "${expected_count}" "${AFTER_JSON}"; then
+    return 0
+  fi
+  return $?
+}
+
+main() {
+  record_system_info
+  capture_existing_crash_list
+  download_release_dmg
+  install_release_app
+  launch_release_app
+
+  if ! wait_for_process_launch; then
+    fail "cmux app process never stayed alive after launch"
+  fi
+
+  local cli_status=0
+  if wait_for_cli_ready "${BEFORE_JSON}"; then
+    :
+  else
+    cli_status=$?
+    if [[ "${cli_status}" -eq 2 ]]; then
+      fail "cmux crashed before the CLI became ready"
+    fi
+    fail "cmux CLI never became ready"
+  fi
+
+  local before_count
+  before_count="$(pane_count "${BEFORE_JSON}")"
+  log "Pane count before shortcut: ${before_count}"
+  local expected_count=$((before_count + 1))
+
+  local shortcut_status=0
+  if attempt_shortcut osascript "${expected_count}"; then
+    :
+  else
+    shortcut_status=$?
+    if [[ "${shortcut_status}" -eq 2 ]]; then
+      fail "${SHORTCUT} crashed the app via osascript path"
+    fi
+    log "No split observed after osascript attempt"
+    if attempt_shortcut swift "${expected_count}"; then
+      :
+    else
+      shortcut_status=$?
+      if [[ "${shortcut_status}" -eq 2 ]]; then
+        fail "${SHORTCUT} crashed the app via swift event path"
+      fi
+      fail "${SHORTCUT} did not create a second pane on the release app"
+    fi
+  fi
+
+  local after_count
+  after_count="$(pane_count "${AFTER_JSON}")"
+  log "Pane count after shortcut: ${after_count}"
+
+  if ! kill -0 "${APP_PID}" 2>/dev/null; then
+    fail "cmux exited after reporting a successful pane split"
+  fi
+
+  log "PASS: ${SHORTCUT} created a split without crashing"
+}
+
+main "$@"

--- a/scripts/repro-intel-release-split-shortcuts.sh
+++ b/scripts/repro-intel-release-split-shortcuts.sh
@@ -188,7 +188,11 @@ wait_for_cli_ready() {
       return 2
     fi
     if run_cli_json "${output_path}"; then
-      return 0
+      local current_count
+      current_count="$(pane_count "${output_path}")" || return 1
+      if (( current_count >= 1 )); then
+        return 0
+      fi
     fi
     sleep 1
   done
@@ -332,18 +336,15 @@ attempt_shortcut() {
       fail "Unknown shortcut method ${method}"
       ;;
   esac
-  if wait_for_expected_result "${expected_count}" "${AFTER_JSON}"; then
-    return 0
-  fi
-  return $?
+  wait_for_expected_result "${expected_count}" "${AFTER_JSON}"
 }
 
 main() {
-  record_system_info
-  capture_existing_crash_list
-  download_release_dmg
-  install_release_app
-  launch_release_app
+  record_system_info || fail "Failed to capture system info"
+  capture_existing_crash_list || fail "Failed to capture existing crash list"
+  download_release_dmg || fail "Failed to download release DMG"
+  install_release_app || fail "Failed to install release app"
+  launch_release_app || fail "Failed to launch release app"
 
   if ! wait_for_process_launch; then
     fail "cmux app process never stayed alive after launch"
@@ -361,7 +362,7 @@ main() {
   fi
 
   local before_count
-  before_count="$(pane_count "${BEFORE_JSON}")"
+  before_count="$(pane_count "${BEFORE_JSON}")" || fail "Failed to parse initial pane list"
   log "Pane count before shortcut: ${before_count}"
   local expected_count=$((before_count + 1))
 
@@ -386,7 +387,7 @@ main() {
   fi
 
   local after_count
-  after_count="$(pane_count "${AFTER_JSON}")"
+  after_count="$(pane_count "${AFTER_JSON}")" || fail "Failed to parse post-shortcut pane list"
   log "Pane count after shortcut: ${after_count}"
 
   if ! kill -0 "${APP_PID}" 2>/dev/null; then

--- a/scripts/repro-intel-release-split-shortcuts.sh
+++ b/scripts/repro-intel-release-split-shortcuts.sh
@@ -9,6 +9,7 @@ DMG_PATH="${REPRO_DIR}/cmux-macos.dmg"
 MOUNT_DIR="${REPRO_DIR}/mount"
 APP_PATH="${REPRO_DIR}/cmux.app"
 APP_BINARY="${APP_PATH}/Contents/MacOS/cmux"
+APP_CLI="${APP_PATH}/Contents/Resources/bin/cmux"
 APP_LOG="${ARTIFACT_DIR}/app.log"
 CLI_LOG="${ARTIFACT_DIR}/cli.log"
 RESULT_LOG="${ARTIFACT_DIR}/result.txt"
@@ -130,8 +131,10 @@ install_release_app() {
   ditto "${mounted_app}" "${APP_PATH}"
   xattr -dr com.apple.quarantine "${APP_PATH}" 2>/dev/null || true
   [[ -x "${APP_BINARY}" ]] || fail "Installed app binary not found at ${APP_BINARY}"
+  [[ -x "${APP_CLI}" ]] || fail "Bundled CLI not found at ${APP_CLI}"
   {
     echo "app_binary=${APP_BINARY}"
+    echo "app_cli=${APP_CLI}"
     echo "app_archs=$(lipo -archs "${APP_BINARY}" 2>/dev/null || file "${APP_BINARY}")"
     echo "bundle_id=$(defaults read "${APP_PATH}/Contents/Info.plist" CFBundleIdentifier 2>/dev/null || echo unknown)"
     echo "bundle_version=$(defaults read "${APP_PATH}/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo unknown)"
@@ -159,7 +162,7 @@ wait_for_process_launch() {
 
 run_cli_json() {
   local output_path="$1"
-  CMUX_CLI_SENTRY_DISABLED=1 "${APP_BINARY}" --json list-panes > "${output_path}" 2>> "${CLI_LOG}"
+  CMUX_CLI_SENTRY_DISABLED=1 "${APP_CLI}" --json list-panes > "${output_path}" 2>> "${CLI_LOG}"
 }
 
 wait_for_cli_ready() {

--- a/scripts/repro-intel-release-split-shortcuts.sh
+++ b/scripts/repro-intel-release-split-shortcuts.sh
@@ -145,7 +145,7 @@ install_release_app() {
 launch_release_app() {
   pkill -f "/cmux.app/Contents/MacOS/cmux$" 2>/dev/null || true
   sleep 1
-  "${APP_BINARY}" > "${APP_LOG}" 2>&1 &
+  CMUX_SOCKET_MODE=allowAll "${APP_BINARY}" > "${APP_LOG}" 2>&1 &
   APP_PID=$!
   log "Launched ${APP_BINARY} pid=${APP_PID}"
 }

--- a/scripts/repro-intel-release-split-shortcuts.sh
+++ b/scripts/repro-intel-release-split-shortcuts.sh
@@ -58,16 +58,8 @@ record_system_info() {
   } > "${SYSTEM_INFO_LOG}"
 }
 
-copy_recent_crash_reports() {
-  local dest="${CRASH_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
-  mkdir -p "${dest}"
-  local found=0
-  while IFS= read -r report_path; do
-    [[ -z "${report_path}" ]] && continue
-    cp "${report_path}" "${dest}/" 2>/dev/null || true
-    found=1
-  done < <(
-    python3 - <<'PY' "${BEFORE_CRASH_LIST}"
+new_crash_report_paths() {
+  python3 - <<'PY' "${BEFORE_CRASH_LIST}"
 from pathlib import Path
 import sys
 
@@ -87,7 +79,31 @@ if diag.exists():
         if str(path) not in before:
             print(path)
 PY
-  )
+}
+
+copy_recent_crash_reports() {
+  local dest="${CRASH_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "${dest}"
+  local found=0
+  local report_paths=""
+
+  if [[ -n "${APP_PID}" ]] && ! kill -0 "${APP_PID}" 2>/dev/null; then
+    for _ in $(seq 1 10); do
+      report_paths="$(new_crash_report_paths)"
+      if [[ -n "${report_paths}" ]]; then
+        break
+      fi
+      sleep 1
+    done
+  else
+    report_paths="$(new_crash_report_paths)"
+  fi
+
+  while IFS= read -r report_path; do
+    [[ -z "${report_path}" ]] && continue
+    cp "${report_path}" "${dest}/" 2>/dev/null || true
+    found=1
+  done <<< "${report_paths}"
   if [[ "${found}" -eq 0 ]]; then
     echo "(none)" > "${dest}/none.txt"
   fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -16,6 +16,7 @@ REF=""
 WAIT=false
 RECORD_VIDEO=true
 TIMEOUT=120
+RUNNER=""
 
 usage() {
   cat <<EOF
@@ -29,6 +30,7 @@ Options:
   --wait           Wait for the run to complete and print result
   --no-video       Disable video recording
   --timeout <sec>  Per-test timeout in seconds (default: 120)
+  --runner <name>  Workflow runner (for example depot-macos-latest or macos-15-intel)
   -h, --help       Show this help
 EOF
   exit 0
@@ -59,6 +61,10 @@ while [ $# -gt 0 ]; do
       TIMEOUT="$2"
       shift 2
       ;;
+    --runner)
+      RUNNER="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1" >&2
       usage
@@ -71,8 +77,11 @@ FIELDS=(-f "test_filter=$TEST_FILTER" -f "record_video=$RECORD_VIDEO" -f "test_t
 if [ -n "$REF" ]; then
   FIELDS+=(-f "ref=$REF")
 fi
+if [ -n "$RUNNER" ]; then
+  FIELDS+=(-f "runner=$RUNNER")
+fi
 
-echo "Triggering $WORKFLOW with test_filter=$TEST_FILTER ref=${REF:-<default>} video=$RECORD_VIDEO timeout=$TIMEOUT"
+echo "Triggering $WORKFLOW with test_filter=$TEST_FILTER ref=${REF:-<default>} video=$RECORD_VIDEO timeout=$TIMEOUT runner=${RUNNER:-<default>}"
 gh workflow run "$WORKFLOW" --repo "$REPO" "${FIELDS[@]}"
 
 # Wait a moment for the run to register


### PR DESCRIPTION
## Summary
- add an Intel release split workflow that runs as a daily canary on `nightly`
- keep it manually runnable on `macos-15-intel` or `macos-26-intel` before release work
- preserve the earlier Intel red runs that proved `v0.62.2` crashes on `Cmd+D`

## Why
Open Intel reports say the release app crashes when creating a second terminal surface, especially https://github.com/manaflow-ai/cmux/issues/2024 and https://github.com/manaflow-ai/cmux/issues/2047.

The first part of this PR established a real Intel repro on GitHub runners. From this point forward, Intel checks should run more selectively, once per day as a canary, and on demand before release work, instead of on every PR push.

## Confirmed repro history
These runs already proved the shipped release crash on Intel:
- `Cmd+D` on `macos-15-intel`: https://github.com/manaflow-ai/cmux/actions/runs/23529670507/job/68490475805
- `Cmd+Shift+D` on `macos-15-intel`: https://github.com/manaflow-ai/cmux/actions/runs/23529376424

## Current workflow shape
- `schedule`: daily at `09:17 UTC` on the default branch, targeting `nightly` on `macos-15-intel` with `Cmd+D`
- `workflow_dispatch`: manual run for an explicit release tag such as `nightly` or `v0.62.2`, plus runner and shortcut selection

## Test plan
- let the queued manual dispatch prove the new trigger path works: https://github.com/manaflow-ai/cmux/actions/runs/23530036210
- continue the fix work in this same PR
- use manual Intel runs again before release candidates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added testing infrastructure for Intel-based macOS release build validation via GitHub Actions workflow and associated automation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->