### PR TITLE
Fix display/consent mismatch in cmux.json command execution

### DIFF
--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -13,7 +13,8 @@ struct CmuxConfigExecutor {
     ) {
         if let workspace = command.workspace {
             executeWorkspaceCommand(command: command, workspace: workspace, tabManager: tabManager, baseCwd: baseCwd)
-        } else if let shellCommand = command.command {
+        } else if let rawCommand = command.command {
+            let shellCommand = sanitizeForDisplay(rawCommand)
             let needsConfirm = command.confirm ?? false
             if needsConfirm, let sourcePath = configSourcePath {
                 let trusted = CmuxDirectoryTrust.shared.isTrusted(


### PR DESCRIPTION
## Summary

- Sanitize the command string (strip BiDi/zero-width chars) before both display and execution, not just display
- Previously, the confirm dialog showed a cleaned version but the raw string was sent to the terminal, so a malicious cmux.json could hide dangerous content behind BiDi overrides

## Testing

- Build verified locally
- The sanitized command is now the single source of truth for both the dialog preview and `sendInput`

## Related

- Follow-up from https://github.com/manaflow-ai/cmux/pull/2011 (cubic review comment on display/consent mismatch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes commands from `cmux.json` by stripping BiDi and zero-width characters before both display and execution. This removes the display/consent mismatch so the previewed command is exactly what runs, preventing hidden or misleading input.

<sup>Written for commit 5489cb8783d153bfa28ed6096176fa8da5f04f2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

