### PR TITLE
New window inherits size from current window

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2151,6 +2151,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private var mainWindowContexts: [ObjectIdentifier: MainWindowContext] = [:]
     private var mainWindowControllers: [MainWindowController] = []
+
+    /// Tracks the cascade point for new windows, matching Ghostty's upstream algorithm.
+    /// Reset to `.zero` so the first window seeds the point from its own position.
+    private var lastCascadePoint = NSPoint.zero
     private var startupSessionSnapshot: AppSessionSnapshot?
     private var didPrepareStartupSessionSnapshot = false
     private var didAttemptStartupSessionRestore = false
@@ -5868,11 +5872,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)
-        } else if let existingFrame, sessionWindowSnapshot == nil {
-            // Cascade from the existing window so the new one doesn't stack exactly on top.
-            window.cascadeTopLeft(from: NSPoint(x: existingFrame.minX, y: existingFrame.maxY))
         } else {
             window.center()
+            // Cascade using the same algorithm as upstream Ghostty: seed from
+            // the window's own top-left on the first call, then advance the
+            // cascade point for each subsequent window.
+            if mainWindowContexts.count >= 1 {
+                lastCascadePoint = window.cascadeTopLeft(from: lastCascadePoint)
+            } else {
+                lastCascadePoint = window.cascadeTopLeft(from: NSPoint(x: window.frame.minX, y: window.frame.maxY))
+            }
         }
         window.contentView = MainWindowHostingView(rootView: root)
 
@@ -11083,6 +11092,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func unregisterMainWindow(_ window: NSWindow) {
+        // Reset cascade point so the next new window appears near the closing
+        // window's position, matching upstream Ghostty behavior.
+        let frame = window.frame
+        lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
+
         // Keep geometry available as a fallback even if the full session snapshot
         // is removed when the last window closes.
         persistWindowGeometry(from: window)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5849,18 +5849,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.
-        let existingFrame = NSApp.keyWindow.flatMap { contextForMainTerminalWindow($0) != nil ? $0 : nil }?.frame
-            ?? mainWindowContexts.values.first?.window?.frame
+        let styleMask: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
+        let existingFrame = preferredMainWindowContextForWorkspaceCreation(
+            debugSource: "createMainWindow.initialGeometry"
+        ).flatMap { resolvedWindow(for: $0)?.frame }
         let initialRect: NSRect
         if sessionWindowSnapshot == nil, let existingFrame {
-            initialRect = NSRect(x: 0, y: 0, width: existingFrame.width, height: existingFrame.height)
+            // Convert frame rect to content rect so the new window matches the
+            // source window's actual size (frame includes titlebar insets).
+            initialRect = NSWindow.contentRect(forFrameRect: existingFrame, styleMask: styleMask)
         } else {
             initialRect = NSRect(x: 0, y: 0, width: 460, height: 360)
         }
 
         let window = NSWindow(
             contentRect: initialRect,
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            styleMask: styleMask,
             backing: .buffered,
             defer: false
         )

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5843,8 +5843,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
             .environmentObject(cmuxConfigStore)
 
+        // Use the current key window's size for new windows so Cmd+Shift+N
+        // creates a window matching the previous one's dimensions.
+        let existingFrame = NSApp.keyWindow.flatMap { contextForMainTerminalWindow($0) != nil ? $0 : nil }?.frame
+            ?? mainWindowContexts.values.first?.window?.frame
+        let initialRect: NSRect
+        if sessionWindowSnapshot == nil, let existingFrame {
+            initialRect = NSRect(x: 0, y: 0, width: existingFrame.width, height: existingFrame.height)
+        } else {
+            initialRect = NSRect(x: 0, y: 0, width: 460, height: 360)
+        }
+
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 360),
+            contentRect: initialRect,
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -5857,6 +5868,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)
+        } else if let existingFrame, sessionWindowSnapshot == nil {
+            // Cascade from the existing window so the new one doesn't stack exactly on top.
+            window.cascadeTopLeft(from: NSPoint(x: existingFrame.minX, y: existingFrame.maxY))
         } else {
             window.center()
         }


### PR DESCRIPTION
## Summary
- Cmd+Shift+N now creates a window matching the current key window's dimensions instead of a hardcoded 460x360
- New window cascades from the existing window's position so it doesn't stack directly on top
- Session restore path is unchanged (still uses the snapshot frame)

## Testing
- Open cmux, resize the window, press Cmd+Shift+N. New window should match the previous window's size.
- With no existing window, a new window should still use the 460x360 default and center.

## Related
- Task: new window should be same size as previous window (Cmd+Shift+N)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+Shift+N now opens a new window that exactly matches the current key window’s content size (no titlebar inset growth) and positions it with Ghostty’s cascade algorithm so windows don’t overlap and the next window appears near the last closed one. If no window exists we still use the 460×360 default and center, and session restore still uses the snapshot frame.

<sup>Written for commit abc7126f30ab7abb7521aa574f28c4afdf398570. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New terminal windows now inherit size from the active/most recent window instead of defaulting to a fixed small size, improving initial layout.
  * Window placement behavior updated so newly opened windows cascade from the last known position, reducing overlap and making subsequent windows appear predictably near recently closed ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->