### PR TITLE
Add regression coverage for Cmd+N workspace creation crash

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1142,6 +1142,24 @@ class TabManager: ObservableObject {
         focusedBrowserPanel?.hideFind()
     }
 
+    func makeWorkspaceForCreation(
+        title: String,
+        workingDirectory: String?,
+        portOrdinal: Int,
+        configTemplate: ghostty_surface_config_s?,
+        initialTerminalCommand: String?,
+        initialTerminalEnvironment: [String: String]
+    ) -> Workspace {
+        Workspace(
+            title: title,
+            workingDirectory: workingDirectory,
+            portOrdinal: portOrdinal,
+            configTemplate: configTemplate,
+            initialTerminalCommand: initialTerminalCommand,
+            initialTerminalEnvironment: initialTerminalEnvironment
+        )
+    }
+
     @discardableResult
     func addWorkspace(
         workingDirectory overrideWorkingDirectory: String? = nil,
@@ -1166,7 +1184,7 @@ class TabManager: ObservableObject {
         let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
-        let newWorkspace = Workspace(
+        let newWorkspace = makeWorkspaceForCreation(
             title: "Terminal \(nextTabCount)",
             workingDirectory: workingDirectory,
             portOrdinal: ordinal,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1160,6 +1160,30 @@ class TabManager: ObservableObject {
         )
     }
 
+#if DEBUG
+    private func maybeMutateSelectionDuringWorkspaceCreationForDev(
+        snapshot: WorkspaceCreationSnapshot
+    ) {
+        let env = ProcessInfo.processInfo.environment
+        let isEnabled: Bool = {
+            if let raw = env["CMUX_DEV_MUTATE_WORKSPACE_SELECTION_DURING_CREATION"] {
+                return raw == "1" || raw.caseInsensitiveCompare("true") == .orderedSame
+            }
+            return UserDefaults.standard.bool(forKey: "cmuxDevMutateWorkspaceSelectionDuringCreation")
+        }()
+        guard isEnabled,
+              let selectedTabId = snapshot.selectedTabId,
+              let target = snapshot.tabs.first(where: { $0.id != selectedTabId }) else {
+            return
+        }
+        dlog(
+            "workspace.create.devSelectionMutation from=\(selectedTabId.uuidString.prefix(5)) " +
+            "to=\(target.id.uuidString.prefix(5))"
+        )
+        self.selectedTabId = target.id
+    }
+#endif
+
     @discardableResult
     func addWorkspace(
         workingDirectory overrideWorkingDirectory: String? = nil,
@@ -1173,6 +1197,9 @@ class TabManager: ObservableObject {
         // Snapshot current published state once so workspace creation doesn't repeatedly
         // bounce through Combine-backed accessors while we're preparing the new workspace.
         let snapshot = workspaceCreationSnapshot()
+#if DEBUG
+        maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
+#endif
         let nextTabCount = snapshot.tabs.count + 1
         sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -294,6 +294,29 @@ final class WorkspacePlacementSettingsTests: XCTestCase {
 
 @MainActor
 final class WorkspaceCreationPlacementTests: XCTestCase {
+    private final class SnapshotMutatingTabManager: TabManager {
+        var beforeCreateWorkspace: (() -> Void)?
+
+        override func makeWorkspaceForCreation(
+            title: String,
+            workingDirectory: String?,
+            portOrdinal: Int,
+            configTemplate: ghostty_surface_config_s?,
+            initialTerminalCommand: String?,
+            initialTerminalEnvironment: [String: String]
+        ) -> Workspace {
+            beforeCreateWorkspace?()
+            return super.makeWorkspaceForCreation(
+                title: title,
+                workingDirectory: workingDirectory,
+                portOrdinal: portOrdinal,
+                configTemplate: configTemplate,
+                initialTerminalCommand: initialTerminalCommand,
+                initialTerminalEnvironment: initialTerminalEnvironment
+            )
+        }
+    }
+
     func testAddWorkspaceDefaultPlacementMatchesCurrentSetting() {
         let currentPlacement = WorkspacePlacementSettings.current()
 
@@ -350,6 +373,30 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
 
         XCTAssertEqual(manager.tabs.map(\.id).filter { $0 != inserted.id }, baselineOrder)
         XCTAssertEqual(manager.tabs.last?.id, inserted.id)
+    }
+
+    func testAddWorkspaceAfterCurrentUsesPrecreationSnapshotWhenSelectionMutatesDuringBootstrap() {
+        let manager = SnapshotMutatingTabManager()
+        guard let first = manager.tabs.first else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+
+        manager.setPinned(first, pinned: true)
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+        manager.selectWorkspace(third)
+
+        let baselineOrder = manager.tabs.map(\.id)
+        manager.beforeCreateWorkspace = {
+            manager.selectWorkspace(first)
+        }
+
+        let inserted = manager.addWorkspace(placementOverride: .afterCurrent)
+
+        XCTAssertEqual(manager.tabs.map(\.id).filter { $0 != inserted.id }, baselineOrder)
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, second.id, third.id, inserted.id])
+        XCTAssertEqual(manager.selectedTabId, inserted.id)
     }
 
     private func makeManagerWithThreeWorkspaces() -> TabManager {


### PR DESCRIPTION
## Summary
- add a small `TabManager` workspace-construction seam so tests can mutate selection during workspace bootstrap
- add a regression test proving `.afterCurrent` insertion still uses the pre-creation snapshot even if selection changes mid-creation
- add a debug-only dev flag that deliberately flips selection during workspace creation so Cmd+N can be stress-tested manually

## Context
The runtime fix for #2017 is already present on current `main` in the snapshot-based workspace creation path. This PR locks that behavior in with targeted regression coverage and a dev-only flag for manual verification.

### Dev flag
- env: `CMUX_DEV_MUTATE_WORKSPACE_SELECTION_DURING_CREATION=1`
- defaults key: `cmuxDevMutateWorkspaceSelectionDuringCreation`

When enabled in a DEBUG build, workspace creation intentionally mutates the live selected workspace after the snapshot is taken. Cmd+N should still create the new workspace without crashing and should still honor the original pre-creation selection.

Closes #2017

## Validation
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-issue-1983-newtabinsertindex-crash" -disableAutomaticPackageResolution build`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData/cmux-issue-1983-newtabinsertindex-crash" -disableAutomaticPackageResolution build`

Local GUI launch was not performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying new workspaces are placed correctly even if tab selection changes during creation.

* **Refactor**
  * Centralized and optimized workspace creation to improve consistency during insertion.

* **Developer (debug-only)**
  * Dev-only behavior to optionally mutate selection during workspace creation in debug builds to support testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->