### PR TITLE
Double-click custom titlebar to zoom or minimize

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2489,6 +2489,7 @@ struct ContentView: View {
         .frame(height: titlebarPadding)
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
+        .background(TitlebarDoubleClickMonitorView())
         .background({
             // The terminal area has two stacked semi-transparent layers: the Bonsplit
             // container chrome background plus Ghostty's own Metal-rendered background.
@@ -8610,6 +8611,7 @@ struct VerticalTabsSidebar: View {
                     // drag-to-move and double-click action (zoom/minimize).
                     WindowDragHandleView()
                         .frame(height: trafficLightPadding)
+                        .background(TitlebarDoubleClickMonitorView())
                 }
                 .overlay(alignment: .topLeading) {
                     if isMinimalMode {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -84,23 +84,23 @@ private func windowDragHandleShouldResolveActiveHitCapture(
 
 /// Runs the same action macOS titlebars use for double-click:
 /// zoom by default, or minimize when the user preference is set.
-@discardableResult
-func performStandardTitlebarDoubleClick(window: NSWindow?) -> Bool {
-    guard let window else { return false }
+enum StandardTitlebarDoubleClickAction: Equatable {
+    case miniaturize
+    case zoom
+    case none
+}
 
-    let globalDefaults = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
+func resolvedStandardTitlebarDoubleClickAction(globalDefaults: [String: Any]) -> StandardTitlebarDoubleClickAction {
     if let action = (globalDefaults["AppleActionOnDoubleClick"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines)
         .lowercased() {
         switch action {
-        case "minimize":
-            window.miniaturize(nil)
-            return true
-        case "none":
-            return false
-        case "maximize", "zoom":
-            window.zoom(nil)
-            return true
+        case "minimize", "miniaturize":
+            return .miniaturize
+        case "maximize", "zoom", "fill":
+            return .zoom
+        case "none", "no action":
+            return .none
         default:
             break
         }
@@ -108,12 +108,29 @@ func performStandardTitlebarDoubleClick(window: NSWindow?) -> Bool {
 
     if let miniaturizeOnDoubleClick = globalDefaults["AppleMiniaturizeOnDoubleClick"] as? Bool,
        miniaturizeOnDoubleClick {
-        window.miniaturize(nil)
-        return true
+        return .miniaturize
     }
 
-    window.zoom(nil)
-    return true
+    return .zoom
+}
+
+/// Runs the same action macOS titlebars use for double-click:
+/// zoom by default, or minimize when the user preference is set.
+@discardableResult
+func performStandardTitlebarDoubleClick(window: NSWindow?) -> StandardTitlebarDoubleClickAction? {
+    guard let window else { return nil }
+
+    let globalDefaults = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
+    let action = resolvedStandardTitlebarDoubleClickAction(globalDefaults: globalDefaults)
+    switch action {
+    case .miniaturize:
+        window.miniaturize(nil)
+    case .zoom:
+        window.zoom(nil)
+    case .none:
+        break
+    }
+    return action
 }
 
 private enum WindowDragHandleAssociatedObjectKeys {
@@ -410,11 +427,11 @@ struct WindowDragHandleView: NSViewRepresentable {
             #endif
 
             if event.clickCount >= 2 {
-                let handled = performStandardTitlebarDoubleClick(window: window)
+                let action = performStandardTitlebarDoubleClick(window: window)
                 #if DEBUG
-                dlog("titlebar.dragHandle.mouseDownDoubleClick handled=\(handled ? 1 : 0)")
+                dlog("titlebar.dragHandle.mouseDownDoubleClick action=\(String(describing: action))")
                 #endif
-                if handled {
+                if action != nil {
                     return
                 }
             }
@@ -438,5 +455,50 @@ struct WindowDragHandleView: NSViewRepresentable {
                 super.mouseDown(with: event)
             }
         }
+    }
+}
+
+/// Local monitor that guarantees double-clicks in custom titlebar surfaces trigger
+/// the standard macOS titlebar action even when the visible strip is hosted by
+/// higher-level SwiftUI/AppKit container views.
+struct TitlebarDoubleClickMonitorView: NSViewRepresentable {
+    final class Coordinator {
+        weak var view: NSView?
+        var monitor: Any?
+
+        deinit {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+
+        context.coordinator.view = view
+
+        let coordinator = context.coordinator
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak coordinator] event in
+            guard event.clickCount >= 2 else { return event }
+            guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
+            guard event.window === window else { return event }
+
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) else { return event }
+
+            let action = performStandardTitlebarDoubleClick(window: window)
+            return action == nil ? event : nil
+        }
+
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.view = nsView
     }
 }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -44,6 +44,12 @@ struct TmuxOverlayExperimentSettings {
     }
 }
 
+private enum WorkspaceTitlebarInteractionMetrics {
+    // Keep in sync with Bonsplit's tab bar height so the monitor only covers
+    // the minimal-mode titlebar strip.
+    static let minimalModeTopStripHeight: CGFloat = 30
+}
+
 struct TmuxPaneLayoutPane: Codable, Equatable, Sendable {
     let paneId: String
     let left: Int
@@ -373,6 +379,12 @@ struct WorkspaceContentView: View {
             if isMinimalMode {
                 bonsplitView
                     .ignoresSafeArea(.container, edges: .top)
+                    .overlay(alignment: .top) {
+                        if isWorkspaceInputActive {
+                            TitlebarDoubleClickMonitorView()
+                                .frame(height: WorkspaceTitlebarInteractionMetrics.minimalModeTopStripHeight)
+                        }
+                    }
             } else {
                 bonsplitView
             }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1258,6 +1258,51 @@ final class WorkspaceRemoteConfigurationTransportKeyTests: XCTestCase {
     }
 }
 
+final class TitlebarDoubleClickPreferenceTests: XCTestCase {
+    func testResolvesZoomForFillPreference() {
+        XCTAssertEqual(
+            resolvedStandardTitlebarDoubleClickAction(globalDefaults: [
+                "AppleActionOnDoubleClick": "Fill",
+            ]),
+            .zoom
+        )
+    }
+
+    func testResolvesMiniaturizeForExplicitMinimizePreference() {
+        XCTAssertEqual(
+            resolvedStandardTitlebarDoubleClickAction(globalDefaults: [
+                "AppleActionOnDoubleClick": "Minimize",
+            ]),
+            .miniaturize
+        )
+    }
+
+    func testResolvesNoneForNoActionPreference() {
+        XCTAssertEqual(
+            resolvedStandardTitlebarDoubleClickAction(globalDefaults: [
+                "AppleActionOnDoubleClick": "No Action",
+            ]),
+            .none
+        )
+    }
+
+    func testFallsBackToLegacyMiniaturizePreference() {
+        XCTAssertEqual(
+            resolvedStandardTitlebarDoubleClickAction(globalDefaults: [
+                "AppleMiniaturizeOnDoubleClick": true,
+            ]),
+            .miniaturize
+        )
+    }
+
+    func testDefaultsToZoomWhenPreferenceIsMissing() {
+        XCTAssertEqual(
+            resolvedStandardTitlebarDoubleClickAction(globalDefaults: [:]),
+            .zoom
+        )
+    }
+}
+
 final class WorkspaceRemoteDaemonPendingCallRegistryTests: XCTestCase {
     func testSupportsMultiplePendingCallsResolvedOutOfOrder() {
         let registry = WorkspaceRemoteDaemonPendingCallRegistry()


### PR DESCRIPTION
## Summary

- forward double-clicks on the custom titlebar surfaces to the standard macOS titlebar action
- respect the user's `AppleActionOnDoubleClick` / legacy `AppleMiniaturizeOnDoubleClick` preference when deciding between zoom, minimize, or no action
- cover the preference mapping with unit tests

Fixes #2128.

## Testing

- Built a tagged Debug app with `./scripts/reload.sh --tag issue2128-doubleclick`
- Opened the tagged app for manual verification
- Did not run local automated tests because this repo's policy is to run them in GitHub Actions / VM

## Demo Video

- Video URL or attachment: not included from CLI environment

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-clicking the custom titlebar now performs the standard macOS action (zoom, minimize, or none) based on the user’s setting, and works in minimal mode. Fixes #2128.

- **Bug Fixes**
  - Route double-clicks via `AppleActionOnDoubleClick` and legacy `AppleMiniaturizeOnDoubleClick`, defaulting to zoom when unset.
  - Added `TitlebarDoubleClickMonitorView` and applied it to the drag handle and the minimal-mode top strip.
  - Added unit tests covering preference mapping (fill→zoom, minimize, no action, legacy key, default).

<sup>Written for commit c60d45264f5f30fd34e14d1b175b4b72cf4716b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced titlebar and sidebar double-click interactions to properly respond to macOS system preferences for window actions (minimize, zoom).
  * Improved event detection in titlebar area with support for executing system-preferred window behaviors.

* **Tests**
  * Added test coverage for titlebar double-click preference resolution and action handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->