### PR TITLE
Fix t3code sidecar resolution for bundled install

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -123,6 +123,12 @@
 					CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
+		AA3001000000000000000001 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3001000000000000000011 /* Writer.swift */; };
+		AA3002000000000000000002 /* T3CodeSidecarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3002000000000000000012 /* T3CodeSidecarManager.swift */; };
+		AA3003000000000000000003 /* WriterSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3003000000000000000013 /* WriterSidebarView.swift */; };
+		AA3004000000000000000004 /* ChatPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3004000000000000000014 /* ChatPanel.swift */; };
+		AA3005000000000000000005 /* ChatPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3005000000000000000015 /* ChatPanelView.swift */; };
+		AA3006000000000000000006 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3006000000000000000016 /* Project.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -292,6 +298,12 @@
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		AA3001000000000000000011 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
+		AA3002000000000000000012 /* T3CodeSidecarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = T3CodeSidecarManager.swift; sourceTree = "<group>"; };
+		AA3003000000000000000013 /* WriterSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriterSidebarView.swift; sourceTree = "<group>"; };
+		AA3004000000000000000014 /* ChatPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ChatPanel.swift; sourceTree = "<group>"; };
+		AA3005000000000000000015 /* ChatPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ChatPanelView.swift; sourceTree = "<group>"; };
+		AA3006000000000000000016 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -458,6 +470,12 @@
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
+				AA3001000000000000000011 /* Writer.swift */,
+				AA3002000000000000000012 /* T3CodeSidecarManager.swift */,
+				AA3003000000000000000013 /* WriterSidebarView.swift */,
+				AA3004000000000000000014 /* ChatPanel.swift */,
+				AA3005000000000000000015 /* ChatPanelView.swift */,
+				AA3006000000000000000016 /* Project.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -753,6 +771,12 @@
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
 				A5001640 /* RemoteRelayZshBootstrap.swift in Sources */,
+				AA3001000000000000000001 /* Writer.swift in Sources */,
+				AA3002000000000000000002 /* T3CodeSidecarManager.swift in Sources */,
+				AA3003000000000000000003 /* WriterSidebarView.swift in Sources */,
+				AA3004000000000000000004 /* ChatPanel.swift in Sources */,
+				AA3005000000000000000005 /* ChatPanelView.swift in Sources */,
+				AA3006000000000000000006 /* Project.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
+++ b/GhosttyTabs.xcodeproj/xcshareddata/xcschemes/cmux.xcscheme
@@ -1,32 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion="1500" version="1.7">
-  <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
-        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
-    <Testables>
-      <TestableReference skipped="NO">
-        <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="CB450DF0F0B3839599082C4D" BuildableName="cmuxUITests.xctest" BlueprintName="cmuxUITests" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-      </TestableReference>
-    </Testables>
-    <MacroExpansion>
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </MacroExpansion>
-  </TestAction>
-  <LaunchAction buildConfiguration="Release" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" allowLocationSimulation="YES">
-    <BuildableProductRunnable runnableDebuggingMode="0">
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </BuildableProductRunnable>
-  </LaunchAction>
-  <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
-    <BuildableProductRunnable runnableDebuggingMode="0">
-      <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="A5001050" BuildableName="cmux.app" BlueprintName="GhosttyTabs" ReferencedContainer="container:GhosttyTabs.xcodeproj"/>
-    </BuildableProductRunnable>
-  </ProfileAction>
-  <AnalyzeAction buildConfiguration="Release"/>
-  <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"/>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5001050"
+               BuildableName = "cmux.app"
+               BlueprintName = "GhosttyTabs"
+               ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB450DF0F0B3839599082C4D"
+               BuildableName = "cmuxUITests.xctest"
+               BlueprintName = "cmuxUITests"
+               ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5001050"
+            BuildableName = "cmux.app"
+            BlueprintName = "GhosttyTabs"
+            ReferencedContainer = "container:GhosttyTabs.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -158,5 +158,7 @@
 	<false/>
 	<key>SUPublicEDKey</key>
 	<string>$(SPARKLE_PUBLIC_KEY)</string>
+	<key>CMUXSourceRoot</key>
+	<string>$(SRCROOT)</string>
 </dict>
 </plist>

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -183,6 +183,7 @@ _cmux_tmux_sync_cmux_environment() {
         _cmux_tmux_publish_cmux_environment
     fi
 }
+typeset -g _CMUX_LAST_PROMPT_WRAPPED=0
 
 _cmux_ensure_ghostty_preexec_strips_both_marks() {
     local fn_name="$1"
@@ -237,6 +238,7 @@ _cmux_patch_ghostty_semantic_redraw
 _cmux_prompt_wrap_guard() {
     local cmd_start="$1"
     local pwd="$2"
+    _CMUX_LAST_PROMPT_WRAPPED=0
     [[ -n "$cmd_start" && "$cmd_start" != 0 ]] || return 0
 
     local cols="${COLUMNS:-0}"
@@ -248,6 +250,7 @@ _cmux_prompt_wrap_guard() {
 
     # Keep a spacer line between command output and a wrapped prompt so
     # resize-driven prompt redraw cannot overwrite the command tail.
+    _CMUX_LAST_PROMPT_WRAPPED=1
     builtin print -r -- ""
 }
 
@@ -265,6 +268,7 @@ _cmux_install_winch_guard() {
     TRAPWINCH() {
         [[ -n "$CMUX_TAB_ID" ]] || return 0
         [[ -n "$CMUX_PANEL_ID" ]] || return 0
+        (( _CMUX_LAST_PROMPT_WRAPPED )) || return 0
 
         # Ghostty already marks prompt redraws on SIGWINCH. Writing to the PTY
         # here grows the screen and makes resize look like a fresh prompt.
@@ -645,6 +649,7 @@ _cmux_start_git_head_watch() {
 
 _cmux_preexec() {
     _cmux_tmux_sync_cmux_environment
+    _CMUX_LAST_PROMPT_WRAPPED=0
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2130,6 +2130,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 #endif
 
+    /// Active t3code sidecar managers, keyed by workspace ID.
+    private var sidecarManagers: [UUID: T3CodeSidecarManager] = [:]
+
     private var mainWindowContexts: [ObjectIdentifier: MainWindowContext] = [:]
     private var mainWindowControllers: [MainWindowController] = []
     private var startupSessionSnapshot: AppSessionSnapshot?
@@ -2651,6 +2654,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
+
+        // Shut down all t3code sidecars
+        for (_, manager) in sidecarManagers {
+            manager.shutdown()
+        }
+        sidecarManagers.removeAll()
+
         TerminalController.shared.stop()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
@@ -2915,6 +2925,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         context.tabManager.restoreSessionSnapshot(snapshot.tabManager)
+
+        // Start t3code sidecars for all restored workspaces in this window.
+        for workspace in context.tabManager.tabs {
+            startSidecar(for: workspace)
+        }
+
         context.sidebarState.isVisible = snapshot.sidebar.isVisible
         context.sidebarState.persistedWidth = CGFloat(
             SessionPersistencePolicy.sanitizedSidebarWidth(snapshot.sidebar.width)
@@ -4331,6 +4347,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             select: shouldBringToFront
         )
         return workspace.id
+    }
+
+    /// Start a t3code sidecar for the given workspace. Called from TabManager.addTask and session restore.
+    func startSidecarForWorkspace(_ workspace: Workspace) {
+        startSidecar(for: workspace)
+    }
+
+    /// Start a t3code sidecar for the given workspace.
+    private func startSidecar(for workspace: Workspace) {
+        let directory = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !directory.isEmpty else { return }
+        let directoryURL = URL(fileURLWithPath: directory)
+
+        let manager = T3CodeSidecarManager(projectDirectory: directoryURL)
+
+        manager.onReady = { [weak workspace] port in
+            workspace?.notifyChatPanelsOfPort(port)
+        }
+
+        manager.onCrash = { [weak self, weak workspace] in
+            guard let self = self, let workspace = workspace else { return }
+            self.sidecarManagers[workspace.id]?.restart()
+        }
+
+        sidecarManagers[workspace.id] = manager
+        workspace.t3codeSidecarManager = manager
+        manager.start()
     }
 
     private func markCommandPaletteOpenRequested(for window: NSWindow?) {
@@ -5772,6 +5815,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let tabManager = TabManager(initialWorkingDirectory: initialWorkingDirectory)
         if let tabManagerSnapshot = sessionWindowSnapshot?.tabManager {
             tabManager.restoreSessionSnapshot(tabManagerSnapshot)
+
+            // Start t3code sidecars for all restored workspaces in this window.
+            for workspace in tabManager.tabs {
+                startSidecar(for: workspace)
+            }
         }
 
         let sidebarWidth = sessionWindowSnapshot?.sidebar.width

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2444,7 +2444,20 @@ struct ContentView: View {
                 )
             },
             onNewTab: { tabManager.addTab() },
-            visibilityMode: .alwaysVisible
+            visibilityMode: .alwaysVisible,
+            onNewProject: { [weak tabManager] in
+                guard let tabManager else { return }
+                let panel = NSOpenPanel()
+                panel.canChooseFiles = false
+                panel.canChooseDirectories = true
+                panel.allowsMultipleSelection = false
+                panel.prompt = String(localized: "fullscreen.newProject.panelPrompt", defaultValue: "Choose Project Directory")
+                panel.message = String(localized: "fullscreen.newProject.panelMessage", defaultValue: "Select the root directory for your project")
+                if panel.runModal() == .OK, let url = panel.url {
+                    let projectName = url.lastPathComponent
+                    tabManager.addProject(name: projectName, directory: url.path)
+                }
+            }
         )
     }
 
@@ -4994,6 +5007,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.kind.browser", defaultValue: "Browser")
         case .markdown:
             return String(localized: "commandPalette.kind.markdown", defaultValue: "Markdown")
+        case .chat:
+            return String(localized: "commandPalette.kind.chat", defaultValue: "Chat")
         }
     }
 
@@ -5005,6 +5020,8 @@ struct ContentView: View {
             return ["browser", "web", "page"]
         case .markdown:
             return ["markdown", "note", "preview"]
+        case .chat:
+            return ["chat", "ai", "agent", "t3code"]
         }
     }
 
@@ -5296,6 +5313,14 @@ struct ContentView: View {
                 title: constant(String(localized: "command.newWindow.title", defaultValue: "New Window")),
                 subtitle: constant(String(localized: "command.newWindow.subtitle", defaultValue: "Window")),
                 keywords: ["create", "new", "window"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.newProject",
+                title: constant(String(localized: "command.newProject.title", defaultValue: "New Project…")),
+                subtitle: constant(String(localized: "command.newProject.subtitle", defaultValue: "Project")),
+                keywords: ["create", "new", "project", "folder", "directory"]
             )
         )
         contributions.append(
@@ -5966,6 +5991,21 @@ struct ContentView: View {
     private func registerCommandPaletteHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
         registry.register(commandId: "palette.newWorkspace") {
             tabManager.addWorkspace()
+        }
+        registry.register(commandId: "palette.newProject") {
+            // Defer so the command palette dismisses before the modal sheet appears.
+            DispatchQueue.main.async {
+                let panel = NSOpenPanel()
+                panel.canChooseFiles = false
+                panel.canChooseDirectories = true
+                panel.allowsMultipleSelection = false
+                panel.prompt = String(localized: "panel.newProject.prompt", defaultValue: "Choose Project Directory")
+                panel.message = String(localized: "panel.newProject.message", defaultValue: "Select the root directory for your project")
+                if panel.runModal() == .OK, let url = panel.url {
+                    let projectName = url.lastPathComponent
+                    tabManager.addProject(name: projectName, directory: url.path)
+                }
+            }
         }
         registry.register(commandId: "palette.openFolder") {
             // Defer so the command palette dismisses before the modal sheet appears.
@@ -8481,50 +8521,60 @@ struct VerticalTabsSidebar: View {
                             .frame(height: trafficLightPadding)
 
                         LazyVStack(spacing: tabRowSpacing) {
+                            // Project sections — each project is a collapsible
+                            // group containing its task-workspaces.
+                            ForEach(tabManager.projects) { project in
+                                SidebarProjectSection(project: project)
+                            }
+
+                            // Standalone workspaces not owned by any project
+                            // are shown below projects as regular TabItemViews.
+                            let ownedIds = tabManager.projectOwnedWorkspaceIds
                             ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
-                                let selectedContextIds: Set<UUID> = selectedTabIds.contains(tab.id) ? selectedTabIds : [tab.id]
-                                let contextTargetIds = tabManager.tabs.compactMap { workspace in
-                                    selectedContextIds.contains(workspace.id) ? workspace.id : nil
+                                if !ownedIds.contains(tab.id) {
+                                    let selectedContextIds: Set<UUID> = selectedTabIds.contains(tab.id) ? selectedTabIds : [tab.id]
+                                    let contextTargetIds = tabManager.tabs.compactMap { workspace in
+                                        selectedContextIds.contains(workspace.id) ? workspace.id : nil
+                                    }
+                                    let remoteContextMenuTargets = tabManager.tabs.filter { workspace in
+                                        contextTargetIds.contains(workspace.id) && workspace.isRemoteWorkspace
+                                    }
+                                    TabItemView(
+                                        tabManager: tabManager,
+                                        notificationStore: notificationStore,
+                                        tab: tab,
+                                        index: index,
+                                        isActive: tabManager.selectedTabId == tab.id,
+                                        workspaceShortcutDigit: WorkspaceShortcutMapper.commandDigitForWorkspace(
+                                            at: index,
+                                            workspaceCount: workspaceCount
+                                        ),
+                                        canCloseWorkspace: canCloseWorkspace,
+                                        accessibilityWorkspaceCount: workspaceCount,
+                                        unreadCount: notificationStore.unreadCount(forTabId: tab.id),
+                                        latestNotificationText: {
+                                            guard showsSidebarNotificationMessage,
+                                                  let notification = notificationStore.latestNotification(forTabId: tab.id) else {
+                                                return nil
+                                            }
+                                            let text = notification.body.isEmpty ? notification.title : notification.body
+                                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                            return trimmed.isEmpty ? nil : trimmed
+                                        }(),
+                                        rowSpacing: tabRowSpacing,
+                                        setSelectionToTabs: { selection = .tabs },
+                                        selectedTabIds: $selectedTabIds,
+                                        lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                        showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
+                                        dragAutoScrollController: dragAutoScrollController,
+                                        draggedTabId: $draggedTabId,
+                                        dropIndicator: $dropIndicator,
+                                        remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
+                                        allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
+                                        allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
+                                    )
+                                    .equatable()
                                 }
-                                let remoteContextMenuTargets = tabManager.tabs.filter { workspace in
-                                    contextTargetIds.contains(workspace.id) && workspace.isRemoteWorkspace
-                                }
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
-                                    index: index,
-                                    isActive: tabManager.selectedTabId == tab.id,
-                                    workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                                        at: index,
-                                        workspaceCount: workspaceCount
-                                    ),
-                                    workspaceShortcutModifierSymbol: workspaceNumberShortcut.modifierDisplayString,
-                                    canCloseWorkspace: canCloseWorkspace,
-                                    accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: notificationStore.unreadCount(forTabId: tab.id),
-                                    latestNotificationText: {
-                                        guard showsSidebarNotificationMessage,
-                                              let notification = notificationStore.latestNotification(forTabId: tab.id) else {
-                                            return nil
-                                        }
-                                        let text = notification.body.isEmpty ? notification.title : notification.body
-                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        return trimmed.isEmpty ? nil : trimmed
-                                    }(),
-                                    rowSpacing: tabRowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                                    showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
-                                    remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
-                                    allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
-                                    allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
-                                )
-                                .equatable()
                             }
                         }
                         .padding(.vertical, 8)
@@ -10755,36 +10805,88 @@ private struct SidebarEmptyArea: View {
     @Binding var dropIndicator: SidebarDropIndicator?
 
     var body: some View {
-        Color.clear
-            .contentShape(Rectangle())
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onTapGesture(count: 2) {
-                tabManager.addWorkspace(placementOverride: .end)
-                if let selectedId = tabManager.selectedTabId {
-                    selectedTabIds = [selectedId]
-                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+        ZStack {
+            Color.clear
+                .contentShape(Rectangle())
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onTapGesture(count: 2) {
+                    tabManager.addWorkspace(placementOverride: .end)
+                    if let selectedId = tabManager.selectedTabId {
+                        selectedTabIds = [selectedId]
+                        lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                    }
+                    selection = .tabs
                 }
-                selection = .tabs
-            }
-            .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: SidebarTabDropDelegate(
-                targetTabId: nil,
-                tabManager: tabManager,
-                draggedTabId: $draggedTabId,
-                selectedTabIds: $selectedTabIds,
-                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                targetRowHeight: nil,
-                dragAutoScrollController: dragAutoScrollController,
-                dropIndicator: $dropIndicator
-            ))
-            .overlay(alignment: .top) {
-                if shouldShowTopDropIndicator {
-                    Rectangle()
-                        .fill(cmuxAccentColor())
-                        .frame(height: 2)
-                        .padding(.horizontal, 8)
-                        .offset(y: -(rowSpacing / 2))
+                .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: SidebarTabDropDelegate(
+                    targetTabId: nil,
+                    tabManager: tabManager,
+                    draggedTabId: $draggedTabId,
+                    selectedTabIds: $selectedTabIds,
+                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                    targetRowHeight: nil,
+                    dragAutoScrollController: dragAutoScrollController,
+                    dropIndicator: $dropIndicator
+                ))
+                .overlay(alignment: .top) {
+                    if shouldShowTopDropIndicator {
+                        Rectangle()
+                            .fill(cmuxAccentColor())
+                            .frame(height: 2)
+                            .padding(.horizontal, 8)
+                            .offset(y: -(rowSpacing / 2))
+                    }
                 }
+                .contextMenu {
+                    Button(String(localized: "sidebar.contextMenu.newWorkspace", defaultValue: "New Workspace")) {
+                        tabManager.addWorkspace(placementOverride: .end)
+                        if let selectedId = tabManager.selectedTabId {
+                            selectedTabIds = [selectedId]
+                            lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                        }
+                        selection = .tabs
+                    }
+                    Button(String(localized: "sidebar.contextMenu.newProject", defaultValue: "New Project…")) {
+                        showNewProjectDialog()
+                    }
+                }
+
+            // Prominent "Create a Project" prompt when there are no projects
+            if tabManager.projects.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "folder.badge.plus")
+                        .font(.system(size: 24))
+                        .foregroundColor(.secondary.opacity(0.5))
+                    Text(String(localized: "sidebar.emptyState.title", defaultValue: "No projects yet"))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        showNewProjectDialog()
+                    }) {
+                        Text(String(localized: "sidebar.emptyState.createButton", defaultValue: "Create a Project"))
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+                }
+                .padding(.top, 20)
+                .allowsHitTesting(true)
             }
+        }
+    }
+
+    private func showNewProjectDialog() {
+        DispatchQueue.main.async {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            panel.prompt = String(localized: "sidebar.newProject.panelPrompt", defaultValue: "Choose Project Directory")
+            panel.message = String(localized: "sidebar.newProject.panelMessage", defaultValue: "Select the root directory for your project")
+            if panel.runModal() == .OK, let url = panel.url {
+                let projectName = url.lastPathComponent
+                tabManager.addProject(name: projectName, directory: url.path)
+            }
+        }
     }
 
     private var shouldShowTopDropIndicator: Bool {
@@ -11853,6 +11955,7 @@ private struct TabItemView: View, Equatable {
 
         lastSidebarSelectionIndex = index
         tabManager.selectTab(tab)
+
         if wasSelected, !isCommand, !isShift {
             tabManager.dismissNotificationOnDirectInteraction(
                 tabId: tab.id,

--- a/Sources/Panels/ChatPanel.swift
+++ b/Sources/Panels/ChatPanel.swift
@@ -32,6 +32,10 @@ final class ChatPanel: NSObject, Panel, ObservableObject, WKScriptMessageHandler
     /// The t3code sidecar server port for this workspace.
     private(set) var serverPort: Int?
 
+    /// The workspace project directory passed to the embedded URL so t3code
+    /// can bind the thread to the correct project.
+    private let projectCwd: String?
+
     /// The web view displaying t3code's React UI.
     private(set) var webView: CmuxWebView
 
@@ -58,11 +62,12 @@ final class ChatPanel: NSObject, Panel, ObservableObject, WKScriptMessageHandler
 
     // MARK: - Init
 
-    init(workspaceId: UUID, threadId: String? = nil, serverPort: Int? = nil) {
+    init(workspaceId: UUID, threadId: String? = nil, serverPort: Int? = nil, projectCwd: String? = nil) {
         self.id = UUID()
         self.workspaceId = workspaceId
         self.t3codeThreadId = Self.normalizedThreadId(threadId)
         self.serverPort = serverPort
+        self.projectCwd = projectCwd
 
         let config = WKWebViewConfiguration()
         config.preferences.setValue(true, forKey: "developerExtrasEnabled")
@@ -134,13 +139,22 @@ final class ChatPanel: NSObject, Panel, ObservableObject, WKScriptMessageHandler
         var urlString = "http://127.0.0.1:\(port)"
         let normalizedThreadId = Self.normalizedThreadId(t3codeThreadId)
         t3codeThreadId = normalizedThreadId
+
+        // Build query parameters. Always include embedded=1; optionally
+        // include projectCwd so t3code can bind to the correct project.
+        var queryItems = "embedded=1"
+        if let cwd = projectCwd,
+           let encodedCwd = cwd.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            queryItems += "&projectCwd=\(encodedCwd)"
+        }
+
         if let threadId = normalizedThreadId,
            let encodedThreadId = threadId.addingPercentEncoding(
             withAllowedCharacters: Self.threadIDPathAllowedCharacters
            ) {
-            urlString += "/\(encodedThreadId)?embedded=1"
+            urlString += "/\(encodedThreadId)?\(queryItems)"
         } else {
-            urlString += "/_chat?embedded=1"
+            urlString += "/_chat?\(queryItems)"
         }
 
         guard let url = URL(string: urlString) else {

--- a/Sources/Panels/ChatPanel.swift
+++ b/Sources/Panels/ChatPanel.swift
@@ -1,0 +1,363 @@
+import AppKit
+import Combine
+import WebKit
+import os
+
+/// A panel that displays the t3code chat UI in a CmuxWebView.
+/// Each ChatPanel corresponds to one writer/task within a workspace.
+@MainActor
+final class ChatPanel: NSObject, Panel, ObservableObject, WKScriptMessageHandler {
+
+    private static let threadSyncMessageHandlerName = "cmuxThreadSync"
+    private static let reservedEmbeddedThreadIDs: Set<String> = ["_chat", "settings"]
+    private static let threadIDPathAllowedCharacters: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#")
+        return allowed
+    }()
+
+    private let logger = Logger(subsystem: "com.cmuxterm.app", category: "ChatPanel")
+    private let startupTimeoutSeconds: TimeInterval = 45
+    private let readinessPollIntervalNanoseconds: UInt64 = 500_000_000
+
+    let id: UUID
+    let panelType: PanelType = .chat
+
+    /// The workspace this panel belongs to.
+    private(set) var workspaceId: UUID
+
+    /// The writer's t3code thread ID (set after the first conversation is created).
+    @Published var t3codeThreadId: String?
+
+    /// The t3code sidecar server port for this workspace.
+    private(set) var serverPort: Int?
+
+    /// The web view displaying t3code's React UI.
+    private(set) var webView: CmuxWebView
+
+    /// Callback fired when the embedded web app reports its active thread ID.
+    var onThreadIdChange: ((String?) -> Void)?
+
+    /// Polls the target URL until the sidecar actually starts accepting requests.
+    private var serverReadinessTask: Task<Void, Never>?
+
+    /// Tracks whether the real t3code UI has been loaded yet.
+    private var hasLoadedServerUI = false
+
+    /// Display title shown in the tab bar.
+    @Published private(set) var displayTitle: String = String(
+        localized: "chat.newChat",
+        defaultValue: "Chat"
+    )
+
+    /// SF Symbol icon for the tab bar.
+    var displayIcon: String? { "bubble.left.and.text.bubble.right" }
+
+    /// Token incremented to trigger focus flash animation.
+    @Published private(set) var focusFlashToken: Int = 0
+
+    // MARK: - Init
+
+    init(workspaceId: UUID, threadId: String? = nil, serverPort: Int? = nil) {
+        self.id = UUID()
+        self.workspaceId = workspaceId
+        self.t3codeThreadId = Self.normalizedThreadId(threadId)
+        self.serverPort = serverPort
+
+        let config = WKWebViewConfiguration()
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
+
+        let webView = CmuxWebView(frame: .zero, configuration: config)
+        webView.allowsBackForwardNavigationGestures = false
+        self.webView = webView
+        super.init()
+        config.userContentController.add(self, name: Self.threadSyncMessageHandlerName)
+
+        if let port = serverPort {
+            waitForServerAndLoad(port: port)
+        } else {
+            loadWaitingPage()
+        }
+    }
+
+    // MARK: - Panel protocol
+
+    func focus() {
+        guard let window = webView.window, !webView.isHiddenOrHasHiddenAncestor else { return }
+
+        if webView.window?.firstResponder === webView {
+            return
+        }
+        window.makeFirstResponder(webView)
+    }
+
+    func unfocus() {
+        guard let window = webView.window else { return }
+        if window.firstResponder === webView {
+            window.makeFirstResponder(nil)
+        }
+    }
+
+    func close() {
+        unfocus()
+        serverReadinessTask?.cancel()
+        serverReadinessTask = nil
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: Self.threadSyncMessageHandlerName
+        )
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+    }
+
+    func triggerFlash() {
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
+        focusFlashToken &+= 1
+    }
+
+    // MARK: - t3code UI loading
+
+    /// Load or reload the t3code UI with the given server port.
+    func loadT3CodeUI(port: Int) {
+        self.serverPort = port
+        waitForServerAndLoad(port: port)
+    }
+
+    private func loadLiveT3CodeUI(port: Int) {
+        self.serverPort = port
+        self.hasLoadedServerUI = true
+        self.serverReadinessTask?.cancel()
+        self.serverReadinessTask = nil
+
+        // TanStack's generated route tree exposes thread pages at "/$threadId"
+        // while the embedded bootstrap/index view lives at "/_chat".
+        var urlString = "http://127.0.0.1:\(port)"
+        let normalizedThreadId = Self.normalizedThreadId(t3codeThreadId)
+        t3codeThreadId = normalizedThreadId
+        if let threadId = normalizedThreadId,
+           let encodedThreadId = threadId.addingPercentEncoding(
+            withAllowedCharacters: Self.threadIDPathAllowedCharacters
+           ) {
+            urlString += "/\(encodedThreadId)?embedded=1"
+        } else {
+            urlString += "/_chat?embedded=1"
+        }
+
+        guard let url = URL(string: urlString) else {
+            logger.error("Invalid t3code URL: \(urlString)")
+            loadErrorPage(message: String(
+                localized: "chat.error.invalidURL",
+                defaultValue: "Failed to construct t3code URL."
+            ))
+            return
+        }
+
+        logger.info("Loading t3code UI: \(url.absoluteString)")
+        webView.load(URLRequest(url: url))
+    }
+
+    /// Update the thread ID (called when the user starts or switches conversations).
+    func setThreadId(_ threadId: String?) {
+        let normalizedThreadId = Self.normalizedThreadId(threadId)
+        guard self.t3codeThreadId != normalizedThreadId else { return }
+        self.t3codeThreadId = normalizedThreadId
+        if let port = serverPort, hasLoadedServerUI {
+            loadLiveT3CodeUI(port: port)
+        }
+    }
+
+    /// Reload the web view (used after sidecar restart).
+    func reload() {
+        if let port = serverPort {
+            waitForServerAndLoad(port: port)
+        } else {
+            loadWaitingPage()
+        }
+    }
+
+    private func waitForServerAndLoad(port: Int) {
+        serverPort = port
+        hasLoadedServerUI = false
+        serverReadinessTask?.cancel()
+        loadWaitingPage()
+        let timeoutSeconds = startupTimeoutSeconds
+        let pollInterval = readinessPollIntervalNanoseconds
+
+        serverReadinessTask = Task { [weak self] in
+            let deadline = Date().addingTimeInterval(timeoutSeconds)
+
+            while !Task.isCancelled {
+                if await Self.isServerReachable(port: port) {
+                    await MainActor.run { [weak self] in
+                        guard let self, self.serverPort == port else { return }
+                        self.loadLiveT3CodeUI(port: port)
+                    }
+                    return
+                }
+
+                if Date() >= deadline {
+                    await MainActor.run { [weak self] in
+                        guard let self, self.serverPort == port else { return }
+                        self.loadErrorPage(message: String(
+                            localized: "chat.error.timeout",
+                            defaultValue: "t3code did not respond within 45 seconds."
+                        ))
+                    }
+                    return
+                }
+
+                try? await Task.sleep(nanoseconds: pollInterval)
+            }
+        }
+    }
+
+    nonisolated private static func isServerReachable(port: Int) async -> Bool {
+        guard let url = URL(string: "http://127.0.0.1:\(port)/") else { return false }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 1
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return (200..<600).contains(httpResponse.statusCode)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == Self.threadSyncMessageHandlerName else { return }
+
+        let rawThreadId: String
+        if let payload = message.body as? [String: Any], let payloadThreadId = payload["threadId"] as? String {
+            rawThreadId = payloadThreadId
+        } else if let bodyThreadId = message.body as? String {
+            rawThreadId = bodyThreadId
+        } else {
+            return
+        }
+
+        let trimmedThreadId = rawThreadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nextThreadId = Self.normalizedThreadId(trimmedThreadId)
+        if !trimmedThreadId.isEmpty, nextThreadId == nil {
+            logger.warning("Ignoring invalid embedded thread ID: \(trimmedThreadId, privacy: .public)")
+            return
+        }
+
+        guard t3codeThreadId != nextThreadId else { return }
+        t3codeThreadId = nextThreadId
+        onThreadIdChange?(nextThreadId)
+    }
+
+    static func normalizedThreadId(_ rawThreadId: String?) -> String? {
+        guard let rawThreadId else { return nil }
+        let trimmed = rawThreadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.hasPrefix("_") else { return nil }
+        guard !reservedEmbeddedThreadIDs.contains(trimmed.lowercased()) else { return nil }
+        guard !trimmed.contains("/") && !trimmed.contains("?") && !trimmed.contains("#") else { return nil }
+        return trimmed
+    }
+
+    // MARK: - Placeholder pages
+
+    /// Show a waiting page when no sidecar port is available yet.
+    private func loadWaitingPage() {
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <style>
+                body {
+                    margin: 0;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    height: 100vh;
+                    background: #1a1a2e;
+                    color: #a0a0b8;
+                    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+                    font-size: 14px;
+                }
+                .container {
+                    text-align: center;
+                    padding: 32px;
+                }
+                .spinner {
+                    width: 24px;
+                    height: 24px;
+                    border: 2px solid #333;
+                    border-top-color: #7c7cf0;
+                    border-radius: 50%;
+                    animation: spin 0.8s linear infinite;
+                    margin: 0 auto 16px;
+                }
+                @keyframes spin {
+                    to { transform: rotate(360deg); }
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="spinner"></div>
+                <div>Starting t3code server&hellip;</div>
+            </div>
+        </body>
+        </html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    /// Show an error page with a message.
+    private func loadErrorPage(message: String) {
+        let escapedMessage = message
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <style>
+                body {
+                    margin: 0;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    height: 100vh;
+                    background: #1a1a2e;
+                    color: #a0a0b8;
+                    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+                    font-size: 14px;
+                }
+                .container {
+                    text-align: center;
+                    padding: 32px;
+                }
+                .icon {
+                    font-size: 32px;
+                    margin-bottom: 12px;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <div class="icon">&#x26A0;</div>
+                <div>\(escapedMessage)</div>
+            </div>
+        </body>
+        </html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+}

--- a/Sources/Panels/ChatPanelView.swift
+++ b/Sources/Panels/ChatPanelView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import WebKit
+import Bonsplit
+
+/// SwiftUI view that renders a ChatPanel's WKWebView via NSViewRepresentable.
+struct ChatPanelView: View {
+    @ObservedObject var panel: ChatPanel
+    let paneId: PaneID
+    let isFocused: Bool
+    let isVisibleInUI: Bool
+    let portalPriority: Int
+    let onRequestPanelFocus: () -> Void
+
+    @State private var focusFlashOpacity: Double = 0.0
+    @State private var focusFlashAnimationGeneration: Int = 0
+
+    var body: some View {
+        ChatWebViewRepresentable(panel: panel)
+            .id(panel.id)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay {
+                RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
+                    .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
+                    .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
+                    .padding(FocusFlashPattern.ringInset)
+                    .allowsHitTesting(false)
+            }
+            .onTapGesture {
+                onRequestPanelFocus()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveClick).filter { [weak panel] note in
+                guard let webView = note.object as? CmuxWebView else { return false }
+                return webView === panel?.webView
+            }) { _ in
+                if !isFocused {
+                    onRequestPanelFocus()
+                }
+            }
+            .onChange(of: panel.focusFlashToken) { _ in
+                triggerFocusFlashAnimation()
+            }
+    }
+
+    private func triggerFocusFlashAnimation() {
+        focusFlashAnimationGeneration &+= 1
+        let generation = focusFlashAnimationGeneration
+        focusFlashOpacity = FocusFlashPattern.values.first ?? 0
+
+        for segment in FocusFlashPattern.segments {
+            DispatchQueue.main.asyncAfter(deadline: .now() + segment.delay) {
+                guard focusFlashAnimationGeneration == generation else { return }
+                withAnimation(focusFlashAnimation(for: segment.curve, duration: segment.duration)) {
+                    focusFlashOpacity = segment.targetOpacity
+                }
+            }
+        }
+    }
+
+    private func focusFlashAnimation(for curve: FocusFlashCurve, duration: TimeInterval) -> Animation {
+        switch curve {
+        case .easeIn: return .easeIn(duration: duration)
+        case .easeOut: return .easeOut(duration: duration)
+        }
+    }
+}
+
+// MARK: - NSViewRepresentable wrapper
+
+/// Wraps the ChatPanel's CmuxWebView for hosting in SwiftUI.
+private struct ChatWebViewRepresentable: NSViewRepresentable {
+    let panel: ChatPanel
+
+    private final class HostContainerView: NSView {
+        weak var hostedWebView: WKWebView?
+        var onDidMoveToWindow: (() -> Void)?
+        var onScheduleAttachmentRecovery: (() -> Void)?
+        private var attachmentRecoveryGeneration: Int = 0
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            needsLayout = true
+            layoutSubtreeIfNeeded()
+            onDidMoveToWindow?()
+            scheduleAttachmentRecovery()
+        }
+
+        func scheduleAttachmentRecovery() {
+            attachmentRecoveryGeneration &+= 1
+            let generation = attachmentRecoveryGeneration
+            let retryDelays: [TimeInterval] = [0.0, 0.05, 0.15]
+            for delay in retryDelays {
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                    guard let self, self.attachmentRecoveryGeneration == generation else { return }
+                    self.onScheduleAttachmentRecovery?()
+                }
+            }
+        }
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let container = HostContainerView()
+        container.wantsLayer = true
+        container.onDidMoveToWindow = { [weak container] in
+            guard let container else { return }
+            attachWebView(panel.webView, to: container)
+        }
+        container.onScheduleAttachmentRecovery = { [weak container] in
+            guard let container else { return }
+            attachWebView(panel.webView, to: container)
+        }
+        attachWebView(panel.webView, to: container)
+        return container
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let container = nsView as? HostContainerView else { return }
+        container.onDidMoveToWindow = { [weak container] in
+            guard let container else { return }
+            attachWebView(panel.webView, to: container)
+        }
+        container.onScheduleAttachmentRecovery = { [weak container] in
+            guard let container else { return }
+            attachWebView(panel.webView, to: container)
+        }
+        attachWebView(panel.webView, to: container)
+        if container.window != nil,
+           (panel.webView.superview !== container || panel.webView.frame.isEmpty) {
+            container.scheduleAttachmentRecovery()
+        }
+    }
+
+    private func attachWebView(_ webView: WKWebView, to container: HostContainerView) {
+        let shouldPreserveExistingVisibleHost =
+            container.window == nil &&
+            webView.superview != nil &&
+            !(webView.superview === container || webView.isDescendant(of: container))
+        if shouldPreserveExistingVisibleHost {
+            return
+        }
+
+        let alreadyHostedInContainer =
+            container.hostedWebView === webView &&
+            webView.superview === container &&
+            webView.frame.equalTo(container.bounds) &&
+            webView.translatesAutoresizingMaskIntoConstraints
+        if alreadyHostedInContainer {
+            container.needsLayout = true
+            container.layoutSubtreeIfNeeded()
+            return
+        }
+
+        if let superview = webView.superview {
+            NSLayoutConstraint.deactivate(
+                superview.constraints.filter { constraint in
+                    constraint.firstItem as AnyObject? === webView || constraint.secondItem as AnyObject? === webView
+                }
+            )
+            webView.removeFromSuperview()
+        }
+
+        container.subviews
+            .filter { $0 !== webView }
+            .forEach { $0.removeFromSuperview() }
+
+        webView.translatesAutoresizingMaskIntoConstraints = true
+        webView.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+        webView.frame = container.bounds
+        container.hostedWebView = webView
+        container.needsLayout = true
+        container.layoutSubtreeIfNeeded()
+    }
+}

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -7,6 +7,7 @@ public enum PanelType: String, Codable, Sendable {
     case terminal
     case browser
     case markdown
+    case chat
 }
 
 public enum TerminalPanelFocusIntent: Equatable {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -55,6 +55,17 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .chat:
+            if let chatPanel = panel as? ChatPanel {
+                ChatPanelView(
+                    panel: chatPanel,
+                    paneId: paneId,
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    portalPriority: portalPriority,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         }
     }
 }

--- a/Sources/Project.swift
+++ b/Sources/Project.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Combine
+
+/// A project groups multiple task-workspaces under a shared project directory.
+/// Projects are sidebar-only containers — they don't have their own Bonsplit or panels.
+final class Project: ObservableObject, Identifiable, Codable {
+    let id: UUID
+    @Published var name: String
+    @Published var directory: String
+    @Published var workspaceIds: [UUID]
+    @Published var isExpanded: Bool
+
+    init(id: UUID = UUID(), name: String, directory: String) {
+        self.id = id
+        self.name = name
+        self.directory = directory
+        self.workspaceIds = []
+        self.isExpanded = true
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, directory, workspaceIds, isExpanded
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.directory = try container.decode(String.self, forKey: .directory)
+        self.workspaceIds = try container.decodeIfPresent([UUID].self, forKey: .workspaceIds) ?? []
+        self.isExpanded = try container.decodeIfPresent(Bool.self, forKey: .isExpanded) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(directory, forKey: .directory)
+        try container.encode(workspaceIds, forKey: .workspaceIds)
+        try container.encode(isExpanded, forKey: .isExpanded)
+    }
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -240,6 +240,15 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     var filePath: String
 }
 
+/// Snapshot of a single writer (task/topic) within a workspace.
+struct SessionWriterSnapshot: Codable, Sendable {
+    let id: UUID
+    var name: String
+    var t3codeThreadId: String?
+    var chatPanelId: UUID?
+    var layout: SessionWorkspaceLayoutSnapshot?
+}
+
 struct SessionPanelSnapshot: Codable, Sendable {
     var id: UUID
     var type: PanelType
@@ -251,6 +260,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var gitBranch: SessionGitBranchSnapshot?
     var listeningPorts: [Int]
     var ttyName: String?
+    var t3codeThreadId: String?
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?
@@ -328,6 +338,7 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 }
 
 struct SessionWorkspaceSnapshot: Codable, Sendable {
+    var id: UUID?
     var processTitle: String
     var customTitle: String?
     var customColor: String?
@@ -340,11 +351,22 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var logEntries: [SessionLogEntrySnapshot]
     var progress: SessionProgressSnapshot?
     var gitBranch: SessionGitBranchSnapshot?
+    var writers: [SessionWriterSnapshot]?
+    var activeWriterId: UUID?
+}
+
+struct SessionProjectSnapshot: Codable, Sendable {
+    var id: UUID
+    var name: String
+    var directory: String
+    var workspaceIds: [UUID]
+    var isExpanded: Bool
 }
 
 struct SessionTabManagerSnapshot: Codable, Sendable {
     var selectedWorkspaceIndex: Int?
     var workspaces: [SessionWorkspaceSnapshot]
+    var projects: [SessionProjectSnapshot]?
 }
 
 struct SessionWindowSnapshot: Codable, Sendable {

--- a/Sources/T3CodeSidecarManager.swift
+++ b/Sources/T3CodeSidecarManager.swift
@@ -1,0 +1,346 @@
+import Darwin
+import Foundation
+import os
+
+/// Manages a t3code Node.js server process for a single workspace.
+/// Spawns the server with a preselected port, confirms startup via the
+/// sidecar state directory, and handles restart/shutdown with deduplication.
+final class T3CodeSidecarManager {
+
+    private let logger = Logger(subsystem: "com.cmuxterm.app", category: "T3CodeSidecar")
+
+    /// The configured server port for this sidecar process.
+    private(set) var port: Int?
+
+    /// The workspace's project directory (used as cwd and state-dir base).
+    let projectDirectory: URL
+
+    /// The .cmux state directory for this workspace.
+    private var stateDir: String { projectDirectory.appendingPathComponent(".cmux").path }
+
+    /// The port file path inside the state directory.
+    private var portFilePath: String { (stateDir as NSString).appendingPathComponent("server.port") }
+
+    /// The running Node.js process.
+    private var process: Process?
+
+    /// Whether we're intentionally shutting down (suppress restart).
+    private var isShuttingDown = false
+
+    /// Whether a restart is already scheduled (prevent duplicate restarts).
+    private var isRestartPending = false
+
+    /// Timer for polling the port file.
+    private var portPollTimer: DispatchSourceTimer?
+
+    /// Prevent duplicate port publication while startup probes converge.
+    private var hasPublishedPort = false
+
+    /// Callback when a port is assigned so consumers can start readiness polling.
+    var onReady: ((Int) -> Void)?
+
+    /// Callback when server crashes unexpectedly.
+    var onCrash: (() -> Void)?
+
+    init(projectDirectory: URL) {
+        self.projectDirectory = projectDirectory
+    }
+
+    deinit {
+        shutdown()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start the t3code server process.
+    func start() {
+        guard process == nil else {
+            logger.warning("Sidecar already running for \(self.projectDirectory.path)")
+            return
+        }
+
+        isShuttingDown = false
+        isRestartPending = false
+        hasPublishedPort = false
+
+        // Create .cmux directory if needed
+        try? FileManager.default.createDirectory(atPath: stateDir, withIntermediateDirectories: true)
+
+        // Clean up stale port file from previous run
+        try? FileManager.default.removeItem(atPath: portFilePath)
+
+        // Locate the t3code server binary
+        guard let serverBinary = resolveServerBinary() else {
+            logger.error("Could not find t3code server binary")
+            return
+        }
+
+        logger.info("Using t3code binary: \(serverBinary)")
+
+        guard let selectedPort = port ?? reserveAvailablePort() else {
+            logger.error("Could not reserve a local port for the t3code sidecar")
+            return
+        }
+        port = selectedPort
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = [
+            "node",
+            serverBinary,
+            "--port", String(selectedPort),
+            "--state-dir", stateDir,
+            "--auto-bootstrap-project-from-cwd",
+            "--no-browser",
+            "--mode", "web"
+        ]
+        proc.currentDirectoryURL = projectDirectory
+
+        // Inherit environment but ensure PATH includes common Node locations
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = ["/usr/local/bin", "/opt/homebrew/bin", "/Users/\(NSUserName())/.bun/bin"]
+        if let existingPath = env["PATH"] {
+            env["PATH"] = (extraPaths + [existingPath]).joined(separator: ":")
+        }
+        // The embedded cmux sidecar is loopback-only and does not plumb auth tokens
+        // into the webview/WebSocket client. Ignore any shell-level token override
+        // inherited from the user's environment so the local chat can hydrate.
+        env.removeValue(forKey: "T3CODE_AUTH_TOKEN")
+        proc.environment = env
+
+        // Let stdout/stderr go to /dev/null — cmux relies on the known port
+        // and probes the embedded URL directly.
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+
+        // Handle unexpected termination
+        proc.terminationHandler = { [weak self] proc in
+            guard let self = self, !self.isShuttingDown else { return }
+            self.logger.error("t3code sidecar exited unexpectedly (code \(proc.terminationStatus))")
+            self.process = nil
+            self.port = nil
+            self.stopPortPolling()
+            DispatchQueue.main.async {
+                self.onCrash?()
+            }
+        }
+
+        do {
+            try proc.run()
+            self.process = proc
+            logger.info(
+                "Spawned t3code sidecar (PID \(proc.processIdentifier)) on port \(selectedPort) for \(self.projectDirectory.path)"
+            )
+            publishPort(selectedPort)
+        } catch {
+            logger.error("Failed to spawn t3code sidecar: \(error.localizedDescription)")
+            port = nil
+            return
+        }
+
+        // Keep polling the port file for confirmation and timeout diagnostics.
+        startPortPolling()
+    }
+
+    /// Gracefully shut down the sidecar process.
+    func shutdown() {
+        isShuttingDown = true
+        stopPortPolling()
+
+        guard let proc = process, proc.isRunning else {
+            process = nil
+            return
+        }
+
+        logger.info("Shutting down t3code sidecar (PID \(proc.processIdentifier))")
+        proc.terminate()  // SIGTERM
+
+        // Force kill after 5 seconds if still running
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+            guard let self = self, let proc = self.process, proc.isRunning else { return }
+            self.logger.warning("Force killing t3code sidecar (PID \(proc.processIdentifier))")
+            kill(proc.processIdentifier, SIGKILL)
+        }
+
+        process = nil
+        port = nil
+        hasPublishedPort = false
+
+        // Clean up port file
+        try? FileManager.default.removeItem(atPath: portFilePath)
+    }
+
+    /// Restart the sidecar (used after crash detection). Deduplicates.
+    func restart() {
+        guard !isRestartPending else {
+            logger.info("Restart already pending, skipping duplicate")
+            return
+        }
+        isRestartPending = true
+        shutdown()
+        // Delay to let port be released and SQLite locks clear
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.start()
+        }
+    }
+
+    // MARK: - Port File Polling
+
+    /// Poll the state directory for a server.port file written by t3code.
+    private func startPortPolling() {
+        stopPortPolling()
+
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.schedule(deadline: .now() + 1, repeating: 1.0)
+
+        var attempts = 0
+        let maxAttempts = 30  // Give up after 30 seconds
+
+        timer.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            attempts += 1
+
+            // Check for port file written by t3code server on startup
+            if let portStr = try? String(contentsOfFile: self.portFilePath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+               let port = Int(portStr), port > 0 {
+                self.logger.info("Detected t3code port \(port) from port file at \(self.portFilePath)")
+                self.handlePortDetected(port)
+                return
+            }
+
+            // Check if process is still alive
+            if let proc = self.process, !proc.isRunning {
+                self.logger.error("t3code process died while waiting for port file")
+                self.stopPortPolling()
+                return
+            }
+
+            if attempts >= maxAttempts {
+                self.logger.error("Timed out waiting for t3code port file after \(maxAttempts)s at \(self.portFilePath)")
+                self.stopPortPolling()
+            }
+        }
+
+        timer.resume()
+        self.portPollTimer = timer
+    }
+
+    private func stopPortPolling() {
+        portPollTimer?.cancel()
+        portPollTimer = nil
+    }
+
+    private func handlePortDetected(_ port: Int) {
+        self.stopPortPolling()
+        publishPort(port)
+    }
+
+    private func publishPort(_ port: Int) {
+        self.port = port
+        guard !hasPublishedPort else { return }
+        hasPublishedPort = true
+        DispatchQueue.main.async { [weak self] in
+            self?.onReady?(port)
+        }
+    }
+
+    private func reserveAvailablePort() -> Int? {
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { return nil }
+        defer { close(socketFD) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.stride)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(0)
+        address.sin_addr = in_addr(s_addr: in_addr_t(0))
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                bind(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.stride))
+            }
+        }
+
+        guard bindResult == 0 else { return nil }
+
+        var length = socklen_t(MemoryLayout<sockaddr_in>.stride)
+        let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                getsockname(socketFD, sockaddrPointer, &length)
+            }
+        }
+
+        guard nameResult == 0 else { return nil }
+        return Int(UInt16(bigEndian: address.sin_port))
+    }
+
+    // Port detection is done via port file polling only (see startPortPolling).
+    // The t3code server writes {stateDir}/server.port on startup.
+
+    // MARK: - Server Binary Resolution
+
+    /// Find the t3code server binary.
+    private func resolveServerBinary() -> String? {
+        // 1. Check T3CODE_SERVER_PATH environment variable
+        if let t3codePath = ProcessInfo.processInfo.environment["T3CODE_SERVER_PATH"],
+           FileManager.default.fileExists(atPath: t3codePath) {
+            return t3codePath
+        }
+
+        // 2. Check via Xcode source root (Info.plist CMUXSourceRoot key)
+        #if DEBUG
+        if let sourceRoot = Bundle.main.infoDictionary?["CMUXSourceRoot"] as? String {
+            let monorepoRoot = (sourceRoot as NSString).deletingLastPathComponent
+            let candidate = (monorepoRoot as NSString).appendingPathComponent("t3code/apps/server/dist/index.mjs")
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+        #endif
+
+        // 3. Walk up from project directory looking for t3code sibling
+        var searchDir = projectDirectory.path
+        for _ in 0..<6 {
+            let candidate = (searchDir as NSString).appendingPathComponent("t3code/apps/server/dist/index.mjs")
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+            let parent = (searchDir as NSString).deletingLastPathComponent
+            if parent == searchDir { break }
+            searchDir = parent
+        }
+
+        // 4. Check well-known development paths
+        #if DEBUG
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+        let devPaths = [
+            (homeDir as NSString).appendingPathComponent("Projekte/cmux-t3code/t3code/apps/server/dist/index.mjs"),
+            (homeDir as NSString).appendingPathComponent("Projects/cmux-t3code/t3code/apps/server/dist/index.mjs"),
+        ]
+        for path in devPaths {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+        #endif
+
+        // 5. Check common global install paths
+        let globalPaths = [
+            "/usr/local/lib/node_modules/t3/dist/index.mjs",
+            "/opt/homebrew/lib/node_modules/t3/dist/index.mjs",
+        ]
+        for path in globalPaths {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+
+        // 6. Check app bundle resources
+        if let bundledPath = Bundle.main.path(forResource: "t3code-server", ofType: "mjs") {
+            return bundledPath
+        }
+
+        logger.warning("t3code server binary not found. Set T3CODE_SERVER_PATH env var.")
+        return nil
+    }
+}

--- a/Sources/T3CodeSidecarManager.swift
+++ b/Sources/T3CodeSidecarManager.swift
@@ -15,8 +15,11 @@ final class T3CodeSidecarManager {
     /// The workspace's project directory (used as cwd and state-dir base).
     let projectDirectory: URL
 
-    /// The .cmux state directory for this workspace.
-    private var stateDir: String { projectDirectory.appendingPathComponent(".cmux").path }
+    /// The .cmux home directory for this workspace (passed as --home-dir to t3code).
+    private var homeDir: String { projectDirectory.appendingPathComponent(".cmux").path }
+
+    /// The t3code "userdata" state directory (derived by the server as {homeDir}/userdata).
+    private var stateDir: String { (homeDir as NSString).appendingPathComponent("userdata") }
 
     /// The port file path inside the state directory.
     private var portFilePath: String { (stateDir as NSString).appendingPathComponent("server.port") }
@@ -89,7 +92,7 @@ final class T3CodeSidecarManager {
             "node",
             serverBinary,
             "--port", String(selectedPort),
-            "--state-dir", stateDir,
+            "--home-dir", homeDir,
             "--auto-bootstrap-project-from-cwd",
             "--no-browser",
             "--mode", "web"
@@ -281,13 +284,21 @@ final class T3CodeSidecarManager {
 
     /// Find the t3code server binary.
     private func resolveServerBinary() -> String? {
-        // 1. Check T3CODE_SERVER_PATH environment variable
+        // 1. Check T3CODE_SERVER_PATH environment variable (set by install script)
         if let t3codePath = ProcessInfo.processInfo.environment["T3CODE_SERVER_PATH"],
            FileManager.default.fileExists(atPath: t3codePath) {
             return t3codePath
         }
 
-        // 2. Check via Xcode source root (Info.plist CMUXSourceRoot key)
+        // 2. Check CMUXTERM_REPO_ROOT (set in LSEnvironment by install script)
+        if let repoRoot = ProcessInfo.processInfo.environment["CMUXTERM_REPO_ROOT"] {
+            let candidate = (repoRoot as NSString).appendingPathComponent("t3code/apps/server/dist/index.mjs")
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        // 3. Check via Xcode source root (Info.plist CMUXSourceRoot key)
         #if DEBUG
         if let sourceRoot = Bundle.main.infoDictionary?["CMUXSourceRoot"] as? String {
             let monorepoRoot = (sourceRoot as NSString).deletingLastPathComponent
@@ -298,19 +309,31 @@ final class T3CodeSidecarManager {
         }
         #endif
 
-        // 3. Walk up from project directory looking for t3code sibling
+        // 4. Walk up from project directory looking for t3code sibling.
+        // Stop at the project's git root to avoid escaping the repository
+        // and matching an unrelated standalone t3code installation (e.g.,
+        // ~/Projekte/t3code found when the workspace is ~/Projekte/AgentMux).
+        // Note: submodules use a .git *file* (not directory) as a pointer to
+        // the parent's .git/modules — only treat actual .git directories as
+        // repository boundaries.
         var searchDir = projectDirectory.path
         for _ in 0..<6 {
             let candidate = (searchDir as NSString).appendingPathComponent("t3code/apps/server/dist/index.mjs")
             if FileManager.default.fileExists(atPath: candidate) {
                 return candidate
             }
+            // Only stop at real git root directories, not submodule .git files.
+            let gitMarker = (searchDir as NSString).appendingPathComponent(".git")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: gitMarker, isDirectory: &isDir), isDir.boolValue {
+                break
+            }
             let parent = (searchDir as NSString).deletingLastPathComponent
             if parent == searchDir { break }
             searchDir = parent
         }
 
-        // 4. Check well-known development paths
+        // 5. Check well-known development paths
         #if DEBUG
         let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
         let devPaths = [
@@ -324,7 +347,7 @@ final class T3CodeSidecarManager {
         }
         #endif
 
-        // 5. Check common global install paths
+        // 6. Check common global install paths
         let globalPaths = [
             "/usr/local/lib/node_modules/t3/dist/index.mjs",
             "/opt/homebrew/lib/node_modules/t3/dist/index.mjs",
@@ -335,9 +358,13 @@ final class T3CodeSidecarManager {
             }
         }
 
-        // 6. Check app bundle resources
-        if let bundledPath = Bundle.main.path(forResource: "t3code-server", ofType: "mjs") {
-            return bundledPath
+        // 7. Check app bundle resources (last resort — requires a fully
+        // self-contained bundle with node_modules to actually work)
+        if let resourceURL = Bundle.main.resourceURL {
+            let bundledPath = resourceURL.appendingPathComponent("t3code-server/index.mjs").path
+            if FileManager.default.fileExists(atPath: bundledPath) {
+                return bundledPath
+            }
         }
 
         logger.warning("t3code server binary not found. Set T3CODE_SERVER_PATH env var.")

--- a/Sources/T3CodeSidecarManager.swift
+++ b/Sources/T3CodeSidecarManager.swift
@@ -98,7 +98,7 @@ final class T3CodeSidecarManager {
 
         // Inherit environment but ensure PATH includes common Node locations
         var env = ProcessInfo.processInfo.environment
-        let extraPaths = ["/usr/local/bin", "/opt/homebrew/bin", "/Users/\(NSUserName())/.bun/bin"]
+        let extraPaths = ["/usr/local/bin", "/opt/homebrew/bin", "/opt/homebrew/opt/node/bin", "/Users/\(NSUserName())/.bun/bin"]
         if let existingPath = env["PATH"] {
             env["PATH"] = (extraPaths + [existingPath]).joined(separator: ":")
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -690,6 +690,8 @@ class TabManager: ObservableObject {
     weak var window: NSWindow?
 
     @Published var tabs: [Workspace] = []
+    /// Projects group workspaces (tasks) under a shared project directory.
+    @Published var projects: [Project] = []
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
@@ -1060,7 +1062,8 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: NewWorkspacePlacement? = nil,
-        autoWelcomeIfNeeded: Bool = true
+        autoWelcomeIfNeeded: Bool = true,
+        skipInitialTerminal: Bool = false
     ) -> Workspace {
         // Snapshot current published state once so workspace creation doesn't repeatedly
         // bounce through Combine-backed accessors while we're preparing the new workspace.
@@ -1078,7 +1081,8 @@ class TabManager: ObservableObject {
             portOrdinal: ordinal,
             configTemplate: inheritedConfig,
             initialTerminalCommand: initialTerminalCommand,
-            initialTerminalEnvironment: initialTerminalEnvironment
+            initialTerminalEnvironment: initialTerminalEnvironment,
+            skipInitialTerminal: skipInitialTerminal
         )
         newWorkspace.owningTabManager = self
         wireClosedBrowserTracking(for: newWorkspace)
@@ -1131,6 +1135,10 @@ class TabManager: ObservableObject {
                 sendWelcomeWhenReady(to: newWorkspace)
             }
         }
+
+        // NOTE: Writers (with chat panels) are only created for task workspaces
+        // via addTask(). Standalone workspaces remain pure terminals.
+
         return newWorkspace
     }
 
@@ -2225,6 +2233,10 @@ class TabManager: ObservableObject {
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         clearWorkspaceGitProbes(workspaceId: workspace.id)
         sidebarSelectedWorkspaceIds.remove(workspace.id)
+        // Remove from any project that owns this workspace.
+        for project in projects {
+            project.workspaceIds.removeAll { $0 == workspace.id }
+        }
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         workspace.teardownAllPanels()
@@ -2289,6 +2301,90 @@ class TabManager: ObservableObject {
     // Keep closeTab as convenience alias
     func closeTab(_ tab: Workspace) { closeWorkspace(tab) }
     func closeCurrentTabWithConfirmation() { closeCurrentWorkspaceWithConfirmation() }
+
+    // MARK: - Project / Task Management
+
+    /// Find the project that contains a given workspace.
+    func project(for workspaceId: UUID) -> Project? {
+        projects.first { $0.workspaceIds.contains(workspaceId) }
+    }
+
+    /// Create a new project with the given name and directory, then create its first task.
+    @discardableResult
+    func addProject(name: String, directory: String) -> Project {
+        let project = Project(name: name, directory: directory)
+        projects.append(project)
+        // Create the first task in the project
+        addTask(to: project, name: String(
+            localized: "project.firstTask.defaultName",
+            defaultValue: "Task 1"
+        ))
+        return project
+    }
+
+    /// Delete a project and close all its task workspaces.
+    func deleteProject(_ project: Project) {
+        // Close all task workspaces belonging to this project
+        let workspaceIdsToClose = project.workspaceIds
+        for wsId in workspaceIdsToClose {
+            if let workspace = tabs.first(where: { $0.id == wsId }) {
+                // Only close if there are other workspaces remaining
+                if tabs.count > 1 {
+                    closeWorkspace(workspace)
+                }
+            }
+        }
+        projects.removeAll { $0.id == project.id }
+    }
+
+    /// Create a new task (workspace) within a project.
+    /// The workspace starts with a chat panel only (no terminal).
+    @discardableResult
+    func addTask(to project: Project, name: String? = nil) -> Workspace {
+        let workspace = addWorkspace(
+            workingDirectory: project.directory,
+            select: true,
+            autoWelcomeIfNeeded: false,
+            skipInitialTerminal: true
+        )
+        let resolvedName = name ?? String(
+            localized: "project.newTask.defaultName",
+            defaultValue: "Task \(project.workspaceIds.count + 1)"
+        )
+        workspace.setCustomTitle(resolvedName)
+        project.workspaceIds.append(workspace.id)
+
+        // Create a chat panel as the sole content for this task workspace.
+        // Since we skipped the initial terminal, the workspace is empty — create
+        // a writer which will also create the chat panel.
+        if workspace.writers.isEmpty {
+            workspace.createWriter(name: workspace.customTitle ?? project.name)
+        }
+
+        // Start the t3code sidecar for this new task workspace.
+        AppDelegate.shared?.startSidecarForWorkspace(workspace)
+
+        return workspace
+    }
+
+    /// Remove a task from its project (and close the workspace).
+    func removeTask(workspaceId: UUID, from project: Project) {
+        project.workspaceIds.removeAll { $0 == workspaceId }
+        if let workspace = tabs.first(where: { $0.id == workspaceId }) {
+            closeWorkspace(workspace)
+        }
+    }
+
+    /// All workspace IDs that belong to any project.
+    var projectOwnedWorkspaceIds: Set<UUID> {
+        Set(projects.flatMap(\.workspaceIds))
+    }
+
+    /// Workspaces not owned by any project (standalone).
+    var standaloneWorkspaces: [Workspace] {
+        let owned = projectOwnedWorkspaceIds
+        return tabs.filter { !owned.contains($0.id) }
+    }
 
     func closeCurrentWorkspace() {
         guard let selectedId = selectedTabId,
@@ -5039,9 +5135,19 @@ extension TabManager {
         let selectedWorkspaceIndex = selectedTabId.flatMap { selectedTabId in
             restorableTabs.firstIndex(where: { $0.id == selectedTabId })
         }
+        let projectSnapshots = projects.map { project in
+            SessionProjectSnapshot(
+                id: project.id,
+                name: project.name,
+                directory: project.directory,
+                workspaceIds: project.workspaceIds,
+                isExpanded: project.isExpanded
+            )
+        }
         return SessionTabManagerSnapshot(
             selectedWorkspaceIndex: selectedWorkspaceIndex,
-            workspaces: workspaceSnapshots
+            workspaces: workspaceSnapshots,
+            projects: projectSnapshots.isEmpty ? nil : projectSnapshots
         )
     }
 
@@ -5072,6 +5178,7 @@ extension TabManager {
         // emissions (empty tabs, nil selectedTabId) that can leave SwiftUI's
         // mountedWorkspaceIds empty and cause a frozen blank launch state (#399).
         var newTabs: [Workspace] = []
+        var legacyRestoredWorkspaceIds: Set<UUID> = []
         let workspaceSnapshots = snapshot.workspaces
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
         for workspaceSnapshot in workspaceSnapshots {
@@ -5080,8 +5187,12 @@ extension TabManager {
             let workspace = Workspace(
                 title: workspaceSnapshot.processTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,
+                workspaceId: workspaceSnapshot.id,
                 portOrdinal: ordinal
             )
+            if workspaceSnapshot.id == nil {
+                legacyRestoredWorkspaceIds.insert(workspace.id)
+            }
             workspace.owningTabManager = self
             workspace.restoreSessionSnapshot(workspaceSnapshot)
             wireClosedBrowserTracking(for: workspace)
@@ -5106,9 +5217,29 @@ extension TabManager {
             newSelectedId = newTabs.first?.id
         }
 
+        // Restore projects from snapshot.
+        var restoredProjects: [Project] = []
+        if let projectSnapshots = snapshot.projects {
+            let newTabIds = Set(newTabs.map(\.id))
+            for ps in projectSnapshots {
+                let project = Project(id: ps.id, name: ps.name, directory: ps.directory)
+                // Only keep workspace IDs that still exist in the restored tabs.
+                project.workspaceIds = ps.workspaceIds.filter { newTabIds.contains($0) }
+                project.isExpanded = ps.isExpanded
+                restoredProjects.append(project)
+            }
+            reattachLegacyProjectTaskWorkspaces(
+                projects: &restoredProjects,
+                workspaces: newTabs,
+                legacyWorkspaceIds: legacyRestoredWorkspaceIds
+            )
+        }
+
         // Single atomic assignment of @Published properties so SwiftUI observers
         // never see an intermediate state with empty tabs or nil selection.
         tabs = newTabs
+        projects = restoredProjects
+        normalizeChatThreadAssignments()
         selectedTabId = newSelectedId
         for workspace in newTabs {
             let terminalPanels = workspace.panels.values.compactMap { $0 as? TerminalPanel }
@@ -5131,6 +5262,66 @@ extension TabManager {
                 userInfo: [GhosttyNotificationKey.tabId: selectedTabId]
             )
         }
+    }
+
+    private func normalizeChatThreadAssignments() {
+        var usedThreadIds = Set<String>()
+
+        for workspace in tabs {
+            for writer in workspace.writers {
+                let currentThreadId = ChatPanel.normalizedThreadId(writer.t3codeThreadId)
+                var resolvedThreadId: String
+
+                if let currentThreadId, !usedThreadIds.contains(currentThreadId) {
+                    resolvedThreadId = currentThreadId
+                } else {
+                    resolvedThreadId = Workspace.defaultDraftThreadId(for: writer.id)
+                    while usedThreadIds.contains(resolvedThreadId) {
+                        resolvedThreadId = UUID().uuidString.lowercased()
+                    }
+                }
+
+                usedThreadIds.insert(resolvedThreadId)
+                guard writer.t3codeThreadId != resolvedThreadId else { continue }
+                writer.t3codeThreadId = resolvedThreadId
+
+                if let chatPanelId = writer.chatPanelId,
+                   let chatPanel = workspace.panels[chatPanelId] as? ChatPanel {
+                    chatPanel.setThreadId(resolvedThreadId)
+                }
+            }
+        }
+    }
+
+    private func reattachLegacyProjectTaskWorkspaces(
+        projects: inout [Project],
+        workspaces: [Workspace],
+        legacyWorkspaceIds: Set<UUID>
+    ) {
+        guard !projects.isEmpty, !legacyWorkspaceIds.isEmpty else { return }
+
+        var claimedWorkspaceIds = Set(projects.flatMap(\.workspaceIds))
+
+        for project in projects {
+            let normalizedProjectDirectory = normalizedWorkingDirectory(project.directory)
+            let matchingWorkspaceIds = workspaces.compactMap { workspace -> UUID? in
+                guard legacyWorkspaceIds.contains(workspace.id) else { return nil }
+                guard !claimedWorkspaceIds.contains(workspace.id) else { return nil }
+                guard isLegacyProjectTaskWorkspace(workspace) else { return nil }
+                guard normalizedWorkingDirectory(workspace.currentDirectory) == normalizedProjectDirectory else { return nil }
+                return workspace.id
+            }
+
+            guard !matchingWorkspaceIds.isEmpty else { continue }
+            project.workspaceIds.append(contentsOf: matchingWorkspaceIds)
+            claimedWorkspaceIds.formUnion(matchingWorkspaceIds)
+        }
+    }
+
+    private func isLegacyProjectTaskWorkspace(_ workspace: Workspace) -> Bool {
+        guard !workspace.writers.isEmpty else { return false }
+        guard !workspace.panels.values.contains(where: { $0 is TerminalPanel }) else { return false }
+        return workspace.panels.values.contains(where: { $0 is ChatPanel })
     }
 }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -257,6 +257,7 @@ struct TitlebarControlsView: View {
     let onToggleNotifications: () -> Void
     let onNewTab: () -> Void
     let visibilityMode: TitlebarControlsVisibilityMode
+    let onNewProject: () -> Void
     @AppStorage("titlebarControlsStyle") private var styleRawValue = TitlebarControlsStyle.classic.rawValue
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
     @AppStorage(ShortcutHintDebugSettings.titlebarHintYKey) private var titlebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultTitlebarHintY
@@ -396,14 +397,28 @@ struct TitlebarControlsView: View {
             .accessibilityLabel(String(localized: "titlebar.notifications.accessibilityLabel", defaultValue: "Notifications"))
             .safeHelp(KeyboardShortcutSettings.Action.showNotifications.tooltip(String(localized: "titlebar.notifications.tooltip", defaultValue: "Show notifications")))
 
-            TitlebarControlButton(config: config, action: {
-                #if DEBUG
-                dlog("titlebar.newTab")
-                #endif
-                onNewTab()
-            }) {
+            Menu {
+                Button(String(localized: "titlebar.newMenu.newWorkspace", defaultValue: "New Workspace")) {
+                    #if DEBUG
+                    dlog("titlebar.newTab")
+                    #endif
+                    onNewTab()
+                }
+                .keyboardShortcut("n", modifiers: .command)
+                Button(String(localized: "titlebar.newMenu.newProject", defaultValue: "New Project…")) {
+                    #if DEBUG
+                    dlog("titlebar.newProject")
+                    #endif
+                    onNewProject()
+                }
+                .keyboardShortcut("n", modifiers: [.command, .option])
+            } label: {
                 iconLabel(systemName: "plus", config: config)
+                    .frame(width: config.buttonSize, height: config.buttonSize)
+                    .contentShape(Rectangle())
             }
+            .menuStyle(.borderlessButton)
+            .frame(width: config.buttonSize, height: config.buttonSize)
             .accessibilityIdentifier("titlebarControl.newTab")
             .accessibilityLabel(String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"))
             .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
@@ -566,7 +581,19 @@ struct HiddenTitlebarSidebarControlsView: View {
                 )
             },
             onNewTab: { _ = AppDelegate.shared?.tabManager?.addTab() },
-            visibilityMode: .onHover
+            visibilityMode: .onHover,
+            onNewProject: {
+                let panel = NSOpenPanel()
+                panel.canChooseFiles = false
+                panel.canChooseDirectories = true
+                panel.allowsMultipleSelection = false
+                panel.prompt = String(localized: "titlebar.newProject.panelPrompt", defaultValue: "Choose Project Directory")
+                panel.message = String(localized: "titlebar.newProject.panelMessage", defaultValue: "Select the root directory for your project")
+                if panel.runModal() == .OK, let url = panel.url {
+                    let projectName = url.lastPathComponent
+                    AppDelegate.shared?.tabManager?.addProject(name: projectName, directory: url.path)
+                }
+            }
         )
         .frame(width: hostWidth, height: hostHeight, alignment: .leading)
     }
@@ -790,6 +817,18 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
         let newTab = { _ = AppDelegate.shared?.tabManager?.addTab() }
+        let newProject = {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            panel.prompt = String(localized: "titlebar.newProject.panelPrompt", defaultValue: "Choose Project Directory")
+            panel.message = String(localized: "titlebar.newProject.panelMessage", defaultValue: "Select the root directory for your project")
+            if panel.runModal() == .OK, let url = panel.url {
+                let projectName = url.lastPathComponent
+                AppDelegate.shared?.tabManager?.addProject(name: projectName, directory: url.path)
+            }
+        }
 
         hostingView = NonDraggableHostingView(
             rootView: TitlebarControlsView(
@@ -798,7 +837,8 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
                 onToggleSidebar: toggleSidebar,
                 onToggleNotifications: toggleNotifications,
                 onNewTab: newTab,
-                visibilityMode: .alwaysVisible
+                visibilityMode: .alwaysVisible,
+                onNewProject: newProject
             )
         )
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7642,7 +7642,7 @@ final class Workspace: Identifiable, ObservableObject {
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        let chatPanel = ChatPanel(workspaceId: id, threadId: threadId, serverPort: serverPort)
+        let chatPanel = ChatPanel(workspaceId: id, threadId: threadId, serverPort: serverPort, projectCwd: currentDirectory)
         chatPanel.onThreadIdChange = { [weak self, panelId = chatPanel.id] nextThreadId in
             self?.updateWriterThreadId(nextThreadId, forChatPanelId: panelId)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -236,7 +236,22 @@ extension Workspace {
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
 
+        let writerSnapshots: [SessionWriterSnapshot] = writers.map { writer in
+            let panelThreadId = writer.chatPanelId
+                .flatMap { panels[$0] as? ChatPanel }
+                .flatMap { ChatPanel.normalizedThreadId($0.t3codeThreadId) }
+            let writerThreadId = ChatPanel.normalizedThreadId(writer.t3codeThreadId)
+            return SessionWriterSnapshot(
+                id: writer.id,
+                name: writer.name,
+                t3codeThreadId: panelThreadId ?? writerThreadId,
+                chatPanelId: writer.chatPanelId,
+                layout: nil
+            )
+        }
+
         return SessionWorkspaceSnapshot(
+            id: id,
             processTitle: processTitle,
             customTitle: customTitle,
             customColor: customColor,
@@ -248,7 +263,9 @@ extension Workspace {
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
             progress: progressSnapshot,
-            gitBranch: gitBranchSnapshot
+            gitBranch: gitBranchSnapshot,
+            writers: writerSnapshots.isEmpty ? nil : writerSnapshots,
+            activeWriterId: activeWriterId
         )
     }
 
@@ -307,6 +324,32 @@ extension Workspace {
             focusPanel(fallbackFocusedPanelId)
         } else {
             scheduleFocusReconcile()
+        }
+
+        // Restore writers
+        if let writerSnapshots = snapshot.writers {
+            self.writers = writerSnapshots.map { ws in
+                // Remap chatPanelId through the old-to-new panel ID mapping
+                let remappedChatPanelId = ws.chatPanelId.flatMap { oldToNewPanelIds[$0] }
+                let panelThreadId = remappedChatPanelId
+                    .flatMap { panels[$0] as? ChatPanel }
+                    .flatMap { ChatPanel.normalizedThreadId($0.t3codeThreadId) }
+                let restoredThreadId = panelThreadId ?? ChatPanel.normalizedThreadId(ws.t3codeThreadId)
+                return Writer(
+                    id: ws.id,
+                    name: ws.name,
+                    t3codeThreadId: restoredThreadId,
+                    chatPanelId: remappedChatPanelId
+                )
+            }
+            self.activeWriterId = snapshot.activeWriterId ?? writerSnapshots.first?.id
+            self.isWritersExpanded = true
+        } else {
+            // Legacy terminal-first workspaces may not have any writers.
+            // Preserve that state rather than retrofitting a chat task on restore.
+            self.writers = []
+            self.activeWriterId = nil
+            self.isWritersExpanded = false
         }
     }
 
@@ -385,6 +428,7 @@ extension Workspace {
         let terminalSnapshot: SessionTerminalPanelSnapshot?
         let browserSnapshot: SessionBrowserPanelSnapshot?
         let markdownSnapshot: SessionMarkdownPanelSnapshot?
+        let chatThreadSnapshot: String?
         switch panel.panelType {
         case .terminal:
             guard let terminalPanel = panel as? TerminalPanel else { return nil }
@@ -408,6 +452,7 @@ extension Workspace {
             )
             browserSnapshot = nil
             markdownSnapshot = nil
+            chatThreadSnapshot = nil
         case .browser:
             guard let browserPanel = panel as? BrowserPanel else { return nil }
             terminalSnapshot = nil
@@ -422,11 +467,19 @@ extension Workspace {
                 forwardHistoryURLStrings: historySnapshot.forwardHistoryURLStrings
             )
             markdownSnapshot = nil
+            chatThreadSnapshot = nil
         case .markdown:
             guard let markdownPanel = panel as? MarkdownPanel else { return nil }
             terminalSnapshot = nil
             browserSnapshot = nil
             markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
+            chatThreadSnapshot = nil
+        case .chat:
+            guard let chatPanel = panel as? ChatPanel else { return nil }
+            terminalSnapshot = nil
+            browserSnapshot = nil
+            markdownSnapshot = nil
+            chatThreadSnapshot = ChatPanel.normalizedThreadId(chatPanel.t3codeThreadId)
         }
 
         return SessionPanelSnapshot(
@@ -440,6 +493,7 @@ extension Workspace {
             gitBranch: branchSnapshot,
             listeningPorts: listeningPorts,
             ttyName: ttyName,
+            t3codeThreadId: chatThreadSnapshot,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
             markdown: markdownSnapshot
@@ -618,6 +672,16 @@ extension Workspace {
             }
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
             return markdownPanel.id
+        case .chat:
+            guard let chatPanel = newChatSurface(
+                inPane: paneId,
+                threadId: ChatPanel.normalizedThreadId(snapshot.t3codeThreadId),
+                focus: false
+            ) else {
+                return nil
+            }
+            applySessionPanelMetadata(snapshot, toPanelId: chatPanel.id)
+            return chatPanel.id
         }
     }
 
@@ -5153,6 +5217,9 @@ final class Workspace: Identifiable, ObservableObject {
     /// The bonsplit controller managing the split panes for this workspace
     let bonsplitController: BonsplitController
 
+    /// The t3code sidecar manager for this workspace. Set by AppDelegate.
+    var t3codeSidecarManager: T3CodeSidecarManager?
+
     /// Mapping from bonsplit TabID to our Panel instances
     @Published private(set) var panels: [UUID: any Panel] = [:]
 
@@ -5262,6 +5329,17 @@ final class Workspace: Identifiable, ObservableObject {
     var agentPIDs: [String: pid_t] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
 
+    // MARK: - Writer Management Properties
+
+    /// All writers in this workspace.
+    @Published var writers: [Writer] = []
+
+    /// The currently active writer.
+    @Published var activeWriterId: UUID?
+
+    /// Whether the writer list is expanded in the sidebar.
+    @Published var isWritersExpanded: Bool = true
+
     private static func isProxyOnlyRemoteError(_ detail: String) -> Bool {
         let lowered = detail.lowercased()
         return lowered.contains("remote proxy")
@@ -5293,6 +5371,7 @@ final class Workspace: Identifiable, ObservableObject {
         static let terminal = "terminal"
         static let browser = "browser"
         static let markdown = "markdown"
+        static let chat = "chat"
     }
 
     enum PanelShellActivityState: String {
@@ -5401,12 +5480,14 @@ final class Workspace: Identifiable, ObservableObject {
     init(
         title: String = "Terminal",
         workingDirectory: String? = nil,
+        workspaceId: UUID? = nil,
         portOrdinal: Int = 0,
         configTemplate: ghostty_surface_config_s? = nil,
         initialTerminalCommand: String? = nil,
-        initialTerminalEnvironment: [String: String] = [:]
+        initialTerminalEnvironment: [String: String] = [:],
+        skipInitialTerminal: Bool = false
     ) {
-        self.id = UUID()
+        self.id = workspaceId ?? UUID()
         self.portOrdinal = portOrdinal
         self.processTitle = title
         self.title = title
@@ -5443,32 +5524,35 @@ final class Workspace: Identifiable, ObservableObject {
         // Remove the default "Welcome" tab that bonsplit creates
         let welcomeTabIds = bonsplitController.allTabIds
 
-        // Create initial terminal panel
-        let terminalPanel = TerminalPanel(
-            workspaceId: id,
-            context: GHOSTTY_SURFACE_CONTEXT_TAB,
-            configTemplate: configTemplate,
-            workingDirectory: hasWorkingDirectory ? trimmedWorkingDirectory : nil,
-            portOrdinal: portOrdinal,
-            initialCommand: initialTerminalCommand,
-            initialEnvironmentOverrides: initialTerminalEnvironment
-        )
-        configureTerminalPanel(terminalPanel)
-        panels[terminalPanel.id] = terminalPanel
-        panelTitles[terminalPanel.id] = terminalPanel.displayTitle
-        seedTerminalInheritanceFontPoints(panelId: terminalPanel.id, configTemplate: configTemplate)
-
-        // Create initial tab in bonsplit and store the mapping
         var initialTabId: TabID?
-        if let tabId = bonsplitController.createTab(
-            title: title,
-            icon: "terminal.fill",
-            kind: SurfaceKind.terminal,
-            isDirty: false,
-            isPinned: false
-        ) {
-            surfaceIdToPanelId[tabId] = terminalPanel.id
-            initialTabId = tabId
+
+        if !skipInitialTerminal {
+            // Create initial terminal panel
+            let terminalPanel = TerminalPanel(
+                workspaceId: id,
+                context: GHOSTTY_SURFACE_CONTEXT_TAB,
+                configTemplate: configTemplate,
+                workingDirectory: hasWorkingDirectory ? trimmedWorkingDirectory : nil,
+                portOrdinal: portOrdinal,
+                initialCommand: initialTerminalCommand,
+                initialEnvironmentOverrides: initialTerminalEnvironment
+            )
+            configureTerminalPanel(terminalPanel)
+            panels[terminalPanel.id] = terminalPanel
+            panelTitles[terminalPanel.id] = terminalPanel.displayTitle
+            seedTerminalInheritanceFontPoints(panelId: terminalPanel.id, configTemplate: configTemplate)
+
+            // Create initial tab in bonsplit and store the mapping
+            if let tabId = bonsplitController.createTab(
+                title: title,
+                icon: "terminal.fill",
+                kind: SurfaceKind.terminal,
+                isDirty: false,
+                isPinned: false
+            ) {
+                surfaceIdToPanelId[tabId] = terminalPanel.id
+                initialTabId = tabId
+            }
         }
 
         // Close the default Welcome tab(s)
@@ -5518,6 +5602,88 @@ final class Workspace: Identifiable, ObservableObject {
         guard configuration.appearance.splitButtonTooltips != tooltips else { return }
         configuration.appearance.splitButtonTooltips = tooltips
         bonsplitController.configuration = configuration
+    }
+
+    // MARK: - Writer Management
+
+    static func defaultDraftThreadId(for writerId: UUID) -> String {
+        writerId.uuidString.lowercased()
+    }
+
+    /// Create a new writer with a default name and a chat panel.
+    @discardableResult
+    func createWriter(name: String? = nil) -> Writer {
+        let writerName = name ?? "New task \(writers.count + 1)"
+        let writer = Writer(name: writerName)
+        writer.t3codeThreadId = Self.defaultDraftThreadId(for: writer.id)
+        writers.append(writer)
+        activeWriterId = writer.id
+
+        // Create a chat panel for this writer
+        if let rootPaneId = bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first {
+            if let chatPanel = newChatSurface(
+                inPane: rootPaneId,
+                threadId: writer.t3codeThreadId,
+                serverPort: t3codeSidecarManager?.port
+            ) {
+                writer.chatPanelId = chatPanel.id
+            }
+        }
+
+        return writer
+    }
+
+    /// Select a writer and focus its chat panel.
+    func selectWriter(_ writerId: UUID) {
+        activeWriterId = writerId
+        if let writer = writers.first(where: { $0.id == writerId }),
+           let chatPanelId = writer.chatPanelId,
+           let tabId = surfaceIdFromPanelId(chatPanelId) {
+            bonsplitController.selectTab(tabId)
+        }
+    }
+
+    /// Delete a writer and clean up its resources.
+    func deleteWriter(_ writer: Writer) {
+        // Close the writer's chat panel before removing
+        if let chatPanelId = writer.chatPanelId {
+            _ = closePanel(chatPanelId, force: true)
+        }
+
+        writers.removeAll { $0.id == writer.id }
+        if activeWriterId == writer.id {
+            activeWriterId = writers.first?.id
+            // Focus the new active writer's chat panel
+            if let newActiveId = activeWriterId {
+                selectWriter(newActiveId)
+            }
+        }
+    }
+
+    /// Rename a writer.
+    func renameWriter(_ writer: Writer, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        writer.name = trimmed
+
+        // Project tasks currently model a single writer per workspace.
+        // Keep the workspace title path in sync so sidebar rows, workspace tabs,
+        // and restored task names all stay aligned.
+        if writers.count == 1, writers.first?.id == writer.id {
+            setCustomTitle(trimmed)
+        }
+    }
+
+    func updateWriterThreadId(_ threadId: String?, forChatPanelId chatPanelId: UUID) {
+        guard let writer = writers.first(where: { $0.chatPanelId == chatPanelId }) else { return }
+        let normalizedThreadId = ChatPanel.normalizedThreadId(threadId)
+        guard writer.t3codeThreadId != normalizedThreadId else { return }
+        writer.t3codeThreadId = normalizedThreadId
+    }
+
+    /// Move a writer from one index to another (reorder).
+    func moveWriter(from source: IndexSet, to destination: Int) {
+        writers.move(fromOffsets: source, toOffset: destination)
     }
 
     // MARK: - Surface ID to Panel ID Mapping
@@ -5773,6 +5939,8 @@ final class Workspace: Identifiable, ObservableObject {
             return SurfaceKind.browser
         case .markdown:
             return SurfaceKind.markdown
+        case .chat:
+            return SurfaceKind.chat
         }
     }
 
@@ -6010,6 +6178,17 @@ final class Workspace: Identifiable, ObservableObject {
 
     static func shouldShowUnreadIndicator(hasUnreadNotification: Bool, isManuallyUnread: Bool) -> Bool {
         hasUnreadNotification || isManuallyUnread
+    }
+
+    // MARK: - T3Code Sidecar
+
+    /// Called when the t3code sidecar becomes ready. Updates all chat panels with the port.
+    func notifyChatPanelsOfPort(_ port: Int) {
+        for (_, panel) in panels {
+            if let chatPanel = panel as? ChatPanel {
+                chatPanel.loadT3CodeUI(port: port)
+            }
+        }
     }
 
     // MARK: - Title Management
@@ -7451,6 +7630,54 @@ final class Workspace: Identifiable, ObservableObject {
 
         installMarkdownPanelSubscription(markdownPanel)
         return markdownPanel
+    }
+
+    func newChatSurface(
+        inPane paneId: PaneID,
+        threadId: String? = nil,
+        serverPort: Int? = nil,
+        focus: Bool? = nil
+    ) -> ChatPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+
+        let chatPanel = ChatPanel(workspaceId: id, threadId: threadId, serverPort: serverPort)
+        chatPanel.onThreadIdChange = { [weak self, panelId = chatPanel.id] nextThreadId in
+            self?.updateWriterThreadId(nextThreadId, forChatPanelId: panelId)
+        }
+        panels[chatPanel.id] = chatPanel
+        panelTitles[chatPanel.id] = chatPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: chatPanel.displayTitle,
+            icon: chatPanel.displayIcon,
+            kind: SurfaceKind.chat,
+            isDirty: false,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: chatPanel.id)
+            panelTitles.removeValue(forKey: chatPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = chatPanel.id
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            chatPanel.focus()
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: chatPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        return chatPanel
     }
 
     /// Tear down all panels in this workspace, freeing their Ghostty surfaces.
@@ -9739,6 +9966,15 @@ extension Workspace: BonsplitDelegate {
 
         if let panelId = panelIdFromSurfaceId(tab.id),
            pinnedPanelIds.contains(panelId) {
+            clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
+            NSSound.beep()
+            return false
+        }
+
+        // Chat panels can't be closed directly — delete the writer instead.
+        if let panelId = panelIdFromSurfaceId(tab.id),
+           let panel = panels[panelId],
+           panel.panelType == .chat {
             clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
             NSSound.beep()
             return false

--- a/Sources/Writer.swift
+++ b/Sources/Writer.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Combine
+
+/// A writer represents a task/topic within a workspace.
+/// Each writer has a t3code chat session and optional terminal splits.
+final class Writer: ObservableObject, Identifiable, Codable {
+    let id: UUID
+    @Published var name: String
+    @Published var t3codeThreadId: String?
+    @Published var isActive: Bool
+
+    /// The UUID of the ChatPanel associated with this writer, if one has been created.
+    var chatPanelId: UUID?
+
+    init(id: UUID = UUID(), name: String, t3codeThreadId: String? = nil, chatPanelId: UUID? = nil) {
+        self.id = id
+        self.name = name
+        self.t3codeThreadId = t3codeThreadId
+        self.isActive = false
+        self.chatPanelId = chatPanelId
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, t3codeThreadId, isActive, chatPanelId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.t3codeThreadId = try container.decodeIfPresent(String.self, forKey: .t3codeThreadId)
+        self.isActive = try container.decodeIfPresent(Bool.self, forKey: .isActive) ?? false
+        self.chatPanelId = try container.decodeIfPresent(UUID.self, forKey: .chatPanelId)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(t3codeThreadId, forKey: .t3codeThreadId)
+        try container.encode(isActive, forKey: .isActive)
+        try container.encodeIfPresent(chatPanelId, forKey: .chatPanelId)
+    }
+}

--- a/Sources/WriterSidebarView.swift
+++ b/Sources/WriterSidebarView.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+
+// MARK: - ProjectSidebarHeader
+
+/// Collapsible project row shown in the sidebar.
+/// Displays the project name, directory, a chevron toggle, and the task count when collapsed.
+struct ProjectSidebarHeader: View {
+    @ObservedObject var project: Project
+    @EnvironmentObject var tabManager: TabManager
+    @State private var isHovering = false
+    @State private var isEditing = false
+    @State private var editText = ""
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Chevron toggle
+            Image(systemName: project.isExpanded ? "chevron.down" : "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.secondary)
+                .frame(width: 12)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        project.isExpanded.toggle()
+                    }
+                }
+
+            // Project icon
+            Image(systemName: "folder.fill")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary.opacity(0.8))
+
+            if isEditing {
+                TextField(
+                    String(localized: "projectSidebar.renameField.placeholder", defaultValue: "Project name"),
+                    text: $editText,
+                    onCommit: {
+                        commitRename()
+                    }
+                )
+                .font(.system(size: 12, weight: .semibold))
+                .textFieldStyle(.plain)
+                .onExitCommand {
+                    isEditing = false
+                }
+            } else {
+                Text(project.name)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
+
+            // Task count badge when collapsed
+            if !project.isExpanded {
+                let liveCount = project.workspaceIds.filter { wsId in
+                    tabManager.tabs.contains { $0.id == wsId }
+                }.count
+                Text("\(liveCount)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(
+                        Capsule()
+                            .fill(Color.secondary.opacity(0.12))
+                    )
+            }
+
+            // Add task button on hover
+            if isHovering {
+                Button(action: {
+                    tabManager.addTask(to: project)
+                }) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(String(localized: "projectSidebar.addTask.tooltip", defaultValue: "New task"))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(isHovering ? Color.primary.opacity(0.04) : Color.clear)
+                .padding(.horizontal, 4)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                project.isExpanded.toggle()
+            }
+        }
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                startEditing()
+            }
+        )
+        .contextMenu {
+            Button(String(localized: "projectSidebar.contextMenu.newTask", defaultValue: "New task")) {
+                tabManager.addTask(to: project)
+            }
+            Divider()
+            Button(String(localized: "projectSidebar.contextMenu.rename", defaultValue: "Rename")) {
+                startEditing()
+            }
+            Divider()
+            Button(String(localized: "projectSidebar.contextMenu.delete", defaultValue: "Delete project"), role: .destructive) {
+                tabManager.deleteProject(project)
+            }
+        }
+    }
+
+    private func startEditing() {
+        editText = project.name
+        isEditing = true
+    }
+
+    private func commitRename() {
+        let trimmed = editText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            project.name = trimmed
+        }
+        isEditing = false
+    }
+}
+
+// MARK: - ProjectTaskRow
+
+/// A single task (workspace) row displayed under a project in the sidebar.
+struct ProjectTaskRow: View {
+    @ObservedObject var workspace: Workspace
+    @EnvironmentObject var tabManager: TabManager
+    let isActive: Bool
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isHovering = false
+    @State private var isEditing = false
+    @State private var editText = ""
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Task icon
+            Image(systemName: "bubble.left.and.text.bubble.right")
+                .font(.system(size: 10))
+                .foregroundColor(.secondary.opacity(0.7))
+
+            if isEditing {
+                TextField(
+                    String(localized: "projectSidebar.taskRenameField.placeholder", defaultValue: "Task name"),
+                    text: $editText,
+                    onCommit: {
+                        commitRename()
+                    }
+                )
+                .font(.system(size: 12))
+                .textFieldStyle(.plain)
+                .onExitCommand {
+                    isEditing = false
+                }
+            } else {
+                Text(workspace.customTitle ?? workspace.title)
+                    .font(.system(size: 12))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 0)
+
+            // Active indicator (green dot)
+            if workspace.writers.contains(where: { $0.isActive }) {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 6, height: 6)
+            }
+
+            // Close button on hover
+            if isHovering {
+                Button(action: onDelete) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .padding(.leading, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(rowBackground)
+                .padding(.horizontal, 6)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onSelect()
+        }
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                startEditing()
+            }
+        )
+        .contextMenu {
+            Button(String(localized: "projectSidebar.task.contextMenu.rename", defaultValue: "Rename")) {
+                startEditing()
+            }
+            Divider()
+            Button(String(localized: "projectSidebar.task.contextMenu.delete", defaultValue: "Delete"), role: .destructive) {
+                onDelete()
+            }
+        }
+    }
+
+    private var rowBackground: Color {
+        if isActive {
+            return Color.accentColor.opacity(0.15)
+        }
+        if isHovering {
+            return Color.primary.opacity(0.04)
+        }
+        return Color.clear
+    }
+
+    private func startEditing() {
+        editText = workspace.customTitle ?? workspace.title
+        isEditing = true
+    }
+
+    private func commitRename() {
+        let trimmed = editText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            tabManager.setCustomTitle(tabId: workspace.id, title: trimmed)
+            if workspace.writers.count == 1, let writer = workspace.writers.first {
+                workspace.renameWriter(writer, to: trimmed)
+            }
+        }
+        isEditing = false
+    }
+}
+
+// MARK: - ProjectTasksList
+
+/// The list of task-workspaces nested under a single project in the sidebar.
+struct ProjectTasksList: View {
+    @ObservedObject var project: Project
+    @EnvironmentObject var tabManager: TabManager
+
+    var body: some View {
+        VStack(spacing: 1) {
+            ForEach(liveWorkspaces) { workspace in
+                ProjectTaskRow(
+                    workspace: workspace,
+                    isActive: tabManager.selectedTabId == workspace.id,
+                    onSelect: {
+                        tabManager.selectedTabId = workspace.id
+                    },
+                    onDelete: {
+                        tabManager.removeTask(workspaceId: workspace.id, from: project)
+                    }
+                )
+            }
+
+            // "+ New task" button
+            Button(action: {
+                tabManager.addTask(to: project)
+            }) {
+                HStack(spacing: 4) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .medium))
+                    Text(String(localized: "projectSidebar.newTask", defaultValue: "New task"))
+                        .font(.system(size: 11))
+                }
+                .foregroundColor(.secondary.opacity(0.7))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .padding(.leading, 14)
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+        }
+    }
+
+    /// Workspaces that still exist in tabManager, in the order stored by the project.
+    private var liveWorkspaces: [Workspace] {
+        project.workspaceIds.compactMap { wsId in
+            tabManager.tabs.first { $0.id == wsId }
+        }
+    }
+}
+
+// MARK: - SidebarProjectSection
+
+/// Renders a single project group: collapsible header + task list when expanded.
+struct SidebarProjectSection: View {
+    @ObservedObject var project: Project
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ProjectSidebarHeader(project: project)
+
+            if project.isExpanded {
+                ProjectTasksList(project: project)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+}
+
+// MARK: - Legacy compatibility aliases
+
+// Keep SidebarWritersSection available for any remaining references.
+// It now renders nothing since writer lists are no longer shown nested
+// under workspaces in the sidebar — tasks are shown under projects instead.
+struct SidebarWritersSection: View {
+    @ObservedObject var workspace: Workspace
+
+    var body: some View {
+        EmptyView()
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -606,6 +606,22 @@ struct cmuxApp: App {
                         }
                     }
                 }
+
+                Divider()
+
+                Button(String(localized: "menu.file.newProject", defaultValue: "New Project…")) {
+                    let panel = NSOpenPanel()
+                    panel.canChooseFiles = false
+                    panel.canChooseDirectories = true
+                    panel.allowsMultipleSelection = false
+                    panel.prompt = String(localized: "menu.file.newProject.panelPrompt", defaultValue: "Choose Project Directory")
+                    panel.message = String(localized: "menu.file.newProject.panelMessage", defaultValue: "Select the root directory for your project")
+                    if panel.runModal() == .OK, let url = panel.url {
+                        let projectName = url.lastPathComponent
+                        activeTabManager.addProject(name: projectName, directory: url.path)
+                    }
+                }
+                .keyboardShortcut("n", modifiers: [.command, .option])
             }
 
             // Close tab/workspace

--- a/scripts/install-cmux-t3code.sh
+++ b/scripts/install-cmux-t3code.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="cmux-t3code"
+BUNDLE_ID="com.cmuxterm.app.t3code"
+INSTALL_DIR="/Applications"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/cmux"
+CMUX_SOCKET="/tmp/cmux-t3code.sock"
+CMUXD_SOCKET="${APP_SUPPORT_DIR}/cmuxd-t3code.sock"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUPERPROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-t3code-install"
+
+echo "============================================================"
+echo "  Installing ${APP_NAME} as standalone app"
+echo "============================================================"
+echo ""
+echo "  Bundle ID:      ${BUNDLE_ID}"
+echo "  Install path:   ${INSTALL_DIR}/${APP_NAME}.app"
+echo "  Socket:         ${CMUX_SOCKET}"
+echo "  Daemon socket:  ${CMUXD_SOCKET}"
+echo ""
+
+cd "$REPO_ROOT"
+
+echo "▸ Building Release configuration..."
+XCODE_LOG="/tmp/cmux-t3code-xcodebuild.log"
+xcodebuild \
+  -project GhosttyTabs.xcodeproj \
+  -scheme cmux \
+  -configuration Release \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$DERIVED_DATA" \
+  build 2>&1 | tee "$XCODE_LOG" | grep -E '(warning:|error:|fatal:|BUILD FAILED|BUILD SUCCEEDED|\*\* BUILD)' || true
+XCODE_EXIT="${PIPESTATUS[0]}"
+echo "Full build log: $XCODE_LOG"
+[[ "$XCODE_EXIT" -ne 0 ]] && echo "error: build failed ($XCODE_EXIT)" >&2 && exit "$XCODE_EXIT"
+echo "▸ Build succeeded."
+sleep 0.2
+
+BUILT_APP="${DERIVED_DATA}/Build/Products/Release/cmux.app"
+[[ ! -d "$BUILT_APP" ]] && echo "error: cmux.app not found" >&2 && exit 1
+
+CMUXD_SRC="${REPO_ROOT}/cmuxd/zig-out/bin/cmuxd"
+[[ -d "${REPO_ROOT}/cmuxd" ]] && echo "▸ Building cmuxd..." && (cd "${REPO_ROOT}/cmuxd" && zig build -Doptimize=ReleaseFast) || true
+
+GHOSTTY_HELPER_SRC="${REPO_ROOT}/ghostty/zig-out/bin/ghostty"
+[[ -d "${REPO_ROOT}/ghostty" ]] && command -v zig >/dev/null 2>&1 && echo "▸ Building ghostty helper..." && \
+  (cd "${REPO_ROOT}/ghostty" && zig build cli-helper -Dapp-runtime=none -Demit-macos-app=false -Demit-xcframework=false -Doptimize=ReleaseFast) || true
+
+echo "▸ Quitting any running ${APP_NAME}..."
+/usr/bin/osascript -e "tell application id \"${BUNDLE_ID}\" to quit" >/dev/null 2>&1 || true
+sleep 0.3
+pkill -f "${APP_NAME}.app/Contents/MacOS/cmux" 2>/dev/null || true
+sleep 0.3
+
+INSTALL_PATH="${INSTALL_DIR}/${APP_NAME}.app"
+echo "▸ Installing to ${INSTALL_PATH}..."
+[[ -d "$INSTALL_PATH" ]] && rm -rf "$INSTALL_PATH"
+cp -R "$BUILT_APP" "$INSTALL_PATH"
+
+INFO_PLIST="$INSTALL_PATH/Contents/Info.plist"
+echo "▸ Patching Info.plist..."
+/usr/libexec/PlistBuddy -c "Set :CFBundleName ${APP_NAME}" "$INFO_PLIST" 2>/dev/null \
+  || /usr/libexec/PlistBuddy -c "Add :CFBundleName string ${APP_NAME}" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName ${APP_NAME}" "$INFO_PLIST" 2>/dev/null \
+  || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string ${APP_NAME}" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier ${BUNDLE_ID}" "$INFO_PLIST" 2>/dev/null \
+  || /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string ${BUNDLE_ID}" "$INFO_PLIST"
+
+/usr/libexec/PlistBuddy -c "Add :LSEnvironment dict" "$INFO_PLIST" 2>/dev/null || true
+for kv in \
+  "CMUX_SOCKET_PATH:${CMUX_SOCKET}" \
+  "CMUXD_UNIX_PATH:${CMUXD_SOCKET}" \
+  "CMUX_SOCKET_ENABLE:1" \
+  "CMUX_SOCKET_MODE:automation" \
+  "CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD:1" \
+  "CMUXTERM_REPO_ROOT:${SUPERPROJECT_ROOT}"; do
+  KEY="${kv%%:*}"; VAL="${kv#*:}"
+  /usr/libexec/PlistBuddy -c "Set :LSEnvironment:${KEY} \"${VAL}\"" "$INFO_PLIST" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:${KEY} string \"${VAL}\"" "$INFO_PLIST"
+done
+
+BIN_DIR="$INSTALL_PATH/Contents/Resources/bin"
+mkdir -p "$BIN_DIR"
+[[ -x "$CMUXD_SRC" ]] && cp "$CMUXD_SRC" "$BIN_DIR/cmuxd" && chmod +x "$BIN_DIR/cmuxd" && echo "▸ Bundled cmuxd"
+[[ -x "$GHOSTTY_HELPER_SRC" ]] && cp "$GHOSTTY_HELPER_SRC" "$BIN_DIR/ghostty" && chmod +x "$BIN_DIR/ghostty" && echo "▸ Bundled ghostty"
+
+echo "▸ Re-codesigning..."
+/usr/bin/codesign --force --deep --sign - --timestamp=none --generate-entitlement-der "$INSTALL_PATH" >/dev/null 2>&1 || true
+
+[[ -S "$CMUXD_SOCKET" ]] && rm -f "$CMUXD_SOCKET"
+[[ -S "$CMUX_SOCKET" ]] && rm -f "$CMUX_SOCKET"
+
+CLI_SRC="${INSTALL_PATH}/Contents/Resources/bin/cmux"
+CLI_TARGET=""
+if [[ -x "$CLI_SRC" ]]; then
+  for d in /opt/homebrew/bin /usr/local/bin "$HOME/.local/bin"; do
+    [[ -d "$d" && -w "$d" ]] && CLI_TARGET="$d/cmux-t3code" && break
+  done
+  [[ -z "$CLI_TARGET" ]] && mkdir -p "$HOME/.local/bin" && CLI_TARGET="$HOME/.local/bin/cmux-t3code"
+  ln -sfn "$CLI_SRC" "$CLI_TARGET"
+  echo "▸ CLI: ${CLI_TARGET}"
+fi
+
+mkdir -p "$APP_SUPPORT_DIR"
+
+echo ""
+echo "============================================================"
+echo "  ✓ Installation complete!"
+echo "============================================================"
+echo "  App:       ${INSTALL_PATH}"
+echo "  Bundle ID: ${BUNDLE_ID}"
+echo "  Socket:    ${CMUX_SOCKET}"
+echo "  CLI:       ${CLI_TARGET:-N/A}"
+echo ""
+echo "  Launch:    open /Applications/cmux-t3code.app"

--- a/scripts/install-cmux-t3code.sh
+++ b/scripts/install-cmux-t3code.sh
@@ -24,6 +24,27 @@ echo ""
 
 cd "$REPO_ROOT"
 
+# --- Build t3code server (Node.js sidecar) ---
+T3CODE_DIR="${SUPERPROJECT_ROOT}/t3code"
+T3CODE_DIST="${T3CODE_DIR}/apps/server/dist/index.mjs"
+if [ -d "$T3CODE_DIR" ]; then
+  echo "▸ Building t3code server..."
+  if command -v bun >/dev/null 2>&1; then
+    (cd "$T3CODE_DIR" && bun install && bun run build)
+  elif command -v npm >/dev/null 2>&1; then
+    (cd "$T3CODE_DIR" && npm install && npm run build)
+  else
+    echo "warning: neither bun nor npm found — skipping t3code build" >&2
+  fi
+  if [ -f "$T3CODE_DIST" ]; then
+    echo "▸ t3code server built successfully"
+  else
+    echo "warning: t3code dist not found after build — sidecar will not be bundled" >&2
+  fi
+else
+  echo "warning: t3code submodule not found at ${T3CODE_DIR}" >&2
+fi
+
 echo "▸ Building Release configuration..."
 XCODE_LOG="/tmp/cmux-t3code-xcodebuild.log"
 xcodebuild \
@@ -76,7 +97,8 @@ for kv in \
   "CMUX_SOCKET_ENABLE:1" \
   "CMUX_SOCKET_MODE:automation" \
   "CMUX_REMOTE_DAEMON_ALLOW_LOCAL_BUILD:1" \
-  "CMUXTERM_REPO_ROOT:${SUPERPROJECT_ROOT}"; do
+  "CMUXTERM_REPO_ROOT:${SUPERPROJECT_ROOT}" \
+  "T3CODE_SERVER_PATH:${T3CODE_DIST}"; do
   KEY="${kv%%:*}"; VAL="${kv#*:}"
   /usr/libexec/PlistBuddy -c "Set :LSEnvironment:${KEY} \"${VAL}\"" "$INFO_PLIST" 2>/dev/null \
     || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:${KEY} string \"${VAL}\"" "$INFO_PLIST"


### PR DESCRIPTION
## Summary

- **Install script**: adds `T3CODE_SERVER_PATH` to `LSEnvironment` so every workspace finds the t3code binary via env var, regardless of CWD
- **Sidecar manager**: adds `CMUXTERM_REPO_ROOT` fallback check and fixes `.git` file vs directory detection so the upward directory walk doesn't stop at submodule boundaries (`.git` files)
- **Resolution reorder**: env var > repo root > source root > directory walk > global paths > bundle resources

Previously only workspaces whose CWD happened to be the superproject root could find the t3code binary. Workspaces inside submodules (e.g. `cmux-t3code/cmux/`) or in unrelated projects (e.g. `data_cv/`) would hang at "Starting t3code server..." forever.

## Test plan

- [ ] Run `./scripts/install-cmux-t3code.sh` and launch the app
- [ ] Open task workspaces in different project directories
- [ ] Verify all chat panels load t3code (no "Starting t3code server..." hang)
- [ ] Verify `ps aux | grep t3code` shows one sidecar per workspace using the source tree binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the t3code chat into cmux with per-workspace sidecars and fixes sidecar discovery for bundled installs. Prevents the “Starting t3code server…” hang in submodules and non-repo workspaces.

- **New Features**
  - Added `ChatPanel` and `ChatPanelView` embedding the t3code web UI; passes `projectCwd` in the URL for correct project binding.
  - Introduced `T3CodeSidecarManager` for per-workspace Node server lifecycle (fixed port selection, readiness, restart, shutdown on app quit).
  - Added `Project` and `Writer` models with a sidebar UI and “New Project…” actions; group workspaces by project.
  - Extended session persistence for writers and chat thread IDs.
  - Added `scripts/install-cmux-t3code.sh` to build/install the sidecar and set `T3CODE_SERVER_PATH` via `LSEnvironment` (includes Homebrew Node in PATH).
  - `Info.plist`: added `CMUXSourceRoot` for path resolution.

- **Bug Fixes**
  - Reliable sidecar binary resolution across all workspaces: `T3CODE_SERVER_PATH` > `CMUXTERM_REPO_ROOT` > `CMUXSourceRoot` > upward walk (handles `.git` file for submodules) > global paths > bundle resources.
  - Workspaces in submodules or unrelated directories now start t3code correctly (no startup hang).

<sup>Written for commit 8adb5a5d8bbe7b722833f3251f2c80d36c76da1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added project creation and management—organize workspaces into projects from the sidebar or menu
  * Added task management within projects to create and manage related workspaces
  * Added chat panel with embedded AI assistance for interactive development
  * Added "New Project" command accessible via menu and keyboard shortcut (Cmd+Option+N)
  * Enhanced sidebar with collapsible project sections showing task counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->