### PR TITLE
Fix browser panes rendering blank after reopen

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2987,14 +2987,39 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         let restoredBack = Self.sanitizedSessionHistoryURLs(backHistoryURLStrings)
         let restoredForward = Self.sanitizedSessionHistoryURLs(forwardHistoryURLStrings)
-        guard !restoredBack.isEmpty || !restoredForward.isEmpty else { return }
+        let restoredCurrent = Self.sanitizedSessionHistoryURL(currentURLString)
+        guard !restoredBack.isEmpty || !restoredForward.isEmpty || restoredCurrent != nil else { return }
 
         usesRestoredSessionHistory = true
         restoredBackHistoryStack = restoredBack
         // Store nearest-forward entries at the end to make stack pop operations trivial.
         restoredForwardHistoryStack = Array(restoredForward.reversed())
-        restoredHistoryCurrentURL = Self.sanitizedSessionHistoryURL(currentURLString)
+        restoredHistoryCurrentURL = restoredCurrent
         refreshNavigationAvailability()
+    }
+
+    func restoreSessionSnapshot(_ snapshot: SessionBrowserPanelSnapshot) {
+        let restoredURL = Self.sanitizedSessionHistoryURL(snapshot.urlString)
+
+        restoreSessionNavigationHistory(
+            backHistoryURLStrings: snapshot.backHistoryURLStrings ?? [],
+            forwardHistoryURLStrings: snapshot.forwardHistoryURLStrings ?? [],
+            currentURLString: snapshot.urlString
+        )
+
+        currentURL = snapshot.shouldRenderWebView ? restoredURL : nil
+        shouldRenderWebView = snapshot.shouldRenderWebView
+
+        guard snapshot.shouldRenderWebView, let restoredURL else {
+            refreshNavigationAvailability()
+            return
+        }
+
+        navigateWithoutInsecureHTTPPrompt(
+            to: restoredURL,
+            recordTypedNavigation: false,
+            preserveRestoredSessionHistory: true
+        )
     }
 
     private func setupObservers(for webView: WKWebView) {
@@ -4132,6 +4157,20 @@ extension BrowserPanel {
     /// Reload the current page
     func reload() {
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
+        if Self.serializableSessionHistoryURLString(Self.remoteProxyDisplayURL(for: webView.url)) == nil {
+            let fallbackURL = resolvedCurrentSessionHistoryURL()
+                ?? Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
+
+            if let fallbackURL,
+               Self.serializableSessionHistoryURLString(fallbackURL) != nil {
+                navigateWithoutInsecureHTTPPrompt(
+                    to: fallbackURL,
+                    recordTypedNavigation: false,
+                    preserveRestoredSessionHistory: usesRestoredSessionHistory
+                )
+                return
+            }
+        }
         webView.reload()
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -596,10 +596,9 @@ extension Workspace {
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
             return terminalPanel.id
         case .browser:
-            let initialURL = snapshot.browser?.urlString.flatMap { URL(string: $0) }
             guard let browserPanel = newBrowserSurface(
                 inPane: paneId,
-                url: initialURL,
+                url: nil,
                 focus: false,
                 preferredProfileID: snapshot.browser?.profileID
             ) else {
@@ -655,16 +654,12 @@ extension Workspace {
 
         if let browserSnapshot = snapshot.browser,
            let browserPanel = browserPanel(for: panelId) {
-            browserPanel.restoreSessionNavigationHistory(
-                backHistoryURLStrings: browserSnapshot.backHistoryURLStrings ?? [],
-                forwardHistoryURLStrings: browserSnapshot.forwardHistoryURLStrings ?? [],
-                currentURLString: browserSnapshot.urlString
-            )
-
             let pageZoom = CGFloat(max(0.25, min(5.0, browserSnapshot.pageZoom)))
             if pageZoom.isFinite {
                 _ = browserPanel.setPageZoomFactor(pageZoom)
             }
+
+            browserPanel.restoreSessionSnapshot(browserSnapshot)
 
             if browserSnapshot.developerToolsVisible {
                 _ = browserPanel.showDeveloperTools()


### PR DESCRIPTION
Fixes #2137

## Summary
- restore browser session state through an explicit session-restore path instead of constructor-time initial URL loading
- preserve restored current URL even when there is no back/forward history
- make browser refresh fall back to the restored/current URL when WKWebView has no live URL

## Testing
- built and launched with `./scripts/reload.sh --tag browser-blank-fix --launch`
- local tests not run per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2137 by restoring browser panes via an explicit session-restore path. Reload now falls back to the restored URL to avoid blank pages after reopen.

- **Bug Fixes**
  - Added a `restoreSessionSnapshot` path that restores history, current URL, and `shouldRenderWebView`, then navigates without constructor-time URL loading.
  - During session restore, create the browser with `url: nil` to prevent premature loads; apply page zoom and devtools state after restoration.
  - Preserve and use the restored current URL even with empty history; on reload, if `WKWebView` has no live URL, navigate to the resolved current or last attempted URL.

<sup>Written for commit 0b891ffb1e293650a967b284ef2c4e39c46d5daa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

