### PR TITLE
fix: strip markdown syntax from desktop notification text

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1127,13 +1127,14 @@ final class TerminalNotificationStore: ObservableObject {
         )
 
         // Italic: *text* or _text_
+        // Word-boundary assertions prevent matching inside identifiers like CMUX_NOTIFICATION_BODY.
         result = result.replacingOccurrences(
-            of: #"\*(.+?)\*"#,
+            of: #"(?<!\w)\*(.+?)\*(?!\w)"#,
             with: "$1",
             options: .regularExpression
         )
         result = result.replacingOccurrences(
-            of: #"_(.+?)_"#,
+            of: #"(?<!\w)_(.+?)_(?!\w)"#,
             with: "$1",
             options: .regularExpression
         )

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1089,6 +1089,113 @@ final class TerminalNotificationStore: ObservableObject {
         center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
     }
 
+    // Strip markdown syntax from notification text so that desktop notifications
+    // display clean plain text instead of raw markdown characters like **bold**,
+    // ## headings, `code`, etc.
+    private func stripMarkdown(_ text: String) -> String {
+        var result = text
+
+        // Headings: ## Heading → Heading
+        result = result.replacingOccurrences(
+            of: #"^#{1,6}\s+"#,
+            with: "",
+            options: [.regularExpression, .anchored]
+        )
+        // Also handle headings mid-line (after a newline)
+        result = result.replacingOccurrences(
+            of: #"(?m)^#{1,6}\s+"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        // Bold+italic: ***text*** or ___text___
+        result = result.replacingOccurrences(
+            of: #"\*{3}(.+?)\*{3}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"_{3}(.+?)_{3}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Bold: **text** or __text__
+        result = result.replacingOccurrences(
+            of: #"\*{2}(.+?)\*{2}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"_{2}(.+?)_{2}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Italic: *text* or _text_
+        result = result.replacingOccurrences(
+            of: #"\*(.+?)\*"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"_(.+?)_"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Inline code: `code`
+        result = result.replacingOccurrences(
+            of: #"`(.+?)`"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Links: [text](url) → text
+        result = result.replacingOccurrences(
+            of: #"\[(.+?)\]\(.+?\)"#,
+            with: "$1",
+            options: .regularExpression
+        )
+
+        // Blockquotes: > text → text
+        result = result.replacingOccurrences(
+            of: #"(?m)^>\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        // Unordered list markers: - item or * item or + item
+        result = result.replacingOccurrences(
+            of: #"(?m)^[-*+]\s+"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        // Ordered list markers: 1. item
+        result = result.replacingOccurrences(
+            of: #"(?m)^\d+\.\s+"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        // Horizontal rules: --- or *** or ___
+        result = result.replacingOccurrences(
+            of: #"(?m)^[-*_]{3,}\s*$"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        // Collapse multiple blank lines into one
+        result = result.replacingOccurrences(
+            of: #"\n{3,}"#,
+            with: "\n\n",
+            options: .regularExpression
+        )
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func resolvedNotificationTitle(for notification: TerminalNotification) -> String {
         let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
@@ -1102,8 +1209,8 @@ final class TerminalNotificationStore: ObservableObject {
 
             let content = UNMutableNotificationContent()
             content.title = self.resolvedNotificationTitle(for: notification)
-            content.subtitle = notification.subtitle
-            content.body = notification.body
+            content.subtitle = stripMarkdown(notification.subtitle)
+            content.body = stripMarkdown(notification.body)
             content.sound = NotificationSoundSettings.sound()
             content.categoryIdentifier = Self.categoryIdentifier
             content.userInfo = [
@@ -1138,8 +1245,8 @@ final class TerminalNotificationStore: ObservableObject {
         NotificationSoundSettings.playSelectedSound()
         NotificationSoundSettings.runCustomCommand(
             title: resolvedNotificationTitle(for: notification),
-            subtitle: notification.subtitle,
-            body: notification.body
+            subtitle: stripMarkdown(notification.subtitle),
+            body: stripMarkdown(notification.body)
         )
     }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1095,13 +1095,7 @@ final class TerminalNotificationStore: ObservableObject {
     private func stripMarkdown(_ text: String) -> String {
         var result = text
 
-        // Headings: ## Heading → Heading
-        result = result.replacingOccurrences(
-            of: #"^#{1,6}\s+"#,
-            with: "",
-            options: [.regularExpression, .anchored]
-        )
-        // Also handle headings mid-line (after a newline)
+        // Headings: ## Heading → Heading (multiline mode covers all lines including the first)
         result = result.replacingOccurrences(
             of: #"(?m)^#{1,6}\s+"#,
             with: "",

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1109,7 +1109,7 @@ final class TerminalNotificationStore: ObservableObject {
             options: .regularExpression
         )
         result = result.replacingOccurrences(
-            of: #"_{3}(.+?)_{3}"#,
+            of: #"(?<!\w)_{3}(.+?)_{3}(?!\w)"#,
             with: "$1",
             options: .regularExpression
         )
@@ -1121,7 +1121,7 @@ final class TerminalNotificationStore: ObservableObject {
             options: .regularExpression
         )
         result = result.replacingOccurrences(
-            of: #"_{2}(.+?)_{2}"#,
+            of: #"(?<!\w)_{2}(.+?)_{2}(?!\w)"#,
             with: "$1",
             options: .regularExpression
         )


### PR DESCRIPTION
## Summary

- Fixes #2044
- Native macOS notifications triggered by AI agent output (e.g. Claude Code) were displaying raw markdown syntax — `**bold**`, `## headings`, `` `code` ``, `- list items` — instead of clean plain text.
- Adds a `stripMarkdown(_ text: String) -> String` private helper on `TerminalNotificationStore` that removes common markdown formatting before delivering text to `UNUserNotificationCenter` and the custom notification shell command.

## What's stripped

| Pattern | Before | After |
|---|---|---|
| Headings | `## Task complete` | `Task complete` |
| Bold | `**important**` | `important` |
| Italic | `*note*` | `note` |
| Bold+italic | `***critical***` | `critical` |
| Inline code | `` `git status` `` | `git status` |
| Links | `[see docs](https://example.com)` | `see docs` |
| Blockquotes | `> some quote` | `some quote` |
| Unordered lists | `- item` | `item` |
| Ordered lists | `1. item` | `item` |
| Horizontal rules | `---` | *(removed)* |

## Design decisions

- The raw markdown is preserved in `TerminalNotification.body` / `.subtitle` so the in-app notifications panel (which may render markdown in the future) keeps the original text.
- Only the text sent to `UNUserNotificationCenter` (`content.subtitle`, `content.body`) and to the custom shell command (`CMUX_NOTIFICATION_SUBTITLE`, `CMUX_NOTIFICATION_BODY`) is stripped.
- No third-party dependency. Simple regex replacements are sufficient — a full markdown parser would be overkill for notification text.
- Title is intentionally not stripped here; notification titles in cmux are typically short, generated tab names or the app name, not markdown prose.

## Test plan

- [ ] Trigger a notification from a Claude Code session that outputs markdown (e.g. a response with `**bold**` or `## Heading`) and confirm the desktop banner shows plain text
- [ ] Confirm that the in-app Notifications panel still shows the original text (markdown not stripped from the stored model)
- [ ] Confirm test notification from Settings still works correctly
- [ ] Confirm custom notification command still receives `CMUX_NOTIFICATION_BODY` as plain text
- [ ] Review unit tests in `TerminalNotificationStoreTests` pass without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2044. Desktop notifications now strip Markdown from the subtitle and body so macOS shows clean plain text instead of raw formatting.

- **Bug Fixes**
  - Added `stripMarkdown(_:)` in `TerminalNotificationStore` to remove headings, emphasis, inline code, links, blockquotes, list markers, and horizontal rules; collapses extra blank lines and adds word-boundary guards for italics and underscore-based `__bold__`/`___bold+italic___` to avoid mangling `snake_case` identifiers.
  - Applied only to payloads sent to `UNUserNotificationCenter` and the custom notification command; stored notification text stays unchanged. Titles are not modified.

- **Refactors**
  - Removed a redundant anchored heading regex in `stripMarkdown(_:)` to simplify the implementation without changing behavior.

<sup>Written for commit f40ff9a47867fc4263165d1df5738546616f2a89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop notifications now strip Markdown-like formatting (headings, emphasis, inline code, links, blockquote/list prefixes, horizontal rules), collapse extra blank lines, and trim whitespace so alerts display as plain, readable text.
  * Custom notification sound commands now receive the cleaned plain-text subtitle and body (Markdown removed) when executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->