### PR TITLE
feat: per-workspace notification mute toggle (#2038)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -29825,6 +29825,40 @@
         }
       }
     },
+    "contextMenu.muteNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知をミュート"
+          }
+        }
+      }
+    },
+    "contextMenu.unmuteNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmute Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知のミュートを解除"
+          }
+        }
+      }
+    },
     "contextMenu.workspaceColor": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10855,42 +10855,19 @@ private struct SidebarEmptyArea: View {
 enum SidebarPathFormatter {
     static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
 
-    /// Maximum number of path segments shown before adding a leading ellipsis.
-    /// e.g. `~/a/b/c/d` → `…/c/d` when maxSegments == 2.
-    static let maxDisplaySegments: Int = 3
-
     static func shortenedPath(
         _ path: String,
         homeDirectoryPath: String = Self.homeDirectoryPath
     ) -> String {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return path }
-
-        // Replace home directory prefix with ~
-        let tildeReplaced: String
         if trimmed == homeDirectoryPath {
             return "~"
-        } else if trimmed.hasPrefix(homeDirectoryPath + "/") {
-            tildeReplaced = "~" + trimmed.dropFirst(homeDirectoryPath.count)
-        } else {
-            tildeReplaced = trimmed
         }
-
-        // Apply smart truncation: keep only the last maxDisplaySegments segments
-        // so paths with a long common prefix remain distinguishable in the sidebar.
-        // e.g. `~/Desktop/YOKE/Claude Code/Projects/Athlete Merch/nilclub`
-        //   → `…/Projects/Athlete Merch/nilclub`
-        let segments = tildeReplaced.split(separator: "/", omittingEmptySubsequences: false)
-        // For a tilde-replaced path like `~/a/b/c`, split on "/" yields
-        // ["~", "a", "b", "c"]. The tilde token is always a single leading segment.
-        // For an absolute path like `/tmp/a/b`, split yields ["", "tmp", "a", "b"].
-        // We only truncate when there are strictly more segments than allowed.
-        let effectiveMax = maxDisplaySegments + 1 // +1 for the leading "~" or "" token
-        guard segments.count > effectiveMax else {
-            return tildeReplaced
+        if trimmed.hasPrefix(homeDirectoryPath + "/") {
+            return "~" + trimmed.dropFirst(homeDirectoryPath.count)
         }
-        let tail = segments.suffix(maxDisplaySegments).joined(separator: "/")
-        return "…/" + tail
+        return trimmed
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10855,19 +10855,42 @@ private struct SidebarEmptyArea: View {
 enum SidebarPathFormatter {
     static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
 
+    /// Maximum number of path segments shown before adding a leading ellipsis.
+    /// e.g. `~/a/b/c/d` → `…/c/d` when maxSegments == 2.
+    static let maxDisplaySegments: Int = 3
+
     static func shortenedPath(
         _ path: String,
         homeDirectoryPath: String = Self.homeDirectoryPath
     ) -> String {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return path }
+
+        // Replace home directory prefix with ~
+        let tildeReplaced: String
         if trimmed == homeDirectoryPath {
             return "~"
+        } else if trimmed.hasPrefix(homeDirectoryPath + "/") {
+            tildeReplaced = "~" + trimmed.dropFirst(homeDirectoryPath.count)
+        } else {
+            tildeReplaced = trimmed
         }
-        if trimmed.hasPrefix(homeDirectoryPath + "/") {
-            return "~" + trimmed.dropFirst(homeDirectoryPath.count)
+
+        // Apply smart truncation: keep only the last maxDisplaySegments segments
+        // so paths with a long common prefix remain distinguishable in the sidebar.
+        // e.g. `~/Desktop/YOKE/Claude Code/Projects/Athlete Merch/nilclub`
+        //   → `…/Projects/Athlete Merch/nilclub`
+        let segments = tildeReplaced.split(separator: "/", omittingEmptySubsequences: false)
+        // For a tilde-replaced path like `~/a/b/c`, split on "/" yields
+        // ["~", "a", "b", "c"]. The tilde token is always a single leading segment.
+        // For an absolute path like `/tmp/a/b`, split yields ["", "tmp", "a", "b"].
+        // We only truncate when there are strictly more segments than allowed.
+        let effectiveMax = maxDisplaySegments + 1 // +1 for the leading "~" or "" token
+        guard segments.count > effectiveMax else {
+            return tildeReplaced
         }
-        return trimmed
+        let tail = segments.suffix(maxDisplaySegments).joined(separator: "/")
+        return "…/" + tail
     }
 }
 
@@ -11634,6 +11657,10 @@ private struct TabItemView: View, Equatable {
                 multi: String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces"),
                 single: String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace"),
                 isMulti: isMulti)
+        let shouldMute = !tab.isMuted
+        let muteLabel = shouldMute
+            ? String(localized: "contextMenu.muteNotifications", defaultValue: "Mute Notifications")
+            : String(localized: "contextMenu.unmuteNotifications", defaultValue: "Unmute Notifications")
         let closeLabel = contextMenuLabel(
             multi: String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces"),
             single: String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
@@ -11655,6 +11682,14 @@ private struct TabItemView: View, Equatable {
                 }
             }
             syncSelectionAfterMutation()
+        }
+
+        Button(muteLabel) {
+            for id in targetIds {
+                if let workspace = tabManager.tabs.first(where: { $0.id == id }) {
+                    workspace.isMuted = shouldMute
+                }
+            }
         }
 
         if let key = renameWorkspaceShortcut.keyEquivalent {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11284,6 +11284,13 @@ private struct TabItemView: View, Equatable {
                         .safeHelp(protectedWorkspaceTooltip)
                 }
 
+                if tab.isMuted {
+                    Image(systemName: "bell.slash.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(activeSecondaryColor(0.8))
+                        .safeHelp(String(localized: "sidebar.mutedWorkspace.tooltip", defaultValue: "Notifications muted"))
+                }
+
                 Text(tab.title)
                     .font(.system(size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10996,7 +10996,8 @@ private struct TabItemView: View, Equatable {
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
-        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected
+        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
+        lhs.tab.isMuted == rhs.tab.isMuted
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -332,6 +332,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customTitle: String?
     var customColor: String?
     var isPinned: Bool
+    var isMuted: Bool?
     var currentDirectory: String
     var focusedPanelId: UUID?
     var layout: SessionWorkspaceLayoutSnapshot

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -891,6 +891,11 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
+        // Skip all notification activity when the workspace has been muted by the user.
+        if AppDelegate.shared?.tabManager?.tabs.first(where: { $0.id == tabId })?.isMuted == true {
+            return
+        }
+
         var updated = notifications
         var idsToClear: [String] = []
         updated.removeAll { existing in

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -910,8 +910,9 @@ final class TerminalNotificationStore: ObservableObject {
             focusedReadIndicatorByTabId.removeValue(forKey: tabId)
         }
 
-        let isActiveTab = AppDelegate.shared?.tabManager?.selectedTabId == tabId
-        let focusedSurfaceId = AppDelegate.shared?.tabManager?.focusedSurfaceId(for: tabId)
+        let tabManager = AppDelegate.shared?.tabManagerFor(tabId: tabId)
+        let isActiveTab = tabManager?.selectedTabId == tabId
+        let focusedSurfaceId = tabManager?.focusedSurfaceId(for: tabId)
         let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId
         let isFocusedPanel = isActiveTab && isFocusedSurface
         let isAppFocused = AppFocusState.isAppFocused()
@@ -921,7 +922,7 @@ final class TerminalNotificationStore: ObservableObject {
         }
 
         if WorkspaceAutoReorderSettings.isEnabled() {
-            AppDelegate.shared?.tabManager?.moveTabToTopForNotification(tabId)
+            tabManager?.moveTabToTopForNotification(tabId)
         }
 
         let notification = TerminalNotification(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -892,7 +892,8 @@ final class TerminalNotificationStore: ObservableObject {
 
     func addNotification(tabId: UUID, surfaceId: UUID?, title: String, subtitle: String, body: String) {
         // Skip all notification activity when the workspace has been muted by the user.
-        if AppDelegate.shared?.tabManager?.tabs.first(where: { $0.id == tabId })?.isMuted == true {
+        // Use tabManagerFor(tabId:) to search across all windows, not just the key window's tabManager.
+        if AppDelegate.shared?.tabManagerFor(tabId: tabId)?.tabs.first(where: { $0.id == tabId })?.isMuted == true {
             return
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -241,6 +241,7 @@ extension Workspace {
             customTitle: customTitle,
             customColor: customColor,
             isPinned: isPinned,
+            isMuted: isMuted,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
             layout: layout,
@@ -280,6 +281,7 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
+        isMuted = snapshot.isMuted ?? false
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -5359,6 +5361,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var title: String
     @Published var customTitle: String?
     @Published var isPinned: Bool = false
+    @Published var isMuted: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?


### PR DESCRIPTION
## Summary

Implements per-workspace notification mute as requested in #2038.

- Adds `@Published var isMuted: Bool = false` to `Workspace`
- Adds `var isMuted: Bool?` to `SessionWorkspaceSnapshot` for session persistence (optional/backward-compatible — old sessions decode `nil` → `false`)
- Restores `isMuted` in `restoreSessionSnapshot(_:)` so mute state survives app restart
- Early-returns in `TerminalNotificationStore.addNotification()` when the workspace is muted — no sound, no tab flash, no desktop notification
- Adds **Mute Notifications / Unmute Notifications** context menu button immediately after Pin/Unpin, toggling all selected workspaces
- Adds localized strings for `en` and `ja`

## Test plan

- [ ] Create two or more workspaces running noisy commands (e.g. `while true; do echo hello; sleep 0.5; done`)
- [ ] Right-click a workspace tab → verify **Mute Notifications** appears in the context menu next to Pin/Unpin
- [ ] Click **Mute Notifications** → verify the menu item now reads **Unmute Notifications** on re-open
- [ ] Confirm no sound, no tab flash, and no desktop notification fires for the muted workspace while the noisy command runs
- [ ] Confirm the other (unmuted) workspace still receives notifications normally
- [ ] Quit and relaunch the app; verify the muted workspace is still muted after restore
- [ ] Multi-select two workspaces, right-click → **Mute Notifications** — both should be muted simultaneously

Fixes #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-workspace notification mute with session persistence, a context menu toggle, and a bell-slash icon on muted tabs. Works across windows and fully silences notifications (fixes #2038).

- **New Features**
  - Added `isMuted` on `Workspace` with session persistence (`SessionWorkspaceSnapshot.isMuted` optional, default false).
  - Context menu adds Mute/Unmute Notifications next to Pin/Unpin; supports multi-select; muted tabs show a bell-slash icon.
  - Muted workspaces skip sound, tab flash, and desktop notifications via `TerminalNotificationStore.addNotification()`; localized strings for en/ja.

- **Bug Fixes**
  - Cross-window enforcement using `tabManagerFor(tabId:)` for active/focus checks and reordering.
  - `TabItemView` Equatable includes `isMuted`, so the Mute/Unmute label updates after toggling.
  - Reverted unrelated sidebar path changes that were accidentally included earlier.

<sup>Written for commit 40583432ad7e75ff519e70bbf295f35568276e4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mute/unmute notifications per workspace via context menu
  * Sidebar shows a muted indicator for muted workspaces
  * Muted workspaces suppress notifications immediately
  * Mute preferences are saved and restored across sessions

* **Localization**
  * Added English and Japanese strings for "Mute Notifications" and "Unmute Notifications"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->