### PR TITLE
fix(cli): suppress premature stop-hook notifications during auto-continue

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -328,9 +328,36 @@ private struct ClaudeHookSessionRecord: Codable {
     var lastBody: String?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
-    /// Timestamp of the most recent pre-tool-use event. Used to suppress
-    /// premature stop-hook notifications when Claude auto-continues mid-task.
-    var lastToolUseAt: TimeInterval?
+    /// Whether a tool was used during the current turn. Reset to false on prompt-submit
+    /// so that only tool uses within the same turn suppress stop-hook notifications.
+    /// Using a per-turn Bool rather than a session-level timestamp prevents stale
+    /// timestamps from a previous turn from incorrectly suppressing later notifications.
+    var toolUsedThisTurn: Bool
+
+    init(
+        sessionId: String, workspaceId: String, surfaceId: String,
+        cwd: String?, pid: Int?, lastSubtitle: String?, lastBody: String?,
+        startedAt: TimeInterval, updatedAt: TimeInterval, toolUsedThisTurn: Bool = false
+    ) {
+        self.sessionId = sessionId; self.workspaceId = workspaceId; self.surfaceId = surfaceId
+        self.cwd = cwd; self.pid = pid; self.lastSubtitle = lastSubtitle; self.lastBody = lastBody
+        self.startedAt = startedAt; self.updatedAt = updatedAt; self.toolUsedThisTurn = toolUsedThisTurn
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sessionId = try c.decode(String.self, forKey: .sessionId)
+        workspaceId = try c.decode(String.self, forKey: .workspaceId)
+        surfaceId = try c.decode(String.self, forKey: .surfaceId)
+        cwd = try c.decodeIfPresent(String.self, forKey: .cwd)
+        pid = try c.decodeIfPresent(Int.self, forKey: .pid)
+        lastSubtitle = try c.decodeIfPresent(String.self, forKey: .lastSubtitle)
+        lastBody = try c.decodeIfPresent(String.self, forKey: .lastBody)
+        startedAt = try c.decode(TimeInterval.self, forKey: .startedAt)
+        updatedAt = try c.decode(TimeInterval.self, forKey: .updatedAt)
+        // Default to false for records persisted before this field was introduced.
+        toolUsedThisTurn = try c.decodeIfPresent(Bool.self, forKey: .toolUsedThisTurn) ?? false
+    }
 }
 
 private struct ClaudeHookSessionStoreFile: Codable {
@@ -377,7 +404,7 @@ private final class ClaudeHookSessionStore {
         pid: Int? = nil,
         lastSubtitle: String? = nil,
         lastBody: String? = nil,
-        lastToolUseAt: TimeInterval? = nil
+        toolUsedThisTurn: Bool? = nil
     ) throws {
         let normalized = normalizeSessionId(sessionId)
         guard !normalized.isEmpty else { return }
@@ -392,7 +419,8 @@ private final class ClaudeHookSessionStore {
                 lastSubtitle: nil,
                 lastBody: nil,
                 startedAt: now,
-                updatedAt: now
+                updatedAt: now,
+                toolUsedThisTurn: false
             )
             record.workspaceId = workspaceId
             if !surfaceId.isEmpty {
@@ -410,8 +438,8 @@ private final class ClaudeHookSessionStore {
             if let body = normalizeOptional(lastBody) {
                 record.lastBody = body
             }
-            if let lastToolUseAt {
-                record.lastToolUseAt = lastToolUseAt
+            if let toolUsedThisTurn {
+                record.toolUsedThisTurn = toolUsedThisTurn
             }
             record.updatedAt = now
             state.sessions[normalized] = record
@@ -10335,19 +10363,13 @@ struct CMUXCLI {
                 }
 
                 if let completion {
-                    // Suppress notification if a tool was used very recently — this
-                    // indicates an auto-continue turn (Claude stopped briefly between
-                    // tool calls) rather than true task completion. The threshold of
-                    // 2 seconds is generous: auto-continue stop→pre-tool-use gaps are
-                    // typically < 500 ms, while genuine completions require user think-time.
-                    let shouldNotify: Bool
-                    if let lastToolUse = mappedSession?.lastToolUseAt {
-                        shouldNotify = Date().timeIntervalSince1970 - lastToolUse > 2.0
-                    } else {
-                        shouldNotify = true
-                    }
+                    // Suppress notification if a tool was used this turn — this indicates
+                    // an auto-continue turn (Claude stopped briefly between tool calls)
+                    // rather than true task completion. The flag is reset to false on each
+                    // prompt-submit so it only reflects activity within the current turn.
+                    let shouldNotify = !(mappedSession?.toolUsedThisTurn ?? false)
                     if shouldNotify {
-                        let title = "Claude Code"
+                        let title = String(localized: "notification.title.claude-code", defaultValue: "Claude Code")
                         let subtitle = sanitizeNotificationField(completion.subtitle)
                         let body = sanitizeNotificationField(completion.body)
                         let payload = "\(title)|\(subtitle)|\(body)"
@@ -10380,6 +10402,17 @@ struct CMUXCLI {
                 fallback: workspaceArg,
                 client: client
             )
+            // Reset per-turn tool flag at the start of each new turn so stale state
+            // from a previous turn cannot suppress the stop-hook notification.
+            if let sessionId = parsedInput.sessionId, let existingSession = mappedSession {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: existingSession.surfaceId,
+                    cwd: parsedInput.cwd,
+                    toolUsedThisTurn: false
+                )
+            }
             _ = try sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
             try setClaudeStatus(
                 client: client,
@@ -10413,7 +10446,7 @@ struct CMUXCLI {
                 client: client
             )
 
-            let title = "Claude Code"
+            let title = String(localized: "notification.title.claude-code", defaultValue: "Claude Code")
             let subtitle = sanitizeNotificationField(summary.subtitle)
             let body = sanitizeNotificationField(summary.body)
             let payload = "\(title)|\(subtitle)|\(body)"
@@ -10485,16 +10518,15 @@ struct CMUXCLI {
             )
             let claudePid = mappedSession?.pid
 
-            // Record the timestamp of this tool use so the stop handler can detect
-            // auto-continue turns (stop fired immediately after a tool use) and
-            // suppress premature notifications.
+            // Mark that a tool was used this turn so the stop handler can detect
+            // auto-continue turns (stop fired mid-task) and suppress premature notifications.
             if let sessionId = parsedInput.sessionId, let existingSession = mappedSession {
                 try? sessionStore.upsert(
                     sessionId: sessionId,
                     workspaceId: workspaceId,
                     surfaceId: existingSession.surfaceId,
                     cwd: parsedInput.cwd,
-                    lastToolUseAt: Date().timeIntervalSince1970
+                    toolUsedThisTurn: true
                 )
             }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10365,9 +10365,24 @@ struct CMUXCLI {
                 if let completion {
                     // Suppress notification if a tool was used this turn — this indicates
                     // an auto-continue turn (Claude stopped briefly between tool calls)
-                    // rather than true task completion. The flag is reset to false on each
-                    // prompt-submit so it only reflects activity within the current turn.
+                    // rather than true task completion.
                     let shouldNotify = !(mappedSession?.toolUsedThisTurn ?? false)
+
+                    // Reset the flag immediately after reading it so that a stale `true`
+                    // from this turn cannot suppress the *next* stop in an auto-continue
+                    // chain that does not produce a new tool use. Without this reset, every
+                    // stop after the first tool-using turn would be suppressed until a
+                    // prompt-submit fires (which may never happen for auto-continue turns).
+                    if let sessionId = parsedInput.sessionId {
+                        try? sessionStore.upsert(
+                            sessionId: sessionId,
+                            workspaceId: workspaceId,
+                            surfaceId: mappedSession?.surfaceId ?? surfaceId,
+                            cwd: parsedInput.cwd,
+                            toolUsedThisTurn: false
+                        )
+                    }
+
                     if shouldNotify {
                         let title = String(localized: "notification.title.claude-code", defaultValue: "Claude Code")
                         let subtitle = sanitizeNotificationField(completion.subtitle)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -328,6 +328,9 @@ private struct ClaudeHookSessionRecord: Codable {
     var lastBody: String?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
+    /// Timestamp of the most recent pre-tool-use event. Used to suppress
+    /// premature stop-hook notifications when Claude auto-continues mid-task.
+    var lastToolUseAt: TimeInterval?
 }
 
 private struct ClaudeHookSessionStoreFile: Codable {
@@ -373,7 +376,8 @@ private final class ClaudeHookSessionStore {
         cwd: String?,
         pid: Int? = nil,
         lastSubtitle: String? = nil,
-        lastBody: String? = nil
+        lastBody: String? = nil,
+        lastToolUseAt: TimeInterval? = nil
     ) throws {
         let normalized = normalizeSessionId(sessionId)
         guard !normalized.isEmpty else { return }
@@ -405,6 +409,9 @@ private final class ClaudeHookSessionStore {
             }
             if let body = normalizeOptional(lastBody) {
                 record.lastBody = body
+            }
+            if let lastToolUseAt {
+                record.lastToolUseAt = lastToolUseAt
             }
             record.updatedAt = now
             state.sessions[normalized] = record
@@ -10328,11 +10335,24 @@ struct CMUXCLI {
                 }
 
                 if let completion {
-                    let title = "Claude Code"
-                    let subtitle = sanitizeNotificationField(completion.subtitle)
-                    let body = sanitizeNotificationField(completion.body)
-                    let payload = "\(title)|\(subtitle)|\(body)"
-                    _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+                    // Suppress notification if a tool was used very recently — this
+                    // indicates an auto-continue turn (Claude stopped briefly between
+                    // tool calls) rather than true task completion. The threshold of
+                    // 2 seconds is generous: auto-continue stop→pre-tool-use gaps are
+                    // typically < 500 ms, while genuine completions require user think-time.
+                    let shouldNotify: Bool
+                    if let lastToolUse = mappedSession?.lastToolUseAt {
+                        shouldNotify = Date().timeIntervalSince1970 - lastToolUse > 2.0
+                    } else {
+                        shouldNotify = true
+                    }
+                    if shouldNotify {
+                        let title = "Claude Code"
+                        let subtitle = sanitizeNotificationField(completion.subtitle)
+                        let body = sanitizeNotificationField(completion.body)
+                        let payload = "\(title)|\(subtitle)|\(body)"
+                        _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+                    }
                 }
 
                 try? setClaudeStatus(
@@ -10464,6 +10484,19 @@ struct CMUXCLI {
                 client: client
             )
             let claudePid = mappedSession?.pid
+
+            // Record the timestamp of this tool use so the stop handler can detect
+            // auto-continue turns (stop fired immediately after a tool use) and
+            // suppress premature notifications.
+            if let sessionId = parsedInput.sessionId, let existingSession = mappedSession {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: existingSession.surfaceId,
+                    cwd: parsedInput.cwd,
+                    lastToolUseAt: Date().timeIntervalSince1970
+                )
+            }
 
             // AskUserQuestion means Claude is about to ask the user something.
             // Save question text in session so the Notification handler can use it

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10362,34 +10362,27 @@ struct CMUXCLI {
                     )
                 }
 
-                if let completion {
-                    // Suppress notification if a tool was used this turn — this indicates
-                    // an auto-continue turn (Claude stopped briefly between tool calls)
-                    // rather than true task completion.
-                    let shouldNotify = !(mappedSession?.toolUsedThisTurn ?? false)
+                // Consume the tool-used flag *before* checking completion so it is
+                // always reset — even when completion is nil (e.g. no cwd/transcript
+                // yet). Without this, a nil-completion stop leaves the flag stuck at
+                // true and the next legitimate completion notification is suppressed.
+                let suppressThisStop = mappedSession?.toolUsedThisTurn ?? false
+                if let sessionId = parsedInput.sessionId {
+                    try? sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: mappedSession?.surfaceId ?? surfaceId,
+                        cwd: parsedInput.cwd,
+                        toolUsedThisTurn: false
+                    )
+                }
 
-                    // Reset the flag immediately after reading it so that a stale `true`
-                    // from this turn cannot suppress the *next* stop in an auto-continue
-                    // chain that does not produce a new tool use. Without this reset, every
-                    // stop after the first tool-using turn would be suppressed until a
-                    // prompt-submit fires (which may never happen for auto-continue turns).
-                    if let sessionId = parsedInput.sessionId {
-                        try? sessionStore.upsert(
-                            sessionId: sessionId,
-                            workspaceId: workspaceId,
-                            surfaceId: mappedSession?.surfaceId ?? surfaceId,
-                            cwd: parsedInput.cwd,
-                            toolUsedThisTurn: false
-                        )
-                    }
-
-                    if shouldNotify {
-                        let title = String(localized: "notification.title.claude-code", defaultValue: "Claude Code")
-                        let subtitle = sanitizeNotificationField(completion.subtitle)
-                        let body = sanitizeNotificationField(completion.body)
-                        let payload = "\(title)|\(subtitle)|\(body)"
-                        _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
-                    }
+                if let completion, !suppressThisStop {
+                    let title = String(localized: "notification.title.claude-code", defaultValue: "Claude Code")
+                    let subtitle = sanitizeNotificationField(completion.subtitle)
+                    let body = sanitizeNotificationField(completion.body)
+                    let payload = "\(title)|\(subtitle)|\(body)"
+                    _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
                 }
 
                 try? setClaudeStatus(


### PR DESCRIPTION
## Problem

Closes #2077

The `claude-hook stop` handler fires on **every Claude Code turn**, not just when the task is fully complete. This caused spurious desktop notifications mid-task: each time Claude finished a response and paused (even briefly between tool calls), the user received a "Completed" notification.

## Root cause

`CLI/cmux.swift` stop handler calls `notify_target` unconditionally whenever `stop` fires. Claude Code's `stop` hook is a per-turn lifecycle event; there is no built-in way to distinguish "Claude paused between tool calls (auto-continue)" from "Claude finished the task and is waiting for the human."

## Fix: timestamp-based deduplication

Track the last `pre-tool-use` event time in the session record. In the stop handler, skip the notification if a tool was used within the past **2 seconds**:

- **Auto-continue turns:** `stop` fires immediately after Claude finishes a response, then `pre-tool-use` fires within ~500 ms as Claude resumes. When the *next* `stop` arrives, `lastToolUseAt` is fresh — notification is suppressed.
- **Genuine completions:** Claude produces a final response with no follow-up tool call. The 2-second window expires before any `pre-tool-use` updates the timestamp, so the notification fires normally.
- **First turn / no tool history:** `lastToolUseAt` is `nil` → notification fires as before (no regression).

### Changes

| File | Change |
|------|--------|
| `CLI/cmux.swift` | Add `lastToolUseAt: TimeInterval?` field to `ClaudeHookSessionRecord` |
| `CLI/cmux.swift` | Add `lastToolUseAt` parameter to `ClaudeHookSessionStore.upsert()` |
| `CLI/cmux.swift` | In `pre-tool-use` handler: record `Date().timeIntervalSince1970` on every tool call |
| `CLI/cmux.swift` | In `stop` handler: guard `notify_target` behind 2-second staleness check |

The `notification` hook path, OSC 777, and Codex notification paths are **not affected**.

## Test plan

- [ ] Start Claude Code with a multi-step task (file edits + shell commands). Verify **no** notification during intermediate turns.
- [ ] After the task finishes and Claude stops calling tools, verify the notification **does** fire (> 2 s elapsed).
- [ ] Single-turn question-answer (no tool calls, `lastToolUseAt` is nil). Verify notification fires normally.
- [ ] Trigger the `notification` hook (e.g. Claude uses `AskUserQuestion`). Verify notification is unaffected by this change.
- [ ] Rapid stop/restart within 2 s (e.g. user sends immediate follow-up). No spurious notification expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress premature "Completed" notifications during auto-continue by gating the `stop` hook with a per-turn `toolUsedThisTurn` flag and consuming/resetting it each turn so alerts only fire on true completion. Fixes #2077.

- **Bug Fixes**
  - Replace session-level timestamp with per-turn `toolUsedThisTurn`; set on `pre-tool-use`, reset on prompt submit and immediately after `stop`, and consume before the completion check to avoid stuck suppression when completion is nil.
  - In `stop`, send `notify_target` only when the flag is false; localize the "Claude Code" title in both the stop and `notification` handlers.

<sup>Written for commit ccf67f3e493ee15b3a7fd25a00c228e07a5fc167. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Per-turn session tracking of tool usage added to better control notification behavior.
  * Completion notifications are suppressed when a tool was used during the current turn, reducing premature or noisy alerts.
  * Tool-usage state is reset at the start of each new turn so normal notifications resume.
  * Notification title now uses a localized lookup with a sensible default for improved internationalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->