### PR TITLE
fix: route PWD action to correct TabManager per tabId

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2474,7 +2474,7 @@ class GhosttyApp {
                   let surfaceId = surfaceView.terminalSurface?.id else { return true }
             let pwd = action.action.pwd.pwd.flatMap { String(cString: $0) } ?? ""
             DispatchQueue.main.async {
-                AppDelegate.shared?.tabManager?.updateSurfaceDirectory(
+                AppDelegate.shared?.tabManagerFor(tabId: tabId)?.updateSurfaceDirectory(
                     tabId: tabId,
                     surfaceId: surfaceId,
                     directory: pwd


### PR DESCRIPTION
## Summary

Fixes #2125 — session restore does not recover working directories.

- **Root cause:** `GHOSTTY_ACTION_PWD` used `AppDelegate.shared?.tabManager` to update the current working directory. The `tabManager` property only returns the *key window's* TabManager. In multi-window scenarios, cwd updates from non-key windows were dispatched to the wrong TabManager, leaving `panelDirectories[panelId]` empty at save time and causing a fallback to `$HOME` on restore.
- **Fix:** Replace `tabManager?` with `tabManagerFor(tabId: tabId)?`, which looks up the TabManager that actually owns the tab by ID — routing the update to the correct window regardless of which window currently has focus.
- **Single-window safety:** When only one window exists, `tabManagerFor(tabId:)` returns the same manager as `tabManager`, so there is no behavioral change for single-window users.

## Changed files

- `Sources/GhosttyTerminalView.swift` — 1-line change in `GHOSTTY_ACTION_PWD` handler

## Test plan

- [ ] Open cmux with multiple windows, `cd` into different project directories in each window's workspaces
- [ ] Quit cmux (Cmd+Q)
- [ ] Relaunch cmux
- [ ] Verify each window/workspace restores to its correct working directory (not `$HOME`)
- [ ] Verify the single-window case still restores working directories correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session restore so each window/tab keeps its correct working directory. Routes the `PWD` action to the TabManager that owns the tab instead of the key window’s manager. Fixes #2125.

- **Bug Fixes**
  - In `GHOSTTY_ACTION_PWD`, replace `AppDelegate.shared?.tabManager` with `tabManagerFor(tabId:)` to update the right TabManager in multi-window setups; single-window behavior unchanged.

<sup>Written for commit 6736e8ef93fa176956997939244f58b3a10ae278. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of working directory updates to ensure changes are correctly applied to the specific tab, preventing cross-tab directory synchronization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->