### PR TITLE
fix(sidebar): smart path truncation for deeply-nested cwds (#2061)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10856,7 +10856,7 @@ enum SidebarPathFormatter {
     static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
 
     /// Maximum number of path segments shown before adding a leading ellipsis.
-    /// e.g. `~/a/b/c/d` → `…/c/d` when maxSegments == 2.
+    /// e.g. `~/a/b/c/d` → `…/b/c/d` when maxSegments == 3.
     static let maxDisplaySegments: Int = 3
 
     static func shortenedPath(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10855,19 +10855,42 @@ private struct SidebarEmptyArea: View {
 enum SidebarPathFormatter {
     static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
 
+    /// Maximum number of path segments shown before adding a leading ellipsis.
+    /// e.g. `~/a/b/c/d` → `…/c/d` when maxSegments == 2.
+    static let maxDisplaySegments: Int = 3
+
     static func shortenedPath(
         _ path: String,
         homeDirectoryPath: String = Self.homeDirectoryPath
     ) -> String {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return path }
+
+        // Replace home directory prefix with ~
+        let tildeReplaced: String
         if trimmed == homeDirectoryPath {
             return "~"
+        } else if trimmed.hasPrefix(homeDirectoryPath + "/") {
+            tildeReplaced = "~" + trimmed.dropFirst(homeDirectoryPath.count)
+        } else {
+            tildeReplaced = trimmed
         }
-        if trimmed.hasPrefix(homeDirectoryPath + "/") {
-            return "~" + trimmed.dropFirst(homeDirectoryPath.count)
+
+        // Apply smart truncation: keep only the last maxDisplaySegments segments
+        // so paths with a long common prefix remain distinguishable in the sidebar.
+        // e.g. `~/Desktop/YOKE/Claude Code/Projects/Athlete Merch/nilclub`
+        //   → `…/Projects/Athlete Merch/nilclub`
+        let segments = tildeReplaced.split(separator: "/", omittingEmptySubsequences: false)
+        // For a tilde-replaced path like `~/a/b/c`, split on "/" yields
+        // ["~", "a", "b", "c"]. The tilde token is always a single leading segment.
+        // For an absolute path like `/tmp/a/b`, split yields ["", "tmp", "a", "b"].
+        // We only truncate when there are strictly more segments than allowed.
+        let effectiveMax = maxDisplaySegments + 1 // +1 for the leading "~" or "" token
+        guard segments.count > effectiveMax else {
+            return tildeReplaced
         }
-        return trimmed
+        let tail = segments.suffix(maxDisplaySegments).joined(separator: "/")
+        return "…/" + tail
     }
 }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -38,6 +38,85 @@ final class SidebarPathFormatterTests: XCTestCase {
             "/tmp/cmux"
         )
     }
+
+    // MARK: - Smart truncation (issue #2061)
+
+    func testShortenedPathKeepsThreeSegmentsUnchanged() {
+        // ~/a/b/c — exactly maxDisplaySegments; no ellipsis added
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example/a/b/c",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "~/a/b/c"
+        )
+    }
+
+    func testShortenedPathTruncatesLongHomePath() {
+        // ~/Desktop/YOKE/Claude Code/Projects/Athlete Merch/nilclub → …/Projects/Athlete Merch/nilclub
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example/Desktop/YOKE/Claude Code/Projects/Athlete Merch/nilclub",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "…/Projects/Athlete Merch/nilclub"
+        )
+    }
+
+    func testShortenedPathTruncatesFourSegmentHomePath() {
+        // ~/a/b/c/d — one segment over limit → …/b/c/d
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example/a/b/c/d",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "…/b/c/d"
+        )
+    }
+
+    func testShortenedPathLeavesShortHomePathUnchanged() {
+        // ~/projects/cmux — only 2 segments; no ellipsis
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/Users/example/projects/cmux",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "~/projects/cmux"
+        )
+    }
+
+    func testShortenedPathTruncatesLongAbsolutePath() {
+        // /a/b/c/d/e — 5 segments (no home match) → …/c/d/e
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/a/b/c/d/e",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "…/c/d/e"
+        )
+    }
+
+    func testShortenedPathLeavesShortAbsolutePathUnchanged() {
+        // /tmp/a/b — exactly 3 segments; no truncation
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/tmp/a/b",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "/tmp/a/b"
+        )
+    }
+
+    func testShortenedPathTruncatesLongAbsolutePathBeyondThree() {
+        // /tmp/a/b/c — 4 segments; triggers truncation → …/a/b/c
+        XCTAssertEqual(
+            SidebarPathFormatter.shortenedPath(
+                "/tmp/a/b/c",
+                homeDirectoryPath: "/Users/example"
+            ),
+            "…/a/b/c"
+        )
+    }
 }
 
 final class GhosttyConfigTests: XCTestCase {


### PR DESCRIPTION
## Summary

Fixes #2061

Sidebar entries for workspaces with a long shared directory prefix all truncate to identical strings, making it impossible to distinguish them:

**Before**
```
~/Desktop/YOKE/Claude Code/Ad...
~/Desktop/YOKE/Claude Code/Ad...
~/Desktop/YOKE/Claude Code/Ad...
```

**After**
```
…/Athlete Merch/nilclub
…/Cartoon Gen Gating/nilclub
…/Sport Routing Admin/nilclub
```

## Implementation

`SidebarPathFormatter.shortenedPath` now applies smart left-truncation after the existing `~` substitution:

- If the resulting path has **3 or fewer segments**, it is displayed as-is (e.g. `~/projects/cmux` unchanged).
- If it has **more than 3 segments**, only the last 3 are kept and a `…/` prefix is prepended (e.g. `~/a/b/c/d` → `…/b/c/d`).

The threshold (`maxDisplaySegments = 3`) is a named constant so it can be tuned later without a search-and-replace.

This is a **display-only change**. No data model, settings, or socket API is affected. Both the vertical and compact branch/directory rows in `TabItemView` share the same formatter and benefit automatically.

## Test plan

- [ ] New unit tests in `SidebarPathFormatterTests` cover: exact 3-segment path (no truncation), 4-segment path (truncated), long home path, short home path, long absolute path, short absolute path.
- [ ] Existing tests (`testShortenedPathReplacesExactHomeDirectory`, `testShortenedPathReplacesHomeDirectoryPrefix`, `testShortenedPathLeavesExternalPathUnchanged`) still pass unchanged.
- [ ] Build succeeds with `xcodebuild` on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve sidebar path display by smartly truncating deep directories so similar entries stay distinguishable. Shows only the last 3 segments with a leading …/; shallow paths are unchanged.

- **Bug Fixes**
  - Updated `SidebarPathFormatter.shortenedPath` to left-truncate after `~` replacement, keeping only the last 3 segments and prefixing `…/`.
  - Added `maxDisplaySegments = 3` for easy tuning and corrected its doc comment example; display-only change used by both sidebar layouts.
  - Added unit tests for 3- vs 4-segment paths, home vs absolute, and long vs short paths.

<sup>Written for commit 988aefbf190b0339c47f35007a213bc22bafcfe8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sidebar path display with smarter truncation: home directories show as ~ and long paths abbreviate to an ellipsis plus trailing segments for clearer, more readable location display.
* **Tests**
  * Added unit tests covering the new truncation and tilde-handling behaviors to ensure consistent display across path varieties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->