### PR TITLE
fix: respect OS default editor when opening Ghostty config file

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1916,9 +1916,29 @@ class GhosttyApp {
         let path = ghosttyStringValue(ghostty_config_open_path())
         guard !path.isEmpty else { return }
         let fileURL = URL(fileURLWithPath: path)
-        let editorURL = URL(fileURLWithPath: "/System/Applications/TextEdit.app")
-        let configuration = NSWorkspace.OpenConfiguration()
-        NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: configuration)
+        // Resolve the OS-configured default editor for the file. We first try the
+        // UTType for the file's extension (e.g. "public.plain-text" for .ghostty),
+        // then fall back to the generic plain-text default. This mirrors Ghostty's
+        // own implementation and respects the user's OS default editor setting
+        // instead of hard-coding TextEdit.
+        let editorURL: URL? = {
+            // Try extension-specific UTI first (e.g. user sets Zed as handler for .ghostty)
+            if !fileURL.pathExtension.isEmpty,
+               let uti = UTType(filenameExtension: fileURL.pathExtension),
+               let url = LSCopyDefaultApplicationURLForContentType(
+                   uti.identifier as CFString, .all, nil)?.takeRetainedValue() as? URL {
+                return url
+            }
+            // Fall back to the default plain-text editor (e.g. VS Code, Zed, etc.)
+            return LSCopyDefaultApplicationURLForContentType(
+                UTType.plainText.identifier as CFString, .all, nil)?.takeRetainedValue() as? URL
+        }()
+        if let editorURL {
+            NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: NSWorkspace.OpenConfiguration())
+        } else {
+            // Last resort: let the OS pick any associated application
+            NSWorkspace.shared.open(fileURL)
+        }
         #endif
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1916,25 +1916,18 @@ class GhosttyApp {
         let path = ghosttyStringValue(ghostty_config_open_path())
         guard !path.isEmpty else { return }
         let fileURL = URL(fileURLWithPath: path)
-        // Resolve the OS-configured default editor for the file. We first try the
-        // UTType for the file's extension (e.g. "public.plain-text" for .ghostty),
-        // then fall back to the generic plain-text default. This mirrors Ghostty's
-        // own implementation and respects the user's OS default editor setting
-        // instead of hard-coding TextEdit.
-        let editorURL: URL? = {
-            // Try extension-specific UTI first (e.g. user sets Zed as handler for .ghostty)
-            if !fileURL.pathExtension.isEmpty,
-               let uti = UTType(filenameExtension: fileURL.pathExtension),
-               let url = LSCopyDefaultApplicationURLForContentType(
-                   uti.identifier as CFString, .all, nil)?.takeRetainedValue() as? URL {
-                return url
-            }
-            // Fall back to the default plain-text editor (e.g. VS Code, Zed, etc.)
-            return LSCopyDefaultApplicationURLForContentType(
-                UTType.plainText.identifier as CFString, .all, nil)?.takeRetainedValue() as? URL
-        }()
-        if let editorURL {
-            NSWorkspace.shared.open([fileURL], withApplicationAt: editorURL, configuration: NSWorkspace.OpenConfiguration())
+        // Resolve the OS-configured default editor for the file using the modern
+        // NSWorkspace API (macOS 12+). We first try the app registered for the
+        // specific file URL (honours per-extension default app settings), then
+        // fall back to letting the OS open the file with whatever app it chooses.
+        // This replaces the deprecated LSCopyDefaultApplicationURLForContentType
+        // (deprecated in macOS 12) while preserving the same user-intent semantics.
+        if let editorURL = NSWorkspace.shared.urlForApplication(toOpen: fileURL) {
+            NSWorkspace.shared.open(
+                [fileURL],
+                withApplicationAt: editorURL,
+                configuration: NSWorkspace.OpenConfiguration()
+            )
         } else {
             // Last resort: let the OS pick any associated application
             NSWorkspace.shared.open(fileURL)


### PR DESCRIPTION
## Summary

- Fixes the bug where opening Ghostty Settings from the cmux menu always opened the config file in **TextEdit**, ignoring the user's OS-configured default editor (e.g. Zed, VS Code, Sublime Text).
- The editor URL was previously hard-coded to `/System/Applications/TextEdit.app`.
- Now uses `LSCopyDefaultApplicationURLForContentType` (Launch Services) to resolve the correct editor at runtime, mirroring the implementation in Ghostty's own `NSWorkspace+Extension.swift`.

**Resolution order:**
1. Default app for the file's UTI (e.g. Zed registered for `.ghostty` files)
2. System default plain-text editor (`UTType.plainText`)
3. Last resort: `NSWorkspace.open()` — let the OS pick any associated application

No new API was introduced; `LSCopyDefaultApplicationURLForContentType` and `UTType` are already available on macOS 14+, and `UniformTypeIdentifiers` was already imported in `GhosttyTerminalView.swift`.

## Test plan

- [ ] Set a non-TextEdit editor (e.g. Zed or VS Code) as the default text editor in macOS System Settings → Default Apps
- [ ] Open cmux → menu → **Ghostty Settings…**
- [ ] Verify the config file opens in the configured editor, not TextEdit
- [ ] With no custom default set (TextEdit as default), verify it still opens correctly in TextEdit

Fixes #2071, Fixes #2067

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the Ghostty config with the macOS default editor instead of always using TextEdit. Works with Zed, VS Code, or any OS default.

- **Bug Fixes**
  - Removed hard-coded `/System/Applications/TextEdit.app`; resolve the editor via `NSWorkspace.shared.urlForApplication(toOpen:)` (replaces deprecated Launch Services lookup).
  - Resolution: default app for the file → fallback to `NSWorkspace.open(fileURL)` to let the OS choose.

<sup>Written for commit bd164e49681d609a3102ef77bf4ba70a8f1b698d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now open in your preferred system default editor instead of always launching in TextEdit.
  * Added an intelligent fallback so the OS-assigned editor is used when no specific default handler is configured for the file type.
  * Improves reliability when opening config files and aligns behavior with system preferences for a more consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->