### PR TITLE
fix(socket): return not_found when surface_id is provided but unresolvable

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5278,7 +5278,16 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
                 return
@@ -5329,7 +5338,16 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
                 return
@@ -5363,7 +5381,16 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
                 return
@@ -5414,7 +5441,16 @@ class TerminalController {
                 return
             }
 
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
                 return


### PR DESCRIPTION
## Summary

- When `surface_id` is explicitly provided in a socket command but fails to resolve (stale ref, unknown ordinal, etc.), the four affected functions now return a `not_found` error instead of silently falling back to `ws.focusedPanelId`.
- When `surface_id` is **not** provided, the existing focused-pane fallback is preserved unchanged (backward compatible).
- Affected functions: `v2SurfaceSendText`, `v2SurfaceSendKey`, `v2SurfaceClearHistory`, `v2SurfaceReadText` (all in `Sources/TerminalController.swift`).

## Root Cause

`v2UUID(params, "surface_id")` calls `v2ResolveHandleRef()` internally. If the ref is unresolvable, it returns `nil`. The previous pattern `v2UUID(params, "surface_id") ?? ws.focusedPanelId` silently promoted this `nil` to the focused panel, causing two distinct failure modes:

- **#2042** — Commands succeed with exit code 0 but operate on the wrong surface (the focused pane), making automation that targets specific surfaces dangerous.
- **#2045** — When the fallback panel happens to be a browser surface, the subsequent `ws.terminalPanel(for:)` guard fails and returns `invalid_params: Surface is not a terminal`, making valid terminal surfaces appear broken when addressed by ref.

## Fix

```swift
// Before
let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId

// After
let surfaceId: UUID?
if params["surface_id"] != nil {
    surfaceId = v2UUID(params, "surface_id")
    guard surfaceId != nil else {
        result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
        return
    }
} else {
    surfaceId = ws.focusedPanelId
}
```

## Test Plan

- [ ] `cmux send --surface surface:9999 "hello"` → `ERROR: not_found: Surface not found for the given surface_id` (non-zero exit)
- [ ] `cmux send-key --surface surface:9999 Enter` → same error
- [ ] `cmux read-screen --surface surface:9999` → same error
- [ ] `cmux send "hello"` (no `--surface`) → operates on focused pane (backward compat preserved)
- [ ] `cmux send --surface surface:1 "hello"` with a valid ref → succeeds as before
- [ ] `cmux read-screen --surface surface:29` with a valid terminal ref → returns screen content

Fixes #2042, Fixes #2045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `not_found` when a socket command includes an unresolvable `surface_id`, instead of silently targeting the focused pane. Behavior with no `surface_id` is unchanged. Fixes #2042 and #2045.

- **Bug Fixes**
  - Updated `v2SurfaceSendText`, `v2SurfaceSendKey`, `v2SurfaceClearHistory`, and `v2SurfaceReadText` to error with `not_found` if the provided `surface_id` cannot be resolved.
  - If `surface_id` is not provided, continue falling back to `ws.focusedPanelId` (backward compatible).

<sup>Written for commit 4c977f1a51c8d263b8118bb049f97bf75ad7e652. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling for terminal surface operations. Explicitly provided surface identifiers are now validated more rigorously, with clearer "Surface not found" error messages for invalid identifiers. When no identifier is provided, operations default to the currently focused surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->