### PR TITLE
chore: remove unused koreanRanges constant

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1406,12 +1406,6 @@ class GhosttyApp {
         "U+30A0-U+30FF",  // Katakana
     ]
 
-    /// Unicode ranges specific to Korean (Hangul).
-    private static let koreanRanges = [
-        "U+AC00-U+D7AF",  // Hangul Syllables
-        "U+1100-U+11FF",  // Hangul Jamo
-    ]
-
     private struct UserFontConfigSummary {
         var containsCodepointMap = false
         var effectiveFontFamilies: [String] = []


### PR DESCRIPTION
## Summary
- Remove dead `koreanRanges` static property left behind after #1700 removed Korean from CJK auto-injection

## Context
PR #1017 added Korean font mapping (`ko` → `Apple SD Gothic Neo`). PR #1700 removed it because Ghostty's native `CTFontCreateForString` fallback produces better results for Hangul. The `koreanRanges` constant was left as dead code — this PR cleans it up.

## Changes
- Removed unused `koreanRanges` from `GhosttyTerminalView.swift` (6 lines)

Related: #1700, #1693

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused `koreanRanges` constant from `GhosttyTerminalView.swift`, left over after Korean was removed from CJK auto-injection. No behavior change.

<sup>Written for commit bf8c90bb21e15a5074427fba73cc0f04b0affbf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified font fallback configuration by removing Korean Unicode range mappings. Other CJK language support remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->