### PR TITLE
Add --name flag to new-workspace CLI command

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1684,14 +1684,18 @@ struct CMUXCLI {
 
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
-            let (cwdOpt, remaining) = parseOption(rem0, name: "--cwd")
+            let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
+            let (nameOpt, remaining) = parseOption(rem1, name: "--name")
             if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --command <text>, --cwd <path>")
+                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --command <text>, --cwd <path>")
             }
             var params: [String: Any] = [:]
             if let cwdOpt {
                 let resolved = resolvePath(cwdOpt)
                 params["cwd"] = resolved
+            }
+            if let nameOpt {
+                params["title"] = nameOpt
             }
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
@@ -6335,16 +6339,18 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--cwd <path>] [--command <text>]
+            Usage: cmux new-workspace [--name <title>] [--cwd <path>] [--command <text>]
 
             Create a new workspace in the current window.
 
             Flags:
+              --name <title>    Set a custom name for the new workspace
               --cwd <path>      Set the working directory for the new workspace
               --command <text>   Send text+Enter to the new workspace after creation
 
             Example:
               cmux new-workspace
+              cmux new-workspace --name "Build Server"
               cmux new-workspace --cwd ~/projects/myapp
               cmux new-workspace --cwd . --command "npm test"
             """
@@ -11996,7 +12002,7 @@ struct CMUXCLI {
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>]
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>]
           list-workspaces
-          new-workspace [--cwd <path>] [--command <text>]
+          new-workspace [--name <title>] [--cwd <path>] [--command <text>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1199,6 +1199,7 @@ class TabManager: ObservableObject {
 
     @discardableResult
     func addWorkspace(
+        title: String? = nil,
         workingDirectory overrideWorkingDirectory: String? = nil,
         initialTerminalCommand: String? = nil,
         initialTerminalEnvironment: [String: String] = [:],
@@ -1226,7 +1227,7 @@ class TabManager: ObservableObject {
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
         let newWorkspace = makeWorkspaceForCreation(
-            title: "Terminal \(nextTabCount)",
+            title: title ?? "Terminal \(nextTabCount)",
             workingDirectory: workingDirectory,
             portOrdinal: ordinal,
             configTemplate: inheritedConfig,
@@ -1234,6 +1235,9 @@ class TabManager: ObservableObject {
             initialTerminalEnvironment: initialTerminalEnvironment
         )
         newWorkspace.owningTabManager = self
+        if title != nil {
+            newWorkspace.setCustomTitle(title)
+        }
         wireClosedBrowserTracking(for: newWorkspace)
         if eagerLoadTerminal && !select {
             requestBackgroundWorkspaceLoad(for: newWorkspace.id)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1673,7 +1673,7 @@ class TerminalController {
             return listWorkspaces()
 
 	        case "new_workspace":
-	            return newWorkspace()
+	            return newWorkspace(args)
 
 	        case "new_split":
 	            return newSplit(args)
@@ -3336,10 +3336,14 @@ class TerminalController {
             cwd = nil
         }
 
+        let requestedTitle = v2RawString(params, "title")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = (requestedTitle?.isEmpty == false) ? requestedTitle : nil
+
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
         v2MainSync {
             let ws = tabManager.addWorkspace(
+                title: title,
                 workingDirectory: cwd,
                 initialTerminalCommand: initialCommand,
                 initialTerminalEnvironment: initialEnv,
@@ -12036,13 +12040,16 @@ class TerminalController {
         return result.isEmpty ? "No workspaces" : result
     }
 
-    private func newWorkspace() -> String {
+    private func newWorkspace(_ args: String = "") -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
+
+        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title: String? = trimmed.isEmpty ? nil : trimmed
 
         var newTabId: UUID?
         let focus = socketCommandAllowsInAppFocusMutations()
         DispatchQueue.main.sync {
-            let workspace = tabManager.addTab(select: focus, eagerLoadTerminal: !focus)
+            let workspace = tabManager.addWorkspace(title: title, select: focus, eagerLoadTerminal: !focus)
             newTabId = workspace.id
         }
         return "OK \(newTabId?.uuidString ?? "unknown")"


### PR DESCRIPTION
## Summary
- Adds `--name <title>` flag to the `new-workspace` CLI command to set a custom workspace name on creation
- Threads the `title` parameter through CLI → v2 socket handler → `TabManager.addWorkspace()` → `makeWorkspaceForCreation`
- Uses `setCustomTitle()` to persist the user-set name so it isn't overwritten by automatic title updates

## Test plan
- [ ] `cmux new-workspace --name "Build Server"` creates workspace with custom name
- [ ] `cmux new-workspace` without `--name` still uses default "Terminal N" naming
- [ ] `cmux new-workspace --name "  "` (whitespace only) falls back to default name
- [ ] `cmux help new-workspace` shows updated usage with `--name` flag
- [ ] v2 socket `workspace.create` with `title` param sets custom name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--name` flag to the `new-workspace` CLI so users can set a custom workspace name at creation. The title is passed through v2/v1 handlers to `TabManager` and persisted so auto updates don’t overwrite it.

- **New Features**
  - `cmux new-workspace --name "<title>"` sets a custom name; whitespace-only falls back to default.
  - Threads `title` via v2 `workspace.create` to `TabManager.addWorkspace(title:)`.
  - Persists user-set titles with `setCustomTitle()`; default remains "Terminal N" if none provided.
  - Updates CLI help and unknown-flag error to include `--name`.
  - v1 `new_workspace` now accepts an optional name argument.

<sup>Written for commit 0f033568cda25d3d8cecdd13ac7c78f5ed60ac36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Users can now specify a custom name when creating a new workspace using the `--name` flag.

* **Documentation**
  - Updated help text and usage information to document the new workspace naming option and example invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->