### PR TITLE
Update ghostty to latest upstream

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
 			A5001093 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001090 /* AppDelegate.swift */; };
+		67CB701D9927 /* NiriCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8A8C88F846 /* NiriCanvasView.swift */; };
 			A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 			A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
 			A5001250 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
@@ -217,6 +218,7 @@
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		EF8A8C88F846 /* NiriCanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriCanvasView.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		A5001092 /* TerminalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationStore.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
@@ -434,6 +436,7 @@
 				A5001600 /* SentryHelper.swift */,
 				A5001620 /* AppleScriptSupport.swift */,
 				A5001090 /* AppDelegate.swift */,
+				EF8A8C88F846 /* NiriCanvasView.swift */,
 				A5001091 /* NotificationsPage.swift */,
 				A5001092 /* TerminalNotificationStore.swift */,
 				A5001301 /* SurfaceSearchOverlay.swift */,
@@ -733,6 +736,7 @@
 				A5001601 /* SentryHelper.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
+				67CB701D9927 /* NiriCanvasView.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				A5001095 /* TerminalNotificationStore.swift in Sources */,
 				A5001303 /* SurfaceSearchOverlay.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9082,6 +9082,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
+
+        #if DEBUG
+        // Cmd+Ctrl+N: Open niri canvas demo
+        if hasCommand && hasControl && !flags.contains(.shift) && (chars.lowercased() == "n" || event.keyCode == 45) {
+            openNiriCanvas()
+            return true
+        }
+        #endif
+
         let commandPaletteTargetWindow = commandPaletteWindowForShortcutEvent(event)
         let commandPaletteShortcutWindow = shouldHandleCommandPaletteShortcutEvent(
             event,
@@ -11545,6 +11554,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 #endif
 
+    // MARK: - Niri Canvas (experimental)
+
+    #if DEBUG
+    private var niriCanvasController: NiriCanvasWindowController?
+
+    /// Opens a niri-style horizontal terminal strip with new terminal surfaces.
+    func openNiriCanvas() {
+        if niriCanvasController == nil {
+            niriCanvasController = NiriCanvasWindowController()
+        }
+        niriCanvasController?.open(terminalCount: 5)
+    }
+    #endif
+
 }
 
 @MainActor
@@ -12897,5 +12920,4 @@ private extension NSWindow {
         }
         return hitWebView === webView
     }
-
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9084,6 +9084,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
 
         #if DEBUG
+        // Skip all shortcut handling when the niri canvas window is key.
+        // It handles its own shortcuts via sendEvent/performKeyEquivalent.
+        if event.window is NiriCanvasWindow { return false }
+
         // Cmd+Ctrl+N: Open niri canvas demo
         if hasCommand && hasControl && !flags.contains(.shift) && (chars.lowercased() == "n" || event.keyCode == 45) {
             openNiriCanvas()
@@ -11564,7 +11568,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if niriCanvasController == nil {
             niriCanvasController = NiriCanvasWindowController()
         }
-        niriCanvasController?.open(terminalCount: 5)
+        NSLog("niri.openCanvas")
+        niriCanvasController?.open(terminalCount: 3)
     }
     #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1099,7 +1099,7 @@ class GhosttyApp {
             return GhosttyApp.shared.handleAction(target: target, action: action)
         }
         runtimeConfig.read_clipboard_cb = { userdata, location, state in
-            guard let callbackContext = GhosttyApp.callbackContext(from: userdata) else { return }
+            guard let callbackContext = GhosttyApp.callbackContext(from: userdata) else { return false }
 
             DispatchQueue.main.async {
                 guard let requestSurface = callbackContext.runtimeSurface else { return }
@@ -1205,6 +1205,7 @@ class GhosttyApp {
                     )
                 }
             }
+            return true
         }
         runtimeConfig.confirm_read_clipboard_cb = { userdata, content, state, _ in
             guard let content else { return }
@@ -2450,6 +2451,10 @@ class GhosttyApp {
             DispatchQueue.main.async {
                 terminalSurface.searchState?.selected = selected
             }
+            return true
+        case GHOSTTY_ACTION_SET_TAB_TITLE:
+            // Tab title override from the terminal (e.g. OSC escape).
+            // cmux handles tab titles through its own tab manager, so we ignore this.
             return true
         case GHOSTTY_ACTION_SET_TITLE:
             let title = action.action.set_title.title

--- a/Sources/NiriCanvasView.swift
+++ b/Sources/NiriCanvasView.swift
@@ -1,0 +1,415 @@
+#if DEBUG
+import AppKit
+import QuartzCore
+
+/// Niri/PaperWM-style horizontal strip with real ghostty terminal surfaces.
+/// Each panel has its own width preset. Resize only affects the focused panel.
+final class NiriCanvasView: NSView {
+
+    private struct Slot {
+        let surface: TerminalSurface
+        var closing: Bool = false
+        var closeProgress: CGFloat = 1.0
+        var presetIndex: Int = 1        // default to 0.67
+        var currentWidth: CGFloat = 0.67
+        var targetWidth: CGFloat = 0.67
+    }
+
+    private var slots: [Slot] = []
+    private(set) var focusedIndex: Int = 0
+    private var scrollOffset: CGFloat = 0
+    private var targetOffset: CGFloat = 0
+    private var displayLink: CVDisplayLink?
+
+    private let panelGap: CGFloat = 12
+    private let peekWidth: CGFloat = 60
+    private let springK: CGFloat = 0.16
+    private let widthPresets: [CGFloat] = [0.33, 0.67, 1.0]
+
+    // MARK: - Init
+
+    override init(frame: NSRect) { super.init(frame: frame); setup() }
+    required init?(coder: NSCoder) { super.init(coder: coder); setup() }
+
+    private func setup() {
+        wantsLayer = true
+        layer!.backgroundColor = NSColor(red: 0.06, green: 0.06, blue: 0.08, alpha: 1).cgColor
+        startDisplayLink()
+    }
+
+    deinit { if let displayLink { CVDisplayLinkStop(displayLink) } }
+
+    // MARK: - Surfaces
+
+    func setSurfaces(_ newSurfaces: [TerminalSurface]) {
+        for s in slots { s.surface.hostedView.removeFromSuperview() }
+        slots = newSurfaces.map { Slot(surface: $0) }
+        for s in slots { let h = s.surface.hostedView; h.removeFromSuperview(); addSubview(h) }
+        focusedIndex = min(focusedIndex, max(0, liveCount - 1))
+        targetOffset = stripX(forLive: focusedIndex)
+        scrollOffset = targetOffset
+        layoutStrip()
+    }
+
+    private var liveCount: Int { slots.count(where: { !$0.closing }) }
+
+    private var liveIndices: [(slot: Int, live: Int)] {
+        var result: [(Int, Int)] = []
+        var li = 0
+        for (i, s) in slots.enumerated() where !s.closing {
+            result.append((i, li)); li += 1
+        }
+        return result
+    }
+
+    var focusedSurface: TerminalSurface? {
+        let live = liveIndices
+        guard focusedIndex >= 0, focusedIndex < live.count else { return nil }
+        return slots[live[focusedIndex].slot].surface
+    }
+
+    // MARK: - Geometry
+
+    private var maxW: CGFloat { bounds.width - peekWidth * 2 - panelGap * 2 }
+
+    private func pw(for slot: Slot) -> CGFloat { max(300, maxW * slot.currentWidth) }
+
+    /// Strip-space X for a live index, based on current (animated) widths.
+    private func stripX(forLive target: Int) -> CGFloat {
+        var x: CGFloat = 0; var li = 0
+        for s in slots {
+            if s.closing { x += pw(for: s) * s.closeProgress + panelGap * s.closeProgress; continue }
+            if li == target { return x }
+            x += pw(for: s) + panelGap; li += 1
+        }
+        return x
+    }
+
+    // MARK: - Layout
+
+    private func layoutStrip() {
+        let ph = max(300, bounds.height - 20)
+        let topY = (bounds.height - ph) / 2
+        var xCursor: CGFloat = 0; var li = 0
+
+        for i in 0..<slots.count {
+            let s = slots[i]; let hosted = s.surface.hostedView
+            let progress = s.closing ? s.closeProgress : 1.0
+            let w = pw(for: s) * progress; let gap = panelGap * progress
+            let screenX = peekWidth + panelGap + (xCursor - scrollOffset)
+            let isFocused = !s.closing && li == focusedIndex
+            let opacity: CGFloat = s.closing ? max(0, progress) : 1.0
+
+            hosted.frame = CGRect(x: screenX, y: topY, width: max(0, w), height: ph)
+            hosted.alphaValue = CGFloat(opacity)
+
+            if let l = hosted.layer {
+                l.transform = CATransform3DIdentity; l.zPosition = 0
+                l.cornerRadius = 0; l.masksToBounds = true
+                l.borderWidth = isFocused ? 2 : 1
+                l.borderColor = isFocused
+                    ? NSColor.controlAccentColor.withAlphaComponent(0.7).cgColor
+                    : NSColor.white.withAlphaComponent(0.08).cgColor
+            }
+            xCursor += w + gap
+            if !s.closing { li += 1 }
+        }
+    }
+
+    override func layout() { super.layout(); layoutStrip() }
+
+    // MARK: - Keys
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let f = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let cmd = f.contains(.command), opt = f.contains(.option), ctrl = f.contains(.control)
+        let ch = event.charactersIgnoringModifiers?.lowercased() ?? ""
+
+        if cmd && opt {
+            if event.keyCode == 123 { navigateLeft(); return true }
+            if event.keyCode == 124 { navigateRight(); return true }
+        }
+        if cmd && ctrl {
+            if ch == "h" { navigateLeft(); return true }
+            if ch == "l" { navigateRight(); return true }
+            if ch == "r" { cycleResize(); return true }
+        }
+        if cmd && !ctrl && !opt && ch == "w" { closeFocusedTerminal(); return true }
+        if cmd && !ctrl && !opt && ch == "t" { addNewTerminal(); return true }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    func handleCtrlD() { closeFocusedTerminal() }
+
+    // MARK: - Navigation
+
+    func navigateLeft() {
+        guard focusedIndex > 0 else { return }
+        focusedIndex -= 1; scrollToReveal(); focusCurrentTerminal()
+    }
+
+    func navigateRight() {
+        guard focusedIndex < liveCount - 1 else { return }
+        focusedIndex += 1; scrollToReveal(); focusCurrentTerminal()
+    }
+
+    /// Adjust targetOffset so the focused panel is fully visible.
+    /// If the panel is wider than the viewport, left-align it.
+    /// Otherwise, scroll the minimum amount to bring both edges into view.
+    private func scrollToReveal() {
+        let live = liveIndices
+        guard focusedIndex < live.count else { return }
+        let panelStart = stripX(forLive: focusedIndex)
+        let w = pw(for: slots[live[focusedIndex].slot])
+        ensureVisible(panelStart: panelStart, panelWidth: w)
+    }
+
+    /// Like scrollToReveal but uses the target (final) width for resize preview.
+    private func scrollToRevealTarget() {
+        let live = liveIndices
+        guard focusedIndex < live.count else { return }
+        let panelStart = stripX(forLive: focusedIndex)
+        let slot = slots[live[focusedIndex].slot]
+        let w = max(300, maxW * slot.targetWidth)
+        ensureVisible(panelStart: panelStart, panelWidth: w)
+    }
+
+    private func ensureVisible(panelStart: CGFloat, panelWidth w: CGFloat) {
+        let viewport = maxW
+
+        if w >= viewport {
+            // Panel wider than viewport: left-align
+            targetOffset = panelStart
+        } else {
+            // Valid scroll range to keep both edges visible:
+            //   panelStart + w - viewport <= targetOffset <= panelStart
+            let minOffset = panelStart + w - viewport
+            let maxOffset = panelStart
+
+            if targetOffset > maxOffset {
+                targetOffset = maxOffset  // left edge was off-screen
+            } else if targetOffset < minOffset {
+                targetOffset = minOffset  // right edge was off-screen
+            }
+            // else: already fully visible, don't move
+        }
+        targetOffset = max(0, targetOffset)
+    }
+
+    // MARK: - Resize
+
+    func cycleResize() {
+        let live = liveIndices
+        guard focusedIndex < live.count else { return }
+        let si = live[focusedIndex].slot
+        slots[si].presetIndex = (slots[si].presetIndex + 1) % widthPresets.count
+        slots[si].targetWidth = widthPresets[slots[si].presetIndex]
+        // Immediately ensure the final size will be visible (scroll starts animating now)
+        scrollToRevealTarget()
+    }
+
+    // MARK: - Close / Add
+
+    func closeFocusedTerminal() {
+        let live = liveIndices
+        guard !live.isEmpty, focusedIndex < live.count else { return }
+        let si = live[focusedIndex].slot
+        slots[si].closing = true
+        if let s = slots[si].surface.surface { ghostty_surface_request_close(s) }
+        if liveCount > 0 {
+            focusedIndex = min(focusedIndex, liveCount - 1)
+            focusCurrentTerminal()
+        }
+    }
+
+    func addNewTerminal() {
+        guard GhosttyApp.shared.app != nil else { return }
+        let surface = TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+        let live = liveIndices
+        let insertAt = focusedIndex < live.count ? live[focusedIndex].slot + 1 : slots.count
+        slots.insert(Slot(surface: surface), at: insertAt)
+        surface.hostedView.removeFromSuperview(); addSubview(surface.hostedView)
+        focusedIndex += 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.focusCurrentTerminal()
+        }
+    }
+
+    // MARK: - Focus
+
+    func focusCurrentTerminal() {
+        guard let surface = focusedSurface else { return }
+        if let gv = findGhosttyNSView(in: surface.hostedView) {
+            window?.makeFirstResponder(gv)
+        }
+    }
+
+    private func findGhosttyNSView(in view: NSView) -> NSView? {
+        if type(of: view) == GhosttyNSView.self { return view }
+        for sub in view.subviews { if let v = findGhosttyNSView(in: sub) { return v } }
+        return nil
+    }
+
+    // MARK: - Scroll
+
+    override func scrollWheel(with event: NSEvent) {
+        var dx = event.scrollingDeltaX; var dy = event.scrollingDeltaY
+        if event.isDirectionInvertedFromDevice { dx = -dx; dy = -dy }
+        let delta = abs(dx) > abs(dy) ? dx : dy
+        targetOffset += delta * 2.0
+        targetOffset = max(0, targetOffset)
+        let newFocus = nearestLiveIndex(forOffset: targetOffset)
+        if newFocus != focusedIndex { focusedIndex = newFocus; focusCurrentTerminal() }
+    }
+
+    private func nearestLiveIndex(forOffset offset: CGFloat) -> Int {
+        var best = 0; var bestDist = CGFloat.infinity; var x: CGFloat = 0; var li = 0
+        for s in slots where !s.closing {
+            let mid = x + pw(for: s) / 2
+            let d = abs(mid - offset)
+            if d < bestDist { bestDist = d; best = li }
+            x += pw(for: s) + panelGap; li += 1
+        }
+        return best
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    // MARK: - Display Link
+
+    private func startDisplayLink() {
+        CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
+        guard let displayLink else { return }
+        let cb: CVDisplayLinkOutputCallback = { _, _, _, _, _, ud -> CVReturn in
+            let v = Unmanaged<NiriCanvasView>.fromOpaque(ud!).takeUnretainedValue()
+            DispatchQueue.main.async { v.tick() }; return kCVReturnSuccess
+        }
+        CVDisplayLinkSetOutputCallback(displayLink, cb, Unmanaged.passUnretained(self).toOpaque())
+        CVDisplayLinkStart(displayLink)
+    }
+
+    private func tick() {
+        // Animate per-slot widths
+        var anyResizing = false
+        for i in 0..<slots.count {
+            let d = slots[i].targetWidth - slots[i].currentWidth
+            if abs(d) < 0.001 { slots[i].currentWidth = slots[i].targetWidth }
+            else { slots[i].currentWidth += d * 0.14; anyResizing = true }
+        }
+
+        // During resize: directly clamp scroll to keep focused panel visible.
+        // No separate scroll spring, scroll is derived from width animation.
+        if anyResizing {
+            let live = liveIndices
+            if focusedIndex < live.count {
+                let panelStart = stripX(forLive: focusedIndex)
+                let w = pw(for: slots[live[focusedIndex].slot])
+                let viewport = maxW
+
+                if w >= viewport {
+                    scrollOffset = panelStart
+                } else {
+                    let minScroll = panelStart + w - viewport
+                    let maxScroll = panelStart
+                    scrollOffset = max(minScroll, min(maxScroll, scrollOffset))
+                }
+                scrollOffset = max(0, scrollOffset)
+                targetOffset = scrollOffset
+            }
+        }
+
+        // Animate closing
+        var removed = false
+        for i in (0..<slots.count).reversed() where slots[i].closing {
+            slots[i].closeProgress -= 0.06
+            if slots[i].closeProgress <= 0 {
+                slots[i].surface.hostedView.removeFromSuperview()
+                slots.remove(at: i); removed = true
+            }
+        }
+        if removed && liveCount == 0 { window?.close(); return }
+
+        // Animate scroll (only when not resizing, resize drives scroll directly above)
+        if !anyResizing {
+            let diff = targetOffset - scrollOffset
+            if abs(diff) < 0.3 { scrollOffset = targetOffset }
+            else { scrollOffset += diff * springK }
+        }
+
+        layoutStrip()
+    }
+}
+
+// MARK: - Window
+
+private final class NiriCanvasWindow: NSWindow {
+    weak var canvasView: NiriCanvasView?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let c = canvasView, c.performKeyEquivalent(with: event) { return true }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .keyDown {
+            let f = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let ctrlOnly = f.contains(.control) && !f.contains(.command) && !f.contains(.option)
+            let ch = event.charactersIgnoringModifiers?.lowercased() ?? ""
+            if ctrlOnly && (ch == "d" || event.characters == "\u{04}") {
+                canvasView?.handleCtrlD(); return
+            }
+        }
+        super.sendEvent(event)
+    }
+}
+
+// MARK: - Controller
+
+final class NiriCanvasWindowController: NSWindowController {
+    private let canvasView: NiriCanvasView
+
+    init() {
+        let scr = NSScreen.main!.frame
+        let win = NiriCanvasWindow(
+            contentRect: NSRect(x: scr.midX - 700, y: scr.midY - 350, width: 1400, height: 700),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false
+        )
+        win.title = "Terminal Canvas"
+        win.titlebarAppearsTransparent = true
+        win.backgroundColor = NSColor(red: 0.06, green: 0.06, blue: 0.08, alpha: 1)
+        win.titleVisibility = .hidden
+        win.minSize = NSSize(width: 800, height: 400)
+
+        canvasView = NiriCanvasView(frame: win.contentView!.bounds)
+        canvasView.autoresizingMask = [.width, .height]
+        win.contentView!.addSubview(canvasView)
+        win.canvasView = canvasView
+        super.init(window: win)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func open(terminalCount: Int = 3) {
+        guard GhosttyApp.shared.app != nil else { return }
+        let surfaces = (0..<terminalCount).map { _ in
+            TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+        }
+        canvasView.setSurfaces(surfaces)
+        showWindow(nil); window?.makeKeyAndOrderFront(nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.canvasView.focusCurrentTerminal()
+        }
+    }
+
+    func openWithExisting(_ surfaces: [TerminalSurface]) {
+        canvasView.setSurfaces(surfaces)
+        showWindow(nil); window?.makeKeyAndOrderFront(nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.canvasView.focusCurrentTerminal()
+        }
+    }
+
+    var canvas: NiriCanvasView { canvasView }
+}
+#endif

--- a/Sources/NiriCanvasView.swift
+++ b/Sources/NiriCanvasView.swift
@@ -1,32 +1,219 @@
 #if DEBUG
 import AppKit
 import QuartzCore
+import CoreText
+import Bonsplit
 
-/// Niri/PaperWM-style horizontal strip with real ghostty terminal surfaces.
-/// Each panel has its own width preset. Resize only affects the focused panel.
-final class NiriCanvasView: NSView {
+// MARK: - Tab Bar
 
-    private struct Slot {
-        let surface: TerminalSurface
-        var closing: Bool = false
-        var closeProgress: CGFloat = 1.0
-        var presetIndex: Int = 1        // default to 0.67
-        var currentWidth: CGFloat = 0.67
-        var targetWidth: CGFloat = 0.67
+final class NiriTabBarView: NSView {
+
+    struct Tab: Equatable { let id: UUID; var title: String }
+
+    var tabs: [Tab] = [] { didSet { needsDisplay = true } }
+    var selectedIndex: Int = 0 { didSet { needsDisplay = true } }
+    var onSelect: ((Int) -> Void)?
+    /// Called when user starts dragging a tab. Canvas takes over from here.
+    var onDragStart: ((Int, NSEvent) -> Void)?
+
+    static let height: CGFloat = 30
+    private var hoveredIndex: Int? { didSet { if oldValue != hoveredIndex { needsDisplay = true } } }
+    /// Set by canvas during drag to show drop indicator
+    var dropIndicatorIndex: Int? { didSet { if oldValue != dropIndicatorIndex { needsDisplay = true } } }
+    private var trackingArea: NSTrackingArea?
+    private var mouseDownIdx: Int?
+    private var mouseDownX: CGFloat = 0
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    override var mouseDownCanMoveWindow: Bool { false }
+    override var isFlipped: Bool { false }
+    override var acceptsFirstResponder: Bool { true }
+
+    var tabWidth: CGFloat {
+        min(220, max(48, bounds.width / CGFloat(max(1, tabs.count))))
     }
 
-    private var slots: [Slot] = []
-    private(set) var focusedIndex: Int = 0
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let t = trackingArea { removeTrackingArea(t) }
+        trackingArea = NSTrackingArea(rect: bounds, options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow], owner: self)
+        addTrackingArea(trackingArea!)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        hoveredIndex = tabIndex(at: convert(event.locationInWindow, from: nil))
+    }
+
+    override func mouseExited(with event: NSEvent) { hoveredIndex = nil }
+
+    func tabIndex(at point: NSPoint) -> Int? {
+        guard !tabs.isEmpty else { return nil }
+        let idx = Int(point.x / tabWidth)
+        return idx >= 0 && idx < tabs.count ? idx : nil
+    }
+
+    /// Insertion index (0...tabs.count) for drop indicator
+    func insertionIndex(at point: NSPoint) -> Int {
+        let raw = point.x / tabWidth
+        return max(0, min(tabs.count, Int(raw + 0.5)))
+    }
+
+    // MARK: - Mouse: click-to-select + drag-start detection
+    // On drag, the canvas takes over via onDragStart callback.
+
+    override func mouseDown(with event: NSEvent) {
+        let pt = convert(event.locationInWindow, from: nil)
+        mouseDownIdx = tabIndex(at: pt)
+        mouseDownX = pt.x
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let idx = mouseDownIdx else { return }
+        let pt = convert(event.locationInWindow, from: nil)
+        if abs(pt.x - mouseDownX) > 5 {
+            mouseDownIdx = nil  // hand off to canvas
+            onDragStart?(idx, event)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if let idx = mouseDownIdx {
+            onSelect?(idx)
+        }
+        mouseDownIdx = nil
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        guard bounds.width > 1, bounds.height > 1 else { return }
+
+        ctx.setFillColor(CGColor(gray: 0.15, alpha: 1))
+        ctx.fill(bounds)
+
+        guard !tabs.isEmpty else { return }
+        let tw = tabWidth
+        guard tw > 1 else { return }
+
+        let activeBg = CGColor(gray: 0.22, alpha: 1)
+        let hoverBg = CGColor(gray: 0.19, alpha: 1)
+        let accent = CGColor(srgbRed: 0.0, green: 0.48, blue: 1.0, alpha: 1.0)
+        let sep = CGColor(gray: 0.3, alpha: 1)
+
+        for (i, tab) in tabs.enumerated() {
+            let x = CGFloat(i) * tw
+
+            if i == selectedIndex {
+                ctx.setFillColor(activeBg)
+                ctx.fill(CGRect(x: x, y: 0, width: tw, height: bounds.height))
+                ctx.setFillColor(accent)
+                ctx.fill(CGRect(x: x, y: 0, width: tw, height: 2))
+            } else if hoveredIndex == i && mouseDownIdx == nil {
+                ctx.setFillColor(hoverBg)
+                ctx.fill(CGRect(x: x, y: 0, width: tw, height: bounds.height))
+            }
+
+            if i > 0 {
+                ctx.setFillColor(sep)
+                ctx.fill(CGRect(x: x, y: 5, width: 1, height: bounds.height - 10))
+            }
+
+            // Title
+            let title = tab.title.isEmpty ? "Shell" : String(tab.title.prefix(20))
+            let alpha: CGFloat = i == selectedIndex ? 0.9 : 0.5
+            drawText(ctx: ctx, text: title, x: x + 10, centerY: bounds.height / 2,
+                     fontSize: 11, fontName: "Helvetica Neue", alpha: alpha)
+
+            // Tab number hint
+            if i < 9 {
+                let hintW = measureText("\(i + 1)", fontSize: 9, fontName: "Menlo")
+                drawText(ctx: ctx, text: "\(i + 1)", x: x + tw - hintW - 8, centerY: bounds.height / 2,
+                         fontSize: 9, fontName: "Menlo", alpha: 0.25)
+            }
+        }
+
+        // Bottom border
+        ctx.setFillColor(sep)
+        ctx.fill(CGRect(x: 0, y: 0, width: bounds.width, height: 1))
+
+        // Drop indicator (blue line)
+        if let dropIdx = dropIndicatorIndex {
+            let dropX = CGFloat(dropIdx) * tw
+            ctx.setFillColor(accent)
+            ctx.fill(CGRect(x: dropX - 1.5, y: 4, width: 3, height: bounds.height - 8))
+        }
+    }
+
+    private func drawText(ctx: CGContext, text: String, x: CGFloat, centerY: CGFloat,
+                          fontSize: CGFloat, fontName: String, alpha: CGFloat) {
+        let ctFont = CTFontCreateWithName(fontName as CFString, fontSize, nil)
+        let attrs: [CFString: Any] = [kCTFontAttributeName: ctFont, kCTForegroundColorFromContextAttributeName: true]
+        let attrStr = CFAttributedStringCreate(nil, text as CFString, attrs as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attrStr)
+        let r = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
+        ctx.saveGState()
+        ctx.setFillColor(CGColor(gray: 1.0, alpha: alpha))
+        ctx.textPosition = CGPoint(x: x, y: centerY - r.height / 2 + 2)
+        CTLineDraw(line, ctx)
+        ctx.restoreGState()
+    }
+
+    private func measureText(_ text: String, fontSize: CGFloat, fontName: String) -> CGFloat {
+        let ctFont = CTFontCreateWithName(fontName as CFString, fontSize, nil)
+        let attrs: [CFString: Any] = [kCTFontAttributeName: ctFont]
+        let attrStr = CFAttributedStringCreate(nil, text as CFString, attrs as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attrStr)
+        return CTLineGetBoundsWithOptions(line, .useOpticalBounds).width
+    }
+
+    /// Show a drop indicator at the given insertion index (called by NiriCanvasView during cross-panel drag)
+    func showDropIndicator(at index: Int?) { dropIndicatorIndex = index }
+}
+
+// MARK: - Niri Canvas View
+
+final class NiriCanvasView: NSView {
+
+    struct Panel {
+        var tabs: [TerminalSurface]
+        var activeTab: Int = 0
+        var closing: Bool = false
+        var closeProgress: CGFloat = 1.0
+        var presetIndex: Int = 1
+        var currentWidth: CGFloat = 0.67
+        var targetWidth: CGFloat = 0.67
+        var tabBar: NiriTabBarView
+        var containerView: NSView
+
+        var activeSurface: TerminalSurface? {
+            guard activeTab >= 0, activeTab < tabs.count else { return nil }
+            return tabs[activeTab]
+        }
+
+        mutating func syncTabBar() {
+            tabBar.tabs = tabs.map { NiriTabBarView.Tab(id: $0.id, title: "Shell") }
+            tabBar.selectedIndex = activeTab
+        }
+    }
+
+    private(set) var panels: [Panel] = []
+    var focusedIndex: Int = 0
     private var scrollOffset: CGFloat = 0
     private var targetOffset: CGFloat = 0
     private var displayLink: CVDisplayLink?
 
+    /// Blue drop indicator between panels (index = insertion point, 0...panels.count)
+    private var panelDropIndex: Int? { didSet { if oldValue != panelDropIndex { needsDisplay = true } } }
+
     private let panelGap: CGFloat = 12
     private let peekWidth: CGFloat = 60
     private let springK: CGFloat = 0.16
-    private let widthPresets: [CGFloat] = [0.33, 0.67, 1.0]
-
-    // MARK: - Init
+    let widthPresets: [CGFloat] = [0.33, 0.67, 1.0]
 
     override init(frame: NSRect) { super.init(frame: frame); setup() }
     required init?(coder: NSCoder) { super.init(coder: coder); setup() }
@@ -39,48 +226,412 @@ final class NiriCanvasView: NSView {
 
     deinit { if let displayLink { CVDisplayLinkStop(displayLink) } }
 
-    // MARK: - Surfaces
+    // MARK: - Logging
 
-    func setSurfaces(_ newSurfaces: [TerminalSurface]) {
-        for s in slots { s.surface.hostedView.removeFromSuperview() }
-        slots = newSurfaces.map { Slot(surface: $0) }
-        for s in slots { let h = s.surface.hostedView; h.removeFromSuperview(); addSubview(h) }
+    private func nlog(_ msg: String) {
+        let state = "focus=\(focusedIndex) live=\(liveCount) panels=\(panels.count)"
+        dlog("niri: \(msg) [\(state)]")
+    }
+
+    // MARK: - Panel Management
+
+    func setSurfaces(_ surfaces: [TerminalSurface]) {
+        for p in panels { p.containerView.removeFromSuperview() }
+        panels = surfaces.map { makePanel(with: [$0]) }
+        for p in panels { addSubview(p.containerView) }
         focusedIndex = min(focusedIndex, max(0, liveCount - 1))
         targetOffset = stripX(forLive: focusedIndex)
         scrollOffset = targetOffset
         layoutStrip()
     }
 
-    private var liveCount: Int { slots.count(where: { !$0.closing }) }
-
-    private var liveIndices: [(slot: Int, live: Int)] {
-        var result: [(Int, Int)] = []
-        var li = 0
-        for (i, s) in slots.enumerated() where !s.closing {
-            result.append((i, li)); li += 1
+    /// Container that prioritizes the tab bar for hit testing.
+    private final class PanelContainerView: NSView {
+        weak var tabBar: NiriTabBarView?
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            // hitTest point is in superview's coordinate space.
+            let localPt = convert(point, from: superview)
+            if let tb = tabBar {
+                // Check if the click is in the tab bar's frame (in our local coords)
+                if localPt.y >= tb.frame.minY && localPt.y <= tb.frame.maxY
+                    && localPt.x >= tb.frame.minX && localPt.x <= tb.frame.maxX {
+                    NSLog("niri.hitTest -> TAB BAR local=\(localPt) tbFrame=\(tb.frame)")
+                    return tb
+                }
+            }
+            let result = super.hitTest(point)
+            if localPt.y >= (frame.height - 40) {
+                // Near the tab bar area but missed - log for debugging
+                NSLog("niri.hitTest MISS near tabBar local=\(localPt) tbFrame=\(tabBar?.frame ?? .zero) result=\(type(of: result).self)")
+            }
+            return result
         }
-        return result
+    }
+
+    /// Set to true to use plain colored views instead of ghostty terminals (for debugging hit test)
+    var debugNoGhostty = false
+
+    private func makePanel(with surfaces: [TerminalSurface]) -> Panel {
+        let container = PanelContainerView()
+        container.wantsLayer = true
+        if debugNoGhostty {
+            // Plain colored placeholder instead of ghostty terminal
+            let placeholder = NSView()
+            placeholder.wantsLayer = true
+            placeholder.layer?.backgroundColor = CGColor(gray: 0.12, alpha: 1)
+            container.addSubview(placeholder)
+        } else if let active = surfaces.first {
+            active.hostedView.removeFromSuperview()
+            container.addSubview(active.hostedView)
+        }
+        let tabBar = NiriTabBarView(frame: .zero)
+        container.addSubview(tabBar)
+        container.tabBar = tabBar
+        var panel = Panel(tabs: surfaces, activeTab: 0, tabBar: tabBar, containerView: container)
+        panel.syncTabBar()
+
+        let panelId = ObjectIdentifier(container)
+        tabBar.onSelect = { [weak self] idx in self?.selectTab(idx, inPanel: panelId) }
+        tabBar.onDragStart = { [weak self] idx, event in self?.beginTabDrag(tabIndex: idx, fromPanel: panelId, event: event) }
+        return panel
+    }
+
+    private func panelIndex(for id: ObjectIdentifier) -> Int? {
+        panels.firstIndex(where: { ObjectIdentifier($0.containerView) == id })
+    }
+
+    var liveCount: Int { panels.count(where: { !$0.closing }) }
+
+    var liveIndices: [(panel: Int, live: Int)] {
+        var r: [(Int, Int)] = []; var li = 0
+        for (i, p) in panels.enumerated() where !p.closing { r.append((i, li)); li += 1 }
+        return r
     }
 
     var focusedSurface: TerminalSurface? {
         let live = liveIndices
         guard focusedIndex >= 0, focusedIndex < live.count else { return nil }
-        return slots[live[focusedIndex].slot].surface
+        return panels[live[focusedIndex].panel].activeSurface
+    }
+
+    // MARK: - Tab Operations
+
+    func selectTab(_ idx: Int, inPanel id: ObjectIdentifier) {
+        nlog("selectTab idx=\(idx) panel=\(panelIndex(for: id) ?? -1)")
+        guard let pi = panelIndex(for: id), idx < panels[pi].tabs.count else { return }
+        // Focus this panel if it's not already focused
+        let live = liveIndices
+        if let li = live.first(where: { $0.panel == pi })?.live, li != focusedIndex {
+            focusedIndex = li
+            scrollToReveal()
+        }
+        panels[pi].activeSurface?.hostedView.removeFromSuperview()
+        panels[pi].activeTab = idx
+        panels[pi].syncTabBar()
+        if let s = panels[pi].activeSurface {
+            s.hostedView.removeFromSuperview()
+            panels[pi].containerView.addSubview(s.hostedView)
+        }
+        layoutStrip(); focusCurrentTerminal()
+    }
+
+    func reorderTab(from: Int, to: Int, inPanel id: ObjectIdentifier) {
+        nlog("reorderTab from=\(from) to=\(to) panel=\(panelIndex(for: id) ?? -1)")
+        guard let pi = panelIndex(for: id) else { return }
+        guard from < panels[pi].tabs.count, to < panels[pi].tabs.count, from != to else { return }
+        let tab = panels[pi].tabs.remove(at: from)
+        panels[pi].tabs.insert(tab, at: to)
+        if panels[pi].activeTab == from { panels[pi].activeTab = to }
+        else if from < panels[pi].activeTab && to >= panels[pi].activeTab { panels[pi].activeTab -= 1 }
+        else if from > panels[pi].activeTab && to <= panels[pi].activeTab { panels[pi].activeTab += 1 }
+        panels[pi].syncTabBar()
+    }
+
+    // MARK: - Tab Drag (canvas-level, cross-panel)
+
+    private var dragLayer: CALayer?
+    private var currentDropTarget: DropTarget?
+    private var lastAutoScrolledLive: Int = -1
+    var suppressHitTestFocus = false  // true during drag to prevent hitTest from stealing focus
+
+    struct DropTarget {
+        enum Kind: Equatable { case inTabBar(livePanel: Int, insertionIndex: Int); case betweenPanels(insertionIndex: Int) }
+        let kind: Kind
+    }
+
+    private func beginTabDrag(tabIndex: Int, fromPanel panelId: ObjectIdentifier, event: NSEvent) {
+        nlog("beginTabDrag tab=\(tabIndex) panel=\(panelIndex(for: panelId) ?? -1)")
+        guard let srcPi = panelIndex(for: panelId) else { return }
+        let srcTabCount = panels[srcPi].tabs.count
+
+        // Create floating drag layer with tab title
+        let title = panels[srcPi].tabBar.tabs.indices.contains(tabIndex)
+            ? (panels[srcPi].tabBar.tabs[tabIndex].title.isEmpty ? "Shell" : panels[srcPi].tabBar.tabs[tabIndex].title)
+            : "Shell"
+        let dl = CATextLayer()
+        dl.string = title
+        dl.font = CTFontCreateWithName("Helvetica Neue" as CFString, 11, nil)
+        dl.fontSize = 11
+        dl.foregroundColor = CGColor(gray: 1, alpha: 0.9)
+        dl.alignmentMode = .center
+        dl.truncationMode = .end
+        dl.frame = CGRect(x: 0, y: 0, width: 100, height: NiriTabBarView.height)
+        dl.backgroundColor = CGColor(gray: 0.22, alpha: 0.95)
+        dl.cornerRadius = 6
+        dl.borderColor = CGColor(srgbRed: 0, green: 0.48, blue: 1, alpha: 0.8)
+        dl.borderWidth = 1.5
+        dl.shadowColor = CGColor(gray: 0, alpha: 1)
+        dl.shadowOpacity = 0.5
+        dl.shadowRadius = 8
+        dl.contentsScale = window?.backingScaleFactor ?? 2
+        dl.zPosition = 1000
+        dl.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        layer?.addSublayer(dl)
+        dragLayer = dl
+
+        let mousePt = convert(event.locationInWindow, from: nil)
+        dl.position = CGPoint(x: mousePt.x, y: mousePt.y)
+        lastAutoScrolledLive = -1
+        suppressHitTestFocus = true
+
+        // Tracking loop: mouse events + keyboard (Escape to cancel)
+        var cancelled = false
+        while let next = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp, .keyDown]) {
+            if next.type == .keyDown && next.keyCode == 53 { cancelled = true; break }  // Escape
+            let pt = convert(next.locationInWindow, from: nil)
+
+            if next.type == .leftMouseUp {
+                if !cancelled {
+                    completeDrag(sourcePi: srcPi, sourceTab: tabIndex)
+                }
+                break
+            }
+
+            // Move drag layer
+            CATransaction.begin(); CATransaction.setDisableActions(true)
+            dl.position = CGPoint(x: pt.x, y: pt.y)
+            CATransaction.commit()
+
+            // Auto-scroll: when hovering over a panel, scroll it fully into view.
+            // Find which panel the mouse is over and snap-scroll to reveal it.
+            let hoveredLive = liveIndexAtPoint(pt)
+            if let hl = hoveredLive, hl != lastAutoScrolledLive {
+                lastAutoScrolledLive = hl
+                let live = liveIndices
+                if hl < live.count {
+                    let panelStart = stripX(forLive: hl)
+                    let w = pw(for: panels[live[hl].panel])
+                    ensureVisible(panelStart: panelStart, panelWidth: w)
+                }
+            }
+
+            // Update drop target
+            updateDropTarget(at: pt, srcPi: srcPi, srcTab: tabIndex, srcTabCount: srcTabCount)
+        }
+
+        // Clean up
+        cleanupDrag()
+    }
+
+    private func updateDropTarget(at pt: NSPoint, srcPi: Int, srcTab: Int, srcTabCount: Int) {
+        for p in panels { p.tabBar.dropIndicatorIndex = nil }
+        panelDropIndex = nil
+        currentDropTarget = nil
+
+        let live = liveIndices
+        let isSingleTab = srcTabCount <= 1
+
+        // 1. Check tab bars
+        for (li, entry) in live.enumerated() {
+            let p = panels[entry.panel]
+            let cf = p.containerView.frame
+            // Extended hit area above and below the tab bar
+            let hitRect = CGRect(x: cf.minX, y: cf.minY + cf.height - NiriTabBarView.height - 10,
+                                 width: cf.width, height: NiriTabBarView.height + 30)
+            guard hitRect.contains(pt) else { continue }
+
+            let localX = pt.x - cf.minX
+            let insertIdx = p.tabBar.insertionIndex(at: NSPoint(x: localX, y: 0))
+            let isSamePanel = entry.panel == srcPi
+
+            // Skip: same position in same panel
+            if isSamePanel && (insertIdx == srcTab || insertIdx == srcTab + 1) { return }
+
+            p.tabBar.dropIndicatorIndex = insertIdx
+            currentDropTarget = .init(kind: .inTabBar(livePanel: li, insertionIndex: insertIdx))
+            return
+        }
+
+        // 2. Check gaps between panels
+        for li in 0...live.count {
+            // Skip gaps adjacent to source panel if it only has 1 tab
+            // (dragging the only tab to the gap next to its own panel is a no-op)
+            if isSingleTab {
+                let srcLive = live.first(where: { $0.panel == srcPi })?.live
+                if let sl = srcLive {
+                    if li == sl || li == sl + 1 { continue }
+                }
+            }
+
+            let gapX = gapScreenX(atLive: li, live: live)
+            if abs(pt.x - gapX) < 25 {
+                panelDropIndex = li
+                currentDropTarget = .init(kind: .betweenPanels(insertionIndex: li))
+                needsDisplay = true
+                return
+            }
+        }
+    }
+
+    private func gapScreenX(atLive li: Int, live: [(panel: Int, live: Int)]) -> CGFloat {
+        if li <= 0 {
+            return peekWidth + panelGap + (stripX(forLive: 0) - scrollOffset) - panelGap / 2
+        } else if li >= live.count {
+            let lastStart = stripX(forLive: live.count - 1)
+            let lastW = pw(for: panels[live[live.count - 1].panel])
+            return peekWidth + panelGap + (lastStart + lastW - scrollOffset) + panelGap / 2
+        } else {
+            return peekWidth + panelGap + (stripX(forLive: li) - scrollOffset) - panelGap / 2
+        }
+    }
+
+    private func completeDrag(sourcePi: Int, sourceTab: Int) {
+        nlog("completeDrag srcPanel=\(sourcePi) srcTab=\(sourceTab) target=\(currentDropTarget.map { String(describing: $0.kind) } ?? "nil")")
+        guard let target = currentDropTarget else { return }
+
+        switch target.kind {
+        case .inTabBar(let targetLive, let insertIdx):
+            let live = liveIndices
+            guard targetLive < live.count else { break }
+            let targetPi = live[targetLive].panel
+
+            if targetPi == sourcePi {
+                reorderTab(from: sourceTab,
+                           to: min(insertIdx, panels[sourcePi].tabs.count - 1),
+                           inPanel: ObjectIdentifier(panels[sourcePi].containerView))
+            } else {
+                moveTab(fromPanel: sourcePi, tabIndex: sourceTab, toPanel: targetPi, insertAt: insertIdx)
+            }
+            // Recompute focused index: find the destination panel's current live index
+            // (may have shifted if source panel was closed)
+            let newLive = liveIndices
+            focusedIndex = newLive.first(where: { $0.panel == targetPi })?.live ?? min(targetLive, liveCount - 1)
+
+        case .betweenPanels(let insertLive):
+            moveTabToNewPanel(fromPanel: sourcePi, tabIndex: sourceTab, atLiveIndex: insertLive)
+        }
+
+        scrollToReveal()
+        layoutStrip()
+        focusCurrentTerminal()
+    }
+
+    private func cleanupDrag() {
+        dragLayer?.removeFromSuperlayer()
+        dragLayer = nil
+        for p in panels { p.tabBar.dropIndicatorIndex = nil }
+        panelDropIndex = nil
+        currentDropTarget = nil
+        needsDisplay = true
+        // Delay clearing the suppress flag so the post-drag hitTest doesn't steal focus
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.suppressHitTestFocus = false
+        }
+    }
+
+    private func moveTab(fromPanel srcPi: Int, tabIndex srcTab: Int, toPanel dstPi: Int, insertAt dstTab: Int) {
+        nlog("moveTab src=\(srcPi):\(srcTab) dst=\(dstPi):\(dstTab)")
+        guard srcTab < panels[srcPi].tabs.count else { return }
+        let surface = panels[srcPi].tabs[srcTab]
+
+        // Remove from source
+        panels[srcPi].activeSurface?.hostedView.removeFromSuperview()
+        panels[srcPi].tabs.remove(at: srcTab)
+        if panels[srcPi].tabs.isEmpty {
+            panels[srcPi].closing = true
+        } else {
+            panels[srcPi].activeTab = min(panels[srcPi].activeTab, panels[srcPi].tabs.count - 1)
+            panels[srcPi].syncTabBar()
+            // Show new active in source
+            if let s = panels[srcPi].activeSurface {
+                s.hostedView.removeFromSuperview()
+                panels[srcPi].containerView.addSubview(s.hostedView)
+            }
+        }
+
+        // Remove old active from destination before inserting
+        panels[dstPi].activeSurface?.hostedView.removeFromSuperview()
+
+        let clampedDst = min(dstTab, panels[dstPi].tabs.count)
+        panels[dstPi].tabs.insert(surface, at: clampedDst)
+        panels[dstPi].activeTab = clampedDst
+        panels[dstPi].syncTabBar()
+
+        // Show the new active surface in destination
+        if let s = panels[dstPi].activeSurface {
+            s.hostedView.removeFromSuperview()
+            panels[dstPi].containerView.addSubview(s.hostedView)
+        }
+    }
+
+    private func moveTabToNewPanel(fromPanel srcPi: Int, tabIndex srcTab: Int, atLiveIndex insertLive: Int) {
+        nlog("moveTabToNewPanel src=\(srcPi):\(srcTab) insertLive=\(insertLive)")
+        guard srcTab < panels[srcPi].tabs.count else { return }
+        let surface = panels[srcPi].tabs[srcTab]
+
+        // Remove from source
+        panels[srcPi].activeSurface?.hostedView.removeFromSuperview()
+        panels[srcPi].tabs.remove(at: srcTab)
+        if panels[srcPi].tabs.isEmpty {
+            panels[srcPi].closing = true
+        } else {
+            panels[srcPi].activeTab = min(panels[srcPi].activeTab, panels[srcPi].tabs.count - 1)
+            panels[srcPi].syncTabBar()
+            if let s = panels[srcPi].activeSurface {
+                s.hostedView.removeFromSuperview()
+                panels[srcPi].containerView.addSubview(s.hostedView)
+            }
+        }
+
+        // New panel inherits the source panel's width preset
+        var newPanel = makePanel(with: [surface])
+        newPanel.presetIndex = panels[srcPi].presetIndex
+        newPanel.currentWidth = panels[srcPi].currentWidth
+        newPanel.targetWidth = panels[srcPi].targetWidth
+
+        let live = liveIndices
+        let insertAt = insertLive < live.count ? live[insertLive].panel : panels.count
+        panels.insert(newPanel, at: insertAt)
+        addSubview(newPanel.containerView)
+        // Find the new panel's live index after insertion
+        let newLive = liveIndices
+        let newPanelId = ObjectIdentifier(newPanel.containerView)
+        focusedIndex = newLive.first(where: { ObjectIdentifier(panels[$0.panel].containerView) == newPanelId })?.live
+            ?? min(insertLive, liveCount - 1)
+        nlog("moveTabToNewPanel done newFocus=\(focusedIndex)")
     }
 
     // MARK: - Geometry
 
     private var maxW: CGFloat { bounds.width - peekWidth * 2 - panelGap * 2 }
+    func pw(for p: Panel) -> CGFloat { max(300, maxW * p.currentWidth) }
 
-    private func pw(for slot: Slot) -> CGFloat { max(300, maxW * slot.currentWidth) }
+    /// Returns the live panel index whose container frame contains the given point (in canvas coords).
+    func liveIndexAtPoint(_ pt: NSPoint) -> Int? {
+        let live = liveIndices
+        for (li, entry) in live.enumerated() {
+            let cf = panels[entry.panel].containerView.frame
+            if pt.x >= cf.minX && pt.x <= cf.maxX { return li }
+        }
+        return nil
+    }
 
-    /// Strip-space X for a live index, based on current (animated) widths.
-    private func stripX(forLive target: Int) -> CGFloat {
+    func stripX(forLive target: Int) -> CGFloat {
         var x: CGFloat = 0; var li = 0
-        for s in slots {
-            if s.closing { x += pw(for: s) * s.closeProgress + panelGap * s.closeProgress; continue }
+        for p in panels {
+            if p.closing { x += pw(for: p) * p.closeProgress + panelGap * p.closeProgress; continue }
             if li == target { return x }
-            x += pw(for: s) + panelGap; li += 1
+            x += pw(for: p) + panelGap; li += 1
         }
         return x
     }
@@ -88,41 +639,103 @@ final class NiriCanvasView: NSView {
     // MARK: - Layout
 
     private func layoutStrip() {
-        let ph = max(300, bounds.height - 20)
-        let topY = (bounds.height - ph) / 2
+        let viewH = bounds.height
+        let tabH = NiriTabBarView.height
+        let ph = max(300, viewH - 20)
+        let termH = ph - tabH
+        let topY = (viewH - ph) / 2
         var xCursor: CGFloat = 0; var li = 0
 
-        for i in 0..<slots.count {
-            let s = slots[i]; let hosted = s.surface.hostedView
-            let progress = s.closing ? s.closeProgress : 1.0
-            let w = pw(for: s) * progress; let gap = panelGap * progress
+        for i in 0..<panels.count {
+            let p = panels[i]
+            let progress = p.closing ? p.closeProgress : 1.0
+            let w = pw(for: p) * progress
+            let gap = panelGap * progress
             let screenX = peekWidth + panelGap + (xCursor - scrollOffset)
-            let isFocused = !s.closing && li == focusedIndex
-            let opacity: CGFloat = s.closing ? max(0, progress) : 1.0
+            let isFocused = !p.closing && li == focusedIndex
 
-            hosted.frame = CGRect(x: screenX, y: topY, width: max(0, w), height: ph)
-            hosted.alphaValue = CGFloat(opacity)
+            p.containerView.frame = CGRect(x: screenX, y: topY, width: max(0, w), height: ph)
+            p.containerView.alphaValue = p.closing ? max(0, progress) : 1.0
+            p.tabBar.frame = CGRect(x: 0, y: ph - tabH, width: max(0, w), height: tabH)
+            p.tabBar.needsDisplay = true
+            if debugNoGhostty {
+                // Size the placeholder view
+                if let placeholder = p.containerView.subviews.first(where: { !($0 is NiriTabBarView) }) {
+                    placeholder.frame = CGRect(x: 0, y: 0, width: max(0, w), height: termH)
+                }
+            } else {
+                p.activeSurface?.hostedView.frame = CGRect(x: 0, y: 0, width: max(0, w), height: termH)
+            }
 
-            if let l = hosted.layer {
-                l.transform = CATransform3DIdentity; l.zPosition = 0
+            if let l = p.containerView.layer {
                 l.cornerRadius = 0; l.masksToBounds = true
                 l.borderWidth = isFocused ? 2 : 1
                 l.borderColor = isFocused
-                    ? NSColor.controlAccentColor.withAlphaComponent(0.7).cgColor
-                    : NSColor.white.withAlphaComponent(0.08).cgColor
+                    ? CGColor(srgbRed: 0.0, green: 0.48, blue: 1.0, alpha: 0.7)
+                    : CGColor(gray: 0.3, alpha: 1)
             }
             xCursor += w + gap
-            if !s.closing { li += 1 }
+            if !p.closing { li += 1 }
         }
     }
 
     override func layout() { super.layout(); layoutStrip() }
+
+    // Top-level hitTest: check ALL tab bars first before anything else.
+    // This bypasses the entire subview hitTest chain so ghostty views can't steal the hit.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let localPt = convert(point, from: superview)
+        let live = liveIndices
+        for (li, entry) in live.enumerated() {
+            let p = panels[entry.panel]
+            let cf = p.containerView.frame
+            guard cf.contains(localPt) else { continue }
+
+            // Tab bar region: route to tab bar
+            let tabBarFrame = CGRect(x: cf.minX, y: cf.minY + cf.height - NiriTabBarView.height,
+                                     width: cf.width, height: NiriTabBarView.height)
+            if tabBarFrame.contains(localPt) { return p.tabBar }
+
+            // Terminal region: let the click through to ghostty
+            // Focus is handled in NiriCanvasWindow.sendEvent, not here.
+            return super.hitTest(point)
+        }
+        return super.hitTest(point)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        // Draw panel drop indicator (blue line between panels)
+        guard let dropIdx = panelDropIndex, let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let live = liveIndices
+        guard !live.isEmpty else { return }
+
+        let ph = max(300, bounds.height - 20)
+        let topY = (bounds.height - ph) / 2
+
+        // Compute the X position for the drop indicator
+        let dropX: CGFloat
+        if dropIdx <= 0 {
+            dropX = peekWidth + panelGap + (stripX(forLive: 0) - scrollOffset) - panelGap / 2
+        } else if dropIdx >= liveCount {
+            let lastStart = stripX(forLive: liveCount - 1)
+            let lastW = pw(for: panels[live[liveCount - 1].panel])
+            dropX = peekWidth + panelGap + (lastStart + lastW - scrollOffset) + panelGap / 2
+        } else {
+            let nextStart = stripX(forLive: dropIdx)
+            dropX = peekWidth + panelGap + (nextStart - scrollOffset) - panelGap / 2
+        }
+
+        ctx.setFillColor(CGColor(srgbRed: 0.0, green: 0.48, blue: 1.0, alpha: 1.0))
+        ctx.fill(CGRect(x: dropX - 1.5, y: topY + 10, width: 3, height: ph - 20))
+    }
 
     // MARK: - Keys
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         let f = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let cmd = f.contains(.command), opt = f.contains(.option), ctrl = f.contains(.control)
+        let shift = f.contains(.shift)
         let ch = event.charactersIgnoringModifiers?.lowercased() ?? ""
 
         if cmd && opt {
@@ -134,114 +747,153 @@ final class NiriCanvasView: NSView {
             if ch == "l" { navigateRight(); return true }
             if ch == "r" { cycleResize(); return true }
         }
-        if cmd && !ctrl && !opt && ch == "w" { closeFocusedTerminal(); return true }
-        if cmd && !ctrl && !opt && ch == "t" { addNewTerminal(); return true }
+        if ctrl && !cmd && !opt {
+            if let n = Int(ch), n >= 1, n <= 9 { switchToTab(n - 1); return true }
+        }
+        if cmd && !ctrl && !opt && !shift && ch == "w" { closeActiveTab(); return true }
+        if cmd && !ctrl && !opt && !shift && ch == "t" { addNewTab(); return true }
+        if cmd && !ctrl && !opt && !shift && ch == "n" { addNewPanel(); return true }
         return super.performKeyEquivalent(with: event)
     }
 
-    func handleCtrlD() { closeFocusedTerminal() }
+    func handleCtrlD() { closeActiveTab() }
 
-    // MARK: - Navigation
+    // MARK: - Panel Navigation
 
     func navigateLeft() {
+        nlog("navigateLeft")
         guard focusedIndex > 0 else { return }
         focusedIndex -= 1; scrollToReveal(); focusCurrentTerminal()
     }
 
     func navigateRight() {
+        nlog("navigateRight")
         guard focusedIndex < liveCount - 1 else { return }
         focusedIndex += 1; scrollToReveal(); focusCurrentTerminal()
     }
 
-    /// Adjust targetOffset so the focused panel is fully visible.
-    /// If the panel is wider than the viewport, left-align it.
-    /// Otherwise, scroll the minimum amount to bring both edges into view.
-    private func scrollToReveal() {
+    func scrollToReveal() {
         let live = liveIndices
         guard focusedIndex < live.count else { return }
-        let panelStart = stripX(forLive: focusedIndex)
-        let w = pw(for: slots[live[focusedIndex].slot])
-        ensureVisible(panelStart: panelStart, panelWidth: w)
+        ensureVisible(panelStart: stripX(forLive: focusedIndex), panelWidth: pw(for: panels[live[focusedIndex].panel]))
     }
 
-    /// Like scrollToReveal but uses the target (final) width for resize preview.
     private func scrollToRevealTarget() {
         let live = liveIndices
         guard focusedIndex < live.count else { return }
-        let panelStart = stripX(forLive: focusedIndex)
-        let slot = slots[live[focusedIndex].slot]
-        let w = max(300, maxW * slot.targetWidth)
-        ensureVisible(panelStart: panelStart, panelWidth: w)
+        let p = panels[live[focusedIndex].panel]
+        ensureVisible(panelStart: stripX(forLive: focusedIndex), panelWidth: max(300, maxW * p.targetWidth))
     }
 
     private func ensureVisible(panelStart: CGFloat, panelWidth w: CGFloat) {
-        let viewport = maxW
-
-        if w >= viewport {
-            // Panel wider than viewport: left-align
-            targetOffset = panelStart
-        } else {
-            // Valid scroll range to keep both edges visible:
-            //   panelStart + w - viewport <= targetOffset <= panelStart
-            let minOffset = panelStart + w - viewport
-            let maxOffset = panelStart
-
-            if targetOffset > maxOffset {
-                targetOffset = maxOffset  // left edge was off-screen
-            } else if targetOffset < minOffset {
-                targetOffset = minOffset  // right edge was off-screen
-            }
-            // else: already fully visible, don't move
+        let vp = maxW
+        if w >= vp { targetOffset = panelStart }
+        else {
+            let minO = panelStart + w - vp; let maxO = panelStart
+            if targetOffset > maxO { targetOffset = maxO }
+            else if targetOffset < minO { targetOffset = minO }
         }
         targetOffset = max(0, targetOffset)
+    }
+
+    // MARK: - Tab Navigation
+
+    func switchToTabPublic(_ idx: Int) { switchToTab(idx) }
+
+    private func switchToTab(_ idx: Int) {
+        let live = liveIndices
+        guard focusedIndex < live.count else { return }
+        let pi = live[focusedIndex].panel
+        guard idx < panels[pi].tabs.count else { return }
+        selectTab(idx, inPanel: ObjectIdentifier(panels[pi].containerView))
     }
 
     // MARK: - Resize
 
     func cycleResize() {
+        nlog("cycleResize")
         let live = liveIndices
         guard focusedIndex < live.count else { return }
-        let si = live[focusedIndex].slot
-        slots[si].presetIndex = (slots[si].presetIndex + 1) % widthPresets.count
-        slots[si].targetWidth = widthPresets[slots[si].presetIndex]
-        // Immediately ensure the final size will be visible (scroll starts animating now)
+        let pi = live[focusedIndex].panel
+        panels[pi].presetIndex = (panels[pi].presetIndex + 1) % widthPresets.count
+        panels[pi].targetWidth = widthPresets[panels[pi].presetIndex]
         scrollToRevealTarget()
     }
 
     // MARK: - Close / Add
 
-    func closeFocusedTerminal() {
+    func closeActiveTab() {
+        nlog("closeActiveTab")
         let live = liveIndices
         guard !live.isEmpty, focusedIndex < live.count else { return }
-        let si = live[focusedIndex].slot
-        slots[si].closing = true
-        if let s = slots[si].surface.surface { ghostty_surface_request_close(s) }
-        if liveCount > 0 {
-            focusedIndex = min(focusedIndex, liveCount - 1)
-            focusCurrentTerminal()
+        let pi = live[focusedIndex].panel
+        if panels[pi].tabs.count <= 1 {
+            panels[pi].closing = true
+            if let s = panels[pi].activeSurface?.surface { ghostty_surface_request_close(s) }
+            if liveCount > 0 {
+                focusedIndex = min(focusedIndex, liveCount - 1)
+                scrollToReveal()
+                focusCurrentTerminal()
+            }
+        } else {
+            let idx = panels[pi].activeTab
+            let surface = panels[pi].tabs[idx]
+            surface.hostedView.removeFromSuperview()
+            if let s = surface.surface { ghostty_surface_request_close(s) }
+            panels[pi].tabs.remove(at: idx)
+            panels[pi].activeTab = min(idx, panels[pi].tabs.count - 1)
+            panels[pi].syncTabBar()
+            if let a = panels[pi].activeSurface {
+                a.hostedView.removeFromSuperview()
+                panels[pi].containerView.addSubview(a.hostedView)
+            }
+            layoutStrip(); scrollToReveal(); focusCurrentTerminal()
         }
     }
 
-    func addNewTerminal() {
+    func addNewTab() {
+        nlog("addNewTab")
+        guard GhosttyApp.shared.app != nil else { return }
+        let live = liveIndices
+        guard focusedIndex < live.count else { addNewPanel(); return }
+        let pi = live[focusedIndex].panel
+        let surface = TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+        panels[pi].activeSurface?.hostedView.removeFromSuperview()
+        let idx = panels[pi].activeTab + 1
+        panels[pi].tabs.insert(surface, at: idx)
+        panels[pi].activeTab = idx
+        panels[pi].syncTabBar()
+        surface.hostedView.removeFromSuperview()
+        panels[pi].containerView.addSubview(surface.hostedView)
+        layoutStrip()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in self?.focusCurrentTerminal() }
+    }
+
+    func addNewPanel() {
+        nlog("addNewPanel")
         guard GhosttyApp.shared.app != nil else { return }
         let surface = TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+        let panel = makePanel(with: [surface])
         let live = liveIndices
-        let insertAt = focusedIndex < live.count ? live[focusedIndex].slot + 1 : slots.count
-        slots.insert(Slot(surface: surface), at: insertAt)
-        surface.hostedView.removeFromSuperview(); addSubview(surface.hostedView)
-        focusedIndex += 1
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.focusCurrentTerminal()
-        }
+        let insertAt = focusedIndex < live.count ? live[focusedIndex].panel + 1 : panels.count
+        panels.insert(panel, at: insertAt)
+        addSubview(panel.containerView)
+        focusedIndex += 1; scrollToReveal(); layoutStrip()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in self?.focusCurrentTerminal() }
     }
 
     // MARK: - Focus
 
     func focusCurrentTerminal() {
-        guard let surface = focusedSurface else { return }
-        if let gv = findGhosttyNSView(in: surface.hostedView) {
-            window?.makeFirstResponder(gv)
+        nlog("focusCurrentTerminal surface=\(focusedSurface?.id.uuidString.prefix(5) ?? "nil")")
+        for p in panels where !p.closing {
+            for tab in p.tabs {
+                if let s = tab.surface { ghostty_surface_set_focus(s, false) }
+            }
         }
+        guard let surface = focusedSurface else { return }
+        if let s = surface.surface { ghostty_surface_set_focus(s, true) }
+        if let gv = findGhosttyNSView(in: surface.hostedView) { window?.makeFirstResponder(gv) }
     }
 
     private func findGhosttyNSView(in view: NSView) -> NSView? {
@@ -256,19 +908,17 @@ final class NiriCanvasView: NSView {
         var dx = event.scrollingDeltaX; var dy = event.scrollingDeltaY
         if event.isDirectionInvertedFromDevice { dx = -dx; dy = -dy }
         let delta = abs(dx) > abs(dy) ? dx : dy
-        targetOffset += delta * 2.0
-        targetOffset = max(0, targetOffset)
-        let newFocus = nearestLiveIndex(forOffset: targetOffset)
-        if newFocus != focusedIndex { focusedIndex = newFocus; focusCurrentTerminal() }
+        targetOffset += delta * 2.0; targetOffset = max(0, targetOffset)
+        let nf = nearestLive(forOffset: targetOffset)
+        if nf != focusedIndex { focusedIndex = nf; focusCurrentTerminal() }
     }
 
-    private func nearestLiveIndex(forOffset offset: CGFloat) -> Int {
-        var best = 0; var bestDist = CGFloat.infinity; var x: CGFloat = 0; var li = 0
-        for s in slots where !s.closing {
-            let mid = x + pw(for: s) / 2
-            let d = abs(mid - offset)
-            if d < bestDist { bestDist = d; best = li }
-            x += pw(for: s) + panelGap; li += 1
+    private func nearestLive(forOffset off: CGFloat) -> Int {
+        var best = 0; var bestD = CGFloat.infinity; var x: CGFloat = 0; var li = 0
+        for p in panels where !p.closing {
+            let d = abs(x + pw(for: p) / 2 - off)
+            if d < bestD { bestD = d; best = li }
+            x += pw(for: p) + panelGap; li += 1
         }
         return best
     }
@@ -282,67 +932,51 @@ final class NiriCanvasView: NSView {
         guard let displayLink else { return }
         let cb: CVDisplayLinkOutputCallback = { _, _, _, _, _, ud -> CVReturn in
             let v = Unmanaged<NiriCanvasView>.fromOpaque(ud!).takeUnretainedValue()
-            DispatchQueue.main.async { v.tick() }; return kCVReturnSuccess
+            DispatchQueue.main.async { [weak v] in v?.tick() }
+            return kCVReturnSuccess
         }
         CVDisplayLinkSetOutputCallback(displayLink, cb, Unmanaged.passUnretained(self).toOpaque())
         CVDisplayLinkStart(displayLink)
     }
 
     private func tick() {
-        // Animate per-slot widths
         var anyResizing = false
-        for i in 0..<slots.count {
-            let d = slots[i].targetWidth - slots[i].currentWidth
-            if abs(d) < 0.001 { slots[i].currentWidth = slots[i].targetWidth }
-            else { slots[i].currentWidth += d * 0.14; anyResizing = true }
+        for i in 0..<panels.count {
+            let d = panels[i].targetWidth - panels[i].currentWidth
+            if abs(d) < 0.001 { panels[i].currentWidth = panels[i].targetWidth }
+            else { panels[i].currentWidth += d * 0.14; anyResizing = true }
         }
-
-        // During resize: directly clamp scroll to keep focused panel visible.
-        // No separate scroll spring, scroll is derived from width animation.
         if anyResizing {
             let live = liveIndices
             if focusedIndex < live.count {
-                let panelStart = stripX(forLive: focusedIndex)
-                let w = pw(for: slots[live[focusedIndex].slot])
-                let viewport = maxW
-
-                if w >= viewport {
-                    scrollOffset = panelStart
-                } else {
-                    let minScroll = panelStart + w - viewport
-                    let maxScroll = panelStart
-                    scrollOffset = max(minScroll, min(maxScroll, scrollOffset))
-                }
-                scrollOffset = max(0, scrollOffset)
-                targetOffset = scrollOffset
+                let ps = stripX(forLive: focusedIndex)
+                let w = pw(for: panels[live[focusedIndex].panel])
+                let vp = maxW
+                if w >= vp { scrollOffset = ps }
+                else { scrollOffset = max(ps + w - vp, min(ps, scrollOffset)) }
+                scrollOffset = max(0, scrollOffset); targetOffset = scrollOffset
             }
         }
-
-        // Animate closing
         var removed = false
-        for i in (0..<slots.count).reversed() where slots[i].closing {
-            slots[i].closeProgress -= 0.06
-            if slots[i].closeProgress <= 0 {
-                slots[i].surface.hostedView.removeFromSuperview()
-                slots.remove(at: i); removed = true
+        for i in (0..<panels.count).reversed() where panels[i].closing {
+            panels[i].closeProgress -= 0.06
+            if panels[i].closeProgress <= 0 {
+                panels[i].containerView.removeFromSuperview(); panels.remove(at: i); removed = true
             }
         }
         if removed && liveCount == 0 { window?.close(); return }
-
-        // Animate scroll (only when not resizing, resize drives scroll directly above)
         if !anyResizing {
             let diff = targetOffset - scrollOffset
             if abs(diff) < 0.3 { scrollOffset = targetOffset }
             else { scrollOffset += diff * springK }
         }
-
         layoutStrip()
     }
 }
 
 // MARK: - Window
 
-private final class NiriCanvasWindow: NSWindow {
+final class NiriCanvasWindow: NSWindow {
     weak var canvasView: NiriCanvasView?
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -351,13 +985,31 @@ private final class NiriCanvasWindow: NSWindow {
     }
 
     override func sendEvent(_ event: NSEvent) {
+        // Focus-on-click: when user clicks on a terminal area, focus that panel
+        if event.type == .leftMouseDown, let canvas = canvasView, !canvas.suppressHitTestFocus {
+            let pt = canvas.convert(event.locationInWindow, from: nil)
+            if let clickedLive = canvas.liveIndexAtPoint(pt), clickedLive != canvas.focusedIndex {
+                canvas.focusedIndex = clickedLive
+                canvas.scrollToReveal()
+                canvas.focusCurrentTerminal()
+            }
+        }
+
         if event.type == .keyDown {
             let f = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            let ctrlOnly = f.contains(.control) && !f.contains(.command) && !f.contains(.option)
+            let cmd = f.contains(.command)
+            let ctrl = f.contains(.control)
+            let opt = f.contains(.option)
             let ch = event.charactersIgnoringModifiers?.lowercased() ?? ""
-            if ctrlOnly && (ch == "d" || event.characters == "\u{04}") {
+
+            if ctrl && !cmd && !opt && (ch == "d" || event.characters == "\u{04}") {
                 canvasView?.handleCtrlD(); return
             }
+            if ctrl && !cmd && !opt, let n = Int(ch), n >= 1, n <= 9 {
+                canvasView?.switchToTabPublic(n - 1); return
+            }
+            if (cmd || ctrl), let canvas = canvasView, canvas.performKeyEquivalent(with: event) { return }
+            if cmd { return } // consume unhandled Cmd combos to prevent cmux crash
         }
         super.sendEvent(event)
     }
@@ -369,18 +1021,19 @@ final class NiriCanvasWindowController: NSWindowController {
     private let canvasView: NiriCanvasView
 
     init() {
+        NSSetUncaughtExceptionHandler { exception in
+            NSLog("niri.UNCAUGHT: \(exception.name) reason=\(exception.reason ?? "nil")")
+            NSLog("niri.UNCAUGHT.stack: \(exception.callStackSymbols.joined(separator: "\n"))")
+        }
         let scr = NSScreen.main!.frame
         let win = NiriCanvasWindow(
             contentRect: NSRect(x: scr.midX - 700, y: scr.midY - 350, width: 1400, height: 700),
-            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .resizable],
             backing: .buffered, defer: false
         )
         win.title = "Terminal Canvas"
-        win.titlebarAppearsTransparent = true
         win.backgroundColor = NSColor(red: 0.06, green: 0.06, blue: 0.08, alpha: 1)
-        win.titleVisibility = .hidden
         win.minSize = NSSize(width: 800, height: 400)
-
         canvasView = NiriCanvasView(frame: win.contentView!.bounds)
         canvasView.autoresizingMask = [.width, .height]
         win.contentView!.addSubview(canvasView)
@@ -390,23 +1043,24 @@ final class NiriCanvasWindowController: NSWindowController {
 
     required init?(coder: NSCoder) { fatalError() }
 
-    func open(terminalCount: Int = 3) {
-        guard GhosttyApp.shared.app != nil else { return }
-        let surfaces = (0..<terminalCount).map { _ in
-            TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+    func open(terminalCount: Int = 3, debugNoGhostty: Bool = false) {
+        canvasView.debugNoGhostty = debugNoGhostty
+        if debugNoGhostty {
+            // Create dummy surfaces (won't actually init ghostty)
+            canvasView.setSurfaces((0..<terminalCount).map { _ in
+                TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+            })
+        } else {
+            guard GhosttyApp.shared.app != nil else { return }
+            canvasView.setSurfaces((0..<terminalCount).map { _ in
+                TerminalSurface(tabId: UUID(), context: GHOSTTY_SURFACE_CONTEXT_SPLIT, configTemplate: nil)
+            })
         }
-        canvasView.setSurfaces(surfaces)
         showWindow(nil); window?.makeKeyAndOrderFront(nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.canvasView.focusCurrentTerminal()
-        }
-    }
-
-    func openWithExisting(_ surfaces: [TerminalSurface]) {
-        canvasView.setSurfaces(surfaces)
-        showWindow(nil); window?.makeKeyAndOrderFront(nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.canvasView.focusCurrentTerminal()
+        if !debugNoGhostty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.canvasView.focusCurrentTerminal()
+            }
         }
     }
 

--- a/cmuxUITests/NiriCanvasUITests.swift
+++ b/cmuxUITests/NiriCanvasUITests.swift
@@ -1,0 +1,236 @@
+import XCTest
+import Foundation
+import AppKit
+import CoreGraphics
+
+/// Tests for the niri canvas demo's tab bar drag-to-reorder functionality.
+///
+/// The niri canvas opens via Cmd+Ctrl+N and creates terminal panels with a
+/// NiriTabBarView at the top of each panel. This test exercises tab creation
+/// (Cmd+T) and drag-to-reorder within a single panel's tab bar.
+final class NiriCanvasUITests: XCTestCase {
+    private let launchTimeout: TimeInterval = 20.0
+    private let surfaceTimeout: TimeInterval = 15.0
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        let cleanup = XCUIApplication()
+        cleanup.terminate()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+    }
+
+    /// Launch the app, open the niri canvas (Cmd+Ctrl+N), wait for terminal
+    /// surfaces to appear, create extra tabs with Cmd+T, then attempt to
+    /// drag-reorder tabs in the first panel's tab bar.
+    func testNiriCanvasTabBarDragReorder() {
+        let app = XCUIApplication()
+        app.launch()
+        app.activate()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch in foreground. state=\(app.state.rawValue)"
+        )
+
+        // Wait briefly for the initial window to settle
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        // Open the niri canvas with Cmd+Ctrl+N
+        app.typeKey("n", modifierFlags: [.command, .control])
+        RunLoop.current.run(until: Date().addingTimeInterval(2.0))
+
+        // Look for the "Terminal Canvas" window
+        let canvasWindow = app.windows["Terminal Canvas"]
+        XCTAssertTrue(
+            canvasWindow.waitForExistence(timeout: 5.0),
+            "Expected 'Terminal Canvas' window to appear after Cmd+Ctrl+N. windows=\(app.windows.debugDescription)"
+        )
+
+        // Wait for terminal surfaces to initialize
+        RunLoop.current.run(until: Date().addingTimeInterval(3.0))
+
+        // The canvas starts with 3 panels, each with 1 tab. Focus is on the first panel.
+        // Create 2 more tabs in the focused panel with Cmd+T
+        app.typeKey("t", modifierFlags: [.command])
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        app.typeKey("t", modifierFlags: [.command])
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        // Now the focused panel should have 3 tabs.
+        // The tab bar is at the top of each panel container.
+        // Since NiriTabBarView is a raw NSView (not accessibility-enabled), we need
+        // to use coordinate-based interaction to test drag.
+
+        let windowFrame = canvasWindow.frame
+
+        // The tab bar sits at the top of the first panel. In the layout:
+        //   - peekWidth = 60, panelGap = 12
+        //   - Panel starts at x = peekWidth + panelGap = 72 from the window's content area
+        //   - Tab bar height = 30, positioned at y = ph - tabH (top of panel in bottom-up coords)
+        //   - Panel height ph = max(300, viewH - 20)
+        //
+        // In screen coordinates (Accessibility uses top-left origin):
+        //   - Tab bar Y is near the top of the window content area
+        //   - Tab bar X starts at ~72pt from the left edge of the window
+
+        // Target the tab bar area: roughly 100pt from the left of the window, 20pt from the top
+        // (accounting for titlebar). We'll click and drag horizontally within this region.
+
+        // First, let's just try clicking in the tab bar area to see if it responds
+        let tabBarY = windowFrame.minY + 40  // near top of window (below titlebar)
+        let tabBarStartX = windowFrame.minX + 100  // first panel's tab bar region
+
+        // Click on what should be the second tab (roughly 1 tab-width to the right)
+        let tab1Center = CGPoint(x: tabBarStartX + 50, y: tabBarY)
+        let tab2Center = CGPoint(x: tabBarStartX + 150, y: tabBarY)
+        let tab3Center = CGPoint(x: tabBarStartX + 250, y: tabBarY)
+
+        // Try clicking tab 2 to select it
+        let coordTab2 = canvasWindow.coordinate(withNormalizedOffset: .zero).withOffset(
+            CGVector(dx: tab2Center.x - windowFrame.minX, dy: tab2Center.y - windowFrame.minY)
+        )
+        coordTab2.click()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        // Try clicking tab 3 to select it
+        let coordTab3 = canvasWindow.coordinate(withNormalizedOffset: .zero).withOffset(
+            CGVector(dx: tab3Center.x - windowFrame.minX, dy: tab3Center.y - windowFrame.minY)
+        )
+        coordTab3.click()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        // Now attempt a drag from tab 3's position to tab 1's position
+        // This should trigger the NSPanGestureRecognizer on NiriTabBarView
+        guard let dragSession = beginMouseDrag(
+            fromAccessibilityPoint: tab3Center,
+            holdDuration: 0.20
+        ) else {
+            XCTFail("Expected raw mouse drag session to start for niri tab bar drag")
+            return
+        }
+
+        continueMouseDrag(
+            dragSession,
+            toAccessibilityPoint: tab1Center,
+            steps: 20,
+            dragDuration: 0.40
+        )
+
+        // Hold briefly at the destination
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        endMouseDrag(dragSession, atAccessibilityPoint: tab1Center)
+
+        // Wait for any reorder animation
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        // Since NiriTabBarView doesn't expose accessibility elements for individual tabs,
+        // we can't directly verify the reorder through the accessibility hierarchy.
+        // This test primarily verifies that:
+        // 1. The canvas opens successfully
+        // 2. Cmd+T creates tabs
+        // 3. Click and drag in the tab bar area doesn't crash
+        // 4. The gesture recognizer path is exercised
+        //
+        // A more robust test would require adding accessibility identifiers to the
+        // NiriTabBarView tabs or using a data file exchange mechanism like the
+        // BonsplitTabDragUITests use.
+
+        // Verify the window is still alive and not crashed
+        XCTAssertTrue(canvasWindow.exists, "Expected canvas window to still exist after tab drag attempt")
+    }
+
+    // MARK: - Helpers
+
+    private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) {
+            return true
+        }
+        if app.state == .runningBackground {
+            app.activate()
+            return app.wait(for: .runningForeground, timeout: 6.0)
+        }
+        return false
+    }
+
+    private struct RawMouseDragSession {
+        let source: CGEventSource
+    }
+
+    private func beginMouseDrag(
+        fromAccessibilityPoint start: CGPoint,
+        holdDuration: TimeInterval = 0.15
+    ) -> RawMouseDragSession? {
+        let source = CGEventSource(stateID: .hidSystemState)
+        XCTAssertNotNil(source, "Expected CGEventSource for raw mouse drag")
+        guard let source else { return nil }
+
+        let quartzStart = quartzPoint(fromAccessibilityPoint: start)
+
+        postMouseEvent(type: .mouseMoved, at: quartzStart, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        postMouseEvent(type: .leftMouseDown, at: quartzStart, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(holdDuration))
+        return RawMouseDragSession(source: source)
+    }
+
+    private func continueMouseDrag(
+        _ session: RawMouseDragSession,
+        toAccessibilityPoint end: CGPoint,
+        steps: Int = 20,
+        dragDuration: TimeInterval = 0.30
+    ) {
+        let currentLocation = NSEvent.mouseLocation
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+        let clampedSteps = max(2, steps)
+        for step in 1...clampedSteps {
+            let progress = CGFloat(step) / CGFloat(clampedSteps)
+            let point = CGPoint(
+                x: currentLocation.x + ((quartzEnd.x - currentLocation.x) * progress),
+                y: currentLocation.y + ((quartzEnd.y - currentLocation.y) * progress)
+            )
+            postMouseEvent(type: .leftMouseDragged, at: point, source: session.source)
+            RunLoop.current.run(until: Date().addingTimeInterval(dragDuration / Double(clampedSteps)))
+        }
+    }
+
+    private func endMouseDrag(
+        _ session: RawMouseDragSession,
+        atAccessibilityPoint end: CGPoint
+    ) {
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+        postMouseEvent(type: .leftMouseUp, at: quartzEnd, source: session.source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+    }
+
+    private func postMouseEvent(
+        type: CGEventType,
+        at point: CGPoint,
+        source: CGEventSource
+    ) {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else {
+            XCTFail("Expected CGEvent for mouse type \(type.rawValue) at \(point)")
+            return
+        }
+
+        event.setIntegerValueField(.mouseEventClickState, value: 1)
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func quartzPoint(fromAccessibilityPoint point: CGPoint) -> CGPoint {
+        let desktopBounds = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+        XCTAssertFalse(desktopBounds.isNull, "Expected at least one screen when converting raw mouse coordinates")
+        guard !desktopBounds.isNull else { return point }
+        return CGPoint(x: point.x, y: desktopBounds.maxY - point.y)
+    }
+}

--- a/ghostty.h
+++ b/ghostty.h
@@ -17,6 +17,11 @@ extern "C" {
 #include <stdint.h>
 #include <sys/types.h>
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 //-------------------------------------------------------------------
 // Macros
 
@@ -437,6 +442,13 @@ typedef enum {
   GHOSTTY_SURFACE_CONTEXT_SPLIT = 2,
 } ghostty_surface_context_e;
 
+typedef enum {
+  GHOSTTY_SURFACE_IO_EXEC = 0,
+  GHOSTTY_SURFACE_IO_MANUAL = 1,
+} ghostty_surface_io_mode_e;
+
+typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+
 typedef struct {
   ghostty_platform_e platform_tag;
   ghostty_platform_u platform;
@@ -450,6 +462,9 @@ typedef struct {
   const char* initial_input;
   bool wait_after_command;
   ghostty_surface_context_e context;
+  ghostty_surface_io_mode_e io_mode;
+  ghostty_io_write_cb io_write_cb;
+  void* io_write_userdata;
 } ghostty_surface_config_s;
 
 typedef struct {
@@ -514,6 +529,15 @@ typedef struct {
   ghostty_quick_terminal_size_s primary;
   ghostty_quick_terminal_size_s secondary;
 } ghostty_config_quick_terminal_size_s;
+
+// config.Fullscreen
+typedef enum {
+  GHOSTTY_CONFIG_FULLSCREEN_FALSE,
+  GHOSTTY_CONFIG_FULLSCREEN_TRUE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_CONFIG_FULLSCREEN_NON_NATIVE_PADDED_NOTCH,
+} ghostty_config_fullscreen_e;
 
 // apprt.Target.Key
 typedef enum {
@@ -583,9 +607,9 @@ typedef enum {
 // apprt.action.Fullscreen
 typedef enum {
   GHOSTTY_FULLSCREEN_NATIVE,
-  GHOSTTY_FULLSCREEN_NON_NATIVE,
-  GHOSTTY_FULLSCREEN_NON_NATIVE_VISIBLE_MENU,
-  GHOSTTY_FULLSCREEN_NON_NATIVE_PADDED_NOTCH,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_VISIBLE_MENU,
+  GHOSTTY_FULLSCREEN_MACOS_NON_NATIVE_PADDED_NOTCH,
 } ghostty_action_fullscreen_e;
 
 // apprt.action.FloatWindow
@@ -715,7 +739,7 @@ typedef struct {
 
 // renderer.Health
 typedef enum {
-  GHOSTTY_RENDERER_HEALTH_OK,
+  GHOSTTY_RENDERER_HEALTH_HEALTHY,
   GHOSTTY_RENDERER_HEALTH_UNHEALTHY,
 } ghostty_action_renderer_health_e;
 
@@ -880,6 +904,7 @@ typedef enum {
   GHOSTTY_ACTION_RENDER_INSPECTOR,
   GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
   GHOSTTY_ACTION_SET_TITLE,
+  GHOSTTY_ACTION_SET_TAB_TITLE,
   GHOSTTY_ACTION_PROMPT_TITLE,
   GHOSTTY_ACTION_PWD,
   GHOSTTY_ACTION_MOUSE_SHAPE,
@@ -910,6 +935,7 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_TOTAL,
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
+  GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -927,6 +953,7 @@ typedef union {
   ghostty_action_inspector_e inspector;
   ghostty_action_desktop_notification_s desktop_notification;
   ghostty_action_set_title_s set_title;
+  ghostty_action_set_title_s set_tab_title;
   ghostty_action_prompt_title_e prompt_title;
   ghostty_action_pwd_s pwd;
   ghostty_action_mouse_shape_e mouse_shape;
@@ -958,7 +985,7 @@ typedef struct {
 } ghostty_action_s;
 
 typedef void (*ghostty_runtime_wakeup_cb)(void*);
-typedef void (*ghostty_runtime_read_clipboard_cb)(void*,
+typedef bool (*ghostty_runtime_read_clipboard_cb)(void*,
                                                   ghostty_clipboard_e,
                                                   void*);
 typedef void (*ghostty_runtime_confirm_read_clipboard_cb)(
@@ -1085,6 +1112,7 @@ bool ghostty_surface_key_is_binding(ghostty_surface_t,
                                     ghostty_binding_flags_e*);
 void ghostty_surface_text(ghostty_surface_t, const char*, uintptr_t);
 void ghostty_surface_preedit(ghostty_surface_t, const char*, uintptr_t);
+void ghostty_surface_process_output(ghostty_surface_t, const char*, uintptr_t);
 bool ghostty_surface_mouse_captured(ghostty_surface_t);
 bool ghostty_surface_mouse_button(ghostty_surface_t,
                                   ghostty_input_mouse_state_e,
@@ -1114,8 +1142,6 @@ void ghostty_surface_complete_clipboard_request(ghostty_surface_t,
                                                 void*,
                                                 bool);
 bool ghostty_surface_has_selection(ghostty_surface_t);
-bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
-bool ghostty_surface_clear_selection(ghostty_surface_t);
 bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 bool ghostty_surface_read_text(ghostty_surface_t,
                                ghostty_selection_s,
@@ -1127,6 +1153,8 @@ void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);
 void* ghostty_surface_quicklook_font(ghostty_surface_t);
 bool ghostty_surface_quicklook_word(ghostty_surface_t, ghostty_text_s*);
 #endif
+bool ghostty_surface_select_cursor_cell(ghostty_surface_t);
+bool ghostty_surface_clear_selection(ghostty_surface_t);
 
 ghostty_inspector_t ghostty_surface_inspector(ghostty_surface_t);
 void ghostty_inspector_free(ghostty_surface_t);

--- a/scripts/demo-paperwm.swift
+++ b/scripts/demo-paperwm.swift
@@ -1,0 +1,368 @@
+#!/usr/bin/env swift
+// PaperWM-style terminal canvas demo
+// Usage: swift scripts/demo-paperwm.swift
+//
+// Demonstrates: multiple "terminal" surfaces arranged in a horizontal strip
+// with perspective transforms and smooth 120fps scrolling via Core Animation.
+// Replace the colored placeholder layers with real IOSurface-backed layers
+// from ghostty to get actual terminal content.
+
+import AppKit
+import QuartzCore
+
+// MARK: - PaperWM Strip View
+
+class PaperStripView: NSView {
+    private var rootLayer = CATransformLayer()
+    private var panels: [CALayer] = []
+    private var scrollOffset: CGFloat = 0
+    private var targetOffset: CGFloat = 0
+    private var focusedIndex: Int = 0
+    private var displayLink: CVDisplayLink?
+    private var lastTimestamp: Double = 0
+
+    // Layout
+    let panelWidth: CGFloat = 700
+    let panelHeight: CGFloat = 450
+    let panelGap: CGFloat = 30
+    let perspectiveZ: CGFloat = -120  // how far unfocused panels recede
+    let edgeRotation: CGFloat = .pi / 14  // rotation for off-screen panels
+
+    // Terminal placeholder colors (dark themes)
+    static let themes: [(bg: NSColor, accent: NSColor, name: String)] = [
+        (.init(red: 0.11, green: 0.11, blue: 0.14, alpha: 1), .systemCyan, "neovim"),
+        (.init(red: 0.10, green: 0.12, blue: 0.10, alpha: 1), .systemGreen, "htop"),
+        (.init(red: 0.13, green: 0.11, blue: 0.15, alpha: 1), .systemPurple, "claude"),
+        (.init(red: 0.12, green: 0.10, blue: 0.08, alpha: 1), .systemOrange, "cargo build"),
+        (.init(red: 0.08, green: 0.11, blue: 0.14, alpha: 1), .systemBlue, "ssh prod"),
+        (.init(red: 0.14, green: 0.10, blue: 0.10, alpha: 1), .systemRed, "git log"),
+        (.init(red: 0.10, green: 0.13, blue: 0.12, alpha: 1), .systemTeal, "docker ps"),
+    ]
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer = CALayer()
+        layer!.backgroundColor = NSColor(red: 0.06, green: 0.06, blue: 0.08, alpha: 1).cgColor
+
+        // Sublayer transform with perspective
+        var perspective = CATransform3DIdentity
+        perspective.m34 = -1.0 / 1200
+        layer!.sublayerTransform = perspective
+
+        rootLayer.frame = bounds
+        layer!.addSublayer(rootLayer)
+
+        createPanels()
+        startDisplayLink()
+    }
+
+    private func createPanels() {
+        for (i, theme) in Self.themes.enumerated() {
+            let panel = CALayer()
+            panel.frame = CGRect(x: 0, y: 0, width: panelWidth, height: panelHeight)
+            panel.cornerRadius = 10
+            panel.masksToBounds = true
+            panel.backgroundColor = theme.bg.cgColor
+            panel.borderColor = theme.accent.withAlphaComponent(0.3).cgColor
+            panel.borderWidth = 1
+            panel.shadowColor = NSColor.black.cgColor
+            panel.shadowOpacity = 0.6
+            panel.shadowRadius = 20
+            panel.shadowOffset = CGSize(width: 0, height: -5)
+            panel.masksToBounds = false
+
+            // Title bar
+            let titleBar = CALayer()
+            titleBar.frame = CGRect(x: 0, y: panelHeight - 32, width: panelWidth, height: 32)
+            titleBar.backgroundColor = theme.bg.blended(withFraction: 0.15, of: .white)?.cgColor
+            panel.addSublayer(titleBar)
+
+            // Title text
+            let title = CATextLayer()
+            title.frame = CGRect(x: 12, y: panelHeight - 28, width: panelWidth - 24, height: 20)
+            title.string = theme.name
+            title.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)
+            title.fontSize = 12
+            title.foregroundColor = NSColor.white.withAlphaComponent(0.8).cgColor
+            title.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+            panel.addSublayer(title)
+
+            // Fake terminal content lines
+            let contentLayer = CALayer()
+            contentLayer.frame = CGRect(x: 0, y: 0, width: panelWidth, height: panelHeight - 32)
+            panel.addSublayer(contentLayer)
+
+            for line in 0..<18 {
+                let textLine = CATextLayer()
+                let y = panelHeight - 32 - CGFloat(line + 1) * 22 - 8
+                textLine.frame = CGRect(x: 14, y: y, width: panelWidth - 28, height: 18)
+                textLine.fontSize = 13
+                textLine.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+                textLine.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+
+                if line == 0 {
+                    // Prompt line
+                    let prompt = NSMutableAttributedString()
+                    prompt.append(NSAttributedString(string: "~ ", attributes: [
+                        .foregroundColor: theme.accent,
+                        .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .bold),
+                    ]))
+                    prompt.append(NSAttributedString(string: randomCommand(i, line), attributes: [
+                        .foregroundColor: NSColor.white.withAlphaComponent(0.9),
+                        .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+                    ]))
+                    textLine.string = prompt
+                } else {
+                    let alpha = max(0.15, 0.6 - Double(line) * 0.03)
+                    textLine.string = NSAttributedString(string: randomOutput(i, line), attributes: [
+                        .foregroundColor: NSColor.white.withAlphaComponent(alpha),
+                        .font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+                    ])
+                }
+                panel.addSublayer(textLine)
+            }
+
+            // Cursor blink layer
+            if i == 0 {
+                let cursor = CALayer()
+                cursor.frame = CGRect(x: 50, y: panelHeight - 32 - 22 - 8, width: 8, height: 16)
+                cursor.backgroundColor = theme.accent.cgColor
+                let blink = CABasicAnimation(keyPath: "opacity")
+                blink.fromValue = 1.0
+                blink.toValue = 0.0
+                blink.duration = 0.6
+                blink.autoreverses = true
+                blink.repeatCount = .infinity
+                cursor.add(blink, forKey: "blink")
+                panel.addSublayer(cursor)
+            }
+
+            panels.append(panel)
+            rootLayer.addSublayer(panel)
+        }
+    }
+
+    private func randomCommand(_ panel: Int, _ line: Int) -> String {
+        let commands = ["nvim src/main.zig", "htop -t", "claude", "cargo build --release",
+                        "ssh prod-web-03", "git log --oneline -20", "docker ps -a"]
+        return commands[panel % commands.count]
+    }
+
+    private func randomOutput(_ panel: Int, _ line: Int) -> String {
+        let seed = panel * 100 + line
+        let outputs = [
+            "  const std = @import(\"std\");",
+            "  pub fn main() !void {",
+            "      const allocator = std.heap.page_allocator;",
+            "  PID  USER  PR  NI  VIRT   RES   SHR S %CPU",
+            "  1284 root  20  0  45.2g  1.2g  840m S 12.3",
+            "  Compiling ghostty v0.15.2",
+            "     Running `target/release/ghostty`",
+            "  9746942 Add r/cmux to social skill subreddit list",
+            "  608d687 Add merge guardrails to community-prs skill",
+            "  CONTAINER ID  IMAGE         STATUS        PORTS",
+            "  a1b2c3d4e5f6  nginx:latest  Up 3 days     80/tcp",
+            "  Last login: Tue Mar 25 14:22:01 2026 from 10.0.1.5",
+            "  root@prod-web-03:~#",
+            "  [user] Let me check the crash logs...",
+            "  Analyzing 1043 upstream commits...",
+            "      try stdout.print(\"hello\\n\", .{});",
+            "  }",
+            "      var buf: [4096]u8 = undefined;",
+        ]
+        return outputs[seed % outputs.count]
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        rootLayer.frame = bounds
+        updateLayout(animated: false)
+    }
+
+    private func updateLayout(animated: Bool) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(!animated)
+        if animated {
+            CATransaction.setAnimationDuration(0.02)
+            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
+        }
+
+        let centerX = bounds.midX
+        let centerY = bounds.midY
+
+        for (i, panel) in panels.enumerated() {
+            let stripX = CGFloat(i) * (panelWidth + panelGap)
+            let relativeX = stripX - scrollOffset
+
+            // Position relative to center of view
+            let screenX = centerX + relativeX - panelWidth / 2
+
+            // Depth: panels further from center recede
+            let distFromCenter = abs(relativeX) / (panelWidth + panelGap)
+            let zOffset = -abs(distFromCenter) * perspectiveZ
+            let scale = max(0.75, 1.0 - distFromCenter * 0.08)
+
+            // Subtle rotation for panels going off-screen
+            let rotation = -relativeX / (bounds.width * 1.5) * edgeRotation
+
+            // Opacity falloff
+            let opacity = max(0.3, 1.0 - distFromCenter * 0.25)
+
+            var transform = CATransform3DIdentity
+            transform = CATransform3DTranslate(transform, screenX + panelWidth / 2 - centerX, 0, zOffset)
+            transform = CATransform3DRotate(transform, rotation, 0, 1, 0)
+            transform = CATransform3DScale(transform, scale, scale, 1)
+
+            panel.transform = transform
+            panel.position = CGPoint(x: centerX, y: centerY)
+            panel.opacity = Float(opacity)
+            panel.zPosition = -abs(relativeX)
+
+            // Highlight focused panel border
+            let isFocused = i == focusedIndex
+            panel.borderWidth = isFocused ? 2 : 1
+            panel.borderColor = isFocused
+                ? Self.themes[i % Self.themes.count].accent.withAlphaComponent(0.8).cgColor
+                : Self.themes[i % Self.themes.count].accent.withAlphaComponent(0.2).cgColor
+        }
+
+        CATransaction.commit()
+    }
+
+    // MARK: - Scrolling
+
+    override func scrollWheel(with event: NSEvent) {
+        // Horizontal scroll (trackpad or shift+scroll)
+        var dx = event.scrollingDeltaX
+        if event.isDirectionInvertedFromDevice { dx = -dx }
+
+        // Also support vertical scroll as horizontal
+        var dy = event.scrollingDeltaY
+        if event.isDirectionInvertedFromDevice { dy = -dy }
+
+        let delta = abs(dx) > abs(dy) ? dx : dy
+        targetOffset += delta * 2.5
+
+        // Clamp
+        let maxOffset = CGFloat(panels.count - 1) * (panelWidth + panelGap)
+        targetOffset = max(0, min(maxOffset, targetOffset))
+
+        // Update focused index
+        focusedIndex = Int(round(targetOffset / (panelWidth + panelGap)))
+        focusedIndex = max(0, min(panels.count - 1, focusedIndex))
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 123: // left arrow
+            focusedIndex = max(0, focusedIndex - 1)
+            targetOffset = CGFloat(focusedIndex) * (panelWidth + panelGap)
+        case 124: // right arrow
+            focusedIndex = min(panels.count - 1, focusedIndex + 1)
+            targetOffset = CGFloat(focusedIndex) * (panelWidth + panelGap)
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    // MARK: - Display Link (120fps)
+
+    private func startDisplayLink() {
+        CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
+        guard let displayLink else { return }
+
+        let callback: CVDisplayLinkOutputCallback = { _, _, _, _, _, userInfo -> CVReturn in
+            let view = Unmanaged<PaperStripView>.fromOpaque(userInfo!).takeUnretainedValue()
+            DispatchQueue.main.async { view.tick() }
+            return kCVReturnSuccess
+        }
+
+        CVDisplayLinkSetOutputCallback(displayLink, callback,
+            Unmanaged.passUnretained(self).toOpaque())
+        CVDisplayLinkStart(displayLink)
+    }
+
+    private func tick() {
+        // Smooth spring-like interpolation
+        let stiffness: CGFloat = 0.15
+        let damping: CGFloat = 0.85
+        let diff = targetOffset - scrollOffset
+        scrollOffset += diff * stiffness
+        scrollOffset = scrollOffset * damping + targetOffset * (1 - damping)
+
+        // Snap when close enough
+        if abs(diff) < 0.5 {
+            scrollOffset = targetOffset
+        }
+
+        updateLayout(animated: false)
+    }
+
+    deinit {
+        if let displayLink {
+            CVDisplayLinkStop(displayLink)
+        }
+    }
+}
+
+// MARK: - App Setup
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var window: NSWindow!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let screen = NSScreen.main!.frame
+        let windowRect = NSRect(
+            x: screen.midX - 700,
+            y: screen.midY - 300,
+            width: 1400,
+            height: 600
+        )
+
+        window = NSWindow(
+            contentRect: windowRect,
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "PaperWM Terminal Canvas"
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = NSColor(red: 0.06, green: 0.06, blue: 0.08, alpha: 1)
+        window.isMovableByWindowBackground = true
+        window.minSize = NSSize(width: 800, height: 400)
+
+        let stripView = PaperStripView(frame: window.contentView!.bounds)
+        stripView.autoresizingMask = [.width, .height]
+        window.contentView!.addSubview(stripView)
+        window.makeFirstResponder(stripView)
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+}
+
+// MARK: - Main
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/scripts/test-tabbar.swift
+++ b/scripts/test-tabbar.swift
@@ -1,0 +1,127 @@
+#!/usr/bin/env swift
+// Minimal test: NiriTabBarView in a plain window. Does drag work?
+import AppKit
+import CoreText
+
+final class TestTabBar: NSView {
+    var tabs: [String] = ["Tab 1", "Tab 2", "Tab 3"]
+    var selectedIndex = 0
+    private var dragSrcIdx: Int?
+    private var dragStartX: CGFloat = 0
+    private var dragActive = false
+    private var dropIdx: Int?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+    override var isFlipped: Bool { false }
+    override var acceptsFirstResponder: Bool { true }
+
+    var tabWidth: CGFloat { bounds.width / CGFloat(max(1, tabs.count)) }
+
+    func tabIndex(at pt: NSPoint) -> Int? {
+        let idx = Int(pt.x / tabWidth)
+        return idx >= 0 && idx < tabs.count ? idx : nil
+    }
+
+    func insertionIndex(at pt: NSPoint) -> Int {
+        max(0, min(tabs.count, Int(pt.x / tabWidth + 0.5)))
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let pt = convert(event.locationInWindow, from: nil)
+        dragSrcIdx = tabIndex(at: pt)
+        dragStartX = pt.x
+        dragActive = false
+        print("mouseDown pt=\(pt) idx=\(dragSrcIdx ?? -1)")
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let src = dragSrcIdx else { return }
+        let pt = convert(event.locationInWindow, from: nil)
+        if !dragActive && abs(pt.x - dragStartX) > 5 { dragActive = true }
+        guard dragActive else { return }
+        let ins = insertionIndex(at: pt)
+        dropIdx = (ins != src && ins != src + 1) ? ins : nil
+        print("mouseDragged pt=\(pt) dropIdx=\(dropIdx ?? -1)")
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        print("mouseUp dragActive=\(dragActive) src=\(dragSrcIdx ?? -1)")
+        if dragActive, let src = dragSrcIdx, let ins = dropIdx {
+            var dest = ins
+            if dest > src { dest -= 1 }
+            if dest != src && dest >= 0 && dest < tabs.count {
+                let tab = tabs.remove(at: src)
+                tabs.insert(tab, at: dest)
+                selectedIndex = dest
+                print("REORDER: \(src) -> \(dest) tabs=\(tabs)")
+            }
+        } else if let idx = dragSrcIdx {
+            selectedIndex = idx
+            print("SELECT: \(idx)")
+        }
+        dragSrcIdx = nil; dragActive = false; dropIdx = nil
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        ctx.setFillColor(CGColor(gray: 0.15, alpha: 1))
+        ctx.fill(bounds)
+
+        let tw = tabWidth
+        for (i, title) in tabs.enumerated() {
+            let x = CGFloat(i) * tw
+            if i == selectedIndex {
+                ctx.setFillColor(CGColor(gray: 0.25, alpha: 1))
+                ctx.fill(CGRect(x: x, y: 0, width: tw, height: bounds.height))
+                ctx.setFillColor(CGColor(srgbRed: 0, green: 0.48, blue: 1, alpha: 1))
+                ctx.fill(CGRect(x: x, y: 0, width: tw, height: 2))
+            }
+            if i > 0 {
+                ctx.setFillColor(CGColor(gray: 0.3, alpha: 1))
+                ctx.fill(CGRect(x: x, y: 5, width: 1, height: bounds.height - 10))
+            }
+            let font = CTFontCreateWithName("Helvetica Neue" as CFString, 12, nil)
+            let attrs: [CFString: Any] = [kCTFontAttributeName: font, kCTForegroundColorFromContextAttributeName: true]
+            let str = CFAttributedStringCreate(nil, title as CFString, attrs as CFDictionary)!
+            let line = CTLineCreateWithAttributedString(str)
+            ctx.saveGState()
+            ctx.setFillColor(CGColor(gray: 1, alpha: 0.8))
+            ctx.textPosition = CGPoint(x: x + 10, y: bounds.height / 2 - 4)
+            CTLineDraw(line, ctx)
+            ctx.restoreGState()
+        }
+
+        // Drop indicator
+        if let di = dropIdx {
+            let dx = CGFloat(di) * tw
+            ctx.setFillColor(CGColor(srgbRed: 0, green: 0.48, blue: 1, alpha: 1))
+            ctx.fill(CGRect(x: dx - 1.5, y: 4, width: 3, height: bounds.height - 8))
+        }
+    }
+}
+
+// -- App --
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+
+let w = NSWindow(contentRect: NSRect(x: 400, y: 400, width: 600, height: 400),
+                 styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
+w.title = "Tab Bar Test"
+
+let content = NSView(frame: w.contentView!.bounds)
+content.autoresizingMask = [.width, .height]
+content.wantsLayer = true
+content.layer?.backgroundColor = CGColor(gray: 0.1, alpha: 1)
+
+let tabBar = TestTabBar(frame: NSRect(x: 0, y: content.bounds.height - 30, width: content.bounds.width, height: 30))
+tabBar.autoresizingMask = [.width, .minYMargin]
+content.addSubview(tabBar)
+
+w.contentView = content
+w.makeKeyAndOrderFront(nil)
+app.activate(ignoringOtherApps: true)
+
+print("Tab bar test running. Click and drag tabs to reorder.")
+app.run()


### PR DESCRIPTION
## Summary

Merges 1043 new commits from ghostty-org/ghostty into the manaflow-ai/ghostty fork, then updates the submodule pointer.

All cmux-specific patches preserved:
- OSC 99 notification parser
- cursor-click-to-move for OSC133
- macOS resize frame fixes (display link restart, stale-frame gravity)
- Pure prompt redraw markers
- Theme picker helper hooks

## Testing

- Conflict resolution verified: no conflict markers remain
- Zig build cannot be tested locally (macOS 26 zig linker issue, pre-existing), CI will verify
- Ghostty fork branch: https://github.com/manaflow-ai/ghostty/tree/task-ghostty-upstream-sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `ghostty` to the latest upstream (1043 commits), preserves all cmux patches, and adapts to upstream API changes. Adds a debug-only Niri/PaperWM-style terminal canvas with per-panel tabs and drag-and-drop.

- New Features
  - Debug-only Niri canvas (Cmd+Ctrl+N): per-panel tabs with cross-panel drag-drop and blue drop indicators.
  - Keyboard controls: Cmd+Opt+Arrows / Cmd+Ctrl+H/L navigate, Cmd+Ctrl+R resize, Cmd+T add tab, Cmd+N add panel, Cmd+W/Ctrl+D close, Ctrl+1–9 switch tabs.
  - Smooth 120fps animations, auto-scroll to reveal focused panels.

- Upstream/API Changes
  - Clipboard read callback now returns Bool; we return true when scheduled and false on missing context.
  - Handle new GHOSTTY_ACTION_SET_TAB_TITLE (ignored; cmux manages titles).
  - Update `ghostty.h` to upstream: IO mode/write callback, fullscreen enum updates, renderer health rename, new actions/functions; cmux-specific selection APIs retained.

<sup>Written for commit 007569f57b8370447705987be13f4721c5bf479e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal can set tab titles and copy titles to the clipboard.
  * Experimental multi-panel "Niri Canvas" terminal canvas with keyboard controls (debug/experimental).
  * Demo "PaperWM"-style strip and a standalone tab-bar test app added.

* **Bug Fixes**
  * Clipboard-read flow now reliably reports success when a read is scheduled/performed.

* **Chores**
  * Updated the embedded Ghostty component to a newer checked-in version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->