### PR TITLE
Fix update attempt refreshing pill without actually updating

### DIFF
--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -177,7 +177,6 @@ class UpdateController {
     func attemptUpdate() {
         stopAttemptUpdateMonitoring()
         didObserveAttemptUpdateProgress = false
-        userDriver.autoInstallOnNextUpdate = true
 
         attemptInstallCancellable = viewModel.$state
             .receive(on: DispatchQueue.main)
@@ -188,9 +187,6 @@ class UpdateController {
                     self.didObserveAttemptUpdateProgress = true
                 }
 
-                // Fallback: auto-confirm if we reach .updateAvailable
-                // (e.g. the driver flag was cleared by a dismiss before
-                // showUpdateFound fired).
                 if case .updateAvailable = state {
                     UpdateLogStore.shared.append("attemptUpdate auto-confirming available update")
                     state.confirm()
@@ -200,14 +196,6 @@ class UpdateController {
                 guard self.didObserveAttemptUpdateProgress, !state.isInstallable else {
                     return
                 }
-
-                // While the driver's auto-install flag is set, the Sparkle
-                // check may still be starting up. Don't tear down on a
-                // transient .idle that occurs during retry/probe races.
-                if state.isIdle, self.userDriver.autoInstallOnNextUpdate {
-                    return
-                }
-
                 self.stopAttemptUpdateMonitoring()
             }
 
@@ -291,7 +279,6 @@ class UpdateController {
         attemptInstallCancellable?.cancel()
         attemptInstallCancellable = nil
         didObserveAttemptUpdateProgress = false
-        userDriver.autoInstallOnNextUpdate = false
     }
 
     private func installNoUpdateDismissObserver() {

--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -193,7 +193,10 @@ class UpdateController {
                     return
                 }
 
-                guard self.didObserveAttemptUpdateProgress, !state.isInstallable else {
+                // Only stop on terminal failure states (.notFound, .error).
+                // Don't stop on .idle — the check may still be starting up
+                // (e.g. retry loop, background probe finishing).
+                guard self.didObserveAttemptUpdateProgress, !state.isInstallable, !state.isIdle else {
                     return
                 }
                 self.stopAttemptUpdateMonitoring()

--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -177,6 +177,7 @@ class UpdateController {
     func attemptUpdate() {
         stopAttemptUpdateMonitoring()
         didObserveAttemptUpdateProgress = false
+        userDriver.autoInstallOnNextUpdate = true
 
         attemptInstallCancellable = viewModel.$state
             .receive(on: DispatchQueue.main)
@@ -187,6 +188,9 @@ class UpdateController {
                     self.didObserveAttemptUpdateProgress = true
                 }
 
+                // Fallback: auto-confirm if we reach .updateAvailable
+                // (e.g. the driver flag was cleared by a dismiss before
+                // showUpdateFound fired).
                 if case .updateAvailable = state {
                     UpdateLogStore.shared.append("attemptUpdate auto-confirming available update")
                     state.confirm()
@@ -196,6 +200,14 @@ class UpdateController {
                 guard self.didObserveAttemptUpdateProgress, !state.isInstallable else {
                     return
                 }
+
+                // While the driver's auto-install flag is set, the Sparkle
+                // check may still be starting up. Don't tear down on a
+                // transient .idle that occurs during retry/probe races.
+                if state.isIdle, self.userDriver.autoInstallOnNextUpdate {
+                    return
+                }
+
                 self.stopAttemptUpdateMonitoring()
             }
 
@@ -279,6 +291,7 @@ class UpdateController {
         attemptInstallCancellable?.cancel()
         attemptInstallCancellable = nil
         didObserveAttemptUpdateProgress = false
+        userDriver.autoInstallOnNextUpdate = false
     }
 
     private func installNoUpdateDismissObserver() {

--- a/Sources/Update/UpdateDriver.swift
+++ b/Sources/Update/UpdateDriver.swift
@@ -10,12 +10,6 @@ class UpdateDriver: NSObject, SPUUserDriver {
     private var checkTimeoutWorkItem: DispatchWorkItem?
     private var lastFeedURLString: String?
 
-    /// When true, the next update found by Sparkle is confirmed immediately
-    /// without waiting for the minimum-check-display delay. This prevents
-    /// the delayed `.updateAvailable` transition from being preempted by
-    /// a `dismissUpdateInstallation` call (e.g. from a background probe race).
-    var autoInstallOnNextUpdate: Bool = false
-
     init(viewModel: UpdateViewModel, hostBundle _: Bundle) {
         self.viewModel = viewModel
         super.init()
@@ -50,12 +44,6 @@ class UpdateDriver: NSObject, SPUUserDriver {
                          state: SPUUserUpdateState,
                          reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
         UpdateLogStore.shared.append("show update found: \(appcastItem.displayVersionString)")
-        if autoInstallOnNextUpdate {
-            autoInstallOnNextUpdate = false
-            UpdateLogStore.shared.append("auto-installing update (attemptUpdate)")
-            reply(.install)
-            return
-        }
         setStateAfterMinimumCheckDelay(.updateAvailable(.init(appcastItem: appcastItem, reply: reply)))
     }
 
@@ -69,14 +57,12 @@ class UpdateDriver: NSObject, SPUUserDriver {
 
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
-        autoInstallOnNextUpdate = false
         UpdateLogStore.shared.append("show update not found: \(formatErrorForLog(error))")
         setStateAfterMinimumCheckDelay(.notFound(.init(acknowledgement: acknowledgement)))
     }
 
     func showUpdaterError(_ error: any Error,
                           acknowledgement: @escaping () -> Void) {
-        autoInstallOnNextUpdate = false
         let details = formatErrorForLog(error)
         UpdateLogStore.shared.append("show updater error: \(details)")
         setState(.error(.init(
@@ -165,7 +151,6 @@ class UpdateDriver: NSObject, SPUUserDriver {
     }
 
     func dismissUpdateInstallation() {
-        autoInstallOnNextUpdate = false
         UpdateLogStore.shared.append("dismiss update installation")
         if case .error = viewModel.state {
             UpdateLogStore.shared.append("dismiss update installation ignored (error visible)")

--- a/Sources/Update/UpdateDriver.swift
+++ b/Sources/Update/UpdateDriver.swift
@@ -10,6 +10,12 @@ class UpdateDriver: NSObject, SPUUserDriver {
     private var checkTimeoutWorkItem: DispatchWorkItem?
     private var lastFeedURLString: String?
 
+    /// When true, the next update found by Sparkle is confirmed immediately
+    /// without waiting for the minimum-check-display delay. This prevents
+    /// the delayed `.updateAvailable` transition from being preempted by
+    /// a `dismissUpdateInstallation` call (e.g. from a background probe race).
+    var autoInstallOnNextUpdate: Bool = false
+
     init(viewModel: UpdateViewModel, hostBundle _: Bundle) {
         self.viewModel = viewModel
         super.init()
@@ -44,6 +50,12 @@ class UpdateDriver: NSObject, SPUUserDriver {
                          state: SPUUserUpdateState,
                          reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
         UpdateLogStore.shared.append("show update found: \(appcastItem.displayVersionString)")
+        if autoInstallOnNextUpdate {
+            autoInstallOnNextUpdate = false
+            UpdateLogStore.shared.append("auto-installing update (attemptUpdate)")
+            reply(.install)
+            return
+        }
         setStateAfterMinimumCheckDelay(.updateAvailable(.init(appcastItem: appcastItem, reply: reply)))
     }
 
@@ -57,12 +69,14 @@ class UpdateDriver: NSObject, SPUUserDriver {
 
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
+        autoInstallOnNextUpdate = false
         UpdateLogStore.shared.append("show update not found: \(formatErrorForLog(error))")
         setStateAfterMinimumCheckDelay(.notFound(.init(acknowledgement: acknowledgement)))
     }
 
     func showUpdaterError(_ error: any Error,
                           acknowledgement: @escaping () -> Void) {
+        autoInstallOnNextUpdate = false
         let details = formatErrorForLog(error)
         UpdateLogStore.shared.append("show updater error: \(details)")
         setState(.error(.init(
@@ -151,6 +165,7 @@ class UpdateDriver: NSObject, SPUUserDriver {
     }
 
     func dismissUpdateInstallation() {
+        autoInstallOnNextUpdate = false
         UpdateLogStore.shared.append("dismiss update installation")
         if case .error = viewModel.state {
             UpdateLogStore.shared.append("dismiss update installation ignored (error visible)")


### PR DESCRIPTION
## Summary

- Add `!state.isIdle` to the `attemptUpdate()` subscriber teardown guard so monitoring only stops on terminal failures (`.notFound`, `.error`), not on transient `.idle` during check startup

The subscriber watched `viewModel.$state` to auto-confirm `.updateAvailable`. But it also tore down on any non-installable state after observing progress, including `.idle`. During check startup (retry loop waiting for `canCheckForUpdates`, background probe finishing), state can transiently return to `.idle` before Sparkle's interactive check begins. The subscriber interpreted this as a completed check and stopped, so the auto-confirm never fired.

## Testing

- Timing-dependent race, not reliably reproducible in automated tests. Validated by code review.

## Related

- Task: https://github.com/manaflow-ai/cmux/issues/2166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update monitoring stability to prevent premature termination during transient state transitions, ensuring more reliable update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->