### PR TITLE
Fix Cmd+N crash from workspace creation config snapshots

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -816,7 +816,7 @@ class TabManager: ObservableObject {
         let selectedTabId: UUID?
         let selectedTabWasPinned: Bool
         let preferredWorkingDirectory: String?
-        let inheritedTerminalConfig: ghostty_surface_config_s?
+        let inheritedTerminalFontPoints: Float?
     }
     private var agentPIDSweepTimer: DispatchSourceTimer?
     private var workspaceGitMetadataPollTimer: DispatchSourceTimer?
@@ -1218,7 +1218,9 @@ class TabManager: ObservableObject {
         sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
         let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
-        let inheritedConfig = snapshot.inheritedTerminalConfig
+        let inheritedConfig = workspaceCreationConfigTemplate(
+            inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
+        )
         // Resolve placement against the pre-creation snapshot before Workspace init
         // boots terminal state. The ssh/new-workspace path can otherwise crash while
         // reading @Published placement state from existing workspaces mid-creation.
@@ -2191,7 +2193,7 @@ class TabManager: ObservableObject {
             selectedTabId: currentSelectedTabId,
             selectedTabWasPinned: selectedTabSnapshot?.isPinned ?? false,
             preferredWorkingDirectory: preferredWorkingDirectoryForNewTab(workspace: selectedWorkspace),
-            inheritedTerminalConfig: inheritedTerminalConfigForNewWorkspace(workspace: selectedWorkspace)
+            inheritedTerminalFontPoints: inheritedTerminalFontPointsForNewWorkspace(workspace: selectedWorkspace)
         )
     }
 
@@ -2269,6 +2271,30 @@ class TabManager: ObservableObject {
             return config
         }
         return nil
+    }
+
+    private func inheritedTerminalFontPointsForNewWorkspace(
+        workspace: Workspace?
+    ) -> Float? {
+        guard let inheritedConfig = inheritedTerminalConfigForNewWorkspace(workspace: workspace),
+              inheritedConfig.font_size > 0 else {
+            return nil
+        }
+        return inheritedConfig.font_size
+    }
+
+    private func workspaceCreationConfigTemplate(
+        inheritedTerminalFontPoints: Float?
+    ) -> ghostty_surface_config_s? {
+        guard let inheritedTerminalFontPoints, inheritedTerminalFontPoints > 0 else {
+            return nil
+        }
+        // ghostty_surface_config_s can carry raw C pointers owned by the source surface.
+        // New workspace creation only needs the inherited zoom level, so rebuild a clean
+        // config instead of snapshotting pointer-backed fields across workspace creation.
+        var config = ghostty_surface_config_new()
+        config.font_size = inheritedTerminalFontPoints
+        return config
     }
 
     private func normalizedWorkingDirectory(_ directory: String?) -> String? {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2251,7 +2251,7 @@ class TabManager: ObservableObject {
         inheritedTerminalConfigForNewWorkspace(workspace: selectedWorkspace)
     }
 
-    private func inheritedTerminalConfigForNewWorkspace(
+    func inheritedTerminalConfigForNewWorkspace(
         workspace: Workspace?
     ) -> ghostty_surface_config_s? {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(workspace: workspace),

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -511,6 +511,92 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
     }
 }
 
+@MainActor
+final class WorkspaceCreationConfigSanitizationTests: XCTestCase {
+    private final class UnsafeConfigSnapshotTabManager: TabManager {
+        private var retainedCStringPointers: [UnsafeMutablePointer<CChar>] = []
+        private var retainedEnvVars: UnsafeMutablePointer<ghostty_env_var_s>?
+        private var injectedConfig: ghostty_surface_config_s?
+        var capturedConfigTemplate: ghostty_surface_config_s?
+
+        deinit {
+            retainedEnvVars?.deinitialize(count: 1)
+            retainedEnvVars?.deallocate()
+            for pointer in retainedCStringPointers {
+                free(pointer)
+            }
+        }
+
+        func installInjectedConfig(fontSize: Float) {
+            let workingDirectory = strdup("/tmp/cmux-workspace-snapshot")
+            let command = strdup("echo snapshot")
+            let envKey = strdup("CMUX_INHERITED_ENV")
+            let envValue = strdup("1")
+            let envVars = UnsafeMutablePointer<ghostty_env_var_s>.allocate(capacity: 1)
+            envVars.initialize(
+                to: ghostty_env_var_s(
+                    key: UnsafePointer(envKey),
+                    value: UnsafePointer(envValue)
+                )
+            )
+
+            retainedCStringPointers = [workingDirectory, command, envKey, envValue].compactMap { $0 }
+            retainedEnvVars = envVars
+
+            var config = ghostty_surface_config_new()
+            config.font_size = fontSize
+            config.working_directory = UnsafePointer(workingDirectory)
+            config.command = UnsafePointer(command)
+            config.env_vars = envVars
+            config.env_var_count = 1
+            injectedConfig = config
+        }
+
+        override func inheritedTerminalConfigForNewWorkspace(
+            workspace: Workspace?
+        ) -> ghostty_surface_config_s? {
+            injectedConfig ?? super.inheritedTerminalConfigForNewWorkspace(workspace: workspace)
+        }
+
+        override func makeWorkspaceForCreation(
+            title: String,
+            workingDirectory: String?,
+            portOrdinal: Int,
+            configTemplate: ghostty_surface_config_s?,
+            initialTerminalCommand: String?,
+            initialTerminalEnvironment: [String: String]
+        ) -> Workspace {
+            capturedConfigTemplate = configTemplate
+            return super.makeWorkspaceForCreation(
+                title: title,
+                workingDirectory: workingDirectory,
+                portOrdinal: portOrdinal,
+                configTemplate: configTemplate,
+                initialTerminalCommand: initialTerminalCommand,
+                initialTerminalEnvironment: initialTerminalEnvironment
+            )
+        }
+    }
+
+    func testAddWorkspacePassesSanitizedInheritedConfigTemplate() {
+        let manager = UnsafeConfigSnapshotTabManager()
+        manager.installInjectedConfig(fontSize: 19)
+
+        _ = manager.addWorkspace()
+
+        guard let capturedConfig = manager.capturedConfigTemplate else {
+            XCTFail("Expected captured config template for new workspace")
+            return
+        }
+
+        XCTAssertEqual(capturedConfig.font_size, 19, accuracy: 0.001)
+        XCTAssertNil(capturedConfig.working_directory)
+        XCTAssertNil(capturedConfig.command)
+        XCTAssertNil(capturedConfig.env_vars)
+        XCTAssertEqual(capturedConfig.env_var_count, 0)
+    }
+}
+
 
 final class WorkspaceTabColorSettingsTests: XCTestCase {
     func testNormalizedHexAcceptsAndNormalizesValidInput() {


### PR DESCRIPTION
## Summary
- add a regression test that injects pointer-backed inherited terminal config into workspace creation and asserts only sanitized values are forwarded
- stop `WorkspaceCreationSnapshot` from storing the full `ghostty_surface_config_s`; snapshot only inherited font points and rebuild a clean config template during workspace creation
- keep the regression-test commit separate from the fix commit so CI can show the failure before the sanitization lands

## Context
PR #2133 stopped snapshotting live `Workspace` references, but `WorkspaceCreationSnapshot` still retained a full `ghostty_surface_config_s`. That C struct can include raw pointers owned by the source terminal surface. If Cmd+N captures the snapshot and the source workspace or surface tears down before the new workspace is created, the snapshot can carry dangling pointers and crash in the Cmd+N path described in #2157.

Closes #2157

## Validation
- `./scripts/reload.sh --tag cmd-n-fix --launch`
- Local tests not run per repo policy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal configuration inheritance when creating new workspaces—font size now properly carries over from the parent workspace while other settings are appropriately sanitized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->