### PR TITLE
fix(quit): enforce Warn Before Quit when Cmd+Q arrives via app switcher

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2212,6 +2212,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lastTypingActivityAt: TimeInterval = 0
     private var didHandleExplicitOpenIntentAtStartup = false
     private var isTerminatingApp = false
+    // Set to true when the user has already confirmed quit via the warning dialog,
+    // so applicationShouldTerminate does not show a second alert.
+    private var isQuitWarningConfirmed = false
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -2701,7 +2704,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
-        return .terminateNow
+
+        // If the user already confirmed via the Cmd+Q shortcut warning dialog
+        // (handleQuitShortcutWarning), skip the check to avoid a second alert.
+        if isQuitWarningConfirmed {
+            return .terminateNow
+        }
+
+        // Respect the "Warn Before Quit" setting even when Cmd+Q arrives via
+        // the Cmd+Tab app switcher, bypassing handleCustomShortcut.
+        guard QuitWarningSettings.isEnabled() else {
+            return .terminateNow
+        }
+
+        // Show the same confirmation dialog used by the Cmd+Q shortcut path,
+        // then reply asynchronously so we can return .terminateLater now.
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = String(localized: "dialog.quitCmux.title", defaultValue: "Quit cmux?")
+            alert.informativeText = String(localized: "dialog.quitCmux.message", defaultValue: "This will close all windows and workspaces.")
+            alert.addButton(withTitle: String(localized: "dialog.quitCmux.quit", defaultValue: "Quit"))
+            alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+            alert.showsSuppressionButton = true
+            alert.suppressionButton?.title = String(localized: "dialog.dontWarnCmdQ", defaultValue: "Don't warn again for Cmd+Q")
+
+            let response = alert.runModal()
+            if alert.suppressionButton?.state == .on {
+                QuitWarningSettings.setEnabled(false)
+            }
+
+            let shouldQuit = response == .alertFirstButtonReturn
+            if shouldQuit {
+                self.isQuitWarningConfirmed = true
+            } else {
+                // Reset so that the next quit attempt can show the dialog again.
+                self.isTerminatingApp = false
+            }
+            NSApp.reply(toApplicationShouldTerminate: shouldQuit)
+        }
+        return .terminateLater
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -8983,6 +9025,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if response == .alertFirstButtonReturn {
+            // Mark as confirmed so applicationShouldTerminate does not show a
+            // second alert when NSApp.terminate re-enters the delegate callback.
+            isQuitWarningConfirmed = true
             NSApp.terminate(nil)
         }
         return true


### PR DESCRIPTION
## Summary

- `applicationShouldTerminate` was unconditionally returning `.terminateNow`, bypassing the `QuitWarningSettings` check entirely
- When Cmd+Q is pressed in the Cmd+Tab app switcher, macOS calls `applicationShouldTerminate` directly without going through `handleCustomShortcut`, so the existing dialog in `handleQuitShortcutWarning` was never shown
- Fix: check `QuitWarningSettings.isEnabled()` in `applicationShouldTerminate`; if enabled, show the same confirmation alert (with suppression button) and reply asynchronously via `NSApp.reply(toApplicationShouldTerminate:)`
- Add `isQuitWarningConfirmed` flag to prevent a double dialog when the normal Cmd+Q path (`handleQuitShortcutWarning`) has already obtained user confirmation before calling `NSApp.terminate`

Fixes #2139

## Test plan

- [ ] Enable Settings → Warn Before Quit
- [ ] Press Cmd+Tab to open the app switcher, then press Cmd+Q while cmux is highlighted — confirm that the "Quit cmux?" alert appears and cancelling keeps the app running
- [ ] With warning enabled, press Cmd+Q normally (not via app switcher) — confirm only one alert appears (no double dialog)
- [ ] Tick "Don't warn again for Cmd+Q" in the app-switcher alert — confirm subsequent quits (both paths) skip the dialog
- [ ] Disable Warn Before Quit in Settings — confirm Cmd+Q via app switcher quits immediately without any alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quit confirmation dialog appearing multiple times during app termination.
  * Improved stability when dismissing the quit warning prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->