### PR TITLE
fix: evaluate surface-by-number shortcut before workspace-by-number

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9618,6 +9618,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Numeric shortcuts for surfaces within the focused pane (9 = last).
+        // Evaluated before workspace shortcuts so that when both shortcuts share the
+        // same modifier key (e.g. the user remaps workspace shortcut to Control+N),
+        // the workspace handler's unconditional "return true" cannot swallow a
+        // Control+1 surface-switch event before this check runs. See #2163.
+        if let digit = numberedShortcutDigit(
+            event: event,
+            shortcut: KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber)
+        ) {
+            if digit == 9 {
+                tabManager?.selectLastSurface()
+            } else {
+                tabManager?.selectSurface(at: digit - 1)
+            }
+            return true
+        }
+
         // Numeric shortcuts for specific workspaces (9 = last workspace)
         // Always consume the event when the digit matches to prevent Ghostty's
         // goto_tab fallback from creating a new window when the index is out of bounds.
@@ -9633,19 +9650,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
 #endif
                 manager.selectTab(at: targetIndex)
-            }
-            return true
-        }
-
-        // Numeric shortcuts for surfaces within the focused pane (9 = last)
-        if let digit = numberedShortcutDigit(
-            event: event,
-            shortcut: KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber)
-        ) {
-            if digit == 9 {
-                tabManager?.selectLastSurface()
-            } else {
-                tabManager?.selectSurface(at: digit - 1)
             }
             return true
         }


### PR DESCRIPTION
## Summary

Fixes #2163 — Control+1 cannot switch to the first tab, while Control+2/3/4 work correctly.

### Root cause

PR #2033 changed the workspace numeric shortcut handler to **always consume the key event** (`return true`) even when the target workspace index is out of range, to prevent Ghostty's `goto_tab` fallback from opening a new window. However, this introduced a regression: because the workspace check runs first and unconditionally consumes the event whenever a digit is matched, it can swallow a Control+1 surface-switch event before the surface handler ever gets a chance to execute.

Specifically:

```swift
// Workspace check (runs first) — always returns true if digit matched
if let digit = numberedShortcutDigit(event: event, shortcut: ...selectWorkspaceByNumber) {
    if let targetIndex = ... { manager.selectTab(at: targetIndex) }
    return true  // ← always consumed, blocks the surface check below
}

// Surface check (never reached when modifier collision occurs)
if let digit = numberedShortcutDigit(event: event, shortcut: ...selectSurfaceByNumber) { ... }
```

In the **default configuration** (workspace = Cmd+1, surface = Control+1), the two shortcuts use different modifiers, so the workspace `numberedShortcutDigit` call returns `nil` for a Control+1 event and the collision does not occur. However, if the user **remaps the workspace shortcut to share the same modifier as the surface shortcut** (e.g. Control+N), the workspace block fires first and swallows Control+1 before surface selection can run. Control+2/3/4 are unaffected because at higher digit values the workspace index is often out of range and the original guard would have fallen through — but with the PR #2033 "always consume" change that fallthrough is gone.

### Fix

Move the `selectSurfaceByNumber` check **above** the `selectWorkspaceByNumber` check. Since the two shortcuts have different default modifiers, this is completely transparent for users on default settings. For any custom configuration where both shortcuts share the same modifier, surface selection now takes precedence over workspace selection, which matches the intent of pressing Control+1 to switch the first terminal surface.

## Test plan

- [ ] Press **Control+1** with multiple terminal surfaces open — first surface is selected
- [ ] Press **Control+2**, **Control+3**, **Control+4** — correct surfaces are selected (no regression)
- [ ] Press **Cmd+1**, **Cmd+2** — workspace switching still works correctly
- [ ] With default shortcut settings, verify no change in behavior for workspace switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with numeric keyboard shortcuts used for quick surface navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->