### PR TITLE
fix(workspace): ensure terminal redraws after keyboard workspace switch

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3148,6 +3148,13 @@ class TabManager: ObservableObject {
         // Route workspace reactivation through the normal focus machinery so panel-local
         // activation intents like browser find-field focus are restored on return.
         tab.focusPanel(panelId)
+
+        // During keyboard workspace cycling (isWorkspaceCycleHot), the incoming workspace
+        // may already be mounted and its terminal already visible (isVisibleInUI == true),
+        // so the normal setVisibleInUI false→true transition that triggers a redraw and
+        // AppKit first-responder apply does not fire. Schedule an event-driven follow-up
+        // to ensure the terminal surface redraws and receives focus even in that case.
+        tab.requestTerminalFocusFollowUp(for: panelId)
     }
 
     func completePendingWorkspaceUnfocus(reason: String) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8621,6 +8621,20 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Schedules an event-driven layout follow-up to ensure the given terminal panel
+    /// redraws and acquires AppKit focus after a workspace switch. Called by TabManager
+    /// after changing selectedTabId via keyboard navigation (Cmd+Ctrl+]/[), where the
+    /// workspace and its terminal may already be mounted/visible (isWorkspaceCycleHot),
+    /// so the normal setVisibleInUI false→true transition that triggers a redraw does
+    /// not occur.
+    func requestTerminalFocusFollowUp(for panelId: UUID) {
+        guard panels[panelId] is TerminalPanel else { return }
+        beginEventDrivenLayoutFollowUp(
+            reason: "workspace.switch.followUp",
+            terminalFocusPanelId: panelId
+        )
+    }
+
     private func maybeAutoFocusBrowserAddressBarOnPanelFocus(
         _ browserPanel: BrowserPanel,
         trigger: FocusPanelTrigger


### PR DESCRIPTION
## Summary

- During keyboard workspace cycling (`Cmd+Ctrl+]/[`), `isWorkspaceCycleHot` causes the incoming workspace to remain mounted, so its terminal's `isVisibleInUI` never transitions `false→true`
- This skips the occlusion and automatic first-responder apply chain that normally triggers `forceRefresh()`
- Add `Workspace.requestTerminalFocusFollowUp()` to schedule an event-driven layout follow-up after `focusSelectedTabPanel()`, guaranteeing `ensureFocus` and `forceRefresh` fire even when the workspace is pre-mounted

## Changes

- `Sources/TabManager.swift`: call `tab.requestTerminalFocusFollowUp(for: panelId)` after `tab.focusPanel(panelId)` in `focusSelectedTabPanel`
- `Sources/Workspace.swift`: add `requestTerminalFocusFollowUp(for:)` method that schedules `beginEventDrivenLayoutFollowUp` for terminal panels

## Test plan

- [ ] Switch workspaces using `Cmd+Ctrl+]` / `Cmd+Ctrl+[` rapidly — terminal should always redraw and receive keyboard focus
- [ ] Verify no regression for normal workspace switching via mouse click
- [ ] Verify browser panels still auto-focus address bar on switch

Fixes #2121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal focus behavior when switching between workspaces or panels using keyboard shortcuts. Previously, the terminal might not properly receive focus or refresh its display in certain workspace cycling scenarios. The terminal now reliably gains focus and displays correctly when navigating between workspaces and panels using keyboard commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->