### PR TITLE
fix: clean up per-surface state on tab close to prevent unbounded memory growth

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -201,16 +201,26 @@ class TerminalController {
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
 
-    /// Remove all per-surface browser state for a destroyed surface.
+    /// Remove all per-surface state for a destroyed surface.
     /// Called from Workspace.splitTabBar(_:didCloseTab:fromPane:) to prevent unbounded dictionary growth.
+    ///
+    /// Cleans up:
+    /// - 6 browser panel dictionaries (frame selector, init scripts/styles, dialog queue, download events, unsupported network requests)
+    /// - v2BrowserElementRefs entries whose surfaceId matches (stale refs can never be resolved after surface close)
+    /// - v2RefByUUID[.surface] and v2UUIDByRef[.surface] entries for this surface (written on creation, never removed otherwise)
     @MainActor
-    func cleanupBrowserSurfaceState(surfaceId: UUID) {
+    func cleanupSurfaceState(surfaceId: UUID) {
         v2BrowserFrameSelectorBySurface.removeValue(forKey: surfaceId)
         v2BrowserInitScriptsBySurface.removeValue(forKey: surfaceId)
         v2BrowserInitStylesBySurface.removeValue(forKey: surfaceId)
         v2BrowserDialogQueueBySurface.removeValue(forKey: surfaceId)
         v2BrowserDownloadEventsBySurface.removeValue(forKey: surfaceId)
         v2BrowserUnsupportedNetworkRequestsBySurface.removeValue(forKey: surfaceId)
+        v2BrowserElementRefs = v2BrowserElementRefs.filter { $0.value.surfaceId != surfaceId }
+        if let ref = v2RefByUUID[.surface]?[surfaceId] {
+            v2UUIDByRef[.surface]?.removeValue(forKey: ref)
+        }
+        v2RefByUUID[.surface]?.removeValue(forKey: surfaceId)
     }
     private var browserDownloadObserver: NSObjectProtocol?
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -200,6 +200,18 @@ class TerminalController {
     private var v2BrowserDownloadEventsBySurface: [UUID: [[String: Any]]] = [:]
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
+
+    /// Remove all per-surface browser state for a destroyed surface.
+    /// Called from Workspace.splitTabBar(_:didCloseTab:fromPane:) to prevent unbounded dictionary growth.
+    @MainActor
+    func cleanupBrowserSurfaceState(surfaceId: UUID) {
+        v2BrowserFrameSelectorBySurface.removeValue(forKey: surfaceId)
+        v2BrowserInitScriptsBySurface.removeValue(forKey: surfaceId)
+        v2BrowserInitStylesBySurface.removeValue(forKey: surfaceId)
+        v2BrowserDialogQueueBySurface.removeValue(forKey: surfaceId)
+        v2BrowserDownloadEventsBySurface.removeValue(forKey: surfaceId)
+        v2BrowserUnsupportedNetworkRequestsBySurface.removeValue(forKey: surfaceId)
+    }
     private var browserDownloadObserver: NSObjectProtocol?
 
     private init() {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -208,7 +208,6 @@ class TerminalController {
     /// - 6 browser panel dictionaries (frame selector, init scripts/styles, dialog queue, download events, unsupported network requests)
     /// - v2BrowserElementRefs entries whose surfaceId matches (stale refs can never be resolved after surface close)
     /// - v2RefByUUID[.surface] and v2UUIDByRef[.surface] entries for this surface (written on creation, never removed otherwise)
-    @MainActor
     func cleanupSurfaceState(surfaceId: UUID) {
         v2BrowserFrameSelectorBySurface.removeValue(forKey: surfaceId)
         v2BrowserInitScriptsBySurface.removeValue(forKey: surfaceId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12211,7 +12211,7 @@ extension Workspace: BonsplitDelegate {
             Self.requestSSHControlMasterCleanupIfNeeded(configuration: transferredRemoteCleanupConfiguration)
         }
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
-        TerminalController.shared.cleanupBrowserSurfaceState(surfaceId: panelId)
+        TerminalController.shared.cleanupSurfaceState(surfaceId: panelId)
 
         // Keep the workspace invariant for normal close paths.
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9614,6 +9614,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         let panelEntries = Array(panels)
         for (panelId, panel) in panelEntries {
+            TerminalController.shared.cleanupSurfaceState(surfaceId: panelId)
             removePendingTerminalInputObservers(forPanelId: panelId)
             panelSubscriptions.removeValue(forKey: panelId)
             PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
@@ -12341,6 +12342,7 @@ extension Workspace: BonsplitDelegate {
 
         if !closedPanelIds.isEmpty {
             for panelId in closedPanelIds {
+                TerminalController.shared.cleanupSurfaceState(surfaceId: panelId)
                 removePendingTerminalInputObservers(forPanelId: panelId)
                 panels[panelId]?.close()
                 panels.removeValue(forKey: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12211,6 +12211,7 @@ extension Workspace: BonsplitDelegate {
             Self.requestSSHControlMasterCleanupIfNeeded(configuration: transferredRemoteCleanupConfiguration)
         }
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
+        TerminalController.shared.cleanupBrowserSurfaceState(surfaceId: panelId)
 
         // Keep the workspace invariant for normal close paths.
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12211,7 +12211,9 @@ extension Workspace: BonsplitDelegate {
             Self.requestSSHControlMasterCleanupIfNeeded(configuration: transferredRemoteCleanupConfiguration)
         }
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
-        TerminalController.shared.cleanupSurfaceState(surfaceId: panelId)
+        if !isDetaching {
+            TerminalController.shared.cleanupSurfaceState(surfaceId: panelId)
+        }
 
         // Keep the workspace invariant for normal close paths.
         // Detach/move flows intentionally allow a temporary empty workspace so AppDelegate can


### PR DESCRIPTION
## Problem

`TerminalController` accumulates per-surface state that is never cleaned up when a surface is destroyed:

1. **6 browser panel dictionaries** (`v2BrowserFrameSelectorBySurface`, `v2BrowserInitScriptsBySurface`, `v2BrowserInitStylesBySurface`, `v2BrowserDialogQueueBySurface`, `v2BrowserDownloadEventsBySurface`, `v2BrowserUnsupportedNetworkRequestsBySurface`) — written during browser/socket interactions, never removed
2. **`v2BrowserElementRefs`** — element references keyed by surface ID, never pruned after surface close (stale refs can never be resolved anyway per the guard at L6899)
3. **`v2RefByUUID[.surface]` / `v2UUIDByRef[.surface]`** — handle mappings written on creation, only added-to by `v2RefreshKnownRefs()` but never removed

Over long sessions with many workspaces created and closed, these dictionaries grow without bound.

## Fix

**`Sources/TerminalController.swift`**: Add `cleanupSurfaceState(surfaceId:)` that clears all 8 categories of per-surface data in one call.

**`Sources/Workspace.swift`**: Call `cleanupSurfaceState` from `splitTabBar(_:didCloseTab:fromPane:)` alongside the existing panel dictionary cleanup.

## Note on Leak 1 from #2078

The reported observer accumulation in `GhosttyApp` does **not** exist — `appObservers.append` runs only inside `initializeGhostty()`, which is called once from `private init()`. Since `GhosttyApp` is `static let shared`, the observer count is always exactly 2.

## Test plan

- [ ] Run cmux for an extended session, repeatedly creating and closing workspaces with browser panels
- [ ] Verify via Instruments (Allocations) that the cleaned dictionaries do not grow after tab close
- [ ] Confirm normal browser panel functionality (navigation, script injection, dialogs, downloads) is unaffected

Partially addresses #2078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tab and panel closing now consistently cleans up per-surface terminal and browser state, preventing leftover data from affecting later sessions.
  * Closing via detach/move preserves surface state so tabs moved between panes keep their existing session data.
  * Cleanup now runs at the correct teardown points for improved reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->