### PR TITLE
Fix SEO indexing: hreflang, canonicals, sitemap, trailing slash

### DIFF
--- a/web/app/[locale]/(legal)/eula/page.tsx
+++ b/web/app/[locale]/(legal)/eula/page.tsx
@@ -1,13 +1,10 @@
-import { buildAlternates } from "../../../../i18n/seo";
+import type { Metadata } from "next";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  return {
-    title: "EULA — cmux",
-    description: "End-User License Agreement for cmux",
-    alternates: buildAlternates(locale, "/eula"),
-  };
-}
+export const metadata: Metadata = {
+  title: "EULA — cmux",
+  description: "End-User License Agreement for cmux",
+  alternates: { canonical: "https://cmux.com/eula" },
+};
 
 export default function EulaPage() {
   return (

--- a/web/app/[locale]/(legal)/eula/page.tsx
+++ b/web/app/[locale]/(legal)/eula/page.tsx
@@ -1,10 +1,13 @@
-import type { Metadata } from "next";
+import { buildAlternates } from "../../../../i18n/seo";
 
-export const metadata: Metadata = {
-  title: "EULA — cmux",
-  description: "End-User License Agreement for cmux",
-  alternates: { canonical: "./" },
-};
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return {
+    title: "EULA — cmux",
+    description: "End-User License Agreement for cmux",
+    alternates: buildAlternates(locale, "/eula"),
+  };
+}
 
 export default function EulaPage() {
   return (

--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -1,14 +1,11 @@
-import { buildAlternates } from "../../../../i18n/seo";
+import type { Metadata } from "next";
 import { Link } from "../../../../i18n/navigation";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  return {
-    title: "Privacy Policy — cmux",
-    description: "Privacy policy for cmux",
-    alternates: buildAlternates(locale, "/privacy-policy"),
-  };
-}
+export const metadata: Metadata = {
+  title: "Privacy Policy — cmux",
+  description: "Privacy policy for cmux",
+  alternates: { canonical: "https://cmux.com/privacy-policy" },
+};
 
 export default function PrivacyPolicyPage() {
   return (

--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -1,11 +1,14 @@
-import type { Metadata } from "next";
+import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
 
-export const metadata: Metadata = {
-  title: "Privacy Policy — cmux",
-  description: "Privacy policy for cmux",
-  alternates: { canonical: "./" },
-};
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return {
+    title: "Privacy Policy — cmux",
+    description: "Privacy policy for cmux",
+    alternates: buildAlternates(locale, "/privacy-policy"),
+  };
+}
 
 export default function PrivacyPolicyPage() {
   return (

--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -1,10 +1,13 @@
-import type { Metadata } from "next";
+import { buildAlternates } from "../../../../i18n/seo";
 
-export const metadata: Metadata = {
-  title: "Terms of Service — cmux",
-  description: "Terms of service for cmux",
-  alternates: { canonical: "./" },
-};
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return {
+    title: "Terms of Service — cmux",
+    description: "Terms of service for cmux",
+    alternates: buildAlternates(locale, "/terms-of-service"),
+  };
+}
 
 export default function TermsOfServicePage() {
   return (

--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -1,13 +1,10 @@
-import { buildAlternates } from "../../../../i18n/seo";
+import type { Metadata } from "next";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  return {
-    title: "Terms of Service — cmux",
-    description: "Terms of service for cmux",
-    alternates: buildAlternates(locale, "/terms-of-service"),
-  };
-}
+export const metadata: Metadata = {
+  title: "Terms of Service — cmux",
+  description: "Terms of service for cmux",
+  alternates: { canonical: "https://cmux.com/terms-of-service" },
+};
 
 export default function TermsOfServicePage() {
   return (

--- a/web/app/[locale]/blog/cmd-shift-u/page.tsx
+++ b/web/app/[locale]/blog/cmd-shift-u/page.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.cmdShiftU" });
-  const url = locale === "en" ? "/blog/cmd-shift-u" : `/${locale}/blog/cmd-shift-u`;
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
@@ -18,14 +18,13 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description: t("metaDescription"),
       type: "article",
       publishedTime: "2026-03-04T00:00:00Z",
-      url,
     },
     twitter: {
       card: "summary_large_image",
       title: t("metaTitle"),
       description: t("metaDescription"),
     },
-    alternates: { canonical: url },
+    alternates: buildAlternates(locale, "/blog/cmd-shift-u"),
   };
 }
 

--- a/web/app/[locale]/blog/introducing-cmux/page.tsx
+++ b/web/app/[locale]/blog/introducing-cmux/page.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.introducingCmux" });
-  const url = locale === "en" ? "/blog/introducing-cmux" : `/${locale}/blog/introducing-cmux`;
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
@@ -18,14 +18,13 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description: t("metaDescription"),
       type: "article",
       publishedTime: "2026-02-12T00:00:00Z",
-      url,
     },
     twitter: {
       card: "summary_large_image",
       title: t("metaTitle"),
       description: t("metaDescription"),
     },
-    alternates: { canonical: url },
+    alternates: buildAlternates(locale, "/blog/introducing-cmux"),
   };
 }
 

--- a/web/app/[locale]/blog/layout.tsx
+++ b/web/app/[locale]/blog/layout.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 import { BlogPager } from "../components/blog-pager";
 import { BlogCTA } from "../components/blog-cta";
@@ -19,9 +20,7 @@ export async function generateMetadata({
       siteName: "cmux",
       type: "article" as const,
     },
-    alternates: {
-      canonical: "./",
-    },
+    alternates: buildAlternates(locale, "/blog"),
   };
 }
 

--- a/web/app/[locale]/blog/page.tsx
+++ b/web/app/[locale]/blog/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { Link } from "../../../i18n/navigation";
 
 export async function generateMetadata({
@@ -12,6 +13,7 @@ export async function generateMetadata({
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/blog"),
   };
 }
 

--- a/web/app/[locale]/blog/show-hn-launch/page.tsx
+++ b/web/app/[locale]/blog/show-hn-launch/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
 import { Tweet } from "react-tweet";
 import starHistory from "./star-history.png";
@@ -8,7 +9,6 @@ import starHistory from "./star-history.png";
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.showHnLaunch" });
-  const url = locale === "en" ? "/blog/show-hn-launch" : `/${locale}/blog/show-hn-launch`;
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
@@ -22,14 +22,13 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description: t("metaDescription"),
       type: "article",
       publishedTime: "2026-02-21T00:00:00Z",
-      url,
     },
     twitter: {
       card: "summary_large_image",
       title: t("metaTitle"),
       description: t("metaDescription"),
     },
-    alternates: { canonical: url },
+    alternates: buildAlternates(locale, "/blog/show-hn-launch"),
   };
 }
 

--- a/web/app/[locale]/blog/zen-of-cmux/page.tsx
+++ b/web/app/[locale]/blog/zen-of-cmux/page.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.zenOfCmux" });
-  const url = locale === "en" ? "/blog/zen-of-cmux" : `/${locale}/blog/zen-of-cmux`;
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
@@ -18,14 +18,13 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description: t("metaDescription"),
       type: "article",
       publishedTime: "2026-02-27T00:00:00Z",
-      url,
     },
     twitter: {
       card: "summary_large_image",
       title: t("metaTitle"),
       description: t("metaDescription"),
     },
-    alternates: { canonical: url },
+    alternates: buildAlternates(locale, "/blog/zen-of-cmux"),
   };
 }
 

--- a/web/app/[locale]/community/page.tsx
+++ b/web/app/[locale]/community/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -8,7 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
-    alternates: { canonical: "./" },
+    alternates: buildAlternates(locale, "/community"),
   };
 }
 

--- a/web/app/[locale]/docs/api/page.tsx
+++ b/web/app/[locale]/docs/api/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 import { Callout } from "../../components/callout";
 
@@ -9,6 +10,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/api"),
   };
 }
 

--- a/web/app/[locale]/docs/browser-automation/page.tsx
+++ b/web/app/[locale]/docs/browser-automation/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -8,6 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/browser-automation"),
   };
 }
 

--- a/web/app/[locale]/docs/changelog/page.tsx
+++ b/web/app/[locale]/docs/changelog/page.tsx
@@ -3,6 +3,7 @@ import path from "path";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { changelogMedia, type VersionMedia } from "./changelog-media";
 
 /** Read PNG dimensions from the IHDR chunk (bytes 16-23). */
@@ -21,6 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/changelog"),
   };
 }
 

--- a/web/app/[locale]/docs/concepts/page.tsx
+++ b/web/app/[locale]/docs/concepts/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -8,6 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/concepts"),
   };
 }
 

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 import { Callout } from "../../components/callout";
 
@@ -9,6 +10,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/configuration"),
   };
 }
 

--- a/web/app/[locale]/docs/custom-commands/page.tsx
+++ b/web/app/[locale]/docs/custom-commands/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 import { Callout } from "../../components/callout";
 
@@ -9,6 +10,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/custom-commands"),
   };
 }
 

--- a/web/app/[locale]/docs/getting-started/page.tsx
+++ b/web/app/[locale]/docs/getting-started/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 import { Callout } from "../../components/callout";
 import { DownloadButton } from "../../components/download-button";
@@ -10,6 +11,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/getting-started"),
   };
 }
 

--- a/web/app/[locale]/docs/keyboard-shortcuts/page.tsx
+++ b/web/app/[locale]/docs/keyboard-shortcuts/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { KeyboardShortcuts } from "../../keyboard-shortcuts";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
@@ -8,6 +9,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/keyboard-shortcuts"),
   };
 }
 

--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { DocsNav } from "./docs-nav";
 import { SiteHeader } from "../components/site-header";
 
@@ -18,9 +19,7 @@ export async function generateMetadata({
       siteName: "cmux",
       type: "article" as const,
     },
-    alternates: {
-      canonical: "./",
-    },
+    alternates: buildAlternates(locale, "/docs"),
   };
 }
 

--- a/web/app/[locale]/docs/notifications/page.tsx
+++ b/web/app/[locale]/docs/notifications/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
 import { CodeBlock } from "../../components/code-block";
 import { Callout } from "../../components/callout";
 
@@ -9,6 +10,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/docs/notifications"),
   };
 }
 

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -31,8 +31,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
-  const url =
-    locale === "en" ? "https://cmux.com" : `https://cmux.com/${locale}`;
+  const alternates = buildAlternates(locale, "");
   return {
     title: t("title"),
     description: t("description"),
@@ -53,7 +52,7 @@ export async function generateMetadata({
     openGraph: {
       title: t("title"),
       description: t("ogDescription"),
-      url,
+      url: alternates.canonical,
       siteName: "cmux",
       type: "website",
     },
@@ -62,7 +61,7 @@ export async function generateMetadata({
       title: t("title"),
       description: t("ogDescription"),
     },
-    alternates: buildAlternates(locale, ""),
+    alternates,
     metadataBase: new URL("https://cmux.com"),
   };
 }

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import {
 } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "../../i18n/routing";
+import { buildAlternates } from "../../i18n/seo";
 import { Providers } from "./providers";
 import { DevPanel } from "./components/spacing-control";
 import { SiteFooter } from "./components/site-footer";
@@ -61,6 +62,7 @@ export async function generateMetadata({
       title: t("title"),
       description: t("ogDescription"),
     },
+    alternates: buildAlternates(locale, ""),
     metadataBase: new URL("https://cmux.com"),
   };
 }

--- a/web/app/[locale]/nightly/page.tsx
+++ b/web/app/[locale]/nightly/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 
 export async function generateMetadata({
@@ -12,7 +13,7 @@ export async function generateMetadata({
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
-    alternates: { canonical: "./" },
+    alternates: buildAlternates(locale, "/nightly"),
   };
 }
 

--- a/web/app/[locale]/wall-of-love/page.tsx
+++ b/web/app/[locale]/wall-of-love/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations, useLocale } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 import { testimonials, TestimonialCard, getTestimonialTranslation } from "../testimonials";
 
@@ -9,7 +10,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return {
     title: t("metaTitle"),
     description: t("metaDescription"),
-    alternates: { canonical: "./" },
+    alternates: buildAlternates(locale, "/wall-of-love"),
   };
 }
 

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: { userAgent: "*", allow: "/" },
+    rules: { userAgent: "*", allow: "/", disallow: "/_next/" },
     sitemap: "https://cmux.com/sitemap.xml",
   };
 }

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -14,6 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/docs/getting-started", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.9 },
     { path: "/docs/concepts", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
     { path: "/docs/configuration", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/docs/custom-commands", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/keyboard-shortcuts", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/api", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
     { path: "/docs/notifications", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.8 },
@@ -37,13 +38,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }
     alternates["x-default"] = `${base}${path}`;
 
-    entries.push({
-      url: `${base}${path}`,
-      lastModified,
-      changeFrequency,
-      priority,
-      alternates: { languages: alternates },
-    });
+    // Emit a separate entry for each locale so Google sees every URL declared
+    for (const locale of locales) {
+      const url =
+        locale === "en" ? `${base}${path}` : `${base}/${locale}${path}`;
+      entries.push({
+        url,
+        lastModified,
+        changeFrequency,
+        priority,
+        alternates: { languages: alternates },
+      });
+    }
   }
 
   return entries;

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -28,9 +28,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/eula", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
   ];
 
+  // Legal pages are English-only (not translated), so they only get one entry.
+  const englishOnly = new Set(["/privacy-policy", "/terms-of-service", "/eula"]);
+
   const entries: MetadataRoute.Sitemap = [];
 
   for (const { path, lastModified, changeFrequency, priority } of paths) {
+    if (englishOnly.has(path)) {
+      entries.push({
+        url: `${base}${path}`,
+        lastModified,
+        changeFrequency,
+        priority,
+      });
+      continue;
+    }
+
     const alternates: Record<string, string> = {};
     for (const locale of locales) {
       alternates[locale] =

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -1,0 +1,22 @@
+import { locales } from "./routing";
+
+const BASE = "https://cmux.com";
+
+/**
+ * Build the full alternates object (canonical + hreflang languages)
+ * for a given locale and path. Use in every generateMetadata that
+ * sets alternates so child metadata doesn't wipe parent hreflang.
+ */
+export function buildAlternates(locale: string, path: string) {
+  const languages: Record<string, string> = {};
+  for (const loc of locales) {
+    languages[loc] =
+      loc === "en" ? `${BASE}${path}` : `${BASE}/${loc}${path}`;
+  }
+  languages["x-default"] = `${BASE}${path}`;
+
+  const canonical =
+    locale === "en" ? `${BASE}${path}` : `${BASE}/${locale}${path}`;
+
+  return { canonical, languages };
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -5,7 +5,6 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
 const nextConfig: NextConfig = {
-  skipTrailingSlashRedirect: true,
   images: {
     remotePatterns: [
       {

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -15,6 +15,17 @@ export default function middleware(request: NextRequest) {
     return NextResponse.redirect(url.toString(), 301);
   }
 
+  // Legal pages are English-only. Redirect localized variants to the English version.
+  const legalPages = ["/privacy-policy", "/terms-of-service", "/eula"];
+  const { pathname } = request.nextUrl;
+  for (const page of legalPages) {
+    if (pathname.endsWith(page) && pathname !== page) {
+      const url = request.nextUrl.clone();
+      url.pathname = page;
+      return NextResponse.redirect(url, 301);
+    }
+  }
+
   return intlMiddleware(request);
 }
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -15,9 +15,13 @@ export default function middleware(request: NextRequest) {
     return NextResponse.redirect(url.toString(), 301);
   }
 
-  // Legal pages are English-only. Redirect /<locale>/privacy-policy etc. to /privacy-policy.
+  // Legal pages are English-only. Redirect /<locale>/legal-page to /legal-page,
+  // and skip next-intl for /legal-page so locale detection can't redirect back.
   const legalPages = new Set(["/privacy-policy", "/terms-of-service", "/eula"]);
   const { pathname } = request.nextUrl;
+  if (legalPages.has(pathname)) {
+    return NextResponse.next();
+  }
   const secondSlash = pathname.indexOf("/", 1);
   if (secondSlash !== -1) {
     const rest = pathname.slice(secondSlash);

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -15,13 +15,15 @@ export default function middleware(request: NextRequest) {
     return NextResponse.redirect(url.toString(), 301);
   }
 
-  // Legal pages are English-only. Redirect localized variants to the English version.
-  const legalPages = ["/privacy-policy", "/terms-of-service", "/eula"];
+  // Legal pages are English-only. Redirect /<locale>/privacy-policy etc. to /privacy-policy.
+  const legalPages = new Set(["/privacy-policy", "/terms-of-service", "/eula"]);
   const { pathname } = request.nextUrl;
-  for (const page of legalPages) {
-    if (pathname.endsWith(page) && pathname !== page) {
+  const secondSlash = pathname.indexOf("/", 1);
+  if (secondSlash !== -1) {
+    const rest = pathname.slice(secondSlash);
+    if (legalPages.has(rest)) {
       const url = request.nextUrl.clone();
-      url.pathname = page;
+      url.pathname = rest;
       return NextResponse.redirect(url, 301);
     }
   }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -20,7 +20,9 @@ export default function middleware(request: NextRequest) {
   const legalPages = new Set(["/privacy-policy", "/terms-of-service", "/eula"]);
   const { pathname } = request.nextUrl;
   if (legalPages.has(pathname)) {
-    return NextResponse.next();
+    const url = request.nextUrl.clone();
+    url.pathname = `/en${pathname}`;
+    return NextResponse.rewrite(url);
   }
   const secondSlash = pathname.indexOf("/", 1);
   if (secondSlash !== -1) {


### PR DESCRIPTION
## Summary
- Add `buildAlternates()` utility (`i18n/seo.ts`) that returns both `canonical` and `languages` (hreflang) for a given locale and path, used by every page's metadata
- Add hreflang tags to all rendered pages (previously only in sitemap XML, not in HTML `<link>` tags)
- Add self-referencing canonical URLs to every page (homepage had none, child layouts using `"./"` were wiping parent hreflang)
- Expand sitemap to emit a separate entry per locale (was only listing English URLs with hreflang alternates)
- Add missing `/docs/custom-commands` to sitemap
- Remove `skipTrailingSlashRedirect: true` from `next.config.ts` so Next.js normalizes trailing slash duplicates
- Block `/_next/` in `robots.txt` to stop ~200 JS/CSS chunk files from being crawled as pages

## Context

Google Search Console reported 380 not-indexed pages vs 86 indexed. The coverage report at https://search.google.com/search-console/index?resource_id=sc-domain:cmux.com showed:
- 306 pages "Crawled, currently not indexed" (locale variants without proper signals + `_next/static` chunks)
- 34 pages "Duplicate, Google chose different canonical" (locale pages without hreflang in HTML)
- 26 pages "Duplicate without user-selected canonical" (homepage and pages inheriting `"./"`)
- 8 pages with redirects (expected: `/docs` redirect, `cmux.dev` domain redirect)

## Testing
- `npm run build` passes
- `npx tsc --noEmit` passes
- Verify via Vercel preview that `<link rel="canonical">` and `<link rel="alternate" hreflang="...">` tags appear in page source
- After deploy, re-validate in Google Search Console

## Related
- Task: Fix Google Search Console indexing issues for cmux.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /docs/custom-commands to the sitemap.
  * Added redirects so localized legal page paths now redirect to the English legal pages.

* **Improvements**
  * Sitemap now emits per-locale entries and treats certain legal pages as English-only for search indices.
  * Canonical/alternate link handling updated site-wide to be locale-aware for pages and blog posts.

* **Chores**
  * Robots updated to disallow internal framework assets from being crawled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->