### PR TITLE
feat: Semantic History — resolve bare filenames against OSC 7 CWD on click

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -496,10 +496,10 @@ final class GhosttyDefaultBackgroundNotificationDispatcher {
     }
 }
 
-func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? {
+func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? = nil) -> TerminalOpenURLTarget? {
     let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
     #if DEBUG
-    dlog("link.resolve input=\(trimmed)")
+    dlog("link.resolve input=\(trimmed) cwd=\(workingDirectory ?? "nil")")
     #endif
     guard !trimmed.isEmpty else {
         #if DEBUG
@@ -513,6 +513,19 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
         dlog("link.resolve result=external(absolutePath) url=\(trimmed)")
         #endif
         return .external(URL(fileURLWithPath: trimmed))
+    }
+
+    // Semantic History: resolve bare filenames and relative paths against CWD.
+    // Strip trailing line/column suffix (e.g. "file.swift:42:10") before checking.
+    if let cwd = workingDirectory, !cwd.isEmpty {
+        let pathPart = trimmed.components(separatedBy: ":").first ?? trimmed
+        let resolved = (cwd as NSString).appendingPathComponent(pathPart)
+        if FileManager.default.fileExists(atPath: resolved) {
+            #if DEBUG
+            dlog("link.resolve result=external(cwdResolved) path=\(resolved)")
+            #endif
+            return .external(URL(fileURLWithPath: resolved))
+        }
     }
 
     if let parsed = URL(string: trimmed),
@@ -2588,7 +2601,18 @@ class GhosttyApp {
             #if DEBUG
             dlog("link.openURL raw=\(urlString)")
             #endif
-            guard let target = resolveTerminalOpenURLTarget(urlString) else {
+            // Resolve the terminal CWD for Semantic History (bare filename resolution).
+            let terminalCWD: String? = {
+                guard let tabId = surfaceView.tabId,
+                      let surfaceId = surfaceView.terminalSurface?.id,
+                      let tabManager = AppDelegate.shared?.tabManager,
+                      let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
+                    return nil
+                }
+                return workspace.panelDirectories[surfaceId]
+                    ?? workspace.currentDirectory
+            }()
+            guard let target = resolveTerminalOpenURLTarget(urlString, workingDirectory: terminalCWD) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")
                 #endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -540,7 +540,16 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? 
     // are never misrouted to local files.
     // Strip trailing line/column suffix (e.g. "file.swift:42:10") before checking.
     if let cwd = workingDirectory, !cwd.isEmpty {
-        let pathPart = trimmed.components(separatedBy: ":").first ?? trimmed
+        // Strip trailing ":line" or ":line:col" suffixes only — filenames can
+        // legally contain colons on macOS, so only drop components that are purely numeric.
+        let pathPart: String = {
+            let parts = trimmed.components(separatedBy: ":")
+            var end = parts.count
+            while end > 1, parts[end - 1].allSatisfy(\.isNumber) {
+                end -= 1
+            }
+            return parts[..<end].joined(separator: ":")
+        }()
         let resolved = (cwd as NSString).appendingPathComponent(pathPart)
         if FileManager.default.fileExists(atPath: resolved) {
             #if DEBUG
@@ -2609,7 +2618,7 @@ class GhosttyApp {
                 guard let tabId = surfaceView.tabId,
                       let surfaceId = surfaceView.terminalSurface?.id,
                       let app = AppDelegate.shared,
-                      let tabManager = app.tabManagerFor(tabId: tabId),
+                      let tabManager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
                       let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
                     return nil
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -515,19 +515,6 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? 
         return .external(URL(fileURLWithPath: trimmed))
     }
 
-    // Semantic History: resolve bare filenames and relative paths against CWD.
-    // Strip trailing line/column suffix (e.g. "file.swift:42:10") before checking.
-    if let cwd = workingDirectory, !cwd.isEmpty {
-        let pathPart = trimmed.components(separatedBy: ":").first ?? trimmed
-        let resolved = (cwd as NSString).appendingPathComponent(pathPart)
-        if FileManager.default.fileExists(atPath: resolved) {
-            #if DEBUG
-            dlog("link.resolve result=external(cwdResolved) path=\(resolved)")
-            #endif
-            return .external(URL(fileURLWithPath: resolved))
-        }
-    }
-
     if let parsed = URL(string: trimmed),
        let scheme = parsed.scheme?.lowercased() {
         if scheme == "http" || scheme == "https" {
@@ -546,6 +533,21 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? 
         dlog("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
         #endif
         return .external(parsed)
+    }
+
+    // Semantic History: resolve bare filenames and relative paths against CWD.
+    // Placed after URL/scheme checks so that `localhost:3000` or `http://...`
+    // are never misrouted to local files.
+    // Strip trailing line/column suffix (e.g. "file.swift:42:10") before checking.
+    if let cwd = workingDirectory, !cwd.isEmpty {
+        let pathPart = trimmed.components(separatedBy: ":").first ?? trimmed
+        let resolved = (cwd as NSString).appendingPathComponent(pathPart)
+        if FileManager.default.fileExists(atPath: resolved) {
+            #if DEBUG
+            dlog("link.resolve result=external(cwdResolved) path=\(resolved)")
+            #endif
+            return .external(URL(fileURLWithPath: resolved))
+        }
     }
 
     if let webURL = resolveBrowserNavigableURL(trimmed) {
@@ -2602,10 +2604,12 @@ class GhosttyApp {
             dlog("link.openURL raw=\(urlString)")
             #endif
             // Resolve the terminal CWD for Semantic History (bare filename resolution).
+            // Use tabManagerFor(tabId:) so this works in detached/secondary windows too.
             let terminalCWD: String? = {
                 guard let tabId = surfaceView.tabId,
                       let surfaceId = surfaceView.terminalSurface?.id,
-                      let tabManager = AppDelegate.shared?.tabManager,
+                      let app = AppDelegate.shared,
+                      let tabManager = app.tabManagerFor(tabId: tabId),
                       let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
                     return nil
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -515,8 +515,16 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? 
         return .external(URL(fileURLWithPath: trimmed))
     }
 
+    // Only treat URL(string:) results as real URLs when the scheme is one we
+    // actually expect. RFC 3986 parses "file.swift:42" as scheme="file.swift",
+    // which must NOT short-circuit CWD resolution.
+    let knownSchemes: Set<String> = [
+        "http", "https", "ftp", "ftps", "ssh", "tel", "mailto",
+        "file", "irc", "ircs", "magnet", "slack", "vscode",
+    ]
     if let parsed = URL(string: trimmed),
-       let scheme = parsed.scheme?.lowercased() {
+       let scheme = parsed.scheme?.lowercased(),
+       knownSchemes.contains(scheme) {
         if scheme == "http" || scheme == "https" {
             guard BrowserInsecureHTTPSettings.normalizeHost(parsed.host ?? "") != nil else {
                 #if DEBUG
@@ -536,26 +544,44 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, workingDirectory: String? 
     }
 
     // Semantic History: resolve bare filenames and relative paths against CWD.
-    // Placed after URL/scheme checks so that `localhost:3000` or `http://...`
-    // are never misrouted to local files.
-    // Strip trailing line/column suffix (e.g. "file.swift:42:10") before checking.
+    // Placed after known-scheme URL checks so that real URLs are never misrouted.
     if let cwd = workingDirectory, !cwd.isEmpty {
-        // Strip trailing ":line" or ":line:col" suffixes only — filenames can
-        // legally contain colons on macOS, so only drop components that are purely numeric.
+        let cwdCanonical = (cwd as NSString).standardizingPath
+        // When CWD is "/" the prefix must stay "/" not "//".
+        let cwdPrefix = cwdCanonical == "/" ? "/" : cwdCanonical + "/"
+
+        // 1) Try the raw value as-is — handles filenames that legitimately
+        //    contain colons (e.g. a file literally named "foo:42").
+        let rawResolved = (cwd as NSString).appendingPathComponent(trimmed)
+        let rawCanonical = (rawResolved as NSString).standardizingPath
+        if rawCanonical.hasPrefix(cwdPrefix) || rawCanonical == cwdCanonical,
+           FileManager.default.fileExists(atPath: rawCanonical) {
+            #if DEBUG
+            dlog("link.resolve result=external(cwdResolved) path=\(rawCanonical)")
+            #endif
+            return .external(URL(fileURLWithPath: rawCanonical))
+        }
+
+        // 2) Strip trailing ":line" or ":line:col" suffixes — only drop
+        //    components that are purely numeric and non-empty.
         let pathPart: String = {
             let parts = trimmed.components(separatedBy: ":")
             var end = parts.count
-            while end > 1, parts[end - 1].allSatisfy(\.isNumber) {
+            while end > 1, !parts[end - 1].isEmpty, parts[end - 1].allSatisfy(\.isNumber) {
                 end -= 1
             }
             return parts[..<end].joined(separator: ":")
         }()
-        let resolved = (cwd as NSString).appendingPathComponent(pathPart)
-        if FileManager.default.fileExists(atPath: resolved) {
-            #if DEBUG
-            dlog("link.resolve result=external(cwdResolved) path=\(resolved)")
-            #endif
-            return .external(URL(fileURLWithPath: resolved))
+        if pathPart != trimmed, !pathPart.isEmpty {
+            let resolved = (cwd as NSString).appendingPathComponent(pathPart)
+            let canonical = (resolved as NSString).standardizingPath
+            if canonical.hasPrefix(cwdPrefix) || canonical == cwdCanonical,
+               FileManager.default.fileExists(atPath: canonical) {
+                #if DEBUG
+                dlog("link.resolve result=external(cwdResolved-stripped) path=\(canonical)")
+                #endif
+                return .external(URL(fileURLWithPath: canonical))
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

When a user clicks a bare filename (e.g. `README.md`, `src/main.py`) in the terminal, resolve it against the terminal's current working directory (reported via OSC 7) and open it if the file exists on disk.

This is the terminal equivalent of iTerm2's **Semantic History** feature, and the #1 workflow gap for AI coding agent users (Claude Code, Codex, etc.) who frequently see bare filenames in output.

## Changes

- **`resolveTerminalOpenURLTarget()`** now accepts an optional `workingDirectory` parameter
- Before falling through to browser URL heuristics (`resolveBrowserNavigableURL`), it checks whether `CWD/clicked_text` resolves to an existing file via `FileManager.default.fileExists(atPath:)`
- Line/column suffixes (e.g. `file.swift:42:10`) are stripped before the file existence check
- **`GHOSTTY_ACTION_OPEN_URL` handler** now retrieves the terminal's CWD from `workspace.panelDirectories[surfaceId]` (per-panel) or `workspace.currentDirectory` (workspace-level fallback)

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Click `README.md` | Opens `https://README.md` (bug #1154) or no action | Opens `/Users/me/project/README.md` in editor |
| Click `src/main.py:42` | No action | Opens `/Users/me/project/src/main.py` in editor |
| Click `/absolute/path.md` | Opens correctly ✅ | No change ✅ |
| Click `https://google.com` | Opens correctly ✅ | No change ✅ |
| Click `nonexistent.xyz` | Falls through | Falls through (file doesn't exist, no change) |

## How it works

```
User clicks "file.md" in terminal output
  → resolveTerminalOpenURLTarget("file.md", workingDirectory: "/Users/me/project")
  → Not an absolute path
  → CWD check: does /Users/me/project/file.md exist?
  → Yes → return .external(URL(fileURLWithPath: "/Users/me/project/file.md"))
  → NSWorkspace.shared.open() → opens in default editor
```

## Why this matters

AI coding agents output bare filenames constantly:

```
I've updated the following files:
  proposal_draft.md
  workflow_v2.md
  src/coordinator.ts
```

In iTerm2, every one of these is Cmd+clickable. In cmux, none of them are. This PR fixes that.

## Related

- Closes #2199
- Related to #1154 (relative paths misrouted to browser URL — this PR also fixes that case when the file exists locally)

## Test plan

- [ ] Click bare filename in terminal output → opens in editor
- [ ] Click `file.swift:42` → opens file (line number stripped)
- [ ] Click absolute path → still works as before
- [ ] Click URL → still works as before
- [ ] Click non-existent filename → falls through to existing behavior
- [ ] Works in split panes with different CWDs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path resolution when opening files from terminal output: relative paths and bare filenames (including trailing :line or :line:column numeric suffixes) are now resolved against the terminal's working directory, and files are opened only if the resolved path exists.
* **Other**
  * Enhanced debug logging for open-from-terminal actions to include the resolved working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->