### PR TITLE
fix: keyboard shortcuts not working with Russian layout

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10652,15 +10652,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // so keep ANSI keyCode fallback for control-modified shortcuts. Also allow fallback for
         // command punctuation shortcuts, since some non-US layouts report different characters
         // for the same physical key even when menu-equivalent semantics should still apply.
-        // When a non-Latin input source is active, treat non-ASCII event chars the same as
-        // absent chars — they carry no usable Latin key identity.
+        // When a non-Latin input source is active (Russian, Korean, Chinese, Japanese, etc.),
+        // event chars carry no usable Latin key identity. Always allow keyCode fallback as a
+        // safety net — even when the layout-based translation resolved a character, the
+        // physical key code is the definitive identifier for the intended shortcut.
         let hasUsableEventChars = hasEventChars && eventCharsAreASCII
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
                 && (
                     !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (!hasUsableEventChars && (layoutCharacter?.isEmpty ?? true))
+                        || !hasUsableEventChars
                 ))
         if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10623,7 +10623,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // For command-based shortcuts, trust AppKit's layout-aware characters when present.
         // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
         // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
-        // When a non-Latin input source is active (Korean, Chinese, Japanese, etc.),
+        // When a non-Latin input source is active (Russian, Korean, Chinese, Japanese, etc.),
         // charactersIgnoringModifiers returns non-ASCII characters that can never match
         // a Latin shortcut key — skip this guard and fall through to layout-based matching.
         let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
@@ -10656,13 +10656,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // event chars carry no usable Latin key identity. Always allow keyCode fallback as a
         // safety net — even when the layout-based translation resolved a character, the
         // physical key code is the definitive identifier for the intended shortcut.
+        // For empty-character events (synthetic/browser key equivalents), preserve the original
+        // behavior: only fall back when the layout translation also failed.
         let hasUsableEventChars = hasEventChars && eventCharsAreASCII
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
                 && (
                     !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || !hasUsableEventChars
+                        || (hasEventChars && !eventCharsAreASCII)
+                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
                 ))
         if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2997,6 +2997,112 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(activateApplicationCallCount, 1)
     }
 
+    // MARK: - Non-Latin keyboard layout shortcut tests
+
+    func testCmdTWorksWithRussianKeyboardLayout() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window context")
+            return
+        }
+
+        let surfaceCountBefore = workspace.panels.count
+
+        // Simulate Russian keyboard: layout provider returns "t" via ASCII fallback,
+        // but event.charactersIgnoringModifiers returns Cyrillic "е".
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 17 ? "t" : nil
+        }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "t",
+            charactersIgnoringModifiers: "е", // Cyrillic е (Russian layout)
+            isARepeat: false,
+            keyCode: 17 // kVK_ANSI_T
+        ) else {
+            XCTFail("Failed to construct Russian-layout Cmd+T event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event), "Cmd+T should be handled with Russian keyboard layout")
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertEqual(workspace.panels.count, surfaceCountBefore + 1, "Cmd+T should create a new surface with Russian keyboard layout")
+    }
+
+    func testCmdTFallsBackToKeyCodeWithNonLatinLayoutWhenLayoutTranslationFails() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected test window context")
+            return
+        }
+
+        let surfaceCountBefore = workspace.panels.count
+
+        // Simulate non-Latin layout where layout translation also fails (returns nil).
+        // The ANSI keyCode fallback should still match the physical T key.
+        appDelegate.shortcutLayoutCharacterProvider = { _, _ in nil }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "е", // Cyrillic е — non-ASCII
+            isARepeat: false,
+            keyCode: 17 // kVK_ANSI_T
+        ) else {
+            XCTFail("Failed to construct non-Latin Cmd+T event with failed layout translation")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event), "Cmd+T should fall back to keyCode with non-Latin layout")
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertEqual(workspace.panels.count, surfaceCountBefore + 1, "Cmd+T keyCode fallback should create a new surface")
+    }
+
     private func makeKeyDownEvent(
         key: String,
         modifiers: NSEvent.ModifierFlags,


### PR DESCRIPTION
## Summary
- When a non-Latin keyboard layout (Russian, etc.) is active, `event.charactersIgnoringModifiers` returns Cyrillic characters. The ANSI keyCode fallback in `matchShortcut` was blocked when the layout-based translation resolved a non-empty character, leaving no safety net if that path failed.
- Now the keyCode fallback is always available when event chars are non-ASCII, matching the physical key position — similar to Ghostty's `physical:` keybinding behavior.
- Affects all Cmd+letter shortcuts (Cmd+T, Cmd+W, Cmd+N, etc.) with Russian and other non-Latin layouts.

## Test plan
- [x] Manually verified: switch to Russian keyboard layout, Cmd+T opens a new tab
- [ ] Verify existing shortcuts still work with US/English layout
- [ ] Verify Cmd+1-9 numbered shortcuts unaffected (they already have unconditional keyCode fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+letter shortcuts failing on Russian and other non‑Latin layouts by allowing ANSI keyCode fallback when event characters are non‑ASCII, even if the layout returns a character. Shortcuts now resolve by physical key position, restoring Cmd+T/W/N, etc.

- **Bug Fixes**
  - Allow ANSI keyCode fallback for Command shortcuts when event chars are non‑ASCII, and restrict fallback for empty‑char events to only when layout translation fails; prevents unintended fallback on Dvorak/Colemak while keeping US/English and Cmd+1–9 behavior unchanged.
  - Added unit tests for Russian layout covering layout-translation and keyCode-fallback paths.

<sup>Written for commit 911ecc190be0432c8e1a52b1f12711be9e1ee665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling so common shortcuts (e.g., New Tab) work reliably with non‑Latin input layouts, including better fallback to physical key codes when events contain non‑ASCII characters.
* **Tests**
  * Added automated tests validating shortcut routing and key‑code fallback behavior across non‑Latin keyboard layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->