### PR TITLE
Fix Cmd+N nightly crash: avoid local Workspace refs in ARC hotpath

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1207,97 +1207,102 @@ class TabManager: ObservableObject {
         placementOverride: NewWorkspacePlacement? = nil,
         autoWelcomeIfNeeded: Bool = true
     ) -> Workspace {
+        // Extract Workspace-dependent data through `self` BEFORE capturing locals.
+        // Accessing through `self` is safe because the method retains `self` for its
+        // duration, keeping all Workspace objects reachable via `self.tabs`. Local copies
+        // of Workspace references (like a `selectedWorkspace` local) are vulnerable to
+        // Xcode 16.x's aggressive ARC optimizer eliding retains through inlined call
+        // chains (workspace → panel → surface → C pointer), causing use-after-free.
+        let preferredDir = preferredWorkingDirectoryForNewTab()
+        let inheritedFontPoints = inheritedTerminalFontPointsForNewWorkspace()
+
         let capturedTabs = tabs
         let capturedSelectedTabId = selectedTabId
-        // Keep the pre-creation workspace array alive for the full Cmd+N path. Release ARC
-        // can otherwise drop intermediate retains before we re-read `tabs` for insertion,
-        // which turns mid-creation closes into use-after-free crashes in `swift_retain`.
-        return withExtendedLifetime(capturedTabs) {
-            // Snapshot current published state once so workspace creation doesn't repeatedly
-            // bounce through Combine-backed accessors while we're preparing the new workspace.
-            let snapshot = workspaceCreationSnapshot(
-                currentTabs: capturedTabs,
-                currentSelectedTabId: capturedSelectedTabId
-            )
-            didCaptureWorkspaceCreationSnapshot()
+
+        let snapshot = workspaceCreationSnapshotLite(
+            currentTabs: capturedTabs,
+            currentSelectedTabId: capturedSelectedTabId,
+            preferredWorkingDirectory: preferredDir,
+            inheritedTerminalFontPoints: inheritedFontPoints
+        )
+        didCaptureWorkspaceCreationSnapshot()
 #if DEBUG
-            maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
+        maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
 #endif
-            let nextTabCount = snapshot.tabs.count + 1
-            sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
-            let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-            let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
-            let inheritedConfig = workspaceCreationConfigTemplate(
-                inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
-            )
-            // Resolve placement against the pre-creation snapshot before Workspace init
-            // boots terminal state. The ssh/new-workspace path can otherwise crash while
-            // reading @Published placement state from existing workspaces mid-creation.
-            let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
-            let ordinal = Self.nextPortOrdinal
-            Self.nextPortOrdinal += 1
-            let newWorkspace = makeWorkspaceForCreation(
-                title: "Terminal \(nextTabCount)",
-                workingDirectory: workingDirectory,
-                portOrdinal: ordinal,
-                configTemplate: inheritedConfig,
-                initialTerminalCommand: initialTerminalCommand,
-                initialTerminalEnvironment: initialTerminalEnvironment
-            )
-            newWorkspace.owningTabManager = self
-            wireClosedBrowserTracking(for: newWorkspace)
-            if eagerLoadTerminal && !select {
-                requestBackgroundWorkspaceLoad(for: newWorkspace.id)
-            }
-            // Apply insertion to the current live array so post-snapshot closes/reorders
-            // are preserved instead of reintroducing stale workspace instances.
-            var updatedTabs = tabs
-            if insertIndex >= 0 && insertIndex <= updatedTabs.count {
-                updatedTabs.insert(newWorkspace, at: insertIndex)
-            } else {
-                updatedTabs.append(newWorkspace)
-            }
-            tabs = updatedTabs
-            if let explicitWorkingDirectory,
-               let terminalPanel = newWorkspace.focusedTerminalPanel {
-                scheduleInitialWorkspaceGitMetadataRefresh(
-                    workspaceId: newWorkspace.id,
-                    panelId: terminalPanel.id,
-                    directory: explicitWorkingDirectory
-                )
-            }
-            if eagerLoadTerminal {
-                if select {
-                    newWorkspace.focusedTerminalPanel?.surface.requestBackgroundSurfaceStartIfNeeded()
-                }
-            }
-            if select {
-#if DEBUG
-                debugPrimeWorkspaceSwitchTrigger("create", to: newWorkspace.id)
-#endif
-                selectedTabId = newWorkspace.id
-                NotificationCenter.default.post(
-                    name: .ghosttyDidFocusTab,
-                    object: nil,
-                    userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
-                )
-            }
-#if DEBUG
-            UITestRecorder.incrementInt("addTabInvocations")
-            UITestRecorder.record([
-                "tabCount": String(updatedTabs.count),
-                "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
-            ])
-#endif
-            if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
-                if let appDelegate = AppDelegate.shared {
-                    appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
-                } else {
-                    sendWelcomeWhenReady(to: newWorkspace)
-                }
-            }
-            return newWorkspace
+        let nextTabCount = snapshot.tabs.count + 1
+        sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
+        let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
+        let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
+        let inheritedConfig = workspaceCreationConfigTemplate(
+            inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
+        )
+        // Resolve placement against the pre-creation snapshot before Workspace init
+        // boots terminal state. The ssh/new-workspace path can otherwise crash while
+        // reading @Published placement state from existing workspaces mid-creation.
+        let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
+        let ordinal = Self.nextPortOrdinal
+        Self.nextPortOrdinal += 1
+        let newWorkspace = makeWorkspaceForCreation(
+            title: "Terminal \(nextTabCount)",
+            workingDirectory: workingDirectory,
+            portOrdinal: ordinal,
+            configTemplate: inheritedConfig,
+            initialTerminalCommand: initialTerminalCommand,
+            initialTerminalEnvironment: initialTerminalEnvironment
+        )
+        newWorkspace.owningTabManager = self
+        wireClosedBrowserTracking(for: newWorkspace)
+        if eagerLoadTerminal && !select {
+            requestBackgroundWorkspaceLoad(for: newWorkspace.id)
         }
+        // Apply insertion to the current live array so post-snapshot closes/reorders
+        // are preserved instead of reintroducing stale workspace instances.
+        var updatedTabs = tabs
+        if insertIndex >= 0 && insertIndex <= updatedTabs.count {
+            updatedTabs.insert(newWorkspace, at: insertIndex)
+        } else {
+            updatedTabs.append(newWorkspace)
+        }
+        tabs = updatedTabs
+        if let explicitWorkingDirectory,
+           let terminalPanel = newWorkspace.focusedTerminalPanel {
+            scheduleInitialWorkspaceGitMetadataRefresh(
+                workspaceId: newWorkspace.id,
+                panelId: terminalPanel.id,
+                directory: explicitWorkingDirectory
+            )
+        }
+        if eagerLoadTerminal {
+            if select {
+                newWorkspace.focusedTerminalPanel?.surface.requestBackgroundSurfaceStartIfNeeded()
+            }
+        }
+        if select {
+#if DEBUG
+            debugPrimeWorkspaceSwitchTrigger("create", to: newWorkspace.id)
+#endif
+            selectedTabId = newWorkspace.id
+            NotificationCenter.default.post(
+                name: .ghosttyDidFocusTab,
+                object: nil,
+                userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
+            )
+        }
+#if DEBUG
+        UITestRecorder.incrementInt("addTabInvocations")
+        UITestRecorder.record([
+            "tabCount": String(updatedTabs.count),
+            "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
+        ])
+#endif
+        if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
+            if let appDelegate = AppDelegate.shared {
+                appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
+            } else {
+                sendWelcomeWhenReady(to: newWorkspace)
+            }
+        }
+        return newWorkspace
     }
 
     @MainActor
@@ -2187,31 +2192,36 @@ class TabManager: ObservableObject {
         terminalPanelForWorkspaceConfigInheritanceSource(workspace: selectedWorkspace)
     }
 
-    private func workspaceCreationSnapshot(
+    /// Build a snapshot using pre-extracted value-type data. The caller is responsible
+    /// for obtaining `preferredWorkingDirectory` and `inheritedTerminalFontPoints` through
+    /// `self` (where `self.tabs` keeps all Workspace objects alive) so that no local
+    /// Workspace references are needed here.
+    private func workspaceCreationSnapshotLite(
         currentTabs: [Workspace],
-        currentSelectedTabId: UUID?
+        currentSelectedTabId: UUID?,
+        preferredWorkingDirectory: String?,
+        inheritedTerminalFontPoints: Float?
     ) -> WorkspaceCreationSnapshot {
         let tabSnapshots = currentTabs.map { WorkspaceCreationTabSnapshot(workspace: $0) }
         let selectedTabSnapshot = currentSelectedTabId.flatMap { selectedTabId in
             tabSnapshots.first(where: { $0.id == selectedTabId })
-        }
-        let selectedWorkspace = currentSelectedTabId.flatMap { selectedTabId in
-            currentTabs.first(where: { $0.id == selectedTabId })
         }
 
         return WorkspaceCreationSnapshot(
             tabs: tabSnapshots,
             selectedTabId: currentSelectedTabId,
             selectedTabWasPinned: selectedTabSnapshot?.isPinned ?? false,
-            preferredWorkingDirectory: preferredWorkingDirectoryForNewTab(workspace: selectedWorkspace),
-            inheritedTerminalFontPoints: inheritedTerminalFontPointsForNewWorkspace(workspace: selectedWorkspace)
+            preferredWorkingDirectory: preferredWorkingDirectory,
+            inheritedTerminalFontPoints: inheritedTerminalFontPoints
         )
     }
 
     private func workspaceCreationSnapshot() -> WorkspaceCreationSnapshot {
-        workspaceCreationSnapshot(
+        workspaceCreationSnapshotLite(
             currentTabs: tabs,
-            currentSelectedTabId: selectedTabId
+            currentSelectedTabId: selectedTabId,
+            preferredWorkingDirectory: preferredWorkingDirectoryForNewTab(),
+            inheritedTerminalFontPoints: inheritedTerminalFontPointsForNewWorkspace()
         )
     }
 
@@ -2289,6 +2299,10 @@ class TabManager: ObservableObject {
             return config
         }
         return nil
+    }
+
+    private func inheritedTerminalFontPointsForNewWorkspace() -> Float? {
+        inheritedTerminalFontPointsForNewWorkspace(workspace: selectedWorkspace)
     }
 
     private func inheritedTerminalFontPointsForNewWorkspace(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1207,87 +1207,97 @@ class TabManager: ObservableObject {
         placementOverride: NewWorkspacePlacement? = nil,
         autoWelcomeIfNeeded: Bool = true
     ) -> Workspace {
-        // Snapshot current published state once so workspace creation doesn't repeatedly
-        // bounce through Combine-backed accessors while we're preparing the new workspace.
-        let snapshot = workspaceCreationSnapshot()
-        didCaptureWorkspaceCreationSnapshot()
-#if DEBUG
-        maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
-#endif
-        let nextTabCount = snapshot.tabs.count + 1
-        sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
-        let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-        let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
-        let inheritedConfig = workspaceCreationConfigTemplate(
-            inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
-        )
-        // Resolve placement against the pre-creation snapshot before Workspace init
-        // boots terminal state. The ssh/new-workspace path can otherwise crash while
-        // reading @Published placement state from existing workspaces mid-creation.
-        let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
-        let ordinal = Self.nextPortOrdinal
-        Self.nextPortOrdinal += 1
-        let newWorkspace = makeWorkspaceForCreation(
-            title: "Terminal \(nextTabCount)",
-            workingDirectory: workingDirectory,
-            portOrdinal: ordinal,
-            configTemplate: inheritedConfig,
-            initialTerminalCommand: initialTerminalCommand,
-            initialTerminalEnvironment: initialTerminalEnvironment
-        )
-        newWorkspace.owningTabManager = self
-        wireClosedBrowserTracking(for: newWorkspace)
-        if eagerLoadTerminal && !select {
-            requestBackgroundWorkspaceLoad(for: newWorkspace.id)
-        }
-        // Apply insertion to the current live array so post-snapshot closes/reorders
-        // are preserved instead of reintroducing stale workspace instances.
-        var updatedTabs = tabs
-        if insertIndex >= 0 && insertIndex <= updatedTabs.count {
-            updatedTabs.insert(newWorkspace, at: insertIndex)
-        } else {
-            updatedTabs.append(newWorkspace)
-        }
-        tabs = updatedTabs
-        if let explicitWorkingDirectory,
-           let terminalPanel = newWorkspace.focusedTerminalPanel {
-            scheduleInitialWorkspaceGitMetadataRefresh(
-                workspaceId: newWorkspace.id,
-                panelId: terminalPanel.id,
-                directory: explicitWorkingDirectory
+        let capturedTabs = tabs
+        let capturedSelectedTabId = selectedTabId
+        // Keep the pre-creation workspace array alive for the full Cmd+N path. Release ARC
+        // can otherwise drop intermediate retains before we re-read `tabs` for insertion,
+        // which turns mid-creation closes into use-after-free crashes in `swift_retain`.
+        return withExtendedLifetime(capturedTabs) {
+            // Snapshot current published state once so workspace creation doesn't repeatedly
+            // bounce through Combine-backed accessors while we're preparing the new workspace.
+            let snapshot = workspaceCreationSnapshot(
+                currentTabs: capturedTabs,
+                currentSelectedTabId: capturedSelectedTabId
             )
-        }
-        if eagerLoadTerminal {
-            if select {
-                newWorkspace.focusedTerminalPanel?.surface.requestBackgroundSurfaceStartIfNeeded()
+            didCaptureWorkspaceCreationSnapshot()
+#if DEBUG
+            maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
+#endif
+            let nextTabCount = snapshot.tabs.count + 1
+            sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
+            let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
+            let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
+            let inheritedConfig = workspaceCreationConfigTemplate(
+                inheritedTerminalFontPoints: snapshot.inheritedTerminalFontPoints
+            )
+            // Resolve placement against the pre-creation snapshot before Workspace init
+            // boots terminal state. The ssh/new-workspace path can otherwise crash while
+            // reading @Published placement state from existing workspaces mid-creation.
+            let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
+            let ordinal = Self.nextPortOrdinal
+            Self.nextPortOrdinal += 1
+            let newWorkspace = makeWorkspaceForCreation(
+                title: "Terminal \(nextTabCount)",
+                workingDirectory: workingDirectory,
+                portOrdinal: ordinal,
+                configTemplate: inheritedConfig,
+                initialTerminalCommand: initialTerminalCommand,
+                initialTerminalEnvironment: initialTerminalEnvironment
+            )
+            newWorkspace.owningTabManager = self
+            wireClosedBrowserTracking(for: newWorkspace)
+            if eagerLoadTerminal && !select {
+                requestBackgroundWorkspaceLoad(for: newWorkspace.id)
             }
-        }
-        if select {
-#if DEBUG
-            debugPrimeWorkspaceSwitchTrigger("create", to: newWorkspace.id)
-#endif
-            selectedTabId = newWorkspace.id
-            NotificationCenter.default.post(
-                name: .ghosttyDidFocusTab,
-                object: nil,
-                userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
-            )
-        }
-#if DEBUG
-        UITestRecorder.incrementInt("addTabInvocations")
-        UITestRecorder.record([
-            "tabCount": String(updatedTabs.count),
-            "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
-        ])
-#endif
-        if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
-            if let appDelegate = AppDelegate.shared {
-                appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
+            // Apply insertion to the current live array so post-snapshot closes/reorders
+            // are preserved instead of reintroducing stale workspace instances.
+            var updatedTabs = tabs
+            if insertIndex >= 0 && insertIndex <= updatedTabs.count {
+                updatedTabs.insert(newWorkspace, at: insertIndex)
             } else {
-                sendWelcomeWhenReady(to: newWorkspace)
+                updatedTabs.append(newWorkspace)
             }
+            tabs = updatedTabs
+            if let explicitWorkingDirectory,
+               let terminalPanel = newWorkspace.focusedTerminalPanel {
+                scheduleInitialWorkspaceGitMetadataRefresh(
+                    workspaceId: newWorkspace.id,
+                    panelId: terminalPanel.id,
+                    directory: explicitWorkingDirectory
+                )
+            }
+            if eagerLoadTerminal {
+                if select {
+                    newWorkspace.focusedTerminalPanel?.surface.requestBackgroundSurfaceStartIfNeeded()
+                }
+            }
+            if select {
+#if DEBUG
+                debugPrimeWorkspaceSwitchTrigger("create", to: newWorkspace.id)
+#endif
+                selectedTabId = newWorkspace.id
+                NotificationCenter.default.post(
+                    name: .ghosttyDidFocusTab,
+                    object: nil,
+                    userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
+                )
+            }
+#if DEBUG
+            UITestRecorder.incrementInt("addTabInvocations")
+            UITestRecorder.record([
+                "tabCount": String(updatedTabs.count),
+                "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
+            ])
+#endif
+            if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.sendWelcomeCommandWhenReady(to: newWorkspace, markShownOnSend: true)
+                } else {
+                    sendWelcomeWhenReady(to: newWorkspace)
+                }
+            }
+            return newWorkspace
         }
-        return newWorkspace
     }
 
     @MainActor
@@ -2177,9 +2187,10 @@ class TabManager: ObservableObject {
         terminalPanelForWorkspaceConfigInheritanceSource(workspace: selectedWorkspace)
     }
 
-    private func workspaceCreationSnapshot() -> WorkspaceCreationSnapshot {
-        let currentTabs = tabs
-        let currentSelectedTabId = selectedTabId
+    private func workspaceCreationSnapshot(
+        currentTabs: [Workspace],
+        currentSelectedTabId: UUID?
+    ) -> WorkspaceCreationSnapshot {
         let tabSnapshots = currentTabs.map { WorkspaceCreationTabSnapshot(workspace: $0) }
         let selectedTabSnapshot = currentSelectedTabId.flatMap { selectedTabId in
             tabSnapshots.first(where: { $0.id == selectedTabId })
@@ -2194,6 +2205,13 @@ class TabManager: ObservableObject {
             selectedTabWasPinned: selectedTabSnapshot?.isPinned ?? false,
             preferredWorkingDirectory: preferredWorkingDirectoryForNewTab(workspace: selectedWorkspace),
             inheritedTerminalFontPoints: inheritedTerminalFontPointsForNewWorkspace(workspace: selectedWorkspace)
+        )
+    }
+
+    private func workspaceCreationSnapshot() -> WorkspaceCreationSnapshot {
+        workspaceCreationSnapshot(
+            currentTabs: tabs,
+            currentSelectedTabId: selectedTabId
         )
     }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -448,26 +448,19 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
         XCTAssertEqual(manager.selectedTabId, inserted.id)
     }
 
-    func testAddWorkspaceKeepsCapturedWorkspaceAliveUntilCreationFinishes() {
+    func testAddWorkspaceSurvivesMidCreationClose() {
         let manager = SnapshotMutatingTabManager()
         guard let first = manager.tabs.first else {
             XCTFail("Expected initial workspace")
             return
         }
 
-        var closingWorkspace: Workspace? = manager.addWorkspace()
+        let closingWorkspace = manager.addWorkspace()
         let third = manager.addWorkspace()
         manager.selectWorkspace(third)
 
-        guard let capturedClosingWorkspace = closingWorkspace else {
-            XCTFail("Expected secondary workspace")
-            return
-        }
-
-        let closingWorkspaceId = capturedClosingWorkspace.id
-        weak var weakClosingWorkspace = capturedClosingWorkspace
+        let closingWorkspaceId = closingWorkspace.id
         XCTAssertEqual(manager.tabs.map(\.id), [first.id, closingWorkspaceId, third.id])
-        closingWorkspace = nil
 
         manager.afterCaptureWorkspaceCreationSnapshot = {
             guard let liveWorkspace = manager.tabs.first(where: { $0.id == closingWorkspaceId }) else {
@@ -477,22 +470,11 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
             manager.closeWorkspace(liveWorkspace)
         }
 
-        var didReachBeforeCreateWorkspace = false
-        manager.beforeCreateWorkspace = {
-            didReachBeforeCreateWorkspace = true
-            XCTAssertNotNil(
-                weakClosingWorkspace,
-                "Expected the workspace captured before Cmd+N to stay alive until creation finishes"
-            )
-        }
-
         let inserted = manager.addWorkspace(placementOverride: .afterCurrent)
 
-        XCTAssertTrue(didReachBeforeCreateWorkspace)
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == closingWorkspaceId }))
         XCTAssertEqual(manager.tabs.map(\.id), [first.id, third.id, inserted.id])
         XCTAssertEqual(manager.selectedTabId, inserted.id)
-        XCTAssertNil(weakClosingWorkspace)
     }
 
     func testAddWorkspaceAfterCurrentUsesSnapshotPinnedStateWhenPinningMutatesAfterSnapshot() {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -448,6 +448,53 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
         XCTAssertEqual(manager.selectedTabId, inserted.id)
     }
 
+    func testAddWorkspaceKeepsCapturedWorkspaceAliveUntilCreationFinishes() {
+        let manager = SnapshotMutatingTabManager()
+        guard let first = manager.tabs.first else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+
+        var closingWorkspace: Workspace? = manager.addWorkspace()
+        let third = manager.addWorkspace()
+        manager.selectWorkspace(third)
+
+        guard let closingWorkspace else {
+            XCTFail("Expected secondary workspace")
+            return
+        }
+
+        let closingWorkspaceId = closingWorkspace.id
+        weak var weakClosingWorkspace = closingWorkspace
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, closingWorkspaceId, third.id])
+        closingWorkspace = nil
+
+        manager.afterCaptureWorkspaceCreationSnapshot = {
+            guard let liveWorkspace = manager.tabs.first(where: { $0.id == closingWorkspaceId }) else {
+                XCTFail("Expected captured workspace to still be present when closing after snapshot")
+                return
+            }
+            manager.closeWorkspace(liveWorkspace)
+        }
+
+        var didReachBeforeCreateWorkspace = false
+        manager.beforeCreateWorkspace = {
+            didReachBeforeCreateWorkspace = true
+            XCTAssertNotNil(
+                weakClosingWorkspace,
+                "Expected the workspace captured before Cmd+N to stay alive until creation finishes"
+            )
+        }
+
+        let inserted = manager.addWorkspace(placementOverride: .afterCurrent)
+
+        XCTAssertTrue(didReachBeforeCreateWorkspace)
+        XCTAssertFalse(manager.tabs.contains(where: { $0.id == closingWorkspaceId }))
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, third.id, inserted.id])
+        XCTAssertEqual(manager.selectedTabId, inserted.id)
+        XCTAssertNil(weakClosingWorkspace)
+    }
+
     func testAddWorkspaceAfterCurrentUsesSnapshotPinnedStateWhenPinningMutatesAfterSnapshot() {
         let manager = SnapshotMutatingTabManager()
         guard let first = manager.tabs.first else {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -459,13 +459,13 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
         let third = manager.addWorkspace()
         manager.selectWorkspace(third)
 
-        guard let closingWorkspace else {
+        guard let capturedClosingWorkspace = closingWorkspace else {
             XCTFail("Expected secondary workspace")
             return
         }
 
-        let closingWorkspaceId = closingWorkspace.id
-        weak var weakClosingWorkspace = closingWorkspace
+        let closingWorkspaceId = capturedClosingWorkspace.id
+        weak var weakClosingWorkspace = capturedClosingWorkspace
         XCTAssertEqual(manager.tabs.map(\.id), [first.id, closingWorkspaceId, third.id])
         closingWorkspace = nil
 


### PR DESCRIPTION
## Summary
- Extract `preferredWorkingDirectory` and `inheritedTerminalFontPoints` through `self` (always retained) **before** capturing locals, instead of navigating workspace → panel → surface through local variables inside the snapshot
- Xcode 16.4's `-O` ARC optimizer aggressively elides retains on local Workspace references through inlined call chains, causing use-after-free on every Cmd+N in CI-built nightlies
- The snapshot is now purely value-typed — no Workspace references held in locals that the optimizer can release prematurely
- Removes `withExtendedLifetime` wrapper which was insufficient against the inlining optimizer

## Context
This crash reproduced on every Cmd+N in the CI nightly (Xcode 16.4, macOS 15) but not in local builds (Xcode 26.4, macOS 26). The root cause was `c1998e34` introducing `workspaceCreationSnapshot()` which held local Workspace refs across deep call chains.

## Test plan
- [x] Updated regression test for mid-creation workspace close
- [ ] CI nightly build on Xcode 16.4 — Cmd+N should no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+N crashes in CI nightlies by removing local Workspace refs from the creation path and making the snapshot value-only. Addresses issue 2180; config is pulled via self to avoid Xcode 16.4 ARC retain elision.

- Bug Fixes
  - Pre-extract preferred working directory and inherited terminal font points via self before capturing locals; no local Workspace refs in the hot path.
  - Replace workspaceCreationSnapshot with workspaceCreationSnapshotLite(...) that takes value params; remove withExtendedLifetime as ineffective under inlining.
  - Update regression test to ensure Cmd+N survives a mid-creation close with correct tab order and selection; remove brittle lifetime assertion.
  - Preserve the hardened addWorkspace implementation after updating to the latest main.

<sup>Written for commit 71d89b2548d2294d650fbd21912bb29a6d323729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace snapshot logic for better efficiency.

* **Tests**
  * Added test coverage for workspace closure during creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->