### PR TITLE
fix: skip hook injection for non-interactive claude invocations

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -155,6 +155,24 @@ case "${1:-}" in
     mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
 esac
 
+# Pass through non-interactive invocations (e.g., programmatic token refresh).
+# Hooks create phantom sessions that burn API credits when no human is present.
+# See #2206.
+NON_INTERACTIVE=false
+for arg in "$@"; do
+    [[ "$arg" == "--" ]] && break
+    case "$arg" in
+        -p|--print|--output-format|--output-format=*|--print-auth-token)
+            NON_INTERACTIVE=true
+            break
+            ;;
+    esac
+done
+if [[ "$NON_INTERACTIVE" == true ]]; then
+    unset CLAUDECODE
+    exec "$REAL_CLAUDE" "$@"
+fi
+
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
 # independent sessions even when the parent shell was launched from Claude Code.
 unset CLAUDECODE

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -351,6 +351,23 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def test_print_flag_skips_hook_injection(failures: list[str]) -> None:
+    """Non-interactive flags (-p/--print) should bypass hooks entirely.  See #2206."""
+    for flag, label in [
+        ("-p", "-p"),
+        ("--print", "--print"),
+        ("--output-format", "--output-format"),
+        ("--output-format=json", "--output-format=json"),
+        ("--print-auth-token", "--print-auth-token"),
+    ]:
+        argv = [flag, ".", "--model", "haiku"] if flag in ("-p", "--print") else [flag]
+        code, real_argv, _cmux_log, stderr, *_ = run_wrapper(socket_state="live", argv=argv)
+        expect(code == 0, f"{label}: wrapper exited {code}: {stderr}", failures)
+        expect("--settings" not in real_argv, f"{label}: expected no --settings (hooks), got {real_argv}", failures)
+        expect("--session-id" not in real_argv, f"{label}: expected no --session-id, got {real_argv}", failures)
+
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
@@ -358,6 +375,7 @@ def main() -> int:
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_print_flag_skips_hook_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
## Summary

Fixes #2206.

The claude wrapper shim injects `--settings` with lifecycle hooks into **every** `claude` invocation inside a cmux terminal — including non-interactive, programmatic calls that were never meant to start a conversation.

This caused phantom sessions that burned API credits unattended (e.g. `opencode-claude-auth` calling `claude -p . --model haiku` for token refresh every ~30 minutes).

## Changes

- **`Resources/bin/claude`**: Detect non-interactive flags (`-p`/`--print`, `--output-format`, `--print-auth-token`) and pass through to the real binary without hook or session-id injection — same pattern as the existing subcommand passthrough on line 59-61.
- **`tests/test_claude_wrapper_hooks.py`**: Add regression test verifying all non-interactive flags bypass hooks.

## Why flag detection (not TTY check)

The issue suggests `[[ ! -t 0 ]]` as a catch-all, but the existing test harness uses `subprocess.run(capture_output=True)` which makes stdin a pipe — a TTY check would break all existing tests without a significant test refactor. Flag detection is precise, testable, and directly addresses the reported bug (`claude -p .`).

A TTY check could be added later as defense-in-depth once the test harness supports pseudo-TTY simulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Print/output-related CLI flags (e.g., -p, --print, --output-format, --print-auth-token) are now detected and passed through unchanged — the wrapper no longer injects session/settings arguments for these invocations and preserves normal exit behavior.

* **Tests**
  * Added regression tests verifying print/output flags skip hook injection, preserve original arguments, and do not trigger socket/hook activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip hook injection for non-interactive `claude` invocations to avoid phantom sessions and wasted API credits. The wrapper now forwards print/output/auth-token calls directly to the real binary without `--settings` or `--session-id`.

- **Bug Fixes**
  - Detect `-p`/`--print`, `--output-format`/`--output-format=*`, and `--print-auth-token`; stop scanning at `--`; unset `CLAUDECODE`; exec passthrough.
  - Add regression tests (incl. `--output-format=json`) to ensure no hooks/session-id and exit code 0.

<sup>Written for commit aa798f813966368084c30c1d910d61924f304baf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

