### PR TITLE
refactor: physical keyCode as primary match path in matchShortcut

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10649,6 +10649,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     /// Match a shortcut against an event, handling normal keys.
+    ///
+    /// Uses physical keyCode as the primary match path (aligned with Ghostty's
+    /// `Binding.Set.getEvent()` which checks physical key before character),
+    /// then falls back to character-based matching for alternative layouts
+    /// (Dvorak, Colemak) where users bind to logical characters.
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
         // Some keys can include extra flags (e.g. .function) depending on the responder chain.
         // Strip those for consistent matching across first responders (terminal, WebKit, etc).
@@ -10661,9 +10666,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return event.keyCode == 36 || event.keyCode == 76
         }
 
-        let eventCharsIgnoringModifiers = event.charactersIgnoringModifiers
+        // --- Primary path: physical keyCode matching ---
+        // Check if the event's physical ANSI key position matches the shortcut.
+        // This handles non-Latin layouts (Russian, Korean, Arabic, etc.) where
+        // charactersIgnoringModifiers returns non-ASCII characters that can never
+        // match a Latin shortcut key, without needing special-case guards.
+        if let expectedKeyCode = keyCodeForShortcutKey(shortcutKey),
+           event.keyCode == expectedKeyCode {
+            if isLetterShortcutKey(shortcutKey) {
+                // For letter shortcuts, verify the character identity doesn't disagree.
+                // On Dvorak/Colemak, physical key I produces "c", so pressing that key
+                // should NOT match a Cmd+I shortcut (the user intends Cmd+C).
+                let eventChars = event.charactersIgnoringModifiers ?? ""
+                let hasUsableEventChars = !eventChars.isEmpty
+                    && eventChars.allSatisfy { $0.isASCII && ($0.asciiValue ?? 0) >= 0x20 }
+                if hasUsableEventChars {
+                    let normalized = normalizedShortcutEventCharacter(
+                        eventChars,
+                        applyShiftSymbolNormalization: flags.contains(.shift),
+                        eventKeyCode: event.keyCode
+                    )
+                    if normalized == shortcutKey { return true }
+                    // Character disagrees: fall through to character matching (Dvorak override)
+                } else {
+                    // No usable ASCII chars (non-Latin layout, control chars, empty).
+                    // Check layout translation for disambiguation.
+                    let layoutChar = shortcutLayoutCharacterProvider(event.keyCode, event.modifierFlags)
+                    let hasUsableLayoutChar = !(layoutChar?.isEmpty ?? true)
+                        && (layoutChar?.allSatisfy(\.isASCII) ?? false)
+                    if !hasUsableLayoutChar || layoutChar?.lowercased() == shortcutKey {
+                        // No layout info to contradict, or layout agrees: accept physical match
+                        return true
+                    }
+                    // Layout translation disagrees: fall through to character matching
+                }
+            } else {
+                // Non-letter shortcuts (digits, punctuation, symbols): physical match accepted.
+                // Digit/punctuation key positions are stable across Latin layouts, and non-Latin
+                // layouts need the physical fallback for these keys (e.g. AZERTY Cmd+1).
+                return true
+            }
+        }
+
+        // --- Fallback: character-based matching ---
+        // Try matching via event.charactersIgnoringModifiers for alternative Latin layouts
+        // (Dvorak, Colemak) where logical character identity differs from physical position.
         if shortcutCharacterMatches(
-            eventCharacter: eventCharsIgnoringModifiers,
+            eventCharacter: event.charactersIgnoringModifiers,
             shortcutKey: shortcutKey,
             applyShiftSymbolNormalization: flags.contains(.shift),
             eventKeyCode: event.keyCode
@@ -10671,24 +10720,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // For command-based shortcuts, trust AppKit's layout-aware characters when present.
-        // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
-        // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
-        // When a non-Latin input source is active (Russian, Korean, Chinese, Japanese, etc.),
-        // charactersIgnoringModifiers returns non-ASCII characters that can never match
-        // a Latin shortcut key — skip this guard and fall through to layout-based matching.
-        let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
-        let eventCharsAreASCII = eventCharsIgnoringModifiers?.allSatisfy(\.isASCII) ?? true
-        if hasEventChars,
-           eventCharsAreASCII,
-           flags.contains(.command),
-           !flags.contains(.control),
-           shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
-            return false
-        }
-
-        // Match using the current keyboard layout so Command shortcuts stay character-based
-        // across layouts (QWERTY, Dvorak, etc.) instead of being tied to ANSI physical keys.
+        // Try layout translation (UCKeyTranslate) for cases where charactersIgnoringModifiers
+        // is unavailable or non-ASCII but the layout can still resolve the key.
         let layoutCharacter = shortcutLayoutCharacterProvider(event.keyCode, event.modifierFlags)
         if shortcutCharacterMatches(
             eventCharacter: layoutCharacter,
@@ -10699,28 +10732,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // Control-key combos can surface as ASCII control characters (e.g. Ctrl+H => backspace),
-        // so keep ANSI keyCode fallback for control-modified shortcuts. Also allow fallback for
-        // command punctuation shortcuts, since some non-US layouts report different characters
-        // for the same physical key even when menu-equivalent semantics should still apply.
-        // When a non-Latin input source is active (Russian, Korean, Chinese, Japanese, etc.),
-        // event chars carry no usable Latin key identity. Always allow keyCode fallback as a
-        // safety net — even when the layout-based translation resolved a character, the
-        // physical key code is the definitive identifier for the intended shortcut.
-        // For empty-character events (synthetic/browser key equivalents), preserve the original
-        // behavior: only fall back when the layout translation also failed.
-        let hasUsableEventChars = hasEventChars && eventCharsAreASCII
-        let allowANSIKeyCodeFallback = flags.contains(.control)
-            || (flags.contains(.command)
-                && !flags.contains(.control)
-                && (
-                    !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (hasEventChars && !eventCharsAreASCII)
-                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
-                ))
-        if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
-            return event.keyCode == expectedKeyCode
-        }
         return false
     }
 
@@ -10764,7 +10775,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return digit
     }
 
-    private func shouldRequireCharacterMatchForCommandShortcut(shortcutKey: String) -> Bool {
+    private func isLetterShortcutKey(_ shortcutKey: String) -> Bool {
         guard shortcutKey.count == 1, let scalar = shortcutKey.unicodeScalars.first else {
             return false
         }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3103,6 +3103,214 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(workspace.panels.count, surfaceCountBefore + 1, "Cmd+T keyCode fallback should create a new surface")
     }
 
+    // MARK: - Physical-first keyCode matching (Dvorak/Colemak)
+
+    func testDvorakCmdPhysicalCProducingJMatchesShortcutBoundToJ() {
+        // On Dvorak, physical C key (keyCode 8) produces "j".
+        // A shortcut bound to "j" should match via character matching, not physical keyCode.
+        // Physical matching would look for keyCodeForShortcutKey("j") = 38, but event keyCode is 8.
+        // Character matching finds "j" == "j".
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        withTemporaryShortcut(
+            action: .showNotifications,
+            shortcut: StoredShortcut(key: "j", command: true, shift: false, option: false, control: false)
+        ) {
+            // Dvorak: physical ANSI "C" key (keyCode 8) produces "j".
+            guard let event = NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.command],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "j",
+                charactersIgnoringModifiers: "j",
+                isARepeat: false,
+                keyCode: 8 // kVK_ANSI_C
+            ) else {
+                XCTFail("Failed to construct Dvorak Cmd+J event on physical ANSI C key")
+                return
+            }
+
+#if DEBUG
+            XCTAssertTrue(
+                appDelegate.debugHandleCustomShortcut(event: event),
+                "Dvorak: Cmd+physical-C producing 'j' should match shortcut bound to 'j'"
+            )
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+    }
+
+    func testDvorakCmdPhysicalCDoesNotMatchShortcutBoundToC() {
+        // On Dvorak, physical C key (keyCode 8) produces "j", not "c".
+        // A shortcut bound to "c" should NOT match because the character identity is "j".
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        withTemporaryShortcut(
+            action: .showNotifications,
+            shortcut: StoredShortcut(key: "c", command: true, shift: false, option: false, control: false)
+        ) {
+            guard let event = NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.command],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "j",
+                charactersIgnoringModifiers: "j",
+                isARepeat: false,
+                keyCode: 8 // kVK_ANSI_C (produces "j" on Dvorak)
+            ) else {
+                XCTFail("Failed to construct Dvorak event on physical ANSI C key")
+                return
+            }
+
+#if DEBUG
+            XCTAssertFalse(
+                appDelegate.debugHandleCustomShortcut(event: event),
+                "Dvorak: physical C producing 'j' should NOT match shortcut bound to 'c'"
+            )
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+    }
+
+    func testColemakCmdPhysicalFProducingEMatchesShortcutBoundToE() {
+        // On Colemak, physical F key (keyCode 3) produces "e".
+        // A shortcut bound to "e" should match via character matching.
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        withTemporaryShortcut(
+            action: .showNotifications,
+            shortcut: StoredShortcut(key: "e", command: true, shift: false, option: false, control: false)
+        ) {
+            // Colemak: physical ANSI "F" key (keyCode 3) produces "e".
+            guard let event = NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.command],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "e",
+                charactersIgnoringModifiers: "e",
+                isARepeat: false,
+                keyCode: 3 // kVK_ANSI_F
+            ) else {
+                XCTFail("Failed to construct Colemak Cmd+E event on physical ANSI F key")
+                return
+            }
+
+#if DEBUG
+            XCTAssertTrue(
+                appDelegate.debugHandleCustomShortcut(event: event),
+                "Colemak: Cmd+physical-F producing 'e' should match shortcut bound to 'e'"
+            )
+#else
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        }
+    }
+
+    func testPhysicalKeyCodeMatchWorksForRussianWithoutSpecialGuards() {
+        // With the physical-first approach, Russian layout shortcuts work via
+        // physical keyCode matching (primary path), not through special non-Latin
+        // guards. This test verifies that Cmd+N (new workspace) works with Russian
+        // layout active, where charactersIgnoringModifiers returns Cyrillic "т".
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+            XCTFail("Expected test window context")
+            return
+        }
+
+        let tabCountBefore = manager.tabs.count
+
+        // Simulate Russian keyboard: layout provider returns "n" via ASCII fallback.
+        appDelegate.shortcutLayoutCharacterProvider = { keyCode, _ in
+            keyCode == 45 ? "n" : nil
+        }
+        defer {
+            appDelegate.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "n",
+            charactersIgnoringModifiers: "т", // Cyrillic т (Russian layout)
+            isARepeat: false,
+            keyCode: 45 // kVK_ANSI_N
+        ) else {
+            XCTFail("Failed to construct Russian-layout Cmd+N event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Cmd+N should be handled with Russian keyboard layout via physical keyCode"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertEqual(
+            manager.tabs.count, tabCountBefore + 1,
+            "Russian Cmd+N via physical keyCode should create a new workspace"
+        )
+    }
+
     private func makeKeyDownEvent(
         key: String,
         modifiers: NSEvent.ModifierFlags,


### PR DESCRIPTION
## Summary

- Refactors `matchShortcut` to try physical ANSI keyCode matching first, aligning with Ghostty's `Binding.Set.getEvent()` which checks physical key before character
- Removes the special non-Latin guards added in https://github.com/manaflow-ai/cmux/pull/2202, since physical-first matching handles Russian, Korean, Arabic, etc. without special cases
- Preserves Dvorak/Colemak behavior: when a physical keyCode matches a letter shortcut but the event's character identity disagrees (e.g. physical I producing "c" on Dvorak), the physical match is rejected and character-based fallback takes over
- Non-letter shortcuts (digits, punctuation) always accept physical matches, handling AZERTY and non-US layouts correctly
- Adds new tests for Dvorak (physical C producing "j"), Colemak (physical F producing "e"), and Russian layout via physical keyCode

Closes https://github.com/manaflow-ai/cmux/issues/2215

## Test plan

- [ ] All existing shortcut routing tests pass in CI
- [ ] New Dvorak tests verify character-based matching when physical key disagrees
- [ ] New Colemak test verifies character-based matching for remapped keys
- [ ] New Russian physical keyCode test verifies non-Latin matching without special guards
- [ ] Manual test with Russian keyboard layout: Cmd+T, Cmd+N, Cmd+W should all work
- [ ] Manual test with Dvorak layout: Cmd+C (copy) should not trigger Cmd+I shortcut when pressing physical I

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut recognition for non-US keyboard layouts, including Dvorak, Colemak, and Russian layouts.

* **Tests**
  * Added comprehensive test coverage for keyboard shortcut routing with international keyboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors shortcut matching to prioritize the physical ANSI `keyCode`, with a character-based fallback. This simplifies non‑Latin handling and makes shortcuts reliable on Dvorak, Colemak, AZERTY, and other layouts. Closes #2215.

- **Refactors**
  - Match via `event.keyCode` first (aligned with Ghostty’s physical‑first approach).
  - For letter shortcuts, require character agreement; otherwise fall back to character/layout matching.
  - For digits/punctuation, always accept the physical match.
  - Remove non‑Latin guards; add tests for Dvorak, Colemak, and Russian.

<sup>Written for commit 5f098dff3752bb7e977a2a976cfe8f69766bb232. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

