### PR TITLE
Fix minimal mode toggle not updating titlebar state

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 					D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 					FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */; };
 					E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */; };
+					AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */; };
 					F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 					F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */; };
@@ -267,6 +268,7 @@
 						D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
 						FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportProfilesUITests.swift; sourceTree = "<group>"; };
 						E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
+						AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 							FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 							C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */,
 						E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */,
+						AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */,
 					);
 				path = cmuxUITests;
 				sourceTree = "<group>";
@@ -789,6 +792,7 @@
 							FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,
 							C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */,
 						E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */,
+						AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */,
 					);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7,9 +7,7 @@ import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
 
-#if DEBUG
-private var _minimalDragDebugMonitorKey: UInt8 = 0
-#endif
+private var _minimalModeDoubleClickMonitorKey: UInt8 = 0
 
 private extension Color {
     init?(hex: String) {
@@ -2642,37 +2640,29 @@ struct ContentView: View {
                 .background(Color.clear)
         )
 
-        #if DEBUG
+        // In minimal mode, intercept double-clicks in the tab bar area and perform
+        // the standard titlebar action (zoom/minimize) instead of letting Bonsplit
+        // create a new tab. The monitor is installed once per window and checks the
+        // current mode on each event so it adapts to mode toggles.
         view = AnyView(view.background(
             WindowAccessor { window in
-                if WorkspacePresentationModeSettings.isMinimal() {
-                    // One-shot monitor to log hit view info on next click
-                    if objc_getAssociatedObject(window, &_minimalDragDebugMonitorKey) == nil {
-                        let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                            guard let window = event.window,
-                                  WorkspacePresentationModeSettings.isMinimal() else { return event }
-                            let loc = event.locationInWindow
-                            if let hitView = window.contentView?.hitTest(loc) {
-                                var chain = [String]()
-                                var v: NSView? = hitView
-                                while let current = v, chain.count < 8 {
-                                    chain.append("\(type(of: current))(canMove=\(current.mouseDownCanMoveWindow))")
-                                    v = current.superview
-                                }
-                                dlog("window.drag.hitTest loc=\(loc) chain=\(chain.joined(separator: " > "))")
-                            } else {
-                                dlog("window.drag.hitTest loc=\(loc) hit=nil")
-                            }
-                            dlog("window.drag.state isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground) toolbar=\(window.toolbar != nil)")
-                            return event
-                        }
-                        objc_setAssociatedObject(window, &_minimalDragDebugMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
-                    }
+                guard objc_getAssociatedObject(window, &_minimalModeDoubleClickMonitorKey) == nil else { return }
+                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                    guard event.clickCount >= 2,
+                          WorkspacePresentationModeSettings.isMinimal(),
+                          let window = event.window else { return event }
+                    // Only intercept in the top strip (tab bar area)
+                    let contentHeight = window.contentLayoutRect.height
+                    let clickY = event.locationInWindow.y
+                    let distFromTop = contentHeight - clickY
+                    guard distFromTop <= 30 else { return event }
+                    performStandardTitlebarDoubleClick(window: window)
+                    return nil
                 }
+                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
             }
             .frame(width: 0, height: 0)
         ))
-        #endif
         view = AnyView(view.onAppear {
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()
@@ -3147,9 +3137,6 @@ struct ContentView: View {
             // to avoid interfering with sidebar tab reordering.
             window.isMovableByWindowBackground = isMinimal
             window.isMovable = isMinimal
-            #if DEBUG
-            dlog("window.drag.config isMinimal=\(isMinimal) isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground) presentationMode=\(workspacePresentationMode)")
-            #endif
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3109,9 +3109,12 @@ struct ContentView: View {
             // Do not make the entire background draggable; it interferes with drag gestures
             // like sidebar tab reordering in multi-window mode.
             window.isMovableByWindowBackground = false
-            // Keep the window immovable by default so titlebar controls (like the folder icon)
-            // cannot accidentally initiate native window drags.
-            window.isMovable = false
+            // In minimal mode the custom titlebar is hidden and the toolbar is removed,
+            // so enable native titlebar dragging so the tab bar area (which overlaps the
+            // native titlebar) can move the window. In standard mode keep it disabled
+            // because our custom WindowDragHandleView handles dragging.
+            let isMinimal = WorkspacePresentationModeSettings.isMinimal()
+            window.isMovable = isMinimal
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2653,7 +2653,7 @@ struct ContentView: View {
                           WorkspacePresentationModeSettings.isMinimal(),
                           let eventWindow = event.window else { return event }
                     let distFromTop = eventWindow.frame.height - event.locationInWindow.y
-                    guard distFromTop <= 30 else { return event }
+                    guard distFromTop <= 40 else { return event }
                     performStandardTitlebarDoubleClick(window: eventWindow)
                     return nil
                 }
@@ -3130,10 +3130,11 @@ struct ContentView: View {
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
             let isMinimal = WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
-            // In minimal mode enable background dragging so the tab bar area
-            // acts as a window drag handle. In standard mode keep it disabled
-            // to avoid interfering with sidebar tab reordering.
-            window.isMovableByWindowBackground = isMinimal
+            // Do not make the entire background draggable; it interferes with
+            // drag gestures like tab reordering. In minimal mode, enable
+            // isMovable so the native titlebar area (overlapping the tab bar via
+            // negative padding) handles drag-to-move from the sidebar strip.
+            window.isMovableByWindowBackground = false
             window.isMovable = isMinimal
             window.styleMask.insert(.fullSizeContentView)
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2348,8 +2348,6 @@ struct ContentView: View {
     }
 
     private var terminalContent: some View {
-        // In minimal mode with sidebar collapsed, add leading inset for traffic lights.
-        let trafficLightInset: CGFloat = (isMinimalMode && !sidebarState.isVisible) ? titlebarLeadingInset : 0
         let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
         let mountedWorkspaces = tabManager.tabs.filter { mountedWorkspaceIdSet.contains($0.id) }
         let selectedWorkspaceId = tabManager.selectedTabId
@@ -2372,11 +2370,6 @@ struct ContentView: View {
                     // delay handoff completion and make browser returns feel laggy.
                     let isInputActive = isSelectedWorkspace
                     let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
-                    let _ = {
-                        if tab.bonsplitController.configuration.appearance.tabBarLeadingInset != trafficLightInset {
-                            tab.bonsplitController.configuration.appearance.tabBarLeadingInset = trafficLightInset
-                        }
-                    }()
                     WorkspaceContentView(
                         workspace: tab,
                         isWorkspaceVisible: presentation.isPanelVisible,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2344,7 +2344,7 @@ struct ContentView: View {
     }
 
     private var effectiveTitlebarPadding: CGFloat {
-        isMinimalMode ? 0 : titlebarPadding
+        isMinimalMode ? -titlebarPadding : titlebarPadding
     }
 
     private var terminalContent: some View {
@@ -2624,31 +2624,19 @@ struct ContentView: View {
     }
 
     var body: some View {
-        let mainLayout: AnyView
-        if isMinimalMode {
-            mainLayout = AnyView(
-                contentAndSidebarLayout
-                    .ignoresSafeArea(.container, edges: .top)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
-                    .background(Color.clear)
-            )
-        } else {
-            mainLayout = AnyView(
-                contentAndSidebarLayout
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .overlay(alignment: .topLeading) {
-                        if isFullScreen && sidebarState.isVisible {
-                            fullscreenControls
-                                .padding(.leading, 10)
-                                .padding(.top, 4)
-                        }
+        var view = AnyView(
+            contentAndSidebarLayout
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .overlay(alignment: .topLeading) {
+                    if isFullScreen && sidebarState.isVisible && !isMinimalMode {
+                        fullscreenControls
+                            .padding(.leading, 10)
+                            .padding(.top, 4)
                     }
-                    .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
-                    .background(Color.clear)
-            )
-        }
-        var view = mainLayout
+                }
+                .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+                .background(Color.clear)
+        )
 
         view = AnyView(view.onAppear {
             tabManager.applyWindowBackgroundForSelectedTab()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7,6 +7,10 @@ import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
 
+#if DEBUG
+private var _minimalDragDebugMonitorKey: UInt8 = 0
+#endif
+
 private extension Color {
     init?(hex: String) {
         let hex = hex.trimmingCharacters(in: .init(charactersIn: "#"))
@@ -2638,6 +2642,37 @@ struct ContentView: View {
                 .background(Color.clear)
         )
 
+        #if DEBUG
+        view = AnyView(view.background(
+            WindowAccessor { window in
+                if WorkspacePresentationModeSettings.isMinimal() {
+                    // One-shot monitor to log hit view info on next click
+                    if objc_getAssociatedObject(window, &_minimalDragDebugMonitorKey) == nil {
+                        let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                            guard let window = event.window,
+                                  WorkspacePresentationModeSettings.isMinimal() else { return event }
+                            let loc = event.locationInWindow
+                            if let hitView = window.contentView?.hitTest(loc) {
+                                var chain = [String]()
+                                var v: NSView? = hitView
+                                while let current = v, chain.count < 8 {
+                                    chain.append("\(type(of: current))(canMove=\(current.mouseDownCanMoveWindow))")
+                                    v = current.superview
+                                }
+                                dlog("window.drag.hitTest loc=\(loc) chain=\(chain.joined(separator: " > "))")
+                            } else {
+                                dlog("window.drag.hitTest loc=\(loc) hit=nil")
+                            }
+                            dlog("window.drag.state isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground) toolbar=\(window.toolbar != nil)")
+                            return event
+                        }
+                        objc_setAssociatedObject(window, &_minimalDragDebugMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
+                    }
+                }
+            }
+            .frame(width: 0, height: 0)
+        ))
+        #endif
         view = AnyView(view.onAppear {
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()
@@ -3112,6 +3147,9 @@ struct ContentView: View {
             // to avoid interfering with sidebar tab reordering.
             window.isMovableByWindowBackground = isMinimal
             window.isMovable = isMinimal
+            #if DEBUG
+            dlog("window.drag.config isMinimal=\(isMinimal) isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground) presentationMode=\(workspacePresentationMode)")
+            #endif
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7,8 +7,6 @@ import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
 
-private var _minimalModeDoubleClickMonitorKey: UInt8 = 0
-
 private extension Color {
     init?(hex: String) {
         let hex = hex.trimmingCharacters(in: .init(charactersIn: "#"))
@@ -2647,27 +2645,6 @@ struct ContentView: View {
                 .background(Color.clear)
         )
 
-        // In minimal mode, intercept double-clicks in the tab bar area and perform
-        // the standard titlebar action (zoom/minimize) instead of letting Bonsplit
-        // create a new tab. This monitor is installed via a .background modifier
-        // which SwiftUI processes after the content tree, so it's added after
-        // Bonsplit's monitors. NSEvent local monitors are LIFO, so ours runs first.
-        view = AnyView(view.background(
-            WindowAccessor { window in
-                guard objc_getAssociatedObject(window, &_minimalModeDoubleClickMonitorKey) == nil else { return }
-                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                    guard event.clickCount >= 2,
-                          WorkspacePresentationModeSettings.isMinimal(),
-                          let eventWindow = event.window else { return event }
-                    let distFromTop = eventWindow.frame.height - event.locationInWindow.y
-                    guard distFromTop <= 40 else { return event }
-                    performStandardTitlebarDoubleClick(window: eventWindow)
-                    return nil
-                }
-                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
-            }
-            .frame(width: 0, height: 0)
-        ))
         view = AnyView(view.onAppear {
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2508,6 +2508,15 @@ struct ContentView: View {
         }
     }
 
+    private func syncTrafficLightInset() {
+        let inset: CGFloat = (isMinimalMode && !sidebarState.isVisible) ? 80 : 0
+        for tab in tabManager.tabs {
+            if tab.bonsplitController.configuration.appearance.tabBarLeadingInset != inset {
+                tab.bonsplitController.configuration.appearance.tabBarLeadingInset = inset
+            }
+        }
+    }
+
     private func updateTitlebarText() {
         guard let selectedId = tabManager.selectedTabId,
               let tab = tabManager.tabs.first(where: { $0.id == selectedId }) else {
@@ -2657,6 +2666,7 @@ struct ContentView: View {
             syncSidebarSelectedWorkspaceIds()
             applyUITestSidebarSelectionIfNeeded(tabs: tabManager.tabs)
             updateTitlebarText()
+            syncTrafficLightInset()
 
             // Startup recovery (#399): if session restore or a race condition leaves the
             // view in a broken state (empty tabs, no selection, unmounted workspaces),
@@ -3075,6 +3085,11 @@ struct ContentView: View {
                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
             }
             updateSidebarResizerBandState()
+            syncTrafficLightInset()
+        })
+
+        view = AnyView(view.onChange(of: isMinimalMode) { _, _ in
+            syncTrafficLightInset()
         })
 
         view = AnyView(view.onChange(of: sidebarState.persistedWidth) { newValue in

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3126,16 +3126,15 @@ struct ContentView: View {
             removeSidebarResizerPointerMonitor()
         })
 
-        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity, workspacePresentationMode] window in
+        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
-            let isMinimal = WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
-            // Do not make the entire background draggable; it interferes with
-            // drag gestures like tab reordering. In minimal mode, enable
-            // isMovable so the native titlebar area (overlapping the tab bar via
-            // negative padding) handles drag-to-move from the sidebar strip.
+            // Keep window immovable; the sidebar's WindowDragHandleView handles
+            // drag-to-move via performDrag with temporary movable override.
+            // isMovableByWindowBackground=true breaks tab reordering, and
+            // isMovable=true blocks clicks on sidebar buttons in minimal mode.
             window.isMovableByWindowBackground = false
-            window.isMovable = isMinimal
+            window.isMovable = false
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2406,6 +2406,7 @@ struct ContentView: View {
                 .accessibilityHidden(sidebarSelectionState.selection != .notifications)
         }
         .padding(.top, effectiveTitlebarPadding)
+        .padding(.leading, isMinimalMode && !sidebarState.isVisible ? titlebarLeadingInset : 0)
         .overlay(alignment: .top) {
             if !isMinimalMode {
                 // Titlebar overlay is only over terminal content, not the sidebar.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3103,17 +3103,14 @@ struct ContentView: View {
             removeSidebarResizerPointerMonitor()
         })
 
-        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
+        view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity, workspacePresentationMode] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
-            // Do not make the entire background draggable; it interferes with drag gestures
-            // like sidebar tab reordering in multi-window mode.
-            window.isMovableByWindowBackground = false
-            // In minimal mode the custom titlebar is hidden and the toolbar is removed,
-            // so enable native titlebar dragging so the tab bar area (which overlaps the
-            // native titlebar) can move the window. In standard mode keep it disabled
-            // because our custom WindowDragHandleView handles dragging.
-            let isMinimal = WorkspacePresentationModeSettings.isMinimal()
+            let isMinimal = WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
+            // In minimal mode enable background dragging so the tab bar area
+            // acts as a window drag handle. In standard mode keep it disabled
+            // to avoid interfering with sidebar tab reordering.
+            window.isMovableByWindowBackground = isMinimal
             window.isMovable = isMinimal
             window.styleMask.insert(.fullSizeContentView)
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2350,6 +2350,8 @@ struct ContentView: View {
     }
 
     private var terminalContent: some View {
+        // In minimal mode with sidebar collapsed, add leading inset for traffic lights.
+        let trafficLightInset: CGFloat = (isMinimalMode && !sidebarState.isVisible) ? titlebarLeadingInset : 0
         let mountedWorkspaceIdSet = Set(mountedWorkspaceIds)
         let mountedWorkspaces = tabManager.tabs.filter { mountedWorkspaceIdSet.contains($0.id) }
         let selectedWorkspaceId = tabManager.selectedTabId
@@ -2372,6 +2374,11 @@ struct ContentView: View {
                     // delay handoff completion and make browser returns feel laggy.
                     let isInputActive = isSelectedWorkspace
                     let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
+                    let _ = {
+                        if tab.bonsplitController.configuration.appearance.tabBarLeadingInset != trafficLightInset {
+                            tab.bonsplitController.configuration.appearance.tabBarLeadingInset = trafficLightInset
+                        }
+                    }()
                     WorkspaceContentView(
                         workspace: tab,
                         isWorkspaceVisible: presentation.isPanelVisible,
@@ -2406,7 +2413,6 @@ struct ContentView: View {
                 .accessibilityHidden(sidebarSelectionState.selection != .notifications)
         }
         .padding(.top, effectiveTitlebarPadding)
-        .padding(.leading, isMinimalMode && !sidebarState.isVisible ? titlebarLeadingInset : 0)
         .overlay(alignment: .top) {
             if !isMinimalMode {
                 // Titlebar overlay is only over terminal content, not the sidebar.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2624,19 +2624,31 @@ struct ContentView: View {
     }
 
     var body: some View {
-        var view = AnyView(
-            contentAndSidebarLayout
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .overlay(alignment: .topLeading) {
-                    if isFullScreen && sidebarState.isVisible && !isMinimalMode {
-                        fullscreenControls
-                            .padding(.leading, 10)
-                            .padding(.top, 4)
+        let mainLayout: AnyView
+        if isMinimalMode {
+            mainLayout = AnyView(
+                contentAndSidebarLayout
+                    .ignoresSafeArea(.container, edges: .top)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+                    .background(Color.clear)
+            )
+        } else {
+            mainLayout = AnyView(
+                contentAndSidebarLayout
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .overlay(alignment: .topLeading) {
+                        if isFullScreen && sidebarState.isVisible {
+                            fullscreenControls
+                                .padding(.leading, 10)
+                                .padding(.top, 4)
+                        }
                     }
-                }
-                .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
-                .background(Color.clear)
-        )
+                    .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+                    .background(Color.clear)
+            )
+        }
+        var view = mainLayout
 
         view = AnyView(view.onAppear {
             tabManager.applyWindowBackgroundForSelectedTab()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2642,31 +2642,22 @@ struct ContentView: View {
 
         // In minimal mode, intercept double-clicks in the tab bar area and perform
         // the standard titlebar action (zoom/minimize) instead of letting Bonsplit
-        // create a new tab. Install with a delay so this monitor is added AFTER
-        // Bonsplit's EmptyTabBarDoubleClickMonitorView monitors — NSEvent local
-        // monitors are called in LIFO order, so the last-installed runs first.
+        // create a new tab. This monitor is installed via a .background modifier
+        // which SwiftUI processes after the content tree, so it's added after
+        // Bonsplit's monitors. NSEvent local monitors are LIFO, so ours runs first.
         view = AnyView(view.background(
             WindowAccessor { window in
                 guard objc_getAssociatedObject(window, &_minimalModeDoubleClickMonitorKey) == nil else { return }
-                // Mark immediately to avoid duplicate installations.
-                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, NSNull(), .OBJC_ASSOCIATION_RETAIN)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak window] in
-                    guard let window else { return }
-                    let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                        guard event.clickCount >= 2,
-                              WorkspacePresentationModeSettings.isMinimal(),
-                              let eventWindow = event.window else { return event }
-                        // Only intercept in the top strip (tab bar area).
-                        // In AppKit window coords, y increases upward from bottom.
-                        let windowHeight = eventWindow.frame.height
-                        let clickY = event.locationInWindow.y
-                        let distFromTop = windowHeight - clickY
-                        guard distFromTop <= 30 else { return event }
-                        performStandardTitlebarDoubleClick(window: eventWindow)
-                        return nil
-                    }
-                    objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
+                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                    guard event.clickCount >= 2,
+                          WorkspacePresentationModeSettings.isMinimal(),
+                          let eventWindow = event.window else { return event }
+                    let distFromTop = eventWindow.frame.height - event.locationInWindow.y
+                    guard distFromTop <= 30 else { return event }
+                    performStandardTitlebarDoubleClick(window: eventWindow)
+                    return nil
                 }
+                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
             }
             .frame(width: 0, height: 0)
         ))

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2642,24 +2642,31 @@ struct ContentView: View {
 
         // In minimal mode, intercept double-clicks in the tab bar area and perform
         // the standard titlebar action (zoom/minimize) instead of letting Bonsplit
-        // create a new tab. The monitor is installed once per window and checks the
-        // current mode on each event so it adapts to mode toggles.
+        // create a new tab. Install with a delay so this monitor is added AFTER
+        // Bonsplit's EmptyTabBarDoubleClickMonitorView monitors — NSEvent local
+        // monitors are called in LIFO order, so the last-installed runs first.
         view = AnyView(view.background(
             WindowAccessor { window in
                 guard objc_getAssociatedObject(window, &_minimalModeDoubleClickMonitorKey) == nil else { return }
-                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                    guard event.clickCount >= 2,
-                          WorkspacePresentationModeSettings.isMinimal(),
-                          let window = event.window else { return event }
-                    // Only intercept in the top strip (tab bar area)
-                    let contentHeight = window.contentLayoutRect.height
-                    let clickY = event.locationInWindow.y
-                    let distFromTop = contentHeight - clickY
-                    guard distFromTop <= 30 else { return event }
-                    performStandardTitlebarDoubleClick(window: window)
-                    return nil
+                // Mark immediately to avoid duplicate installations.
+                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, NSNull(), .OBJC_ASSOCIATION_RETAIN)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak window] in
+                    guard let window else { return }
+                    let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                        guard event.clickCount >= 2,
+                              WorkspacePresentationModeSettings.isMinimal(),
+                              let eventWindow = event.window else { return event }
+                        // Only intercept in the top strip (tab bar area).
+                        // In AppKit window coords, y increases upward from bottom.
+                        let windowHeight = eventWindow.frame.height
+                        let clickY = event.locationInWindow.y
+                        let distFromTop = windowHeight - clickY
+                        guard distFromTop <= 30 else { return event }
+                        performStandardTitlebarDoubleClick(window: eventWindow)
+                        return nil
+                    }
+                    objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
                 }
-                objc_setAssociatedObject(window, &_minimalModeDoubleClickMonitorKey, monitor, .OBJC_ASSOCIATION_RETAIN)
             }
             .frame(width: 0, height: 0)
         ))

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -918,12 +918,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
     private func applyWorkspaceTitlebarVisibility() {
         let shouldShow = showsWorkspaceTitlebar
-        view.isHidden = !shouldShow
-        if !shouldShow {
-            preferredContentSize = .zero
-            containerView.frame = .zero
-            hostingView.frame = .zero
-        }
+        self.isHidden = !shouldShow
     }
 
     func toggleNotificationsPopover(animated: Bool = true, externalAnchor: NSView? = nil) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1270,24 +1270,20 @@ final class UpdateTitlebarAccessoryController {
         let currentMode = WorkspacePresentationModeSettings.mode()
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
+        // Ensure accessories exist on all windows. TitlebarControlsAccessoryViewController
+        // handles its own visibility (hidden in minimal, visible in standard) via its
+        // UserDefaults observer, so we just need to make sure it's attached.
+        attachToExistingWindows()
 
-        if currentMode == .minimal {
-            attachToExistingWindows()
-        } else {
-            // When switching back to standard, the WindowAccessor in ContentView
-            // calls attachUpdateAccessory on re-render (workspacePresentationMode
-            // is in its capture list). Do a deferred safety-net scan with enough
-            // delay for the window identifier and toolbar to be fully set up.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                guard let self else { return }
-                self.attachToExistingWindows()
-                let controlsId = self.controlsIdentifier
-                for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
-                    for accessory in window.titlebarAccessoryViewControllers
-                        where accessory.view.identifier == controlsId {
-                        accessory.isHidden = true
-                        accessory.view.alphaValue = 0
-                    }
+        // When switching back to standard mode while a window is in fullscreen,
+        // hide the accessories because fullscreen uses SwiftUI overlay controls.
+        if currentMode == .standard {
+            let controlsId = self.controlsIdentifier
+            for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
+                for accessory in window.titlebarAccessoryViewControllers
+                    where accessory.view.identifier == controlsId {
+                    accessory.isHidden = true
+                    accessory.view.alphaValue = 0
                 }
             }
         }
@@ -1348,10 +1344,9 @@ final class UpdateTitlebarAccessoryController {
 
         pendingAttachRetries.removeValue(forKey: ObjectIdentifier(window))
 
-        guard !WorkspacePresentationModeSettings.isMinimal() else {
-            removeAccessoryIfPresent(from: window)
-            return
-        }
+        // Don't remove accessories in minimal mode. TitlebarControlsAccessoryViewController
+        // hides itself and zeros its frame via its own UserDefaults observer. Keeping it
+        // attached avoids fragile remove/re-add cycles on mode toggle.
 
         guard !attachedWindows.contains(window) else { return }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -821,7 +821,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             queue: .main
         ) { [weak self] _ in
             self?.applyWorkspaceTitlebarVisibility()
-            self?.scheduleSizeUpdate(invalidateFittingSize: true)
+            if self?.showsWorkspaceTitlebar == true {
+                self?.restoreSizeAfterMinimalMode()
+            }
         }
 
         applyWorkspaceTitlebarVisibility()
@@ -918,13 +920,25 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
     private func applyWorkspaceTitlebarVisibility() {
         let shouldShow = showsWorkspaceTitlebar
-        // Use both self.isHidden (for AppKit space management) and
-        // view.alphaValue (for visual hiding). Don't zero frames or
-        // preferredContentSize so fittingSize can still return valid
-        // values when switching back to standard mode.
         self.isHidden = !shouldShow
-        view.alphaValue = shouldShow ? 1 : 0
         view.isHidden = !shouldShow
+        view.alphaValue = shouldShow ? 1 : 0
+        if !shouldShow {
+            preferredContentSize = .zero
+        }
+    }
+
+    /// Restore the accessory size after it was zeroed in minimal mode.
+    /// Seeds the hosting view with a non-zero frame so fittingSize returns
+    /// valid values even after the view was collapsed.
+    private func restoreSizeAfterMinimalMode() {
+        guard showsWorkspaceTitlebar else { return }
+        let seed = cachedFittingSize ?? NSSize(width: 200, height: 28)
+        if hostingView.frame.size == .zero || containerView.frame.size == .zero {
+            containerView.frame.size = seed
+            hostingView.frame.size = seed
+        }
+        scheduleSizeUpdate(invalidateFittingSize: true)
     }
 
     func toggleNotificationsPopover(animated: Bool = true, externalAnchor: NSView? = nil) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1278,7 +1278,7 @@ final class UpdateTitlebarAccessoryController {
             // is re-added first (WindowToolbarController also observes the same
             // UserDefaults change). The accessory needs a valid toolbar/titlebar
             // area to lay out correctly.
-            DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                 self?.attachToExistingWindows()
                 // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
                 // overlay controls instead).

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1271,6 +1271,13 @@ final class UpdateTitlebarAccessoryController {
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
 
+        #if DEBUG
+        let env = ProcessInfo.processInfo.environment
+        if env["CMUX_UI_TEST_MODE"] != "1" {
+            dlog("minimal.titlebarAccessory.modeChange mode=\(currentMode) windows=\(NSApp.windows.count)")
+        }
+        #endif
+
         if currentMode == .minimal {
             attachToExistingWindows()
         } else {
@@ -1279,6 +1286,11 @@ final class UpdateTitlebarAccessoryController {
             // UserDefaults change). The accessory needs a valid toolbar/titlebar
             // area to lay out correctly.
             DispatchQueue.main.async { [weak self] in
+                #if DEBUG
+                if env["CMUX_UI_TEST_MODE"] != "1" {
+                    dlog("minimal.titlebarAccessory.reattachDeferred mode=standard")
+                }
+                #endif
                 self?.attachToExistingWindows()
                 // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
                 // overlay controls instead).

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1271,13 +1271,6 @@ final class UpdateTitlebarAccessoryController {
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
 
-        #if DEBUG
-        let env = ProcessInfo.processInfo.environment
-        if env["CMUX_UI_TEST_MODE"] != "1" {
-            dlog("minimal.titlebarAccessory.modeChange mode=\(currentMode) windows=\(NSApp.windows.count)")
-        }
-        #endif
-
         if currentMode == .minimal {
             attachToExistingWindows()
         } else {
@@ -1286,11 +1279,6 @@ final class UpdateTitlebarAccessoryController {
             // UserDefaults change). The accessory needs a valid toolbar/titlebar
             // area to lay out correctly.
             DispatchQueue.main.async { [weak self] in
-                #if DEBUG
-                if env["CMUX_UI_TEST_MODE"] != "1" {
-                    dlog("minimal.titlebarAccessory.reattachDeferred mode=standard")
-                }
-                #endif
                 self?.attachToExistingWindows()
                 // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
                 // overlay controls instead).

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1271,6 +1271,9 @@ final class UpdateTitlebarAccessoryController {
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
 
+        #if DEBUG
+        dlog("minimal.accessory.modeChange to=\(currentMode) windows=\(NSApp.windows.count)")
+        #endif
         if currentMode == .minimal {
             attachToExistingWindows()
         } else {
@@ -1279,12 +1282,25 @@ final class UpdateTitlebarAccessoryController {
             // UserDefaults change). The accessory needs a valid toolbar/titlebar
             // area to lay out correctly.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.attachToExistingWindows()
+                guard let self else { return }
+                #if DEBUG
+                dlog("minimal.accessory.reattachNow windows=\(NSApp.windows.count) attached=\(self.attachedWindows.allObjects.count)")
+                let controlsId = self.controlsIdentifier
+                for window in NSApp.windows {
+                    let id = window.identifier?.rawValue ?? "<nil>"
+                    let isMain = self.isMainTerminalWindow(window)
+                    let isAttached = self.attachedWindows.contains(window)
+                    let hasAccessory = window.titlebarAccessoryViewControllers.contains { $0.view.identifier == controlsId }
+                    let hasToolbar = window.toolbar != nil
+                    dlog("minimal.accessory.windowCheck id=\(id) isMain=\(isMain) isAttached=\(isAttached) hasAccessory=\(hasAccessory) hasToolbar=\(hasToolbar)")
+                }
+                #endif
+                self.attachToExistingWindows()
                 // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
                 // overlay controls instead).
                 for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
                     for accessory in window.titlebarAccessoryViewControllers
-                        where accessory.view.identifier == self?.controlsIdentifier {
+                        where accessory.view.identifier == controlsId {
                         accessory.isHidden = true
                         accessory.view.alphaValue = 0
                     }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1270,17 +1270,24 @@ final class UpdateTitlebarAccessoryController {
         let currentMode = WorkspacePresentationModeSettings.mode()
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
-        attachToExistingWindows()
 
-        // When switching back to standard mode while a window is in fullscreen,
-        // hide the newly attached accessories because fullscreen uses SwiftUI
-        // overlay controls instead of the titlebar accessories.
-        if currentMode == .standard {
-            for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
-                for accessory in window.titlebarAccessoryViewControllers
-                    where accessory.view.identifier == controlsIdentifier {
-                    accessory.isHidden = true
-                    accessory.view.alphaValue = 0
+        if currentMode == .minimal {
+            attachToExistingWindows()
+        } else {
+            // When switching back to standard, delay re-attachment so the toolbar
+            // is re-added first (WindowToolbarController also observes the same
+            // UserDefaults change). The accessory needs a valid toolbar/titlebar
+            // area to lay out correctly.
+            DispatchQueue.main.async { [weak self] in
+                self?.attachToExistingWindows()
+                // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
+                // overlay controls instead).
+                for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
+                    for accessory in window.titlebarAccessoryViewControllers
+                        where accessory.view.identifier == self?.controlsIdentifier {
+                        accessory.isHidden = true
+                        accessory.view.alphaValue = 0
+                    }
                 }
             }
         }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1271,33 +1271,17 @@ final class UpdateTitlebarAccessoryController {
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
 
-        #if DEBUG
-        dlog("minimal.accessory.modeChange to=\(currentMode) windows=\(NSApp.windows.count)")
-        #endif
         if currentMode == .minimal {
             attachToExistingWindows()
         } else {
-            // When switching back to standard, delay re-attachment so the toolbar
-            // is re-added first (WindowToolbarController also observes the same
-            // UserDefaults change). The accessory needs a valid toolbar/titlebar
-            // area to lay out correctly.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            // When switching back to standard, the WindowAccessor in ContentView
+            // calls attachUpdateAccessory on re-render (workspacePresentationMode
+            // is in its capture list). Do a deferred safety-net scan with enough
+            // delay for the window identifier and toolbar to be fully set up.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 guard let self else { return }
-                #if DEBUG
-                dlog("minimal.accessory.reattachNow windows=\(NSApp.windows.count) attached=\(self.attachedWindows.allObjects.count)")
-                let controlsId = self.controlsIdentifier
-                for window in NSApp.windows {
-                    let id = window.identifier?.rawValue ?? "<nil>"
-                    let isMain = self.isMainTerminalWindow(window)
-                    let isAttached = self.attachedWindows.contains(window)
-                    let hasAccessory = window.titlebarAccessoryViewControllers.contains { $0.view.identifier == controlsId }
-                    let hasToolbar = window.toolbar != nil
-                    dlog("minimal.accessory.windowCheck id=\(id) isMain=\(isMain) isAttached=\(isAttached) hasAccessory=\(hasAccessory) hasToolbar=\(hasToolbar)")
-                }
-                #endif
                 self.attachToExistingWindows()
-                // Hide accessories on fullscreen windows (fullscreen uses SwiftUI
-                // overlay controls instead).
+                let controlsId = self.controlsIdentifier
                 for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
                     for accessory in window.titlebarAccessoryViewControllers
                         where accessory.view.identifier == controlsId {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1202,6 +1202,7 @@ final class UpdateTitlebarAccessoryController {
     private var startupScanWorkItems: [DispatchWorkItem] = []
     private let controlsIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarControls")
     private let controlsControllers = NSHashTable<TitlebarControlsAccessoryViewController>.weakObjects()
+    private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
 
     init(viewModel: UpdateViewModel) {
         self.updateViewModel = viewModel
@@ -1249,8 +1250,40 @@ final class UpdateTitlebarAccessoryController {
             }
         })
 
+        // Re-evaluate all windows when the presentation mode changes so that
+        // accessories are removed in minimal mode and re-attached in standard mode.
+        observers.append(center.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.reattachIfPresentationModeChanged()
+            }
+        })
+
         // We intentionally do not rely on "window became visible" notifications here:
         // AppKit does not provide a stable cross-SDK API for this. Startup scans handle this case.
+    }
+
+    private func reattachIfPresentationModeChanged() {
+        let currentMode = WorkspacePresentationModeSettings.mode()
+        guard currentMode != lastKnownPresentationMode else { return }
+        lastKnownPresentationMode = currentMode
+        attachToExistingWindows()
+
+        // When switching back to standard mode while a window is in fullscreen,
+        // hide the newly attached accessories because fullscreen uses SwiftUI
+        // overlay controls instead of the titlebar accessories.
+        if currentMode == .standard {
+            for window in NSApp.windows where window.styleMask.contains(.fullScreen) {
+                for accessory in window.titlebarAccessoryViewControllers
+                    where accessory.view.identifier == controlsIdentifier {
+                    accessory.isHidden = true
+                    accessory.view.alphaValue = 0
+                }
+            }
+        }
     }
 
     private func attachToExistingWindows() {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -918,7 +918,13 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
     private func applyWorkspaceTitlebarVisibility() {
         let shouldShow = showsWorkspaceTitlebar
+        // Use both self.isHidden (for AppKit space management) and
+        // view.alphaValue (for visual hiding). Don't zero frames or
+        // preferredContentSize so fittingSize can still return valid
+        // values when switching back to standard mode.
         self.isHidden = !shouldShow
+        view.alphaValue = shouldShow ? 1 : 0
+        view.isHidden = !shouldShow
     }
 
     func toggleNotificationsPopover(animated: Bool = true, externalAnchor: NSView? = nil) {

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -85,9 +85,6 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             } else {
                 attach(to: window)
             }
-            #if DEBUG
-            NSLog("window.toolbar.modeChange mode=\(currentMode) toolbar=\(window.toolbar != nil) isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground)")
-            #endif
         }
     }
 

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -86,6 +86,24 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
                 attach(to: window)
             }
         }
+        // After toolbar changes, force titlebar accessories to recalculate.
+        // Toolbar removal/re-addition changes the titlebar geometry, and
+        // accessories hidden via isHidden need a layout pass to reappear.
+        if !isMinimal {
+            DispatchQueue.main.async {
+                for window in NSApp.windows {
+                    for accessory in window.titlebarAccessoryViewControllers {
+                        if !accessory.isHidden {
+                            accessory.view.needsLayout = true
+                            accessory.view.superview?.needsLayout = true
+                        }
+                    }
+                    window.contentView?.needsLayout = true
+                    window.contentView?.superview?.needsLayout = true
+                    window.invalidateShadow()
+                }
+            }
+        }
     }
 
     private func attachToExistingWindows() {

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -85,6 +85,9 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             } else {
                 attach(to: window)
             }
+            #if DEBUG
+            NSLog("window.toolbar.modeChange mode=\(currentMode) toolbar=\(window.toolbar != nil) isMovable=\(window.isMovable) isMovableByBg=\(window.isMovableByWindowBackground)")
+            #endif
         }
     }
 

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -11,6 +11,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
     private var commandLabels: [ObjectIdentifier: NSTextField] = [:]
     private var observers: [NSObjectProtocol] = []
     private let focusedCommandUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
+    private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
 
     override init() {
         super.init()
@@ -61,6 +62,26 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
                 self?.attach(to: window)
             }
         })
+
+        observers.append(center.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateToolbarVisibilityIfNeeded()
+            }
+        })
+    }
+
+    private func updateToolbarVisibilityIfNeeded() {
+        let currentMode = WorkspacePresentationModeSettings.mode()
+        guard currentMode != lastKnownPresentationMode else { return }
+        lastKnownPresentationMode = currentMode
+        let visible = currentMode != .minimal
+        for window in NSApp.windows {
+            window.toolbar?.isVisible = visible
+        }
     }
 
     private func attachToExistingWindows() {
@@ -78,6 +99,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
         toolbar.allowsUserCustomization = false
         toolbar.autosavesConfiguration = false
         toolbar.showsBaselineSeparator = false
+        toolbar.isVisible = !WorkspacePresentationModeSettings.isMinimal()
         window.toolbar = toolbar
         window.toolbarStyle = .unifiedCompact
         window.titleVisibility = .hidden

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -78,9 +78,13 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
         let currentMode = WorkspacePresentationModeSettings.mode()
         guard currentMode != lastKnownPresentationMode else { return }
         lastKnownPresentationMode = currentMode
-        let visible = currentMode != .minimal
+        let isMinimal = currentMode == .minimal
         for window in NSApp.windows {
-            window.toolbar?.isVisible = visible
+            if isMinimal {
+                window.toolbar = nil
+            } else {
+                attach(to: window)
+            }
         }
     }
 
@@ -92,6 +96,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
 
     private func attach(to window: NSWindow) {
         guard window.toolbar == nil else { return }
+        guard !WorkspacePresentationModeSettings.isMinimal() else { return }
         let toolbar = NSToolbar(identifier: NSToolbar.Identifier("cmux.toolbar"))
         toolbar.delegate = self
         toolbar.displayMode = .iconOnly
@@ -99,7 +104,6 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
         toolbar.allowsUserCustomization = false
         toolbar.autosavesConfiguration = false
         toolbar.showsBaselineSeparator = false
-        toolbar.isVisible = !WorkspacePresentationModeSettings.isMinimal()
         window.toolbar = toolbar
         window.toolbarStyle = .unifiedCompact
         window.titleVisibility = .hidden

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -379,13 +379,6 @@ struct WorkspaceContentView: View {
             if isMinimalMode {
                 bonsplitView
                     .ignoresSafeArea(.container, edges: .top)
-                    .overlay(alignment: .top) {
-                        if isWorkspaceInputActive {
-                            WindowDragHandleView()
-                                .frame(height: WorkspaceTitlebarInteractionMetrics.minimalModeTopStripHeight)
-                                .background(TitlebarDoubleClickMonitorView())
-                        }
-                    }
             } else {
                 bonsplitView
             }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -384,19 +384,6 @@ struct WorkspaceContentView: View {
                 bonsplitView
             }
         }
-        .onAppear {
-            syncSplitButtonsOnHover()
-        }
-        .onChange(of: isMinimalMode) { _, _ in
-            syncSplitButtonsOnHover()
-        }
-    }
-
-    private func syncSplitButtonsOnHover() {
-        let onHover = isMinimalMode
-        if workspace.bonsplitController.configuration.appearance.splitButtonsOnHover != onHover {
-            workspace.bonsplitController.configuration.appearance.splitButtonsOnHover = onHover
-        }
     }
 
     private func syncBonsplitNotificationBadges() {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -263,13 +263,6 @@ struct WorkspaceContentView: View {
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
         let _ = { workspace.bonsplitController.isInteractive = isWorkspaceInputActive }()
 
-        // In minimal mode, split buttons only appear on hover.
-        let _ = {
-            let onHover = isMinimalMode
-            if workspace.bonsplitController.configuration.appearance.splitButtonsOnHover != onHover {
-                workspace.bonsplitController.configuration.appearance.splitButtonsOnHover = onHover
-            }
-        }()
 
         // Wire up file drop handling so bonsplit's PaneDragContainerView can forward
         // Finder file drops to the correct terminal panel.
@@ -390,6 +383,22 @@ struct WorkspaceContentView: View {
             } else {
                 bonsplitView
             }
+        }
+        .onAppear {
+            syncSplitButtonsOnHover()
+        }
+        .onChange(of: isMinimalMode) { _, _ in
+            syncSplitButtonsOnHover()
+        }
+    }
+
+    private func syncSplitButtonsOnHover() {
+        let onHover = isMinimalMode
+        #if DEBUG
+        dlog("minimal.splitButtonsOnHover sync isMinimal=\(isMinimalMode) onHover=\(onHover) current=\(workspace.bonsplitController.configuration.appearance.splitButtonsOnHover)")
+        #endif
+        if workspace.bonsplitController.configuration.appearance.splitButtonsOnHover != onHover {
+            workspace.bonsplitController.configuration.appearance.splitButtonsOnHover = onHover
         }
     }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -381,8 +381,9 @@ struct WorkspaceContentView: View {
                     .ignoresSafeArea(.container, edges: .top)
                     .overlay(alignment: .top) {
                         if isWorkspaceInputActive {
-                            TitlebarDoubleClickMonitorView()
+                            WindowDragHandleView()
                                 .frame(height: WorkspaceTitlebarInteractionMetrics.minimalModeTopStripHeight)
+                                .background(TitlebarDoubleClickMonitorView())
                         }
                     }
             } else {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -394,9 +394,6 @@ struct WorkspaceContentView: View {
 
     private func syncSplitButtonsOnHover() {
         let onHover = isMinimalMode
-        #if DEBUG
-        dlog("minimal.splitButtonsOnHover sync isMinimal=\(isMinimalMode) onHover=\(onHover) current=\(workspace.bonsplitController.configuration.appearance.splitButtonsOnHover)")
-        #endif
         if workspace.bonsplitController.configuration.appearance.splitButtonsOnHover != onHover {
             workspace.bonsplitController.configuration.appearance.splitButtonsOnHover = onHover
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -263,6 +263,14 @@ struct WorkspaceContentView: View {
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
         let _ = { workspace.bonsplitController.isInteractive = isWorkspaceInputActive }()
 
+        // In minimal mode, split buttons only appear on hover.
+        let _ = {
+            let onHover = isMinimalMode
+            if workspace.bonsplitController.configuration.appearance.splitButtonsOnHover != onHover {
+                workspace.bonsplitController.configuration.appearance.splitButtonsOnHover = onHover
+            }
+        }()
+
         // Wire up file drop handling so bonsplit's PaneDragContainerView can forward
         // Finder file drops to the correct terminal panel.
         let _ = {


### PR DESCRIPTION
## Summary

- `UpdateTitlebarAccessoryController` only evaluated `isMinimal()` on window focus events, so toggling minimal mode while a window was already focused left the titlebar accessories in an inconsistent state (not removed in minimal, not re-attached in standard)
- Add a `UserDefaults.didChangeNotification` observer that detects presentation mode changes and re-evaluates all windows immediately
- Handle the fullscreen edge case: when re-attaching accessories in fullscreen, hide them so they don't double up with the SwiftUI overlay controls

## Testing

- Toggle minimal mode on: titlebar accessories should be removed immediately
- Toggle minimal mode off: titlebar accessories (sidebar toggle, notifications, new tab) should reappear immediately
- Rapidly toggle on/off several times: state should always be consistent
- Toggle minimal mode while in fullscreen: no doubled controls

## Related

- Task: minimal mode state derivation bugs (titlebar not hiding, inconsistent states on toggle)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Titlebar accessory and window toolbar visibility now refresh across all windows when presentation mode or preferences change; accessories are hidden in fullscreen when returning to standard.

* **UI**
  * Minimal mode layout adjusted: titlebar padding and top safe-area behavior changed; native window dragging enabled in minimal mode.
  * Suppress unwanted tab creation on top-area double-clicks and removed a minimal-mode top overlay in some cases.

* **Tests**
  * Added a new UI test for tab-drag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minimal mode so titlebar accessories and the toolbar update instantly across all windows, take no space, and tabs/buttons stay clickable. Removes the titlebar gap; tabs auto‑clear the traffic lights only when the top‑left pane has no sidebar.

- **Bug Fixes**
  - React to presentation mode changes via `UserDefaults.didChangeNotification`; keep accessories attached. In minimal, hide via `isHidden`/`view.isHidden`/`view.alphaValue` and set `preferredContentSize = .zero`. On return to standard, seed frames from cached fitting size to restore; hide in fullscreen.
  - Remove the toolbar in minimal (`window.toolbar = nil`), skip attach on launch in minimal, re‑attach in standard, and force layout so controls reappear.
  - Eliminate the top gap with `.ignoresSafeArea(.container, edges: .top)` and negative titlebar padding; keep `window.isMovableByWindowBackground = false` and `window.isMovable = false` so tab reordering and sidebar clicks work.
  - Drive traffic‑light clearance from ContentView: set an 80pt tab bar leading inset in minimal when the sidebar is collapsed; sync on appear, sidebar toggle, and mode toggle; apply only to the top‑left pane.

- **Dependencies**
  - Update `vendor/bonsplit` (merged main) for hover‑only split buttons in minimal mode, tab‑bar double‑click zoom/minimize, tab‑click passthrough with a background drag view, and host‑driven tab bar leading inset.

<sup>Written for commit 0e1d2dad79664ef35686e84bc265fac1ef6baa01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

