### PR TITLE
Revert liveSurfaceForGhosttyAccess: fix Cmd+N @Published nil crash

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2285,9 +2285,7 @@ class TabManager: ObservableObject {
         workspace: Workspace?
     ) -> ghostty_surface_config_s? {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(workspace: workspace),
-           let sourceSurface = panel.surface.liveSurfaceForGhosttyAccess(
-               reason: "tabManager.inheritedTerminalConfigForNewWorkspace"
-           ) {
+           let sourceSurface = panel.surface.surface {
             return cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -45,14 +45,6 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
-    // Best-effort check: reject unretained font pointers that no longer belong
-    // to a live malloc allocation. This does not prove the object is still a
-    // valid CTFont, but it filters out the common fully-freed/unmapped cases
-    // that previously crashed on Intel Macs (#1496, #1870).
-    guard cmuxPointerAppearsLive(quicklookFont) else {
-        return nil
-    }
-
     let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
@@ -7225,9 +7217,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
         lastTerminalConfigInheritancePanelId = terminalPanel.id
-        if let sourceSurface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
-            reason: "workspace.rememberConfigInheritanceSource"
-        ),
+        if let sourceSurface = terminalPanel.surface.surface,
            let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface) {
             let existing = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
             if existing == nil || abs((existing ?? runtimePoints) - runtimePoints) > 0.05 {
@@ -7319,25 +7309,13 @@ final class Workspace: Identifiable, ObservableObject {
         preferredPanelId: UUID? = nil,
         inPane preferredPaneId: PaneID? = nil
     ) -> ghostty_surface_config_s? {
-        var staleRootedFontFallback: Float?
-
-        // Walk candidates in priority order and use the first panel with a live surface.
-        // This avoids returning nil when the top candidate exists but is not attached yet.
+        // Walk candidates in priority order and use the first panel that still exposes
+        // a runtime surface pointer.
         for terminalPanel in terminalPanelConfigInheritanceCandidates(
             preferredPanelId: preferredPanelId,
             inPane: preferredPaneId
         ) {
-            let rootedFontFallback = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
-            guard let sourceSurface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
-                reason: "workspace.inheritedTerminalConfig"
-            ) else {
-                if staleRootedFontFallback == nil,
-                   let rootedFontFallback,
-                   rootedFontFallback > 0 {
-                    staleRootedFontFallback = rootedFontFallback
-                }
-                continue
-            }
+            guard let sourceSurface = terminalPanel.surface.surface else { continue }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT
@@ -7357,13 +7335,12 @@ final class Workspace: Identifiable, ObservableObject {
             return config
         }
 
-        if let fallbackFontPoints = staleRootedFontFallback ?? lastTerminalConfigInheritanceFontPoints {
+        if let fallbackFontPoints = lastTerminalConfigInheritanceFontPoints {
             var config = ghostty_surface_config_new()
             config.font_size = fallbackFontPoints
 #if DEBUG
-            let fallbackSource = staleRootedFontFallback != nil ? "quarantinedRootedFont" : "lastKnownFont"
             dlog(
-                "zoom.inherit fallback=\(fallbackSource) context=split font=\(String(format: "%.2f", fallbackFontPoints))"
+                "zoom.inherit fallback=lastKnownFont context=split font=\(String(format: "%.2f", fallbackFontPoints))"
             )
 #endif
             return config


### PR DESCRIPTION
## Summary
- Reverts PR #1915 (`liveSurfaceForGhosttyAccess` / `cmuxPointerAppearsLive` guard) which introduced a regression causing Cmd+N to crash with a nil `@Published` value
- Restores direct `.surface` access for config inheritance in `TabManager` and `Workspace`, removing the quarantine/liveness-check layer that was rejecting valid surfaces during new-tab creation
- Removes the `cmuxPointerAppearsLive` pointer guard from `cmuxCurrentSurfaceFontSizePoints` and simplifies the font fallback logic

Fixes #2212

## Test plan
- [ ] Cmd+N to create new tabs repeatedly — no crash
- [ ] Split panes inherit font size correctly
- [ ] Verify on Intel Mac if possible (original #1870 fix target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized terminal configuration inheritance by streamlining internal surface access patterns and simplifying font fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when pressing Cmd+N caused by a nil @Published value during new-tab creation. Reverts the `liveSurfaceForGhosttyAccess` quarantine and restores direct `.surface` access for config inheritance. Fixes #2212.

- **Bug Fixes**
  - Revert the `liveSurfaceForGhosttyAccess`/`cmux` liveness guard from PR #1915 that blocked valid surfaces.
  - Restore direct `.surface` usage in `TabManager` and `Workspace` for inheritance.
  - Remove `cmuxPointerAppearsLive` from `cmuxCurrentSurfaceFontSizePoints` and simplify font fallback to last known size.

<sup>Written for commit a47c8af851f24ae9e780d68a76126e9a8591cc55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

