### PR TITLE
Revert PR #1915 stale font pointer / live surface guards

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2285,9 +2285,7 @@ class TabManager: ObservableObject {
         workspace: Workspace?
     ) -> ghostty_surface_config_s? {
         if let panel = terminalPanelForWorkspaceConfigInheritanceSource(workspace: workspace),
-           let sourceSurface = panel.surface.liveSurfaceForGhosttyAccess(
-               reason: "tabManager.inheritedTerminalConfigForNewWorkspace"
-           ) {
+           let sourceSurface = panel.surface.surface {
             return cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_TAB

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -45,14 +45,6 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
-    // Best-effort check: reject unretained font pointers that no longer belong
-    // to a live malloc allocation. This does not prove the object is still a
-    // valid CTFont, but it filters out the common fully-freed/unmapped cases
-    // that previously crashed on Intel Macs (#1496, #1870).
-    guard cmuxPointerAppearsLive(quicklookFont) else {
-        return nil
-    }
-
     let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
@@ -7225,9 +7217,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
         lastTerminalConfigInheritancePanelId = terminalPanel.id
-        if let sourceSurface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
-            reason: "workspace.rememberConfigInheritanceSource"
-        ),
+        if let sourceSurface = terminalPanel.surface.surface,
            let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface) {
             let existing = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
             if existing == nil || abs((existing ?? runtimePoints) - runtimePoints) > 0.05 {
@@ -7319,25 +7309,13 @@ final class Workspace: Identifiable, ObservableObject {
         preferredPanelId: UUID? = nil,
         inPane preferredPaneId: PaneID? = nil
     ) -> ghostty_surface_config_s? {
-        var staleRootedFontFallback: Float?
-
-        // Walk candidates in priority order and use the first panel with a live surface.
-        // This avoids returning nil when the top candidate exists but is not attached yet.
+        // Walk candidates in priority order and use the first panel that still exposes
+        // a runtime surface pointer.
         for terminalPanel in terminalPanelConfigInheritanceCandidates(
             preferredPanelId: preferredPanelId,
             inPane: preferredPaneId
         ) {
-            let rootedFontFallback = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
-            guard let sourceSurface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
-                reason: "workspace.inheritedTerminalConfig"
-            ) else {
-                if staleRootedFontFallback == nil,
-                   let rootedFontFallback,
-                   rootedFontFallback > 0 {
-                    staleRootedFontFallback = rootedFontFallback
-                }
-                continue
-            }
+            guard let sourceSurface = terminalPanel.surface.surface else { continue }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT
@@ -7357,13 +7335,12 @@ final class Workspace: Identifiable, ObservableObject {
             return config
         }
 
-        if let fallbackFontPoints = staleRootedFontFallback ?? lastTerminalConfigInheritanceFontPoints {
+        if let fallbackFontPoints = lastTerminalConfigInheritanceFontPoints {
             var config = ghostty_surface_config_new()
             config.font_size = fallbackFontPoints
 #if DEBUG
-            let fallbackSource = staleRootedFontFallback != nil ? "quarantinedRootedFont" : "lastKnownFont"
             dlog(
-                "zoom.inherit fallback=\(fallbackSource) context=split font=\(String(format: "%.2f", fallbackFontPoints))"
+                "zoom.inherit fallback=lastKnownFont context=split font=\(String(format: "%.2f", fallbackFontPoints))"
             )
 #endif
             return config


### PR DESCRIPTION
## Summary
- revert PR #1915 (`c5b30665`) as a regression rollback
- remove the stale font pointer / inherited terminal config guard behavior introduced there
- keep later unrelated work intact where possible

## Why
- the regression window points at #1915
- this code path did not resolve the original Intel issue either, so rolling it back is safe for now

## Verification
- built locally with `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag revert-pr-1915`
- app artifact produced successfully for repro testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace configuration inheritance by streamlining internal surface management logic.
  * Refined font-size handling and removed obsolete fallback tracking for improved reliability.
  * Updated debug logging for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts PR #1915 to remove stale font pointer and live-surface guard logic that introduced a regression. Restores direct surface access and simpler font fallback to reduce null configs during new workspace/split creation (addresses Linear issue 2212).

- **Bug Fixes**
  - Use panel.surface.surface instead of liveSurfaceForGhosttyAccess to prevent lost config inheritance (Cmd+N).
  - Remove pointer liveness check in cmuxCurrentSurfaceFontSizePoints to avoid false nil font sizes.
  - Simplify fallback: drop quarantined rooted font; rely on last-known font and update debug text.

<sup>Written for commit a47c8af851f24ae9e780d68a76126e9a8591cc55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

