### PR TITLE
Add --no-focus flag to cmux ssh

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3808,7 +3808,7 @@ struct CMUXCLI {
         }
     }
 
-    func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
+    private func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
         var destination: String?
         var port: Int?
         var identityFile: String?

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3576,6 +3576,7 @@ struct CMUXCLI {
         let port: Int?
         let identityFile: String?
         let workspaceName: String?
+        let noFocus: Bool
         let sshOptions: [String]
         let extraArguments: [String]
         let localSocketPath: String
@@ -3761,8 +3762,10 @@ struct CMUXCLI {
             }
             // `cmux ssh` is an explicit "open this remote workspace now" action,
             // so we intentionally select the newly created workspace after wiring
-            // up the remote connection.
-            _ = try client.sendV2(method: "workspace.select", params: selectParams)
+            // up the remote connection — unless --no-focus is passed.
+            if !sshOptions.noFocus {
+                _ = try client.sendV2(method: "workspace.select", params: selectParams)
+            }
             let remoteState = ((configuredPayload["remote"] as? [String: Any])?["state"] as? String) ?? "unknown"
             cliDebugLog(
                 "cli.ssh.remote.configure.ok workspace=\(String(workspaceId.prefix(8))) state=\(remoteState)"
@@ -3810,6 +3813,7 @@ struct CMUXCLI {
         var port: Int?
         var identityFile: String?
         var workspaceName: String?
+        var noFocus = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
 
@@ -3848,6 +3852,9 @@ struct CMUXCLI {
                 }
                 workspaceName = commandArgs[index + 1]
                 index += 2
+            case "--no-focus":
+                noFocus = true
+                index += 1
             case "--ssh-option":
                 guard index + 1 < commandArgs.count else {
                     throw CLIError(message: "ssh: --ssh-option requires a value")
@@ -3883,6 +3890,7 @@ struct CMUXCLI {
             port: port,
             identityFile: identityFile,
             workspaceName: workspaceName,
+            noFocus: noFocus,
             sshOptions: sshOptions,
             extraArguments: extraArguments,
             localSocketPath: localSocketPath,
@@ -6410,6 +6418,7 @@ struct CMUXCLI {
               --port <n>              SSH port
               --identity <path>       SSH identity file path
               --ssh-option <opt>      Extra SSH -o option (repeatable)
+              --no-focus              Create workspace without switching to it
 
             Example:
               cmux ssh dev@my-host

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3808,7 +3808,7 @@ struct CMUXCLI {
         }
     }
 
-    private func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
+    func parseSSHCommandOptions(_ commandArgs: [String], localSocketPath: String = "", remoteRelayPort: Int = 0) throws -> SSHCommandOptions {
         var destination: String?
         var port: Int?
         var identityFile: String?

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12617,7 +12617,7 @@ struct CMUXCLI {
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>]
           list-workspaces
           new-workspace [--name <title>] [--cwd <path>] [--command <text>]
-          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [-- <remote-command-args>]
+          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
           list-panes [--workspace <id|ref>]


### PR DESCRIPTION
## Summary

Add `--no-focus` flag to `cmux ssh` so scripted/background SSH workspace creation does not steal the user's active workspace focus.

Cherry-picked from https://github.com/manaflow-ai/cmux/pull/1942 by @maucher, rebased onto main with conflict resolution.

## Changes

- `SSHCommandOptions`: add `noFocus: Bool` field
- `parseSSHCommandOptions`: parse `--no-focus` flag
- `runSSH`: guard `workspace.select` call with `if !sshOptions.noFocus`
- Help text: document `--no-focus` flag

## Test plan

- `cmux ssh <host> --no-focus` creates SSH workspace without switching focus
- `cmux ssh <host>` (without flag) still switches focus as before
- `--no-focus` alongside other flags (`--name`, `--port`) parses correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--no-focus` flag to `cmux ssh` so scripts can create SSH workspaces without switching the active workspace. Default behavior remains unchanged.

- **New Features**
  - Parse `--no-focus` into `SSHCommandOptions.noFocus`.
  - Skip `workspace.select` when `--no-focus` is set.
  - Update CLI help and top-level `ssh` synopsis to include the flag.

<sup>Written for commit 66e132d7302667a497b79b760d701fae18a54bcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-focus` option to the SSH command so users can create/configure a remote workspace without automatically selecting or focusing it.

* **Documentation**
  * Updated SSH command help/usage to document the `--no-focus` option and its effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->