### PR TITLE
Improve cmux omo error when opencode is not installed

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9770,30 +9770,14 @@ struct CMUXCLI {
             } else {
                 throw CLIError(message: "Neither bun nor npm found in PATH. Install oh-my-opencode manually: bunx oh-my-opencode install")
             }
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-            FileHandle.standardError.write("Installing oh-my-opencode plugin...\n".data(using: .utf8)!)
+            // Show install output directly so the user sees progress (npm can take 30s+)
+            process.standardOutput = FileHandle.standardError
+            process.standardError = FileHandle.standardError
+            FileHandle.standardError.write("Installing oh-my-opencode plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
             try process.run()
-            // Drain pipes concurrently to prevent deadlock from full buffers
-            var stderrData = Data()
-            let drainGroup = DispatchGroup()
-            drainGroup.enter()
-            DispatchQueue.global().async {
-                stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                drainGroup.leave()
-            }
-            drainGroup.enter()
-            DispatchQueue.global().async {
-                _ = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                drainGroup.leave()
-            }
-            drainGroup.wait()
             process.waitUntilExit()
             if process.terminationStatus != 0 {
-                let errText = String(data: stderrData, encoding: .utf8) ?? ""
-                throw CLIError(message: "Failed to install oh-my-opencode: \(errText)")
+                throw CLIError(message: "Failed to install oh-my-opencode. Try manually: npm install -g oh-my-opencode")
             }
             FileHandle.standardError.write("oh-my-opencode plugin installed\n".data(using: .utf8)!)
             // Re-create symlink if we installed into user dir

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9874,9 +9874,6 @@ struct CMUXCLI {
         socketPath: String,
         explicitPassword: String?
     ) throws {
-        // Ensure oh-my-opencode plugin is registered and installed
-        try omoEnsurePlugin()
-
         let processEnvironment = ProcessInfo.processInfo.environment
         var launcherEnvironment = processEnvironment
         launcherEnvironment["CMUX_SOCKET_PATH"] = socketPath
@@ -9885,15 +9882,10 @@ struct CMUXCLI {
            !explicitPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             launcherEnvironment["CMUX_SOCKET_PASSWORD"] = explicitPassword
         }
-        let shimDirectory = try createOMOShimDirectory()
-        let executablePath = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
-        let focusedContext = tmuxCompatFocusedContext(
-            processEnvironment: launcherEnvironment,
-            explicitPassword: explicitPassword
-        )
+
+        // Check for opencode before doing expensive plugin setup
         let openCodeExecutablePath = resolveOpenCodeExecutable(searchPath: launcherEnvironment["PATH"])
         if openCodeExecutablePath == nil {
-            // Check if opencode is anywhere in PATH before doing expensive setup
             let checkProcess = Process()
             checkProcess.executableURL = URL(fileURLWithPath: "/usr/bin/which")
             checkProcess.arguments = ["opencode"]
@@ -9905,6 +9897,16 @@ struct CMUXCLI {
                 throw CLIError(message: "opencode is not installed. Install it first:\n  npm install -g opencode-ai\n  # or\n  bun install -g opencode-ai\n\nThen run: cmux omo")
             }
         }
+
+        // Ensure oh-my-opencode plugin is registered and installed
+        try omoEnsurePlugin()
+
+        let shimDirectory = try createOMOShimDirectory()
+        let executablePath = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
+        let focusedContext = tmuxCompatFocusedContext(
+            processEnvironment: launcherEnvironment,
+            explicitPassword: explicitPassword
+        )
         configureOMOEnvironment(
             processEnvironment: launcherEnvironment,
             shimDirectory: shimDirectory,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9908,6 +9908,19 @@ struct CMUXCLI {
             explicitPassword: explicitPassword
         )
         let openCodeExecutablePath = resolveOpenCodeExecutable(searchPath: launcherEnvironment["PATH"])
+        if openCodeExecutablePath == nil {
+            // Check if opencode is anywhere in PATH before doing expensive setup
+            let checkProcess = Process()
+            checkProcess.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+            checkProcess.arguments = ["opencode"]
+            checkProcess.standardOutput = Pipe()
+            checkProcess.standardError = Pipe()
+            try? checkProcess.run()
+            checkProcess.waitUntilExit()
+            if checkProcess.terminationStatus != 0 {
+                throw CLIError(message: "opencode is not installed. Install it first:\n  npm install -g opencode-ai\n  # or\n  bun install -g opencode-ai\n\nThen run: cmux omo")
+            }
+        }
         configureOMOEnvironment(
             processEnvironment: launcherEnvironment,
             shimDirectory: shimDirectory,
@@ -9940,7 +9953,7 @@ struct CMUXCLI {
             execvp("opencode", &argv)
         }
         let code = errno
-        throw CLIError(message: "Failed to launch opencode: \(String(cString: strerror(code)))")
+        throw CLIError(message: "Failed to launch opencode: \(String(cString: strerror(code)))\n\nIs opencode installed? Install with:\n  npm install -g opencode-ai")
     }
 
     private func runClaudeTeamsTmuxCompat(


### PR DESCRIPTION
Adds pre-flight check for opencode before plugin setup. Shows install instructions instead of "No such file or directory". Related: https://github.com/manaflow-ai/cmux/issues/2085

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve `cmux omo` error handling when `opencode` isn’t installed and show progress during first-run plugin install. Checks for `opencode` before plugin setup and fails fast with clear install steps instead of “No such file or directory”.

- **Bug Fixes**
  - Moved `opencode` check ahead of plugin setup; if missing, show install steps: npm install -g `opencode-ai` or bun install -g `opencode-ai`.
  - Stream `oh-my-opencode` install output to stderr with a “may take a minute” note; on failure, suggest: npm install -g `oh-my-opencode`; improved launch error to remind installing `opencode-ai`.

<sup>Written for commit 355c3ebc5668da9236297d9aef3bbd65ed3408bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, consistent CLI install and error messages with actionable “try manual install” guidance when tools are missing.
  * Earlier detection of missing dependencies to avoid unnecessary setup steps and fail fast.
  * Consolidated output on failure so installation hints are reliably shown alongside errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->