### PR TITLE
Switch nightly builds to macOS Tahoe runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,7 +100,7 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout build ref


### PR DESCRIPTION
## Summary
- Switch nightly build runner from `warp-macos-15-arm64-6x` (Sequoia) to `warp-macos-26-arm64-6x` (Tahoe)
- Gets latest Xcode toolchain for nightly builds
- Deployment target stays at 14.0, so binaries remain compatible with Sonoma, Sequoia, and Tahoe

## Testing
- Triggered a nightly build from this branch to verify the Tahoe runner works: https://github.com/manaflow-ai/cmux/actions/runs/23628170500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches nightly builds to the macOS Tahoe runner to use the latest Xcode toolchain, while keeping the deployment target at 14.0 for compatibility with Sonoma, Sequoia, and Tahoe.
Updates the workflow to run on `warp-macos-26-arm64-6x` instead of `warp-macos-15-arm64-6x`.

<sup>Written for commit ccf1578200a2202b54241846e2186333ddaf6816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment for nightly releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->