### PR TITLE
feat: auto-match sidebar background to Ghostty terminal theme

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13777,8 +13777,11 @@ private struct SidebarBackdrop: View {
                         Color(nsColor: tintColor)
                     }
                 }
+            } else {
+                // No material — render solid tint color (used when sidebar
+                // matches the terminal theme background).
+                Color(nsColor: tintColor)
             }
-            // When material is none or useWindowLevelGlass, render nothing
         }
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -160,10 +160,26 @@ struct GhosttyConfig {
     }
 
     func applySidebarAppearanceToUserDefaults() {
-        guard rawSidebarBackground != nil else {
-            if let opacity = sidebarTintOpacity {
-                UserDefaults.standard.set(opacity, forKey: "sidebarTintOpacity")
+        if rawSidebarBackground == nil {
+            let defaults = UserDefaults.standard
+
+            // If the user has manually chosen a non-default material in
+            // Settings, respect their choice and skip auto-sync.
+            let currentMaterial = defaults.string(forKey: "sidebarMaterial")
+            if let currentMaterial,
+               currentMaterial != SidebarMaterialOption.none.rawValue,
+               currentMaterial != SidebarMaterialOption.sidebar.rawValue {
+                return
             }
+
+            // No explicit sidebar-background set — fall back to the terminal's
+            // background color so the sidebar matches the active Ghostty theme.
+            // Use material "none" to render a solid color without glass distortion.
+            defaults.set(backgroundColor.hexString(), forKey: "sidebarTintHex")
+            defaults.removeObject(forKey: "sidebarTintHexLight")
+            defaults.removeObject(forKey: "sidebarTintHexDark")
+            defaults.set(sidebarTintOpacity ?? backgroundOpacity, forKey: "sidebarTintOpacity")
+            defaults.set(SidebarMaterialOption.none.rawValue, forKey: "sidebarMaterial")
             return
         }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -669,6 +669,12 @@ struct WorkspaceContentView: View {
         let chromeReason =
             "refreshGhosttyAppearanceConfig:reason=\(reason):event=\(eventLabel):source=\(sourceLabel):payload=\(payloadLabel)"
         workspace.applyGhosttyChrome(from: next, reason: chromeReason)
+        // When no explicit sidebar-background is configured, keep sidebar
+        // UserDefaults in sync with the runtime Ghostty background so the
+        // sidebar visually matches the terminal.
+        if next.rawSidebarBackground == nil {
+            next.applySidebarAppearanceToUserDefaults()
+        }
         if let terminalPanel = workspace.focusedTerminalPanel {
             terminalPanel.applyWindowBackgroundIfActive()
             logTheme(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2481,19 +2481,86 @@ final class SidebarBackgroundConfigTests: XCTestCase {
         XCTAssertNil(config.sidebarBackgroundDark)
     }
 
-    func testApplyToUserDefaultsSkipsWritesWhenNoConfig() {
+    func testApplyToUserDefaultsFallsBackToTerminalBackground() {
         let defaults = UserDefaults.standard
-        let testKey = "sidebarTintHex"
-        let original = defaults.string(forKey: testKey)
-        defer { restoreDefaultsValue(original, key: testKey, defaults: defaults) }
+        let keys = ["sidebarTintHex", "sidebarTintHexLight", "sidebarTintHexDark",
+                     "sidebarTintOpacity", "sidebarMaterial"]
+        let originals = keys.map { defaults.object(forKey: $0) }
+        defer {
+            for (key, original) in zip(keys, originals) {
+                restoreDefaultsValue(original, key: key, defaults: defaults)
+            }
+        }
 
-        defaults.set("#AAAAAA", forKey: testKey)
+        defaults.set("#AAAAAA", forKey: "sidebarTintHex")
+        defaults.set("#BBBBBB", forKey: "sidebarTintHexLight")
+        defaults.set("#CCCCCC", forKey: "sidebarTintHexDark")
 
         var config = GhosttyConfig()
+        config.backgroundColor = NSColor(hex: "#1e1e2e")!
+        config.backgroundOpacity = 0.9
         config.applySidebarAppearanceToUserDefaults()
 
-        XCTAssertEqual(defaults.string(forKey: testKey), "#AAAAAA",
-                       "Should not overwrite UserDefaults when rawSidebarBackground is nil")
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHex"), "#1e1e2e",
+                       "Should fall back to terminal background when rawSidebarBackground is nil")
+        XCTAssertNil(defaults.string(forKey: "sidebarTintHexLight"),
+                     "Should clear stale light key")
+        XCTAssertNil(defaults.string(forKey: "sidebarTintHexDark"),
+                     "Should clear stale dark key")
+        XCTAssertEqual(defaults.double(forKey: "sidebarTintOpacity"), 0.9, accuracy: 0.0001,
+                       "Should use backgroundOpacity when sidebarTintOpacity is nil")
+        XCTAssertEqual(defaults.string(forKey: "sidebarMaterial"),
+                       SidebarMaterialOption.none.rawValue,
+                       "Should set material to none for solid color rendering")
+    }
+
+    func testApplyToUserDefaultsSkipsAutoSyncWhenUserChoseCustomMaterial() {
+        let defaults = UserDefaults.standard
+        let keys = ["sidebarTintHex", "sidebarMaterial"]
+        let originals = keys.map { defaults.object(forKey: $0) }
+        defer {
+            for (key, original) in zip(keys, originals) {
+                restoreDefaultsValue(original, key: key, defaults: defaults)
+            }
+        }
+
+        defaults.set(SidebarMaterialOption.hudWindow.rawValue, forKey: "sidebarMaterial")
+        defaults.set("#FFFFFF", forKey: "sidebarTintHex")
+
+        var config = GhosttyConfig()
+        config.backgroundColor = NSColor(hex: "#151144")!
+        config.applySidebarAppearanceToUserDefaults()
+
+        XCTAssertEqual(defaults.string(forKey: "sidebarMaterial"),
+                       SidebarMaterialOption.hudWindow.rawValue,
+                       "Should not overwrite user's manual material choice")
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHex"), "#FFFFFF",
+                       "Should not overwrite user's manual tint hex")
+    }
+
+    func testApplyToUserDefaultsAutoSyncsWhenMaterialIsDefault() {
+        let defaults = UserDefaults.standard
+        let keys = ["sidebarTintHex", "sidebarMaterial"]
+        let originals = keys.map { defaults.object(forKey: $0) }
+        defer {
+            for (key, original) in zip(keys, originals) {
+                restoreDefaultsValue(original, key: key, defaults: defaults)
+            }
+        }
+
+        // "sidebar" is the default material — auto-sync should still apply
+        defaults.set(SidebarMaterialOption.sidebar.rawValue, forKey: "sidebarMaterial")
+        defaults.set("#FFFFFF", forKey: "sidebarTintHex")
+
+        var config = GhosttyConfig()
+        config.backgroundColor = NSColor(hex: "#151144")!
+        config.applySidebarAppearanceToUserDefaults()
+
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHex"), "#151144",
+                       "Should auto-sync when material is the default sidebar")
+        XCTAssertEqual(defaults.string(forKey: "sidebarMaterial"),
+                       SidebarMaterialOption.none.rawValue,
+                       "Should switch material to none for solid color rendering")
     }
 
     func testApplyToUserDefaultsWritesHexWhenConfigSet() {


### PR DESCRIPTION
## Summary

- When no explicit `sidebar-background` is configured, the sidebar now automatically uses the terminal's Ghostty theme background color and opacity
- Bypasses the glass/blur material (sets material to `none`) so the sidebar color matches the terminal exactly — no visual distortion from `NSVisualEffectView`
- Keeps sidebar in sync on runtime theme changes via the existing `refreshGhosttyAppearanceConfig` notification flow
- Respects manual Settings UI overrides: if the user has chosen a non-default material (e.g. HUD Window), auto-sync is skipped

## Changes

| File | Change |
|------|--------|
| `Sources/ContentView.swift` | Fix `SidebarBackdrop` to render solid `Color` when material is `none` |
| `Sources/GhosttyConfig.swift` | Fall back to terminal background + settings protection guard |
| `Sources/WorkspaceContentView.swift` | Runtime sidebar sync after theme changes |
| `cmuxTests/GhosttyConfigTests.swift` | Updated + 2 new tests |

## Test plan

- [ ] Verify sidebar matches terminal background with no `sidebar-background` in Ghostty config
- [ ] Verify sidebar stays in sync when changing Ghostty theme at runtime
- [ ] Verify explicit `sidebar-background` in config still works
- [ ] Verify manual Settings UI material choice is not overwritten
- [ ] Verify unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-match the sidebar background to the active Ghostty terminal theme when no sidebar color is set. Uses a solid color (material set to none) for an exact match, stays in sync on theme changes, and respects manual material choices.

- **New Features**
  - Falls back to terminal background color and opacity; removes glass/blur by setting material to none.
  - Syncs on runtime theme changes; skips auto-sync if the user selected a non-default material in Settings.
  - `SidebarBackdrop` now renders a solid color when material is none; tests cover fallback and override cases.

<sup>Written for commit 472f08f579b3f29b31b8e8839da5b3f1c3806472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sidebar appearing empty when no custom material is configured; now displays a solid tint color based on the terminal theme.
  
* **Improvements**
  * Sidebar appearance now automatically synchronizes with the active terminal theme when no custom background is set, while preserving user-chosen custom material settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->