### PR TITLE
Switch release builds to macOS Tahoe runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
             remote-daemon-assets/cmuxd-remote-manifest.json
 
       - name: Upload build artifacts (dry-run)
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && !startsWith(github.ref, 'refs/tags/')
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cmux-release-dry-run
@@ -340,7 +340,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release asset
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && startsWith(github.ref, 'refs/tags/')
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-sign-notarize:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -328,8 +328,19 @@ jobs:
             remote-daemon-assets/cmuxd-remote-checksums.txt
             remote-daemon-assets/cmuxd-remote-manifest.json
 
+      - name: Upload build artifacts (dry-run)
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && !startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cmux-release-dry-run
+          path: |
+            cmux-macos.dmg
+            appcast.xml
+            remote-daemon-assets/cmuxd-remote-*
+          if-no-files-found: error
+
       - name: Upload release asset
-        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |


### PR DESCRIPTION
## Summary
- Switch release build runner from `warp-macos-15-arm64-6x` (Sequoia) to `warp-macos-26-arm64-6x` (Tahoe) to match nightly
- Add dry-run artifact upload path for `workflow_dispatch` so the release pipeline can be tested without creating a real release

## Testing
- Dry-run triggered from branch: https://github.com/manaflow-ai/cmux/actions/runs/23630127438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release builds from `warp-macos-15-arm64-6x` (Sequoia) to `warp-macos-26-arm64-6x` (Tahoe) to match nightly and keep environments consistent. Add a dry-run path for `workflow_dispatch` that uploads artifacts via `actions/upload-artifact`; GitHub Release uploads via `softprops/action-gh-release` now run only for push events on tag refs to prevent accidental releases.

<sup>Written for commit a67a3d192b801b70936dab0f337371c74adfa753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS build runner for CI.
  * Added a conditional artifact upload step for manual workflow runs (dry-run) that uploads build artifacts when enabled.
  * Restricted automated release publishing to tag pushes, preventing non-tag pushes from creating GitHub Releases.

---

Note: No user-facing changes; updates apply to release automation only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->