### PR TITLE
fix: play system bell sound when bell-features is not configured

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1995,11 +1995,13 @@ class GhosttyApp {
         return String(cString: value)
     }
 
-    private func bellFeatures() -> CUnsignedInt {
-        guard let config else { return 0 }
+    private func bellFeatures() -> CUnsignedInt? {
+        guard let config else { return nil }
         var features: CUnsignedInt = 0
         let key = "bell-features"
-        _ = ghostty_config_get(config, &features, key, UInt(key.lengthOfBytes(using: .utf8)))
+        guard ghostty_config_get(config, &features, key, UInt(key.lengthOfBytes(using: .utf8))) else {
+            return nil
+        }
         return features
     }
 
@@ -2024,7 +2026,14 @@ class GhosttyApp {
     }
 
     private func ringBell() {
-        let features = bellFeatures()
+        guard let features = bellFeatures() else {
+            // bell-features is not present in the config. Ghostty's built-in default enables
+            // attention and title features but not system sound, so terminal bell produces no
+            // audio unless the user explicitly sets bell-features = system. Fall back to
+            // NSSound.beep() so the bell works out of the box without requiring configuration.
+            NSSound.beep()
+            return
+        }
 
         if (features & (1 << 0)) != 0 {
             NSSound.beep()


### PR DESCRIPTION
Fixes #2209

Terminal bell (\a) did not produce any sound because Ghostty's default `bell-features` has `system` disabled. When a user hasn't explicitly configured `bell-features = system` in their Ghostty config, the `ringBell()` function checked the feature bits, found none set, and did nothing.

This adds a fallback: when no bell features are configured (features == 0), play the system beep sound by default. Users who explicitly set bell-features to a specific value are unaffected.

## Test plan
- Remove any `bell-features` line from Ghostty config
- Run `echo -e '\a'` in terminal → should hear system beep
- Set `bell-features = none` → should be silent (explicit opt-out)
- Set `bell-features = system` → should hear beep (explicit opt-in)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Play the system bell by default when `bell-features` isn’t set, so the terminal bell (\a) makes a sound out of the box. Also fixes Ctrl shortcuts being dropped when a CJK IME is active.

- **Bug Fixes**
  - Bell: If `bell-features` is missing from the config, call `NSSound.beep()`. Explicit settings (including `bell-features = none`) are unchanged.
  - Input: Remove the `hasMarkedText()` check from the Ctrl key path so Ctrl+C/Z/D work even with IMEs that leave empty marked text.

<sup>Written for commit d09733164df7664059cbf6215346310bd296d5cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal bell behavior so the fallback system beep reliably when bell configuration is missing or unreadable.
  * Ensured feature-based bell options are only applied when valid configuration is present, preventing incorrect bell handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->