### PR TITLE
fix: allow Ctrl shortcuts through when CJK input method is active

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5577,8 +5577,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // These keys are terminal control input, not text composition, so we bypass
         // AppKit text interpretation and send a single deterministic Ghostty key event.
         // This avoids intermittent drops after rapid split close/reparent transitions.
+        //
+        // Note: we intentionally do NOT check hasMarkedText() here. Ctrl combinations
+        // (Ctrl+C, Ctrl+D, etc.) are never part of IME candidate sequences, so they
+        // must always be forwarded to the terminal regardless of IME state. CJK input
+        // methods (e.g. Korean) can leave an empty marked-text state even when no
+        // candidate is being composed, which would otherwise cause Ctrl shortcuts to
+        // be silently dropped. (#2197)
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) && !hasMarkedText() {
+        if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) {
             terminalSurface?.recordExternalFocusState(true)
             ghostty_surface_set_focus(surface, true)
             var keyEvent = ghostty_input_key_s()


### PR DESCRIPTION
Fixes #2197

Ctrl+C (and other Ctrl combinations) stopped working when a CJK input method (e.g. Korean) was active. The Ctrl shortcut path in `keyDown` was gated on `!hasMarkedText()`, but macOS IME can leave an empty marked-text state even when no candidate is being composed, causing the guard to skip the Ctrl path entirely.

Since Ctrl combinations are never part of IME candidate sequences, the `hasMarkedText()` check is unnecessary for this path. Removing it allows Ctrl+C/Z/D etc. to work regardless of IME state.

## Test plan
- Enable Korean (or any CJK) input method
- Open terminal in cmux
- Run a long command, press Ctrl+C → should interrupt
- Type Korean text normally → IME should still work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2197. Restores Ctrl shortcuts (Ctrl+C/Z/D) when a CJK input method (e.g., Korean) is active by removing the `hasMarkedText()` check from the Ctrl path in `keyDown`, since Ctrl combos are never part of IME sequences.

<sup>Written for commit 5f381a12c3dd3aae73d887752a433f96feb485bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Control key combinations were not being recognized when certain input methods had active text composition, improving keyboard shortcut reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->