### PR TITLE
fix: prevent Cmd+Shift+U escape sequence leak in kitty protocol mode

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10671,24 +10671,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        // For command-based shortcuts, trust AppKit's layout-aware characters when present.
-        // Keep this strict for letter shortcuts to avoid physical-key collisions across layouts,
-        // while still allowing keyCode fallback for digit/punctuation shortcuts on non-US layouts.
-        // When a non-Latin input source is active (Russian, Korean, Chinese, Japanese, etc.),
-        // charactersIgnoringModifiers returns non-ASCII characters that can never match
-        // a Latin shortcut key — skip this guard and fall through to layout-based matching.
         let hasEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
         let eventCharsAreASCII = eventCharsIgnoringModifiers?.allSatisfy(\.isASCII) ?? true
-        if hasEventChars,
-           eventCharsAreASCII,
-           flags.contains(.command),
-           !flags.contains(.control),
-           shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
-            return false
-        }
 
         // Match using the current keyboard layout so Command shortcuts stay character-based
         // across layouts (QWERTY, Dvorak, etc.) instead of being tied to ANSI physical keys.
+        // This also provides a reliable fallback when the kitty keyboard protocol is active:
+        // in that mode, charactersIgnoringModifiers may be empty or carry a synthetic value
+        // that does not match the shortcut key, but the keyCode-based layout translation
+        // still correctly identifies the physical key (e.g. keyCode 32 → "u").
         let layoutCharacter = shortcutLayoutCharacterProvider(event.keyCode, event.modifierFlags)
         if shortcutCharacterMatches(
             eventCharacter: layoutCharacter,
@@ -10697,6 +10688,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             eventKeyCode: event.keyCode
         ) {
             return true
+        }
+
+        // For command-based shortcuts, once both character sources have been tried, block
+        // further keyCode fallback for letter shortcuts to avoid physical-key collisions
+        // across layouts. Non-ASCII characters (Russian, Korean, CJK, etc.) cannot match
+        // a Latin shortcut key, so always allow keyCode fallback in that case.
+        if hasEventChars,
+           eventCharsAreASCII,
+           flags.contains(.command),
+           !flags.contains(.control),
+           shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
+            return false
         }
 
         // Control-key combos can surface as ASCII control characters (e.g. Ctrl+H => backspace),
@@ -10709,7 +10712,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // physical key code is the definitive identifier for the intended shortcut.
         // For empty-character events (synthetic/browser key equivalents), preserve the original
         // behavior: only fall back when the layout translation also failed.
-        let hasUsableEventChars = hasEventChars && eventCharsAreASCII
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)


### PR DESCRIPTION
Fixes #2198

When no unread notifications exist, pressing Cmd+Shift+U would output the escape sequence `[12629;10u` into the terminal. This happened because the kitty keyboard protocol encodes key events differently, causing `matchShortcut` to fail character matching and letting the event pass through to the terminal.

## Root Cause

In `matchShortcut`, the layout-character match (`shortcutLayoutCharacterProvider`, which uses keyCode → keyboard layout translation) was placed *after* an early-return guard that blocked further matching for letter shortcuts when `charactersIgnoringModifiers` was non-empty ASCII but didn't match the shortcut key. In kitty protocol mode, `charactersIgnoringModifiers` carries a synthetic value, so the guard fired before the reliable keyCode-based translation had a chance to run.

## Fix

Move the `shortcutLayoutCharacterProvider` match *before* the guard. The keyCode → layout translation reliably identifies the physical key (e.g. keyCode 32 → "u") regardless of keyboard protocol mode. The guard is preserved after both character sources have been tried, so cross-layout collision protection for letter shortcuts remains intact.

## Test plan
- Press Cmd+Shift+U with no unread notifications → should do nothing (no escape sequence output)
- Press Cmd+Shift+U with unread notifications → should jump to latest unread
- Test with kitty keyboard protocol enabled (`echo -e '\e[>1u'`)
- Verify other letter shortcuts (Cmd+Shift+P, Cmd+N, etc.) still work correctly on non-US keyboard layouts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2198. Stops Cmd+Shift+U from printing a kitty keyboard protocol escape sequence when there are no unread notifications by matching the keyCode→layout character before the early guard.

- **Bug Fixes**
  - Move layout-character match ahead of the ASCII guard so letter shortcuts are recognized in kitty protocol mode; Cmd+Shift+U no longer passes through.
  - Keep the guard after both character sources to avoid cross-layout collisions; other shortcuts still work on non‑US layouts.

<sup>Written for commit fbb7d8f74e171ab124f116f192ccbfbd313044d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut matching for Cmd-based letter shortcuts to enhance character recognition and behavior across different keyboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->