### PR TITLE
fix: suppress TabManager not available error in Claude Code stop hook

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10991,15 +10991,14 @@ struct CMUXCLI {
                 print("OK")
                 return
             }
-            guard let surfaceId = try? resolvePreferredSurfaceIdForClaudeHook(
+            let surfaceId = try? resolvePreferredSurfaceIdForClaudeHook(
                 preferred: mappedSession?.surfaceId,
                 fallback: surfaceArg,
                 workspaceId: workspaceId,
                 client: client
-            ) else {
+            )
+            if surfaceId == nil {
                 telemetry.breadcrumb("claude-hook.stop.no-surface")
-                print("OK")
-                return
             }
 
             // Update session with transcript summary and send completion notification.
@@ -11007,7 +11006,7 @@ struct CMUXCLI {
                 parsedInput: parsedInput,
                 sessionRecord: mappedSession
             )
-            if let sessionId = parsedInput.sessionId, let completion {
+            if let sessionId = parsedInput.sessionId, let completion, let surfaceId {
                 try? sessionStore.upsert(
                     sessionId: sessionId,
                     workspaceId: workspaceId,
@@ -11018,7 +11017,7 @@ struct CMUXCLI {
                 )
             }
 
-            if let completion {
+            if let completion, let surfaceId {
                 let title = "Claude Code"
                 let subtitle = sanitizeNotificationField(completion.subtitle)
                 let body = sanitizeNotificationField(completion.body)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10978,27 +10978,36 @@ struct CMUXCLI {
             // Turn ended. Don't consume session or clear PID — Claude is still alive.
             // Notification hook handles user-facing notifications; SessionEnd handles cleanup.
             //
-            // Use try? for workspace/surface resolution: during app teardown the TabManager
-            // may already be nil, causing these calls to throw "TabManager not available".
-            // That is expected and harmless — we simply skip the status update and exit cleanly.
+            // During app teardown the TabManager may already be nil, causing resolution
+            // calls to throw "TabManager not available". We selectively ignore known
+            // teardown errors via shouldIgnoreClaudeHookTeardownError and rethrow
+            // unexpected errors so they surface through the outer failure telemetry path.
             let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
-            guard let workspaceId = try? resolvePreferredWorkspaceIdForClaudeHook(
-                preferred: mappedSession?.workspaceId,
-                fallback: workspaceArg,
-                client: client
-            ) else {
-                telemetry.breadcrumb("claude-hook.stop.no-workspace")
+            let workspaceId: String
+            do {
+                workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                    preferred: mappedSession?.workspaceId,
+                    fallback: workspaceArg,
+                    client: client
+                )
+            } catch {
+                guard shouldIgnoreClaudeHookTeardownError(error) else { throw error }
+                telemetry.breadcrumb("claude-hook.stop.no-workspace", data: ["error": String(describing: error)])
                 print("OK")
                 return
             }
-            let surfaceId = try? resolvePreferredSurfaceIdForClaudeHook(
-                preferred: mappedSession?.surfaceId,
-                fallback: surfaceArg,
-                workspaceId: workspaceId,
-                client: client
-            )
-            if surfaceId == nil {
-                telemetry.breadcrumb("claude-hook.stop.no-surface")
+            let surfaceId: String?
+            do {
+                surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
+                    preferred: mappedSession?.surfaceId,
+                    fallback: surfaceArg,
+                    workspaceId: workspaceId,
+                    client: client
+                )
+            } catch {
+                guard shouldIgnoreClaudeHookTeardownError(error) else { throw error }
+                telemetry.breadcrumb("claude-hook.stop.no-surface", data: ["error": String(describing: error)])
+                surfaceId = nil
             }
 
             // Update session with transcript summary and send completion notification.
@@ -11007,14 +11016,18 @@ struct CMUXCLI {
                 sessionRecord: mappedSession
             )
             if let sessionId = parsedInput.sessionId, let completion, let surfaceId {
-                try? sessionStore.upsert(
-                    sessionId: sessionId,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId,
-                    cwd: parsedInput.cwd,
-                    lastSubtitle: completion.subtitle,
-                    lastBody: completion.body
-                )
+                do {
+                    try sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        cwd: parsedInput.cwd,
+                        lastSubtitle: completion.subtitle,
+                        lastBody: completion.body
+                    )
+                } catch {
+                    guard shouldIgnoreClaudeHookTeardownError(error) else { throw error }
+                }
             }
 
             if let completion, let surfaceId {
@@ -11022,16 +11035,24 @@ struct CMUXCLI {
                 let subtitle = sanitizeNotificationField(completion.subtitle)
                 let body = sanitizeNotificationField(completion.body)
                 let payload = "\(title)|\(subtitle)|\(body)"
-                _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+                do {
+                    _ = try sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+                } catch {
+                    guard shouldIgnoreClaudeHookTeardownError(error) else { throw error }
+                }
             }
 
-            try? setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Idle",
-                icon: "pause.circle.fill",
-                color: "#8E8E93"
-            )
+            do {
+                try setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Idle",
+                    icon: "pause.circle.fill",
+                    color: "#8E8E93"
+                )
+            } catch {
+                guard shouldIgnoreClaudeHookTeardownError(error) else { throw error }
+            }
             print("OK")
 
         case "prompt-submit":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10975,62 +10975,65 @@ struct CMUXCLI {
 
         case "stop", "idle":
             telemetry.breadcrumb("claude-hook.stop")
-            do {
-                // Turn ended. Don't consume session or clear PID — Claude is still alive.
-                // Notification hook handles user-facing notifications; SessionEnd handles cleanup.
-                let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
-                let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
-                    preferred: mappedSession?.workspaceId,
-                    fallback: workspaceArg,
-                    client: client
-                )
-                let surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
-                    preferred: mappedSession?.surfaceId,
-                    fallback: surfaceArg,
-                    workspaceId: workspaceId,
-                    client: client
-                )
-
-                // Update session with transcript summary and send completion notification.
-                let completion = summarizeClaudeHookStop(
-                    parsedInput: parsedInput,
-                    sessionRecord: mappedSession
-                )
-                if let sessionId = parsedInput.sessionId, let completion {
-                    try? sessionStore.upsert(
-                        sessionId: sessionId,
-                        workspaceId: workspaceId,
-                        surfaceId: surfaceId,
-                        cwd: parsedInput.cwd,
-                        lastSubtitle: completion.subtitle,
-                        lastBody: completion.body
-                    )
-                }
-
-                if let completion {
-                    let title = "Claude Code"
-                    let subtitle = sanitizeNotificationField(completion.subtitle)
-                    let body = sanitizeNotificationField(completion.body)
-                    let payload = "\(title)|\(subtitle)|\(body)"
-                    _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
-                }
-
-                try? setClaudeStatus(
-                    client: client,
-                    workspaceId: workspaceId,
-                    value: "Idle",
-                    icon: "pause.circle.fill",
-                    color: "#8E8E93"
-                )
+            // Turn ended. Don't consume session or clear PID — Claude is still alive.
+            // Notification hook handles user-facing notifications; SessionEnd handles cleanup.
+            //
+            // Use try? for workspace/surface resolution: during app teardown the TabManager
+            // may already be nil, causing these calls to throw "TabManager not available".
+            // That is expected and harmless — we simply skip the status update and exit cleanly.
+            let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+            guard let workspaceId = try? resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: mappedSession?.workspaceId,
+                fallback: workspaceArg,
+                client: client
+            ) else {
+                telemetry.breadcrumb("claude-hook.stop.no-workspace")
                 print("OK")
-            } catch {
-                if shouldIgnoreClaudeHookTeardownError(error) {
-                    telemetry.breadcrumb("claude-hook.stop.ignored", data: ["error": String(describing: error)])
-                    print("OK")
-                    return
-                }
-                throw error
+                return
             }
+            guard let surfaceId = try? resolvePreferredSurfaceIdForClaudeHook(
+                preferred: mappedSession?.surfaceId,
+                fallback: surfaceArg,
+                workspaceId: workspaceId,
+                client: client
+            ) else {
+                telemetry.breadcrumb("claude-hook.stop.no-surface")
+                print("OK")
+                return
+            }
+
+            // Update session with transcript summary and send completion notification.
+            let completion = summarizeClaudeHookStop(
+                parsedInput: parsedInput,
+                sessionRecord: mappedSession
+            )
+            if let sessionId = parsedInput.sessionId, let completion {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: parsedInput.cwd,
+                    lastSubtitle: completion.subtitle,
+                    lastBody: completion.body
+                )
+            }
+
+            if let completion {
+                let title = "Claude Code"
+                let subtitle = sanitizeNotificationField(completion.subtitle)
+                let body = sanitizeNotificationField(completion.body)
+                let payload = "\(title)|\(subtitle)|\(body)"
+                _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+            }
+
+            try? setClaudeStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: "Idle",
+                icon: "pause.circle.fill",
+                color: "#8E8E93"
+            )
+            print("OK")
 
         case "prompt-submit":
             telemetry.breadcrumb("claude-hook.prompt-submit")


### PR DESCRIPTION
Fixes #2201

## Problem

On every Claude Code session exit, the stop hook printed:
```
Stop hook error: Failed with non-blocking status code: Error: unavailable: TabManager not available
```

During app teardown, `TabManager` may be `nil` when the stop hook fires.
The workspace/surface resolution calls `workspace.current` (or `surface.list`) which
returns an `"unavailable: TabManager not available"` error from the app.
This error propagated out of the handler and reached the top-level `catch` in `main`,
which wrote it to stderr and exited with code 1.

While `shouldIgnoreClaudeHookTeardownError` already whitelisted `"tabmanager not available"`,
the previous `do-catch` structure had subtle paths where the error could escape before
reaching the ignore check.

## Fix

Replace the `do-catch + shouldIgnoreClaudeHookTeardownError` pattern in the `stop/idle`
handler with explicit `guard let ... = try? ...` checks for workspace and surface resolution.
If either resolution fails for any reason during teardown, the hook exits cleanly with `"OK"`
and a telemetry breadcrumb, rather than propagating the error.

This removes the dependency on `shouldIgnoreClaudeHookTeardownError` for the stop hook's
workspace resolution path — making it impossible for TabManager-unavailable errors to
surface on session exit, regardless of which specific error propagation path is triggered.

## Test plan
- Run Claude Code inside cmux terminal (`cmux claude-teams` or with CMUX hooks installed)
- Exit the session (`/exit` or Ctrl+D)
- Verify terminal output shows no "TabManager not available" error
- Verify with cmux app closed → should exit cleanly with no error
- Normal session (app healthy): stop hook still updates status to Idle and sends completion notification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the "TabManager not available" error on Claude Code session exit by making the stop/idle hook teardown-safe and only suppressing known teardown errors, exiting cleanly with "OK" and keeping stderr clean. Resolves #2201.

- **Bug Fixes**
  - Switched to targeted do/catch with `shouldIgnoreClaudeHookTeardownError` for workspace, surface, session update, notification, and status calls; unexpected errors rethrow through the telemetry path.
  - If workspace resolution fails during teardown, add a breadcrumb and return "OK"; if surface resolution fails, skip summary/notification but still set workspace status to Idle.
  - Added breadcrumbs for missing workspace/surface and always print "OK" on the successful path.

<sup>Written for commit 0e35436379faeb4b4a478005b141a9aa6ff5de3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined stop/idle CLI handler with clearer staged resolution and early-exit behavior for missing resources.
  * Workspace and surface resolution now fail fast for absent resources and suppress teardown-related errors.
  * Session transcript updates and completion notifications only run after resources are confirmed.
  * Status updates use explicit error handling to suppress expected teardown errors while surfacing unexpected failures.
  * Success acknowledgement now occurs after all staged steps complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->