### PR TITLE
Update ghostty for fallback font sizing

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -102,6 +102,19 @@ The fork branch HEAD is now the section 6 zsh redraw follow-up commit.
 
 The fork branch HEAD is now the section 7 cmux theme picker helper commit.
 
+### 8) CoreText fallback glyph height clamp
+
+- Commit: `bb60bc964` (coretext: clamp fallback glyphs to primary cell height)
+- Files:
+  - `src/font/Collection.zig`
+  - `src/font/face/coretext.zig`
+- Summary:
+  - Propagates the collection fallback flag onto loaded CoreText faces so rasterization can distinguish fallback glyphs from primary-font glyphs.
+  - Caches CoreText face metrics at load time and preserves the fallback flag across synthetic/style/size copies.
+  - Uniformly shrinks unconstrained fallback text glyphs to fit the primary grid cell's vertical extents, preventing Hangul/CJK fallbacks from rendering larger than the primary monospace font.
+
+The fork branch HEAD is now the section 8 fallback sizing commit.
+
 ## Upstreamed fork changes
 
 ### cursor-click-to-move respects OSC 133 click-to-move
@@ -129,5 +142,11 @@ These files change frequently upstream; be careful when rebasing the fork:
   - cmux now relies on the upstream picker UI plus local env-driven hooks for live preview and restore.
     If upstream reorganizes the preview loop or key handling, re-check the cmux mode path and keep the
     stock Ghostty behavior unchanged when the cmux env vars are absent.
+
+- `src/font/face/coretext.zig`
+  - Keep the cached face metrics and fallback-only height clamp together. The glyph-size remap is intentionally limited to unconstrained fallback text glyphs; don't accidentally apply it to primary fonts or icon/emoji constraint paths.
+
+- `src/font/Collection.zig`
+  - Keep the fallback flag propagation from `Collection.Entry` into loaded `Face` values, including deferred-face loads, or the CoreText clamp logic will silently stop applying to discovered fallback fonts.
 
 If you resolve a conflict, update this doc with what changed.


### PR DESCRIPTION
## Summary
- update the Ghostty submodule to clamp CoreText fallback glyphs to the primary cell height
- document the new Ghostty fork-only change in `docs/ghostty-fork.md`
- depend on manaflow-ai/ghostty#19 for the submodule commit

## Testing
- manually launched a tagged local dev build to verify the app bundle still opens
- not run: local automated tests (repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `ghostty` to clamp CoreText fallback glyphs to the primary cell height so Hangul/CJK fallback text fits the cell (meets Linear issue 2162). Adds docs detailing the fork-only change in `docs/ghostty-fork.md`.

<sup>Written for commit 0de6601e03c40252ab7d329b49f66bd9d536f4e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented improvements to fallback font glyph rendering and sizing.

* **Chores**
  * Updated ghostty submodule dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->