### PR TITLE
fix(wrapper): add fallback paths when resolving real claude binary

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -6,15 +6,52 @@
 # so that Claude Code hooks fire back into cmux for notifications/status.
 # Outside cmux, it passes through to the real claude binary unchanged.
 
-# Find the real claude binary, skipping our own directory.
+# Return 0 if the given path is a real claude binary (not another cmux wrapper).
+is_real_claude() {
+    local file="$1"
+    # cmux wrappers contain a marker string in the first 512 bytes.
+    local header
+    header="$(head -c 512 "$file" 2>/dev/null)" || return 0
+    [[ "$header" != *"cmux claude wrapper"* ]]
+}
+
+# Find the real claude binary.
+# 1) Search $PATH, skipping our own directory and other cmux wrappers.
+# 2) Fall back to well-known installation paths.
+# 3) Fall back to the Claude Desktop App bundle (latest version).
 find_real_claude() {
     local self_dir
     self_dir="$(cd "$(dirname "$0")" && pwd)"
+
+    # Search PATH.
     local IFS=:
     for d in $PATH; do
         [[ "$d" == "$self_dir" ]] && continue
-        [[ -x "$d/claude" ]] && printf '%s' "$d/claude" && return 0
+        [[ -x "$d/claude" ]] && is_real_claude "$d/claude" && printf '%s' "$d/claude" && return 0
     done
+
+    # Well-known installation paths.
+    local candidate
+    for candidate in \
+        "$HOME/.local/bin/claude" \
+        "/usr/local/bin/claude"; do
+        [[ -x "$candidate" ]] && is_real_claude "$candidate" && printf '%s' "$candidate" && return 0
+    done
+
+    # Claude Desktop App bundle (newest version first via reverse-sorted glob).
+    local app_support="$HOME/Library/Application Support/Claude/claude-code"
+    if [[ -d "$app_support" ]]; then
+        local -a bundles=()
+        for candidate in "$app_support"/*/claude.app/Contents/MacOS/claude; do
+            [[ -x "$candidate" ]] && bundles+=("$candidate")
+        done
+        # Try newest version first (highest version directory sorts last, so reverse).
+        local i
+        for (( i=${#bundles[@]}-1; i>=0; i-- )); do
+            printf '%s' "${bundles[$i]}" && return 0
+        done
+    fi
+
     return 1
 }
 
@@ -48,12 +85,12 @@ if [[ "$IN_CMUX" == "0" || "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]] || ! cmux_soc
     if [[ "$IN_CMUX" == "1" ]]; then
         unset CLAUDECODE
     fi
-    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH or well-known locations. Install Claude Code (https://docs.anthropic.com/s/claude-code) or add it to your PATH." >&2; exit 127; }
     exec "$REAL_CLAUDE" "$@"
 fi
 
 # Find real claude.
-REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH or well-known locations. Install Claude Code (https://docs.anthropic.com/s/claude-code) or add it to your PATH." >&2; exit 127; }
 
 # Pass through subcommands that don't support session/hook flags.
 case "${1:-}" in


### PR DESCRIPTION
## Summary

- Add `is_real_claude()` content check to skip cmux wrappers at any path (mirrors the Swift-side `isCmuxClaudeWrapper` logic that reads the first 512 bytes)
- Fall back to well-known Claude Code installation paths when PATH search fails: `~/.local/bin/claude`, `/usr/local/bin/claude`
- Fall back to the Claude Desktop App bundle at `~/Library/Application Support/Claude/claude-code/*/claude.app/Contents/MacOS/claude` (newest version first)
- Improve error message with actionable guidance and docs link

Closes #2048

## Context

The cmux claude wrapper (`Resources/bin/claude`) only searched `$PATH` for the real `claude` executable. When users installed Claude Code via the Desktop App (which places the binary under `~/Library/Application Support/Claude/claude-code/<version>/claude.app/Contents/MacOS/claude`), the wrapper failed with `Error: claude not found in PATH` because that location is not in `$PATH`.

The Swift-side launcher code (`CLI/cmux.swift`) already had bundled-path fallback logic, but the bash wrapper lacked it entirely.

## Test plan

- [ ] Verify wrapper resolves claude from PATH (existing behavior unchanged)
- [ ] Verify wrapper resolves claude via `~/.local/bin/claude` fallback when PATH has no claude
- [ ] Verify wrapper resolves claude via Desktop App bundle when no other claude exists
- [ ] Verify `is_real_claude()` correctly skips cmux wrappers at arbitrary paths
- [ ] Verify `shellcheck` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the `claude` wrapper finds the real `claude` binary even when it’s not on `$PATH`, fixing failures for Desktop App installs. Adds a content check to skip other cmux wrappers and improves the error message.

- **Bug Fixes**
  - Search `$PATH` while skipping the wrapper’s directory and require `is_real_claude()` (checks first 512 bytes for wrapper marker).
  - Add fallbacks: `~/.local/bin/claude`, `/usr/local/bin/claude`, and the newest Desktop App bundle at `~/Library/Application Support/Claude/claude-code/*/claude.app/Contents/MacOS/claude`.
  - Error now mentions well-known locations and links to install docs.

<sup>Written for commit a54918fc09d1bf7ea41b02d24aa777b7519bd7b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Claude binary detection to search additional installation paths, including macOS Desktop App directories
  * Improved error messages with clearer guidance when Claude binary cannot be located

<!-- end of auto-generated comment: release notes by coderabbit.ai -->