### PR TITLE
fix: skip hook injection for non-interactive claude invocations

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -60,6 +60,13 @@ case "${1:-}" in
     mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
 esac
 
+# Pass through non-interactive (piped/scripted) invocations without injecting
+# hooks. Headless callers like auth-token refreshers have no TTY and should
+# not trigger session-start hooks that create phantom sessions burning API credits.
+if [[ ! -t 0 ]]; then
+    exec "$REAL_CLAUDE" "$@"
+fi
+
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
 # independent sessions even when the parent shell was launched from Claude Code.
 unset CLAUDECODE

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -64,6 +64,7 @@ esac
 # hooks. Headless callers like auth-token refreshers have no TTY and should
 # not trigger session-start hooks that create phantom sessions burning API credits.
 if [[ ! -t 0 ]]; then
+    unset CLAUDECODE
     exec "$REAL_CLAUDE" "$@"
 fi
 


### PR DESCRIPTION
## Problem

The `claude` PATH shim inside cmux terminals injects `--session-id` and `--settings` with lifecycle hooks into *every* `claude` invocation where `CMUX_SURFACE_ID` is set. This includes non-interactive, headless calls — such as OAuth token refresh via `opencode-claude-auth` — that have no interactive TTY and were never meant to start a conversation.

When the `SessionStart` hook fires, it enqueues `"."` in the JSONL session file. Claude receives it as a user prompt and generates a full response, triggering `PreToolUse`, `Stop`, and more hooks in a chain. The result is phantom session files with 10–27 messages each, generated every ~30 minutes, burning API credits unattended.

Fixes #2206

## Fix

Add a `[[ ! -t 0 ]]` guard after the subcommand passthrough block. Headless invocations have no stdin TTY, so this check cleanly detects piped/scripted calls without requiring exhaustive flag enumeration (`--print`, `--output-format`, `--print-auth-token`, etc.).

Interactive claude sessions inside cmux always have a TTY (the terminal provides stdin), so the check does not affect normal cmux usage.

## Test plan

- [ ] Non-interactive: `echo "test" | claude` inside a cmux terminal → no hook injection, passes through to real claude binary
- [ ] Interactive: `claude` inside a cmux terminal → hooks injected as before, session tracking works
- [ ] Subcommand passthrough still works: `claude mcp`, `claude config` → no hooks
- [ ] `cmux claude-hook` commands still fire for interactive sessions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip hook injection for non-interactive `claude` runs inside `cmux`, preventing phantom sessions and wasted API credits (fixes #2206). Headless calls now pass through to the real binary without starting a session.

- **Bug Fixes**
  - Detect non-interactive calls via `[[ ! -t 0 ]]`, unset `CLAUDECODE`, and bypass hook injection.
  - Keep passthrough for `claude mcp`, `claude config`, etc.
  - Interactive sessions are unchanged; hooks still run and sessions track normally.

<sup>Written for commit 904baed483926b931ab15dcdc3b5c6617c36074a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-interactive (piped/scripted) invocations now bypass session injection and lifecycle hooks, preserving original arguments and avoiding added session/settings flags—resulting in faster, more predictable behavior for scripted use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->