### PR TITLE
fix: Option+Delete deletes single char instead of previous word

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5792,6 +5792,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Alt+Backspace and generates ESC+DEL.
         if flags.contains(.option) && !flags.contains(.command) && !flags.contains(.control) && !hasMarkedText(),
            event.keyCode == 51 {
+            terminalSurface?.recordExternalFocusState(true)
             ghostty_surface_set_focus(surface, true)
             var keyEvent = ghostty_input_key_s()
             keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5785,6 +5785,37 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if handled { return }
         }
 
+        // Fast path for Option+Delete (backward word-delete).
+        // macOS maps Option+Delete to "∂" (U+2202) through AppKit text input.
+        // In terminals, Alt+Backspace should delete the previous word.
+        // Bypass interpretKeyEvents so Ghostty's key encoder receives the raw
+        // Alt+Backspace and generates ESC+DEL.
+        if flags.contains(.option) && !flags.contains(.command) && !flags.contains(.control) && !hasMarkedText(),
+           event.keyCode == 51 {
+            ghostty_surface_set_focus(surface, true)
+            var keyEvent = ghostty_input_key_s()
+            keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
+            keyEvent.keycode = UInt32(event.keyCode)
+            keyEvent.mods = modsFromEvent(event)
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.composing = false
+            keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
+            keyEvent.text = nil
+            #if DEBUG
+            let ghosttySendStart = ProcessInfo.processInfo.systemUptime
+            let handled = sendTimedGhosttyKey(
+                surface,
+                keyEvent,
+                path: "terminal.keyDown.optDeleteGhosttySend",
+                event: event
+            )
+            ghosttySendMs = (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+            #else
+            let handled = ghostty_surface_key(surface, keyEvent)
+            #endif
+            if handled { return }
+        }
+
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt)

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1190,8 +1190,9 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             pressEvent = keyEvent
         }
 
+        // Real macOS produces "∂" (U+2202) for Option+Delete, not "\u{7F}".
         let sent = hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
-            characters: "\u{7F}",
+            characters: "\u{2202}",
             charactersIgnoringModifiers: "\u{7F}",
             keyCode: 51,
             modifierFlags: [.option]


### PR DESCRIPTION
## Summary

- Option+Delete deletes a single character instead of the previous word. Most noticeable in TUI apps (Claude Code, Codex); plain shell may mask it via readline bindings.
- Root cause: AppKit's `interpretKeyEvents` transforms Option+Delete into "∂" (U+2202) via `insertText`. The accumulated-text path sends this to Ghostty with `consumed_mods = ALT`, which tells the key encoder "Alt was already used to produce text." The encoder strips Alt from effective modifiers and encodes bare backspace (`\x7F`) instead of Alt+Backspace (`ESC DEL`).
- Fix: add a fast path for Option+Delete (keyCode 51) before `interpretKeyEvents`, mirroring the existing Ctrl fast path. Sends `text = nil`, `consumed_mods = NONE` so the encoder sees Alt+Backspace and produces ESC+DEL (backward-kill-word).
- Works regardless of `macos-option-as-alt` config and keyboard layout since it bypasses AppKit text transformation entirely.

Fixes #1424
Fixes #1153

## Test plan

- [x] Open terminal, type a few words, press Option+Delete → previous word deleted
- [x] Repeat inside a TUI app (e.g. vim, htop, Claude Code) → same behavior
- [x] Verify Option+Delete during IME composition (e.g. Japanese) still cancels composition normally (hasMarkedText guard)
- [x] Verify Ctrl+Delete still works as before
- [x] Verify regular Delete (no modifiers) still works
- [x] If `macos-option-as-alt` is configured, verify Option+Delete still works

<!-- cubic -->

## Summary by cubic

AppKit's interpretKeyEvents transforms Option+Delete into insertText("∂"), filling the keyTextAccumulator. The accumulated-text path sends this to Ghostty with consumed_mods=ALT, which strips Alt from effective modifiers — the encoder sees bare backspace and produces \x7F (single char delete) instead of ESC+DEL (backward-kill-word).

Add a fast path for Option+Delete (keyCode 51) before interpretKeyEvents, mirroring the existing Ctrl fast path. Sends text=nil, consumed_mods=NONE so the encoder sees Alt+Backspace and produces ESC+DEL.

Also fix the regression test to use realistic characters: macOS produces "∂" (U+2202) for Option+Delete, not "\u{7F}".

Written for commit 8723cde7. Summary will update on new commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Option+Delete handling so the app correctly preserves the Alt/Option modifier and delivers the expected delete behavior on macOS.

* **Tests**
  * Updated keyboard input test to more accurately synthesize the Option+Delete scenario, ensuring modifier preservation and expected input behavior remain verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->