### PR TITLE
fix: prevent zombie process leak in async claude-hook stdin read

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10906,6 +10906,48 @@ struct CMUXCLI {
         }
     }
 
+    /// Reads stdin without waiting for EOF, draining all available data with a
+    /// short idle timeout. This prevents zombie processes when the parent
+    /// (Claude Code) spawns async hooks without closing the stdin pipe, while
+    /// still supporting payloads larger than the OS pipe buffer (~64 KB).
+    /// See: https://github.com/manaflow-ai/cmux/issues/2248
+    private func readStdinWithoutWaitingForEOF(idleTimeoutMs: Int = 20, maxWaitMs: Int = 200) -> String {
+        let handle = FileHandle.standardInput
+        let fd = handle.fileDescriptor
+
+        // Set stdin to non-blocking mode
+        let originalFlags = fcntl(fd, F_GETFL)
+        fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK)
+        defer { fcntl(fd, F_SETFL, originalFlags) }
+
+        var accumulated = Data()
+        let startTime = DispatchTime.now()
+        var lastReadTime = startTime
+
+        while true {
+            let chunk = handle.availableData
+            if !chunk.isEmpty {
+                accumulated.append(chunk)
+                lastReadTime = DispatchTime.now()
+                continue
+            }
+
+            let now = DispatchTime.now()
+            let idleNs = now.uptimeNanoseconds - lastReadTime.uptimeNanoseconds
+            let totalNs = now.uptimeNanoseconds - startTime.uptimeNanoseconds
+
+            // Stop if idle too long (no more data coming) or total wait exceeded
+            if idleNs > UInt64(idleTimeoutMs) * 1_000_000 ||
+               totalNs > UInt64(maxWaitMs) * 1_000_000 {
+                break
+            }
+
+            usleep(1000) // 1ms poll interval
+        }
+
+        return String(data: accumulated, encoding: .utf8) ?? ""
+    }
+
     private func runClaudeHook(
         commandArgs: [String],
         client: SocketClient,
@@ -10916,12 +10958,7 @@ struct CMUXCLI {
         let hookWsFlag = optionValue(hookArgs, name: "--workspace")
         let workspaceArg = hookWsFlag ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
         let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
-        // Use availableData instead of readDataToEndOfFile to prevent indefinite
-        // blocking when the parent process (Claude Code) spawns async hooks without
-        // closing the stdin pipe. readDataToEndOfFile waits for EOF which never
-        // arrives for async hooks, causing zombie process accumulation.
-        // See: https://github.com/manaflow-ai/cmux/issues/2248
-        let rawInput = String(data: FileHandle.standardInput.availableData, encoding: .utf8) ?? ""
+        let rawInput = readStdinWithoutWaitingForEOF()
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore()
         telemetry.breadcrumb(
@@ -12143,8 +12180,7 @@ struct CMUXCLI {
         let hookWsFlag = optionValue(hookArgs, name: "--workspace")
         let workspaceArg = hookWsFlag ?? env["CMUX_WORKSPACE_ID"]
         let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? env["CMUX_SURFACE_ID"] : nil)
-        // See runClaudeHook comment — availableData prevents async hook zombie leak
-        let rawInput = String(data: FileHandle.standardInput.availableData, encoding: .utf8) ?? ""
+        let rawInput = readStdinWithoutWaitingForEOF()
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore(
             processEnv: env.merging(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10916,7 +10916,12 @@ struct CMUXCLI {
         let hookWsFlag = optionValue(hookArgs, name: "--workspace")
         let workspaceArg = hookWsFlag ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
         let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
-        let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        // Use availableData instead of readDataToEndOfFile to prevent indefinite
+        // blocking when the parent process (Claude Code) spawns async hooks without
+        // closing the stdin pipe. readDataToEndOfFile waits for EOF which never
+        // arrives for async hooks, causing zombie process accumulation.
+        // See: https://github.com/manaflow-ai/cmux/issues/2248
+        let rawInput = String(data: FileHandle.standardInput.availableData, encoding: .utf8) ?? ""
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore()
         telemetry.breadcrumb(
@@ -12138,7 +12143,8 @@ struct CMUXCLI {
         let hookWsFlag = optionValue(hookArgs, name: "--workspace")
         let workspaceArg = hookWsFlag ?? env["CMUX_WORKSPACE_ID"]
         let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? env["CMUX_SURFACE_ID"] : nil)
-        let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        // See runClaudeHook comment — availableData prevents async hook zombie leak
+        let rawInput = String(data: FileHandle.standardInput.availableData, encoding: .utf8) ?? ""
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore(
             processEnv: env.merging(


### PR DESCRIPTION
## Summary

- Replace `FileHandle.standardInput.readDataToEndOfFile()` with `.availableData` in `runClaudeHook` and `runCodexHook`
- `readDataToEndOfFile()` blocks indefinitely when Claude Code spawns async hooks without closing the stdin pipe, causing zombie process accumulation

## Problem

When `PreToolUse` hooks run with `"async": true`, Claude Code writes to stdin but doesn't close the pipe (since it doesn't wait for the result). `readDataToEndOfFile()` waits for EOF which never arrives, so the process hangs forever.

**Impact:** ~440 zombie processes/hour → IOSurface exhaustion → WindowServer watchdog timeout → kernel panic

See #2248 for full diagnostic data.

## Fix

`availableData` returns whatever data is currently buffered without waiting for EOF. This is safe because:
1. Claude Code writes the full JSON payload before the process starts reading
2. `parseClaudeHookInput` already handles empty/partial input gracefully (returns default `ClaudeHookParsedInput`)
3. All sync hooks (session-start, stop, etc.) also benefit — they complete faster since they don't wait for pipe close

## Testing

- Verified zombie process accumulation stops after this change (manual testing with 6 concurrent sessions)
- All existing hook functionality preserved (status updates, notifications, AskUserQuestion detection)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent zombie process leaks by switching hook stdin reads to a non-blocking, multi-chunk drain. Stops hangs in Claude hooks and safely handles large payloads without waiting for EOF.

- **Bug Fixes**
  - Use `readStdinWithoutWaitingForEOF()` (O_NONBLOCK + loop with short idle/max wait) in `runClaudeHook` and `runCodexHook`.
  - Prevents blocking when async hooks don’t close stdin and avoids truncation beyond the ~64 KB pipe buffer.

<sup>Written for commit da5a45a9fcadb0995fc81748a0ef271df9193744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI hook input handling updated: hooks no longer block waiting for EOF and will process available stdin after a short idle/timeout, improving responsiveness when input isn’t explicitly closed.

---

*Note: This is an internal implementation change affecting CLI behavior; no new UI features were added.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->