### PR TITLE
feat: auto-match sidebar background to Ghostty terminal theme

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -77798,6 +77798,74 @@
         }
       }
     },
+    "settings.sidebarAppearance.theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Theme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのテーマ"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.theme.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.theme.matchGhostty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Match Ghostty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty に合わせる"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.theme.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose whether the sidebar follows Ghostty's current background or uses your custom tint settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーを Ghostty の現在の背景に合わせるか、カスタムのティント設定を使うかを選びます。"
+          }
+        }
+      }
+    },
     "settings.sidebarAppearance.tintColorLight": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13730,6 +13730,7 @@ private struct TitlebarLeadingInsetReader: NSViewRepresentable {
 }
 
 private struct SidebarBackdrop: View {
+    @AppStorage(SidebarThemeSettings.modeKey) private var sidebarTheme = SidebarThemeSettings.defaultMode.rawValue
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarTintHex") private var sidebarTintHex = SidebarTintDefaults.hex
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
@@ -13740,12 +13741,15 @@ private struct SidebarBackdrop: View {
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
     @Environment(\.colorScheme) private var colorScheme
+    @State private var refreshGeneration = 0
 
     var body: some View {
-        let materialOption = SidebarMaterialOption(rawValue: sidebarMaterial)
+        let preferredColorScheme: GhosttyConfig.ColorSchemePreference = colorScheme == .dark ? .dark : .light
+        let ghosttyConfig = GhosttyConfig.load(preferredColorScheme: preferredColorScheme)
+        let selectedSidebarTheme = SidebarThemeSettings.mode(for: sidebarTheme)
         let blendingMode = SidebarBlendModeOption(rawValue: sidebarBlendMode)?.mode ?? .behindWindow
         let state = SidebarStateOption(rawValue: sidebarState)?.state ?? .active
-        let resolvedHex: String = {
+        let resolvedCustomHex: String = {
             if colorScheme == .dark, let dark = sidebarTintHexDark {
                 return dark
             } else if colorScheme == .light, let light = sidebarTintHexLight {
@@ -13753,13 +13757,45 @@ private struct SidebarBackdrop: View {
             }
             return sidebarTintHex
         }()
-        let tintColor = (NSColor(hex: resolvedHex) ?? NSColor(hex: sidebarTintHex) ?? .black).withAlphaComponent(sidebarTintOpacity)
+        let customTintColor = (NSColor(hex: resolvedCustomHex) ?? NSColor(hex: sidebarTintHex) ?? .black)
+            .withAlphaComponent(sidebarTintOpacity)
+        let explicitSidebarBackground: NSColor? = {
+            if colorScheme == .dark, let dark = ghosttyConfig.sidebarBackgroundDark {
+                return dark
+            } else if colorScheme == .light, let light = ghosttyConfig.sidebarBackgroundLight {
+                return light
+            }
+            return ghosttyConfig.sidebarBackground
+        }()
+        let hasExplicitSidebarBackground = ghosttyConfig.rawSidebarBackground != nil && explicitSidebarBackground != nil
+        let tintColor: NSColor = {
+            guard let explicitSidebarBackground else {
+                return customTintColor
+            }
+            let resolvedOpacity = ghosttyConfig.sidebarTintOpacity ?? sidebarTintOpacity
+            return explicitSidebarBackground.withAlphaComponent(resolvedOpacity)
+        }()
+        let baseColor: NSColor? =
+            hasExplicitSidebarBackground || selectedSidebarTheme == .custom
+            ? nil
+            : GhosttyBackgroundTheme.currentColor()
+        let materialOption: SidebarMaterialOption? = {
+            if hasExplicitSidebarBackground || selectedSidebarTheme == .custom {
+                return SidebarMaterialOption(rawValue: sidebarMaterial)
+            }
+            return SidebarMaterialOption.none
+        }()
         let cornerRadius = CGFloat(max(0, sidebarCornerRadius))
         let useLiquidGlass = materialOption?.usesLiquidGlass ?? false
         let useWindowLevelGlass = useLiquidGlass && blendingMode == .behindWindow
 
         return ZStack {
-            if let material = materialOption?.material {
+            if let baseColor {
+                SidebarSolidColorBackground(color: baseColor)
+                if tintColor.alphaComponent > 0.0001 {
+                    SidebarSolidColorBackground(color: tintColor)
+                }
+            } else if let material = materialOption?.material {
                 // When using liquidGlass + behindWindow, window handles glass + tint
                 // Sidebar is fully transparent
                 if !useWindowLevelGlass {
@@ -13777,10 +13813,69 @@ private struct SidebarBackdrop: View {
                         Color(nsColor: tintColor)
                     }
                 }
+            } else {
+                // No material — render solid tint color (used when sidebar
+                // matches the terminal theme background). Uses a custom
+                // NSView instead of SwiftUI Color because
+                // makeViewHierarchyTransparent clears layer.backgroundColor
+                // on all views when the terminal has background-opacity < 1.
+                SidebarSolidColorBackground(color: tintColor)
             }
-            // When material is none or useWindowLevelGlass, render nothing
         }
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
+            refreshGeneration &+= 1
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+            GhosttyConfig.invalidateLoadCache()
+            refreshGeneration &+= 1
+        }
+    }
+}
+
+/// Renders a solid color using the same compositing path as the terminal's
+/// CAMetalLayer (bgra8Unorm / sRGB blending). Uses a display link callback
+/// to re-apply layer.backgroundColor after makeViewHierarchyTransparent
+/// clears it on transparent windows.
+private struct SidebarSolidColorBackground: NSViewRepresentable {
+    let color: NSColor
+
+    final class SolidColorView: NSView {
+        var fillColor: NSColor = .clear {
+            didSet { applyColor() }
+        }
+
+        override func makeBackingLayer() -> CALayer {
+            let layer = CALayer()
+            layer.isOpaque = false
+            // Match the terminal's sRGB compositing by using the same
+            // contentsFormat as CAMetalLayer's bgra8Unorm pixel format.
+            layer.contentsFormat = .RGBA8Uint
+            return layer
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            // Re-apply after makeViewHierarchyTransparent clears it.
+            DispatchQueue.main.async { [weak self] in
+                self?.applyColor()
+            }
+        }
+
+        func applyColor() {
+            wantsLayer = true
+            layer?.backgroundColor = fillColor.cgColor
+        }
+    }
+
+    func makeNSView(context: Context) -> SolidColorView {
+        let view = SolidColorView()
+        view.wantsLayer = true
+        return view
+    }
+
+    func updateNSView(_ nsView: SolidColorView, context: Context) {
+        nsView.fillColor = color
     }
 }
 
@@ -13891,6 +13986,81 @@ enum SidebarStateOption: String, CaseIterable, Identifiable {
 enum SidebarTintDefaults {
     static let hex = "#000000"
     static let opacity = 0.18
+}
+
+enum SidebarThemeOption: String, CaseIterable, Identifiable {
+    case matchGhostty
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .matchGhostty:
+            return String(localized: "settings.sidebarAppearance.theme.matchGhostty", defaultValue: "Match Ghostty")
+        case .custom:
+            return String(localized: "settings.sidebarAppearance.theme.custom", defaultValue: "Custom")
+        }
+    }
+}
+
+enum SidebarThemeSettings {
+    static let modeKey = "sidebarTheme"
+    static let defaultMode: SidebarThemeOption = .matchGhostty
+
+    static func mode(for rawValue: String?) -> SidebarThemeOption {
+        guard let rawValue, let mode = SidebarThemeOption(rawValue: rawValue) else {
+            return defaultMode
+        }
+        return mode
+    }
+
+    static func mode(defaults: UserDefaults = .standard) -> SidebarThemeOption {
+        mode(for: defaults.string(forKey: modeKey))
+    }
+
+    static func ensureStoredMode(defaults: UserDefaults = .standard) {
+        guard defaults.string(forKey: modeKey) == nil else { return }
+        defaults.set(inferredMode(defaults: defaults).rawValue, forKey: modeKey)
+    }
+
+    static func inferredMode(defaults: UserDefaults = .standard) -> SidebarThemeOption {
+        usesCustomAppearance(defaults: defaults) ? .custom : .matchGhostty
+    }
+
+    static func usesCustomAppearance(defaults: UserDefaults = .standard) -> Bool {
+        let preset = SidebarPresetOption.nativeSidebar
+        let material = defaults.string(forKey: "sidebarMaterial") ?? preset.material.rawValue
+        let blendMode = defaults.string(forKey: "sidebarBlendMode") ?? preset.blendMode.rawValue
+        let state = defaults.string(forKey: "sidebarState") ?? preset.state.rawValue
+        let tintHex = defaults.string(forKey: "sidebarTintHex") ?? preset.tintHex
+        let tintOpacity = defaults.object(forKey: "sidebarTintOpacity") as? Double ?? preset.tintOpacity
+        let blurOpacity = defaults.object(forKey: "sidebarBlurOpacity") as? Double ?? preset.blurOpacity
+        let cornerRadius = defaults.object(forKey: "sidebarCornerRadius") as? Double ?? preset.cornerRadius
+        let tintHexLight = defaults.string(forKey: "sidebarTintHexLight")
+        let tintHexDark = defaults.string(forKey: "sidebarTintHexDark")
+
+        return material != preset.material.rawValue ||
+            blendMode != preset.blendMode.rawValue ||
+            state != preset.state.rawValue ||
+            normalizeHex(tintHex) != normalizeHex(preset.tintHex) ||
+            !approximatelyEqual(tintOpacity, preset.tintOpacity) ||
+            !approximatelyEqual(blurOpacity, preset.blurOpacity) ||
+            !approximatelyEqual(cornerRadius, preset.cornerRadius) ||
+            tintHexLight != nil ||
+            tintHexDark != nil
+    }
+
+    private static func normalizeHex(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "#", with: "")
+            .uppercased()
+    }
+
+    private static func approximatelyEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.0001) -> Bool {
+        abs(lhs - rhs) <= tolerance
+    }
 }
 
 enum SidebarPresetOption: String, CaseIterable, Identifiable {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13744,6 +13744,7 @@ private struct SidebarBackdrop: View {
     @State private var refreshGeneration = 0
 
     var body: some View {
+        let _ = refreshGeneration  // explicit dependency for notification-driven re-renders
         let preferredColorScheme: GhosttyConfig.ColorSchemePreference = colorScheme == .dark ? .dark : .light
         let ghosttyConfig = GhosttyConfig.load(preferredColorScheme: preferredColorScheme)
         let selectedSidebarTheme = SidebarThemeSettings.mode(for: sidebarTheme)
@@ -13759,7 +13760,9 @@ private struct SidebarBackdrop: View {
         }()
         let customTintColor = (NSColor(hex: resolvedCustomHex) ?? NSColor(hex: sidebarTintHex) ?? .black)
             .withAlphaComponent(sidebarTintOpacity)
+        let usesGhosttyTheme = selectedSidebarTheme == .matchGhostty
         let explicitSidebarBackground: NSColor? = {
+            guard usesGhosttyTheme else { return nil }
             if colorScheme == .dark, let dark = ghosttyConfig.sidebarBackgroundDark {
                 return dark
             } else if colorScheme == .light, let light = ghosttyConfig.sidebarBackgroundLight {
@@ -13769,9 +13772,8 @@ private struct SidebarBackdrop: View {
         }()
         let hasExplicitSidebarBackground = ghosttyConfig.rawSidebarBackground != nil && explicitSidebarBackground != nil
         let tintColor: NSColor = {
-            guard let explicitSidebarBackground else {
-                return customTintColor
-            }
+            guard usesGhosttyTheme else { return customTintColor }
+            guard let explicitSidebarBackground else { return .clear }
             let resolvedOpacity = ghosttyConfig.sidebarTintOpacity ?? sidebarTintOpacity
             return explicitSidebarBackground.withAlphaComponent(resolvedOpacity)
         }()
@@ -13826,7 +13828,11 @@ private struct SidebarBackdrop: View {
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
             refreshGeneration &+= 1
         }
-        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+        .onReceive(
+            NotificationCenter.default
+                .publisher(for: .ghosttyConfigDidReload)
+                .receive(on: RunLoop.main)
+        ) { _ in
             GhosttyConfig.invalidateLoadCache()
             refreshGeneration &+= 1
         }
@@ -13834,9 +13840,9 @@ private struct SidebarBackdrop: View {
 }
 
 /// Renders a solid color using the same compositing path as the terminal's
-/// CAMetalLayer (bgra8Unorm / sRGB blending). Uses a display link callback
-/// to re-apply layer.backgroundColor after makeViewHierarchyTransparent
-/// clears it on transparent windows.
+/// CAMetalLayer (bgra8Unorm / sRGB blending). Uses `viewDidMoveToWindow` with a
+/// deferred main-queue dispatch to re-apply `layer.backgroundColor` after
+/// `makeViewHierarchyTransparent` clears it on transparent windows.
 private struct SidebarSolidColorBackground: NSViewRepresentable {
     let color: NSColor
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -211,6 +211,7 @@ struct cmuxApp: App {
             SocketControlPasswordStore.migrateLegacyKeychainPasswordIfNeeded(defaults: defaults)
         }
         migrateSidebarAppearanceDefaultsIfNeeded(defaults: defaults)
+        SidebarThemeSettings.ensureStoredMode(defaults: defaults)
 
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
@@ -1721,6 +1722,7 @@ private enum DebugWindowConfigSnapshot {
     static func combinedPayload(defaults: UserDefaults = .standard) -> String {
         let sidebarPayload = """
         sidebarPreset=\(stringValue(defaults, key: "sidebarPreset", fallback: SidebarPresetOption.nativeSidebar.rawValue))
+        sidebarTheme=\(stringValue(defaults, key: SidebarThemeSettings.modeKey, fallback: SidebarThemeSettings.defaultMode.rawValue))
         sidebarMaterial=\(stringValue(defaults, key: "sidebarMaterial", fallback: SidebarMaterialOption.sidebar.rawValue))
         sidebarBlendMode=\(stringValue(defaults, key: "sidebarBlendMode", fallback: SidebarBlendModeOption.withinWindow.rawValue))
         sidebarState=\(stringValue(defaults, key: "sidebarState", fallback: SidebarStateOption.followWindow.rawValue))
@@ -2864,6 +2866,7 @@ private struct AboutPanelView: View {
 
 private struct SidebarDebugView: View {
     @AppStorage("sidebarPreset") private var sidebarPreset = SidebarPresetOption.nativeSidebar.rawValue
+    @AppStorage(SidebarThemeSettings.modeKey) private var sidebarTheme = SidebarThemeSettings.defaultMode.rawValue
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarTintHex") private var sidebarTintHex = SidebarTintDefaults.hex
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
@@ -3099,6 +3102,7 @@ private struct SidebarDebugView: View {
     private func copySidebarConfig() {
         let payload = """
         sidebarPreset=\(sidebarPreset)
+        sidebarTheme=\(sidebarTheme)
         sidebarMaterial=\(sidebarMaterial)
         sidebarBlendMode=\(sidebarBlendMode)
         sidebarState=\(sidebarState)
@@ -3870,6 +3874,7 @@ struct SettingsView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
+    @AppStorage(SidebarThemeSettings.modeKey) private var sidebarTheme = SidebarThemeSettings.defaultMode.rawValue
     @AppStorage("sidebarTintHex") private var sidebarTintHex = SidebarTintDefaults.hex
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
@@ -4912,6 +4917,22 @@ struct SettingsView: View {
 
                     SettingsSectionHeader(title: String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar Appearance"))
                     SettingsCard {
+                        SettingsPickerRow(
+                            String(localized: "settings.sidebarAppearance.theme", defaultValue: "Sidebar Theme"),
+                            subtitle: String(
+                                localized: "settings.sidebarAppearance.theme.subtitle",
+                                defaultValue: "Choose whether the sidebar follows Ghostty's current background or uses your custom tint settings."
+                            ),
+                            controlWidth: pickerColumnWidth,
+                            selection: $sidebarTheme
+                        ) {
+                            ForEach(SidebarThemeOption.allCases) { option in
+                                Text(option.title).tag(option.rawValue)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsCardRow(
                             String(localized: "settings.sidebarAppearance.tintColorLight", defaultValue: "Light Mode Tint"),
                             subtitle: String(localized: "settings.sidebarAppearance.tintColorLight.subtitle", defaultValue: "Sidebar tint color when using light appearance.")
@@ -5670,6 +5691,7 @@ struct SettingsView: View {
         sidebarShowLog = true
         sidebarShowProgress = true
         sidebarShowMetadata = true
+        sidebarTheme = SidebarThemeSettings.defaultMode.rawValue
         sidebarTintHex = SidebarTintDefaults.hex
         sidebarTintHexLight = nil
         sidebarTintHexDark = nil

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2483,17 +2483,37 @@ final class SidebarBackgroundConfigTests: XCTestCase {
 
     func testApplyToUserDefaultsSkipsWritesWhenNoConfig() {
         let defaults = UserDefaults.standard
-        let testKey = "sidebarTintHex"
-        let original = defaults.string(forKey: testKey)
-        defer { restoreDefaultsValue(original, key: testKey, defaults: defaults) }
+        let keys = ["sidebarTintHex", "sidebarTintHexLight", "sidebarTintHexDark",
+                     "sidebarTintOpacity", "sidebarMaterial"]
+        let originals = keys.map { defaults.object(forKey: $0) }
+        defer {
+            for (key, original) in zip(keys, originals) {
+                restoreDefaultsValue(original, key: key, defaults: defaults)
+            }
+        }
 
-        defaults.set("#AAAAAA", forKey: testKey)
+        defaults.set("#AAAAAA", forKey: "sidebarTintHex")
+        defaults.set("#BBBBBB", forKey: "sidebarTintHexLight")
+        defaults.set("#CCCCCC", forKey: "sidebarTintHexDark")
+        defaults.set(0.42, forKey: "sidebarTintOpacity")
+        defaults.set(SidebarMaterialOption.hudWindow.rawValue, forKey: "sidebarMaterial")
 
         var config = GhosttyConfig()
+        config.backgroundColor = NSColor(hex: "#1E1E2E")!
+        config.backgroundOpacity = 0.9
         config.applySidebarAppearanceToUserDefaults()
 
-        XCTAssertEqual(defaults.string(forKey: testKey), "#AAAAAA",
-                       "Should not overwrite UserDefaults when rawSidebarBackground is nil")
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHex"), "#AAAAAA",
+                       "Should not overwrite tint hex when rawSidebarBackground is nil")
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHexLight"), "#BBBBBB",
+                       "Should not clear the light tint override")
+        XCTAssertEqual(defaults.string(forKey: "sidebarTintHexDark"), "#CCCCCC",
+                       "Should not clear the dark tint override")
+        XCTAssertEqual(defaults.double(forKey: "sidebarTintOpacity"), 0.42, accuracy: 0.0001,
+                       "Should not overwrite opacity when sidebar-tint-opacity is unset")
+        XCTAssertEqual(defaults.string(forKey: "sidebarMaterial"),
+                       SidebarMaterialOption.hudWindow.rawValue,
+                       "Should not overwrite the current material")
     }
 
     func testApplyToUserDefaultsWritesHexWhenConfigSet() {
@@ -2568,6 +2588,42 @@ final class SidebarBackgroundConfigTests: XCTestCase {
         } else {
             defaults.removeObject(forKey: key)
         }
+    }
+}
+
+final class SidebarThemeSettingsTests: XCTestCase {
+    func testInferredModeDefaultsToMatchGhosttyForNativeSidebarAppearance() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(SidebarThemeSettings.inferredMode(defaults: defaults), .matchGhostty)
+    }
+
+    func testInferredModeUsesCustomWhenTintOverridesExist() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("#224466", forKey: "sidebarTintHexLight")
+
+        XCTAssertEqual(SidebarThemeSettings.inferredMode(defaults: defaults), .custom)
+    }
+
+    func testEnsureStoredModePersistsCustomForCustomizedSidebarAppearance() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(0.42, forKey: "sidebarTintOpacity")
+
+        SidebarThemeSettings.ensureStoredMode(defaults: defaults)
+
+        XCTAssertEqual(defaults.string(forKey: SidebarThemeSettings.modeKey), SidebarThemeOption.custom.rawValue)
+    }
+
+    private func makeDefaults() -> (UserDefaults, String) {
+        let suiteName = "SidebarThemeSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Sidebar Theme** setting ("Match Ghostty" / "Custom") under Sidebar Appearance in Settings
- When set to "Match Ghostty" (default for new installs), the sidebar reads `GhosttyBackgroundTheme.currentColor()` directly and renders a solid color via a CALayer-backed NSView — bypassing the glass material that distorts theme colors
- Tracks live theme changes via `.ghosttyDefaultBackgroundDidChange` and `.ghosttyConfigDidReload` notifications
- Existing users with customized sidebar appearance are auto-detected as "Custom" mode via `SidebarThemeSettings.inferredMode()` so their settings are preserved on upgrade
- Localized in English and Japanese

## Test plan

- [ ] Fresh install: sidebar matches terminal Ghostty theme out of the box
- [ ] Change Ghostty theme at runtime — sidebar updates to match
- [ ] Explicit `sidebar-background` in Ghostty config still works
- [ ] Switching to "Custom" in Settings restores user tint/material controls
- [ ] Existing users with customized sidebar aren't affected (inferred as Custom)
- [ ] Unit tests pass (`xcodebuild -scheme cmux-unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Sidebar Theme” setting that lets the sidebar auto-match the Ghostty terminal background for accurate colors and live updates. New installs default to “Match Ghostty”; existing customized sidebars stay unchanged.

- **New Features**
  - Sidebar Theme setting: “Match Ghostty” (default for new installs) or “Custom”.
  - When matching, renders a CALayer-backed solid color that mirrors Ghostty’s background and updates on theme/config changes.
  - Modes are mutually exclusive: no tint overlay in Match Ghostty; explicit `sidebar-background` applies only in Match Ghostty, while Custom ignores it and restores tint/material controls.
  - Existing customized setups are inferred as Custom to preserve settings; localized in English and Japanese.

<sup>Written for commit 00b7834baf47ad5d6fb96ac87aedaf6a0eb80697. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar theme setting in Settings to choose between following the app's current background or using a custom tint.

* **Bug Fixes**
  * Sidebar now reliably shows a solid tint when window materials are disabled and refreshes promptly when external theme/config changes.

* **Tests**
  * Expanded test coverage for sidebar theme behaviors and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->