### PR TITLE
Add web-browser entitlement for Keychain password autofill

### DIFF
--- a/cmux.entitlements
+++ b/cmux.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds the `com.apple.developer.web-browser` entitlement so that macOS Keychain password autofill works in browser panes. The WKWebView configuration already uses the default persistent `WKWebsiteDataStore`, so the entitlement is the only missing piece.

Since cmux is distributed directly via Sparkle (not the App Store), this entitlement doesn't require Apple's approval process.

Closes #2258

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable macOS Keychain password autofill in browser panes by adding the `com.apple.developer.web-browser` entitlement. `WKWebView` already uses the default persistent store; distribution via Sparkle means no Apple approval needed.

<sup>Written for commit 681152d50c1580a0c6a9364b7cc95200e31151f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app permissions to enable web browser capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->