### PR TITLE
Fix titlebar workspace creation crashes in release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+
+# Local planning and CI package caches
+.ci-source-packages/
+docs/plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,18 @@ cd cmuxd && zig build -Doptimize=ReleaseFast
 ./scripts/reloadp.sh
 ```
 
+To replace the downloaded `/Applications/cmux.app` with a source-built Release app, use:
+
+```bash
+./scripts/reloadp.sh --install
+```
+
+This keeps the normal `cmux.app` identity and stores the first downloaded app backup at:
+
+```bash
+/Applications/cmux.downloaded.app
+```
+
 `reloads` = kill and launch the Release app as "cmux STAGING" (isolated from production cmux):
 
 ```bash
@@ -180,12 +192,15 @@ This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the
 
 ## Testing policy
 
-**Never run tests locally.** All tests (E2E, UI, python socket tests) run via GitHub Actions or on the VM.
+Avoid running full test suites locally by default. E2E, broad UI suites, and python socket suites still prefer GitHub Actions or the VM.
 
 - **E2E / UI tests:** trigger via `gh workflow run test-e2e.yml` (see cmuxterm-hq CLAUDE.md for details)
+- **Targeted local UI tests:** allowed when explicitly debugging a local regression. Use `./scripts/run-ui-test-local.sh <cmuxUITests filter>` and keep the run narrow.
+- **Targeted local smoke runs:** allowed for live-app validation. Use `./scripts/mac-smoke.sh --app debug|release --scenario titlebar-new-workspace` and collect artifacts from `/tmp/cmux-smoke/...`.
 - **Unit tests:** `xcodebuild -scheme cmux-unit` is safe (no app launch), but prefer CI
 - **Python socket tests (tests_v2/):** these connect to a running cmux instance's socket. Never launch an untagged `cmux DEV.app` to run them. If you must test locally, use a tagged build's socket (`/tmp/cmux-debug-<tag>.sock`) with `CMUX_SOCKET=/tmp/cmux-debug-<tag>.sock`
 - **Never `open` an untagged `cmux DEV.app`** from DerivedData. It conflicts with the user's running debug instance.
+- **Local macOS automation prerequisites:** Accessibility is required for `mac-smoke.sh`; screenshots may also require Screen Recording permission for the invoking terminal/agent process.
 
 ## Ghostty submodule workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@
 | `./scripts/reload2.sh` | Reload both Debug and Release |
 | `./scripts/rebuild.sh` | Clean rebuild |
 
+To replace the downloaded `/Applications/cmux.app` with a source-built Release app
+that keeps the normal app identity and removes the Debug banner, run:
+
+```bash
+./scripts/reloadp.sh --install
+```
+
+The first time this runs, it backs up the existing app to
+`/Applications/cmux.downloaded.app`.
+
 ## Rebuilding GhosttyKit
 
 If you make changes to the ghostty submodule, rebuild the xcframework:
@@ -62,6 +72,43 @@ ssh cmux-vm 'cd /Users/cmux/GhosttyTabs && xcodebuild -project GhosttyTabs.xcode
 ```bash
 ssh cmux-vm 'cd /Users/cmux/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" -only-testing:cmuxUITests test'
 ```
+
+### Targeted local UI tests
+
+Use targeted local UI runs when you need to debug a specific macOS regression on your machine. Keep the scope narrow rather than running the whole suite.
+
+```bash
+./scripts/run-ui-test-local.sh MenuKeyEquivalentRoutingUITests/testTitlebarNewWorkspaceButtonCreatesWorkspaceWithoutCrash
+```
+
+Artifacts are written under `/tmp/cmux-ui-local/...` unless you pass `--artifacts-dir`.
+
+### Local macOS smoke automation
+
+Use the smoke helper to exercise a live app build end-to-end through Accessibility APIs and capture screenshots plus crash artifacts.
+
+Tagged Debug build:
+
+```bash
+./scripts/mac-smoke.sh --app debug --scenario titlebar-new-workspace --tag local-smoke
+```
+
+Installed Release app:
+
+```bash
+./scripts/mac-smoke.sh --app release --scenario titlebar-new-workspace
+```
+
+Rebuild and reinstall the source-built Release app first:
+
+```bash
+./scripts/mac-smoke.sh --app release --scenario titlebar-new-workspace --reinstall-release
+```
+
+Notes:
+- `mac-smoke.sh` writes artifacts under `/tmp/cmux-smoke/...` by default.
+- Accessibility is required for the terminal/agent process running the helper.
+- Screenshot capture may also require Screen Recording permission.
 
 ## Ghostty Submodule
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -17773,6 +17773,23 @@
         }
       }
     },
+    "command.openSelectedLinkOrPath.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Selected Link or Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したリンクまたはパスを開く"
+          }
+        }
+      }
+    },
     "command.openSettings.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -62018,6 +62035,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klasör Aç"
+          }
+        }
+      }
+    },
+    "shortcut.openSelectedLinkOrPath.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Selected Link or Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したリンクまたはパスを開く"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9,27 +9,174 @@ import Combine
 import ObjectiveC.runtime
 import Darwin
 
-final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
-    private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
+private let cmuxWorkspaceCrashBreadcrumbsURL = URL(fileURLWithPath: "/tmp/cmux-workspace-crash-breadcrumbs.log")
 
+private let cmuxWorkspaceCrashBreadcrumbsPathPointerURL = URL(fileURLWithPath: "/tmp/cmux-last-workspace-crash-log-path")
+
+private let cmuxWorkspaceCrashBreadcrumbsFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+}()
+
+func cmuxWorkspaceCrashBreadcrumb(_ event: String, fields: [String: String] = [:]) {
+    var line = "[\(cmuxWorkspaceCrashBreadcrumbsFormatter.string(from: Date()))] \(event)"
+    if !fields.isEmpty {
+        let payload = fields
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value.replacingOccurrences(of: "\n", with: "\\n"))" }
+            .joined(separator: " ")
+        line += " \(payload)"
+    }
+    line += "\n"
+
+    if let data = line.data(using: .utf8) {
+        if !FileManager.default.fileExists(atPath: cmuxWorkspaceCrashBreadcrumbsURL.path) {
+            FileManager.default.createFile(atPath: cmuxWorkspaceCrashBreadcrumbsURL.path, contents: nil)
+        }
+        if let handle = try? FileHandle(forWritingTo: cmuxWorkspaceCrashBreadcrumbsURL) {
+            do {
+                try handle.seekToEnd()
+                try handle.write(contentsOf: data)
+                try handle.close()
+            } catch {
+                try? handle.close()
+            }
+        }
+        try? cmuxWorkspaceCrashBreadcrumbsURL.path.write(to: cmuxWorkspaceCrashBreadcrumbsPathPointerURL, atomically: true, encoding: .utf8)
+    }
+}
+
+final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
-    override var safeAreaRect: NSRect { bounds }
-    override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
 
     required init(rootView: Content) {
         super.init(rootView: rootView)
-        addLayoutGuide(zeroSafeAreaLayoutGuide)
-        NSLayoutConstraint.activate([
-            zeroSafeAreaLayoutGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
-            zeroSafeAreaLayoutGuide.trailingAnchor.constraint(equalTo: trailingAnchor),
-            zeroSafeAreaLayoutGuide.topAnchor.constraint(equalTo: topAnchor),
-            zeroSafeAreaLayoutGuide.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+enum TerminalSelectionOpenResolver {
+    static func resolve(_ rawSelection: String, baseDirectory: String?) -> TerminalOpenURLTarget? {
+        let candidates = normalizedCandidates(from: rawSelection)
+        guard !candidates.isEmpty else { return nil }
+
+        for candidate in candidates {
+            if hasExplicitScheme(candidate) || NSString(string: candidate).isAbsolutePath {
+                if let target = resolveTerminalOpenURLTarget(candidate) {
+                    return target
+                }
+            }
+        }
+
+        for candidate in candidates {
+            if let fileURL = resolveExistingPath(candidate, baseDirectory: baseDirectory) {
+                return .external(fileURL)
+            }
+        }
+
+        for candidate in candidates {
+            if let target = resolveTerminalOpenURLTarget(candidate) {
+                return target
+            }
+        }
+
+        return nil
+    }
+
+    private static func normalizedCandidates(from rawSelection: String) -> [String] {
+        var candidates: [String] = []
+
+        func append(_ candidate: String?) {
+            guard let candidate else { return }
+            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            guard !candidates.contains(trimmed) else { return }
+            candidates.append(trimmed)
+        }
+
+        let trimmed = rawSelection.trimmingCharacters(in: .whitespacesAndNewlines)
+        append(trimmed)
+
+        let unwrapped = stripWrappingDelimiters(from: trimmed)
+        append(unwrapped)
+
+        append(stripLineSuffix(from: trimmed))
+        append(stripLineSuffix(from: unwrapped))
+
+        return candidates
+    }
+
+    private static func stripWrappingDelimiters(from value: String) -> String {
+        let pairs: [(Character, Character)] = [
+            ("\"", "\""),
+            ("'", "'"),
+            ("`", "`"),
+            ("<", ">"),
+            ("(", ")"),
+            ("[", "]"),
+            ("{", "}"),
+        ]
+
+        var result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        while result.count >= 2,
+              let first = result.first,
+              let last = result.last,
+              pairs.contains(where: { $0.0 == first && $0.1 == last }) {
+            result.removeFirst()
+            result.removeLast()
+            result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return result
+    }
+
+    private static func stripLineSuffix(from value: String) -> String? {
+        var candidate = value
+        var stripped = false
+
+        for _ in 0..<2 {
+            let parts = candidate.split(separator: ":", omittingEmptySubsequences: false)
+            guard parts.count >= 2,
+                  let lastPart = parts.last,
+                  !lastPart.isEmpty,
+                  lastPart.allSatisfy(\.isNumber) else {
+                break
+            }
+            candidate = parts.dropLast().joined(separator: ":")
+            stripped = true
+        }
+
+        return stripped ? candidate : nil
+    }
+
+    private static func resolveExistingPath(_ candidate: String, baseDirectory: String?) -> URL? {
+        let fileManager = FileManager.default
+        let trimmedBaseDirectory = baseDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let basePath = trimmedBaseDirectory.isEmpty ? fileManager.currentDirectoryPath : trimmedBaseDirectory
+        let baseURL = URL(fileURLWithPath: basePath, isDirectory: true)
+        let expandedCandidate = NSString(string: candidate).expandingTildeInPath
+
+        let url: URL
+        if NSString(string: expandedCandidate).isAbsolutePath {
+            url = URL(fileURLWithPath: expandedCandidate)
+        } else {
+            url = URL(fileURLWithPath: expandedCandidate, relativeTo: baseURL)
+        }
+
+        let standardized = url.standardizedFileURL
+        guard fileManager.fileExists(atPath: standardized.path) else { return nil }
+        return standardized
+    }
+
+    private static func hasExplicitScheme(_ value: String) -> Bool {
+        value.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*:"#,
+            options: .regularExpression
+        ) != nil
     }
 }
 
@@ -1968,9 +2115,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private final class MainWindowContext {
         let windowId: UUID
-        let tabManager: TabManager
-        let sidebarState: SidebarState
-        let sidebarSelectionState: SidebarSelectionState
+        var tabManager: TabManager
+        var sidebarState: SidebarState
+        var sidebarSelectionState: SidebarSelectionState
         weak var window: NSWindow?
 
         init(
@@ -3810,8 +3957,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let priorManagerToken = debugManagerToken(self.tabManager)
         #endif
         if let existing = mainWindowContexts[key] {
+            existing.tabManager = tabManager
+            existing.sidebarState = sidebarState
+            existing.sidebarSelectionState = sidebarSelectionState
             existing.window = window
         } else if let existing = mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
+            existing.tabManager = tabManager
+            existing.sidebarState = sidebarState
+            existing.sidebarSelectionState = sidebarSelectionState
             existing.window = window
             reindexMainWindowContextIfNeeded(existing, for: window)
         } else {
@@ -4384,17 +4537,86 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
-    func addWorkspace(windowId: UUID, workingDirectory: String? = nil, bringToFront shouldBringToFront: Bool = false) -> UUID? {
+    func addWorkspace(
+        windowId: UUID,
+        workingDirectory: String? = nil,
+        bringToFront shouldBringToFront: Bool = false,
+        debugSource: String = "unspecified"
+    ) -> UUID? {
         guard let state = scriptableMainWindow(windowId: windowId) else { return nil }
-        if shouldBringToFront, let window = state.window {
-            setActiveMainWindow(window)
-            bringToFront(window)
+        if let window = state.window {
+            return addWorkspace(
+                in: window,
+                workingDirectory: workingDirectory,
+                shouldBringToFront: shouldBringToFront,
+                debugSource: debugSource
+            )
         }
-        let workspace = state.tabManager.addWorkspace(
+
+        guard let context = mainWindowContexts.values.first(where: { $0.windowId == windowId }) else {
+            return nil
+        }
+        return createWorkspace(
+            in: context,
             workingDirectory: workingDirectory,
-            select: shouldBringToFront
+            shouldBringToFront: shouldBringToFront,
+            event: nil,
+            debugSource: debugSource
         )
-        return workspace.id
+    }
+
+    @discardableResult
+    func requestWorkspaceCreation(
+        windowId: UUID? = nil,
+        workingDirectory: String? = nil,
+        shouldBringToFront: Bool = false,
+        debugSource: String = "unspecified"
+    ) -> UUID? {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.request",
+            fields: [
+                "source": debugSource,
+                "windowId": windowId?.uuidString ?? "nil",
+                "workingDirectory": workingDirectory ?? "nil",
+                "bringToFront": shouldBringToFront ? "1" : "0",
+            ]
+        )
+        if let windowId,
+           let workspaceId = addWorkspace(
+               windowId: windowId,
+               workingDirectory: workingDirectory,
+               bringToFront: shouldBringToFront,
+               debugSource: debugSource
+           ) {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.request.resolved-windowId",
+                fields: [
+                    "source": debugSource,
+                    "workspaceId": workspaceId.uuidString,
+                ]
+            )
+            return workspaceId
+        }
+        if let workspaceId = addWorkspaceInPreferredMainWindow(
+            workingDirectory: workingDirectory,
+            shouldBringToFront: shouldBringToFront,
+            debugSource: debugSource
+        ) {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.request.resolved-preferred-window",
+                fields: [
+                    "source": debugSource,
+                    "workspaceId": workspaceId.uuidString,
+                ]
+            )
+            return workspaceId
+        }
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.request.open-new-window",
+            fields: ["source": debugSource]
+        )
+        openNewMainWindow(nil)
+        return nil
     }
 
     private func markCommandPaletteOpenRequested(for window: NSWindow?) {
@@ -4741,6 +4963,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         return nil
+    }
+
+    @discardableResult
+    func openResolvedTerminalTarget(
+        _ target: TerminalOpenURLTarget,
+        sourceWorkspaceId: UUID,
+        sourcePanelId: UUID
+    ) -> Bool {
+        if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
+            return NSWorkspace.shared.open(target.url)
+        }
+
+        switch target {
+        case let .external(url):
+            return NSWorkspace.shared.open(url)
+        case let .embeddedBrowser(url):
+            if BrowserLinkOpenSettings.shouldOpenExternally(url) {
+                return NSWorkspace.shared.open(url)
+            }
+            guard let host = BrowserInsecureHTTPSettings.normalizeHost(url.host ?? "") else {
+                return NSWorkspace.shared.open(url)
+            }
+            if !BrowserLinkOpenSettings.hostMatchesWhitelist(host) {
+                return NSWorkspace.shared.open(url)
+            }
+            guard let resolved = workspaceContainingPanel(
+                panelId: sourcePanelId,
+                preferredWorkspaceId: sourceWorkspaceId
+            ) else {
+                return false
+            }
+            let workspace = resolved.workspace
+            if let targetPane = workspace.preferredBrowserTargetPane(fromPanelId: sourcePanelId) {
+                return workspace.newBrowserSurface(inPane: targetPane, url: url, focus: true) != nil
+            }
+            return workspace.newBrowserSplit(
+                from: sourcePanelId,
+                orientation: .horizontal,
+                url: url
+            ) != nil
+        }
     }
 
     func locateGhosttySurface(_ surface: ghostty_surface_t?) -> (windowId: UUID, workspaceId: UUID, panelId: UUID, tabManager: TabManager)? {
@@ -5352,6 +5615,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    @discardableResult
+    func openSelectedTextInTerminal(
+        tabManager: TabManager,
+        workspaceId: UUID,
+        panelId: UUID
+    ) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }),
+              let terminalPanel = workspace.panels[panelId] as? TerminalPanel,
+              let selectedText = terminalPanel.selectedText() else {
+            return false
+        }
+
+        let baseDirectory = workspace.panelDirectories[panelId] ?? workspace.currentDirectory
+        guard let target = TerminalSelectionOpenResolver.resolve(
+            selectedText,
+            baseDirectory: baseDirectory
+        ) else {
+            return false
+        }
+
+        return openResolvedTerminalTarget(
+            target,
+            sourceWorkspaceId: workspace.id,
+            sourcePanelId: panelId
+        )
+    }
+
+    @discardableResult
+    private func openSelectedTextInFocusedTerminal(preferredWindow: NSWindow? = nil) -> Bool {
+        guard let context = focusedTerminalShortcutContext(preferredWindow: preferredWindow) else {
+            return false
+        }
+        return openSelectedTextInTerminal(
+            tabManager: context.tabManager,
+            workspaceId: context.workspaceId,
+            panelId: context.panelId
+        )
+    }
+
     private func preferredMainWindowContextForShortcuts(event: NSEvent) -> MainWindowContext? {
         if let context = contextForMainWindow(event.window) {
             return context
@@ -5566,36 +5868,86 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @discardableResult
-    func addWorkspaceInPreferredMainWindow(
+    func addWorkspace(
+        in window: NSWindow,
         workingDirectory: String? = nil,
         shouldBringToFront: Bool = false,
-        event: NSEvent? = nil,
         debugSource: String = "unspecified"
     ) -> UUID? {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.add-window",
+            fields: [
+                "source": debugSource,
+                "windowNumber": String(window.windowNumber),
+                "windowTitle": window.title,
+                "workingDirectory": workingDirectory ?? "nil",
+                "bringToFront": shouldBringToFront ? "1" : "0",
+            ]
+        )
         #if DEBUG
         logWorkspaceCreationRouting(
             phase: "request",
             source: debugSource,
             reason: "add_workspace",
-            event: event,
+            event: nil,
             chosenContext: nil,
             workingDirectory: workingDirectory
         )
         #endif
-        guard let context = preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource) else {
+        guard let context = contextForMainTerminalWindow(window) else {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.add-window.no-context",
+                fields: [
+                    "source": debugSource,
+                    "windowNumber": String(window.windowNumber),
+                ]
+            )
             #if DEBUG
             logWorkspaceCreationRouting(
                 phase: "no_context",
                 source: debugSource,
-                reason: "context_selection_failed",
-                event: event,
+                reason: "window_context_missing",
+                event: nil,
                 chosenContext: nil,
                 workingDirectory: workingDirectory
             )
             #endif
             return nil
         }
+        return createWorkspace(
+            in: context,
+            workingDirectory: workingDirectory,
+            shouldBringToFront: shouldBringToFront,
+            event: nil,
+            debugSource: debugSource
+        )
+    }
+
+    @discardableResult
+    private func createWorkspace(
+        in context: MainWindowContext,
+        workingDirectory: String?,
+        shouldBringToFront: Bool,
+        event: NSEvent?,
+        debugSource: String
+    ) -> UUID? {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.create-context",
+            fields: [
+                "source": debugSource,
+                "windowId": context.windowId.uuidString,
+                "workingDirectory": workingDirectory ?? "nil",
+                "bringToFront": shouldBringToFront ? "1" : "0",
+            ]
+        )
         guard let window = resolvedWindow(for: context) else {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.create-context.window-missing",
+                fields: [
+                    "source": debugSource,
+                    "windowId": context.windowId.uuidString,
+                ]
+            )
             #if DEBUG
             logWorkspaceCreationRouting(
                 phase: "no_context",
@@ -5616,10 +5968,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let workspace: Workspace
         if let workingDirectory {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.create-context.addWorkspace",
+                fields: [
+                    "source": debugSource,
+                    "windowId": context.windowId.uuidString,
+                    "workingDirectory": workingDirectory,
+                ]
+            )
             workspace = context.tabManager.addWorkspace(workingDirectory: workingDirectory, select: true)
         } else {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.create-context.addTab",
+                fields: [
+                    "source": debugSource,
+                    "windowId": context.windowId.uuidString,
+                ]
+            )
             workspace = context.tabManager.addTab(select: true)
         }
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.create-context.created",
+            fields: [
+                "source": debugSource,
+                "windowId": context.windowId.uuidString,
+                "workspaceId": workspace.id.uuidString,
+            ]
+        )
         #if DEBUG
         logWorkspaceCreationRouting(
             phase: "created",
@@ -5632,6 +6007,58 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         #endif
         return workspace.id
+    }
+
+    @discardableResult
+    func addWorkspaceInPreferredMainWindow(
+        workingDirectory: String? = nil,
+        shouldBringToFront: Bool = false,
+        event: NSEvent? = nil,
+        debugSource: String = "unspecified"
+    ) -> UUID? {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.add-preferred-window",
+            fields: [
+                "source": debugSource,
+                "workingDirectory": workingDirectory ?? "nil",
+                "bringToFront": shouldBringToFront ? "1" : "0",
+                "hasEvent": event == nil ? "0" : "1",
+            ]
+        )
+        #if DEBUG
+        logWorkspaceCreationRouting(
+            phase: "request",
+            source: debugSource,
+            reason: "add_workspace",
+            event: event,
+            chosenContext: nil,
+            workingDirectory: workingDirectory
+        )
+        #endif
+        guard let context = preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource) else {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.add-preferred-window.no-context",
+                fields: ["source": debugSource]
+            )
+            #if DEBUG
+            logWorkspaceCreationRouting(
+                phase: "no_context",
+                source: debugSource,
+                reason: "context_selection_failed",
+                event: event,
+                chosenContext: nil,
+                workingDirectory: workingDirectory
+            )
+            #endif
+            return nil
+        }
+        return createWorkspace(
+            in: context,
+            workingDirectory: workingDirectory,
+            shouldBringToFront: shouldBringToFront,
+            event: event,
+            debugSource: debugSource
+        )
     }
 
     private func preferredMainWindowContextForWorkspaceCreation(
@@ -9496,6 +9923,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             // Only consume when a focused terminal actually handled the toggle.
             // Otherwise allow the event to continue through the responder chain.
             return handled
+        }
+
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .openSelectedLinkOrPath)) {
+            let targetWindow = event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            guard focusedTerminalShortcutContext(preferredWindow: targetWindow) != nil else {
+                return false
+            }
+            let handled = openSelectedTextInFocusedTerminal(preferredWindow: targetWindow)
+#if DEBUG
+            dlog(
+                "shortcut.action name=openSelectedLinkOrPath handled=\(handled ? 1 : 0) " +
+                "\(debugShortcutRouteSnapshot(event: event))"
+            )
+#endif
+            if !handled {
+                NSSound.beep()
+            }
+            return true
         }
 
         // Workspace navigation: Cmd+Ctrl+] / Cmd+Ctrl+[

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2429,12 +2429,17 @@ struct ContentView: View {
 
     @State private var titlebarLeadingInset: CGFloat = 12
     private var windowIdentifier: String { "cmux.main.\(windowId.uuidString)" }
+    private let titlebarFolderIconSize: CGFloat = 16
+    private let titlebarFolderIconShift: CGFloat = -6
     private var fakeTitlebarTextColor: Color {
         _ = titlebarThemeGeneration
         let ghosttyBackground = GhosttyApp.shared.defaultBackgroundColor
         return ghosttyBackground.isLightColor
             ? Color.black.opacity(0.78)
             : Color.white.opacity(0.82)
+    }
+    private var titlebarFolderIconLayoutWidth: CGFloat {
+        max(0, titlebarFolderIconSize + titlebarFolderIconShift)
     }
     private var fullscreenControls: some View {
         TitlebarControlsView(
@@ -2469,7 +2474,10 @@ struct ContentView: View {
                 // Draggable folder icon + focused command name
                 if let directory = focusedDirectory {
                     DraggableFolderIcon(directory: directory)
-                        .padding(.leading, -6)
+                        // Keep the visual nudge without shrinking the HStack slot.
+                        // Negative padding here makes the title text overlap the icon.
+                        .frame(width: titlebarFolderIconLayoutWidth, alignment: .leading)
+                        .offset(x: titlebarFolderIconShift)
                 }
 
                 Text(titlebarText)
@@ -3106,6 +3114,10 @@ struct ContentView: View {
         view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
+            // cmux renders its own draggable folder/title chrome when the
+            // sidebar is hidden. Clear AppKit's native proxy icon so it
+            // never stacks on top of the custom titlebar content.
+            window.representedURL = nil
             // Do not make the entire background draggable; it interferes with drag gestures
             // like sidebar tab reordering in multi-window mode.
             window.isMovableByWindowBackground = false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2323,6 +2323,7 @@ struct ContentView: View {
 
     private var sidebarView: some View {
         VerticalTabsSidebar(
+            windowId: windowId,
             updateViewModel: updateViewModel,
             onSendFeedback: presentFeedbackComposer,
             selection: $sidebarSelectionState.selection,
@@ -2428,6 +2429,7 @@ struct ContentView: View {
     @AppStorage("debugTitlebarLeadingExtra") private var debugTitlebarLeadingExtra: Double = 0
 
     @State private var titlebarLeadingInset: CGFloat = 12
+    @State private var titlebarLeadingInsetRefreshToken: UInt64 = 0
     private var windowIdentifier: String { "cmux.main.\(windowId.uuidString)" }
     private let titlebarFolderIconSize: CGFloat = 16
     private let titlebarFolderIconShift: CGFloat = -6
@@ -2441,6 +2443,24 @@ struct ContentView: View {
     private var titlebarFolderIconLayoutWidth: CGFloat {
         max(0, titlebarFolderIconSize + titlebarFolderIconShift)
     }
+
+    @MainActor
+    private func requestFullscreenWorkspaceCreation() {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.fullscreen-titlebar.button",
+            fields: ["windowId": windowId.uuidString]
+        )
+        AppDelegate.shared?.requestWorkspaceCreation(
+            windowId: windowId,
+            debugSource: "fullscreenTitlebar.newWorkspace"
+        )
+    }
+
+    @MainActor
+    private func scheduleTitlebarLeadingInsetRefresh() {
+        titlebarLeadingInsetRefreshToken &+= 1
+    }
+
     private var fullscreenControls: some View {
         TitlebarControlsView(
             notificationStore: TerminalNotificationStore.shared,
@@ -2452,7 +2472,7 @@ struct ContentView: View {
                     anchorView: fullscreenControlsViewModel.notificationsAnchorView
                 )
             },
-            onNewTab: { tabManager.addTab() },
+            onNewTab: requestFullscreenWorkspaceCreation,
             visibilityMode: .alwaysVisible
         )
     }
@@ -2463,7 +2483,10 @@ struct ContentView: View {
             // view draggable (which breaks drag gestures like tab reordering).
             WindowDragHandleView()
 
-            TitlebarLeadingInsetReader(inset: $titlebarLeadingInset)
+            TitlebarLeadingInsetReader(
+                inset: $titlebarLeadingInset,
+                refreshToken: titlebarLeadingInsetRefreshToken
+            )
                 .allowsHitTesting(false)
 
             HStack(spacing: 8) {
@@ -3083,6 +3106,13 @@ struct ContentView: View {
                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
             }
             updateSidebarResizerBandState()
+            scheduleTitlebarLeadingInsetRefresh()
+        })
+
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .cmuxTitlebarAccessoryLayoutDidChange)) { notification in
+            guard let window = notification.object as? NSWindow else { return }
+            guard observedWindow == nil || window === observedWindow else { return }
+            scheduleTitlebarLeadingInsetRefresh()
         })
 
         view = AnyView(view.onChange(of: sidebarState.persistedWidth) { newValue in
@@ -3112,23 +3142,31 @@ struct ContentView: View {
         })
 
         view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
-            window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
-            window.titlebarAppearsTransparent = true
-            // cmux renders its own draggable folder/title chrome when the
-            // sidebar is hidden. Clear AppKit's native proxy icon so it
-            // never stacks on top of the custom titlebar content.
-            window.representedURL = nil
-            // Do not make the entire background draggable; it interferes with drag gestures
-            // like sidebar tab reordering in multi-window mode.
-            window.isMovableByWindowBackground = false
-            // Keep the window immovable by default so titlebar controls (like the folder icon)
-            // cannot accidentally initiate native window drags.
-            window.isMovable = false
-            window.styleMask.insert(.fullSizeContentView)
+            DispatchQueue.main.async {
+                window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
+                if !window.titlebarAppearsTransparent {
+                    window.titlebarAppearsTransparent = true
+                }
+                // cmux renders its own draggable folder/title chrome when the
+                // sidebar is hidden. Clear AppKit's native proxy icon so it
+                // never stacks on top of the custom titlebar content.
+                window.representedURL = nil
+                // Do not make the entire background draggable; it interferes with drag gestures
+                // like sidebar tab reordering in multi-window mode.
+                if window.isMovableByWindowBackground {
+                    window.isMovableByWindowBackground = false
+                }
+                // Keep the window immovable by default so titlebar controls (like the folder icon)
+                // cannot accidentally initiate native window drags.
+                if window.isMovable {
+                    window.isMovable = false
+                }
+                if !window.styleMask.contains(.fullSizeContentView) {
+                    window.styleMask.insert(.fullSizeContentView)
+                }
 
-            // Track this window for fullscreen notifications
-            if observedWindow !== window {
-                DispatchQueue.main.async {
+                // Track this window for fullscreen notifications
+                if observedWindow !== window {
                     observedWindow = window
                     isFullScreen = window.styleMask.contains(.fullScreen)
                     clampSidebarWidthIfNeeded(availableWidth: window.contentView?.bounds.width ?? window.contentLayoutRect.width)
@@ -3136,64 +3174,62 @@ struct ContentView: View {
                     installSidebarResizerPointerMonitorIfNeeded()
                     updateSidebarResizerBandState()
                 }
-            }
 
-            // Keep content below the titlebar so drags on Bonsplit's tab bar don't
-            // get interpreted as window drags.
-            let computedTitlebarHeight = window.frame.height - window.contentLayoutRect.height
-            let nextPadding = max(28, min(72, computedTitlebarHeight))
-            if abs(titlebarPadding - nextPadding) > 0.5 {
-                DispatchQueue.main.async {
+                // Keep content below the titlebar so drags on Bonsplit's tab bar don't
+                // get interpreted as window drags.
+                let computedTitlebarHeight = window.frame.height - window.contentLayoutRect.height
+                let nextPadding = max(28, min(72, computedTitlebarHeight))
+                if abs(titlebarPadding - nextPadding) > 0.5 {
                     titlebarPadding = nextPadding
                 }
-            }
 #if DEBUG
-            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
-                UpdateLogStore.shared.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
-            }
-#endif
-            // Background glass: skip on macOS 26+ where NSGlassEffectView can cause blank
-            // or incorrectly tinted SwiftUI content. Keep native window rendering there so
-            // Ghostty theme colors remain authoritative.
-            let currentThemeBackground = GhosttyBackgroundTheme.currentColor()
-            let shouldApplyWindowGlassFallback =
-                sidebarBlendMode == SidebarBlendModeOption.behindWindow.rawValue
-                && bgGlassEnabled
-                && !WindowGlassEffect.isAvailable
-            let shouldForceTransparentHosting =
-                shouldApplyWindowGlassFallback || currentThemeBackground.alphaComponent < 0.999
-
-            if shouldForceTransparentHosting {
-                window.isOpaque = false
-                // Keep the window clear whenever translucency is active. Relying only on
-                // terminal focus-driven updates can leave stale opaque window fills.
-                window.backgroundColor = NSColor.white.withAlphaComponent(0.001)
-                // Configure contentView hierarchy for transparency.
-                if let contentView = window.contentView {
-                    makeViewHierarchyTransparent(contentView)
+                if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
+                    UpdateLogStore.shared.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
                 }
-            } else {
-                // Browser-focused workspaces may not have an active terminal panel to refresh
-                // the NSWindow background. Keep opaque theme changes applied here as well.
-                window.backgroundColor = currentThemeBackground
-                window.isOpaque = currentThemeBackground.alphaComponent >= 0.999
-            }
+#endif
+                // Background glass: skip on macOS 26+ where NSGlassEffectView can cause blank
+                // or incorrectly tinted SwiftUI content. Keep native window rendering there so
+                // Ghostty theme colors remain authoritative.
+                let currentThemeBackground = GhosttyBackgroundTheme.currentColor()
+                let shouldApplyWindowGlassFallback =
+                    sidebarBlendMode == SidebarBlendModeOption.behindWindow.rawValue
+                    && bgGlassEnabled
+                    && !WindowGlassEffect.isAvailable
+                let shouldForceTransparentHosting =
+                    shouldApplyWindowGlassFallback || currentThemeBackground.alphaComponent < 0.999
 
-            if shouldApplyWindowGlassFallback {
-                // Apply liquid glass effect to the window with tint from settings
-                let tintColor = (NSColor(hex: bgGlassTintHex) ?? .black).withAlphaComponent(bgGlassTintOpacity)
-                WindowGlassEffect.apply(to: window, tintColor: tintColor)
+                if shouldForceTransparentHosting {
+                    window.isOpaque = false
+                    // Keep the window clear whenever translucency is active. Relying only on
+                    // terminal focus-driven updates can leave stale opaque window fills.
+                    window.backgroundColor = NSColor.white.withAlphaComponent(0.001)
+                    // Configure contentView hierarchy for transparency.
+                    if let contentView = window.contentView {
+                        makeViewHierarchyTransparent(contentView)
+                    }
+                } else {
+                    // Browser-focused workspaces may not have an active terminal panel to refresh
+                    // the NSWindow background. Keep opaque theme changes applied here as well.
+                    window.backgroundColor = currentThemeBackground
+                    window.isOpaque = currentThemeBackground.alphaComponent >= 0.999
+                }
+
+                if shouldApplyWindowGlassFallback {
+                    // Apply liquid glass effect to the window with tint from settings
+                    let tintColor = (NSColor(hex: bgGlassTintHex) ?? .black).withAlphaComponent(bgGlassTintOpacity)
+                    WindowGlassEffect.apply(to: window, tintColor: tintColor)
+                }
+                AppDelegate.shared?.attachUpdateAccessory(to: window)
+                AppDelegate.shared?.applyWindowDecorations(to: window)
+                AppDelegate.shared?.registerMainWindow(
+                    window,
+                    windowId: windowId,
+                    tabManager: tabManager,
+                    sidebarState: sidebarState,
+                    sidebarSelectionState: sidebarSelectionState
+                )
+                installFileDropOverlay(on: window, tabManager: tabManager)
             }
-            AppDelegate.shared?.attachUpdateAccessory(to: window)
-            AppDelegate.shared?.applyWindowDecorations(to: window)
-            AppDelegate.shared?.registerMainWindow(
-                window,
-                windowId: windowId,
-                tabManager: tabManager,
-                sidebarState: sidebarState,
-                sidebarSelectionState: sidebarSelectionState
-            )
-            installFileDropOverlay(on: window, tabManager: tabManager)
         }))
 
         return view
@@ -5154,6 +5190,8 @@ struct ContentView: View {
             return .splitRight
         case "palette.terminalSplitDown":
             return .splitDown
+        case "palette.openSelectedLinkOrPath":
+            return .openSelectedLinkOrPath
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
         case "palette.triggerFlash":
@@ -5875,6 +5913,15 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.openSelectedLinkOrPath",
+                title: constant(String(localized: "command.openSelectedLinkOrPath.title", defaultValue: "Open Selected Link or Path")),
+                subtitle: terminalPanelSubtitle,
+                keywords: ["terminal", "selection", "open", "path", "file", "link", "url"],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.terminalFind",
                 title: constant(String(localized: "command.terminalFind.title", defaultValue: "Find…")),
                 subtitle: terminalPanelSubtitle,
@@ -6298,6 +6345,18 @@ struct ContentView: View {
         registry.register(commandId: "palette.vscodeServeWebRestart") {
             if !restartInlineVSCodeServeWeb() {
                 NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.openSelectedLinkOrPath") {
+            guard let panelContext = focusedPanelContext,
+                  panelContext.panel is TerminalPanel,
+                  AppDelegate.shared?.openSelectedTextInTerminal(
+                    tabManager: tabManager,
+                    workspaceId: panelContext.workspace.id,
+                    panelId: panelContext.panelId
+                  ) == true else {
+                NSSound.beep()
+                return
             }
         }
         registry.register(commandId: "palette.terminalFind") {
@@ -8481,6 +8540,7 @@ private struct SidebarResizerAccessibilityModifier: ViewModifier {
 }
 
 struct VerticalTabsSidebar: View {
+    let windowId: UUID
     @ObservedObject var updateViewModel: UpdateViewModel
     let onSendFeedback: () -> Void
     @EnvironmentObject var tabManager: TabManager
@@ -8627,7 +8687,10 @@ struct VerticalTabsSidebar: View {
                 }
                 .overlay(alignment: .topLeading) {
                     if isMinimalMode {
-                        HiddenTitlebarSidebarControlsView(notificationStore: notificationStore)
+                        HiddenTitlebarSidebarControlsView(
+                            windowId: windowId,
+                            notificationStore: notificationStore
+                        )
                             .padding(.leading, hiddenTitlebarControlsLeadingInset)
                             .padding(.top, 2)
                     }
@@ -11601,6 +11664,7 @@ private struct TabItemView: View, Equatable {
             isHovering = hovering
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("SidebarWorkspaceRow.\(tab.id.uuidString)")
         .accessibilityLabel(Text(accessibilityTitle))
         .accessibilityHint(Text(accessibilityHintText))
         .accessibilityAction(named: Text(moveUpActionText)) {
@@ -13686,6 +13750,7 @@ final class TitlebarLeadingInsetPassthroughView: NSView {
 
 private struct TitlebarLeadingInsetReader: NSViewRepresentable {
     @Binding var inset: CGFloat
+    let refreshToken: UInt64
 
     func makeNSView(context: Context) -> NSView {
         let view = TitlebarLeadingInsetPassthroughView()
@@ -13694,21 +13759,29 @@ private struct TitlebarLeadingInsetReader: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
+        _ = refreshToken
         DispatchQueue.main.async {
             guard let window = nsView.window else { return }
-            // Start past the traffic lights
-            var leading: CGFloat = 78
-            // Add width of all left-aligned titlebar accessories
-            for accessory in window.titlebarAccessoryViewControllers
-                where accessory.layoutAttribute == .leading || accessory.layoutAttribute == .left {
-                leading += accessory.view.frame.width
-            }
-            leading += 0
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.contentView?.superview?.layoutSubtreeIfNeeded()
+            let leading = resolvedTitlebarLeadingInset(for: window)
             if leading != inset {
                 inset = leading
             }
         }
     }
+}
+
+func resolvedTitlebarLeadingInset(for window: NSWindow) -> CGFloat {
+    var leading: CGFloat = 78
+    for accessory in window.titlebarAccessoryViewControllers
+        where (accessory.layoutAttribute == .leading || accessory.layoutAttribute == .left) && !accessory.isHidden {
+        let measuredWidth = max(accessory.view.frame.width, accessory.preferredContentSize.width)
+        if measuredWidth > 0 {
+            leading += measuredWidth
+        }
+    }
+    return leading
 }
 
 private struct SidebarBackdrop: View {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4049,6 +4049,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return ghostty_surface_has_selection(surface)
     }
 
+    func selectedText() -> String? {
+        surfaceView.selectedText()
+    }
+
 #if DEBUG
     @MainActor
     func setNeedsConfirmCloseOverrideForTesting(_ value: Bool?) {
@@ -5069,8 +5073,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func accessibilitySelectedText() -> String? {
+        selectedText()
+    }
+
+    func selectedText() -> String? {
         guard let snapshot = readSelectionSnapshot() else { return nil }
-        return snapshot.string.isEmpty ? nil : snapshot.string
+        let trimmed = snapshot.string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func readSelectionSnapshot() -> SelectionSnapshot? {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -30,6 +30,7 @@ enum KeyboardShortcutSettings {
         case closeWorkspace
         case newSurface
         case toggleTerminalCopyMode
+        case openSelectedLinkOrPath
 
         // Panes / splits
         case focusLeft
@@ -71,6 +72,7 @@ enum KeyboardShortcutSettings {
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
+            case .openSelectedLinkOrPath: return String(localized: "shortcut.openSelectedLinkOrPath.label", defaultValue: "Open Selected Link or Path")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -107,6 +109,7 @@ enum KeyboardShortcutSettings {
             case .focusRight: return "shortcut.focusRight"
             case .focusUp: return "shortcut.focusUp"
             case .focusDown: return "shortcut.focusDown"
+            case .openSelectedLinkOrPath: return "shortcut.openSelectedLinkOrPath"
             case .splitRight: return "shortcut.splitRight"
             case .splitDown: return "shortcut.splitDown"
             case .toggleSplitZoom: return "shortcut.toggleSplitZoom"
@@ -181,6 +184,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
+            case .openSelectedLinkOrPath:
+                return StoredShortcut(key: "o", command: true, shift: true, option: false, control: false)
             case .selectWorkspaceByNumber:
                 return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
             case .openBrowser:

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -203,6 +203,10 @@ final class TerminalPanel: Panel, ObservableObject {
         surface.hasSelection()
     }
 
+    func selectedText() -> String? {
+        surface.selectedText()
+    }
+
     func needsConfirmClose() -> Bool {
         surface.needsConfirmClose()
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -812,11 +812,15 @@ class TabManager: ObservableObject {
     }
 
     private struct WorkspaceCreationSnapshot {
-        let tabs: [WorkspaceCreationTabSnapshot]
+        let totalCount: Int
+        let pinnedCount: Int
         let selectedTabId: UUID?
+        let selectedIndex: Int?
         let selectedTabWasPinned: Bool
         let preferredWorkingDirectory: String?
-        let inheritedTerminalConfig: ghostty_surface_config_s?
+#if DEBUG
+        let availableTabIds: [UUID]
+#endif
     }
     private var agentPIDSweepTimer: DispatchSourceTimer?
     private var workspaceGitMetadataPollTimer: DispatchSourceTimer?
@@ -1185,7 +1189,7 @@ class TabManager: ObservableObject {
         }()
         guard isEnabled,
               let selectedTabId = snapshot.selectedTabId,
-              let targetId = snapshot.tabs.lazy.map(\.id).first(where: { $0 != selectedTabId }),
+              let targetId = snapshot.availableTabIds.first(where: { $0 != selectedTabId }),
               tabs.contains(where: { $0.id == targetId }) else {
             return
         }
@@ -1209,20 +1213,69 @@ class TabManager: ObservableObject {
     ) -> Workspace {
         // Snapshot current published state once so workspace creation doesn't repeatedly
         // bounce through Combine-backed accessors while we're preparing the new workspace.
-        let snapshot = workspaceCreationSnapshot()
+        let currentTabs = tabs
+        let currentSelectedTabId = selectedTabId
+        let selectedWorkspaceForSnapshot = currentSelectedTabId.flatMap { selectedTabId in
+            currentTabs.first(where: { $0.id == selectedTabId })
+        }
+        let tabSnapshots = currentTabs.map { WorkspaceCreationTabSnapshot(workspace: $0) }
+        let pinnedCount = tabSnapshots.reduce(into: 0) { partial, tab in
+            if tab.isPinned {
+                partial += 1
+            }
+        }
+        let selectedIndex = currentSelectedTabId.flatMap { selectedTabId in
+            tabSnapshots.firstIndex(where: { $0.id == selectedTabId })
+        }
+        let preferredWorkingDirectory = preferredWorkingDirectoryForNewTab(
+            workspace: selectedWorkspaceForSnapshot
+        )
+        let selectedTabWasPinned = selectedWorkspaceForSnapshot?.isPinned ?? false
+#if DEBUG
+        let debugSnapshot = WorkspaceCreationSnapshot(
+            totalCount: tabSnapshots.count,
+            pinnedCount: pinnedCount,
+            selectedTabId: currentSelectedTabId,
+            selectedIndex: selectedIndex,
+            selectedTabWasPinned: selectedTabWasPinned,
+            preferredWorkingDirectory: preferredWorkingDirectory,
+            availableTabIds: tabSnapshots.map(\.id)
+        )
+#endif
+        let inheritedConfig = inheritedTerminalConfigForWorkspaceCreationSource(selectedWorkspaceForSnapshot)
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.tab-manager.snapshot",
+            fields: [
+                "tabCount": String(tabSnapshots.count),
+                "selectedTabId": currentSelectedTabId?.uuidString ?? "nil",
+                "selectedTabWasPinned": selectedTabWasPinned ? "1" : "0",
+                "overrideWorkingDirectory": overrideWorkingDirectory ?? "nil",
+            ]
+        )
         didCaptureWorkspaceCreationSnapshot()
 #if DEBUG
-        maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: snapshot)
+        maybeMutateSelectionDuringWorkspaceCreationForDev(snapshot: debugSnapshot)
 #endif
-        let nextTabCount = snapshot.tabs.count + 1
+        let nextTabCount = tabSnapshots.count + 1
         sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-        let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
-        let inheritedConfig = snapshot.inheritedTerminalConfig
-        // Resolve placement against the pre-creation snapshot before Workspace init
-        // boots terminal state. The ssh/new-workspace path can otherwise crash while
-        // reading @Published placement state from existing workspaces mid-creation.
-        let insertIndex = newTabInsertIndex(snapshot: snapshot, placementOverride: placementOverride)
+        let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectory
+        let insertIndex = WorkspacePlacementSettings.insertionIndex(
+            placement: placementOverride ?? WorkspacePlacementSettings.current(),
+            selectedIndex: selectedIndex,
+            selectedIsPinned: selectedTabWasPinned,
+            pinnedCount: pinnedCount,
+            totalCount: tabSnapshots.count
+        )
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.tab-manager.insert-index",
+            fields: [
+                "nextTabCount": String(nextTabCount),
+                "insertIndex": String(insertIndex),
+                "placementOverride": placementOverride?.rawValue ?? "nil",
+                "workingDirectory": workingDirectory ?? "nil",
+            ]
+        )
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
         let newWorkspace = makeWorkspaceForCreation(
@@ -1232,6 +1285,13 @@ class TabManager: ObservableObject {
             configTemplate: inheritedConfig,
             initialTerminalCommand: initialTerminalCommand,
             initialTerminalEnvironment: initialTerminalEnvironment
+        )
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.tab-manager.workspace-created",
+            fields: [
+                "workspaceId": newWorkspace.id.uuidString,
+                "ordinal": String(ordinal),
+            ]
         )
         newWorkspace.owningTabManager = self
         wireClosedBrowserTracking(for: newWorkspace)
@@ -1246,6 +1306,13 @@ class TabManager: ObservableObject {
         } else {
             updatedTabs.append(newWorkspace)
         }
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.tab-manager.tabs-updated",
+            fields: [
+                "workspaceId": newWorkspace.id.uuidString,
+                "updatedTabCount": String(updatedTabs.count),
+            ]
+        )
         tabs = updatedTabs
         if let explicitWorkingDirectory,
            let terminalPanel = newWorkspace.focusedTerminalPanel {
@@ -1264,6 +1331,10 @@ class TabManager: ObservableObject {
 #if DEBUG
             debugPrimeWorkspaceSwitchTrigger("create", to: newWorkspace.id)
 #endif
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.tab-manager.select-new-workspace",
+                fields: ["workspaceId": newWorkspace.id.uuidString]
+            )
             selectedTabId = newWorkspace.id
             NotificationCenter.default.post(
                 name: .ghosttyDidFocusTab,
@@ -1275,7 +1346,7 @@ class TabManager: ObservableObject {
         UITestRecorder.incrementInt("addTabInvocations")
         UITestRecorder.record([
             "tabCount": String(updatedTabs.count),
-            "selectedTabId": select ? newWorkspace.id.uuidString : (snapshot.selectedTabId?.uuidString ?? "")
+            "selectedTabId": select ? newWorkspace.id.uuidString : (currentSelectedTabId?.uuidString ?? "")
         ])
 #endif
         if autoWelcomeIfNeeded && select && !UserDefaults.standard.bool(forKey: WelcomeSettings.shownKey) {
@@ -1285,6 +1356,13 @@ class TabManager: ObservableObject {
                 sendWelcomeWhenReady(to: newWorkspace)
             }
         }
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.tab-manager.completed",
+            fields: [
+                "workspaceId": newWorkspace.id.uuidString,
+                "tabCount": String(tabs.count),
+            ]
+        )
         return newWorkspace
     }
 
@@ -2181,14 +2259,37 @@ class TabManager: ObservableObject {
         let selectedWorkspace = currentSelectedTabId.flatMap { selectedTabId in
             currentTabs.first(where: { $0.id == selectedTabId })
         }
+        let tabSnapshots = currentTabs.map { WorkspaceCreationTabSnapshot(workspace: $0) }
+        let pinnedCount = tabSnapshots.reduce(into: 0) { partial, tab in
+            if tab.isPinned {
+                partial += 1
+            }
+        }
 
+        let selectedIndex = currentSelectedTabId.flatMap { selectedTabId in
+            tabSnapshots.firstIndex(where: { $0.id == selectedTabId })
+        }
+        let preferredWorkingDirectory = preferredWorkingDirectoryForNewTab(workspace: selectedWorkspace)
+#if DEBUG
         return WorkspaceCreationSnapshot(
-            tabs: currentTabs.map { WorkspaceCreationTabSnapshot(workspace: $0) },
+            totalCount: tabSnapshots.count,
+            pinnedCount: pinnedCount,
             selectedTabId: currentSelectedTabId,
+            selectedIndex: selectedIndex,
             selectedTabWasPinned: selectedWorkspace?.isPinned ?? false,
-            preferredWorkingDirectory: preferredWorkingDirectoryForNewTab(workspace: selectedWorkspace),
-            inheritedTerminalConfig: inheritedTerminalConfigForNewWorkspace(workspace: selectedWorkspace)
+            preferredWorkingDirectory: preferredWorkingDirectory,
+            availableTabIds: tabSnapshots.map(\.id)
         )
+#else
+        return WorkspaceCreationSnapshot(
+            totalCount: tabSnapshots.count,
+            pinnedCount: pinnedCount,
+            selectedTabId: currentSelectedTabId,
+            selectedIndex: selectedIndex,
+            selectedTabWasPinned: selectedWorkspace?.isPinned ?? false,
+            preferredWorkingDirectory: preferredWorkingDirectory
+        )
+#endif
     }
 
     private func terminalPanelForWorkspaceConfigInheritanceSource(
@@ -2208,21 +2309,12 @@ class TabManager: ObservableObject {
         return workspace.terminalPanelForConfigInheritance()
     }
 
-    private func inheritedTerminalConfigForNewWorkspace() -> ghostty_surface_config_s? {
-        inheritedTerminalConfigForNewWorkspace(workspace: selectedWorkspace)
-    }
-
-    private func inheritedTerminalConfigForNewWorkspace(
-        workspace: Workspace?
+    func inheritedTerminalConfigForWorkspaceCreationSource(
+        _ workspace: Workspace?
     ) -> ghostty_surface_config_s? {
-        if let panel = terminalPanelForWorkspaceConfigInheritanceSource(workspace: workspace),
-           panel.surface.hasLiveSurface,
-           let sourceSurface = panel.surface.surface {
-            return cmuxInheritedSurfaceConfig(
-                sourceSurface: sourceSurface,
-                context: GHOSTTY_SURFACE_CONTEXT_TAB
-            )
-        }
+        // Workspace creation often runs during titlebar/window transitions, so avoid
+        // reading through live Ghostty surface pointers here. Seed the new workspace
+        // from the last remembered runtime font size instead.
         if let fallbackFontPoints = workspace?.lastRememberedTerminalFontPointsForConfigInheritance() {
             var config = ghostty_surface_config_new()
             config.font_size = fallbackFontPoints
@@ -2247,30 +2339,23 @@ class TabManager: ObservableObject {
         placementOverride: NewWorkspacePlacement? = nil
     ) -> Int {
         let placement = placementOverride ?? WorkspacePlacementSettings.current()
-        let liveTabs = tabs.map { WorkspaceCreationTabSnapshot(workspace: $0) }
-        let pinnedCount = liveTabs.reduce(into: 0) { partial, tab in
-            if tab.isPinned {
-                partial += 1
-            }
-        }
 
         switch placement {
         case .top:
-            return pinnedCount
+            return snapshot.pinnedCount
         case .end:
-            return liveTabs.count
+            return snapshot.totalCount
         case .afterCurrent:
-            if let selectedTabId = snapshot.selectedTabId,
-               let selectedIndex = liveTabs.firstIndex(where: { $0.id == selectedTabId }) {
+            if let selectedIndex = snapshot.selectedIndex {
                 return WorkspacePlacementSettings.insertionIndex(
                     placement: placement,
                     selectedIndex: selectedIndex,
                     selectedIsPinned: snapshot.selectedTabWasPinned,
-                    pinnedCount: pinnedCount,
-                    totalCount: liveTabs.count
+                    pinnedCount: snapshot.pinnedCount,
+                    totalCount: snapshot.totalCount
                 )
             }
-            return snapshot.selectedTabWasPinned ? pinnedCount : liveTabs.count
+            return snapshot.selectedTabWasPinned ? snapshot.pinnedCount : snapshot.totalCount
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -7,6 +7,21 @@ final class NonDraggableHostingView<Content: View>: NSHostingView<Content> {
     override var mouseDownCanMoveWindow: Bool { false }
 }
 
+@MainActor
+private func requestNewWorkspaceFromAppDelegate(windowId: UUID? = nil, debugSource: String) {
+    cmuxWorkspaceCrashBreadcrumb(
+        "workspace.titlebar.request-app-delegate",
+        fields: [
+            "source": debugSource,
+            "windowId": windowId?.uuidString ?? "nil",
+        ]
+    )
+    AppDelegate.shared?.requestWorkspaceCreation(
+        windowId: windowId,
+        debugSource: debugSource
+    )
+}
+
 enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
     case classic
     case compact
@@ -121,6 +136,7 @@ final class TitlebarControlsViewModel: ObservableObject {
 
 extension Notification.Name {
     static let cmuxNotificationsPopoverVisibilityDidChange = Notification.Name("cmux.notificationsPopoverVisibilityDidChange")
+    static let cmuxTitlebarAccessoryLayoutDidChange = Notification.Name("cmux.titlebarAccessoryLayoutDidChange")
 }
 
 private enum NotificationsPopoverVisibilityUserInfoKey {
@@ -132,6 +148,14 @@ private func postNotificationsPopoverVisibilityDidChange(isShown: Bool) {
         name: .cmuxNotificationsPopoverVisibilityDidChange,
         object: nil,
         userInfo: [NotificationsPopoverVisibilityUserInfoKey.isShown: isShown]
+    )
+}
+
+private func postTitlebarAccessoryLayoutDidChange(window: NSWindow?) {
+    guard let window else { return }
+    NotificationCenter.default.post(
+        name: .cmuxTitlebarAccessoryLayoutDidChange,
+        object: window
     )
 }
 
@@ -548,6 +572,7 @@ struct TitlebarControlsView: View {
 }
 
 struct HiddenTitlebarSidebarControlsView: View {
+    let windowId: UUID
     @ObservedObject var notificationStore: TerminalNotificationStore
     @StateObject private var viewModel = TitlebarControlsViewModel()
 
@@ -565,7 +590,16 @@ struct HiddenTitlebarSidebarControlsView: View {
                     anchorView: viewModel.notificationsAnchorView
                 )
             },
-            onNewTab: { _ = AppDelegate.shared?.tabManager?.addTab() },
+            onNewTab: {
+                cmuxWorkspaceCrashBreadcrumb(
+                    "workspace.hidden-titlebar.button",
+                    fields: ["windowId": windowId.uuidString]
+                )
+                requestNewWorkspaceFromAppDelegate(
+                    windowId: windowId,
+                    debugSource: "hiddenTitlebar.newWorkspace"
+                )
+            },
             visibilityMode: .onHover
         )
         .frame(width: hostWidth, height: hostHeight, alignment: .leading)
@@ -780,29 +814,42 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     private var cachedFittingSize: NSSize?
     private var lastObservedViewSize: NSSize = .zero
     private var lastAppliedLayoutSnapshot: TitlebarControlsLayoutSnapshot?
-    private let viewModel = TitlebarControlsViewModel()
+    private let viewModel: TitlebarControlsViewModel
     private var userDefaultsObserver: NSObjectProtocol?
     var popoverIsShownForTesting: Bool { notificationsPopover.isShown }
     private var showsWorkspaceTitlebar: Bool { !WorkspacePresentationModeSettings.isMinimal() }
 
     init(notificationStore: TerminalNotificationStore) {
         self.notificationStore = notificationStore
+        let viewModel = TitlebarControlsViewModel()
+        self.viewModel = viewModel
         let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
-        let newTab = { _ = AppDelegate.shared?.tabManager?.addTab() }
-
-        hostingView = NonDraggableHostingView(
-            rootView: TitlebarControlsView(
+        let fallbackNewTab: () -> Void = {
+            requestNewWorkspaceFromAppDelegate(debugSource: "titlebar.newWorkspace.fallback")
+        }
+        func makeRootView(onNewTab: @escaping () -> Void) -> TitlebarControlsView {
+            TitlebarControlsView(
                 notificationStore: notificationStore,
                 viewModel: viewModel,
                 onToggleSidebar: toggleSidebar,
                 onToggleNotifications: toggleNotifications,
-                onNewTab: newTab,
+                onNewTab: onNewTab,
                 visibilityMode: .alwaysVisible
             )
+        }
+
+        hostingView = NonDraggableHostingView(
+            rootView: makeRootView(onNewTab: fallbackNewTab)
         )
 
         super.init(nibName: nil, bundle: nil)
+
+        let newTab: () -> Void = { [weak self] in
+            guard let self else { return }
+            self.createWorkspaceFromAttachedWindow()
+        }
+        hostingView.rootView = makeRootView(onNewTab: newTab)
 
         view = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = true
@@ -826,6 +873,32 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 
         applyWorkspaceTitlebarVisibility()
         scheduleSizeUpdate(invalidateFittingSize: true)
+    }
+
+    @MainActor
+    private func createWorkspaceFromAttachedWindow() {
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.attached-titlebar.button",
+            fields: [
+                "windowNumber": view.window.map { String($0.windowNumber) } ?? "nil",
+            ]
+        )
+        guard let appDelegate = AppDelegate.shared else { return }
+        if let window = view.window,
+           appDelegate.addWorkspace(in: window, debugSource: "titlebar.newWorkspace") != nil {
+            cmuxWorkspaceCrashBreadcrumb(
+                "workspace.attached-titlebar.button.resolved-window",
+                fields: ["windowNumber": String(window.windowNumber)]
+            )
+            return
+        }
+        cmuxWorkspaceCrashBreadcrumb(
+            "workspace.attached-titlebar.button.fallback",
+            fields: [
+                "windowNumber": view.window.map { String($0.windowNumber) } ?? "nil",
+            ]
+        )
+        requestNewWorkspaceFromAppDelegate(debugSource: "titlebar.newWorkspace.fallback")
     }
 
     required init?(coder: NSCoder) {
@@ -914,6 +987,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         preferredContentSize = NSSize(width: contentSize.width, height: containerHeight)
         containerView.frame = NSRect(x: 0, y: 0, width: contentSize.width, height: containerHeight)
         hostingView.frame = NSRect(x: 0, y: yOffset, width: contentSize.width, height: contentSize.height)
+        postTitlebarAccessoryLayoutDidChange(window: view.window)
     }
 
     private func applyWorkspaceTitlebarVisibility() {
@@ -924,6 +998,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             containerView.frame = .zero
             hostingView.frame = .zero
         }
+        postTitlebarAccessoryLayoutDidChange(window: view.window)
     }
 
     func toggleNotificationsPopover(animated: Bool = true, externalAnchor: NSView? = nil) {
@@ -1222,7 +1297,10 @@ final class UpdateTitlebarAccessoryController {
     }
 
     func attach(to window: NSWindow) {
-        attachIfNeeded(to: window)
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self, let window else { return }
+            self.attachIfNeeded(to: window)
+        }
     }
 
     private func installObservers() {
@@ -1359,6 +1437,7 @@ final class UpdateTitlebarAccessoryController {
             window.contentView?.layoutSubtreeIfNeeded()
             window.contentView?.superview?.layoutSubtreeIfNeeded()
             window.invalidateShadow()
+            postTitlebarAccessoryLayoutDidChange(window: window)
         }
 
 #if DEBUG

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -135,6 +135,76 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Workspace creation should target key/main window context")
     }
 
+    func testAddWorkspaceInSpecificWindowIgnoresStaleTabManagerPointer() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId) else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+
+        let firstCount = firstManager.tabs.count
+        let secondCount = secondManager.tabs.count
+
+        secondWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        _ = appDelegate.addWorkspace(in: secondWindow, debugSource: "titlebar.newWorkspace.test")
+
+        XCTAssertEqual(firstManager.tabs.count, firstCount, "Titlebar workspace creation must not route to a stale active manager")
+        XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Titlebar workspace creation should target the accessory window context")
+        XCTAssertTrue(appDelegate.tabManager === secondManager, "Expected exact-window routing to activate the clicked window's manager")
+    }
+
+    func testAddWorkspaceByWindowIdIgnoresStaleTabManagerPointer() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId) else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+
+        let firstCount = firstManager.tabs.count
+        let secondCount = secondManager.tabs.count
+
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        _ = appDelegate.addWorkspace(windowId: secondWindowId, debugSource: "titlebar.newWorkspace.windowId.test")
+
+        XCTAssertEqual(firstManager.tabs.count, firstCount, "Window-id workspace creation must not route to a stale active manager")
+        XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Window-id workspace creation should target the requested window context")
+        XCTAssertTrue(appDelegate.tabManager === secondManager, "Expected window-id routing to activate the requested window's manager")
+    }
+
     func testCmdNResolvesEventWindowWhenObjectKeyLookupIsMismatched() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
@@ -983,6 +1053,27 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(
             defaults.string(forKey: WorkspaceButtonFadeSettings.modeKey),
             WorkspaceButtonFadeSettings.Mode.disabled.rawValue
+        )
+    }
+
+    func testResolvedTitlebarLeadingInsetUsesAccessoryPreferredWidthWhenFrameIsZero() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1200, height: 800),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let accessory = NSTitlebarAccessoryViewController()
+        accessory.layoutAttribute = .left
+        accessory.preferredContentSize = NSSize(width: 124, height: 28)
+        accessory.view = NSView(frame: .zero)
+
+        window.addTitlebarAccessoryViewController(accessory)
+
+        XCTAssertEqual(
+            resolvedTitlebarLeadingInset(for: window),
+            202,
+            accuracy: 0.5
         )
     }
 

--- a/cmuxTests/TerminalSelectionOpenResolverTests.swift
+++ b/cmuxTests/TerminalSelectionOpenResolverTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class TerminalSelectionOpenResolverTests: XCTestCase {
+    func testResolveRelativePathAgainstBaseDirectory() throws {
+        let directory = try makeTemporaryDirectory()
+        let fileURL = directory.appendingPathComponent("docs/plan.md")
+        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+
+        let target = TerminalSelectionOpenResolver.resolve(
+            "docs/plan.md",
+            baseDirectory: directory.path
+        )
+
+        XCTAssertEqual(target, .some(.external(fileURL.standardizedFileURL)))
+    }
+
+    func testResolveRelativePathWithLineSuffix() throws {
+        let directory = try makeTemporaryDirectory()
+        let fileURL = directory.appendingPathComponent("notes/todo.md")
+        try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+
+        let target = TerminalSelectionOpenResolver.resolve(
+            "notes/todo.md:12:4",
+            baseDirectory: directory.path
+        )
+
+        XCTAssertEqual(target, .some(.external(fileURL.standardizedFileURL)))
+    }
+
+    func testResolveExistingRelativeFileBeforeBareHostFallback() throws {
+        let directory = try makeTemporaryDirectory()
+        let fileURL = directory.appendingPathComponent("README.md")
+        XCTAssertTrue(FileManager.default.createFile(atPath: fileURL.path, contents: Data()))
+
+        let target = TerminalSelectionOpenResolver.resolve(
+            "README.md",
+            baseDirectory: directory.path
+        )
+
+        XCTAssertEqual(target, .some(.external(fileURL.standardizedFileURL)))
+    }
+
+    func testResolveHTTPSURLAsEmbeddedBrowser() {
+        let target = TerminalSelectionOpenResolver.resolve(
+            "https://example.com/docs",
+            baseDirectory: nil
+        )
+
+        XCTAssertEqual(target, .some(.embeddedBrowser(URL(string: "https://example.com/docs")!)))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -133,6 +133,48 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         XCTAssertTrue(app.tabManager === manager)
     }
 
+    func testRegisterMainWindowReplacesContextManagerWhenWindowIdIsReused() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+
+        let windowId = UUID()
+        let firstWindow = makeMainWindow(id: windowId)
+        let secondWindow = makeMainWindow(id: windowId)
+        defer {
+            firstWindow.orderOut(nil)
+            secondWindow.orderOut(nil)
+        }
+
+        let firstManager = TabManager()
+        let secondManager = TabManager()
+
+        app.registerMainWindow(
+            firstWindow,
+            windowId: windowId,
+            tabManager: firstManager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+        XCTAssertTrue(app.tabManagerFor(windowId: windowId) === firstManager)
+
+        app.registerMainWindow(
+            secondWindow,
+            windowId: windowId,
+            tabManager: secondManager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+
+        XCTAssertTrue(app.tabManagerFor(windowId: windowId) === secondManager)
+
+        let firstCount = firstManager.tabs.count
+        let secondCount = secondManager.tabs.count
+        _ = app.addWorkspace(in: secondWindow, debugSource: "windowContext.reuse.test")
+
+        XCTAssertEqual(firstManager.tabs.count, firstCount, "Reused window context must not keep routing to the old manager")
+        XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Reused window context should route to the latest manager")
+    }
+
     func testAddWorkspaceWithoutBringToFrontPreservesActiveWindowAndSelection() {
         _ = NSApplication.shared
         let app = AppDelegate()

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -297,9 +297,20 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
     private final class SnapshotMutatingTabManager: TabManager {
         var afterCaptureWorkspaceCreationSnapshot: (() -> Void)?
         var beforeCreateWorkspace: (() -> Void)?
+        var inheritedConfigTemplate: ghostty_surface_config_s?
+        var lastCapturedConfigTemplateFontSize: Float?
 
         override func didCaptureWorkspaceCreationSnapshot() {
             afterCaptureWorkspaceCreationSnapshot?()
+        }
+
+        override func inheritedTerminalConfigForWorkspaceCreationSource(
+            _ workspace: Workspace?
+        ) -> ghostty_surface_config_s? {
+            if let inheritedConfigTemplate {
+                return inheritedConfigTemplate
+            }
+            return super.inheritedTerminalConfigForWorkspaceCreationSource(workspace)
         }
 
         override func makeWorkspaceForCreation(
@@ -311,6 +322,7 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
             initialTerminalEnvironment: [String: String]
         ) -> Workspace {
             beforeCreateWorkspace?()
+            lastCapturedConfigTemplateFontSize = configTemplate?.font_size
             return super.makeWorkspaceForCreation(
                 title: title,
                 workingDirectory: workingDirectory,
@@ -446,6 +458,40 @@ final class WorkspaceCreationPlacementTests: XCTestCase {
         XCTAssertEqual(manager.tabs.map(\.id), [first.id, second.id, inserted.id])
         XCTAssertFalse(manager.tabs.contains(where: { $0.id == third.id }))
         XCTAssertEqual(manager.selectedTabId, inserted.id)
+    }
+
+    func testAddWorkspaceAfterCurrentKeepsPinnedPlacementFromSnapshotWhenPinnedStateMutatesAfterSnapshot() {
+        let manager = SnapshotMutatingTabManager()
+        guard let first = manager.tabs.first else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+        manager.setPinned(first, pinned: true)
+        manager.setPinned(second, pinned: true)
+        manager.selectWorkspace(first)
+
+        manager.afterCaptureWorkspaceCreationSnapshot = {
+            manager.setPinned(second, pinned: false)
+        }
+
+        let inserted = manager.addWorkspace(placementOverride: .afterCurrent)
+
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, second.id, inserted.id, third.id])
+        XCTAssertEqual(manager.selectedTabId, inserted.id)
+    }
+
+    func testAddWorkspacePassesInheritedConfigCapturedOutsideSnapshotStorage() {
+        let manager = SnapshotMutatingTabManager()
+        var inheritedConfig = ghostty_surface_config_new()
+        inheritedConfig.font_size = 19
+        manager.inheritedConfigTemplate = inheritedConfig
+
+        _ = manager.addWorkspace()
+
+        XCTAssertEqual(manager.lastCapturedConfigTemplateFontSize, 19)
     }
 
     private func makeManagerWithThreeWorkspaces() -> TabManager {

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -51,6 +51,27 @@ final class MenuKeyEquivalentRoutingUITests: XCTestCase {
         )
     }
 
+    func testTitlebarNewWorkspaceButtonCreatesWorkspaceWithoutCrash() {
+        let app = launchWithBrowserSetup()
+
+        let newWorkspaceButton = app.buttons["titlebarControl.newTab"]
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) {
+                newWorkspaceButton.exists && newWorkspaceButton.isHittable
+            },
+            "Expected the titlebar new-workspace button to be visible and clickable"
+        )
+
+        let baseline = loadKeyequiv()["addTabInvocations"].flatMap(Int.init) ?? 0
+        newWorkspaceButton.click()
+
+        XCTAssertTrue(
+            waitForKeyequivInt(key: "addTabInvocations", toBeAtLeast: baseline + 1, timeout: 5.0),
+            "Expected clicking the titlebar new-workspace button to create a workspace without crashing the app"
+        )
+        XCTAssertEqual(app.state, .runningForeground, "Expected app to remain running after clicking the titlebar new-workspace button")
+    }
+
     func testCmdWWorksWhenWebViewFocusedAfterTabSwitch() {
         let app = launchWithBrowserSetup()
 

--- a/scripts/capture-latest-cmux-crash.sh
+++ b/scripts/capture-latest-cmux-crash.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACTS_DIR="${1:-/tmp/cmux-crash-capture-$(date +%Y%m%d-%H%M%S)}"
+REPORTS_DIR="$HOME/Library/Logs/DiagnosticReports"
+CRASH_BREADCRUMBS="/tmp/cmux-workspace-crash-breadcrumbs.log"
+
+mkdir -p "$ARTIFACTS_DIR"
+
+LATEST_REPORT="$(ls -1t "$REPORTS_DIR"/cmux* 2>/dev/null | head -n 1 || true)"
+if [[ -z "$LATEST_REPORT" ]]; then
+  echo "error: no cmux crash report found in $REPORTS_DIR" >&2
+  exit 1
+fi
+
+cp "$LATEST_REPORT" "$ARTIFACTS_DIR/"
+
+if [[ -f "$CRASH_BREADCRUMBS" ]]; then
+  cp "$CRASH_BREADCRUMBS" "$ARTIFACTS_DIR/"
+fi
+
+{
+  echo "artifact_dir=$ARTIFACTS_DIR"
+  echo "latest_report=$LATEST_REPORT"
+  echo "breadcrumbs=$CRASH_BREADCRUMBS"
+} > "$ARTIFACTS_DIR/summary.txt"
+
+echo
+echo "Captured crash artifacts:"
+echo "  $ARTIFACTS_DIR"

--- a/scripts/mac-smoke.sh
+++ b/scripts/mac-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP_KIND="debug"
+SCENARIO="titlebar-new-workspace"
+TAG="local-smoke"
+ARTIFACTS_DIR=""
+REINSTALL_RELEASE=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/mac-smoke.sh [options]
+
+Options:
+  --app debug|release      App variant to smoke (default: debug)
+  --scenario <name>        Smoke scenario (default: titlebar-new-workspace)
+  --tag <name>             Tagged debug build name (default: local-smoke)
+  --artifacts-dir <path>   Directory for screenshots/report output
+  --reinstall-release      Rebuild and reinstall /Applications/cmux.app before smoke
+  -h, --help               Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      APP_KIND="${2:-}"
+      shift 2
+      ;;
+    --scenario)
+      SCENARIO="${2:-}"
+      shift 2
+      ;;
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --artifacts-dir)
+      ARTIFACTS_DIR="${2:-}"
+      shift 2
+      ;;
+    --reinstall-release)
+      REINSTALL_RELEASE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$APP_KIND" != "debug" && "$APP_KIND" != "release" ]]; then
+  echo "error: --app must be debug or release" >&2
+  exit 1
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+if [[ -z "$ARTIFACTS_DIR" ]]; then
+  ARTIFACTS_DIR="/tmp/cmux-smoke/${APP_KIND}-${SCENARIO}-${timestamp}"
+fi
+mkdir -p "$ARTIFACTS_DIR"
+
+APP_PATH=""
+
+if [[ "$APP_KIND" == "debug" ]]; then
+  echo "== build tagged debug =="
+  BUILD_OUTPUT="$(./scripts/reload.sh --tag "$TAG")"
+  printf '%s\n' "$BUILD_OUTPUT"
+  APP_PATH="$(printf '%s\n' "$BUILD_OUTPUT" | sed -n '/^App path:/{n;s/^[[:space:]]*//;p;q;}')"
+  if [[ -z "$APP_PATH" || ! -d "$APP_PATH" ]]; then
+    echo "error: failed to determine debug app path from reload.sh output" >&2
+    exit 1
+  fi
+else
+  if [[ "$REINSTALL_RELEASE" -eq 1 ]]; then
+    echo "== rebuild/install release =="
+    ./scripts/reloadp.sh --install --no-launch
+  fi
+  APP_PATH="/Applications/cmux.app"
+  if [[ ! -d "$APP_PATH" ]]; then
+    echo "error: release app not found at $APP_PATH" >&2
+    exit 1
+  fi
+  if [[ "$(/usr/libexec/PlistBuddy -c 'Print :CMUXSourceBuildInstall' "$APP_PATH/Contents/Info.plist" 2>/dev/null || true)" != "1" ]]; then
+    echo "error: $APP_PATH is not marked as a source-built install; rerun with --reinstall-release" >&2
+    exit 1
+  fi
+fi
+
+printf '%s\n' "app_path=$APP_PATH" > "$ARTIFACTS_DIR/command.txt"
+printf '%s\n' "scenario=$SCENARIO" >> "$ARTIFACTS_DIR/command.txt"
+printf '%s\n' "app_kind=$APP_KIND" >> "$ARTIFACTS_DIR/command.txt"
+
+swift ./scripts/mac-smoke.swift \
+  --app-path "$APP_PATH" \
+  --scenario "$SCENARIO" \
+  --artifacts-dir "$ARTIFACTS_DIR" \
+  --launch
+
+echo
+echo "Artifacts:"
+echo "  $ARTIFACTS_DIR"

--- a/scripts/mac-smoke.swift
+++ b/scripts/mac-smoke.swift
@@ -1,0 +1,586 @@
+#!/usr/bin/env swift
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+struct Config {
+    let appPath: String
+    let scenario: String
+    let artifactsDir: String
+    let launch: Bool
+}
+
+enum SmokeError: LocalizedError {
+    case invalidArguments(String)
+    case unsupportedScenario(String)
+    case missingBundleIdentifier(String)
+    case accessibilityNotTrusted
+    case launchFailed(String)
+    case appNotRunning(String)
+    case windowUnavailable
+    case elementNotFound(String)
+    case pressFailed(String)
+    case workspaceCountDidNotIncrease(Int, Int)
+    case crashDetected(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidArguments(message):
+            return message
+        case let .unsupportedScenario(name):
+            return "Unsupported scenario: \(name)"
+        case let .missingBundleIdentifier(path):
+            return "Could not read CFBundleIdentifier from \(path)"
+        case .accessibilityNotTrusted:
+            return "Accessibility access is required. Grant it to the process running this script, then retry."
+        case let .launchFailed(message):
+            return "Failed to launch app: \(message)"
+        case let .appNotRunning(bundleId):
+            return "App is not running for bundle id \(bundleId)"
+        case .windowUnavailable:
+            return "Timed out waiting for the app window to appear"
+        case let .elementNotFound(identifier):
+            return "Could not find accessibility element \(identifier)"
+        case let .pressFailed(identifier):
+            return "Failed to press accessibility element \(identifier)"
+        case let .workspaceCountDidNotIncrease(before, after):
+            return "Workspace row count did not increase after clicking new workspace (\(before) -> \(after))"
+        case let .crashDetected(path):
+            return "Detected new crash report: \(path)"
+        }
+    }
+}
+
+struct PressAttemptDetails {
+    let actionResult: AXError
+    let fallbackAttempted: Bool
+    let fallbackSucceeded: Bool
+}
+
+let exactButtonIdentifiers: [String: String] = [
+    "toggleSidebar": "titlebarControl.toggleSidebar",
+    "newWorkspace": "titlebarControl.newTab",
+]
+let sidebarWorkspaceRowPrefix = "SidebarWorkspaceRow."
+
+func parseArgs() throws -> Config {
+    var appPath: String?
+    var scenario: String?
+    var artifactsDir: String?
+    var launch = false
+
+    var index = 1
+    while index < CommandLine.arguments.count {
+        let argument = CommandLine.arguments[index]
+        switch argument {
+        case "--app-path":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw SmokeError.invalidArguments("--app-path requires a value")
+            }
+            appPath = CommandLine.arguments[index]
+        case "--scenario":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw SmokeError.invalidArguments("--scenario requires a value")
+            }
+            scenario = CommandLine.arguments[index]
+        case "--artifacts-dir":
+            index += 1
+            guard index < CommandLine.arguments.count else {
+                throw SmokeError.invalidArguments("--artifacts-dir requires a value")
+            }
+            artifactsDir = CommandLine.arguments[index]
+        case "--launch":
+            launch = true
+        case "-h", "--help":
+            printUsage()
+            exit(0)
+        default:
+            throw SmokeError.invalidArguments("Unknown argument: \(argument)")
+        }
+        index += 1
+    }
+
+    guard let appPath, !appPath.isEmpty else {
+        throw SmokeError.invalidArguments("--app-path is required")
+    }
+    guard let scenario, !scenario.isEmpty else {
+        throw SmokeError.invalidArguments("--scenario is required")
+    }
+    guard let artifactsDir, !artifactsDir.isEmpty else {
+        throw SmokeError.invalidArguments("--artifacts-dir is required")
+    }
+
+    return Config(
+        appPath: appPath,
+        scenario: scenario,
+        artifactsDir: artifactsDir,
+        launch: launch
+    )
+}
+
+func printUsage() {
+    let usage = """
+    Usage: mac-smoke.swift --app-path <path> --scenario <name> --artifacts-dir <path> [--launch]
+
+    Scenarios:
+      titlebar-new-workspace
+    """
+    print(usage)
+}
+
+func plistValue(_ key: String, in appPath: String) -> Any? {
+    let infoURL = URL(fileURLWithPath: appPath).appendingPathComponent("Contents/Info.plist")
+    guard let data = try? Data(contentsOf: infoURL),
+          let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+        return nil
+    }
+    return plist[key]
+}
+
+func bundleIdentifier(for appPath: String) throws -> String {
+    guard let bundleId = plistValue("CFBundleIdentifier", in: appPath) as? String, !bundleId.isEmpty else {
+        throw SmokeError.missingBundleIdentifier(appPath)
+    }
+    return bundleId
+}
+
+func crashReportURLs() -> [URL] {
+    let reportsDirectory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Logs/DiagnosticReports")
+    guard let urls = try? FileManager.default.contentsOfDirectory(
+        at: reportsDirectory,
+        includingPropertiesForKeys: [.contentModificationDateKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return []
+    }
+
+    return urls
+        .filter { url in
+            let name = url.lastPathComponent
+            return name.hasPrefix("cmux-") && (name.hasSuffix(".ips") || name.hasSuffix(".crash"))
+        }
+        .sorted { lhs, rhs in
+            let leftDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            let rightDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+            return leftDate > rightDate
+        }
+}
+
+func waitFor(
+    timeout: TimeInterval,
+    pollInterval: TimeInterval = 0.2,
+    condition: () -> Bool
+) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() {
+            return true
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+    }
+    return condition()
+}
+
+func runProcess(_ launchPath: String, _ arguments: [String]) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: launchPath)
+    process.arguments = arguments
+    try process.run()
+    process.waitUntilExit()
+}
+
+@discardableResult
+func captureScreenshot(name: String, artifactsURL: URL) -> URL? {
+    let targetURL = artifactsURL.appendingPathComponent(name)
+    do {
+        try runProcess("/usr/sbin/screencapture", ["-x", targetURL.path])
+        return targetURL
+    } catch {
+        return nil
+    }
+}
+
+func launchApplication(at appURL: URL) throws -> NSRunningApplication {
+    let configuration = NSWorkspace.OpenConfiguration()
+    configuration.activates = true
+    configuration.createsNewApplicationInstance = false
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var launchedApplication: NSRunningApplication?
+    var launchError: Error?
+
+    NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { app, error in
+        launchedApplication = app
+        launchError = error
+        semaphore.signal()
+    }
+
+    if semaphore.wait(timeout: .now() + 20) == .timedOut {
+        throw SmokeError.launchFailed("Timed out waiting for LaunchServices")
+    }
+    if let launchError {
+        throw SmokeError.launchFailed(launchError.localizedDescription)
+    }
+    guard let launchedApplication else {
+        throw SmokeError.launchFailed("LaunchServices returned no running app")
+    }
+    return launchedApplication
+}
+
+func runningApplication(bundleIdentifier: String) -> NSRunningApplication? {
+    NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+        .first(where: { !$0.isTerminated })
+}
+
+func axValue(_ element: AXUIElement, attribute: CFString) -> CFTypeRef? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, attribute, &value)
+    guard result == .success else { return nil }
+    return value
+}
+
+func axElements(_ element: AXUIElement, attribute: CFString) -> [AXUIElement] {
+    guard let value = axValue(element, attribute: attribute) else { return [] }
+    if CFGetTypeID(value) == AXUIElementGetTypeID() {
+        return [unsafeBitCast(value, to: AXUIElement.self)]
+    }
+    if let array = value as? [AXUIElement] {
+        return array
+    }
+    return []
+}
+
+func axString(_ element: AXUIElement, attribute: CFString) -> String? {
+    axValue(element, attribute: attribute) as? String
+}
+
+func axStrings(_ element: AXUIElement, attribute: CFString) -> [String] {
+    guard let value = axValue(element, attribute: attribute) else { return [] }
+    return value as? [String] ?? []
+}
+
+func axCGPoint(_ element: AXUIElement, attribute: CFString) -> CGPoint? {
+    guard let value = axValue(element, attribute: attribute) else { return nil }
+    guard CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+    let axValueRef = unsafeBitCast(value, to: AXValue.self)
+    guard AXValueGetType(axValueRef) == .cgPoint else { return nil }
+    var point = CGPoint.zero
+    guard AXValueGetValue(axValueRef, .cgPoint, &point) else { return nil }
+    return point
+}
+
+func axCGSize(_ element: AXUIElement, attribute: CFString) -> CGSize? {
+    guard let value = axValue(element, attribute: attribute) else { return nil }
+    guard CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+    let axValueRef = unsafeBitCast(value, to: AXValue.self)
+    guard AXValueGetType(axValueRef) == .cgSize else { return nil }
+    var size = CGSize.zero
+    guard AXValueGetValue(axValueRef, .cgSize, &size) else { return nil }
+    return size
+}
+
+func axCGRect(_ element: AXUIElement, attribute: CFString) -> CGRect? {
+    guard let value = axValue(element, attribute: attribute) else { return nil }
+    guard CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+    let axValueRef = unsafeBitCast(value, to: AXValue.self)
+    guard AXValueGetType(axValueRef) == .cgRect else { return nil }
+    var rect = CGRect.zero
+    guard AXValueGetValue(axValueRef, .cgRect, &rect) else { return nil }
+    return rect
+}
+
+func axIdentifier(_ element: AXUIElement) -> String? {
+    axString(element, attribute: kAXIdentifierAttribute as CFString)
+}
+
+func axRole(_ element: AXUIElement) -> String? {
+    axString(element, attribute: kAXRoleAttribute as CFString)
+}
+
+func axActionNames(_ element: AXUIElement) -> [String] {
+    var actionNames: CFArray?
+    let result = AXUIElementCopyActionNames(element, &actionNames)
+    guard result == .success, let actionNames else { return [] }
+    return actionNames as? [String] ?? []
+}
+
+func isPressableElement(_ element: AXUIElement) -> Bool {
+    if axRole(element) == kAXButtonRole as String {
+        return true
+    }
+    return axActionNames(element).contains(kAXPressAction as String)
+}
+
+func axPointerKey(_ element: AXUIElement) -> UnsafeMutableRawPointer {
+    Unmanaged.passUnretained(element).toOpaque()
+}
+
+func descendantElements(
+    of root: AXUIElement,
+    maxDepth: Int = 16
+) -> [AXUIElement] {
+    var results: [AXUIElement] = []
+    var visited = Set<UnsafeMutableRawPointer>()
+
+    func traverse(_ element: AXUIElement, depth: Int) {
+        let key = axPointerKey(element)
+        guard visited.insert(key).inserted else { return }
+        results.append(element)
+        guard depth < maxDepth else { return }
+
+        let childAttributes: [CFString] = [
+            kAXChildrenAttribute as CFString,
+            kAXVisibleChildrenAttribute as CFString,
+            kAXRowsAttribute as CFString,
+            kAXContentsAttribute as CFString,
+        ]
+        for attribute in childAttributes {
+            for child in axElements(element, attribute: attribute) {
+                traverse(child, depth: depth + 1)
+            }
+        }
+    }
+
+    traverse(root, depth: 0)
+    return results
+}
+
+func firstElement(
+    in root: AXUIElement,
+    matching predicate: (AXUIElement) -> Bool
+) -> AXUIElement? {
+    descendantElements(of: root).first(where: predicate)
+}
+
+func matchingElements(
+    in root: AXUIElement,
+    matching predicate: (AXUIElement) -> Bool
+) -> [AXUIElement] {
+    descendantElements(of: root).filter(predicate)
+}
+
+func waitForWindow(appElement: AXUIElement, timeout: TimeInterval) -> Bool {
+    waitFor(timeout: timeout) {
+        !axElements(appElement, attribute: kAXWindowsAttribute as CFString).isEmpty
+    }
+}
+
+func findElement(byIdentifier identifier: String, in appElement: AXUIElement) -> AXUIElement? {
+    let matches = matchingElements(in: appElement) { element in
+        axIdentifier(element) == identifier
+    }
+    return matches.first(where: isPressableElement) ?? matches.first
+}
+
+func countSidebarWorkspaceRows(in appElement: AXUIElement) -> Int {
+    matchingElements(in: appElement) { element in
+        guard let identifier = axIdentifier(element) else { return false }
+        return identifier.hasPrefix(sidebarWorkspaceRowPrefix)
+    }.count
+}
+
+func clickElementCenter(_ element: AXUIElement) -> Bool {
+    let center: CGPoint
+    if let frame = axCGRect(element, attribute: "AXFrame" as CFString) {
+        center = CGPoint(x: frame.midX, y: frame.midY)
+    } else if let position = axCGPoint(element, attribute: kAXPositionAttribute as CFString),
+              let size = axCGSize(element, attribute: kAXSizeAttribute as CFString) {
+        center = CGPoint(x: position.x + (size.width / 2), y: position.y + (size.height / 2))
+    } else {
+        return false
+    }
+    guard let source = CGEventSource(stateID: .hidSystemState),
+          let move = CGEvent(mouseEventSource: source, mouseType: .mouseMoved, mouseCursorPosition: center, mouseButton: .left),
+          let down = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: center, mouseButton: .left),
+          let up = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: center, mouseButton: .left) else {
+        return false
+    }
+
+    move.post(tap: .cghidEventTap)
+    down.post(tap: .cghidEventTap)
+    up.post(tap: .cghidEventTap)
+    return true
+}
+
+func press(_ element: AXUIElement) -> PressAttemptDetails {
+    let actionResult = AXUIElementPerformAction(element, kAXPressAction as CFString)
+    if actionResult == .success {
+        return PressAttemptDetails(
+            actionResult: actionResult,
+            fallbackAttempted: false,
+            fallbackSucceeded: false
+        )
+    }
+
+    let fallbackSucceeded = clickElementCenter(element)
+    return PressAttemptDetails(
+        actionResult: actionResult,
+        fallbackAttempted: true,
+        fallbackSucceeded: fallbackSucceeded
+    )
+}
+
+func copyCrashReport(_ reportURL: URL, to artifactsURL: URL) throws -> URL {
+    let destinationURL = artifactsURL.appendingPathComponent(reportURL.lastPathComponent)
+    if FileManager.default.fileExists(atPath: destinationURL.path) {
+        try FileManager.default.removeItem(at: destinationURL)
+    }
+    try FileManager.default.copyItem(at: reportURL, to: destinationURL)
+    return destinationURL
+}
+
+func writeJSON(_ object: [String: Any], to url: URL) {
+    guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]) else {
+        return
+    }
+    try? data.write(to: url, options: .atomic)
+}
+
+let config: Config
+do {
+    config = try parseArgs()
+} catch {
+    fputs("\(error.localizedDescription)\n", stderr)
+    printUsage()
+    exit(2)
+}
+
+let artifactsURL = URL(fileURLWithPath: config.artifactsDir, isDirectory: true)
+try? FileManager.default.createDirectory(at: artifactsURL, withIntermediateDirectories: true)
+
+var summary: [String: Any] = [
+    "appPath": config.appPath,
+    "scenario": config.scenario,
+    "artifactsDir": config.artifactsDir,
+    "launch": config.launch,
+]
+
+let summaryURL = artifactsURL.appendingPathComponent("summary.json")
+let baselineCrashReports = crashReportURLs()
+let baselineCrashNames = Set(baselineCrashReports.map(\.lastPathComponent))
+
+do {
+    guard config.scenario == "titlebar-new-workspace" else {
+        throw SmokeError.unsupportedScenario(config.scenario)
+    }
+
+    let bundleId = try bundleIdentifier(for: config.appPath)
+    summary["bundleId"] = bundleId
+
+    guard AXIsProcessTrusted() else {
+        throw SmokeError.accessibilityNotTrusted
+    }
+
+    let runningApp: NSRunningApplication
+    if config.launch {
+        runningApp = try launchApplication(at: URL(fileURLWithPath: config.appPath))
+    } else if let existing = runningApplication(bundleIdentifier: bundleId) {
+        runningApp = existing
+    } else {
+        throw SmokeError.appNotRunning(bundleId)
+    }
+
+    summary["pid"] = runningApp.processIdentifier
+    _ = runningApp.activate(options: [.activateAllWindows])
+
+    let appElement = AXUIElementCreateApplication(runningApp.processIdentifier)
+    guard waitForWindow(appElement: appElement, timeout: 15) else {
+        throw SmokeError.windowUnavailable
+    }
+
+    var baselineRowCount = countSidebarWorkspaceRows(in: appElement)
+    if baselineRowCount == 0,
+       let toggleButton = findElement(byIdentifier: exactButtonIdentifiers["toggleSidebar"]!, in: appElement) {
+        let togglePress = press(toggleButton)
+        if togglePress.actionResult == .success || togglePress.fallbackSucceeded {
+        _ = waitFor(timeout: 3) {
+            countSidebarWorkspaceRows(in: appElement) > 0
+        }
+        baselineRowCount = countSidebarWorkspaceRows(in: appElement)
+        summary["sidebarToggledForVisibility"] = true
+        } else {
+            summary["sidebarToggledForVisibility"] = false
+        }
+    } else {
+        summary["sidebarToggledForVisibility"] = false
+    }
+    summary["workspaceRowsBefore"] = baselineRowCount
+
+    let beforeScreenshot = captureScreenshot(name: "before.png", artifactsURL: artifactsURL)
+    summary["beforeScreenshot"] = beforeScreenshot?.path ?? ""
+
+    guard let newWorkspaceButton = findElement(byIdentifier: exactButtonIdentifiers["newWorkspace"]!, in: appElement) else {
+        throw SmokeError.elementNotFound(exactButtonIdentifiers["newWorkspace"]!)
+    }
+    summary["newWorkspaceRole"] = axRole(newWorkspaceButton) ?? ""
+    summary["newWorkspaceActions"] = axActionNames(newWorkspaceButton)
+    summary["newWorkspacePosition"] = axCGPoint(newWorkspaceButton, attribute: kAXPositionAttribute as CFString).map(NSStringFromPoint) ?? ""
+    summary["newWorkspaceSize"] = axCGSize(newWorkspaceButton, attribute: kAXSizeAttribute as CFString).map(NSStringFromSize) ?? ""
+    summary["newWorkspaceFrame"] = axCGRect(newWorkspaceButton, attribute: "AXFrame" as CFString).map(NSStringFromRect) ?? ""
+
+    let pressDetails = press(newWorkspaceButton)
+    summary["newWorkspacePressAXError"] = pressDetails.actionResult.rawValue
+    summary["newWorkspacePressFallbackAttempted"] = pressDetails.fallbackAttempted
+    summary["newWorkspacePressFallbackSucceeded"] = pressDetails.fallbackSucceeded
+    guard pressDetails.actionResult == .success || pressDetails.fallbackSucceeded else {
+        throw SmokeError.pressFailed(exactButtonIdentifiers["newWorkspace"]!)
+    }
+
+    let workspaceIncreaseObserved: Bool
+    if baselineRowCount > 0 {
+        workspaceIncreaseObserved = waitFor(timeout: 5) {
+            countSidebarWorkspaceRows(in: appElement) > baselineRowCount
+        }
+        let afterCount = countSidebarWorkspaceRows(in: appElement)
+        summary["workspaceRowsAfter"] = afterCount
+        summary["workspaceIncreaseObserved"] = workspaceIncreaseObserved
+        if !workspaceIncreaseObserved {
+            throw SmokeError.workspaceCountDidNotIncrease(baselineRowCount, afterCount)
+        }
+    } else {
+        workspaceIncreaseObserved = false
+        summary["workspaceRowsAfter"] = 0
+        summary["workspaceIncreaseObserved"] = false
+        summary["workspaceIncreaseAssertion"] = "unavailable"
+        _ = waitFor(timeout: 2) {
+            !runningApp.isTerminated
+        }
+    }
+
+    if runningApp.isTerminated {
+        let newCrashReport = crashReportURLs().first { !baselineCrashNames.contains($0.lastPathComponent) }
+        if let newCrashReport {
+            let copiedReport = try copyCrashReport(newCrashReport, to: artifactsURL)
+            summary["crashReport"] = copiedReport.path
+            throw SmokeError.crashDetected(copiedReport.path)
+        }
+        throw SmokeError.launchFailed("App terminated during smoke scenario")
+    }
+
+    let newCrashReport = crashReportURLs().first { !baselineCrashNames.contains($0.lastPathComponent) }
+    if let newCrashReport {
+        let copiedReport = try copyCrashReport(newCrashReport, to: artifactsURL)
+        summary["crashReport"] = copiedReport.path
+        throw SmokeError.crashDetected(copiedReport.path)
+    }
+
+    let afterScreenshot = captureScreenshot(name: "after.png", artifactsURL: artifactsURL)
+    summary["afterScreenshot"] = afterScreenshot?.path ?? ""
+    summary["status"] = "passed"
+    writeJSON(summary, to: summaryURL)
+    print("Smoke scenario passed")
+    print("Artifacts: \(artifactsURL.path)")
+} catch {
+    summary["status"] = "failed"
+    summary["error"] = error.localizedDescription
+    let failureScreenshot = captureScreenshot(name: "failure.png", artifactsURL: artifactsURL)
+    summary["failureScreenshot"] = failureScreenshot?.path ?? ""
+    writeJSON(summary, to: summaryURL)
+    fputs("\(error.localizedDescription)\n", stderr)
+    fputs("Artifacts: \(artifactsURL.path)\n", stderr)
+    exit(1)
+}

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -17,11 +17,10 @@ LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
 write_dev_cli_shim() {
   local target="$1"
-  local fallback_bin="$2"
   mkdir -p "$(dirname "$target")"
   cat > "$target" <<EOF
 #!/usr/bin/env bash
-# cmux dev shim (managed by scripts/reload.sh)
+# cmux source-build shim (managed by scripts/reload.sh)
 set -euo pipefail
 
 CLI_PATH_FILE="/tmp/cmux-last-cli-path"
@@ -33,11 +32,11 @@ if [[ -r "\$CLI_PATH_FILE" ]] && [[ ! -L "\$CLI_PATH_FILE" ]] && [[ "\$CLI_PATH_
   fi
 fi
 
-if [[ -x "$fallback_bin" ]]; then
-  exec "$fallback_bin" "\$@"
+if [[ -x "/tmp/cmux-cli" ]] && [[ ! -L "/tmp/cmux-cli" || "\$(readlink "/tmp/cmux-cli" 2>/dev/null || true)" != "$target" ]]; then
+  exec "/tmp/cmux-cli" "\$@"
 fi
 
-echo "error: no reload-selected dev cmux CLI found. Run ./scripts/reload.sh --tag <name> first." >&2
+echo "error: no reload-selected source cmux CLI found. Run ./scripts/reload.sh --tag <name> first." >&2
 exit 1
 EOF
   chmod +x "$target"
@@ -407,11 +406,11 @@ if [[ -x "$CLI_PATH" ]]; then
 
   # Stable shim that always follows the last reload-selected dev CLI.
   DEV_CLI_SHIM="$HOME/.local/bin/cmux-dev"
-  write_dev_cli_shim "$DEV_CLI_SHIM" "/Applications/cmux.app/Contents/Resources/bin/cmux"
+  write_dev_cli_shim "$DEV_CLI_SHIM"
 
   CMUX_SHIM_TARGET="$(select_cmux_shim_target || true)"
   if [[ -n "${CMUX_SHIM_TARGET:-}" ]]; then
-    write_dev_cli_shim "$CMUX_SHIM_TARGET" "/Applications/cmux.app/Contents/Resources/bin/cmux"
+    write_dev_cli_shim "$CMUX_SHIM_TARGET"
   fi
 fi
 

--- a/scripts/reloadp.sh
+++ b/scripts/reloadp.sh
@@ -1,9 +1,186 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+INSTALL=0
+INSTALL_PATH="/Applications/cmux.app"
+BACKUP_PATH="/Applications/cmux.downloaded.app"
+LAUNCH=1
+INSTALL_CLI=1
+CLI_LINK_PATH="/usr/local/bin/cmux"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/reloadp.sh [options]
+
+Options:
+  --install              Install the source-built Release app to /Applications/cmux.app.
+                         If an existing app is present there, it is backed up once to
+                         /Applications/cmux.downloaded.app and then replaced.
+                         Also refreshes the PATH CLI symlink unless --no-install-cli
+                         is passed.
+  --install-path <path>  Override the install destination used by --install.
+  --backup-path <path>   Override the backup destination used by --install.
+  --cli-link-path <path> Override the CLI symlink destination used by --install.
+  --no-install-cli       Skip updating the PATH CLI symlink during --install.
+  --no-launch            Build (and optionally install) without opening the app.
+  -h, --help             Show this help.
+EOF
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+run_privileged_shell_command() {
+  local command="$1"
+
+  /usr/bin/osascript \
+    -e 'on run argv' \
+    -e 'do shell script (item 1 of argv) with administrator privileges' \
+    -e 'end run' \
+    "$command"
+}
+
+install_app_bundle() {
+  local source_app="$1"
+  local install_app="$2"
+  local backup_app="$3"
+  local info_plist="$install_app/Contents/Info.plist"
+  local lsregister="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+  mkdir -p "$(dirname "$install_app")"
+
+  if [[ -e "$install_app" || -L "$install_app" ]]; then
+    if [[ ! -e "$backup_app" && ! -L "$backup_app" ]]; then
+      mv "$install_app" "$backup_app"
+      echo "Backed up existing app:"
+      echo "  ${backup_app}"
+    else
+      rm -rf "$install_app"
+    fi
+  fi
+
+  cp -R "$source_app" "$install_app"
+
+  if [[ -f "$info_plist" ]]; then
+    /usr/libexec/PlistBuddy -c "Delete :CMUXSourceBuildInstall" "$info_plist" 2>/dev/null || true
+    /usr/libexec/PlistBuddy -c "Add :CMUXSourceBuildInstall string 1" "$info_plist" >/dev/null 2>&1 || true
+  fi
+
+  /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$install_app" >/dev/null 2>&1 || true
+  if [[ -x "$lsregister" ]]; then
+    "$lsregister" -f "$install_app" >/dev/null 2>&1 || true
+  fi
+}
+
+verify_symlink_target() {
+  local expected_path="$1"
+  local symlink_path="$2"
+  local actual_path=""
+
+  if [[ ! -L "$symlink_path" ]]; then
+    echo "error: expected a symlink at $symlink_path" >&2
+    exit 1
+  fi
+
+  actual_path="$(readlink "$symlink_path" 2>/dev/null || true)"
+  if [[ "$actual_path" != "$expected_path" ]]; then
+    echo "error: CLI symlink verification failed" >&2
+    echo "  expected: ${symlink_path} -> ${expected_path}" >&2
+    echo "  actual:   ${symlink_path} -> ${actual_path:-<missing>}" >&2
+    exit 1
+  fi
+}
+
+install_cli_symlink() {
+  local source_cli="$1"
+  local destination_cli="$2"
+  local destination_parent
+  local install_command=""
+
+  if [[ ! -x "$source_cli" ]]; then
+    echo "error: bundled CLI not found at $source_cli" >&2
+    exit 1
+  fi
+
+  if [[ -d "$destination_cli" && ! -L "$destination_cli" ]]; then
+    echo "error: CLI destination is a directory: $destination_cli" >&2
+    exit 1
+  fi
+
+  destination_parent="$(dirname "$destination_cli")"
+  install_command="/bin/mkdir -p $(shell_quote "$destination_parent") && "
+  install_command+="/bin/rm -f $(shell_quote "$destination_cli") && "
+  install_command+="/bin/ln -s $(shell_quote "$source_cli") $(shell_quote "$destination_cli")"
+
+  if ! {
+    mkdir -p "$destination_parent" 2>/dev/null &&
+    rm -f "$destination_cli" 2>/dev/null &&
+    ln -s "$source_cli" "$destination_cli" 2>/dev/null
+  }; then
+    run_privileged_shell_command "$install_command"
+  fi
+
+  verify_symlink_target "$source_cli" "$destination_cli"
+
+  echo "Installed CLI symlink:"
+  echo "  ${destination_cli} -> ${source_cli}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      INSTALL=1
+      shift
+      ;;
+    --install-path)
+      INSTALL_PATH="${2:-}"
+      if [[ -z "$INSTALL_PATH" ]]; then
+        echo "error: --install-path requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --backup-path)
+      BACKUP_PATH="${2:-}"
+      if [[ -z "$BACKUP_PATH" ]]; then
+        echo "error: --backup-path requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --cli-link-path)
+      CLI_LINK_PATH="${2:-}"
+      if [[ -z "$CLI_LINK_PATH" ]]; then
+        echo "error: --cli-link-path requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --no-install-cli)
+      INSTALL_CLI=0
+      shift
+      ;;
+    --no-launch)
+      LAUNCH=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -destination 'platform=macOS' build
 pkill -x cmux || true
 sleep 0.2
+
 APP_PATH="$(
   find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Release/cmux.app" -print0 \
   | xargs -0 /usr/bin/stat -f "%m %N" 2>/dev/null \
@@ -18,6 +195,27 @@ fi
 
 echo "Release app:"
 echo "  ${APP_PATH}"
+
+if [[ "$INSTALL" -eq 1 ]]; then
+  install_app_bundle "$APP_PATH" "$INSTALL_PATH" "$BACKUP_PATH"
+  APP_PATH="$INSTALL_PATH"
+  echo "Installed source-built app:"
+  echo "  ${APP_PATH}"
+fi
+
+CLI_PATH="${APP_PATH}/Contents/Resources/bin/cmux"
+if [[ -x "$CLI_PATH" ]]; then
+  (umask 077; printf '%s\n' "$CLI_PATH" > /tmp/cmux-last-cli-path) || true
+  ln -sfn "$CLI_PATH" /tmp/cmux-cli || true
+fi
+
+if [[ "$INSTALL" -eq 1 && "$INSTALL_CLI" -eq 1 ]]; then
+  install_cli_symlink "$CLI_PATH" "$CLI_LINK_PATH"
+fi
+
+if [[ "$LAUNCH" -eq 0 ]]; then
+  exit 0
+fi
 
 # Dev shells (including CI/Codex) often force-disable paging by exporting these.
 # Don't leak that into cmux, otherwise `git diff` won't page even with PAGER=less.

--- a/scripts/run-ui-test-local.sh
+++ b/scripts/run-ui-test-local.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TEST_FILTER="${1:-MenuKeyEquivalentRoutingUITests/testTitlebarNewWorkspaceButtonCreatesWorkspaceWithoutCrash}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+ARTIFACTS_DIR=""
+DERIVED_DATA_PATH=""
+SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/run-ui-test-local.sh [test_filter] [options]
+
+Arguments:
+  test_filter             Class or class/method under cmuxUITests
+
+Options:
+  --artifacts-dir <path>  Directory for xcresult/log output
+  --derived-data <path>   DerivedData path for the local run
+  -h, --help              Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifacts-dir)
+      ARTIFACTS_DIR="${2:-}"
+      shift 2
+      ;;
+    --derived-data)
+      DERIVED_DATA_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+if [[ -z "$ARTIFACTS_DIR" ]]; then
+  ARTIFACTS_DIR="/tmp/cmux-ui-local/${timestamp}"
+fi
+if [[ -z "$DERIVED_DATA_PATH" ]]; then
+  DERIVED_DATA_PATH="/tmp/cmux-ui-local-derived-${timestamp}"
+fi
+
+mkdir -p "$ARTIFACTS_DIR" "$SOURCE_PACKAGES_DIR"
+LOG_PATH="$ARTIFACTS_DIR/xcodebuild.log"
+RESULT_BUNDLE_PATH="$ARTIFACTS_DIR/cmux-ui-local.xcresult"
+SUMMARY_PATH="$ARTIFACTS_DIR/summary.json"
+
+echo "== resolve packages =="
+for attempt in 1 2 3; do
+  if xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+    -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+    -resolvePackageDependencies >/dev/null; then
+    break
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    echo "error: failed to resolve Swift packages after 3 attempts" >&2
+    exit 1
+  fi
+  echo "Package resolution failed on attempt $attempt, retrying..."
+  sleep $((attempt * 5))
+done
+
+rm -rf "$DERIVED_DATA_PATH" "$RESULT_BUNDLE_PATH"
+
+set +e
+xcodebuild \
+  -project GhosttyTabs.xcodeproj \
+  -scheme cmux \
+  -configuration Debug \
+  -destination "platform=macOS" \
+  -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -resultBundlePath "$RESULT_BUNDLE_PATH" \
+  -only-testing:cmuxUITests/"$TEST_FILTER" \
+  test 2>&1 | tee "$LOG_PATH"
+status=${PIPESTATUS[0]}
+set -e
+
+FAILURE_HINT=""
+if [[ "$status" -ne 0 ]]; then
+  if rg -q "Timed out while enabling automation mode" "$LOG_PATH"; then
+    FAILURE_HINT="XCUITest could not enable macOS automation mode. Re-run after granting Xcode and the test runner the required UI automation permissions, or retry from a fresh logged-in desktop session."
+    echo "note: $FAILURE_HINT" >&2
+  fi
+fi
+
+python3 - <<PY
+import json
+from pathlib import Path
+
+summary = {
+    "testFilter": ${TEST_FILTER@Q},
+    "artifactsDir": ${ARTIFACTS_DIR@Q},
+    "derivedDataPath": ${DERIVED_DATA_PATH@Q},
+    "resultBundlePath": ${RESULT_BUNDLE_PATH@Q},
+    "logPath": ${LOG_PATH@Q},
+    "status": "passed" if ${status} == 0 else "failed",
+    "exitCode": ${status},
+    "failureHint": ${FAILURE_HINT@Q},
+}
+Path(${SUMMARY_PATH@Q}).write_text(json.dumps(summary, indent=2, sort_keys=True) + "\\n")
+PY
+
+echo
+echo "Artifacts:"
+echo "  $ARTIFACTS_DIR"
+
+exit "$status"

--- a/scripts/watch-cmux-crash.sh
+++ b/scripts/watch-cmux-crash.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PREFIX="${1:-cmux}"
+TIMEOUT_SECONDS="${CMUX_CRASH_WATCH_TIMEOUT:-180}"
+REPORTS_DIR="$HOME/Library/Logs/DiagnosticReports"
+CRASH_BREADCRUMBS="/tmp/cmux-workspace-crash-breadcrumbs.log"
+LAST_CRASH_BREADCRUMBS="/tmp/cmux-last-workspace-crash-log-path"
+ARTIFACTS_DIR="/tmp/cmux-crash-watch-$(date +%Y%m%d-%H%M%S)"
+UNIFIED_LOG="$ARTIFACTS_DIR/unified.log"
+SUMMARY_FILE="$ARTIFACTS_DIR/summary.txt"
+LOG_STREAM_PID=""
+
+mkdir -p "$ARTIFACTS_DIR"
+
+cleanup() {
+  if [[ -n "$LOG_STREAM_PID" ]]; then
+    kill "$LOG_STREAM_PID" >/dev/null 2>&1 || true
+    wait "$LOG_STREAM_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+rm -f "$CRASH_BREADCRUMBS" "$LAST_CRASH_BREADCRUMBS"
+
+BEFORE_LIST_FILE="$ARTIFACTS_DIR/reports-before.txt"
+AFTER_LIST_FILE="$ARTIFACTS_DIR/reports-after.txt"
+
+find "$REPORTS_DIR" -maxdepth 1 -type f -name "${APP_PREFIX}*" -print | sort > "$BEFORE_LIST_FILE"
+
+log stream \
+  --style compact \
+  --predicate 'process == "cmux"' \
+  > "$UNIFIED_LOG" 2>&1 &
+LOG_STREAM_PID="$!"
+
+echo "artifact_dir=$ARTIFACTS_DIR" > "$SUMMARY_FILE"
+echo "app_prefix=$APP_PREFIX" >> "$SUMMARY_FILE"
+echo "reports_dir=$REPORTS_DIR" >> "$SUMMARY_FILE"
+echo "breadcrumbs=$CRASH_BREADCRUMBS" >> "$SUMMARY_FILE"
+echo "timeout_seconds=$TIMEOUT_SECONDS" >> "$SUMMARY_FILE"
+
+echo
+echo "Watching for a new ${APP_PREFIX} crash report for up to ${TIMEOUT_SECONDS}s..."
+echo "Artifacts:"
+echo "  $ARTIFACTS_DIR"
+echo
+echo "Reproduce the crash now."
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+LATEST_NEW_REPORT=""
+
+while (( SECONDS < deadline )); do
+  find "$REPORTS_DIR" -maxdepth 1 -type f -name "${APP_PREFIX}*" -print | sort > "$AFTER_LIST_FILE"
+  LATEST_NEW_REPORT="$(comm -13 "$BEFORE_LIST_FILE" "$AFTER_LIST_FILE" | tail -n 1 || true)"
+  if [[ -n "$LATEST_NEW_REPORT" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -f "$CRASH_BREADCRUMBS" ]]; then
+  cp "$CRASH_BREADCRUMBS" "$ARTIFACTS_DIR/"
+fi
+
+if [[ -n "$LATEST_NEW_REPORT" ]]; then
+  cp "$LATEST_NEW_REPORT" "$ARTIFACTS_DIR/"
+  echo "latest_report=$LATEST_NEW_REPORT" >> "$SUMMARY_FILE"
+  echo "status=captured" >> "$SUMMARY_FILE"
+  echo
+  echo "Captured crash artifacts:"
+  echo "  $ARTIFACTS_DIR"
+  exit 0
+fi
+
+echo "status=timeout" >> "$SUMMARY_FILE"
+echo
+echo "No new crash report appeared before timeout."
+echo "Artifacts:"
+echo "  $ARTIFACTS_DIR"
+exit 1


### PR DESCRIPTION
## Summary
This branch fixes the titlebar new-workspace crash that was still reproducible in the installed Release app, cleans up the hidden-sidebar titlebar overlap that showed up in the same area, and adds a local Mac smoke/crash-capture path so we can validate the live app end to end instead of debugging blind.

## What Changed
- Routed all titlebar new-workspace entry points through window-scoped `AppDelegate` workspace creation instead of relying on stale global manager state.
- Hardened `TabManager.addWorkspace()` for optimized Release builds by removing the fragile workspace-creation snapshot/config path and inheriting only remembered terminal font state during creation.
- Added crash breadcrumbs plus crash-capture/watch scripts so we can preserve the last workspace-creation events before a macOS crash.
- Fixed hidden-sidebar titlebar spacing so the folder icon and title text stay clear of the leading controls as sidebar/titlebar layout changes.
- Added local Mac validation tooling: targeted local UI-test runner, AX-driven smoke helper, Release install flow, and supporting docs.
- Folded in terminal selected-text/path resolution coverage that shares the same AppDelegate plumbing touched by this branch.

## Testing
- `xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/WorkspaceCreationPlacementTests`
- Manual validation on the installed source-built `/Applications/cmux.app`: confirmed the titlebar plus button no longer crashes the app and the hidden-sidebar titlebar layout renders cleanly.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (unknown context, standard reasoning) via [Codex](https://openai.com/codex)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Release crash when creating a new workspace from the titlebar and cleans up titlebar spacing when the sidebar is hidden. Adds local Mac smoke/crash tooling to validate the installed app end to end.

- **Bug Fixes**
  - Route titlebar “new workspace” through window-scoped `AppDelegate` creation to avoid stale global state.
  - Harden `TabManager.addWorkspace()` for optimized builds by removing fragile snapshot/config inheritance and only carrying terminal font state.
  - Adjust hidden‑sidebar titlebar layout so the folder icon and title never overlap the leading controls.

- **New Features**
  - Add local validation and crash-capture tools: breadcrumb logging, `watch-cmux-crash.sh`, `capture-latest-cmux-crash.sh`, AX-driven `mac-smoke.swift`, and a targeted UI test runner; plus Release install flow via `reloadp.sh --install`.
  - Add selection helpers and labels for “Open Selected Link or Path.”

<sup>Written for commit 09674e15074e0e1ef962d0402787de7f816b49d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open Selected Link or Path" keyboard shortcut (Cmd+Shift+O) to open links and file paths directly from terminal selections.
  * Enhanced workspace creation in fullscreen titlebar with improved crash diagnostics.

* **Bug Fixes**
  * Fixed window context re-registration to properly update existing references.
  * Improved titlebar layout calculations for better UI accuracy.
  * Enhanced terminal text selection handling.

* **Documentation**
  * Added local testing and development instructions to contributor guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->