### PR TITLE
Add Apple/Xcode workflow guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,23 @@ When adding a regression test for a bug fix, use a two-commit structure so CI pr
 
 This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
 
+## Apple / Xcode workflow
+
+For Swift, AppKit, SwiftUI, Observation, Foundation-on-Apple, or Xcode-related work:
+
+- Prefer reading the relevant Apple documentation first before proposing architecture, implementation details, or refactors.
+- Prefer local Apple documentation sources when available (Dash, Xcode docs), then fall back to official Apple web docs.
+- When making a non-trivial change, briefly state the API contract, lifecycle rule, threading rule, or Xcode workflow requirement being relied on.
+- If the docs and the current code seem to disagree, surface that conflict instead of silently choosing one.
+
+Preferred execution order for Xcode work:
+
+1. Inspect workspace and diagnostics in Xcode-aware tooling first when available.
+2. Prefer Xcode-aware read/search/build/test/run paths before broad filesystem fallback.
+3. Use direct filesystem edits in Xcode-managed areas carefully, and verify afterward that the project structure still makes sense.
+
+This is guidance, not a hard gate. The goal is to reduce accidental Xcode project churn and avoid relying on memory alone for Apple platform behavior.
+
 ## Pitfalls
 
 - **Custom UTTypes** for drag-and-drop must be declared in `Resources/Info.plist` under `UTExportedTypeDeclarations` (e.g. `com.splittabbar.tabtransfer`, `com.cmux.sidebar-tab-reorder`).


### PR DESCRIPTION
## Summary

- Added a lightweight `Apple / Xcode workflow` section to `CLAUDE.md`.
- Documented soft guidance to prefer Apple docs first for non-trivial Swift/AppKit/SwiftUI/Xcode work, prefer Xcode-aware tooling when practical, and be careful with direct filesystem edits in Xcode-managed areas.
- Kept the guidance intentionally loose and portable rather than depending on any private local scripts, MCP setup, or hard gating.

## Testing

- Reviewed the rendered Markdown section in `CLAUDE.md` for placement, tone, and formatting.
- Verified the new guidance reads as repo policy rather than environment-specific tooling instructions.
- Did not run tests because this is a docs-only change.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A (docs-only change)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an "Apple / Xcode workflow" section to `CLAUDE.md` with soft guidance for Swift and Xcode work. It favors Apple docs first, recommends Xcode-aware tooling over direct filesystem edits, and asks authors to call out relied-on API/lifecycle/threading rules and surface docs-vs-code conflicts.

<sup>Written for commit 8314b422b7452642012f606b9460c9bfdfbdd022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines to include comprehensive guidance for Apple ecosystem development work, emphasizing documentation-first practices and preferred development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->