### PR TITLE
Add hover background to split action buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,14 @@ When adding a regression test for a bug fix, use a two-commit structure so CI pr
 
 This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
 
+## Debug menu
+
+The app has a **Debug** menu in the macOS menu bar (only in DEBUG builds). Use it for visual iteration:
+
+- **Debug > Debug Windows** contains panels for tuning layout, colors, and behavior. Entries are alphabetical with no dividers.
+- To add a debug toggle or visual option: create an `NSWindowController` subclass with a `shared` singleton, add it to the "Debug Windows" menu in `Sources/cmuxApp.swift`, and add a SwiftUI view with `@AppStorage` bindings for live changes.
+- When the user says "debug menu" or "debug window", they mean this menu, not `defaults write`.
+
 ## Pitfalls
 
 - **Custom UTTypes** for drag-and-drop must be declared in `Resources/Info.plist` under `UTExportedTypeDeclarations` (e.g. `com.splittabbar.tabtransfer`, `com.cmux.sidebar-tab-reorder`).

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -500,6 +500,9 @@ struct cmuxApp: App {
                     Button("Sidebar Debug…") {
                         SidebarDebugWindowController.shared.show()
                     }
+                    Button("Split Button Layout Debug…") {
+                        SplitButtonLayoutDebugWindowController.shared.show()
+                    }
                     Button("Open All Debug Windows") {
                         openAllDebugWindows()
                     }
@@ -3321,6 +3324,75 @@ private struct MenuBarExtraDebugView: View {
 
     private func applyLiveUpdate() {
         AppDelegate.shared?.refreshMenuBarExtraForDebug()
+    }
+}
+
+// MARK: - Split Button Layout Debug Window
+
+private final class SplitButtonLayoutDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = SplitButtonLayoutDebugWindowController()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Split Button Layout"
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.splitButtonLayoutDebug")
+        window.center()
+        window.contentView = NSHostingView(rootView: SplitButtonLayoutDebugView())
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+private struct SplitButtonLayoutDebugView: View {
+    @AppStorage("debugSplitButtonLayout") private var layout = 0
+
+    private let options: [(Int, String)] = [
+        (0, "HStack sibling (no overlay)"),
+        (1, "Overlay: solid barFill bg"),
+        (2, "Overlay: opaque windowBg"),
+        (3, "Overlay: ultraThinMaterial"),
+        (4, "Overlay: fade gradient + barFill"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Split Button Layout")
+                .font(.headline)
+
+            ForEach(options, id: \.0) { id, label in
+                HStack {
+                    Image(systemName: layout == id ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(layout == id ? .accentColor : .secondary)
+                    Text(label)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { layout = id }
+            }
+
+            Text("Changes apply live.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -474,14 +474,12 @@ struct cmuxApp: App {
 
                 Divider()
                 Menu("Debug Windows") {
-                    Button("Debug Window Controls…") {
-                        DebugWindowControlsWindowController.shared.show()
+                    Button("Background Debug…") {
+                        BackgroundDebugWindowController.shared.show()
                     }
-
                     Button("Browser Import Hint Debug…") {
                         BrowserImportHintDebugWindowController.shared.show()
                     }
-
                     Button(
                         String(
                             localized: "debug.menu.browserProfilePopoverDebug",
@@ -490,30 +488,18 @@ struct cmuxApp: App {
                     ) {
                         BrowserProfilePopoverDebugWindowController.shared.show()
                     }
-
-                    Button("Settings/About Titlebar Debug…") {
-                        SettingsAboutTitlebarDebugWindowController.shared.show()
+                    Button("Debug Window Controls…") {
+                        DebugWindowControlsWindowController.shared.show()
                     }
-
-                    Divider()
-                    Button("Sidebar Debug…") {
-                        SidebarDebugWindowController.shared.show()
-                    }
-
-                    Button("Background Debug…") {
-                        BackgroundDebugWindowController.shared.show()
-                    }
-
                     Button("Menu Bar Extra Debug…") {
                         MenuBarExtraDebugWindowController.shared.show()
                     }
-
-                    Button("Split Button Style Debug…") {
-                        SplitButtonStyleDebugWindowController.shared.show()
+                    Button("Settings/About Titlebar Debug…") {
+                        SettingsAboutTitlebarDebugWindowController.shared.show()
                     }
-
-                    Divider()
-
+                    Button("Sidebar Debug…") {
+                        SidebarDebugWindowController.shared.show()
+                    }
                     Button("Open All Debug Windows") {
                         openAllDebugWindows()
                     }
@@ -3335,78 +3321,6 @@ private struct MenuBarExtraDebugView: View {
 
     private func applyLiveUpdate() {
         AppDelegate.shared?.refreshMenuBarExtraForDebug()
-    }
-}
-
-// MARK: - Split Button Style Debug Window
-
-private final class SplitButtonStyleDebugWindowController: NSWindowController, NSWindowDelegate {
-    static let shared = SplitButtonStyleDebugWindowController()
-
-    private init() {
-        let window = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 300, height: 200),
-            styleMask: [.titled, .closable, .utilityWindow],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "Split Button Style"
-        window.titleVisibility = .visible
-        window.titlebarAppearsTransparent = false
-        window.isMovableByWindowBackground = true
-        window.isReleasedWhenClosed = false
-        window.identifier = NSUserInterfaceItemIdentifier("cmux.splitButtonStyleDebug")
-        window.center()
-        window.contentView = NSHostingView(rootView: SplitButtonStyleDebugView())
-        AppDelegate.shared?.applyWindowDecorations(to: window)
-        super.init(window: window)
-        window.delegate = self
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func show() {
-        window?.center()
-        window?.makeKeyAndOrderFront(nil)
-    }
-}
-
-private struct SplitButtonStyleDebugView: View {
-    @AppStorage("debugSplitButtonBgStyle") private var style = 0
-
-    private let styles = [
-        (0, "No background"),
-        (1, "Solid barFill"),
-        (2, "Fade gradient + barFill"),
-        (3, "ultraThinMaterial"),
-        (4, "windowBackgroundColor + fade"),
-    ]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Split Button Background")
-                .font(.headline)
-
-            ForEach(styles, id: \.0) { id, label in
-                HStack {
-                    Image(systemName: style == id ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(style == id ? .accentColor : .secondary)
-                    Text("\(id): \(label)")
-                }
-                .contentShape(Rectangle())
-                .onTapGesture { style = id }
-            }
-
-            Divider()
-            Text("Changes apply live.")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -508,6 +508,10 @@ struct cmuxApp: App {
                         MenuBarExtraDebugWindowController.shared.show()
                     }
 
+                    Button("Split Button Style Debug…") {
+                        SplitButtonStyleDebugWindowController.shared.show()
+                    }
+
                     Divider()
 
                     Button("Open All Debug Windows") {
@@ -3331,6 +3335,78 @@ private struct MenuBarExtraDebugView: View {
 
     private func applyLiveUpdate() {
         AppDelegate.shared?.refreshMenuBarExtraForDebug()
+    }
+}
+
+// MARK: - Split Button Style Debug Window
+
+private final class SplitButtonStyleDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = SplitButtonStyleDebugWindowController()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 200),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Split Button Style"
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.splitButtonStyleDebug")
+        window.center()
+        window.contentView = NSHostingView(rootView: SplitButtonStyleDebugView())
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+private struct SplitButtonStyleDebugView: View {
+    @AppStorage("debugSplitButtonBgStyle") private var style = 0
+
+    private let styles = [
+        (0, "No background"),
+        (1, "Solid barFill"),
+        (2, "Fade gradient + barFill"),
+        (3, "ultraThinMaterial"),
+        (4, "windowBackgroundColor + fade"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Split Button Background")
+                .font(.headline)
+
+            ForEach(styles, id: \.0) { id, label in
+                HStack {
+                    Image(systemName: style == id ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(style == id ? .accentColor : .secondary)
+                    Text("\(id): \(label)")
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { style = id }
+            }
+
+            Divider()
+            Text("Changes apply live.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3362,29 +3362,30 @@ private final class SplitButtonLayoutDebugWindowController: NSWindowController, 
 }
 
 private struct SplitButtonLayoutDebugView: View {
-    @AppStorage("debugSplitButtonLayout") private var layout = 0
+    @AppStorage("debugFadeColorStyle") private var fadeColor = 0
 
-    private let options: [(Int, String)] = [
-        (0, "HStack sibling (no overlay)"),
-        (1, "Overlay: solid barFill bg"),
-        (2, "Overlay: opaque windowBg"),
-        (3, "Overlay: ultraThinMaterial"),
-        (4, "Overlay: fade gradient + barFill"),
+    private let fadeOptions: [(Int, String)] = [
+        (0, "barFill with focus opacity"),
+        (1, "barBackground (raw)"),
+        (2, "windowBackgroundColor"),
+        (3, "controlBackgroundColor"),
+        (4, "textBackgroundColor"),
+        (5, "underPageBackgroundColor"),
     ]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Split Button Layout")
+            Text("Fade Gradient Color")
                 .font(.headline)
 
-            ForEach(options, id: \.0) { id, label in
+            ForEach(fadeOptions, id: \.0) { id, label in
                 HStack {
-                    Image(systemName: layout == id ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(layout == id ? .accentColor : .secondary)
+                    Image(systemName: fadeColor == id ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(fadeColor == id ? .accentColor : .secondary)
                     Text(label)
                 }
                 .contentShape(Rectangle())
-                .onTapGesture { layout = id }
+                .onTapGesture { fadeColor = id }
             }
 
             Text("Changes apply live.")

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3362,30 +3362,30 @@ private final class SplitButtonLayoutDebugWindowController: NSWindowController, 
 }
 
 private struct SplitButtonLayoutDebugView: View {
-    @AppStorage("debugFadeColorStyle") private var fadeColor = 0
+    @AppStorage("debugFadeColorStyle") private var backdropStyle = 0
 
-    private let fadeOptions: [(Int, String)] = [
-        (0, "barFill with focus opacity"),
-        (1, "barBackground (raw)"),
-        (2, "windowBackgroundColor"),
-        (3, "controlBackgroundColor"),
-        (4, "textBackgroundColor"),
-        (5, "underPageBackgroundColor"),
+    private let options: [(Int, String)] = [
+        (0, "Pre-composited paneBackground"),
+        (1, "Raw paneBackground (opaque)"),
+        (2, "barBackground (tab chrome)"),
+        (3, "windowBackgroundColor"),
+        (4, "controlBackgroundColor"),
+        (5, "Pre-composited barBackground"),
     ]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Fade Gradient Color")
+            Text("Button Backdrop Color")
                 .font(.headline)
 
-            ForEach(fadeOptions, id: \.0) { id, label in
+            ForEach(options, id: \.0) { id, label in
                 HStack {
-                    Image(systemName: fadeColor == id ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(fadeColor == id ? .accentColor : .secondary)
+                    Image(systemName: backdropStyle == id ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(backdropStyle == id ? .accentColor : .secondary)
                     Text(label)
                 }
                 .contentShape(Rectangle())
-                .onTapGesture { fadeColor = id }
+                .onTapGesture { backdropStyle = id }
             }
 
             Text("Changes apply live.")


### PR DESCRIPTION
## Summary
- Split buttons (terminal, browser, split right/down) show a subtle rounded-rect background on hover

## Related
- Follow-up to https://github.com/manaflow-ai/cmux/pull/2218
- https://github.com/manaflow-ai/cmux/issues/2270

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the tab bar for full-width scrolling and adds a subtle hover background behind the split action buttons. Switches to mask-based button area hiding so no backdrop color is needed; keeps scroll fades masked to eliminate seams and bleed.

- **New Features**
  - Add Split Button Layout debug window with 6 switchable backdrop styles; alphabetize the Debug Windows menu.

- **Bug Fixes**
  - Render bottom separator above scroll fades and clear under the button area to prevent bleed.
  - Fix right fade threshold by excluding the drop zone, with 4pt tolerance and a 32pt buffer.
  - Mask scroll fades to remove color mismatch and seams.
  - Hide the button region with a mask (no backdrop color) to avoid seams and layout shift.
  - Remove split buttons from layout in minimal mode; add trailing scroll padding to reserve space for buttons.

<sup>Written for commit ff8b0a473c84ab8611c0223c6f8acc130f78bab6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a bundled dependency snapshot to a newer compatible version. This behind-the-scenes refresh may improve stability, compatibility, and maintainability without changing public APIs or visible functionality. Low-risk change; no user-facing behavior or exported interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->