### PR TITLE
Resize Ghostty surfaces during split divider drags

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2256,6 +2256,17 @@ struct ContentView: View {
                 if isResizerDragging {
                     TerminalWindowPortalRegistry.endInteractiveGeometryResize()
                     isResizerDragging = false
+#if DEBUG
+                    dlog(
+                        "sidebar.resize.cancel width=\(String(format: "%.1f", sidebarWidth)) " +
+                        "visible=\(sidebarState.isVisible ? 1 : 0)"
+                    )
+#endif
+                    if let observedWindow {
+                        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                    } else {
+                        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                    }
                 }
                 sidebarDragStartWidth = nil
                 isResizerBandActive = false
@@ -2284,6 +2295,17 @@ struct ContentView: View {
                         if isResizerDragging {
                             TerminalWindowPortalRegistry.endInteractiveGeometryResize()
                             isResizerDragging = false
+#if DEBUG
+                            dlog(
+                                "sidebar.resize.end width=\(String(format: "%.1f", sidebarWidth)) " +
+                                "visible=\(sidebarState.isVisible ? 1 : 0)"
+                            )
+#endif
+                            if let observedWindow {
+                                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                            } else {
+                                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                            }
                             sidebarDragStartWidth = nil
                         }
                         activateSidebarResizerCursor()
@@ -3072,6 +3094,12 @@ struct ContentView: View {
             if abs(sidebarState.persistedWidth - sanitized) > 0.5 {
                 sidebarState.persistedWidth = sanitized
             }
+#if DEBUG
+            dlog(
+                "sidebar.resize.change width=\(String(format: "%.1f", sanitized)) " +
+                "dragging=\(isResizerDragging ? 1 : 0) visible=\(sidebarState.isVisible ? 1 : 0)"
+            )
+#endif
             // Sidebar width changes are pure SwiftUI layout updates, so portal-hosted
             // terminals need an explicit post-layout geometry resync.
             if let observedWindow {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2254,16 +2254,27 @@ struct ContentView: View {
             .onDisappear {
                 hoveredResizerHandles.remove(handle)
                 if isResizerDragging {
-                    TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                    let startWidth = sidebarDragStartWidth ?? sidebarWidth
+                    TerminalWindowPortalRegistry.endInteractiveGeometryResize(reason: "sidebar")
                     isResizerDragging = false
 #if DEBUG
                     dlog(
                         "sidebar.resize.cancel width=\(String(format: "%.1f", sidebarWidth)) " +
                         "visible=\(sidebarState.isVisible ? 1 : 0)"
                     )
+                    dlog(
+                        "sizing.sidebar.cancel window=\(observedWindow?.windowNumber ?? -1) " +
+                        "start=\(String(format: "%.1f", startWidth)) " +
+                        "width=\(String(format: "%.1f", sidebarWidth)) " +
+                        "delta=\(String(format: "%.1f", sidebarWidth - startWidth)) " +
+                        "visible=\(sidebarState.isVisible ? 1 : 0)"
+                    )
 #endif
                     if let observedWindow {
-                        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+                            for: observedWindow,
+                            reason: "sidebar.cancel"
+                        )
                     }
                 }
                 sidebarDragStartWidth = nil
@@ -2274,9 +2285,17 @@ struct ContentView: View {
                 DragGesture(minimumDistance: 0, coordinateSpace: .global)
                     .onChanged { value in
                         if !isResizerDragging {
-                            TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+                            TerminalWindowPortalRegistry.beginInteractiveGeometryResize(reason: "sidebar")
                             isResizerDragging = true
                             sidebarDragStartWidth = sidebarWidth
+#if DEBUG
+                            dlog(
+                                "sizing.sidebar.begin window=\(observedWindow?.windowNumber ?? -1) " +
+                                "start=\(String(format: "%.1f", sidebarWidth)) " +
+                                "available=\(String(format: "%.1f", availableWidth)) " +
+                                "visible=\(sidebarState.isVisible ? 1 : 0)"
+                            )
+#endif
                         }
 
                         activateSidebarResizerCursor()
@@ -2291,16 +2310,27 @@ struct ContentView: View {
                     }
                     .onEnded { _ in
                         if isResizerDragging {
-                            TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                            let startWidth = sidebarDragStartWidth ?? sidebarWidth
+                            TerminalWindowPortalRegistry.endInteractiveGeometryResize(reason: "sidebar")
                             isResizerDragging = false
 #if DEBUG
                             dlog(
                                 "sidebar.resize.end width=\(String(format: "%.1f", sidebarWidth)) " +
                                 "visible=\(sidebarState.isVisible ? 1 : 0)"
                             )
+                            dlog(
+                                "sizing.sidebar.end window=\(observedWindow?.windowNumber ?? -1) " +
+                                "start=\(String(format: "%.1f", startWidth)) " +
+                                "width=\(String(format: "%.1f", sidebarWidth)) " +
+                                "delta=\(String(format: "%.1f", sidebarWidth - startWidth)) " +
+                                "visible=\(sidebarState.isVisible ? 1 : 0)"
+                            )
 #endif
                             if let observedWindow {
-                                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+                                    for: observedWindow,
+                                    reason: "sidebar.end"
+                                )
                             }
                             sidebarDragStartWidth = nil
                         }
@@ -3095,22 +3125,40 @@ struct ContentView: View {
                 "sidebar.resize.change width=\(String(format: "%.1f", sanitized)) " +
                 "dragging=\(isResizerDragging ? 1 : 0) visible=\(sidebarState.isVisible ? 1 : 0)"
             )
+            let startWidth = sidebarDragStartWidth ?? sanitized
+            dlog(
+                "sizing.sidebar.change window=\(observedWindow?.windowNumber ?? -1) " +
+                "start=\(String(format: "%.1f", startWidth)) " +
+                "width=\(String(format: "%.1f", sanitized)) " +
+                "delta=\(String(format: "%.1f", sanitized - startWidth)) " +
+                "dragging=\(isResizerDragging ? 1 : 0) visible=\(sidebarState.isVisible ? 1 : 0)"
+            )
 #endif
             // Sidebar width changes are pure SwiftUI layout updates, so portal-hosted
             // terminals need an explicit post-layout geometry resync.
             if let observedWindow {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+                    for: observedWindow,
+                    reason: "sidebar.widthChange"
+                )
             } else {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows(
+                    reason: "sidebar.widthChange"
+                )
             }
             updateSidebarResizerBandState()
         })
 
         view = AnyView(view.onChange(of: sidebarState.isVisible) { _ in
             if let observedWindow {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+                    for: observedWindow,
+                    reason: "sidebar.visibility"
+                )
             } else {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows(
+                    reason: "sidebar.visibility"
+                )
             }
             updateSidebarResizerBandState()
             syncTrafficLightInset()
@@ -3139,7 +3187,7 @@ struct ContentView: View {
 
         view = AnyView(view.onDisappear {
             if isResizerDragging {
-                TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(reason: "sidebar")
                 isResizerDragging = false
                 sidebarDragStartWidth = nil
             }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2264,8 +2264,6 @@ struct ContentView: View {
 #endif
                     if let observedWindow {
                         TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
-                    } else {
-                        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
                     }
                 }
                 sidebarDragStartWidth = nil
@@ -2303,8 +2301,6 @@ struct ContentView: View {
 #endif
                             if let observedWindow {
                                 TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
-                            } else {
-                                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
                             }
                             sidebarDragStartWidth = nil
                         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4455,6 +4455,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var isFindEscapeSuppressionArmed = false
 #if DEBUG
     private var lastSizeSkipSignature: String?
+    private var lastSurfaceSizeApplySignature: String?
 #endif
 
     private var hasUsableFocusGeometry: Bool {
@@ -4826,6 +4827,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     "reason=nonPositive size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
                     "inWindow=\(window != nil ? 1 : 0)"
                 )
+                dlog(
+                    "sizing.surface.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=nonPositive size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                    "inWindow=\(window != nil ? 1 : 0)"
+                )
                 lastSizeSkipSignature = signature
             }
 #endif
@@ -4842,6 +4848,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
                     "inWindow=\(window != nil ? 1 : 0)"
                 )
+                dlog(
+                    "sizing.surface.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=\(deferralReason) size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                    "inWindow=\(window != nil ? 1 : 0)"
+                )
                 lastSizeSkipSignature = signature
             }
 #endif
@@ -4855,6 +4866,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 dlog(
                     "surface.size.defer surface=\(terminalSurface.id.uuidString.prefix(5)) reason=noWindow " +
                     "size=\(String(format: "%.1fx%.1f", size.width, size.height))"
+                )
+                dlog(
+                    "sizing.surface.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=noWindow size=\(String(format: "%.1fx%.1f", size.width, size.height))"
                 )
                 lastSizeSkipSignature = signature
             }
@@ -4874,6 +4889,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
                     "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
                 )
+                dlog(
+                    "sizing.surface.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=zeroBacking size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                    "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
+                )
                 lastSizeSkipSignature = signature
             }
 #endif
@@ -4883,6 +4903,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if lastSizeSkipSignature != nil {
             dlog(
                 "surface.size.resume surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
+            )
+            dlog(
+                "sizing.surface.resume surface=\(terminalSurface.id.uuidString.prefix(5)) " +
                 "size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
                 "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height))"
             )
@@ -4926,6 +4951,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             layerScale: layerScale,
             backingSize: backingSize
         )
+#if DEBUG
+        let applySignature =
+            "\(Int(size.width.rounded()))x\(Int(size.height.rounded()))-" +
+            "\(Int(backingSize.width.rounded()))x\(Int(backingSize.height.rounded()))-" +
+            "\(Int(drawablePixelSize.width.rounded()))x\(Int(drawablePixelSize.height.rounded()))-" +
+            String(format: "%.2f", layerScale)
+        if lastSurfaceSizeApplySignature != applySignature || didChange || surfaceSizeChanged {
+            dlog(
+                "sizing.surface.apply surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                "window=\(window.windowNumber) size=\(String(format: "%.1fx%.1f", size.width, size.height)) " +
+                "backing=\(String(format: "%.1fx%.1f", backingSize.width, backingSize.height)) " +
+                "drawable=\(String(format: "%.1fx%.1f", drawablePixelSize.width, drawablePixelSize.height)) " +
+                "layerScale=\(String(format: "%.2f", layerScale)) " +
+                "surfaceChanged=\(surfaceSizeChanged ? 1 : 0) drawableChanged=\(didChange ? 1 : 0) " +
+                "liveResize=\(window.inLiveResize ? 1 : 0)"
+            )
+            lastSurfaceSizeApplySignature = applySignature
+        }
+#endif
         return didChange || surfaceSizeChanged
     }
 
@@ -7656,6 +7700,18 @@ final class GhosttySurfaceScrollView: NSView {
         synchronizeScrollView()
         synchronizeSurfaceView()
         let didCoreSurfaceChange = synchronizeCoreSurface()
+#if DEBUG
+        if !sizeApproximatelyEqual(previousSurfaceSize, targetSize) || didCoreSurfaceChange {
+            let surfaceId = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+            dlog(
+                "sizing.surface.geometry surface=\(surfaceId) " +
+                "bounds=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                "previous=\(String(format: "%.1fx%.1f", previousSurfaceSize.width, previousSurfaceSize.height)) " +
+                "target=\(String(format: "%.1fx%.1f", targetSize.width, targetSize.height)) " +
+                "coreChanged=\(didCoreSurfaceChange ? 1 : 0)"
+            )
+        }
+#endif
         return !sizeApproximatelyEqual(previousSurfaceSize, targetSize) || didCoreSurfaceChange
     }
 
@@ -10040,7 +10096,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
         // the current layout turn. Re-entrant syncs here can wedge window resize
         // handling and leave the app spinning on the wait cursor.
         guard let window else { return }
-        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+            for: window,
+            reason: "ghostty.hostGeometry"
+        )
     }
 
     func makeNSView(context: Context) -> NSView {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4805,6 +4805,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func activeSurfaceResizeDeferralReason() -> String? {
+        if inLiveResize || window?.inLiveResize == true {
+            return nil
+        }
         return Self.shouldDeferSurfaceResizeForActiveDrag() ? "tabDrag" : nil
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4795,6 +4795,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // The drag pasteboard can retain tab-transfer UTIs briefly after a split command
         // or other layout churn. Only defer terminal resizes while an actual drag event
         // is in flight; otherwise pre-existing panes can stay stuck at their old size.
+        // Interactive geometry resize already has an explicit fast path for sidebar and
+        // split-divider drags. Do not let stale drag-pasteboard state suppress those updates.
+        if TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive {
+            return false
+        }
         guard hasTabDragPasteboardTypes() else { return false }
         return isDragResizeEvent(NSApp.currentEvent?.type)
     }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -7,6 +7,16 @@ import Bonsplit
 private var cmuxWindowTerminalPortalKey: UInt8 = 0
 private var cmuxWindowTerminalPortalCloseObserverKey: UInt8 = 0
 
+private func portalDebugSyncPath(
+    hostInLiveResize: Bool,
+    windowInLiveResize: Bool,
+    forceImmediate: Bool
+) -> String {
+    if forceImmediate { return "interactive" }
+    if hostInLiveResize || windowInLiveResize { return "liveResize" }
+    return "settled"
+}
+
 #if DEBUG
 private func portalDebugToken(_ view: NSView?) -> String {
     guard let view else { return "nil" }
@@ -596,6 +606,8 @@ final class WindowTerminalPortal: NSObject {
     private var hasExternalGeometrySyncScheduled = false
     private var hasPendingExternalGeometrySyncFollowUp = false
     private var pendingExternalGeometrySyncRequiresImmediate = false
+    private var scheduledExternalGeometrySyncReason = "unspecified"
+    private var pendingExternalGeometrySyncReason: String?
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
@@ -636,7 +648,7 @@ final class WindowTerminalPortal: NSObject {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.scheduleExternalGeometrySynchronize()
+                self?.scheduleExternalGeometrySynchronize(reason: "window.didResize")
             }
         })
         geometryObservers.append(center.addObserver(
@@ -645,7 +657,7 @@ final class WindowTerminalPortal: NSObject {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.scheduleExternalGeometrySynchronize()
+                self?.scheduleExternalGeometrySynchronize(reason: "window.didEndLiveResize")
             }
         })
         geometryObservers.append(center.addObserver(
@@ -658,7 +670,7 @@ final class WindowTerminalPortal: NSObject {
                       let splitView = notification.object as? NSSplitView,
                       let window = self.window,
                       splitView.window === window else { return }
-                self.scheduleExternalGeometrySynchronize()
+                self.scheduleExternalGeometrySynchronize(reason: "split.didResizeSubviews")
             }
         })
         geometryObservers.append(center.addObserver(
@@ -667,7 +679,7 @@ final class WindowTerminalPortal: NSObject {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.scheduleExternalGeometrySynchronize()
+                self?.scheduleExternalGeometrySynchronize(reason: "host.frameDidChange")
             }
         })
         geometryObservers.append(center.addObserver(
@@ -676,7 +688,7 @@ final class WindowTerminalPortal: NSObject {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.scheduleExternalGeometrySynchronize()
+                self?.scheduleExternalGeometrySynchronize(reason: "host.boundsDidChange")
             }
         })
     }
@@ -688,42 +700,82 @@ final class WindowTerminalPortal: NSObject {
         geometryObservers.removeAll()
     }
 
-    fileprivate func scheduleExternalGeometrySynchronize() {
+    fileprivate func scheduleExternalGeometrySynchronize(reason: String = "unspecified") {
         scheduleExternalGeometrySynchronize(
-            forceImmediate: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+            forceImmediate: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive,
+            reason: reason
         )
     }
 
-    fileprivate func scheduleExternalGeometrySynchronize(forceImmediate: Bool) {
+    fileprivate func scheduleExternalGeometrySynchronize(forceImmediate: Bool, reason: String = "unspecified") {
+        let hostInLiveResize = hostView.inLiveResize
+        let windowInLiveResize = window?.inLiveResize == true
+        let syncPath = portalDebugSyncPath(
+            hostInLiveResize: hostInLiveResize,
+            windowInLiveResize: windowInLiveResize,
+            forceImmediate: forceImmediate
+        )
         guard !hasExternalGeometrySyncScheduled else {
             hasPendingExternalGeometrySyncFollowUp = true
             pendingExternalGeometrySyncRequiresImmediate =
                 pendingExternalGeometrySyncRequiresImmediate || forceImmediate
 #if DEBUG
+            pendingExternalGeometrySyncReason = reason
             dlog(
                 "portal.externalGeometrySync.coalesce host=\(portalDebugToken(hostView)) " +
                 "immediate=\(forceImmediate ? 1 : 0) " +
+                "frame=\(portalDebugFrame(hostView.frame))"
+            )
+            dlog(
+                "sizing.portal.coalesce window=\(window?.windowNumber ?? -1) " +
+                "reason=\(reason) scheduledReason=\(scheduledExternalGeometrySyncReason) " +
+                "path=\(syncPath) pendingImmediate=\(pendingExternalGeometrySyncRequiresImmediate ? 1 : 0) " +
                 "frame=\(portalDebugFrame(hostView.frame))"
             )
 #endif
             return
         }
         hasExternalGeometrySyncScheduled = true
-        let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || forceImmediate)
+        let requiresSettledLayout = !(hostInLiveResize || windowInLiveResize || forceImmediate)
+#if DEBUG
+        scheduledExternalGeometrySyncReason = reason
+        dlog(
+            "sizing.portal.schedule window=\(window?.windowNumber ?? -1) " +
+            "reason=\(reason) path=\(syncPath) immediate=\(forceImmediate ? 1 : 0) " +
+            "hostLive=\(hostInLiveResize ? 1 : 0) windowLive=\(windowInLiveResize ? 1 : 0) " +
+            "interactiveSource=\(TerminalWindowPortalRegistry.debugInteractiveGeometryResizeSource()) " +
+            "frame=\(portalDebugFrame(hostView.frame))"
+        )
+#endif
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             let performSync = {
                 self.hasExternalGeometrySyncScheduled = false
-                self.synchronizeAllEntriesFromExternalGeometryChange()
+                self.synchronizeAllEntriesFromExternalGeometryChange(reason: reason)
                 if self.hasPendingExternalGeometrySyncFollowUp {
                     let followUpImmediate = self.pendingExternalGeometrySyncRequiresImmediate
+                    let followUpReason = self.pendingExternalGeometrySyncReason ?? self.scheduledExternalGeometrySyncReason
                     self.hasPendingExternalGeometrySyncFollowUp = false
                     self.pendingExternalGeometrySyncRequiresImmediate = false
+                    self.pendingExternalGeometrySyncReason = nil
+#if DEBUG
+                    dlog(
+                        "sizing.portal.followUp window=\(self.window?.windowNumber ?? -1) " +
+                        "reason=\(followUpReason) immediate=\(followUpImmediate ? 1 : 0) " +
+                        "frame=\(portalDebugFrame(self.hostView.frame))"
+                    )
+#endif
                     if !self.hasExternalGeometrySyncScheduled {
-                        self.scheduleExternalGeometrySynchronize(forceImmediate: followUpImmediate)
+                        self.scheduleExternalGeometrySynchronize(
+                            forceImmediate: followUpImmediate,
+                            reason: followUpReason
+                        )
                     }
                 } else {
                     self.pendingExternalGeometrySyncRequiresImmediate = false
+#if DEBUG
+                    self.pendingExternalGeometrySyncReason = nil
+#endif
                 }
             }
             if requiresSettledLayout {
@@ -771,15 +823,22 @@ final class WindowTerminalPortal: NSObject {
         return frameInContainer.width > 1 && frameInContainer.height > 1
     }
 
-    fileprivate func synchronizeAllEntriesFromExternalGeometryChange() {
+    fileprivate func synchronizeAllEntriesFromExternalGeometryChange(reason: String = "unspecified") {
         guard ensureInstalled() else { return }
         synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
 #if DEBUG
         dlog(
             "portal.externalGeometrySync.run host=\(portalDebugToken(hostView)) " +
+            "reason=\(reason) " +
             "frame=\(portalDebugFrame(hostView.frame)) entries=\(entriesByHostedId.count) " +
             "interactive=\(TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive ? 1 : 0)"
+        )
+        dlog(
+            "sizing.portal.run window=\(window?.windowNumber ?? -1) " +
+            "reason=\(reason) entries=\(entriesByHostedId.count) " +
+            "interactiveSource=\(TerminalWindowPortalRegistry.debugInteractiveGeometryResizeSource()) " +
+            "frame=\(portalDebugFrame(hostView.frame))"
         )
 #endif
 
@@ -1721,6 +1780,7 @@ enum TerminalWindowPortalRegistry {
 #if DEBUG
     private static var blockedBindCount: Int = 0
     private static var blockedBindReasons: [String: Int] = [:]
+    private static var lastExplicitInteractiveGeometryResizeReason: String?
 #endif
 
     static var isInteractiveGeometryResizeActive: Bool {
@@ -1730,6 +1790,19 @@ enum TerminalWindowPortalRegistry {
         if Self.interactiveGeometryResizeCount > 0 { return true }
         return isCurrentEventSplitDividerDrag()
     }
+
+#if DEBUG
+    static func debugInteractiveGeometryResizeSource() -> String {
+        if Self.isPointerDragActiveForTesting { return "test" }
+        if Self.interactiveGeometryResizeCount > 0 {
+            return Self.lastExplicitInteractiveGeometryResizeReason ?? "explicit"
+        }
+        if Self.activeSplitDividerDragWindowId != nil {
+            return "splitDivider"
+        }
+        return "none"
+    }
+#endif
 
     private static func isCurrentEventSplitDividerDrag() -> Bool {
         // Bonsplit divider drags do not participate in the explicit resize counter used by
@@ -1936,19 +2009,32 @@ enum TerminalWindowPortalRegistry {
         portal.synchronizeHostedViewForAnchor(anchorView)
     }
 
-    static func scheduleExternalGeometrySynchronize(for window: NSWindow) {
-        existingPortal(for: window)?.scheduleExternalGeometrySynchronize()
+    static func scheduleExternalGeometrySynchronize(for window: NSWindow, reason: String = "unspecified") {
+        existingPortal(for: window)?.scheduleExternalGeometrySynchronize(reason: reason)
     }
 
-    static func beginInteractiveGeometryResize() {
+    static func beginInteractiveGeometryResize(reason: String = "explicit") {
         interactiveGeometryResizeCount += 1
+#if DEBUG
+        lastExplicitInteractiveGeometryResizeReason = reason
+        dlog(
+            "sizing.resizeSession.begin reason=\(reason) count=\(interactiveGeometryResizeCount) " +
+            "splitActive=\(activeSplitDividerDragWindowId != nil ? 1 : 0)"
+        )
+#endif
     }
 
-    static func endInteractiveGeometryResize() {
+    static func endInteractiveGeometryResize(reason: String = "explicit") {
         interactiveGeometryResizeCount = max(0, interactiveGeometryResizeCount - 1)
+#if DEBUG
+        dlog("sizing.resizeSession.end reason=\(reason) count=\(interactiveGeometryResizeCount)")
+        if interactiveGeometryResizeCount == 0 {
+            lastExplicitInteractiveGeometryResizeReason = nil
+        }
+#endif
     }
 
-    static func scheduleExternalGeometrySynchronizeForAllWindows() {
+    static func scheduleExternalGeometrySynchronizeForAllWindows(reason: String = "unspecified") {
         guard !Self.hasPendingExternalGeometrySyncForAllWindows else { return }
         Self.hasPendingExternalGeometrySyncForAllWindows = true
         let isDragEvent = Self.isInteractiveGeometryResizeActive
@@ -1956,7 +2042,7 @@ enum TerminalWindowPortalRegistry {
             let performSync = {
                 Self.hasPendingExternalGeometrySyncForAllWindows = false
                 for portal in Self.portalsByWindowId.values {
-                    portal.synchronizeAllEntriesFromExternalGeometryChange()
+                    portal.synchronizeAllEntriesFromExternalGeometryChange(reason: reason)
                 }
             }
             if isDragEvent {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -594,6 +594,7 @@ final class WindowTerminalPortal: NSObject {
     private var installConstraints: [NSLayoutConstraint] = []
     private var hasDeferredFullSyncScheduled = false
     private var hasExternalGeometrySyncScheduled = false
+    private var hasPendingExternalGeometrySyncFollowUp = false
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
@@ -687,7 +688,16 @@ final class WindowTerminalPortal: NSObject {
     }
 
     fileprivate func scheduleExternalGeometrySynchronize() {
-        guard !hasExternalGeometrySyncScheduled else { return }
+        guard !hasExternalGeometrySyncScheduled else {
+            hasPendingExternalGeometrySyncFollowUp = true
+#if DEBUG
+            dlog(
+                "portal.externalGeometrySync.coalesce host=\(portalDebugToken(hostView)) " +
+                "frame=\(portalDebugFrame(hostView.frame))"
+            )
+#endif
+            return
+        }
         hasExternalGeometrySyncScheduled = true
         let isDragEvent = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
         let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || isDragEvent)
@@ -696,6 +706,12 @@ final class WindowTerminalPortal: NSObject {
             let performSync = {
                 self.hasExternalGeometrySyncScheduled = false
                 self.synchronizeAllEntriesFromExternalGeometryChange()
+                if self.hasPendingExternalGeometrySyncFollowUp {
+                    self.hasPendingExternalGeometrySyncFollowUp = false
+                    if !self.hasExternalGeometrySyncScheduled {
+                        self.scheduleExternalGeometrySynchronize()
+                    }
+                }
             }
             if requiresSettledLayout {
                 DispatchQueue.main.async(execute: performSync)
@@ -746,13 +762,27 @@ final class WindowTerminalPortal: NSObject {
         guard ensureInstalled() else { return }
         synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
+#if DEBUG
+        dlog(
+            "portal.externalGeometrySync.run host=\(portalDebugToken(hostView)) " +
+            "frame=\(portalDebugFrame(hostView.frame)) entries=\(entriesByHostedId.count) " +
+            "interactive=\(TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive ? 1 : 0)"
+        )
+#endif
 
         // During live resize, AppKit can deliver frame churn where host/container geometry
         // settles a tick before the terminal's own scroll/surface hierarchy. Only force an
         // in-place surface refresh when reconciliation actually changed terminal geometry.
         for entry in entriesByHostedId.values {
             guard let hostedView = entry.hostedView, !hostedView.isHidden else { continue }
-            if hostedView.reconcileGeometryNow() {
+            let didChange = hostedView.reconcileGeometryNow()
+#if DEBUG
+            dlog(
+                "portal.externalGeometrySync.entry surface=\(hostedView.debugSurfaceId?.uuidString.prefix(5) ?? "nil") " +
+                "frame=\(portalDebugFrame(hostedView.frame)) changed=\(didChange ? 1 : 0)"
+            )
+#endif
+            if didChange {
                 hostedView.refreshSurfaceNow(reason: "portal.externalGeometrySync")
             }
         }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -165,6 +165,10 @@ final class WindowTerminalHostView: NSView {
             if let kind = splitDividerCursorKind(at: point) {
                 activeDividerCursorKind = kind
                 kind.cursor.set()
+                TerminalWindowPortalRegistry.noteSplitDividerInteraction(
+                    in: window,
+                    eventType: currentEvent?.type
+                )
                 return nil
             }
 
@@ -1807,12 +1811,21 @@ enum TerminalWindowPortalRegistry {
     private static func isCurrentEventSplitDividerDrag() -> Bool {
         // Bonsplit divider drags do not participate in the explicit resize counter used by
         // sidebar drags, but they should still get immediate portal geometry synchronization.
-        guard let event = NSApp.currentEvent else { return false }
         let isLeftButtonDown = (NSEvent.pressedMouseButtons & 1) != 0
         guard isLeftButtonDown else {
             activeSplitDividerDragWindowId = nil
             return false
         }
+
+        if let activeSplitDividerDragWindowId {
+            let hasActiveWindow = NSApp.windows.contains { ObjectIdentifier($0) == activeSplitDividerDragWindowId }
+            if hasActiveWindow {
+                return true
+            }
+            Self.activeSplitDividerDragWindowId = nil
+        }
+
+        guard let event = NSApp.currentEvent else { return false }
 
         switch event.type {
         case .leftMouseUp:
@@ -1844,6 +1857,18 @@ enum TerminalWindowPortalRegistry {
         }
 
         return false
+    }
+
+    fileprivate static func noteSplitDividerInteraction(in window: NSWindow?, eventType: NSEvent.EventType?) {
+        guard let window else { return }
+        guard (NSEvent.pressedMouseButtons & 1) != 0 else { return }
+
+        switch eventType {
+        case .leftMouseDown, .leftMouseDragged:
+            activeSplitDividerDragWindowId = ObjectIdentifier(window)
+        default:
+            break
+        }
     }
 
     private static func currentSplitDividerDragCandidateWindows(for event: NSEvent) -> [NSWindow] {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -337,7 +337,7 @@ final class WindowTerminalHostView: NSView {
         return nil
     }
 
-    static func hasSplitDivider(atScreenPoint screenPoint: NSPoint, in window: NSWindow) -> Bool {
+    fileprivate static func hasSplitDivider(atScreenPoint screenPoint: NSPoint, in window: NSWindow) -> Bool {
         guard let rootView = window.contentView else { return false }
         let windowPoint = window.convertPoint(fromScreen: screenPoint)
         return dividerCursorKind(at: windowPoint, in: rootView) != nil
@@ -595,6 +595,7 @@ final class WindowTerminalPortal: NSObject {
     private var hasDeferredFullSyncScheduled = false
     private var hasExternalGeometrySyncScheduled = false
     private var hasPendingExternalGeometrySyncFollowUp = false
+    private var pendingExternalGeometrySyncRequiresImmediate = false
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
@@ -688,29 +689,41 @@ final class WindowTerminalPortal: NSObject {
     }
 
     fileprivate func scheduleExternalGeometrySynchronize() {
+        scheduleExternalGeometrySynchronize(
+            forceImmediate: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+        )
+    }
+
+    fileprivate func scheduleExternalGeometrySynchronize(forceImmediate: Bool) {
         guard !hasExternalGeometrySyncScheduled else {
             hasPendingExternalGeometrySyncFollowUp = true
+            pendingExternalGeometrySyncRequiresImmediate =
+                pendingExternalGeometrySyncRequiresImmediate || forceImmediate
 #if DEBUG
             dlog(
                 "portal.externalGeometrySync.coalesce host=\(portalDebugToken(hostView)) " +
+                "immediate=\(forceImmediate ? 1 : 0) " +
                 "frame=\(portalDebugFrame(hostView.frame))"
             )
 #endif
             return
         }
         hasExternalGeometrySyncScheduled = true
-        let isDragEvent = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
-        let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || isDragEvent)
+        let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || forceImmediate)
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             let performSync = {
                 self.hasExternalGeometrySyncScheduled = false
                 self.synchronizeAllEntriesFromExternalGeometryChange()
                 if self.hasPendingExternalGeometrySyncFollowUp {
+                    let followUpImmediate = self.pendingExternalGeometrySyncRequiresImmediate
                     self.hasPendingExternalGeometrySyncFollowUp = false
+                    self.pendingExternalGeometrySyncRequiresImmediate = false
                     if !self.hasExternalGeometrySyncScheduled {
-                        self.scheduleExternalGeometrySynchronize()
+                        self.scheduleExternalGeometrySynchronize(forceImmediate: followUpImmediate)
                     }
+                } else {
+                    self.pendingExternalGeometrySyncRequiresImmediate = false
                 }
             }
             if requiresSettledLayout {
@@ -1704,6 +1717,7 @@ enum TerminalWindowPortalRegistry {
     private static var hostedToWindowId: [ObjectIdentifier: ObjectIdentifier] = [:]
     private static var hasPendingExternalGeometrySyncForAllWindows = false
     private static var interactiveGeometryResizeCount = 0
+    private static var activeSplitDividerDragWindowId: ObjectIdentifier?
 #if DEBUG
     private static var blockedBindCount: Int = 0
     private static var blockedBindReasons: [String: Int] = [:]
@@ -1721,16 +1735,45 @@ enum TerminalWindowPortalRegistry {
         // Bonsplit divider drags do not participate in the explicit resize counter used by
         // sidebar drags, but they should still get immediate portal geometry synchronization.
         guard let event = NSApp.currentEvent else { return false }
+        let isLeftButtonDown = (NSEvent.pressedMouseButtons & 1) != 0
+        guard isLeftButtonDown else {
+            activeSplitDividerDragWindowId = nil
+            return false
+        }
+
         switch event.type {
-        case .leftMouseDragged:
+        case .leftMouseUp:
+            activeSplitDividerDragWindowId = nil
+            return false
+        default:
+            break
+        }
+
+        let candidateWindows = currentSplitDividerDragCandidateWindows(for: event)
+        if let activeSplitDividerDragWindowId,
+           candidateWindows.contains(where: { ObjectIdentifier($0) == activeSplitDividerDragWindowId }) {
+            return true
+        }
+
+        switch event.type {
+        case .leftMouseDown, .leftMouseDragged:
             break
         default:
             return false
         }
 
-        guard (NSEvent.pressedMouseButtons & 1) != 0 else { return false }
-
         let mouseLocation = NSEvent.mouseLocation
+        for window in candidateWindows {
+            if WindowTerminalHostView.hasSplitDivider(atScreenPoint: mouseLocation, in: window) {
+                activeSplitDividerDragWindowId = ObjectIdentifier(window)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private static func currentSplitDividerDragCandidateWindows(for event: NSEvent) -> [NSWindow] {
         var candidateWindows: [NSWindow] = []
         if let eventWindow = event.window {
             candidateWindows.append(eventWindow)
@@ -1741,14 +1784,7 @@ enum TerminalWindowPortalRegistry {
         if let mainWindow = NSApp.mainWindow, !candidateWindows.contains(where: { $0 === mainWindow }) {
             candidateWindows.append(mainWindow)
         }
-
-        for window in candidateWindows {
-            if WindowTerminalHostView.hasSplitDivider(atScreenPoint: mouseLocation, in: window) {
-                return true
-            }
-        }
-
-        return false
+        return candidateWindows
     }
 
     private static func bindBlockReason(

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -337,6 +337,12 @@ final class WindowTerminalHostView: NSView {
         return nil
     }
 
+    static func hasSplitDivider(atScreenPoint screenPoint: NSPoint, in window: NSWindow) -> Bool {
+        guard let rootView = window.contentView else { return false }
+        let windowPoint = window.convertPoint(fromScreen: screenPoint)
+        return dividerCursorKind(at: windowPoint, in: rootView) != nil
+    }
+
     private static func collectSplitDividerRegions(in view: NSView, into result: inout [DividerRegion]) {
         guard !view.isHidden else { return }
 
@@ -1677,7 +1683,42 @@ enum TerminalWindowPortalRegistry {
 #if DEBUG
         if Self.isPointerDragActiveForTesting { return true }
 #endif
-        return Self.interactiveGeometryResizeCount > 0
+        if Self.interactiveGeometryResizeCount > 0 { return true }
+        return isCurrentEventSplitDividerDrag()
+    }
+
+    private static func isCurrentEventSplitDividerDrag() -> Bool {
+        // Bonsplit divider drags do not participate in the explicit resize counter used by
+        // sidebar drags, but they should still get immediate portal geometry synchronization.
+        guard let event = NSApp.currentEvent else { return false }
+        switch event.type {
+        case .leftMouseDragged:
+            break
+        default:
+            return false
+        }
+
+        guard (NSEvent.pressedMouseButtons & 1) != 0 else { return false }
+
+        let mouseLocation = NSEvent.mouseLocation
+        var candidateWindows: [NSWindow] = []
+        if let eventWindow = event.window {
+            candidateWindows.append(eventWindow)
+        }
+        if let keyWindow = NSApp.keyWindow, !candidateWindows.contains(where: { $0 === keyWindow }) {
+            candidateWindows.append(keyWindow)
+        }
+        if let mainWindow = NSApp.mainWindow, !candidateWindows.contains(where: { $0 === mainWindow }) {
+            candidateWindows.append(mainWindow)
+        }
+
+        for window in candidateWindows {
+            if WindowTerminalHostView.hasSplitDivider(atScreenPoint: mouseLocation, in: window) {
+                return true
+            }
+        }
+
+        return false
     }
 
     private static func bindBlockReason(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3171,6 +3171,100 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testCoalescedWindowScopedDragSyncKeepsImmediateFollowUpAfterDragEnds() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let shiftedContainer = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        contentView.addSubview(shiftedContainer)
+        let anchor = NSView(frame: shiftedContainer.bounds)
+        anchor.autoresizingMask = [.width, .height]
+        shiftedContainer.addSubview(anchor)
+
+        let hosted = surface.hostedView
+        TerminalWindowPortalRegistry.bind(
+            hostedView: hosted,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        realizeWindowLayout(window)
+
+        let originalAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+
+#if DEBUG
+        TerminalWindowPortalRegistry.isPointerDragActiveForTesting = true
+        defer {
+            TerminalWindowPortalRegistry.isPointerDragActiveForTesting = false
+        }
+#endif
+
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        DispatchQueue.main.async {
+            shiftedContainer.frame.origin.x += 72
+            shiftedContainer.frame.size.width -= 72
+            contentView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+        }
+#if DEBUG
+        TerminalWindowPortalRegistry.isPointerDragActiveForTesting = false
+#endif
+
+        drainMainQueue()
+
+        let shiftedAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        let retiredStaleWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.minX + shiftedAnchorFrameInWindow.minX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+        let shiftedWindowPoint = NSPoint(
+            x: (originalAnchorFrameInWindow.maxX + shiftedAnchorFrameInWindow.maxX) / 2,
+            y: shiftedAnchorFrameInWindow.midY
+        )
+
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(retiredStaleWindowPoint, in: window),
+            "After the first queue drain, the coalesced follow-up should still be pending"
+        )
+        XCTAssertNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
+            "The shifted portal location should not be visible until the coalesced follow-up runs"
+        )
+
+        drainMainQueue()
+
+        XCTAssertNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(retiredStaleWindowPoint, in: window),
+            "The coalesced follow-up should stay on the immediate drag path even after the drag flag clears"
+        )
+        XCTAssertNotNil(
+            TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
+            "The coalesced follow-up should move the hosted terminal on the next queue turn"
+        )
+    }
+
     func testWindowScopedExternalGeometrySyncDoesNotRefreshOtherWindows() {
         let firstWindow = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3171,7 +3171,8 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
-    func testCoalescedWindowScopedDragSyncKeepsImmediateFollowUpAfterDragEnds() {
+    func testCoalescedWindowScopedDragSyncKeepsImmediateFollowUpAfterDragEnds() throws {
+#if DEBUG
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 760, height: 420),
             styleMask: [.titled, .closable],
@@ -3213,24 +3214,19 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
 
         let originalAnchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
 
-#if DEBUG
         TerminalWindowPortalRegistry.isPointerDragActiveForTesting = true
         defer {
             TerminalWindowPortalRegistry.isPointerDragActiveForTesting = false
         }
-#endif
 
         TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
         TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
         DispatchQueue.main.async {
             shiftedContainer.frame.origin.x += 72
-            shiftedContainer.frame.size.width -= 72
             contentView.layoutSubtreeIfNeeded()
             window.displayIfNeeded()
         }
-#if DEBUG
         TerminalWindowPortalRegistry.isPointerDragActiveForTesting = false
-#endif
 
         drainMainQueue()
 
@@ -3263,6 +3259,9 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             TerminalWindowPortalRegistry.terminalViewAtWindowPoint(shiftedWindowPoint, in: window),
             "The coalesced follow-up should move the hosted terminal on the next queue turn"
         )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
     }
 
     func testWindowScopedExternalGeometrySyncDoesNotRefreshOtherWindows() {


### PR DESCRIPTION
## Summary
- treat active split divider drags as interactive geometry resizes in the terminal portal registry
- keep Ghostty surface size updates flowing during pane drags instead of waiting for settled layout
- document the upstream finding in the PR context: Ghostty already supports fluid resize, the gap was cmux's pane-drag sync path

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag task-resize-ghostty-during-live-resize

## Task
- User request: resize Ghostty terminal sizes live while resizing panes, the sidebar, and the window
- Upstream reference: https://github.com/ghostty-org/ghostty/blob/12458e3ace41123899d48729dcf32ef58caf5160/macos/Sources/Ghostty/Surface%20View/SurfaceView.swift#L605-L636
- Upstream reference: https://github.com/ghostty-org/ghostty/blob/12458e3ace41123899d48729dcf32ef58caf5160/macos/Sources/Ghostty/Surface%20View/SurfaceView_AppKit.swift#L476-L484
- Upstream reference: https://github.com/ghostty-org/ghostty/blob/12458e3ace41123899d48729dcf32ef58caf5160/src/Surface.zig#L2423-L2455

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable live resizing of `Ghostty` terminal surfaces during split-divider, sidebar, and window drags, and during AppKit live resize. Geometry streams continuously, with final adjustments applied immediately after drag end or cancel.

- **New Features**
  - Stream geometry updates during drags/live resize; schedule on window, split, and host frame/bounds changes.
  - Auto-detect split-divider drags via hit-testing across current/key/main windows and treat them as interactive resizes.

- **Bug Fixes**
  - Trigger external syncs on sidebar start/end/cancel and on width/visibility changes; keep an immediate follow-up after drag ends.
  - Do not defer `Ghostty` surface resizes due to drag pasteboard while an interactive or live resize is active.
  - Keep coalesced window-scoped syncs on the immediate path even if the drag flag clears between queue turns.

<sup>Written for commit 6e6e26fd51511fb0a9526094befebac18d79f9b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Split-divider drags and pointer hits are now reliably detected; interactive resize state includes split-divider drags.
  * Sidebar resizer cancel/end now trigger proper geometry synchronization.

* **Performance / Sync**
  * External geometry syncs coalesce follow-ups and support immediate-follow-up semantics to reduce redundant work and races.
  * Sync calls now include contextual reasons for clearer coordination.

* **Debug / Logging**
  * Improved debug logging around resize lifecycle, sidebar changes, and surface sizing.

* **Tests**
  * Added regression test for coalesced window-scoped drag sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->