### PR TITLE
Fix Cmd+B sidebar toggle geometry jank

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2083,6 +2083,22 @@ struct ContentView: View {
         Self.clampedSidebarWidth(candidate, maximumWidth: maxSidebarWidth())
     }
 
+    private func scheduleSidebarPortalGeometrySynchronize() {
+        guard let observedWindow else {
+            TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+            return
+        }
+
+        if TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive {
+            TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+        } else {
+            // Sidebar show/hide and non-drag width changes are known local layout
+            // mutations. Promote the portal sync to the next turn so the hosted
+            // terminal snaps to final geometry before slower external syncs land.
+            TerminalWindowPortalRegistry.schedulePostLayoutGeometrySynchronize(for: observedWindow)
+        }
+    }
+
     private func activateSidebarResizerCursor() {
         sidebarResizerCursorReleaseWorkItem?.cancel()
         sidebarResizerCursorReleaseWorkItem = nil
@@ -3074,20 +3090,12 @@ struct ContentView: View {
             }
             // Sidebar width changes are pure SwiftUI layout updates, so portal-hosted
             // terminals need an explicit post-layout geometry resync.
-            if let observedWindow {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
-            } else {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
-            }
+            scheduleSidebarPortalGeometrySynchronize()
             updateSidebarResizerBandState()
         })
 
         view = AnyView(view.onChange(of: sidebarState.isVisible) { _ in
-            if let observedWindow {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
-            } else {
-                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
-            }
+            scheduleSidebarPortalGeometrySynchronize()
             updateSidebarResizerBandState()
             syncTrafficLightInset()
         })

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -699,6 +699,10 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
+    fileprivate func schedulePostLayoutGeometrySynchronize() {
+        scheduleExternalGeometrySynchronize()
+    }
+
     private func synchronizeLayoutHierarchy() {
         installedContainerView?.layoutSubtreeIfNeeded()
         installedReferenceView?.layoutSubtreeIfNeeded()
@@ -1831,6 +1835,10 @@ enum TerminalWindowPortalRegistry {
 
     static func scheduleExternalGeometrySynchronize(for window: NSWindow) {
         existingPortal(for: window)?.scheduleExternalGeometrySynchronize()
+    }
+
+    static func schedulePostLayoutGeometrySynchronize(for window: NSWindow) {
+        existingPortal(for: window)?.schedulePostLayoutGeometrySynchronize()
     }
 
     static func beginInteractiveGeometryResize() {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -587,7 +587,8 @@ final class WindowTerminalPortal: NSObject {
     private weak var installedReferenceView: NSView?
     private var installConstraints: [NSLayoutConstraint] = []
     private var hasDeferredFullSyncScheduled = false
-    private var hasExternalGeometrySyncScheduled = false
+    private var pendingGeometrySyncAsyncTurns: Int?
+    private var pendingGeometrySyncSequence: UInt64 = 0
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
@@ -680,27 +681,43 @@ final class WindowTerminalPortal: NSObject {
         geometryObservers.removeAll()
     }
 
-    fileprivate func scheduleExternalGeometrySynchronize() {
-        guard !hasExternalGeometrySyncScheduled else { return }
-        hasExternalGeometrySyncScheduled = true
-        let isDragEvent = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
-        let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || isDragEvent)
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            let performSync = {
-                self.hasExternalGeometrySyncScheduled = false
+    private func scheduleGeometrySynchronize(afterAsyncTurns asyncTurns: Int) {
+        let requestedTurns = max(1, asyncTurns)
+        if let pendingTurns = pendingGeometrySyncAsyncTurns,
+           pendingTurns <= requestedTurns {
+            return
+        }
+
+        pendingGeometrySyncAsyncTurns = requestedTurns
+        pendingGeometrySyncSequence &+= 1
+        let sequence = pendingGeometrySyncSequence
+
+        func scheduleRemainingTurns(_ remainingTurns: Int) {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard self.pendingGeometrySyncSequence == sequence else { return }
+
+                if remainingTurns > 1 {
+                    scheduleRemainingTurns(remainingTurns - 1)
+                    return
+                }
+
+                self.pendingGeometrySyncAsyncTurns = nil
                 self.synchronizeAllEntriesFromExternalGeometryChange()
             }
-            if requiresSettledLayout {
-                DispatchQueue.main.async(execute: performSync)
-            } else {
-                performSync()
-            }
         }
+
+        scheduleRemainingTurns(requestedTurns)
+    }
+
+    fileprivate func scheduleExternalGeometrySynchronize() {
+        let isDragEvent = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+        let requiresSettledLayout = !(hostView.inLiveResize || window?.inLiveResize == true || isDragEvent)
+        scheduleGeometrySynchronize(afterAsyncTurns: requiresSettledLayout ? 2 : 1)
     }
 
     fileprivate func schedulePostLayoutGeometrySynchronize() {
-        scheduleExternalGeometrySynchronize()
+        scheduleGeometrySynchronize(afterAsyncTurns: 1)
     }
 
     private func synchronizeLayoutHierarchy() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3171,6 +3171,88 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testPostLayoutSidebarGeometrySyncPromotesShiftAndResizeIntoFirstPass() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let shiftedContainer = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        contentView.addSubview(shiftedContainer)
+        let anchor = NSView(frame: shiftedContainer.bounds)
+        anchor.autoresizingMask = [.width, .height]
+        shiftedContainer.addSubview(anchor)
+
+        let hosted = surface.hostedView
+        TerminalWindowPortalRegistry.bind(
+            hostedView: hosted,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        realizeWindowLayout(window)
+        let originalHostedFrame = hosted.frame
+
+        shiftedContainer.frame.origin.x += 72
+        shiftedContainer.frame.size.width -= 72
+        contentView.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        // Host geometry observers take the conservative external path. Sidebar
+        // visibility changes should promote that to a next-turn post-layout sync.
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        TerminalWindowPortalRegistry.schedulePostLayoutGeometrySynchronize(for: window)
+
+        drainMainQueue()
+
+        let firstPassHostedFrame = hosted.frame
+        XCTAssertGreaterThan(
+            firstPassHostedFrame.minX,
+            originalHostedFrame.minX + 1,
+            "Sidebar visibility changes should shift the hosted terminal on the first promoted sync pass"
+        )
+        XCTAssertLessThan(
+            firstPassHostedFrame.width,
+            originalHostedFrame.width - 1,
+            "Sidebar visibility changes should resize the hosted terminal on the first promoted sync pass"
+        )
+
+        drainMainQueue()
+
+        let secondPassHostedFrame = hosted.frame
+        XCTAssertEqual(
+            secondPassHostedFrame.minX,
+            firstPassHostedFrame.minX,
+            accuracy: 0.5,
+            "Promoted sidebar geometry sync should not land a second delayed horizontal terminal shift"
+        )
+        XCTAssertEqual(
+            secondPassHostedFrame.width,
+            firstPassHostedFrame.width,
+            accuracy: 0.5,
+            "Promoted sidebar geometry sync should not land a second delayed terminal resize"
+        )
+    }
+
     func testWindowScopedExternalGeometrySyncDoesNotRefreshOtherWindows() {
         let firstWindow = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420),


### PR DESCRIPTION
## Summary
- add a regression test for the Cmd+B sidebar-toggle portal jank
- promote known sidebar layout changes to the first post-layout terminal portal sync so origin and width update together

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-cmd-b-sidebar-jank`

## Task
- Cmd+B sidebar jank investigation from the user-provided frame-by-frame capture


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes geometry jank when toggling the sidebar with Cmd+B by promoting portal geometry sync to the first post-layout pass so the terminal’s origin and width update together. Adds a regression test to prevent the double-shift/resize behavior.

- **Bug Fixes**
  - Route sidebar show/hide and width changes through a new post-layout sync path in `ContentView` to avoid delayed external syncs.
  - Introduce turn-based geometry scheduling in `TerminalWindowPortal` with async-turn coalescing and sequence gating to prevent redundant or late syncs.
  - Add `schedulePostLayoutGeometrySynchronize` and refine `scheduleExternalGeometrySynchronize` to choose 1 vs 2 async turns based on resize state.
  - Add regression test `testPostLayoutSidebarGeometrySyncPromotesShiftAndResizeIntoFirstPass` to verify first-pass shift/resize and no second-pass drift.

<sup>Written for commit 429088359c9d6ee5243e38a39798df118591b9a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of window layout updates when toggling sidebar visibility or resizing.

* **Refactor**
  * Enhanced internal geometry synchronization mechanism to better handle sidebar-driven layout updates, ensuring proper frame positioning and preventing redundant layout recalculations.

* **Tests**
  * Added test coverage for post-layout geometry synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->