### PR TITLE
Skip quit confirmation for tagged DEV builds

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2706,7 +2706,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
 
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
-        if SocketControlSettings.launchTag() != nil {
+        if SocketControlSettings.isTaggedDevBuild() {
             return .terminateNow
         }
 
@@ -9011,7 +9011,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func handleQuitShortcutWarning() -> Bool {
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
-        if SocketControlSettings.launchTag() != nil {
+        if SocketControlSettings.isTaggedDevBuild() {
             NSApp.terminate(nil)
             return true
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2705,6 +2705,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
 
+        // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
+        if SocketControlSettings.launchTag() != nil {
+            return .terminateNow
+        }
+
         // If the user already confirmed via the Cmd+Q shortcut warning dialog
         // (handleQuitShortcutWarning), skip the check to avoid a second alert.
         if isQuitWarningConfirmed {
@@ -9005,6 +9010,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func handleQuitShortcutWarning() -> Bool {
+        // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
+        if SocketControlSettings.launchTag() != nil {
+            NSApp.terminate(nil)
+            return true
+        }
+
         if !QuitWarningSettings.isEnabled() {
             NSApp.terminate(nil)
             return true

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -533,6 +533,12 @@ struct SocketControlSettings {
             || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
     }
 
+    /// Tagged DEV builds have bundle IDs like `com.cmuxterm.app.debug.<tag>`.
+    static func isTaggedDevBuild(bundleIdentifier: String? = Bundle.main.bundleIdentifier) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier.hasPrefix("\(baseDebugBundleIdentifier).")
+    }
+
     static func taggedDebugSocketPath(
         bundleIdentifier: String?,
         environment: [String: String]


### PR DESCRIPTION
## Summary
- Tagged DEV builds (`cmux DEV <tag>`) now quit immediately without showing the "Quit cmux?" confirmation dialog
- Checks `SocketControlSettings.launchTag()` in both `applicationShouldTerminate` and `handleQuitShortcutWarning`

## Testing
- Built tagged DEV: `./scripts/reload.sh --tag skip-quit-confirm` (compiles clean)
- Behavioral: launch a tagged build, Cmd+Q should quit instantly with no dialog

## Related
- Task: https://github.com/manaflow-ai/cmux/issues/2286

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tagged DEV builds (`cmux DEV <tag>`) now quit immediately without the "Quit cmux?" dialog in both `applicationShouldTerminate` and Cmd+Q flows. Detection uses the bundle ID (`com.cmuxterm.app.debug.<tag>`) via `SocketControlSettings.isTaggedDevBuild()` so it works when launched outside `reload.sh`; closes #2286.

<sup>Written for commit eebea47f0c707347ec941de656c05e2a82a49d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chore**
  * Development-tagged builds now bypass quit confirmation flows and terminate immediately, streamlining shutdown during testing by removing warning dialogs and manual confirmation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->