### PR TITLE
Add Factory Droid hook integration

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1476,18 +1476,49 @@ struct CMUXCLI {
         // Codex hooks management (no socket needed)
         if command == "codex" {
             let sub = commandArgs.first?.lowercased() ?? "help"
-            if sub == "install-hooks" {
+            if sub == "help" || sub == "--help" || sub == "-h" {
+                print(subcommandUsage("codex") ?? "Usage: cmux codex <install-hooks|uninstall-hooks>")
+                return
+            } else if sub == "install-hooks" {
                 try runCodexInstallHooks()
                 return
             } else if sub == "uninstall-hooks" {
                 try runCodexUninstallHooks()
                 return
+            } else {
+                throw CLIError(message: "Unknown codex subcommand: \(sub). Usage: cmux codex <install-hooks|uninstall-hooks>")
+            }
+        }
+
+        // Droid hooks management (no socket needed)
+        if command == "droid" {
+            let sub = commandArgs.first?.lowercased() ?? "help"
+            if sub == "help" || sub == "--help" || sub == "-h" {
+                print(subcommandUsage("droid") ?? "Usage: cmux droid <install-hooks|uninstall-hooks>")
+                return
+            } else if sub == "install-hooks" {
+                try runDroidInstallHooks()
+                return
+            } else if sub == "uninstall-hooks" {
+                try runDroidUninstallHooks()
+                return
+            } else {
+                throw CLIError(message: "Unknown droid subcommand: \(sub). Usage: cmux droid <install-hooks|uninstall-hooks>")
             }
         }
 
         // Codex hook handler: gracefully no-op when not inside cmux
         // (before socket connection, so it doesn't fail when no socket exists)
         if command == "codex-hook" {
+            guard ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil else {
+                print("{}")
+                return
+            }
+        }
+
+        // Droid hook handler: gracefully no-op when not inside cmux
+        // (before socket connection, so it doesn't fail when no socket exists)
+        if command == "droid-hook" {
             guard ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil else {
                 print("{}")
                 return
@@ -2288,6 +2319,17 @@ struct CMUXCLI {
             } catch {
                 cliTelemetry.breadcrumb("codex-hook.failure")
                 cliTelemetry.captureError(stage: "codex_hook_dispatch", error: error)
+                throw error
+            }
+
+        case "droid-hook":
+            cliTelemetry.breadcrumb("droid-hook.dispatch")
+            do {
+                try runDroidHook(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
+                cliTelemetry.breadcrumb("droid-hook.completed")
+            } catch {
+                cliTelemetry.breadcrumb("droid-hook.failure")
+                cliTelemetry.captureError(stage: "droid_hook_dispatch", error: error)
                 throw error
             }
 
@@ -7169,6 +7211,34 @@ struct CMUXCLI {
               --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
               --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
             """
+        case "droid":
+            return """
+            Usage: cmux droid <install-hooks|uninstall-hooks>
+
+            Manage Factory Droid hooks integration.
+
+            Subcommands:
+              install-hooks     Install cmux hooks into ~/.factory/settings.json
+              uninstall-hooks   Remove cmux hooks from ~/.factory/settings.json
+            """
+        case "droid-hook":
+            return """
+            Usage: cmux droid-hook <session-start|notification|prompt-submit|stop|session-end> [flags]
+
+            Hook for Factory Droid integration. Reads JSON from stdin.
+            Gracefully no-ops when not running inside cmux.
+
+            Subcommands:
+              session-start   Register a Droid session
+              notification    Forward a Droid notification / attention request
+              prompt-submit   Set Running status on user prompt
+              stop            Send completion notification, set Idle
+              session-end     Clear final status/notifications on teardown
+
+            Flags:
+              --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
+              --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
+            """
         case "browser":
             return """
             Usage: cmux browser [--surface <id|ref|index> | <surface>] <subcommand> [args]
@@ -11145,9 +11215,10 @@ struct CMUXCLI {
                 )
 
                 // Update session with transcript summary and send completion notification.
-                let completion = summarizeClaudeHookStop(
+                let completion = summarizeHookStop(
                     parsedInput: parsedInput,
-                    sessionRecord: mappedSession
+                    sessionRecord: mappedSession,
+                    defaultCompletionBody: "Claude session completed"
                 )
                 if let sessionId = parsedInput.sessionId, let completion {
                     try? sessionStore.upsert(
@@ -11242,7 +11313,7 @@ struct CMUXCLI {
                 )
             }
 
-            let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
+            let response = try sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
             _ = try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
@@ -11709,9 +11780,10 @@ struct CMUXCLI {
         return nil
     }
 
-    private func summarizeClaudeHookStop(
+    private func summarizeHookStop(
         parsedInput: ClaudeHookParsedInput,
-        sessionRecord: ClaudeHookSessionRecord?
+        sessionRecord: ClaudeHookSessionRecord?,
+        defaultCompletionBody: String
     ) -> (subtitle: String, body: String)? {
         let cwd = parsedInput.cwd ?? sessionRecord?.cwd
         let transcriptPath = parsedInput.transcriptPath
@@ -11739,7 +11811,7 @@ struct CMUXCLI {
         let hasContext = cwd != nil || lastMessage != nil
         guard hasContext else { return nil }
 
-        var body = "Claude session completed"
+        var body = defaultCompletionBody
         if let projectName, !projectName.isEmpty {
             body += " in \(projectName)"
         }
@@ -11823,11 +11895,47 @@ struct CMUXCLI {
             firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
             firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
         ]
-        let session = firstString(in: object, keys: ["session_id", "sessionId"])
         let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
         let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
         var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
+
+        classified.body = truncate(classified.body, maxLength: 180)
+        return classified
+    }
+
+    private func summarizeDroidHookNotification(
+        parsedInput: ClaudeHookParsedInput,
+        sessionRecord: ClaudeHookSessionRecord?
+    ) -> (subtitle: String, body: String) {
+        guard let object = parsedInput.object else {
+            if let savedBody = sessionRecord?.lastBody, !savedBody.isEmpty {
+                return (sessionRecord?.lastSubtitle ?? "Attention", savedBody)
+            }
+            return ("Attention", "Droid needs your attention")
+        }
+
+        let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
+        let signalParts = [
+            firstString(in: object, keys: ["event", "event_name", "hook_event_name", "type", "kind"]),
+            firstString(in: object, keys: ["notification_type", "matcher", "reason"]),
+            firstString(in: nested, keys: ["type", "kind", "reason"])
+        ]
+        let messageCandidates = [
+            firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
+            firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
+        ]
+        let message = messageCandidates.compactMap { $0 }.first
+            ?? sessionRecord?.lastBody
+            ?? "Droid needs your input"
+        let signal = signalParts.compactMap { $0 }.joined(separator: " ")
+        var classified = classifyClaudeNotification(signal: signal, message: normalizedSingleLine(message))
+
+        if classified.body == "Claude reported an error" {
+            classified.body = "Droid reported an error"
+        } else if classified.body == "Claude needs your attention" {
+            classified.body = "Droid needs your attention"
+        }
 
         classified.body = truncate(classified.body, maxLength: 180)
         return classified
@@ -12433,6 +12541,465 @@ struct CMUXCLI {
         _ = try client.send(command: cmd)
     }
 
+    // MARK: - Droid hooks
+
+    /// The hooks content that cmux installs into ~/.factory/settings.json.
+    /// Each hook calls `cmux droid-hook <event>` which gracefully no-ops
+    /// when not running inside cmux. The command checks for cmux on PATH
+    /// first so it silently succeeds even when cmux is not installed.
+    private static func droidHookCommand(_ event: String) -> String {
+        "[ -n \"$CMUX_SURFACE_ID\" ] && command -v cmux >/dev/null 2>&1 && cmux droid-hook \(event) || echo '{}'"
+    }
+
+    private static let droidHooksJSON: [String: Any] = [
+        "hooks": [
+            "SessionStart": [[
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("session-start"),
+                    "timeout": 10
+                ] as [String: Any]]
+            ] as [String: Any]],
+            "UserPromptSubmit": [[
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("prompt-submit"),
+                    "timeout": 10
+                ] as [String: Any]]
+            ] as [String: Any]],
+            "Notification": [[
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("notification"),
+                    "timeout": 10
+                ] as [String: Any]]
+            ] as [String: Any]],
+            "Stop": [[
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("stop"),
+                    "timeout": 10
+                ] as [String: Any]]
+            ] as [String: Any]],
+            "SessionEnd": [[
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("session-end"),
+                    "timeout": 5
+                ] as [String: Any]]
+            ] as [String: Any]]
+        ] as [String: Any]
+    ]
+
+    /// Identifier used to detect cmux-owned Droid hooks during uninstall.
+    private static let droidHookCommandMarker = "cmux droid-hook"
+
+    private func parseJSONDictionaryContent(_ content: String, path: String) throws -> [String: Any] {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [:] }
+        guard let data = trimmed.data(using: .utf8) else {
+            throw CLIError(message: "Invalid UTF-8 in \(path)")
+        }
+        let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let object = parsed as? [String: Any] else {
+            throw CLIError(message: "Expected a JSON object in \(path)")
+        }
+        return object
+    }
+
+    private func managedHookGroup(_ group: [String: Any], marker: String) -> Bool {
+        guard let groupHooks = group["hooks"] as? [[String: Any]], !groupHooks.isEmpty else {
+            return false
+        }
+        return groupHooks.allSatisfy { hook in
+            (hook["command"] as? String)?.contains(marker) == true
+        }
+    }
+
+    private func mergeManagedHooks(
+        into settings: [String: Any],
+        cmuxHooks: [String: Any],
+        marker: String
+    ) -> [String: Any] {
+        var updatedSettings = settings
+        var hooks = updatedSettings["hooks"] as? [String: Any] ?? [:]
+        let hookGroups = cmuxHooks["hooks"] as? [String: Any] ?? [:]
+
+        for (eventName, groups) in hookGroups {
+            guard let managedGroups = groups as? [[String: Any]] else { continue }
+            var eventGroups = hooks[eventName] as? [[String: Any]] ?? []
+            eventGroups.removeAll { managedHookGroup($0, marker: marker) }
+            eventGroups.append(contentsOf: managedGroups)
+            hooks[eventName] = eventGroups
+        }
+
+        if hooks.isEmpty {
+            updatedSettings.removeValue(forKey: "hooks")
+        } else {
+            updatedSettings["hooks"] = hooks
+        }
+        return updatedSettings
+    }
+
+    private func removeManagedHooks(
+        from settings: [String: Any],
+        marker: String
+    ) -> (updatedSettings: [String: Any], removedCount: Int) {
+        var updatedSettings = settings
+        guard var hooks = updatedSettings["hooks"] as? [String: Any] else {
+            return (updatedSettings, 0)
+        }
+
+        var removedCount = 0
+        for eventName in hooks.keys {
+            guard var eventGroups = hooks[eventName] as? [[String: Any]] else { continue }
+            let before = eventGroups.count
+            eventGroups.removeAll { managedHookGroup($0, marker: marker) }
+            removedCount += before - eventGroups.count
+            if eventGroups.isEmpty {
+                hooks.removeValue(forKey: eventName)
+            } else {
+                hooks[eventName] = eventGroups
+            }
+        }
+
+        if hooks.isEmpty {
+            updatedSettings.removeValue(forKey: "hooks")
+        } else {
+            updatedSettings["hooks"] = hooks
+        }
+
+        return (updatedSettings, removedCount)
+    }
+
+    private func runDroidInstallHooks() throws {
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+            || ProcessInfo.processInfo.arguments.contains("-y")
+        let homePath = ProcessInfo.processInfo.environment["HOME"]
+            ?? NSString(string: "~").expandingTildeInPath
+        let factoryHome = ProcessInfo.processInfo.environment["FACTORY_HOME"]
+            ?? (homePath as NSString).appendingPathComponent(".factory")
+        let settingsPath = (factoryHome as NSString).appendingPathComponent("settings.json")
+        let fm = FileManager.default
+
+        try fm.createDirectory(atPath: factoryHome, withIntermediateDirectories: true, attributes: nil)
+
+        let existingSettingsContent: String? = fm.fileExists(atPath: settingsPath)
+            ? (try? String(contentsOfFile: settingsPath, encoding: .utf8))
+            : nil
+        let existingSettings = try parseJSONDictionaryContent(existingSettingsContent ?? "", path: settingsPath)
+        let newSettings = mergeManagedHooks(
+            into: existingSettings,
+            cmuxHooks: Self.droidHooksJSON,
+            marker: Self.droidHookCommandMarker
+        )
+        let newJSONData = try JSONSerialization.data(withJSONObject: newSettings, options: [.prettyPrinted, .sortedKeys])
+        let newSettingsContent = String(data: newJSONData, encoding: .utf8) ?? "{}"
+
+        if existingSettingsContent == newSettingsContent {
+            print("cmux hooks are already installed. Nothing to change.")
+            return
+        }
+
+        print("  \(settingsPath):")
+        if let existingSettingsContent {
+            printSimpleDiff(old: existingSettingsContent, new: newSettingsContent)
+        } else {
+            print("    (new file)")
+            let lines = newSettingsContent.components(separatedBy: "\n")
+            for (i, line) in lines.enumerated() {
+                let lineLabel = String(format: "%3d", i + 1)
+                print("    \u{001B}[32m\(lineLabel) +\(line)\u{001B}[0m")
+            }
+        }
+        print("")
+
+        if !skipConfirm {
+            print("Apply these changes? [Y/n] ", terminator: "")
+            if let response = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+               !response.isEmpty && response != "y" && response != "yes" {
+                print("Aborted.")
+                return
+            }
+        }
+
+        try newJSONData.write(to: URL(fileURLWithPath: settingsPath), options: .atomic)
+        print("")
+        print("Installed. Hooks activate inside cmux and silently no-op elsewhere.")
+        print("To remove: cmux droid uninstall-hooks")
+    }
+
+    private func runDroidUninstallHooks() throws {
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+            || ProcessInfo.processInfo.arguments.contains("-y")
+        let homePath = ProcessInfo.processInfo.environment["HOME"]
+            ?? NSString(string: "~").expandingTildeInPath
+        let factoryHome = ProcessInfo.processInfo.environment["FACTORY_HOME"]
+            ?? (homePath as NSString).appendingPathComponent(".factory")
+        let settingsPath = (factoryHome as NSString).appendingPathComponent("settings.json")
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: settingsPath) else {
+            print("No settings.json found at \(settingsPath)")
+            return
+        }
+
+        let existingSettingsContent = try String(contentsOfFile: settingsPath, encoding: .utf8)
+        let existingSettings = try parseJSONDictionaryContent(existingSettingsContent, path: settingsPath)
+        let removal = removeManagedHooks(from: existingSettings, marker: Self.droidHookCommandMarker)
+
+        if removal.removedCount == 0 {
+            print("No cmux Droid hooks found.")
+            return
+        }
+
+        let newJSONData = try JSONSerialization.data(withJSONObject: removal.updatedSettings, options: [.prettyPrinted, .sortedKeys])
+        let newSettingsContent = String(data: newJSONData, encoding: .utf8) ?? "{}"
+
+        print("  \(settingsPath):")
+        printSimpleDiff(old: existingSettingsContent, new: newSettingsContent)
+        print("")
+
+        if !skipConfirm {
+            print("Apply these changes? [Y/n] ", terminator: "")
+            if let response = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+               !response.isEmpty && response != "y" && response != "yes" {
+                print("Aborted.")
+                return
+            }
+        }
+
+        try newJSONData.write(to: URL(fileURLWithPath: settingsPath), options: .atomic)
+        print("Removed cmux Droid hooks.")
+    }
+
+    private func runDroidHook(
+        commandArgs: [String],
+        client: SocketClient,
+        telemetry: CLISocketSentryTelemetry
+    ) throws {
+        let env = ProcessInfo.processInfo.environment
+
+        guard env["CMUX_SURFACE_ID"] != nil else {
+            print("{}")
+            return
+        }
+
+        let subcommand = commandArgs.first?.lowercased() ?? "help"
+        let hookArgs = Array(commandArgs.dropFirst())
+        let hookWsFlag = optionValue(hookArgs, name: "--workspace")
+        let workspaceArg = hookWsFlag ?? env["CMUX_WORKSPACE_ID"]
+        let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? env["CMUX_SURFACE_ID"] : nil)
+        let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let parsedInput = parseClaudeHookInput(rawInput: rawInput)
+        let statePath = env["CMUX_DROID_HOOK_STATE_PATH"] ?? "~/.cmuxterm/droid-hook-sessions.json"
+        let sessionStore = ClaudeHookSessionStore(
+            processEnv: env.merging(
+                ["CMUX_CLAUDE_HOOK_STATE_PATH": statePath],
+                uniquingKeysWith: { _, new in new }
+            )
+        )
+        telemetry.breadcrumb(
+            "droid-hook.input",
+            data: [
+                "subcommand": subcommand,
+                "has_session_id": parsedInput.sessionId != nil
+            ]
+        )
+
+        switch subcommand {
+        case "session-start":
+            telemetry.breadcrumb("droid-hook.session-start")
+            let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: nil,
+                fallback: workspaceArg,
+                client: client
+            )
+            let surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
+                preferred: nil,
+                fallback: surfaceArg,
+                workspaceId: workspaceId,
+                client: client
+            )
+            if let sessionId = parsedInput.sessionId {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: parsedInput.cwd
+                )
+            }
+            print("{}")
+
+        case "prompt-submit":
+            telemetry.breadcrumb("droid-hook.prompt-submit")
+            let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+            let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: mappedSession?.workspaceId,
+                fallback: workspaceArg,
+                client: client
+            )
+            _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+            try setDroidStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: "Running",
+                icon: "bolt.fill",
+                color: "#4C8DFF"
+            )
+            print("{}")
+
+        case "notification":
+            telemetry.breadcrumb("droid-hook.notification")
+            let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+            let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: mappedSession?.workspaceId,
+                fallback: workspaceArg,
+                client: client
+            )
+            let surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
+                preferred: mappedSession?.surfaceId,
+                fallback: surfaceArg,
+                workspaceId: workspaceId,
+                client: client
+            )
+            let summary = summarizeDroidHookNotification(
+                parsedInput: parsedInput,
+                sessionRecord: mappedSession
+            )
+
+            if let sessionId = parsedInput.sessionId {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: parsedInput.cwd,
+                    lastSubtitle: summary.subtitle,
+                    lastBody: summary.body
+                )
+            }
+
+            let payload = "Droid|\(sanitizeNotificationField(summary.subtitle))|\(sanitizeNotificationField(summary.body))"
+            let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
+            try? setDroidStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: "Needs input",
+                icon: "bell.fill",
+                color: "#4C8DFF"
+            )
+            print(response)
+
+        case "stop":
+            telemetry.breadcrumb("droid-hook.stop")
+            do {
+                let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+                let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                    preferred: mappedSession?.workspaceId,
+                    fallback: workspaceArg,
+                    client: client
+                )
+                let surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
+                    preferred: mappedSession?.surfaceId,
+                    fallback: surfaceArg,
+                    workspaceId: workspaceId,
+                    client: client
+                )
+                let completion = summarizeHookStop(
+                    parsedInput: parsedInput,
+                    sessionRecord: mappedSession,
+                    defaultCompletionBody: "Droid session completed"
+                )
+
+                if let sessionId = parsedInput.sessionId, let completion {
+                    try? sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        cwd: parsedInput.cwd,
+                        lastSubtitle: completion.subtitle,
+                        lastBody: completion.body
+                    )
+                }
+
+                if let completion {
+                    let payload = "Droid|\(sanitizeNotificationField(completion.subtitle))|\(sanitizeNotificationField(completion.body))"
+                    _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
+                }
+
+                try? setDroidStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Idle",
+                    icon: "pause.circle.fill",
+                    color: "#8E8E93"
+                )
+                print("{}")
+            } catch {
+                if shouldIgnoreClaudeHookTeardownError(error) {
+                    telemetry.breadcrumb("droid-hook.stop.ignored", data: ["error": String(describing: error)])
+                    print("{}")
+                    return
+                }
+                throw error
+            }
+
+        case "session-end":
+            telemetry.breadcrumb("droid-hook.session-end")
+            let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+            let fallbackWorkspaceId = try? resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: mappedSession?.workspaceId,
+                fallback: workspaceArg,
+                client: client
+            )
+            let fallbackSurfaceId: String? = {
+                guard let fallbackWorkspaceId else { return nil }
+                return try? resolvePreferredSurfaceIdForClaudeHook(
+                    preferred: mappedSession?.surfaceId,
+                    fallback: surfaceArg,
+                    workspaceId: fallbackWorkspaceId,
+                    client: client
+                )
+            }()
+            let consumedSession = try? sessionStore.consume(
+                sessionId: parsedInput.sessionId,
+                workspaceId: fallbackWorkspaceId,
+                surfaceId: fallbackSurfaceId
+            )
+            if let consumedSession {
+                let workspaceId = consumedSession.workspaceId
+                _ = try? clearDroidStatus(client: client, workspaceId: workspaceId)
+                _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+            }
+            print("{}")
+
+        case "help", "--help", "-h":
+            print(
+                """
+                cmux droid-hook <session-start|notification|prompt-submit|stop|session-end> [--workspace <id>] [--surface <id>]
+                """
+            )
+
+        default:
+            throw CLIError(message: "Unknown droid-hook subcommand: \(subcommand)")
+        }
+    }
+
+    private func setDroidStatus(
+        client: SocketClient,
+        workspaceId: String,
+        value: String,
+        icon: String,
+        color: String
+    ) throws {
+        let cmd = "set_status droid \(value) --icon=\(icon) --color=\(color) --tab=\(workspaceId)"
+        _ = try client.send(command: cmd)
+    }
+
+    private func clearDroidStatus(client: SocketClient, workspaceId: String) throws {
+        _ = try client.send(command: "clear_status droid --tab=\(workspaceId)")
+    }
+
     private func versionSummary() -> String {
         let info = resolvedVersionInfo()
         let commit = info["CMUXCommit"].flatMap { normalizedCommitHash($0) }
@@ -12817,6 +13384,7 @@ struct CMUXCLI {
           claude-teams [claude-args...]
           omo [opencode-args...]
           codex <install-hooks|uninstall-hooks>
+          droid <install-hooks|uninstall-hooks>
           ping
           version
           capabilities

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -366,6 +366,21 @@ private final class ClaudeHookSessionStore {
         }
     }
 
+    func sessions(workspaceId: String) throws -> [ClaudeHookSessionRecord] {
+        let normalizedWorkspaceId = normalizeSessionId(workspaceId)
+        guard !normalizedWorkspaceId.isEmpty else { return [] }
+        return try withLockedState { state in
+            state.sessions.values
+                .filter { $0.workspaceId == normalizedWorkspaceId }
+                .sorted { lhs, rhs in
+                    if lhs.updatedAt != rhs.updatedAt {
+                        return lhs.updatedAt > rhs.updatedAt
+                    }
+                    return lhs.sessionId < rhs.sessionId
+                }
+        }
+    }
+
     func upsert(
         sessionId: String,
         workspaceId: String,
@@ -7223,7 +7238,7 @@ struct CMUXCLI {
             """
         case "droid-hook":
             return """
-            Usage: cmux droid-hook <session-start|notification|prompt-submit|stop|session-end> [flags]
+            Usage: cmux droid-hook <session-start|notification|prompt-submit|pre-tool-use|stop|session-end> [flags]
 
             Hook for Factory Droid integration. Reads JSON from stdin.
             Gracefully no-ops when not running inside cmux.
@@ -7232,6 +7247,7 @@ struct CMUXCLI {
               session-start   Register a Droid session
               notification    Forward a Droid notification / attention request
               prompt-submit   Set Running status on user prompt
+              pre-tool-use    Clear waiting state when Droid resumes work
               stop            Send completion notification, set Idle when Droid fully stops
               session-end     Clear final status and stale notifications on teardown
 
@@ -12021,6 +12037,88 @@ struct CMUXCLI {
         return false
     }
 
+    private func normalizedHookSubtitle(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed.lowercased()
+    }
+
+    private func isRunningHookSubtitle(_ value: String?) -> Bool {
+        guard let normalized = normalizedHookSubtitle(value) else { return false }
+        return normalized == "running" || normalized.hasPrefix("running ")
+    }
+
+    private func isCompletedHookSubtitle(_ value: String?) -> Bool {
+        normalizedHookSubtitle(value)?.hasPrefix("completed") == true
+    }
+
+    private func isPendingDroidSession(_ session: ClaudeHookSessionRecord) -> Bool {
+        guard let normalized = normalizedHookSubtitle(session.lastSubtitle) else { return false }
+        return normalized != "running" && !normalized.hasPrefix("running ") && !normalized.hasPrefix("completed")
+    }
+
+    private func droidPendingStatusValue(for subtitle: String?) -> String {
+        guard let normalized = normalizedHookSubtitle(subtitle) else { return "Needs input" }
+        if normalized.hasPrefix("permission") {
+            return "Permission"
+        }
+        if normalized.hasPrefix("waiting") {
+            return "Waiting"
+        }
+        if normalized.hasPrefix("error") {
+            return "Error"
+        }
+        return "Needs input"
+    }
+
+    private func droidWorkspaceHasActiveSessions(_ sessions: [ClaudeHookSessionRecord]) -> Bool {
+        sessions.contains(where: { isPendingDroidSession($0) || isRunningHookSubtitle($0.lastSubtitle) })
+    }
+
+    private func synchronizeDroidWorkspaceStatus(
+        client: SocketClient,
+        workspaceId: String,
+        sessionStore: ClaudeHookSessionStore
+    ) {
+        let sessions = (try? sessionStore.sessions(workspaceId: workspaceId)) ?? []
+        if let pendingSession = sessions.first(where: { isPendingDroidSession($0) }) {
+            try? setDroidStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: droidPendingStatusValue(for: pendingSession.lastSubtitle),
+                icon: "bell.fill",
+                color: "#4C8DFF"
+            )
+            return
+        }
+
+        if sessions.contains(where: { isRunningHookSubtitle($0.lastSubtitle) }) {
+            try? setDroidStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: "Running",
+                icon: "bolt.fill",
+                color: "#4C8DFF"
+            )
+            return
+        }
+
+        if sessions.contains(where: { isCompletedHookSubtitle($0.lastSubtitle) }) {
+            try? setDroidStatus(
+                client: client,
+                workspaceId: workspaceId,
+                value: "Idle",
+                icon: "pause.circle.fill",
+                color: "#8E8E93"
+            )
+            return
+        }
+
+        _ = try? clearDroidStatus(client: client, workspaceId: workspaceId)
+    }
+
     private func normalizedSingleLine(_ value: String) -> String {
         let collapsed = value.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -12609,6 +12707,14 @@ struct CMUXCLI {
                     "timeout": 10
                 ] as [String: Any]]
             ] as [String: Any]],
+            "PreToolUse": [[
+                "matcher": "*",
+                "hooks": [[
+                    "type": "command",
+                    "command": droidHookCommand("pre-tool-use"),
+                    "timeout": 10
+                ] as [String: Any]]
+            ] as [String: Any]],
             "Notification": [[
                 "hooks": [[
                     "type": "command",
@@ -12881,14 +12987,68 @@ struct CMUXCLI {
                 fallback: workspaceArg,
                 client: client
             )
+            let surfaceId = mappedSession?.surfaceId ?? (surfaceArg ?? "")
+            if let sessionId = parsedInput.sessionId {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: parsedInput.cwd,
+                    lastSubtitle: "Running"
+                )
+            }
             _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
-            try setDroidStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Running",
-                icon: "bolt.fill",
-                color: "#4C8DFF"
+            if parsedInput.sessionId != nil {
+                synchronizeDroidWorkspaceStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    sessionStore: sessionStore
+                )
+            } else {
+                try setDroidStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Running",
+                    icon: "bolt.fill",
+                    color: "#4C8DFF"
+                )
+            }
+            print("{}")
+
+        case "pre-tool-use":
+            telemetry.breadcrumb("droid-hook.pre-tool-use")
+            let mappedSession = parsedInput.sessionId.flatMap { try? sessionStore.lookup(sessionId: $0) }
+            let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(
+                preferred: mappedSession?.workspaceId,
+                fallback: workspaceArg,
+                client: client
             )
+            let surfaceId = mappedSession?.surfaceId ?? (surfaceArg ?? "")
+            if let sessionId = parsedInput.sessionId {
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    cwd: parsedInput.cwd,
+                    lastSubtitle: "Running"
+                )
+            }
+            _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+            if parsedInput.sessionId != nil {
+                synchronizeDroidWorkspaceStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    sessionStore: sessionStore
+                )
+            } else {
+                try setDroidStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Running",
+                    icon: "bolt.fill",
+                    color: "#4C8DFF"
+                )
+            }
             print("{}")
 
         case "notification":
@@ -12923,13 +13083,21 @@ struct CMUXCLI {
 
             let payload = "Droid|\(sanitizeNotificationField(summary.subtitle))|\(sanitizeNotificationField(summary.body))"
             let response = try sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
-            try? setDroidStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Needs input",
-                icon: "bell.fill",
-                color: "#4C8DFF"
-            )
+            if parsedInput.sessionId != nil {
+                synchronizeDroidWorkspaceStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    sessionStore: sessionStore
+                )
+            } else {
+                try? setDroidStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: droidPendingStatusValue(for: summary.subtitle),
+                    icon: "bell.fill",
+                    color: "#4C8DFF"
+                )
+            }
             print(response)
 
         case "stop":
@@ -12954,19 +13122,29 @@ struct CMUXCLI {
                         sessionId: sessionId,
                         workspaceId: workspaceId,
                         surfaceId: surfaceId,
-                        cwd: parsedInput.cwd
+                        cwd: parsedInput.cwd,
+                        lastSubtitle: stopHookActive ? "Running" : "Completed"
                     )
                 }
 
                 if stopHookActive {
                     telemetry.breadcrumb("droid-hook.stop.continuing")
-                    try? setDroidStatus(
-                        client: client,
-                        workspaceId: workspaceId,
-                        value: "Running",
-                        icon: "bolt.fill",
-                        color: "#4C8DFF"
-                    )
+                    _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+                    if parsedInput.sessionId != nil {
+                        synchronizeDroidWorkspaceStatus(
+                            client: client,
+                            workspaceId: workspaceId,
+                            sessionStore: sessionStore
+                        )
+                    } else {
+                        try? setDroidStatus(
+                            client: client,
+                            workspaceId: workspaceId,
+                            value: "Running",
+                            icon: "bolt.fill",
+                            color: "#4C8DFF"
+                        )
+                    }
                     print("{}")
                     return
                 }
@@ -12988,18 +13166,27 @@ struct CMUXCLI {
                     )
                 }
 
-                if let completion {
+                let workspaceSessions = (try? sessionStore.sessions(workspaceId: workspaceId)) ?? []
+                if let completion, !droidWorkspaceHasActiveSessions(workspaceSessions) {
                     let payload = "Droid|\(sanitizeNotificationField(completion.subtitle))|\(sanitizeNotificationField(completion.body))"
                     _ = try? sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
                 }
 
-                try? setDroidStatus(
-                    client: client,
-                    workspaceId: workspaceId,
-                    value: "Idle",
-                    icon: "pause.circle.fill",
-                    color: "#8E8E93"
-                )
+                if parsedInput.sessionId != nil {
+                    synchronizeDroidWorkspaceStatus(
+                        client: client,
+                        workspaceId: workspaceId,
+                        sessionStore: sessionStore
+                    )
+                } else {
+                    try? setDroidStatus(
+                        client: client,
+                        workspaceId: workspaceId,
+                        value: "Idle",
+                        icon: "pause.circle.fill",
+                        color: "#8E8E93"
+                    )
+                }
                 print("{}")
             } catch {
                 if shouldIgnoreClaudeHookTeardownError(error) {
@@ -13034,8 +13221,17 @@ struct CMUXCLI {
             )
             if let consumedSession {
                 let workspaceId = consumedSession.workspaceId
-                _ = try? clearDroidStatus(client: client, workspaceId: workspaceId)
-                if shouldClearHookNotificationsOnSessionEnd(consumedSession) {
+                let remainingSessions = (try? sessionStore.sessions(workspaceId: workspaceId)) ?? []
+                if remainingSessions.isEmpty {
+                    _ = try? clearDroidStatus(client: client, workspaceId: workspaceId)
+                } else {
+                    synchronizeDroidWorkspaceStatus(
+                        client: client,
+                        workspaceId: workspaceId,
+                        sessionStore: sessionStore
+                    )
+                }
+                if remainingSessions.isEmpty && shouldClearHookNotificationsOnSessionEnd(consumedSession) {
                     _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
                 }
             }
@@ -13044,7 +13240,7 @@ struct CMUXCLI {
         case "help", "--help", "-h":
             print(
                 """
-                cmux droid-hook <session-start|notification|prompt-submit|stop|session-end> [--workspace <id>] [--surface <id>]
+                cmux droid-hook <session-start|notification|prompt-submit|pre-tool-use|stop|session-end> [--workspace <id>] [--surface <id>]
                 """
             )
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7233,7 +7233,7 @@ struct CMUXCLI {
               notification    Forward a Droid notification / attention request
               prompt-submit   Set Running status on user prompt
               stop            Send completion notification, set Idle
-              session-end     Clear final status/notifications on teardown
+              session-end     Clear final status and stale notifications on teardown
 
             Flags:
               --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
@@ -11928,17 +11928,25 @@ struct CMUXCLI {
         let message = messageCandidates.compactMap { $0 }.first
             ?? sessionRecord?.lastBody
             ?? "Droid needs your input"
+        let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
-        var classified = classifyClaudeNotification(signal: signal, message: normalizedSingleLine(message))
+        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
 
-        if classified.body == "Claude reported an error" {
-            classified.body = "Droid reported an error"
-        } else if classified.body == "Claude needs your attention" {
-            classified.body = "Droid needs your attention"
+        // Only rewrite classifier-generated Claude placeholder text.
+        if classified.body.hasPrefix("Claude "), classified.body != normalizedMessage {
+            classified.body = "Droid " + String(classified.body.dropFirst("Claude ".count))
         }
 
         classified.body = truncate(classified.body, maxLength: 180)
         return classified
+    }
+
+    private func shouldClearHookNotificationsOnSessionEnd(_ sessionRecord: ClaudeHookSessionRecord) -> Bool {
+        guard let lastSubtitle = sessionRecord.lastSubtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !lastSubtitle.isEmpty else {
+            return true
+        }
+        return !lastSubtitle.lowercased().hasPrefix("completed")
     }
 
     private func classifyClaudeNotification(signal: String, message: String) -> (subtitle: String, body: String) {
@@ -12880,7 +12888,7 @@ struct CMUXCLI {
             }
 
             let payload = "Droid|\(sanitizeNotificationField(summary.subtitle))|\(sanitizeNotificationField(summary.body))"
-            let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
+            let response = try sendV1Command("notify_target \(workspaceId) \(surfaceId) \(payload)", client: client)
             try? setDroidStatus(
                 client: client,
                 workspaceId: workspaceId,
@@ -12969,7 +12977,9 @@ struct CMUXCLI {
             if let consumedSession {
                 let workspaceId = consumedSession.workspaceId
                 _ = try? clearDroidStatus(client: client, workspaceId: workspaceId)
-                _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+                if shouldClearHookNotificationsOnSessionEnd(consumedSession) {
+                    _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+                }
             }
             print("{}")
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7232,7 +7232,7 @@ struct CMUXCLI {
               session-start   Register a Droid session
               notification    Forward a Droid notification / attention request
               prompt-submit   Set Running status on user prompt
-              stop            Send completion notification, set Idle
+              stop            Send completion notification, set Idle when Droid fully stops
               session-end     Clear final status and stale notifications on teardown
 
             Flags:
@@ -11987,6 +11987,40 @@ struct CMUXCLI {
         return nil
     }
 
+    private func firstBool(in object: [String: Any], keys: [String]) -> Bool? {
+        for key in keys {
+            guard let value = object[key] else { continue }
+            if let bool = value as? Bool {
+                return bool
+            }
+            if let number = value as? NSNumber {
+                return number.boolValue
+            }
+            if let string = value as? String,
+               let bool = parseBoolString(string.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return bool
+            }
+        }
+        return nil
+    }
+
+    private func isDroidStopHookContinuationActive(_ parsedInput: ClaudeHookParsedInput) -> Bool {
+        guard let object = parsedInput.object else { return false }
+        let keys = ["stop_hook_active", "stopHookActive"]
+        if let active = firstBool(in: object, keys: keys) {
+            return active
+        }
+        if let nested = object["data"] as? [String: Any],
+           let active = firstBool(in: nested, keys: keys) {
+            return active
+        }
+        if let context = object["context"] as? [String: Any],
+           let active = firstBool(in: context, keys: keys) {
+            return active
+        }
+        return false
+    }
+
     private func normalizedSingleLine(_ value: String) -> String {
         let collapsed = value.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -12913,6 +12947,30 @@ struct CMUXCLI {
                     workspaceId: workspaceId,
                     client: client
                 )
+                let stopHookActive = isDroidStopHookContinuationActive(parsedInput)
+
+                if let sessionId = parsedInput.sessionId {
+                    try? sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        cwd: parsedInput.cwd
+                    )
+                }
+
+                if stopHookActive {
+                    telemetry.breadcrumb("droid-hook.stop.continuing")
+                    try? setDroidStatus(
+                        client: client,
+                        workspaceId: workspaceId,
+                        value: "Running",
+                        icon: "bolt.fill",
+                        color: "#4C8DFF"
+                    )
+                    print("{}")
+                    return
+                }
+
                 let completion = summarizeHookStop(
                     parsedInput: parsedInput,
                     sessionRecord: mappedSession,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -130,6 +130,35 @@ Then use:
 notify = ["bash", "~/.local/bin/codex-notify.sh"]
 ```
 
+### Factory Droid
+
+Install the built-in cmux hook integration:
+
+```bash
+cmux droid install-hooks
+```
+
+This merges cmux-managed hooks into `~/.factory/settings.json` for:
+
+- `SessionStart`
+- `UserPromptSubmit`
+- `Notification`
+- `Stop`
+- `SessionEnd`
+
+The installed hooks:
+
+- map Droid `session_id` values to the current cmux workspace/surface
+- set sidebar status to `Running`, `Needs input`, and `Idle`
+- route Droid attention notifications into the cmux notification panel
+- clear the saved mapping on `SessionEnd`
+
+To remove the integration:
+
+```bash
+cmux droid uninstall-hooks
+```
+
 ### OpenCode Plugin
 
 Create `.opencode/plugins/cmux-notify.js`:

--- a/tests/test_droid_hook_install.py
+++ b/tests/test_droid_hook_install.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Regression test for cmux droid install-hooks/uninstall-hooks.
+
+Validates:
+1) install-hooks merges into ~/.factory/settings.json without clobbering unrelated settings
+2) uninstall-hooks removes only cmux-managed Droid hooks
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+EXPECTED_EVENTS = ["SessionStart", "UserPromptSubmit", "Notification", "Stop", "SessionEnd"]
+
+
+def fail(message: str) -> int:
+    print(f"FAIL: {message}")
+    return 1
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def group_contains_command(groups: list[dict], needle: str) -> bool:
+    for group in groups:
+        for hook in group.get("hooks") or []:
+            if needle in str(hook.get("command") or ""):
+                return True
+    return False
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        return fail(str(exc))
+
+    with tempfile.TemporaryDirectory(prefix="cmux-droid-hooks-") as td:
+        home = Path(td) / "home"
+        factory_dir = home / ".factory"
+        factory_dir.mkdir(parents=True, exist_ok=True)
+        settings_path = factory_dir / "settings.json"
+
+        seed = {
+            "model": "droid-latest",
+            "hooks": {
+                "Notification": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo keep-notification",
+                                "timeout": 3,
+                            }
+                        ]
+                    }
+                ],
+                "Stop": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo keep-stop",
+                                "timeout": 4,
+                            }
+                        ]
+                    }
+                ],
+            },
+        }
+        settings_path.write_text(json.dumps(seed, indent=2, sort_keys=True), encoding="utf-8")
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env.pop("FACTORY_HOME", None)
+
+        install = subprocess.run(
+            [cli_path, "droid", "install-hooks", "--yes"],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        if install.returncode != 0:
+            return fail(
+                "cmux droid install-hooks failed:\n"
+                f"exit={install.returncode}\nstdout={install.stdout}\nstderr={install.stderr}"
+            )
+
+        installed = load_json(settings_path)
+        if installed.get("model") != seed["model"]:
+            return fail("install-hooks changed unrelated settings")
+
+        hooks = installed.get("hooks") or {}
+        for event in EXPECTED_EVENTS:
+            groups = hooks.get(event) or []
+            if not groups:
+                return fail(f"Expected {event} hooks after install")
+            if not group_contains_command(groups, f"cmux droid-hook {event.lower().replace('_', '-')}"):
+                command_map = {
+                    "SessionStart": "cmux droid-hook session-start",
+                    "UserPromptSubmit": "cmux droid-hook prompt-submit",
+                    "Notification": "cmux droid-hook notification",
+                    "Stop": "cmux droid-hook stop",
+                    "SessionEnd": "cmux droid-hook session-end",
+                }
+                if not group_contains_command(groups, command_map[event]):
+                    return fail(f"Expected cmux-managed hook command for {event}")
+
+        if not group_contains_command(hooks.get("Notification") or [], "echo keep-notification"):
+            return fail("install-hooks removed existing Notification hooks")
+        if not group_contains_command(hooks.get("Stop") or [], "echo keep-stop"):
+            return fail("install-hooks removed existing Stop hooks")
+
+        uninstall = subprocess.run(
+            [cli_path, "droid", "uninstall-hooks", "--yes"],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+        if uninstall.returncode != 0:
+            return fail(
+                "cmux droid uninstall-hooks failed:\n"
+                f"exit={uninstall.returncode}\nstdout={uninstall.stdout}\nstderr={uninstall.stderr}"
+            )
+
+        removed = load_json(settings_path)
+        if removed.get("model") != seed["model"]:
+            return fail("uninstall-hooks changed unrelated settings")
+
+        removed_hooks = removed.get("hooks") or {}
+        for event, groups in removed_hooks.items():
+            if group_contains_command(groups or [], "cmux droid-hook"):
+                return fail(f"uninstall-hooks left a cmux-managed Droid hook in {event}")
+
+        if not group_contains_command(removed_hooks.get("Notification") or [], "echo keep-notification"):
+            return fail("uninstall-hooks removed non-cmux Notification hooks")
+        if not group_contains_command(removed_hooks.get("Stop") or [], "echo keep-stop"):
+            return fail("uninstall-hooks removed non-cmux Stop hooks")
+
+        if "SessionStart" in removed_hooks or "UserPromptSubmit" in removed_hooks or "SessionEnd" in removed_hooks:
+            return fail("uninstall-hooks left empty Droid-only hook events behind")
+
+        print("PASS: droid install-hooks/uninstall-hooks merges and removes only cmux-managed hooks")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_droid_hook_install.py
+++ b/tests/test_droid_hook_install.py
@@ -105,20 +105,19 @@ def main() -> int:
             return fail("install-hooks changed unrelated settings")
 
         hooks = installed.get("hooks") or {}
+        command_map = {
+            "SessionStart": "cmux droid-hook session-start",
+            "UserPromptSubmit": "cmux droid-hook prompt-submit",
+            "Notification": "cmux droid-hook notification",
+            "Stop": "cmux droid-hook stop",
+            "SessionEnd": "cmux droid-hook session-end",
+        }
         for event in EXPECTED_EVENTS:
             groups = hooks.get(event) or []
             if not groups:
                 return fail(f"Expected {event} hooks after install")
-            if not group_contains_command(groups, f"cmux droid-hook {event.lower().replace('_', '-')}"):
-                command_map = {
-                    "SessionStart": "cmux droid-hook session-start",
-                    "UserPromptSubmit": "cmux droid-hook prompt-submit",
-                    "Notification": "cmux droid-hook notification",
-                    "Stop": "cmux droid-hook stop",
-                    "SessionEnd": "cmux droid-hook session-end",
-                }
-                if not group_contains_command(groups, command_map[event]):
-                    return fail(f"Expected cmux-managed hook command for {event}")
+            if not group_contains_command(groups, command_map[event]):
+                return fail(f"Expected cmux-managed hook command for {event}")
 
         if not group_contains_command(hooks.get("Notification") or [], "echo keep-notification"):
             return fail("install-hooks removed existing Notification hooks")

--- a/tests/test_droid_hook_install.py
+++ b/tests/test_droid_hook_install.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from claude_teams_test_utils import resolve_cmux_cli
 
 
-EXPECTED_EVENTS = ["SessionStart", "UserPromptSubmit", "Notification", "Stop", "SessionEnd"]
+EXPECTED_EVENTS = ["SessionStart", "UserPromptSubmit", "PreToolUse", "Notification", "Stop", "SessionEnd"]
 
 
 def fail(message: str) -> int:
@@ -108,6 +108,7 @@ def main() -> int:
         command_map = {
             "SessionStart": "cmux droid-hook session-start",
             "UserPromptSubmit": "cmux droid-hook prompt-submit",
+            "PreToolUse": "cmux droid-hook pre-tool-use",
             "Notification": "cmux droid-hook notification",
             "Stop": "cmux droid-hook stop",
             "SessionEnd": "cmux droid-hook session-end",
@@ -151,7 +152,7 @@ def main() -> int:
         if not group_contains_command(removed_hooks.get("Stop") or [], "echo keep-stop"):
             return fail("uninstall-hooks removed non-cmux Stop hooks")
 
-        if "SessionStart" in removed_hooks or "UserPromptSubmit" in removed_hooks or "SessionEnd" in removed_hooks:
+        if "SessionStart" in removed_hooks or "UserPromptSubmit" in removed_hooks or "PreToolUse" in removed_hooks or "SessionEnd" in removed_hooks:
             return fail("uninstall-hooks left empty Droid-only hook events behind")
 
         print("PASS: droid install-hooks/uninstall-hooks merges and removes only cmux-managed hooks")

--- a/tests/test_droid_hook_session_mapping.py
+++ b/tests/test_droid_hook_session_mapping.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+E2E regression test for Droid hook session mapping.
+
+Validates:
+1) session-start records session_id -> workspace/surface mapping on disk
+2) notification targets the mapped surface and stores last context
+3) stop emits a completion notification with project and last-message context
+4) session-end consumes the saved session mapping
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from claude_teams_test_utils import resolve_cmux_cli
+from cmux import cmux, cmuxError
+
+
+def run_droid_hook(
+    cli_path: str,
+    socket_path: str,
+    subcommand: str,
+    payload: dict,
+    env: dict[str, str],
+) -> str:
+    proc = subprocess.run(
+        [cli_path, "--socket", socket_path, "droid-hook", subcommand],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"cmux droid-hook {subcommand} failed:\n"
+            f"exit={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+    return proc.stdout.strip()
+
+
+def wait_for_notification_count(client: cmux, minimum: int, timeout: float = 4.0) -> list[dict]:
+    start = time.time()
+    items: list[dict] = []
+    while time.time() - start < timeout:
+        items = client.list_notifications()
+        if len(items) >= minimum:
+            return items
+        time.sleep(0.05)
+    return items
+
+
+def latest_notification_with_subtitle(items: list[dict], subtitle: str) -> dict | None:
+    for item in items:
+        if item.get("subtitle") == subtitle:
+            return item
+    return None
+
+
+def wait_for_workspace_surface(
+    client: cmux,
+    workspace_id: str,
+    timeout: float = 4.0,
+) -> str | None:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            client.select_workspace(workspace_id)
+            surfaces = client.list_surfaces(workspace_id)
+        except cmuxError:
+            time.sleep(0.05)
+            continue
+        if surfaces:
+            focused = next((surface for surface in surfaces if surface[2]), surfaces[0])
+            return focused[1]
+        time.sleep(0.05)
+    return None
+
+
+def fail(message: str) -> int:
+    print(f"FAIL: {message}")
+    return 1
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        return fail(str(exc))
+
+    state_path = Path(tempfile.gettempdir()) / f"cmux_droid_hook_state_{os.getpid()}.json"
+    lock_path = Path(str(state_path) + ".lock")
+    try:
+        if state_path.exists():
+            state_path.unlink()
+        if lock_path.exists():
+            lock_path.unlink()
+    except OSError:
+        pass
+
+    project_dir = Path(tempfile.gettempdir()) / f"cmux_droid_map_project_{os.getpid()}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    session_id = f"droid-{uuid.uuid4().hex}"
+    last_message = "Please approve deploy migration"
+
+    try:
+        with cmux() as client:
+            client.set_app_focus(False)
+            client.clear_notifications()
+
+            workspace_id = client.new_workspace()
+            surface_id = wait_for_workspace_surface(client, workspace_id)
+            if not surface_id:
+                return fail("Expected at least one surface in new workspace")
+
+            hook_env = os.environ.copy()
+            hook_env["CMUX_SOCKET_PATH"] = client.socket_path
+            hook_env["CMUX_WORKSPACE_ID"] = workspace_id
+            hook_env["CMUX_SURFACE_ID"] = surface_id
+            hook_env["CMUX_DROID_HOOK_STATE_PATH"] = str(state_path)
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "session-start",
+                {
+                    "session_id": session_id,
+                    "cwd": str(project_dir),
+                },
+                hook_env,
+            )
+
+            if not state_path.exists():
+                return fail(f"Expected state file at {state_path}")
+
+            with state_path.open("r", encoding="utf-8") as handle:
+                state_data = json.load(handle)
+            session_row = (state_data.get("sessions") or {}).get(session_id)
+            if not session_row:
+                return fail("Expected mapped session row after session-start")
+            if session_row.get("workspaceId") != workspace_id:
+                return fail("Mapped workspaceId did not match active workspace")
+            if session_row.get("surfaceId") != surface_id:
+                return fail("Mapped surfaceId did not match active surface")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "notification",
+                {
+                    "session_id": session_id,
+                    "message": last_message,
+                    "type": "permission",
+                    "cwd": str(project_dir),
+                },
+                hook_env,
+            )
+
+            items = wait_for_notification_count(client, minimum=1)
+            if not items:
+                return fail("Expected at least one notification after droid-hook notification")
+            permission_notification = latest_notification_with_subtitle(items, "Permission")
+            if permission_notification is None:
+                return fail("Expected a Permission subtitle notification")
+            if permission_notification.get("surface_id") != surface_id:
+                return fail("Expected notification to route to mapped surface")
+            if last_message not in permission_notification.get("body", ""):
+                return fail("Expected notification body to include the Droid message")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "stop",
+                {
+                    "session_id": session_id,
+                    "cwd": str(project_dir),
+                },
+                hook_env,
+            )
+
+            items = wait_for_notification_count(client, minimum=2)
+            completed_notification = latest_notification_with_subtitle(items, "Completed")
+            if completed_notification is None:
+                return fail("Expected a Completed subtitle notification on stop")
+            body = completed_notification.get("body", "")
+            if project_dir.name not in body:
+                return fail("Expected stop notification body to include project directory name")
+            if "Last:" not in body:
+                return fail("Expected stop notification body to include last activity summary")
+            if "approve deploy migration" not in body.lower():
+                return fail("Expected stop notification body to include last Droid message context")
+            if completed_notification.get("surface_id") != surface_id:
+                return fail("Expected stop notification to target mapped surface")
+
+            with state_path.open("r", encoding="utf-8") as handle:
+                post_stop_state = json.load(handle)
+            if session_id not in (post_stop_state.get("sessions") or {}):
+                return fail("Expected session mapping to remain until session-end")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "session-end",
+                {
+                    "session_id": session_id,
+                },
+                hook_env,
+            )
+
+            with state_path.open("r", encoding="utf-8") as handle:
+                post_end_state = json.load(handle)
+            if session_id in (post_end_state.get("sessions") or {}):
+                return fail("Expected session mapping to be consumed on session-end")
+
+            print("PASS: Droid hook session mapping, notification routing, and teardown cleanup")
+            return 0
+
+    except (cmuxError, RuntimeError) as exc:
+        return fail(str(exc))
+    finally:
+        try:
+            if state_path.exists():
+                state_path.unlink()
+            if lock_path.exists():
+                lock_path.unlink()
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_droid_hook_session_mapping.py
+++ b/tests/test_droid_hook_session_mapping.py
@@ -5,9 +5,11 @@ E2E regression test for Droid hook session mapping.
 Validates:
 1) session-start records session_id -> workspace/surface mapping on disk
 2) notification targets the mapped surface and stores last context
-3) stop with stop_hook_active=true keeps Droid in Running and suppresses completion
-4) final stop emits a completion notification with project and last-message context
-5) session-end consumes the saved session mapping without clearing the completion notification
+3) pre-tool-use clears waiting notifications and restores Running
+4) another mission session ending does not clear the active workspace status
+5) stop with stop_hook_active=true keeps Droid in Running and suppresses completion
+6) final stop emits a completion notification with project and last-message context
+7) session-end consumes the saved session mapping without clearing the completion notification
 """
 
 from __future__ import annotations
@@ -154,6 +156,7 @@ def main() -> int:
     project_dir = Path(tempfile.gettempdir()) / f"cmux_droid_map_project_{os.getpid()}"
     project_dir.mkdir(parents=True, exist_ok=True)
     session_id = f"droid-{uuid.uuid4().hex}"
+    worker_session_id = f"droid-worker-{uuid.uuid4().hex}"
     last_message = "Please approve deploy migration"
 
     try:
@@ -183,6 +186,17 @@ def main() -> int:
                 hook_env,
             )
 
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "session-start",
+                {
+                    "session_id": worker_session_id,
+                    "cwd": str(project_dir),
+                },
+                hook_env,
+            )
+
             if not state_path.exists():
                 return fail(f"Expected state file at {state_path}")
 
@@ -195,6 +209,9 @@ def main() -> int:
                 return fail("Mapped workspaceId did not match active workspace")
             if session_row.get("surfaceId") != surface_id:
                 return fail("Mapped surfaceId did not match active surface")
+            worker_row = (state_data.get("sessions") or {}).get(worker_session_id)
+            if not worker_row:
+                return fail("Expected worker mission session row after session-start")
 
             run_droid_hook(
                 cli_path,
@@ -219,23 +236,40 @@ def main() -> int:
                 return fail("Expected notification to route to mapped surface")
             if last_message not in permission_notification.get("body", ""):
                 return fail("Expected notification body to include the Droid message")
+            if wait_for_sidebar_status(client, workspace_id, "droid", "Permission") is None:
+                return fail("Expected Droid status to become Permission after a permission notification")
 
             run_droid_hook(
                 cli_path,
                 client.socket_path,
-                "prompt-submit",
+                "pre-tool-use",
                 {
                     "session_id": session_id,
                     "cwd": str(project_dir),
+                    "tool_name": "Execute",
+                    "tool_input": {"command": "echo resume mission"},
                 },
                 hook_env,
             )
 
             if wait_for_sidebar_status(client, workspace_id, "droid", "Running") is None:
-                return fail("Expected Droid status to become Running after prompt-submit")
+                return fail("Expected Droid status to become Running after pre-tool-use")
             remaining_notifications = wait_for_notifications_empty(client)
             if remaining_notifications:
-                return fail("Expected prompt-submit to clear queued notifications before Droid resumes")
+                return fail("Expected pre-tool-use to clear queued notifications before Droid resumes")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "session-end",
+                {
+                    "session_id": worker_session_id,
+                },
+                hook_env,
+            )
+
+            if wait_for_sidebar_status(client, workspace_id, "droid", "Running") is None:
+                return fail("Expected another mission session ending not to clear the active Droid status")
 
             run_droid_hook(
                 cli_path,
@@ -258,6 +292,8 @@ def main() -> int:
                 mid_mission_state = json.load(handle)
             if session_id not in (mid_mission_state.get("sessions") or {}):
                 return fail("Expected session mapping to remain while mission-mode stop continues")
+            if worker_session_id in (mid_mission_state.get("sessions") or {}):
+                return fail("Expected worker mission session mapping to be consumed on session-end")
 
             run_droid_hook(
                 cli_path,
@@ -310,7 +346,7 @@ def main() -> int:
             if completed_after_end is None:
                 return fail("Expected completion notification to remain after session-end")
 
-            print("PASS: Droid hook session mapping, notification routing, and teardown cleanup")
+            print("PASS: Droid hook mission status stays coherent across resume, stop, and session teardown")
             return 0
 
     except (cmuxError, RuntimeError) as exc:

--- a/tests/test_droid_hook_session_mapping.py
+++ b/tests/test_droid_hook_session_mapping.py
@@ -6,7 +6,7 @@ Validates:
 1) session-start records session_id -> workspace/surface mapping on disk
 2) notification targets the mapped surface and stores last context
 3) stop emits a completion notification with project and last-message context
-4) session-end consumes the saved session mapping
+4) session-end consumes the saved session mapping without clearing the completion notification
 """
 
 from __future__ import annotations
@@ -221,6 +221,10 @@ def main() -> int:
                 post_end_state = json.load(handle)
             if session_id in (post_end_state.get("sessions") or {}):
                 return fail("Expected session mapping to be consumed on session-end")
+            items = client.list_notifications()
+            completed_after_end = latest_notification_with_subtitle(items, "Completed")
+            if completed_after_end is None:
+                return fail("Expected completion notification to remain after session-end")
 
             print("PASS: Droid hook session mapping, notification routing, and teardown cleanup")
             return 0

--- a/tests/test_droid_hook_session_mapping.py
+++ b/tests/test_droid_hook_session_mapping.py
@@ -5,8 +5,9 @@ E2E regression test for Droid hook session mapping.
 Validates:
 1) session-start records session_id -> workspace/surface mapping on disk
 2) notification targets the mapped surface and stores last context
-3) stop emits a completion notification with project and last-message context
-4) session-end consumes the saved session mapping without clearing the completion notification
+3) stop with stop_hook_active=true keeps Droid in Running and suppresses completion
+4) final stop emits a completion notification with project and last-message context
+5) session-end consumes the saved session mapping without clearing the completion notification
 """
 
 from __future__ import annotations
@@ -60,6 +61,17 @@ def wait_for_notification_count(client: cmux, minimum: int, timeout: float = 4.0
     return items
 
 
+def wait_for_notifications_empty(client: cmux, timeout: float = 4.0) -> list[dict]:
+    start = time.time()
+    items: list[dict] = []
+    while time.time() - start < timeout:
+        items = client.list_notifications()
+        if not items:
+            return items
+        time.sleep(0.05)
+    return items
+
+
 def latest_notification_with_subtitle(items: list[dict], subtitle: str) -> dict | None:
     for item in items:
         if item.get("subtitle") == subtitle:
@@ -85,6 +97,37 @@ def wait_for_workspace_surface(
             return focused[1]
         time.sleep(0.05)
     return None
+
+
+def wait_for_sidebar_status(
+    client: cmux,
+    workspace_id: str,
+    key: str,
+    value: str,
+    timeout: float = 4.0,
+) -> str | None:
+    needle = f"  {key}={value}"
+    start = time.time()
+    while time.time() - start < timeout:
+        sidebar_state = client.sidebar_state(workspace_id)
+        if needle in sidebar_state:
+            return sidebar_state
+        time.sleep(0.05)
+    return None
+
+
+def notification_appeared_with_subtitle(
+    client: cmux,
+    subtitle: str,
+    timeout: float = 0.75,
+) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        items = client.list_notifications()
+        if latest_notification_with_subtitle(items, subtitle) is not None:
+            return True
+        time.sleep(0.05)
+    return False
 
 
 def fail(message: str) -> int:
@@ -180,6 +223,45 @@ def main() -> int:
             run_droid_hook(
                 cli_path,
                 client.socket_path,
+                "prompt-submit",
+                {
+                    "session_id": session_id,
+                    "cwd": str(project_dir),
+                },
+                hook_env,
+            )
+
+            if wait_for_sidebar_status(client, workspace_id, "droid", "Running") is None:
+                return fail("Expected Droid status to become Running after prompt-submit")
+            remaining_notifications = wait_for_notifications_empty(client)
+            if remaining_notifications:
+                return fail("Expected prompt-submit to clear queued notifications before Droid resumes")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
+                "stop",
+                {
+                    "session_id": session_id,
+                    "cwd": str(project_dir),
+                    "stop_hook_active": True,
+                },
+                hook_env,
+            )
+
+            if wait_for_sidebar_status(client, workspace_id, "droid", "Running") is None:
+                return fail("Expected stop_hook_active stop to keep Droid status Running")
+            if notification_appeared_with_subtitle(client, "Completed"):
+                return fail("Did not expect a Completed notification while stop_hook_active is true")
+
+            with state_path.open("r", encoding="utf-8") as handle:
+                mid_mission_state = json.load(handle)
+            if session_id not in (mid_mission_state.get("sessions") or {}):
+                return fail("Expected session mapping to remain while mission-mode stop continues")
+
+            run_droid_hook(
+                cli_path,
+                client.socket_path,
                 "stop",
                 {
                     "session_id": session_id,
@@ -188,7 +270,7 @@ def main() -> int:
                 hook_env,
             )
 
-            items = wait_for_notification_count(client, minimum=2)
+            items = wait_for_notification_count(client, minimum=1)
             completed_notification = latest_notification_with_subtitle(items, "Completed")
             if completed_notification is None:
                 return fail("Expected a Completed subtitle notification on stop")
@@ -201,6 +283,8 @@ def main() -> int:
                 return fail("Expected stop notification body to include last Droid message context")
             if completed_notification.get("surface_id") != surface_id:
                 return fail("Expected stop notification to target mapped surface")
+            if wait_for_sidebar_status(client, workspace_id, "droid", "Idle") is None:
+                return fail("Expected final stop to set Droid status to Idle")
 
             with state_path.open("r", encoding="utf-8") as handle:
                 post_stop_state = json.load(handle)


### PR DESCRIPTION
## Summary

- add `cmux droid install-hooks` / `cmux droid uninstall-hooks` for Factory Droid's `~/.factory/settings.json`
- add `cmux droid-hook` handlers to map Droid sessions to the active cmux workspace/surface, update sidebar status, route notifications, and clean up state on session end
- document the Droid integration flow in `docs/notifications.md`
- add regression coverage for hook install/uninstall merging and session mapping / notification routing

## Testing

- Not run locally; this repo's agent policy says not to run local tests for these paths
- User manually confirmed the Droid integration flow worked
- Added `tests/test_droid_hook_install.py`
- Added `tests/test_droid_hook_session_mapping.py`

## Demo Video

- Video URL or attachment: N/A (CLI/docs/tests only)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Factory Droid hook integration to `cmux` with installable hooks and a `droid-hook` that maps sessions, routes notifications, and keeps workspace sidebar status accurate across sessions. Mission-mode stops keep Droid running (`stop_hook_active=true`) and only send a completion on the final stop; hooks no-op outside `cmux`.

- **New Features**
  - `cmux droid install-hooks` / `cmux droid uninstall-hooks` merge/remove cmux-managed hooks in `~/.factory/settings.json`; `droid`/`droid-hook` print help and handle unknown subcommands.
  - `cmux droid-hook <session-start|notification|prompt-submit|pre-tool-use|stop|session-end>` reads JSON; maps `session_id` ➝ workspace/surface; forwards “Droid” notifications; sets status (Running, Permission/Waiting/Error, Idle); `pre-tool-use` clears waiting and resumes Running; mission stop with `stop_hook_active` skips completion; final stop emits completion only if the workspace has no other active sessions; `session-end` reconciles status and clears stale notifications when the last session ends, then consumes the mapping.
  - Docs and tests: Factory Droid setup added to `docs/notifications.md`; regression coverage for hook install/uninstall, session mapping, `pre-tool-use` resume, mission stop continuation, completion only on final stop, and teardown.

<sup>Written for commit 92d99fe07bb85c486af9e354c0f97657f2d97b49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level droid command and full droid-hook system for install/uninstall, session-start, prompt-submit, pre-tool-use, notification, stop, and session-end; updates workspace/sidebar status and routes Droid notifications.

* **Bug Fixes / UX**
  * Improved help/usage and unknown-subcommand handling for droid; droid-hook now exits gracefully when no socket is available.

* **Documentation**
  * Added Factory Droid integration guide.

* **Tests**
  * Added regression tests for Droid hook install and session mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->