### PR TITLE
Fix dock icon Automatic mode ignoring system appearance

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3729,16 +3729,28 @@ enum AppIconSettings {
 final class AppIconAppearanceObserver: NSObject {
     static let shared = AppIconAppearanceObserver()
     private var observation: NSKeyValueObservation?
+    private var distributedObserver: NSObjectProtocol?
 
     private override init() { super.init() }
 
     func startObserving() {
-        applyIconForCurrentAppearance()
+        applyIconForSystemAppearance()
         guard observation == nil else { return }
+        // Observe system appearance changes via AppleInterfaceThemeChangedNotification,
+        // which fires regardless of the app's own appearance override.
+        distributedObserver = DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name("AppleInterfaceThemeChangedNotification"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, self.distributedObserver != nil else { return }
+            self.applyIconForSystemAppearance()
+        }
+        // Also observe effectiveAppearance as a fallback for immediate changes.
         observation = NSApp.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
             DispatchQueue.main.async {
                 guard let self, self.observation != nil else { return }
-                self.applyIconForCurrentAppearance()
+                self.applyIconForSystemAppearance()
             }
         }
     }
@@ -3746,11 +3758,19 @@ final class AppIconAppearanceObserver: NSObject {
     func stopObserving() {
         observation?.invalidate()
         observation = nil
+        if let observer = distributedObserver {
+            DistributedNotificationCenter.default().removeObserver(observer)
+            distributedObserver = nil
+        }
     }
 
-    private func applyIconForCurrentAppearance() {
-        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let imageName = isDark ? "AppIconDark" : "AppIconLight"
+    private static var isSystemDarkMode: Bool {
+        // Read directly from system defaults, bypassing any app-level appearance override.
+        UserDefaults.standard.string(forKey: "AppleInterfaceStyle")?.lowercased() == "dark"
+    }
+
+    private func applyIconForSystemAppearance() {
+        let imageName = Self.isSystemDarkMode ? "AppIconDark" : "AppIconLight"
         if let icon = NSImage(named: imageName) {
             NSApplication.shared.applicationIconImage = icon
         }


### PR DESCRIPTION
## Summary
- Dock icon "Automatic" mode was following the **app's theme** instead of the **system appearance** — if cmux theme was set to Dark, the icon stayed dark even when macOS was in light mode
- Root cause: `NSApp.effectiveAppearance` reflects the app's overridden appearance (set via `NSApplication.shared.appearance`), not the actual system dark/light state
- Fix: read `AppleInterfaceStyle` from `UserDefaults` and observe `AppleInterfaceThemeChangedNotification` via `DistributedNotificationCenter` to detect system appearance independently of the app's own theme setting

## Test plan
- [ ] Set cmux theme to **Dark**, icon mode to **Automatic**
- [ ] Switch macOS to light mode → dock icon should change to light variant
- [ ] Switch macOS to dark mode → dock icon should change to dark variant
- [ ] Set cmux theme to **System**, repeat above → should still work
- [ ] Set icon mode to **Light** or **Dark** → icon stays fixed regardless of system or app appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dock icon Automatic mode to follow the macOS system appearance instead of the app theme. The icon now switches correctly between light and dark when the system changes, regardless of the app’s theme setting.

- Bug Fixes
  - Determine system dark mode by reading `AppleInterfaceStyle` from `UserDefaults`.
  - Observe `AppleInterfaceThemeChangedNotification` via `DistributedNotificationCenter` to react to system changes.
  - Retain `NSApp.effectiveAppearance` observation as a fallback and update to `AppIconLight`/`AppIconDark`; clean up observers on stop.

<sup>Written for commit b7bdc115c19ecd57441a8daa27a4eb650054ba52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App icon now correctly respects the system's appearance setting and automatically updates when you switch the system theme, ensuring proper dark/light mode display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->