### PR TITLE
Defer layout follow-up flush to avoid re-entrant displayIfNeeded crash

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9018,7 +9018,16 @@ final class Workspace: Identifiable, ObservableObject {
             installLayoutFollowUpObservers()
         }
         refreshLayoutFollowUpTimeout()
-        attemptEventDrivenLayoutFollowUp()
+        // Use async scheduling instead of a synchronous call here. beginEventDrivenLayoutFollowUp
+        // is often invoked from splitTabBar(_:didChangeGeometry:), which fires from inside
+        // SwiftUI's .onChange(of: geometry) during an active layout pass. Calling
+        // attemptEventDrivenLayoutFollowUp() synchronously in that context causes
+        // flushWorkspaceWindowLayouts() → displayIfNeeded() to be called re-entrantly,
+        // incrementing AppKit's per-window constraint-pass counter on every display cycle
+        // until it exceeds the limit and crashes with NSGenericException.
+        // scheduleLayoutFollowUpAttempt() defers via asyncAfter(0) so the flush always
+        // happens after the current layout pass completes.
+        scheduleLayoutFollowUpAttempt()
     }
 
     private func installLayoutFollowUpObservers() {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5868,6 +5868,7 @@ final class Workspace: Identifiable, ObservableObject {
     private var layoutFollowUpBrowserExitFocusPanelId: UUID?
     private var layoutFollowUpNeedsGeometryPass = false
     private var layoutFollowUpAttemptScheduled = false
+    private var layoutFollowUpAttemptVersion: Int = 0
     private var layoutFollowUpStalledAttemptCount = 0
     private var isAttemptingLayoutFollowUp = false
     private var isNormalizingPinnedTabOrder = false
@@ -9013,6 +9014,11 @@ final class Workspace: Identifiable, ObservableObject {
         }
         layoutFollowUpNeedsGeometryPass = layoutFollowUpNeedsGeometryPass || includeGeometry
         layoutFollowUpStalledAttemptCount = 0
+        // Invalidate any pending retry whose delay was computed from a stale stall count.
+        // Incrementing the version causes old closures to exit early; clearing the flag
+        // allows scheduleLayoutFollowUpAttempt() below to enqueue a fresh asyncAfter(0).
+        layoutFollowUpAttemptVersion &+= 1
+        layoutFollowUpAttemptScheduled = false
 
         if layoutFollowUpTimeoutWorkItem == nil {
             installLayoutFollowUpObservers()
@@ -9114,6 +9120,7 @@ final class Workspace: Identifiable, ObservableObject {
         layoutFollowUpBrowserPanelId = nil
         layoutFollowUpBrowserExitFocusPanelId = nil
         layoutFollowUpNeedsGeometryPass = false
+        layoutFollowUpAttemptVersion &+= 1
         layoutFollowUpAttemptScheduled = false
         layoutFollowUpStalledAttemptCount = 0
     }
@@ -9124,8 +9131,10 @@ final class Workspace: Identifiable, ObservableObject {
 
         layoutFollowUpAttemptScheduled = true
         let delay = layoutFollowUpBackoffDelay()
+        let version = layoutFollowUpAttemptVersion
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else { return }
+            guard self.layoutFollowUpAttemptVersion == version else { return }
             self.layoutFollowUpAttemptScheduled = false
             self.attemptEventDrivenLayoutFollowUp()
         }


### PR DESCRIPTION
## Summary

- https://github.com/manaflow-ai/cmux/issues/2299
- Can run the latest release

beginEventDrivenLayoutFollowUp() ended with a synchronous call to attemptEventDrivenLayoutFollowUp(), which calls flushWorkspaceWindowLayouts() → window.contentView?.displayIfNeeded(). This is fine when invoked from user-event handlers, but splitTabBar(_:didChangeGeometry:) fires from inside SwiftUI's .onChange(of: geometry) during an active AppKit display/layout pass.

Calling displayIfNeeded() re-entrantly during that pass caused AppKit to increment the per-window Update Constraints pass counter on every display cycle. Once the counter exceeded the view-count limit AppKit threw an NSGenericException and crashed:

 'The window has been marked as needing another Update Constraints in Window
 pass, but it has already had more Update Constraints in Window passes than
 there are views in the window.'

Fix: replace the direct attemptEventDrivenLayoutFollowUp() call with scheduleLayoutFollowUpAttempt(), which defers via asyncAfter(.now() + 0). When layoutFollowUpStalledAttemptCount == 0 the backoff delay is zero, so there is no meaningful latency increase — the flush simply runs at the start of the next run loop iteration, after the current layout pass has fully unwound. The NSWindow.didUpdateNotification observer and the existing timeout still drive retries, so convergence is unaffected.


## Testing
Not yet

- 

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the layout follow-up flush to the next run loop to avoid re-entrant displayIfNeeded() during AppKit layout, preventing the NSGenericException crash. Adds versioned scheduling to cancel stale retries and allow immediate attempts after a reset.

- **Bug Fixes**
  - In beginEventDrivenLayoutFollowUp(), use scheduleLayoutFollowUpAttempt() (asyncAfter(0)) so the flush runs after the current layout pass; existing NSWindow.didUpdateNotification and timeout still drive retries.
  - Introduce a layoutFollowUpAttemptVersion to invalidate pending delayed attempts on reset/clear; scheduled closures capture the version and exit if stale, and the scheduled flag is cleared to permit immediate re-enqueue.

<sup>Written for commit 6f2066351ea9eccb301aae2d06cc81a7869ee7e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred layout follow-up processing to run asynchronously, reducing UI blocking and improving responsiveness during updates.

* **Bug Fixes**
  * Prevented stale delayed retries from applying outdated layout attempts, improving layout stability and reducing visual glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->