### PR TITLE
Fix stale session geometry crash after 0.63.0 upgrade

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2042,12 +2042,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let visibleFrame: CGRect
     }
 
-    private struct PersistedWindowGeometry: Codable, Sendable {
+    struct PersistedWindowGeometry: Codable, Sendable {
+        let version: Int
         let frame: SessionRectSnapshot
         let display: SessionDisplaySnapshot?
     }
 
-    private static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v1"
+    nonisolated static let persistedWindowGeometrySchemaVersion = 2
+    private nonisolated static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v2"
+    private nonisolated static let legacyPersistedWindowGeometryDefaultsKeys = [
+        "cmux.session.lastWindowGeometry.v1"
+    ]
 
     weak var tabManager: TabManager?
     weak var notificationStore: TerminalNotificationStore?
@@ -2874,16 +2879,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard !didPrepareStartupSessionSnapshot else { return }
         didPrepareStartupSessionSnapshot = true
         guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        Self.removeLegacyPersistedWindowGeometry()
         startupSessionSnapshot = SessionPersistenceStore.load()
     }
 
     private func persistedWindowGeometry(
         defaults: UserDefaults = .standard
     ) -> PersistedWindowGeometry? {
+        Self.removeLegacyPersistedWindowGeometry(defaults: defaults)
         guard let data = defaults.data(forKey: Self.persistedWindowGeometryDefaultsKey) else {
             return nil
         }
-        return try? JSONDecoder().decode(PersistedWindowGeometry.self, from: data)
+        guard let payload = Self.decodedPersistedWindowGeometryData(data) else {
+            defaults.removeObject(forKey: Self.persistedWindowGeometryDefaultsKey)
+            return nil
+        }
+        return payload
     }
 
     private func persistWindowGeometry(
@@ -2891,6 +2902,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         display: SessionDisplaySnapshot?,
         defaults: UserDefaults = .standard
     ) {
+        Self.removeLegacyPersistedWindowGeometry(defaults: defaults)
         guard let data = Self.encodedPersistedWindowGeometryData(frame: frame, display: display) else {
             return
         }
@@ -2902,8 +2914,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         display: SessionDisplaySnapshot?
     ) -> Data? {
         guard let frame else { return nil }
-        let payload = PersistedWindowGeometry(frame: frame, display: display)
+        let payload = PersistedWindowGeometry(
+            version: persistedWindowGeometrySchemaVersion,
+            frame: frame,
+            display: display
+        )
         return try? JSONEncoder().encode(payload)
+    }
+
+    nonisolated static func decodedPersistedWindowGeometryData(_ data: Data) -> PersistedWindowGeometry? {
+        guard let payload = try? JSONDecoder().decode(PersistedWindowGeometry.self, from: data),
+              payload.version == persistedWindowGeometrySchemaVersion else {
+            return nil
+        }
+        return payload
+    }
+
+    private nonisolated static func removeLegacyPersistedWindowGeometry(
+        defaults: UserDefaults = .standard
+    ) {
+        legacyPersistedWindowGeometryDefaultsKeys.forEach { defaults.removeObject(forKey: $0) }
     }
 
     private func persistWindowGeometry(from window: NSWindow?) {
@@ -3765,6 +3795,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard snapshot != nil || removeWhenEmpty || persistedGeometryData != nil else { return }
 
         let writeBlock = {
+            Self.removeLegacyPersistedWindowGeometry()
             if let persistedGeometryData {
                 UserDefaults.standard.set(
                     persistedGeometryData,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5868,6 +5868,7 @@ final class Workspace: Identifiable, ObservableObject {
     private var layoutFollowUpBrowserExitFocusPanelId: UUID?
     private var layoutFollowUpNeedsGeometryPass = false
     private var layoutFollowUpAttemptScheduled = false
+    private var layoutFollowUpAttemptVersion: UInt64 = 0
     private var layoutFollowUpStalledAttemptCount = 0
     private var isAttemptingLayoutFollowUp = false
     private var isNormalizingPinnedTabOrder = false
@@ -9013,12 +9014,16 @@ final class Workspace: Identifiable, ObservableObject {
         }
         layoutFollowUpNeedsGeometryPass = layoutFollowUpNeedsGeometryPass || includeGeometry
         layoutFollowUpStalledAttemptCount = 0
+        layoutFollowUpAttemptVersion &+= 1
+        layoutFollowUpAttemptScheduled = false
 
         if layoutFollowUpTimeoutWorkItem == nil {
             installLayoutFollowUpObservers()
         }
         refreshLayoutFollowUpTimeout()
-        attemptEventDrivenLayoutFollowUp()
+        // Defer the first flush to the next run loop turn so we never call
+        // displayIfNeeded() re-entrantly from an active AppKit layout pass.
+        scheduleLayoutFollowUpAttempt()
     }
 
     private func installLayoutFollowUpObservers() {
@@ -9105,6 +9110,7 @@ final class Workspace: Identifiable, ObservableObject {
         layoutFollowUpBrowserPanelId = nil
         layoutFollowUpBrowserExitFocusPanelId = nil
         layoutFollowUpNeedsGeometryPass = false
+        layoutFollowUpAttemptVersion &+= 1
         layoutFollowUpAttemptScheduled = false
         layoutFollowUpStalledAttemptCount = 0
     }
@@ -9115,8 +9121,10 @@ final class Workspace: Identifiable, ObservableObject {
 
         layoutFollowUpAttemptScheduled = true
         let delay = layoutFollowUpBackoffDelay()
+        let version = layoutFollowUpAttemptVersion
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self else { return }
+            guard self.layoutFollowUpAttemptVersion == version else { return }
             self.layoutFollowUpAttemptScheduled = false
             self.attemptEventDrivenLayoutFollowUp()
         }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -7,6 +7,11 @@ import XCTest
 #endif
 
 final class SessionPersistenceTests: XCTestCase {
+    private struct LegacyPersistedWindowGeometry: Codable {
+        let frame: SessionRectSnapshot
+        let display: SessionDisplaySnapshot?
+    }
+
     @MainActor
     func testWorkspaceSessionSnapshotRestoresMarkdownPanel() throws {
         let root = FileManager.default.temporaryDirectory
@@ -639,6 +644,55 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(restored.minY, 160, accuracy: 0.001)
         XCTAssertEqual(restored.width, 980, accuracy: 0.001)
         XCTAssertEqual(restored.height, 700, accuracy: 0.001)
+    }
+
+    func testDecodedPersistedWindowGeometryDataAcceptsCurrentSchema() throws {
+        let data = try JSONEncoder().encode(
+            AppDelegate.PersistedWindowGeometry(
+                version: AppDelegate.persistedWindowGeometrySchemaVersion,
+                frame: SessionRectSnapshot(x: 220, y: 160, width: 980, height: 700),
+                display: SessionDisplaySnapshot(
+                    displayID: 1,
+                    frame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000),
+                    visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000)
+                )
+            )
+        )
+
+        let decoded = try XCTUnwrap(AppDelegate.decodedPersistedWindowGeometryData(data))
+        XCTAssertEqual(decoded.version, AppDelegate.persistedWindowGeometrySchemaVersion)
+        XCTAssertEqual(decoded.frame.x, 220, accuracy: 0.001)
+        XCTAssertEqual(decoded.frame.y, 160, accuracy: 0.001)
+        XCTAssertEqual(decoded.frame.width, 980, accuracy: 0.001)
+        XCTAssertEqual(decoded.frame.height, 700, accuracy: 0.001)
+        XCTAssertEqual(decoded.display?.displayID, 1)
+    }
+
+    func testDecodedPersistedWindowGeometryDataRejectsLegacyUnversionedPayload() throws {
+        let data = try JSONEncoder().encode(
+            LegacyPersistedWindowGeometry(
+                frame: SessionRectSnapshot(x: 180, y: 140, width: 900, height: 640),
+                display: SessionDisplaySnapshot(
+                    displayID: 1,
+                    frame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000),
+                    visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 1_600, height: 1_000)
+                )
+            )
+        )
+
+        XCTAssertNil(AppDelegate.decodedPersistedWindowGeometryData(data))
+    }
+
+    func testDecodedPersistedWindowGeometryDataRejectsDifferentSchemaVersion() throws {
+        let data = try JSONEncoder().encode(
+            AppDelegate.PersistedWindowGeometry(
+                version: AppDelegate.persistedWindowGeometrySchemaVersion + 1,
+                frame: SessionRectSnapshot(x: 220, y: 160, width: 980, height: 700),
+                display: nil
+            )
+        )
+
+        XCTAssertNil(AppDelegate.decodedPersistedWindowGeometryData(data))
     }
 
     func testResolvedWindowFrameCentersInFallbackDisplayWhenOffscreen() {


### PR DESCRIPTION
## Summary
- add regression coverage for stale window geometry migration
- version the persisted window geometry payload and discard legacy `cmux.session.lastWindowGeometry.v1` state during startup and persistence
- defer and invalidate layout follow-up retries to avoid the re-entrant `displayIfNeeded()` crash path called out in #2305

## Scope
- addresses bug1 from #2299 only
- does not include the config parse error UI work from bug2

## Testing
- not run locally per repo policy
- tagged dev build was previously built and launched with `./scripts/reload.sh --tag upgrade-crash-stale-session --launch`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the startup crash after 0.63.0 when restoring stale window geometry (bug 1 in #2299). Adds a versioned `v2` geometry payload, purges legacy `v1` state, and defers layout follow-ups to avoid re-entrant `displayIfNeeded()`.

- **Bug Fixes**
  - Window geometry is now stored under `cmux.session.lastWindowGeometry.v2`; legacy `cmux.session.lastWindowGeometry.v1` is purged on launch and before reads/writes.
  - Reads validate schema/version; invalid or mismatched payloads are removed and ignored. Tests cover current, legacy, and mismatched versions.
  - Layout follow-ups are deferred to the next run loop and guarded with an attempt version to cancel stale retries and prevent re-entrant updates.

<sup>Written for commit 53ff327f3a68bd6352c2b9e5fed5563297d7554f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window geometry persistence with improved data validation and automatic migration of legacy configurations, ensuring windows restore correctly across sessions.

* **Tests**
  * Added comprehensive tests for window persistence migration and data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->