### PR TITLE
Fix macOS compat: versioned geometry persistence and re-entrant layout crash

### DIFF
--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1731,6 +1731,31 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         return false
     }
 
+    @discardableResult
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping () -> Bool
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                if Thread.isMainThread {
+                    return condition()
+                }
+                return DispatchQueue.main.sync(execute: condition)
+            },
+            object: NSObject()
+        )
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        guard result == .completed else {
+            XCTFail("Timed out waiting for \(description)", file: file, line: line)
+            return false
+        }
+        return true
+    }
+
     func testTrackpadScrollRoutesToTerminalSurfaceAndPreservesKeyboardFocusPath() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
@@ -2045,11 +2070,15 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
 
         let searchState = TerminalSurface.SearchState(needle: "example")
         hostedView.setSearchOverlay(searchState: searchState)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        }
         XCTAssertTrue(hostedView.debugHasSearchOverlay())
 
         hostedView.setSearchOverlay(searchState: nil)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        waitUntil(description: "search overlay to unmount") {
+            !hostedView.debugHasSearchOverlay()
+        }
         XCTAssertFalse(hostedView.debugHasSearchOverlay())
     }
 
@@ -2342,12 +2371,17 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             )
             weakSurface = surface
             let hostedView = surface.hostedView
-            hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "retain-check"))
-            return hostedView
+        hostedView.setSearchOverlay(searchState: TerminalSurface.SearchState(needle: "retain-check"))
+        return hostedView
         }()
 
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        waitUntil(description: "search overlay to mount") {
+            hostedView.debugHasSearchOverlay()
+        }
         XCTAssertTrue(hostedView.debugHasSearchOverlay())
+        waitUntil(description: "terminal surface to deallocate after search overlay mount") {
+            weakSurface == nil
+        }
         XCTAssertNil(weakSurface, "Mounted search overlay must not retain TerminalSurface")
     }
 

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -254,7 +254,7 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertTrue(manager.tabs.contains(where: { $0.id == pinnedWorkspace.id }))
     }
 
-    private func waitForSocket(at path: String, timeout: TimeInterval = 2.0) throws {
+    private func waitForSocket(at path: String, timeout: TimeInterval = 5.0) throws {
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate { _, _ in
                 FileManager.default.fileExists(atPath: path)


### PR DESCRIPTION
## Summary
- **Versioned geometry persistence:** Bump persisted window geometry schema to v2 with an explicit `version` field. Decode rejects payloads that don't match the current schema version, and all legacy v1 UserDefaults keys are cleaned up on read/write/restore — prevents crashes from stale data after upgrades.
- **Re-entrant layout crash fix:** Defer `beginEventDrivenLayoutFollowUp` via `scheduleLayoutFollowUpAttempt()` (asyncAfter(0)) instead of calling synchronously from SwiftUI geometry-change callbacks. Adds a `layoutFollowUpAttemptVersion` counter so stale retry closures exit early when a new follow-up invalidates them.
- **Test reliability:** Replace fixed `RunLoop.run(until:)` delays with polling `waitUntil` helpers in surface overlay tests; increase socket wait timeout from 2s to 5s.

## Test plan
- [x] Unit tests for versioned geometry decode/reject (current schema, legacy unversioned, future version)
- [x] Existing layout follow-up and session persistence tests pass
- [ ] Manual: upgrade from older build → verify no crash on startup with stale geometry in UserDefaults
- [ ] Manual: split/tab operations don't trigger re-entrant displayIfNeeded crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents macOS crashes from stale window geometry and re-entrant layout. Adds schema v2 with cleanup and defers layout follow-ups; tests now use polling waits and a 5s socket timeout.

- **Bug Fixes**
  - Geometry persistence: schema v2 with an explicit version; reject mismatches and remove legacy v1 `UserDefaults` keys.
  - Layout: schedule follow-ups asynchronously (0 delay) instead of from SwiftUI geometry callbacks; add an attempt version to drop stale retries and avoid re-entrant displayIfNeeded.

<sup>Written for commit df78394087bb19a7894172a47c53069ae1daf6f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing fixed delays with condition-based waiting mechanisms for overlay lifecycle validation.
  * Increased timeout duration for socket security tests to enhance test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->