### PR TITLE
Release v0.63.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to cmux are documented here.
 
+## [0.63.1] - 2026-03-28
+
+### Fixed
+- Fix crash on startup after upgrading from older versions due to stale window geometry data ([#2306](https://github.com/manaflow-ai/cmux/pull/2306))
+- Fix re-entrant `displayIfNeeded` crash during layout follow-up from SwiftUI geometry changes ([#2305](https://github.com/manaflow-ai/cmux/pull/2305)) — thanks @KyleJamesWalker!
+- Fix macOS compatibility with versioned geometry persistence to prevent future upgrade crashes ([#2308](https://github.com/manaflow-ai/cmux/pull/2308))
+
+### Thanks to 2 contributors!
+
+- [@austinywang](https://github.com/austinywang)
+- [@KyleJamesWalker](https://github.com/KyleJamesWalker)
+
 ## [0.63.0] - 2026-03-28
 
 ### Added

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -941,7 +941,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -980,7 +980,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1050,7 +1050,7 @@
 				CURRENT_PROJECT_VERSION = 78;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1067,7 +1067,7 @@
 				CURRENT_PROJECT_VERSION = 78;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1084,7 +1084,7 @@
 				CURRENT_PROJECT_VERSION = 78;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1103,7 +1103,7 @@
 				CURRENT_PROJECT_VERSION = 78;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.63.0;
+				MARKETING_VERSION = 0.63.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary

Hotfix release for crashes introduced in v0.63.0:

- Fix crash on startup after upgrading from older versions due to stale window geometry data ([#2306](https://github.com/manaflow-ai/cmux/pull/2306))
- Fix re-entrant `displayIfNeeded` crash during layout follow-up from SwiftUI geometry changes ([#2305](https://github.com/manaflow-ai/cmux/pull/2305))
- Fix macOS compatibility with versioned geometry persistence to prevent future upgrade crashes ([#2308](https://github.com/manaflow-ai/cmux/pull/2308))

Also includes the full 0.63.0 changelog in `CHANGELOG.md` (which was missing from the 0.63.0 release).

Version bumped from 0.63.0 → 0.63.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hotfix release v0.63.1 to resolve crashes introduced in v0.63.0. Also adds the missing 0.63.0 notes to `CHANGELOG.md` and bumps the app version.

- **Bug Fixes**
  - Prevent startup crash after upgrading from older versions by clearing stale window geometry.
  - Fix re-entrant `displayIfNeeded` crash triggered during SwiftUI layout updates.
  - Add macOS-safe, versioned geometry persistence to avoid future upgrade crashes.

<sup>Written for commit 4bab7309665561f1f565a8aaecb449d331f9fbc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical crash that prevented the application from launching after upgrading from a previous version
  * Resolved a crash caused by window geometry handling interactions with framework updates
  * Improved macOS compatibility for reliably storing and restoring window geometry settings across application versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->