### PR TITLE
Fix vertical branch layout: show one row per branch, not per directory

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5149,31 +5149,6 @@ enum SidebarBranchOrdering {
         return cleaned.isEmpty ? nil : cleaned
     }
 
-    private static func preferredDisplayedDirectory(
-        existing: String?,
-        replacement: String?,
-        homeDirectoryForTildeExpansion: String?
-    ) -> String? {
-        guard let replacement = normalizedDirectory(replacement) else { return existing }
-        guard let existing = normalizedDirectory(existing) else { return replacement }
-
-        let existingUsesTilde = relativePathFromTilde(existing) != nil
-        let replacementUsesTilde = relativePathFromTilde(replacement) != nil
-        if existingUsesTilde != replacementUsesTilde {
-            return replacementUsesTilde ? existing : replacement
-        }
-
-        if canonicalDirectoryKey(existing, homeDirectoryForTildeExpansion: homeDirectoryForTildeExpansion)
-            == canonicalDirectoryKey(
-                replacement,
-                homeDirectoryForTildeExpansion: homeDirectoryForTildeExpansion
-            ) {
-            return existing
-        }
-
-        return replacement
-    }
-
     static func orderedPaneIds(tree: ExternalTreeNode) -> [String] {
         switch tree {
         case .pane(let pane):
@@ -5353,34 +5328,21 @@ enum SidebarBranchOrdering {
                 ? (panelBranches[panelId]?.isDirty ?? false)
                 : defaultBranchDirty
 
-            let key: EntryKey
-            if let directoryKey = canonicalDirectoryKey(
+            let canonicalDir = canonicalDirectoryKey(
                 directory,
                 homeDirectoryForTildeExpansion: homeDirectoryForTildeExpansion
-            ) {
-                // Keep one line per directory and allow the latest branch state to overwrite.
-                key = EntryKey(directory: directoryKey, branch: nil)
-            } else {
-                key = EntryKey(directory: nil, branch: branch)
-            }
+            )
+            // Key by both branch and canonical directory so each unique (branch, directory)
+            // pair gets its own vertical row. Two panels with the same branch+directory
+            // are merged; panels sharing only a directory but on different branches each
+            // get their own line.
+            let key = EntryKey(directory: canonicalDir, branch: branch)
 
             guard key.directory != nil || key.branch != nil else { continue }
 
             if var existing = entries[key] {
-                if key.directory != nil {
-                    if let branch {
-                        existing.branch = branch
-                        existing.isDirty = panelDirty
-                    } else if existing.branch == nil {
-                        existing.isDirty = panelDirty
-                    }
-                    existing.directory = preferredDisplayedDirectory(
-                        existing: existing.directory,
-                        replacement: directory,
-                        homeDirectoryForTildeExpansion: homeDirectoryForTildeExpansion
-                    )
-                    entries[key] = existing
-                } else if panelDirty {
+                // Same branch+directory: just propagate the dirty flag.
+                if panelDirty {
                     existing.isDirty = true
                     entries[key] = existing
                 }


### PR DESCRIPTION
## Summary

- `orderedUniqueBranchDirectoryEntries` was keying entries by directory only (`EntryKey(directory:, branch: nil)`) after commit `740b4b11`, collapsing all panes in the same directory into a single entry
- In vertical mode, a workspace with multiple panes on different branches in the same directory showed only one branch line (the last one) — making vertical layout appear identical to inline
- Restored the key to use both canonical directory AND branch, so each unique `(branch, directory)` pair gets its own row; panes sharing the same branch+directory still merge (dirty flag is OR'd)
- Removed the now-unreachable `preferredDisplayedDirectory` helper

## Test plan

- Open cmux with multiple split panes in the same directory, each on a different git branch
- Set Sidebar Branch Layout to **Vertical** in Settings
- Verify each branch appears on its own line in the sidebar
- Verify **Inline** mode still shows all branches on one line separated by `|`
- Verify that two panes on the same branch+directory show only one row (with dirty flag OR'd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vertical branch layout to show one row per unique (branch, directory) instead of collapsing by directory. Restores expected behavior; inline layout is unchanged.

- **Bug Fixes**
  - Key sidebar entries by both branch and canonical directory to render separate rows.
  - Merge panes only when branch and directory both match; OR the dirty flag.
  - Remove unreachable `preferredDisplayedDirectory` helper.

<sup>Written for commit 40386aed71b09f20f328ea0f0add1bd0b618a408. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

