### PR TITLE
feat: support Home/End/PageUp/PageDown as shortcut keys

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1684,8 +1684,7 @@ func shouldSubmitCommandPaletteWithReturn(
 }
 
 func commandPaletteFieldEditorHasMarkedText(in window: NSWindow) -> Bool {
-    guard let editor = window.firstResponder as? NSTextView,
-          editor.isFieldEditor else {
+    guard let editor = window.firstResponder as? NSTextView else {
         return false
     }
     return editor.hasMarkedText()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10702,6 +10702,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return event.keyCode == 36 || event.keyCode == 76
         }
 
+        // Home/End/PageUp/PageDown — match by keyCode directly (like arrow keys).
+        if let expected = keyCodeForShortcutKey(shortcutKey),
+           ["↖", "↘", "⇞", "⇟"].contains(shortcutKey) {
+            return event.keyCode == expected
+        }
+
         let eventCharsIgnoringModifiers = event.charactersIgnoringModifiers
         if shortcutCharacterMatches(
             eventCharacter: eventCharsIgnoringModifiers,
@@ -10919,6 +10925,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case "→": return 124 // kVK_RightArrow
         case "↓": return 125 // kVK_DownArrow
         case "↑": return 126 // kVK_UpArrow
+        case "↖": return 115 // kVK_Home
+        case "↘": return 119 // kVK_End
+        case "⇞": return 116 // kVK_PageUp
+        case "⇟": return 121 // kVK_PageDown
         default:
             return nil
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -973,7 +973,6 @@ private final class WindowCommandPaletteOverlayController: NSObject {
     private let hostingView = NSHostingView(rootView: AnyView(EmptyView()))
     private var installConstraints: [NSLayoutConstraint] = []
     private weak var installedThemeFrame: NSView?
-    private var focusLockTimer: DispatchSourceTimer?
     private var scheduledFocusWorkItem: DispatchWorkItem?
     private var isPaletteVisible = false
     private var windowDidBecomeKeyObserver: NSObjectProtocol?
@@ -1060,9 +1059,14 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
         // SwiftUI text fields can keep a field editor delegate that isn't an NSView.
         // Fall back to validating editor ownership from the mounted palette text field.
-        if let textField = firstEditableTextField(in: hostingView),
-           textField.currentEditor() === textView {
-            return true
+        if let textInputView = firstEditableTextInputView(in: hostingView) {
+            if textInputView === textView {
+                return true
+            }
+            if let textField = textInputView as? NSTextField,
+               textField.currentEditor() === textView {
+                return true
+            }
         }
 
         return false
@@ -1072,7 +1076,10 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         guard let responder else { return false }
 
         if let textView = responder as? NSTextView {
-            return isPaletteFieldEditor(textView)
+            if textView.isFieldEditor {
+                return isPaletteFieldEditor(textView)
+            }
+            return textView.isEditable && textView.isDescendant(of: containerView)
         }
 
         if let textField = responder as? NSTextField {
@@ -1082,7 +1089,7 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         return false
     }
 
-    private func firstEditableTextField(in view: NSView) -> NSTextField? {
+    private func firstEditableTextInputView(in view: NSView) -> NSView? {
         if let textField = view as? NSTextField,
            textField.isEditable,
            textField.isEnabled,
@@ -1090,8 +1097,15 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             return textField
         }
 
+        if let textView = view as? NSTextView,
+           !textView.isFieldEditor,
+           textView.isEditable,
+           !textView.isHiddenOrHasHiddenAncestor {
+            return textView
+        }
+
         for subview in view.subviews {
-            if let match = firstEditableTextField(in: subview) {
+            if let match = firstEditableTextInputView(in: subview) {
                 return match
             }
         }
@@ -1114,16 +1128,16 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             return
         }
 
-        if let textField = firstEditableTextField(in: hostingView),
-           window.makeFirstResponder(textField),
+        if let textInputView = firstEditableTextInputView(in: hostingView),
+           window.makeFirstResponder(textInputView),
            isPaletteTextInputFirstResponder(window.firstResponder) {
             normalizeSelectionAfterProgrammaticFocus()
             return
         }
 
         if window.makeFirstResponder(containerView) {
-            if let textField = firstEditableTextField(in: hostingView),
-               window.makeFirstResponder(textField),
+            if let textInputView = firstEditableTextInputView(in: hostingView),
+               window.makeFirstResponder(textInputView),
                isPaletteTextInputFirstResponder(window.firstResponder) {
                 normalizeSelectionAfterProgrammaticFocus()
                 return
@@ -1160,58 +1174,35 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
     private func updateFocusLockForWindowState() {
         guard let window else {
-            stopFocusLockTimer()
+            scheduledFocusWorkItem?.cancel()
+            scheduledFocusWorkItem = nil
             return
         }
         guard isPaletteVisible else {
-            stopFocusLockTimer()
+            scheduledFocusWorkItem?.cancel()
+            scheduledFocusWorkItem = nil
             return
         }
 
         guard window.isKeyWindow else {
-            stopFocusLockTimer()
-            if isPaletteResponder(window.firstResponder) {
-                _ = window.makeFirstResponder(nil)
-            }
+            // Keep the field editor stable while the window is backgrounded or
+            // while a transient system panel is interacting with the palette.
+            // Clearing/reasserting first responder here can detach the emoji
+            // picker from the field and steal its keyboard focus.
+            scheduledFocusWorkItem?.cancel()
+            scheduledFocusWorkItem = nil
             return
         }
 
-        startFocusLockTimer()
         if !isPaletteTextInputFirstResponder(window.firstResponder) {
             scheduleFocusIntoPalette(retries: 8)
         }
     }
 
-    private func startFocusLockTimer() {
-        guard focusLockTimer == nil else { return }
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(80), leeway: .milliseconds(12))
-        timer.setEventHandler { [weak self] in
-            guard let self else { return }
-            guard let window = self.window else {
-                self.stopFocusLockTimer()
-                return
-            }
-            if self.isPaletteTextInputFirstResponder(window.firstResponder) {
-                return
-            }
-            self.focusIntoPalette(retries: 1)
-        }
-        focusLockTimer = timer
-        timer.resume()
-    }
-
-    private func stopFocusLockTimer() {
-        focusLockTimer?.cancel()
-        focusLockTimer = nil
-        scheduledFocusWorkItem?.cancel()
-        scheduledFocusWorkItem = nil
-    }
-
     private func normalizeSelectionAfterProgrammaticFocus() {
         guard let window,
               let editor = window.firstResponder as? NSTextView,
-              editor.isFieldEditor else { return }
+              isPaletteTextInputFirstResponder(editor) else { return }
 
         let text = editor.string
         let length = (text as NSString).length
@@ -1224,6 +1215,10 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         // so the next keystroke appends instead of replacing and switching modes.
         guard text.hasPrefix(">") else { return }
         editor.setSelectedRange(NSRange(location: length, length: 0))
+    }
+
+    func ownsTextInputResponder(_ responder: NSResponder?) -> Bool {
+        isPaletteTextInputFirstResponder(responder)
     }
 
     func update(rootView: AnyView, isVisible: Bool) {
@@ -1243,7 +1238,8 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             }
             updateFocusLockForWindowState()
         } else {
-            stopFocusLockTimer()
+            scheduledFocusWorkItem?.cancel()
+            scheduledFocusWorkItem = nil
             if let window, isPaletteResponder(window.firstResponder) {
                 _ = window.makeFirstResponder(nil)
             }
@@ -2822,10 +2818,11 @@ struct ContentView: View {
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: NSText.didBeginEditingNotification)) { notification in
             guard commandPalettePendingTextSelectionBehavior != nil else { return }
-            guard let editor = notification.object as? NSTextView,
-                  editor.isFieldEditor else { return }
             guard let observedWindow else { return }
+            guard let editor = notification.object as? NSTextView else { return }
             guard editor.window === observedWindow else { return }
+            let overlayController = commandPaletteWindowOverlayController(for: observedWindow)
+            guard overlayController.ownsTextInputResponder(editor) else { return }
             attemptCommandPaletteTextSelectionIfNeeded()
         })
 
@@ -3780,23 +3777,26 @@ struct ContentView: View {
 
     private func commandPaletteRenameInputView(target: CommandPaletteRenameTarget) -> some View {
         VStack(spacing: 0) {
-            TextField(target.placeholder, text: $commandPaletteRenameDraft)
-                .textFieldStyle(.plain)
-                .font(.system(size: 13, weight: .regular))
-                .tint(Color(nsColor: sidebarActiveForegroundNSColor(opacity: 1.0)))
-                .focused($isCommandPaletteRenameFocused)
-                .accessibilityIdentifier("CommandPaletteRenameField")
-                .backport.onKeyPress(.delete) { modifiers in
-                    handleCommandPaletteRenameDeleteBackward(modifiers: modifiers)
-                }
-                .onSubmit {
-                    continueRenameFlow(target: target)
-                }
-                .onTapGesture {
-                    handleCommandPaletteRenameInputInteraction()
-                }
-                .padding(.horizontal, 9)
-                .padding(.vertical, 7)
+            HStack(spacing: 0) {
+                CommandPaletteRenameFieldRepresentable(
+                    text: $commandPaletteRenameDraft,
+                    isFocused: Binding(
+                        get: { isCommandPaletteRenameFocused },
+                        set: { isCommandPaletteRenameFocused = $0 }
+                    ),
+                    tintColor: sidebarActiveForegroundNSColor(opacity: 1.0),
+                    onSubmit: { continueRenameFlow(target: target) },
+                    onEscape: { dismissCommandPalette() },
+                    onDeleteEmpty: {
+                        commandPaletteMode = .commands
+                        resetCommandPaletteSearchFocus()
+                        syncCommandPaletteDebugStateForObservedWindow()
+                    }
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
 
             Divider()
 
@@ -3862,9 +3862,322 @@ struct ContentView: View {
         }
     }
 
-    private final class CommandPaletteNativeTextField: NSTextField {
-        var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
+    private final class CommandPaletteNativeTextView: NSTextView {
+        override var acceptsFirstResponder: Bool { true }
 
+        override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
+            super.init(frame: frameRect, textContainer: container)
+            drawsBackground = false
+            isRichText = false
+            importsGraphics = false
+            isAutomaticQuoteSubstitutionEnabled = false
+            isAutomaticDashSubstitutionEnabled = false
+            isAutomaticDataDetectionEnabled = false
+            isAutomaticLinkDetectionEnabled = false
+            isAutomaticTextCompletionEnabled = false
+            isAutomaticSpellingCorrectionEnabled = false
+            allowsUndo = true
+            focusRingType = .none
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
+
+    private final class CommandPaletteNativeTextInputView: NSView {
+        let scrollView = NSScrollView()
+        let textView: CommandPaletteNativeTextView
+        private let textStorage: NSTextStorage
+        private let layoutManager: NSLayoutManager
+        private let placeholderField = FeedbackComposerPassthroughLabel(labelWithString: "")
+
+        var placeholder: String = "" {
+            didSet {
+                placeholderField.stringValue = placeholder
+                updatePlaceholderVisibility()
+            }
+        }
+
+        private var singleLineHeight: CGFloat {
+            let font = textView.font ?? .systemFont(ofSize: 13)
+            return ceil(layoutManager.defaultLineHeight(for: font))
+        }
+
+        override var intrinsicContentSize: NSSize {
+            NSSize(width: NSView.noIntrinsicMetric, height: singleLineHeight)
+        }
+
+        override init(frame frameRect: NSRect) {
+            let textContainer = NSTextContainer()
+            layoutManager = NSLayoutManager()
+            textStorage = NSTextStorage()
+            layoutManager.addTextContainer(textContainer)
+            textStorage.addLayoutManager(layoutManager)
+            textView = CommandPaletteNativeTextView(frame: .zero, textContainer: textContainer)
+            super.init(frame: frameRect)
+
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.borderType = .noBorder
+            scrollView.drawsBackground = false
+            scrollView.automaticallyAdjustsContentInsets = false
+            scrollView.hasVerticalScroller = false
+            scrollView.hasHorizontalScroller = false
+            scrollView.autohidesScrollers = true
+
+            textView.translatesAutoresizingMaskIntoConstraints = false
+            textView.isEditable = true
+            textView.isSelectable = true
+            textView.isHorizontallyResizable = true
+            textView.isVerticallyResizable = false
+            textView.autoresizingMask = [.height]
+            textView.font = .systemFont(ofSize: 13)
+            textView.textColor = .labelColor
+            textView.insertionPointColor = .labelColor
+            textView.textContainerInset = .zero
+            textView.textContainer?.lineFragmentPadding = 0
+            textView.textContainer?.lineBreakMode = .byClipping
+            textView.textContainer?.widthTracksTextView = false
+            textView.textContainer?.containerSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textView.minSize = .zero
+            textView.maxSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textView.setContentHuggingPriority(.required, for: .vertical)
+            textView.setContentCompressionResistancePriority(.required, for: .vertical)
+
+            scrollView.documentView = textView
+            scrollView.setContentHuggingPriority(.required, for: .vertical)
+            scrollView.setContentCompressionResistancePriority(.required, for: .vertical)
+            addSubview(scrollView)
+            setContentHuggingPriority(.required, for: .vertical)
+            setContentCompressionResistancePriority(.required, for: .vertical)
+
+            placeholderField.translatesAutoresizingMaskIntoConstraints = false
+            placeholderField.font = .systemFont(ofSize: 13)
+            placeholderField.textColor = .secondaryLabelColor
+            placeholderField.lineBreakMode = .byClipping
+            scrollView.contentView.addSubview(placeholderField)
+
+            NSLayoutConstraint.activate([
+                scrollView.topAnchor.constraint(equalTo: topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                placeholderField.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
+                placeholderField.centerYAnchor.constraint(equalTo: scrollView.contentView.centerYAnchor),
+                placeholderField.trailingAnchor.constraint(
+                    lessThanOrEqualTo: scrollView.contentView.trailingAnchor
+                ),
+            ])
+
+            updatePlaceholderVisibility()
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layout() {
+            super.layout()
+            syncTextViewFrameToContentSize()
+        }
+
+        func syncTextViewFrameToContentSize() {
+            let contentSize = scrollView.contentSize
+            guard contentSize.width > 0,
+                  let textContainer = textView.textContainer,
+                  let layoutManager = textView.layoutManager else { return }
+
+            textContainer.containerSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            layoutManager.ensureLayout(for: textContainer)
+            let usedRect = layoutManager.usedRect(for: textContainer)
+            let targetWidth = max(contentSize.width, ceil(usedRect.width) + 4)
+            let targetHeight = max(singleLineHeight, ceil(usedRect.height))
+            let targetFrame = NSRect(origin: .zero, size: NSSize(width: targetWidth, height: targetHeight))
+            if textView.frame != targetFrame {
+                textView.frame = targetFrame
+            }
+            updatePlaceholderVisibility()
+            invalidateIntrinsicContentSize()
+        }
+
+        private func updatePlaceholderVisibility() {
+            placeholderField.isHidden = !textView.string.isEmpty
+        }
+    }
+
+    private struct CommandPaletteTextInputRepresentable: NSViewRepresentable {
+        let placeholder: String
+        let accessibilityIdentifier: String
+        @Binding var text: String
+        @Binding var isFocused: Bool
+        let insertionPointColor: NSColor
+        let onSubmit: () -> Void
+        let onEscape: () -> Void
+        let onMoveSelection: ((Int) -> Void)?
+        let onDeleteEmpty: (() -> Void)?
+
+        final class Coordinator: NSObject, NSTextViewDelegate {
+            var parent: CommandPaletteTextInputRepresentable
+            var isProgrammaticMutation = false
+            var pendingFocusRequest: Bool?
+
+            init(parent: CommandPaletteTextInputRepresentable) {
+                self.parent = parent
+            }
+
+            private func enclosingInputView(for textView: NSTextView) -> CommandPaletteNativeTextInputView? {
+                var current: NSView? = textView
+                while let candidate = current {
+                    if let inputView = candidate as? CommandPaletteNativeTextInputView {
+                        return inputView
+                    }
+                    current = candidate.superview
+                }
+                return nil
+            }
+
+            func textDidChange(_ notification: Notification) {
+                guard !isProgrammaticMutation,
+                      let textView = notification.object as? NSTextView else { return }
+                parent.text = textView.string
+                if let container = enclosingInputView(for: textView) {
+                    container.syncTextViewFrameToContentSize()
+                }
+                invalidateTextInputGeometry(for: textView, reason: "textDidChange")
+            }
+
+            func textDidBeginEditing(_ notification: Notification) {
+                guard let textView = notification.object as? NSTextView else { return }
+                textView.insertionPointColor = parent.insertionPointColor
+                if let container = enclosingInputView(for: textView) {
+                    container.syncTextViewFrameToContentSize()
+                }
+                invalidateTextInputGeometry(for: textView, reason: "beginEditing")
+                if !parent.isFocused {
+                    DispatchQueue.main.async {
+                        self.parent.isFocused = true
+                    }
+                }
+            }
+
+            func textDidEndEditing(_ notification: Notification) {
+                if !(NSApp.isActive && NSApp.keyWindow is NSPanel), parent.isFocused {
+                    DispatchQueue.main.async {
+                        self.parent.isFocused = false
+                    }
+                }
+            }
+
+            func textViewDidChangeSelection(_ notification: Notification) {
+                guard let textView = notification.object as? NSTextView else { return }
+                invalidateTextInputGeometry(for: textView, reason: "selectionDidChange")
+            }
+
+            func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+                switch commandSelector {
+                case #selector(NSResponder.moveDown(_:)):
+                    guard let onMoveSelection = parent.onMoveSelection else { return false }
+                    onMoveSelection(1)
+                    return true
+                case #selector(NSResponder.moveUp(_:)):
+                    guard let onMoveSelection = parent.onMoveSelection else { return false }
+                    onMoveSelection(-1)
+                    return true
+                case #selector(NSResponder.insertNewline(_:)):
+                    guard !textView.hasMarkedText() else { return false }
+                    parent.onSubmit()
+                    return true
+                case #selector(NSResponder.cancelOperation(_:)):
+                    guard !textView.hasMarkedText() else { return false }
+                    parent.onEscape()
+                    return true
+                case #selector(NSResponder.deleteBackward(_:)):
+                    if textView.string.isEmpty, let onDeleteEmpty = parent.onDeleteEmpty {
+                        onDeleteEmpty()
+                        return true
+                    }
+                    return false
+                default:
+                    return false
+                }
+            }
+
+            func invalidateTextInputGeometry(for textView: NSTextView, reason: String) {
+                textView.inputContext?.invalidateCharacterCoordinates()
+                if #available(macOS 15.4, *) {
+                    textView.inputContext?.textInputClientDidUpdateSelection()
+                }
+            }
+        }
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(parent: self)
+        }
+
+        func makeNSView(context: Context) -> CommandPaletteNativeTextInputView {
+            let view = CommandPaletteNativeTextInputView()
+            view.placeholder = placeholder
+            view.textView.string = text
+            view.textView.delegate = context.coordinator
+            view.textView.insertionPointColor = insertionPointColor
+            view.textView.setAccessibilityIdentifier(accessibilityIdentifier)
+            view.setAccessibilityIdentifier(accessibilityIdentifier)
+            return view
+        }
+
+        func updateNSView(_ nsView: CommandPaletteNativeTextInputView, context: Context) {
+            context.coordinator.parent = self
+            nsView.placeholder = placeholder
+            nsView.textView.insertionPointColor = insertionPointColor
+            nsView.textView.setAccessibilityIdentifier(accessibilityIdentifier)
+            nsView.setAccessibilityIdentifier(accessibilityIdentifier)
+
+            if nsView.textView.string != text, !nsView.textView.hasMarkedText() {
+                context.coordinator.isProgrammaticMutation = true
+                nsView.textView.string = text
+                nsView.syncTextViewFrameToContentSize()
+                context.coordinator.isProgrammaticMutation = false
+                context.coordinator.invalidateTextInputGeometry(
+                    for: nsView.textView,
+                    reason: "updateNSView.textSync"
+                )
+            } else {
+                nsView.syncTextViewFrameToContentSize()
+            }
+
+            guard let window = nsView.window else { return }
+            let isFirstResponder = window.firstResponder === nsView.textView
+
+            let systemPanelActive = NSApp.isActive && NSApp.keyWindow is NSPanel
+            if isFocused, !isFirstResponder, !systemPanelActive,
+               context.coordinator.pendingFocusRequest != true {
+                context.coordinator.pendingFocusRequest = true
+                DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
+                    coordinator?.pendingFocusRequest = nil
+                    guard let coordinator, coordinator.parent.isFocused else { return }
+                    guard let nsView, let window = nsView.window else { return }
+                    if NSApp.isActive, NSApp.keyWindow is NSPanel { return }
+                    guard window.firstResponder !== nsView.textView else { return }
+                    window.makeFirstResponder(nsView.textView)
+                }
+            }
+        }
+
+        static func dismantleNSView(_ nsView: CommandPaletteNativeTextInputView, coordinator: Coordinator) {
+            nsView.textView.delegate = nil
+        }
+    }
+
+    private final class CommandPaletteNativeTextField: NSTextField {
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)
             isBordered = false
@@ -3877,31 +4190,8 @@ struct ContentView: View {
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-
-        override func keyDown(with event: NSEvent) {
-            if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
-                super.keyDown(with: event)
-                return
-            }
-            if onHandleKeyEvent?(event, currentEditor() as? NSTextView) == true {
-                return
-            }
-            super.keyDown(with: event)
-        }
-
-        override func performKeyEquivalent(with event: NSEvent) -> Bool {
-            if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
-                return super.performKeyEquivalent(with: event)
-            }
-            if onHandleKeyEvent?(event, currentEditor() as? NSTextView) == true {
-                return true
-            }
-            return super.performKeyEquivalent(with: event)
-        }
     }
 
-    // Keep navigation on the AppKit field editor so deleting the ">" prefix
-    // cannot drop the palette's arrow-key handlers during the scope switch.
     private struct CommandPaletteSearchFieldRepresentable: NSViewRepresentable {
         let placeholder: String
         @Binding var text: String
@@ -3969,38 +4259,6 @@ struct ContentView: View {
                 }
             }
 
-            func handleKeyEvent(_ event: NSEvent, editor: NSTextView?) -> Bool {
-                guard !(editor?.hasMarkedText() ?? false) else { return false }
-
-                if let delta = commandPaletteSelectionDeltaForKeyboardNavigation(
-                    flags: event.modifierFlags,
-                    chars: event.characters ?? event.charactersIgnoringModifiers ?? "",
-                    keyCode: event.keyCode
-                ) {
-                    parent.onMoveSelection(delta)
-                    return true
-                }
-
-                if shouldSubmitCommandPaletteWithReturn(
-                    keyCode: event.keyCode,
-                    flags: event.modifierFlags
-                ) {
-                    parent.onSubmit()
-                    return true
-                }
-
-                if event.keyCode == 53,
-                   event.modifierFlags
-                    .intersection(.deviceIndependentFlagsMask)
-                    .subtracting([.numericPad, .function, .capsLock])
-                    .isEmpty {
-                    parent.onEscape()
-                    return true
-                }
-
-                return false
-            }
-
             func attachEditorTextDidChangeObserverIfNeeded(_ editor: NSTextView) {
                 if observedEditor !== editor {
                     detachEditorTextDidChangeObserver()
@@ -4040,9 +4298,6 @@ struct ContentView: View {
             field.isEditable = true
             field.isSelectable = true
             field.isEnabled = true
-            field.onHandleKeyEvent = { [weak coordinator = context.coordinator] event, editor in
-                coordinator?.handleKeyEvent(event, editor: editor) ?? false
-            }
             context.coordinator.parentField = field
             return field
         }
@@ -4073,13 +4328,15 @@ struct ContentView: View {
                 firstResponder === nsView ||
                 nsView.currentEditor() != nil ||
                 ((firstResponder as? NSTextView)?.delegate as? NSTextField) === nsView
-
-            if isFocused, !isFirstResponder, context.coordinator.pendingFocusRequest != true {
+            let systemPanelActive = NSApp.isActive && NSApp.keyWindow is NSPanel
+            if isFocused, !isFirstResponder, !systemPanelActive,
+               context.coordinator.pendingFocusRequest != true {
                 context.coordinator.pendingFocusRequest = true
                 DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
                     coordinator?.pendingFocusRequest = nil
                     guard let coordinator, coordinator.parent.isFocused else { return }
                     guard let nsView, let window = nsView.window else { return }
+                    if NSApp.isActive, NSApp.keyWindow is NSPanel { return }
                     let firstResponder = window.firstResponder
                     let alreadyFocused =
                         firstResponder === nsView ||
@@ -4093,9 +4350,108 @@ struct ContentView: View {
 
         static func dismantleNSView(_ nsView: CommandPaletteNativeTextField, coordinator: Coordinator) {
             nsView.delegate = nil
-            nsView.onHandleKeyEvent = nil
             coordinator.detachEditorTextDidChangeObserver()
             coordinator.parentField = nil
+        }
+    }
+
+    private struct CommandPaletteRenameFieldRepresentable: NSViewRepresentable {
+        @Binding var text: String
+        @Binding var isFocused: Bool
+        let tintColor: NSColor
+        let onSubmit: () -> Void
+        let onEscape: () -> Void
+        let onDeleteEmpty: () -> Void
+
+        func makeCoordinator() -> CommandPaletteTextInputRepresentable.Coordinator {
+            CommandPaletteTextInputRepresentable(
+                placeholder: "",
+                accessibilityIdentifier: "CommandPaletteRenameField",
+                text: $text,
+                isFocused: $isFocused,
+                insertionPointColor: tintColor,
+                onSubmit: onSubmit,
+                onEscape: onEscape,
+                onMoveSelection: nil,
+                onDeleteEmpty: onDeleteEmpty
+            ).makeCoordinator()
+        }
+
+        func makeNSView(context: Context) -> CommandPaletteNativeTextInputView {
+            let configuration = CommandPaletteTextInputRepresentable(
+                placeholder: "",
+                accessibilityIdentifier: "CommandPaletteRenameField",
+                text: $text,
+                isFocused: $isFocused,
+                insertionPointColor: tintColor,
+                onSubmit: onSubmit,
+                onEscape: onEscape,
+                onMoveSelection: nil,
+                onDeleteEmpty: onDeleteEmpty
+            )
+            let view = CommandPaletteNativeTextInputView()
+            view.placeholder = configuration.placeholder
+            view.textView.string = text
+            view.textView.delegate = context.coordinator
+            view.textView.insertionPointColor = configuration.insertionPointColor
+            view.textView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
+            view.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
+            return view
+        }
+
+        func updateNSView(_ nsView: CommandPaletteNativeTextInputView, context: Context) {
+            let configuration = CommandPaletteTextInputRepresentable(
+                placeholder: "",
+                accessibilityIdentifier: "CommandPaletteRenameField",
+                text: $text,
+                isFocused: $isFocused,
+                insertionPointColor: tintColor,
+                onSubmit: onSubmit,
+                onEscape: onEscape,
+                onMoveSelection: nil,
+                onDeleteEmpty: onDeleteEmpty
+            )
+            context.coordinator.parent = configuration
+            nsView.placeholder = configuration.placeholder
+            nsView.textView.insertionPointColor = configuration.insertionPointColor
+            nsView.textView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
+            nsView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
+
+            if nsView.textView.string != text, !nsView.textView.hasMarkedText() {
+                context.coordinator.isProgrammaticMutation = true
+                nsView.textView.string = text
+                nsView.syncTextViewFrameToContentSize()
+                context.coordinator.isProgrammaticMutation = false
+                context.coordinator.invalidateTextInputGeometry(
+                    for: nsView.textView,
+                    reason: "updateNSView.textSync"
+                )
+            } else {
+                nsView.syncTextViewFrameToContentSize()
+            }
+
+            guard let window = nsView.window else { return }
+            let isFirstResponder = window.firstResponder === nsView.textView
+            let systemPanelActive = NSApp.isActive && NSApp.keyWindow is NSPanel
+            if isFocused, !isFirstResponder, !systemPanelActive,
+               context.coordinator.pendingFocusRequest != true {
+                context.coordinator.pendingFocusRequest = true
+                DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
+                    coordinator?.pendingFocusRequest = nil
+                    guard let coordinator, coordinator.parent.isFocused else { return }
+                    guard let nsView, let window = nsView.window else { return }
+                    if NSApp.isActive, NSApp.keyWindow is NSPanel { return }
+                    guard window.firstResponder !== nsView.textView else { return }
+                    window.makeFirstResponder(nsView.textView)
+                }
+            }
+        }
+
+        static func dismantleNSView(
+            _ nsView: CommandPaletteNativeTextInputView,
+            coordinator: CommandPaletteTextInputRepresentable.Coordinator
+        ) {
+            nsView.textView.delegate = nil
         }
     }
 
@@ -6593,8 +6949,7 @@ struct ContentView: View {
         }
 
         if let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow,
-           let editor = window.firstResponder as? NSTextView,
-           editor.isFieldEditor {
+           let editor = window.firstResponder as? NSTextView {
             editor.deleteBackward(nil)
             commandPaletteRenameDraft = editor.string
         } else if !commandPaletteRenameDraft.isEmpty {
@@ -7146,9 +7501,9 @@ struct ContentView: View {
             }
         }
         guard let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else { return }
-
+        let overlayController = commandPaletteWindowOverlayController(for: window)
         guard let editor = window.firstResponder as? NSTextView,
-              editor.isFieldEditor else {
+              overlayController.ownsTextInputResponder(editor) else {
             return
         }
         let length = (editor.string as NSString).length
@@ -7157,6 +7512,10 @@ struct ContentView: View {
             editor.setSelectedRange(NSRange(location: 0, length: length))
         case .caretAtEnd:
             editor.setSelectedRange(NSRange(location: length, length: 0))
+        }
+        editor.inputContext?.invalidateCharacterCoordinates()
+        if #available(macOS 15.4, *) {
+            editor.inputContext?.textInputClientDidUpdateSelection()
         }
         commandPalettePendingTextSelectionBehavior = nil
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3778,15 +3778,18 @@ struct ContentView: View {
     private func commandPaletteRenameInputView(target: CommandPaletteRenameTarget) -> some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                CommandPaletteRenameFieldRepresentable(
+                CommandPaletteTextInputRepresentable(
+                    placeholder: "",
+                    accessibilityIdentifier: "CommandPaletteRenameField",
                     text: $commandPaletteRenameDraft,
                     isFocused: Binding(
                         get: { isCommandPaletteRenameFocused },
                         set: { isCommandPaletteRenameFocused = $0 }
                     ),
-                    tintColor: sidebarActiveForegroundNSColor(opacity: 1.0),
+                    insertionPointColor: sidebarActiveForegroundNSColor(opacity: 1.0),
                     onSubmit: { continueRenameFlow(target: target) },
                     onEscape: { dismissCommandPalette() },
+                    onMoveSelection: nil,
                     onDeleteEmpty: {
                         commandPaletteMode = .commands
                         resetCommandPaletteSearchFocus()
@@ -4052,7 +4055,7 @@ struct ContentView: View {
                 if let container = enclosingInputView(for: textView) {
                     container.syncTextViewFrameToContentSize()
                 }
-                invalidateTextInputGeometry(for: textView, reason: "textDidChange")
+                invalidateTextInputGeometry(for: textView)
             }
 
             func textDidBeginEditing(_ notification: Notification) {
@@ -4061,7 +4064,7 @@ struct ContentView: View {
                 if let container = enclosingInputView(for: textView) {
                     container.syncTextViewFrameToContentSize()
                 }
-                invalidateTextInputGeometry(for: textView, reason: "beginEditing")
+                invalidateTextInputGeometry(for: textView)
                 if !parent.isFocused {
                     DispatchQueue.main.async {
                         self.parent.isFocused = true
@@ -4079,7 +4082,7 @@ struct ContentView: View {
 
             func textViewDidChangeSelection(_ notification: Notification) {
                 guard let textView = notification.object as? NSTextView else { return }
-                invalidateTextInputGeometry(for: textView, reason: "selectionDidChange")
+                invalidateTextInputGeometry(for: textView)
             }
 
             func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
@@ -4111,7 +4114,7 @@ struct ContentView: View {
                 }
             }
 
-            func invalidateTextInputGeometry(for textView: NSTextView, reason: String) {
+            func invalidateTextInputGeometry(for textView: NSTextView) {
                 textView.inputContext?.invalidateCharacterCoordinates()
                 if #available(macOS 15.4, *) {
                     textView.inputContext?.textInputClientDidUpdateSelection()
@@ -4146,10 +4149,7 @@ struct ContentView: View {
                 nsView.textView.string = text
                 nsView.syncTextViewFrameToContentSize()
                 context.coordinator.isProgrammaticMutation = false
-                context.coordinator.invalidateTextInputGeometry(
-                    for: nsView.textView,
-                    reason: "updateNSView.textSync"
-                )
+                context.coordinator.invalidateTextInputGeometry(for: nsView.textView)
             } else {
                 nsView.syncTextViewFrameToContentSize()
             }
@@ -4178,6 +4178,8 @@ struct ContentView: View {
     }
 
     private final class CommandPaletteNativeTextField: NSTextField {
+        var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
+
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)
             isBordered = false
@@ -4190,8 +4192,31 @@ struct ContentView: View {
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
+
+        override func keyDown(with event: NSEvent) {
+            if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
+                super.keyDown(with: event)
+                return
+            }
+            if onHandleKeyEvent?(event, currentEditor() as? NSTextView) == true {
+                return
+            }
+            super.keyDown(with: event)
+        }
+
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            if (currentEditor() as? NSTextView)?.hasMarkedText() == true {
+                return super.performKeyEquivalent(with: event)
+            }
+            if onHandleKeyEvent?(event, currentEditor() as? NSTextView) == true {
+                return true
+            }
+            return super.performKeyEquivalent(with: event)
+        }
     }
 
+    // Keep navigation on the AppKit field editor so deleting the ">" prefix
+    // cannot drop the palette's arrow-key handlers during the scope switch.
     private struct CommandPaletteSearchFieldRepresentable: NSViewRepresentable {
         let placeholder: String
         @Binding var text: String
@@ -4259,6 +4284,38 @@ struct ContentView: View {
                 }
             }
 
+            func handleKeyEvent(_ event: NSEvent, editor: NSTextView?) -> Bool {
+                guard !(editor?.hasMarkedText() ?? false) else { return false }
+
+                if let delta = commandPaletteSelectionDeltaForKeyboardNavigation(
+                    flags: event.modifierFlags,
+                    chars: event.characters ?? event.charactersIgnoringModifiers ?? "",
+                    keyCode: event.keyCode
+                ) {
+                    parent.onMoveSelection(delta)
+                    return true
+                }
+
+                if shouldSubmitCommandPaletteWithReturn(
+                    keyCode: event.keyCode,
+                    flags: event.modifierFlags
+                ) {
+                    parent.onSubmit()
+                    return true
+                }
+
+                if event.keyCode == 53,
+                   event.modifierFlags
+                    .intersection(.deviceIndependentFlagsMask)
+                    .subtracting([.numericPad, .function, .capsLock])
+                    .isEmpty {
+                    parent.onEscape()
+                    return true
+                }
+
+                return false
+            }
+
             func attachEditorTextDidChangeObserverIfNeeded(_ editor: NSTextView) {
                 if observedEditor !== editor {
                     detachEditorTextDidChangeObserver()
@@ -4298,6 +4355,9 @@ struct ContentView: View {
             field.isEditable = true
             field.isSelectable = true
             field.isEnabled = true
+            field.onHandleKeyEvent = { [weak coordinator = context.coordinator] event, editor in
+                coordinator?.handleKeyEvent(event, editor: editor) ?? false
+            }
             context.coordinator.parentField = field
             return field
         }
@@ -4328,15 +4388,13 @@ struct ContentView: View {
                 firstResponder === nsView ||
                 nsView.currentEditor() != nil ||
                 ((firstResponder as? NSTextView)?.delegate as? NSTextField) === nsView
-            let systemPanelActive = NSApp.isActive && NSApp.keyWindow is NSPanel
-            if isFocused, !isFirstResponder, !systemPanelActive,
+            if isFocused, !isFirstResponder,
                context.coordinator.pendingFocusRequest != true {
                 context.coordinator.pendingFocusRequest = true
                 DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
                     coordinator?.pendingFocusRequest = nil
                     guard let coordinator, coordinator.parent.isFocused else { return }
                     guard let nsView, let window = nsView.window else { return }
-                    if NSApp.isActive, NSApp.keyWindow is NSPanel { return }
                     let firstResponder = window.firstResponder
                     let alreadyFocused =
                         firstResponder === nsView ||
@@ -4350,108 +4408,9 @@ struct ContentView: View {
 
         static func dismantleNSView(_ nsView: CommandPaletteNativeTextField, coordinator: Coordinator) {
             nsView.delegate = nil
+            nsView.onHandleKeyEvent = nil
             coordinator.detachEditorTextDidChangeObserver()
             coordinator.parentField = nil
-        }
-    }
-
-    private struct CommandPaletteRenameFieldRepresentable: NSViewRepresentable {
-        @Binding var text: String
-        @Binding var isFocused: Bool
-        let tintColor: NSColor
-        let onSubmit: () -> Void
-        let onEscape: () -> Void
-        let onDeleteEmpty: () -> Void
-
-        func makeCoordinator() -> CommandPaletteTextInputRepresentable.Coordinator {
-            CommandPaletteTextInputRepresentable(
-                placeholder: "",
-                accessibilityIdentifier: "CommandPaletteRenameField",
-                text: $text,
-                isFocused: $isFocused,
-                insertionPointColor: tintColor,
-                onSubmit: onSubmit,
-                onEscape: onEscape,
-                onMoveSelection: nil,
-                onDeleteEmpty: onDeleteEmpty
-            ).makeCoordinator()
-        }
-
-        func makeNSView(context: Context) -> CommandPaletteNativeTextInputView {
-            let configuration = CommandPaletteTextInputRepresentable(
-                placeholder: "",
-                accessibilityIdentifier: "CommandPaletteRenameField",
-                text: $text,
-                isFocused: $isFocused,
-                insertionPointColor: tintColor,
-                onSubmit: onSubmit,
-                onEscape: onEscape,
-                onMoveSelection: nil,
-                onDeleteEmpty: onDeleteEmpty
-            )
-            let view = CommandPaletteNativeTextInputView()
-            view.placeholder = configuration.placeholder
-            view.textView.string = text
-            view.textView.delegate = context.coordinator
-            view.textView.insertionPointColor = configuration.insertionPointColor
-            view.textView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
-            view.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
-            return view
-        }
-
-        func updateNSView(_ nsView: CommandPaletteNativeTextInputView, context: Context) {
-            let configuration = CommandPaletteTextInputRepresentable(
-                placeholder: "",
-                accessibilityIdentifier: "CommandPaletteRenameField",
-                text: $text,
-                isFocused: $isFocused,
-                insertionPointColor: tintColor,
-                onSubmit: onSubmit,
-                onEscape: onEscape,
-                onMoveSelection: nil,
-                onDeleteEmpty: onDeleteEmpty
-            )
-            context.coordinator.parent = configuration
-            nsView.placeholder = configuration.placeholder
-            nsView.textView.insertionPointColor = configuration.insertionPointColor
-            nsView.textView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
-            nsView.setAccessibilityIdentifier(configuration.accessibilityIdentifier)
-
-            if nsView.textView.string != text, !nsView.textView.hasMarkedText() {
-                context.coordinator.isProgrammaticMutation = true
-                nsView.textView.string = text
-                nsView.syncTextViewFrameToContentSize()
-                context.coordinator.isProgrammaticMutation = false
-                context.coordinator.invalidateTextInputGeometry(
-                    for: nsView.textView,
-                    reason: "updateNSView.textSync"
-                )
-            } else {
-                nsView.syncTextViewFrameToContentSize()
-            }
-
-            guard let window = nsView.window else { return }
-            let isFirstResponder = window.firstResponder === nsView.textView
-            let systemPanelActive = NSApp.isActive && NSApp.keyWindow is NSPanel
-            if isFocused, !isFirstResponder, !systemPanelActive,
-               context.coordinator.pendingFocusRequest != true {
-                context.coordinator.pendingFocusRequest = true
-                DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
-                    coordinator?.pendingFocusRequest = nil
-                    guard let coordinator, coordinator.parent.isFocused else { return }
-                    guard let nsView, let window = nsView.window else { return }
-                    if NSApp.isActive, NSApp.keyWindow is NSPanel { return }
-                    guard window.firstResponder !== nsView.textView else { return }
-                    window.makeFirstResponder(nsView.textView)
-                }
-            }
-        }
-
-        static func dismantleNSView(
-            _ nsView: CommandPaletteNativeTextInputView,
-            coordinator: CommandPaletteTextInputRepresentable.Coordinator
-        ) {
-            nsView.textView.delegate = nil
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3779,7 +3779,7 @@ struct ContentView: View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 CommandPaletteTextInputRepresentable(
-                    placeholder: "",
+                    placeholder: target.placeholder,
                     accessibilityIdentifier: "CommandPaletteRenameField",
                     text: $commandPaletteRenameDraft,
                     isFocused: Binding(
@@ -4048,10 +4048,24 @@ struct ContentView: View {
                 return nil
             }
 
+            private func sanitizedSingleLineText(_ text: String) -> String {
+                text.components(separatedBy: .newlines).joined(separator: " ")
+            }
+
             func textDidChange(_ notification: Notification) {
                 guard !isProgrammaticMutation,
                       let textView = notification.object as? NSTextView else { return }
-                parent.text = textView.string
+                let sanitizedText = sanitizedSingleLineText(textView.string)
+                if sanitizedText != textView.string {
+                    isProgrammaticMutation = true
+                    let selectedRange = textView.selectedRange()
+                    textView.string = sanitizedText
+                    textView.setSelectedRange(
+                        NSRange(location: min(selectedRange.location, (sanitizedText as NSString).length), length: 0)
+                    )
+                    isProgrammaticMutation = false
+                }
+                parent.text = sanitizedText
                 if let container = enclosingInputView(for: textView) {
                     container.syncTextViewFrameToContentSize()
                 }
@@ -6908,7 +6922,8 @@ struct ContentView: View {
         }
 
         if let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow,
-           let editor = window.firstResponder as? NSTextView {
+           let editor = window.firstResponder as? NSTextView,
+           commandPaletteWindowOverlayController(for: window).ownsTextInputResponder(editor) {
             editor.deleteBackward(nil)
             commandPaletteRenameDraft = editor.string
         } else if !commandPaletteRenameDraft.isEmpty {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7650,6 +7650,12 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
             dlog("find.window.didBecomeKey surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") searchActive=\(searchActive) focusTarget=\(self.searchFocusTarget) firstResponder=\(String(describing: self.window?.firstResponder))")
 #endif
+            if self.isCommandPaletteVisible(in: window) {
+#if DEBUG
+                dlog("find.window.didBecomeKey.skip surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") reason=commandPaletteVisible")
+#endif
+                return
+            }
             self.scheduleAutomaticFirstResponderApply(reason: "didBecomeKey")
         })
         windowObservers.append(NotificationCenter.default.addObserver(
@@ -8712,6 +8718,12 @@ final class GhosttySurfaceScrollView: NSView {
             let surfaceShort = self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
             dlog("find.applyFirstResponder.defer surface=\(surfaceShort) reason=\(reason)")
 #endif
+            if let window = self.window, self.isCommandPaletteVisible(in: window) {
+#if DEBUG
+                dlog("find.applyFirstResponder.skip surface=\(surfaceShort) reason=commandPaletteVisible")
+#endif
+                return
+            }
             self.applyFirstResponderIfNeeded()
         }
     }
@@ -8763,6 +8775,12 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
         guard let window, window.isKeyWindow else { return }
+        if isCommandPaletteVisible(in: window) {
+#if DEBUG
+            dlog("focus.apply.skip surface=\(surfaceShort) reason=commandPaletteVisible")
+#endif
+            return
+        }
         guard let tabId = surfaceView.tabId,
               let panelId = surfaceView.terminalSurface?.id,
               matchesCurrentTerminalFocusTarget(tabId: tabId, surfaceId: panelId) else {
@@ -8801,6 +8819,12 @@ final class GhosttySurfaceScrollView: NSView {
     /// Respects `searchFocusTarget` so Escape-to-terminal intent is preserved across window switches.
     private func restoreSearchFocus(window: NSWindow) {
         let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+        if isCommandPaletteVisible(in: window) {
+#if DEBUG
+            dlog("find.restoreSearchFocus.skip surface=\(surfaceShort) reason=commandPaletteVisible")
+#endif
+            return
+        }
         switch searchFocusTarget {
         case .searchField:
             if let firstResponder = window.firstResponder,
@@ -8849,6 +8873,10 @@ final class GhosttySurfaceScrollView: NSView {
             )
 #endif
         }
+    }
+
+    private func isCommandPaletteVisible(in window: NSWindow) -> Bool {
+        AppDelegate.shared?.isCommandPaletteVisible(for: window) == true
     }
 
     func capturePanelFocusIntent(in window: NSWindow?) -> TerminalPanelFocusIntent {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5792,6 +5792,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Alt+Backspace and generates ESC+DEL.
         if flags.contains(.option) && !flags.contains(.command) && !flags.contains(.control) && !hasMarkedText(),
            event.keyCode == 51 {
+            terminalSurface?.recordExternalFocusState(true)
             ghostty_surface_set_focus(surface, true)
             var keyEvent = ghostty_input_key_s()
             keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7650,12 +7650,6 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
             dlog("find.window.didBecomeKey surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") searchActive=\(searchActive) focusTarget=\(self.searchFocusTarget) firstResponder=\(String(describing: self.window?.firstResponder))")
 #endif
-            if self.isCommandPaletteVisible(in: window) {
-#if DEBUG
-                dlog("find.window.didBecomeKey.skip surface=\(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") reason=commandPaletteVisible")
-#endif
-                return
-            }
             self.scheduleAutomaticFirstResponderApply(reason: "didBecomeKey")
         })
         windowObservers.append(NotificationCenter.default.addObserver(
@@ -8718,12 +8712,6 @@ final class GhosttySurfaceScrollView: NSView {
             let surfaceShort = self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
             dlog("find.applyFirstResponder.defer surface=\(surfaceShort) reason=\(reason)")
 #endif
-            if let window = self.window, self.isCommandPaletteVisible(in: window) {
-#if DEBUG
-                dlog("find.applyFirstResponder.skip surface=\(surfaceShort) reason=commandPaletteVisible")
-#endif
-                return
-            }
             self.applyFirstResponderIfNeeded()
         }
     }
@@ -8775,12 +8763,6 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
         guard let window, window.isKeyWindow else { return }
-        if isCommandPaletteVisible(in: window) {
-#if DEBUG
-            dlog("focus.apply.skip surface=\(surfaceShort) reason=commandPaletteVisible")
-#endif
-            return
-        }
         guard let tabId = surfaceView.tabId,
               let panelId = surfaceView.terminalSurface?.id,
               matchesCurrentTerminalFocusTarget(tabId: tabId, surfaceId: panelId) else {
@@ -8819,12 +8801,6 @@ final class GhosttySurfaceScrollView: NSView {
     /// Respects `searchFocusTarget` so Escape-to-terminal intent is preserved across window switches.
     private func restoreSearchFocus(window: NSWindow) {
         let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
-        if isCommandPaletteVisible(in: window) {
-#if DEBUG
-            dlog("find.restoreSearchFocus.skip surface=\(surfaceShort) reason=commandPaletteVisible")
-#endif
-            return
-        }
         switch searchFocusTarget {
         case .searchField:
             if let firstResponder = window.firstResponder,
@@ -8873,10 +8849,6 @@ final class GhosttySurfaceScrollView: NSView {
             )
 #endif
         }
-    }
-
-    private func isCommandPaletteVisible(in window: NSWindow) -> Bool {
-        AppDelegate.shared?.isCommandPaletteVisible(for: window) == true
     }
 
     func capturePanelFocusIntent(in window: NSWindow?) -> TerminalPanelFocusIntent {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5785,6 +5785,37 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if handled { return }
         }
 
+        // Fast path for Option+Delete (backward word-delete).
+        // macOS maps Option+Delete to "∂" (U+2202) through AppKit text input.
+        // In terminals, Alt+Backspace should delete the previous word.
+        // Bypass interpretKeyEvents so Ghostty's key encoder receives the raw
+        // Alt+Backspace and generates ESC+DEL.
+        if flags.contains(.option) && !flags.contains(.command) && !flags.contains(.control) && !hasMarkedText(),
+           event.keyCode == 51 {
+            ghostty_surface_set_focus(surface, true)
+            var keyEvent = ghostty_input_key_s()
+            keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
+            keyEvent.keycode = UInt32(event.keyCode)
+            keyEvent.mods = modsFromEvent(event)
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.composing = false
+            keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
+            keyEvent.text = nil
+            #if DEBUG
+            let ghosttySendStart = ProcessInfo.processInfo.systemUptime
+            let handled = sendTimedGhosttyKey(
+                surface,
+                keyEvent,
+                path: "terminal.keyDown.optDeleteGhosttySend",
+                event: event
+            )
+            ghosttySendMs = (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
+            #else
+            let handled = ghostty_surface_key(surface, keyEvent)
+            #endif
+            if handled { return }
+        }
+
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt)

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -376,6 +376,14 @@ struct StoredShortcut: Codable, Equatable {
             return .upArrow
         case "↓":
             return .downArrow
+        case "↖":
+            return .home
+        case "↘":
+            return .end
+        case "⇞":
+            return .pageUp
+        case "⇟":
+            return .pageDown
         case "\t":
             return .tab
         case "\r":
@@ -418,6 +426,18 @@ struct StoredShortcut: Codable, Equatable {
         case "↓":
             guard let scalar = UnicodeScalar(NSDownArrowFunctionKey) else { return nil }
             return String(Character(scalar))
+        case "↖":
+            guard let scalar = UnicodeScalar(NSHomeFunctionKey) else { return nil }
+            return String(Character(scalar))
+        case "↘":
+            guard let scalar = UnicodeScalar(NSEndFunctionKey) else { return nil }
+            return String(Character(scalar))
+        case "⇞":
+            guard let scalar = UnicodeScalar(NSPageUpFunctionKey) else { return nil }
+            return String(Character(scalar))
+        case "⇟":
+            guard let scalar = UnicodeScalar(NSPageDownFunctionKey) else { return nil }
+            return String(Character(scalar))
         case "\t":
             return "\t"
         case "\r":
@@ -458,6 +478,10 @@ struct StoredShortcut: Codable, Equatable {
         case 124: return "→" // right arrow
         case 125: return "↓" // down arrow
         case 126: return "↑" // up arrow
+        case 115: return "↖" // Home
+        case 119: return "↘" // End
+        case 116: return "⇞" // Page Up
+        case 121: return "⇟" // Page Down
         case 48: return "\t" // tab
         case 36, 76: return "\r" // return, keypad enter
         case 33: return "["  // kVK_ANSI_LeftBracket

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1190,8 +1190,9 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
             pressEvent = keyEvent
         }
 
+        // Real macOS produces "∂" (U+2202) for Option+Delete, not "\u{7F}".
         let sent = hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
-            characters: "\u{7F}",
+            characters: "\u{2202}",
             charactersIgnoringModifiers: "\u{7F}",
             keyCode: 51,
             modifierFlags: [.option]


### PR DESCRIPTION
## Summary

Globe+Arrow keys produce Home/End/PageUp/PageDown at the hardware level on macOS (keyCodes 115/119/116/121). These keys couldn't be used as keyboard shortcuts because the shortcut system didn't handle their keyCodes or Unicode function-key characters. For example, a user binding Shift+Home to "Previous Pane" would see the recording silently fail, and even if manually configured, matching would fail for non-Cmd/Ctrl modifiers.

This mirrors the existing arrow key (←→↑↓) pattern across all five touch points in two files:

1. **`storedKey(from:)`** — map keyCodes 115/119/116/121 to glyphs ↖↘⇞⇟ so the shortcut recorder captures them
2. **`matchShortcut`** — early keyCode-based match (before the Cmd/Ctrl-gated fallback) so Shift+Home etc. work
3. **`keyEquivalent`** — map glyphs to SwiftUI `.home`/`.end`/`.pageUp`/`.pageDown`
4. **`menuItemKeyEquivalent`** — map glyphs to AppKit `NSHomeFunctionKey` etc.
5. **`keyCodeForShortcutKey`** — reverse glyph→keyCode lookup

Related: #1920 added Home/End/PageUp/PageDown to the socket `send-key` API. This extends that support to the keyboard shortcut settings UI.

## Test plan

- [ ] Open Settings → Shortcuts, click any action's shortcut field
- [ ] Press Globe+Left (Home) — verify "⇧↖" or similar glyph appears (not silently rejected)
- [ ] Press Globe+Right (End), Globe+Up (PageUp), Globe+Down (PageDown) — all record correctly
- [ ] Bind Shift+Home to an action (e.g. "Previous Pane"), press Shift+Globe+Left — verify it triggers
- [ ] Bind Cmd+End to an action, press Cmd+Globe+Right — verify it triggers
- [ ] Verify existing arrow key shortcuts still work unchanged
- [ ] Verify Home/End/PageUp/PageDown still scroll normally in the terminal when not bound to a shortcut

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for binding Home, End, Page Up, and Page Down (Globe+Arrows on macOS) as keyboard shortcuts. Also fixes Option+Delete behavior and makes the command palette rename input more reliable.

- **New Features**
  - Recorder and matcher support for ↖, ↘, ⇞, ⇟ with Shift/Ctrl/Cmd modifiers.
  - Maps to SwiftUI `.home`/`.end`/`.pageUp`/`.pageDown`, AppKit function keys, and adds reverse keyCode lookup.

- **Bug Fixes**
  - Option+Delete now deletes the previous word by fast-pathing Alt+Backspace to send ESC+DEL; regression test updated to use the real “∂” character.
  - Command palette rename input: replaced with a native text view to restore placeholder and single-line behavior, fix IME/emoji input, and improve focus/selection handling without stealing focus.

<sup>Written for commit 74708d0c4cf58c78ed2f5b3870d6551654ddc3f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Home, End, Page Up, and Page Down glyph shortcuts (↖, ↘, ⇞, ⇟).
  * Improved command palette text input with enhanced keyboard navigation and editing support.

* **Bug Fixes**
  * Improved keyboard shortcut recognition and event handling for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->