### PR TITLE
fix: enable window.isMovable for third-party window managers (Swish, Rectangle)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -27,6 +27,21 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
         ])
     }
 
+    // Exclude the titlebar from the accessibility frame. safeAreaInsets is
+    // zeroed so this view fills the whole window, but Swish and similar tools
+    // derive titlebar height from the gap between window frame and first child.
+    // No gap = no titlebar = no gestures. Subtract the titlebar height so the
+    // offset is visible.
+    override func accessibilityFrame() -> NSRect {
+        guard let window = window else { return super.accessibilityFrame() }
+        var frame = super.accessibilityFrame()
+        let titlebarHeight = window.frame.height - window.contentLayoutRect.height
+        if titlebarHeight > 0 {
+            frame.size.height -= titlebarHeight
+        }
+        return frame
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -5997,7 +6012,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.isMovable = false
+        window.isMovable = true
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)


### PR DESCRIPTION
Fixes #1383. Swish can't detect cmux's titlebar, so window gestures (snap, tile, move) don't work.

## Root cause

`MainWindowHostingView` zeroes `safeAreaInsets` so content draws behind the titlebar. This makes its accessibility frame match the window frame exactly. Swish derives titlebar height from the gap between the window and its first AX child. Zero gap = no titlebar.

AX tree comparison:
- **Ghostty**: window Y=52, first child Y=80 → 28px titlebar ✓
- **cmux**: window Y=44, first child Y=44 → 0px titlebar ✗

## Fix

1. Override `accessibilityFrame()` on `MainWindowHostingView` to subtract the titlebar height (`frame.height - contentLayoutRect.height`). Layout unchanged.

2. Set `window.isMovable = true` (was `false`). Existing drag suppression during sidebar tab reordering prevents conflicts.

## Testing

- Swish gestures work on cmux windows
- Title bar dragging still works
- Sidebar tab reordering does not move the window
- macOS Window → Move & Resize menu works
