### PR TITLE
feat: dispatch set-hook lifecycle events

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4889,11 +4889,26 @@ struct CMUXCLI {
             return """
             Usage: cmux set-hook [--list] [--unset <event>] | <event> <command>
 
-            Manage tmux-compat hook definitions.
+            Register shell commands to run on app lifecycle events.
+
+            Events:
+              after-restore      Fired after session restore completes on launch
+              session-created    Fired after app finishes launching
+              workspace-created  Fired when a new workspace is created
+              workspace-closed   Fired when a workspace is closed
+              before-shutdown    Fired before the app terminates
+
+            Environment variables passed to hook commands:
+              CMUX_HOOK_EVENT         The event name that triggered this hook
+              CMUX_HOOK_WORKSPACE_ID  Workspace UUID (workspace-created/workspace-closed only)
 
             Flags:
               --list            List configured hooks
               --unset <event>   Remove a hook by event name
+
+            Example:
+              cmux set-hook after-restore "/path/to/restore-sessions.sh"
+              cmux set-hook before-shutdown "echo shutting down >> /tmp/cmux.log"
             """
         case "popup":
             return """

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
+		A5009900 /* LifecycleHookDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5009901 /* LifecycleHookDispatcher.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
@@ -209,6 +210,7 @@
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
+		A5009901 /* LifecycleHookDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHookDispatcher.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
+				A5009901 /* LifecycleHookDispatcher.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -676,6 +679,7 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
+				A5009900 /* LifecycleHookDispatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2243,6 +2243,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 #endif
+        LifecycleHookDispatcher.dispatch("session-created")
     }
 
 #if DEBUG
@@ -2307,6 +2308,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        LifecycleHookDispatcher.dispatch("before-shutdown")
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
@@ -2498,6 +2500,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         startupSessionSnapshot = nil
         isApplyingStartupSessionRestore = false
         _ = saveSessionSnapshot(includeScrollback: false)
+        LifecycleHookDispatcher.dispatch("after-restore")
     }
 
     private func applySessionWindowSnapshot(

--- a/Sources/LifecycleHookDispatcher.swift
+++ b/Sources/LifecycleHookDispatcher.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Dispatches lifecycle hooks stored in the tmux-compat store.
+///
+/// Hooks are persisted by the CLI via `cmux set-hook <event> <command>` in
+/// `~/.cmuxterm/tmux-compat-store.json`.  The app loads that file and fires
+/// matching shell commands asynchronously at the appropriate lifecycle points.
+///
+/// Supported events (fired by the app):
+///   - `after-restore`      — after session restore completes on launch
+///   - `session-created`    — after applicationDidFinishLaunching
+///   - `workspace-created`  — after a new workspace is added
+///   - `workspace-closed`   — after a workspace is closed
+///   - `before-shutdown`    — before the app terminates
+enum LifecycleHookDispatcher {
+
+    // MARK: - Store format (mirrors CLI TmuxCompatStore, decode-only)
+
+    private struct TmuxCompatStore: Decodable {
+        var hooks: [String: String] = [:]
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            hooks = try container.decodeIfPresent([String: String].self, forKey: .hooks) ?? [:]
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case hooks
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Fire the hook for `event` if one is registered.  Runs the command
+    /// asynchronously on a background queue so it never blocks the main thread.
+    /// Environment variables `CMUX_HOOK_EVENT` and optionally
+    /// `CMUX_HOOK_WORKSPACE_ID` are passed to the child process.
+    static func dispatch(
+        _ event: String,
+        workspaceId: String? = nil,
+        environment: [String: String] = [:]
+    ) {
+        guard let command = loadHook(for: event) else { return }
+        dispatchQueue.async {
+            executeShellCommand(command, event: event, workspaceId: workspaceId, environment: environment)
+        }
+    }
+
+    // MARK: - Internals
+
+    private static let dispatchQueue = DispatchQueue(
+        label: "com.cmuxterm.app.lifecycleHooks",
+        qos: .utility
+    )
+
+    private static func storeURL() -> URL {
+        let home = ProcessInfo.processInfo.environment["HOME"]
+            ?? NSString(string: "~").expandingTildeInPath
+        return URL(fileURLWithPath: home)
+            .appendingPathComponent(".cmuxterm")
+            .appendingPathComponent("tmux-compat-store.json")
+    }
+
+    private static func loadHook(for event: String) -> String? {
+        let url = storeURL()
+        guard let data = try? Data(contentsOf: url),
+              let store = try? JSONDecoder().decode(TmuxCompatStore.self, from: data) else {
+            return nil
+        }
+        let command = store.hooks[event]
+        guard let command, !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return command
+    }
+
+    private static func executeShellCommand(
+        _ command: String,
+        event: String,
+        workspaceId: String?,
+        environment: [String: String]
+    ) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", command]
+
+        var env = ProcessInfo.processInfo.environment
+        env["CMUX_HOOK_EVENT"] = event
+        if let workspaceId {
+            env["CMUX_HOOK_WORKSPACE_ID"] = workspaceId
+        }
+        for (key, value) in environment {
+            env[key] = value
+        }
+        process.environment = env
+
+        // Detach stdin so the child doesn't block on terminal input.
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            // Fire-and-forget — don't waitUntilExit on the dispatch queue.
+        } catch {
+            #if DEBUG
+            NSLog("[LifecycleHookDispatcher] Failed to run hook '\(event)': \(error.localizedDescription)")
+            #endif
+        }
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -936,6 +936,7 @@ class TabManager: ObservableObject {
                 sendWelcomeWhenReady(to: newWorkspace)
             }
         }
+        LifecycleHookDispatcher.dispatch("workspace-created", workspaceId: newWorkspace.id.uuidString)
         return newWorkspace
     }
 
@@ -1337,6 +1338,7 @@ class TabManager: ObservableObject {
         guard tabs.count > 1 else { return }
         guard let index = tabs.firstIndex(where: { $0.id == workspace.id }) else { return }
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
+        LifecycleHookDispatcher.dispatch("workspace-closed", workspaceId: workspace.id.uuidString)
         clearInitialWorkspaceGitProbe(workspaceId: workspace.id)
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)


### PR DESCRIPTION
## Summary

- Wire the existing `set-hook` store into actual app lifecycle dispatch points so registered hooks fire at the right time
- Hooks are read from `~/.cmuxterm/tmux-compat-store.json` (the same file `cmux set-hook` already writes) and executed asynchronously via `/bin/zsh`
- Updated `set-hook` CLI help text to document supported events and env vars

## Supported Events

| Event | When it fires | Env vars |
|-------|--------------|----------|
| `after-restore` | Session restore completes on launch | `CMUX_HOOK_EVENT` |
| `session-created` | `applicationDidFinishLaunching` | `CMUX_HOOK_EVENT` |
| `workspace-created` | New workspace added | `CMUX_HOOK_EVENT`, `CMUX_HOOK_WORKSPACE_ID` |
| `workspace-closed` | Workspace removed | `CMUX_HOOK_EVENT`, `CMUX_HOOK_WORKSPACE_ID` |
| `before-shutdown` | `applicationWillTerminate` | `CMUX_HOOK_EVENT` |

## Motivation

`cmux set-hook` has accepted and persisted hooks since the tmux-compat layer was added, but the app never dispatched them. This is the missing piece for #704 and enables use cases like:

- **Resuming Claude Code sessions on relaunch** — `after-restore` hook reads stored session UUIDs from workspace status entries and runs `claude --resume <uuid>` in the right surfaces
- **Spinning up/tearing down cloud sandboxes** on workspace create/close
- **Logging/telemetry** on app lifecycle events

## Changes

- **New file: `Sources/LifecycleHookDispatcher.swift`** (~100 lines) — reads hooks from the tmux-compat store and executes them async on a background dispatch queue
- **`Sources/AppDelegate.swift`** — 3 one-line dispatch calls at `completeStartupSessionRestore`, `applicationDidFinishLaunching`, `applicationWillTerminate`
- **`Sources/TabManager.swift`** — 2 one-line dispatch calls at `addWorkspace`, `closeWorkspace`
- **`CLI/cmux.swift`** — updated `set-hook` help text with supported events and examples
- **`GhosttyTabs.xcodeproj`** — added file reference for `LifecycleHookDispatcher.swift`

## Test plan

- [ ] `cmux set-hook after-restore "echo 'restored at $(date)' >> /tmp/cmux-hooks.log"` → quit and reopen cmux → verify log entry
- [ ] `cmux set-hook workspace-created "echo $CMUX_HOOK_WORKSPACE_ID >> /tmp/cmux-hooks.log"` → create new workspace → verify UUID in log
- [ ] `cmux set-hook before-shutdown "echo 'bye' >> /tmp/cmux-hooks.log"` → quit cmux → verify log entry
- [ ] `cmux set-hook --list` → verify all hooks display correctly
- [ ] `cmux set-hook --unset after-restore` → verify hook removed and no longer fires

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `cmux set-hook` into app lifecycle so registered commands run at the right time. Hooks are read from `~/.cmuxterm/tmux-compat-store.json` and executed asynchronously via `/bin/zsh`.

- **New Features**
  - Hooks fire on: after-restore, session-created, workspace-created, workspace-closed, before-shutdown.
  - Env vars passed: CMUX_HOOK_EVENT, CMUX_HOOK_WORKSPACE_ID (for workspace-created/closed).
  - Updated `cmux set-hook` help text with supported events and examples.

<sup>Written for commit 5e5dd0767dca8913bbf57f3ce9fb352c143505d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for lifecycle hooks that allow registering shell commands to run at app events: session creation, workspace creation/closure, app shutdown, and after session restoration.

* **Documentation**
  * Updated CLI help text with explicit list of supported lifecycle hook events, environment variables available to hook commands (`CMUX_HOOK_EVENT`, `CMUX_HOOK_WORKSPACE_ID`), and example invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->