### PR TITLE
Fix sidebar live refresh for branch and PR state

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -699,6 +699,7 @@ class TabManager: ObservableObject {
     private static var nextPortOrdinal: Int = 0
     private static let initialWorkspaceGitProbeDelays: [TimeInterval] = [0, 0.5, 1.5, 3.0, 6.0, 10.0]
     private static let workspaceGitMetadataPollInterval: TimeInterval = 30
+    private static let selectedWorkspaceGitMetadataPollInterval: TimeInterval = 5
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
     @Published var selectedTabId: UUID? {
         willSet {
@@ -820,6 +821,7 @@ class TabManager: ObservableObject {
     }
     private var agentPIDSweepTimer: DispatchSourceTimer?
     private var workspaceGitMetadataPollTimer: DispatchSourceTimer?
+    private var selectedWorkspaceGitMetadataPollTimer: DispatchSourceTimer?
 #if DEBUG
     private var debugWorkspaceSwitchCounter: UInt64 = 0
     private var debugWorkspaceSwitchId: UInt64 = 0
@@ -867,6 +869,7 @@ class TabManager: ObservableObject {
 
         startAgentPIDSweepTimer()
         startWorkspaceGitMetadataPollTimer()
+        startSelectedWorkspaceGitMetadataPollTimer()
 #if DEBUG
         setupUITestFocusShortcutsIfNeeded()
         setupSplitCloseRightUITestIfNeeded()
@@ -879,6 +882,7 @@ class TabManager: ObservableObject {
         workspaceCycleCooldownTask?.cancel()
         agentPIDSweepTimer?.cancel()
         workspaceGitMetadataPollTimer?.cancel()
+        selectedWorkspaceGitMetadataPollTimer?.cancel()
     }
 
     // MARK: - Agent PID Sweep
@@ -918,6 +922,24 @@ class TabManager: ObservableObject {
         workspaceGitMetadataPollTimer = timer
     }
 
+    /// Refresh the selected workspace more aggressively so branch checkouts and
+    /// newly created PRs show up in the sidebar without waiting for the slower
+    /// background sweep across every tracked workspace.
+    private func startSelectedWorkspaceGitMetadataPollTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        let interval = Self.selectedWorkspaceGitMetadataPollInterval
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.refreshSelectedWorkspaceGitMetadata()
+            }
+        }
+        timer.resume()
+        selectedWorkspaceGitMetadataPollTimer = timer
+    }
+
     private func refreshTrackedWorkspaceGitMetadata() {
         let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
 
@@ -933,6 +955,26 @@ class TabManager: ObservableObject {
                 )
             }
         }
+    }
+
+    private func refreshSelectedWorkspaceGitMetadata() {
+        guard let workspace = selectedWorkspace,
+              let focusedPanelId = workspace.focusedPanelId else {
+            return
+        }
+
+        let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
+        let candidatePanelIds = trackedWorkspaceGitMetadataPollCandidatePanelIds(
+            in: workspace,
+            activeProbeKeys: activeProbeKeys
+        )
+        guard candidatePanelIds.contains(focusedPanelId) else { return }
+
+        scheduleWorkspaceGitMetadataRefreshIfPossible(
+            workspaceId: workspace.id,
+            panelId: focusedPanelId,
+            reason: "selectedPeriodicPoll"
+        )
     }
 
     func refreshTrackedWorkspaceGitMetadataForTesting() {
@@ -965,26 +1007,8 @@ class TabManager: ObservableObject {
 
         return Set(candidatePanelIds.filter { panelId in
             let probeKey = WorkspaceGitProbeKey(workspaceId: workspace.id, panelId: panelId)
-            guard !activeProbeKeys.contains(probeKey) else { return false }
-            return shouldPollTrackedWorkspaceGitMetadata(in: workspace, panelId: panelId)
+            return !activeProbeKeys.contains(probeKey)
         })
-    }
-
-    private func shouldPollTrackedWorkspaceGitMetadata(in workspace: Workspace, panelId: UUID) -> Bool {
-        guard let branch = trackedWorkspaceGitBranch(in: workspace, panelId: panelId) else {
-            return true
-        }
-        return !Self.shouldSkipWorkspacePullRequestLookup(branch: branch)
-    }
-
-    private func trackedWorkspaceGitBranch(in workspace: Workspace, panelId: UUID) -> String? {
-        if let branch = workspace.panelGitBranches[panelId]?.branch {
-            return branch
-        }
-        if workspace.focusedPanelId == panelId {
-            return workspace.gitBranch?.branch
-        }
-        return nil
     }
 
     private func sweepStaleAgentPIDs() {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -404,7 +404,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertFalse(TabManager.shouldSkipWorkspacePullRequestLookup(branch: "release/master-fix"))
     }
 
-    func testTrackedWorkspaceGitMetadataPollCandidatesSkipMainAndMasterPanelsOnly() throws {
+    func testTrackedWorkspaceGitMetadataPollCandidatesIncludeMainAndMasterPanels() throws {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,
               let mainPanelId = workspace.focusedPanelId else {
@@ -435,11 +435,11 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
 
         XCTAssertEqual(
             manager.trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: workspace.id),
-            Set([featurePanel.id, mainlinePanel.id])
+            Set([mainPanelId, masterPanel.id, featurePanel.id, mainlinePanel.id])
         )
     }
 
-    func testTrackedWorkspaceGitMetadataPollCandidatesSkipFocusedFallbackOnMainOnly() {
+    func testTrackedWorkspaceGitMetadataPollCandidatesIncludeFocusedFallbackOnMain() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,
               let panelId = workspace.focusedPanelId else {
@@ -448,8 +448,9 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         }
 
         workspace.gitBranch = SidebarGitBranchState(branch: "main", isDirty: false)
-        XCTAssertTrue(
-            manager.trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: workspace.id).isEmpty
+        XCTAssertEqual(
+            manager.trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: workspace.id),
+            Set([panelId])
         )
 
         workspace.gitBranch = SidebarGitBranchState(branch: "feature/sidebar-pr", isDirty: false)
@@ -457,6 +458,50 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
             manager.trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: workspace.id),
             Set([panelId])
         )
+    }
+
+    func testPeriodicWorkspaceGitMetadataRefreshUpdatesMainWorkspaceAfterCheckoutToFeatureBranch() throws {
+        let fileManager = FileManager.default
+        let repoURL = fileManager.temporaryDirectory.appendingPathComponent("cmux-git-main-refresh-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: repoURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: repoURL) }
+
+        try runGit(["init", "-b", "main"], in: repoURL)
+        try runGit(["config", "user.name", "cmux tests"], in: repoURL)
+        try runGit(["config", "user.email", "cmux@example.invalid"], in: repoURL)
+        try "seed\n".write(
+            to: repoURL.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try runGit(["add", "README.md"], in: repoURL)
+        try runGit(["commit", "-m", "Initial commit"], in: repoURL)
+
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.updatePanelDirectory(panelId: panelId, directory: repoURL.path)
+        workspace.updatePanelGitBranch(panelId: panelId, branch: "main", isDirty: false)
+
+        XCTAssertEqual(
+            manager.trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: workspace.id),
+            Set([panelId])
+        )
+
+        try runGit(["checkout", "-b", "feature/sidebar-live-refresh"], in: repoURL)
+
+        manager.refreshTrackedWorkspaceGitMetadataForTesting()
+
+        XCTAssertTrue(
+            waitForCondition {
+                workspace.panelGitBranches[panelId]?.branch == "feature/sidebar-live-refresh"
+            }
+        )
+        XCTAssertEqual(workspace.gitBranch?.branch, "feature/sidebar-live-refresh")
     }
 
     func testResolvedCommandPathFallsBackOutsideAppPATH() throws {


### PR DESCRIPTION
## Summary
- keep app-side git metadata polling active for tracked workspaces even when the current branch is main/master
- add a faster selected-workspace refresh loop so branch checkout and PR state changes surface without unrelated sidebar redraws
- add regression coverage for checkout-from-main and tracked-workspace polling behavior

Closes #2329

## Testing
- not run locally (per repo policy)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar live refresh so branch checkouts and PR state update within ~5s, even on `main`/`master` (closes #2329). Adds a fast poll for the selected workspace and keeps git metadata polling active for all tracked workspaces.

- **Bug Fixes**
  - Added a 5s selected-workspace Git metadata timer to surface branch/PR changes without full sidebar sweeps.
  - Removed skip logic for `main`/`master`; all tracked panels are now polled unless a probe is active.
  - Added regression tests for `main`/`master` inclusion and for updating after checking out a feature branch.

<sup>Written for commit 5ab3ee1b632237cb0b8e0f8c3beb46447c6ee14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized Git metadata polling for the currently selected workspace's focused panel with increased refresh frequency.
  * Simplified panel selection logic for Git metadata polling.

* **Tests**
  * Updated unit tests to reflect new polling candidate panel behavior.
  * Added test coverage for periodic Git metadata refresh during workspace branch changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->