### PR TITLE
Fix tmux shim surface state and add pane tools opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,58 @@ This creates an isolated app with its own name, bundle ID, socket, and derived d
 
 Before launching a new tagged run, clean up any older tags you started in this session (quit old tagged app + remove its `/tmp` socket/derived data).
 
+## Pane lifecycle (split, run, read, cleanup)
+
+When running commands in split panes, use the full lifecycle instead of fire-and-forget.
+
+### One-liner: run command and capture output
+
+```bash
+OUTPUT=$(run-in-pane "your-command")
+# With options:
+OUTPUT=$(run-in-pane -v -t 60 "npm run build")
+```
+
+`run-in-pane` creates a pane, runs the command, waits for completion, captures output, and cleans up the pane automatically. Use `-h` (default) or `-v` for split direction, `-t` for timeout in seconds (default 30).
+
+### Poll pane output for a pattern
+
+```bash
+PANE=$(tmux split-window -d -h -P)
+tmux send-keys -t "$PANE" 'npm run dev' Enter
+# Wait until "ready" or "error" appears:
+poll-pane -t "$PANE" -p "ready|error" --timeout 60
+tmux kill-pane -t "$PANE"
+```
+
+### Manual lifecycle with wait-for
+
+```bash
+SIGNAL="done-$$"
+PANE=$(tmux split-window -d -h -P)
+tmux send-keys -t "$PANE" "your-command; tmux wait-for -S $SIGNAL" Enter
+tmux wait-for "$SIGNAL" --timeout=30
+OUTPUT=$(tmux capture-pane -t "$PANE" -p)
+tmux kill-pane -t "$PANE"
+```
+
+### Manual lifecycle with signal file (works outside claude-teams env)
+
+```bash
+SIGNAL="done-$$"
+PANE=$(tmux split-window -d -h -P)
+tmux send-keys -t "$PANE" "your-command; touch /tmp/cmux-wait-for-${SIGNAL}.sig" Enter
+tmux wait-for "$SIGNAL" --timeout=30
+OUTPUT=$(tmux capture-pane -t "$PANE" -p)
+tmux kill-pane -t "$PANE"
+```
+
+### Read pane output snapshot
+
+```bash
+tmux capture-pane -t "$PANE" -p
+```
+
 ## Debug event log
 
 All debug events (keys, mouse, focus, splits, tabs) go to a unified log in DEBUG builds:

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9482,11 +9482,45 @@ struct CMUXCLI {
         }
     }
 
+    private static let paneToolsPrompt = """
+    You have pane management shell scripts on PATH for running commands in split terminal panes.
+
+    One-shot (run, capture, close):
+      OUTPUT=$(run-in-pane "your-command")
+      OUTPUT=$(run-in-pane -v -t 60 "npm run build")  # vertical split, 60s timeout
+
+    Long-lived pane (interactive, SSH, etc.):
+      PANE=$(tmux split-window -d -h -P -F "#{pane_id}")
+      tmux send-keys -t "$PANE" "ssh remote-host" Enter
+      SIG="/tmp/done-$$.sig"
+      tmux send-keys -t "$PANE" "your-command; touch $SIG" Enter
+      tmux wait-for "done-$$" --timeout=30
+      tmux capture-pane -t "$PANE" -p
+      tmux kill-pane -t "$PANE"
+
+    Poll pane output for a pattern:
+      poll-pane -t "$PANE" -p "ready|error" --timeout 60
+    """
+
     private func claudeTeamsLaunchArguments(commandArgs: [String]) -> [String] {
-        guard !claudeTeamsHasExplicitTeammateMode(commandArgs: commandArgs) else {
-            return commandArgs
+        var result: [String] = []
+        var hasPaneTools = false
+        let hasTeammateMode = claudeTeamsHasExplicitTeammateMode(commandArgs: commandArgs)
+        // Strip --pane-tools from args (it's a cmux flag, not a claude flag)
+        for arg in commandArgs {
+            if arg == "--pane-tools" {
+                hasPaneTools = true
+                continue
+            }
+            result.append(arg)
         }
-        return ["--teammate-mode", "auto"] + commandArgs
+        if !hasTeammateMode {
+            result = ["--teammate-mode", "auto"] + result
+        }
+        if hasPaneTools {
+            result += ["--append-system-prompt", Self.paneToolsPrompt]
+        }
+        return result
     }
 
     private func configureTmuxCompatEnvironment(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8754,6 +8754,33 @@ struct CMUXCLI {
                 continue
             }
             if arg.hasPrefix("--") {
+                // Parse long flags: --key=value or --key value
+                var key = arg
+                var inlineValue: String? = nil
+                if let eqIdx = arg.firstIndex(of: "=") {
+                    key = String(arg[arg.startIndex..<eqIdx])
+                    inlineValue = String(arg[arg.index(after: eqIdx)...])
+                }
+                if valueFlags.contains(key) {
+                    let value: String
+                    if let v = inlineValue {
+                        value = v
+                    } else {
+                        guard index + 1 < args.count else {
+                            throw CLIError(message: "\(key) requires a value")
+                        }
+                        index += 1
+                        value = args[index]
+                    }
+                    parsed.options[key, default: []].append(value)
+                    index += 1
+                    continue
+                }
+                if boolFlags.contains(key) {
+                    parsed.flags.insert(key)
+                    index += 1
+                    continue
+                }
                 parsed.positional.append(arg)
                 index += 1
                 continue
@@ -8879,6 +8906,21 @@ struct CMUXCLI {
 
     private func tmuxCallerSurfaceHandle() -> String? {
         normalizedTmuxTarget(ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"])
+    }
+
+    /// Returns true if the given surface ID is present in the workspace.
+    private func tmuxSurfaceExists(
+        _ surfaceId: String,
+        workspaceId: String,
+        client: SocketClient
+    ) -> Bool {
+        guard let payload = try? client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId]),
+              let surfaces = payload["surfaces"] as? [[String: Any]] else {
+            return false
+        }
+        return surfaces.contains { surface in
+            (surface["id"] as? String) == surfaceId || (surface["ref"] as? String) == surfaceId
+        }
     }
 
     private func tmuxCanonicalPaneId(
@@ -9542,10 +9584,71 @@ struct CMUXCLI {
         set -euo pipefail
         exec "${CMUX_CLAUDE_TEAMS_CMUX_BIN:-cmux}" __tmux-compat "$@"
         """
-        return try createTmuxCompatShimDirectory(
+        let dir = try createTmuxCompatShimDirectory(
             directoryName: "claude-teams-bin",
             tmuxShimScript: script
         )
+
+        let runInPaneScript = """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Usage: run-in-pane [-h|-v] [-t timeout] [--] <command...>
+        DIR="-h"; TIMEOUT=30
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -h|-v) DIR="$1"; shift ;;
+            -t)    TIMEOUT="$2"; shift 2 ;;
+            --)    shift; break ;;
+            *)     break ;;
+          esac
+        done
+        [[ $# -eq 0 ]] && { echo "run-in-pane: no command specified" >&2; exit 1; }
+        SIGNAL="rip-$$-$RANDOM"
+        SIG_PATH="/tmp/cmux-wait-for-${SIGNAL}.sig"
+        PANE=$(tmux split-window -d "$DIR" -P)
+        trap 'tmux kill-pane -t "$PANE" 2>/dev/null || true; rm -f "$SIG_PATH"' EXIT
+        tmux send-keys -t "$PANE" "$*; touch $SIG_PATH" Enter
+        # Poll for signal file
+        DEADLINE=$(($(date +%s) + TIMEOUT))
+        while [[ $(date +%s) -lt $DEADLINE ]]; do
+          [[ -f "$SIG_PATH" ]] && break
+          sleep 0.05
+        done
+        tmux capture-pane -t "$PANE" -p
+        """
+
+        let pollPaneScript = """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # Usage: poll-pane -t <pane> -p <pattern> [--timeout <secs>] [--interval <secs>]
+        PANE=""; PATTERN=""; TIMEOUT=30; INTERVAL=0.2
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -t)         PANE="$2"; shift 2 ;;
+            -p)         PATTERN="$2"; shift 2 ;;
+            --timeout)  TIMEOUT="$2"; shift 2 ;;
+            --interval) INTERVAL="$2"; shift 2 ;;
+            *)          shift ;;
+          esac
+        done
+        [[ -z "$PANE" ]] && { echo "poll-pane: -t <pane> required" >&2; exit 1; }
+        [[ -z "$PATTERN" ]] && { echo "poll-pane: -p <pattern> required" >&2; exit 1; }
+        DEADLINE=$(($(date +%s) + TIMEOUT))
+        while [[ $(date +%s) -lt $DEADLINE ]]; do
+          OUTPUT=$(tmux capture-pane -t "$PANE" -p 2>/dev/null || true)
+          if echo "$OUTPUT" | grep -qE "$PATTERN"; then
+            echo "$OUTPUT"
+            exit 0
+          fi
+          sleep "$INTERVAL"
+        done
+        echo "poll-pane: timeout waiting for pattern: $PATTERN" >&2
+        exit 1
+        """
+
+        try writeShimIfChanged(runInPaneScript, to: dir.appendingPathComponent("run-in-pane"))
+        try writeShimIfChanged(pollPaneScript, to: dir.appendingPathComponent("poll-pane"))
+        return dir
     }
 
     private func runClaudeTeams(
@@ -10209,17 +10312,29 @@ struct CMUXCLI {
             // successfully. Falling back to target.workspaceId would pair
             // the caller's surface with a different workspace, creating an
             // invalid cross-workspace split.
+            // Anchor splits to the leader surface for agent teams.
+            // Validate that the target surface still exists before using it;
+            // a prior kill-pane may have made CMUX_SURFACE_ID stale.
             if let callerSurface = tmuxCallerSurfaceHandle(),
                let callerWorkspace = tmuxCallerWorkspaceHandle(),
                let wsId = try? resolveWorkspaceId(callerWorkspace, client: client) {
                 let store = loadTmuxCompatStore()
                 if let mvState = store.mainVerticalLayouts[wsId],
                    let lastColumn = mvState.lastColumnSurfaceId {
-                    // Main-vertical active: stack in right column.
-                    target = (wsId, nil, lastColumn)
-                    direction = "down"
-                } else {
-                    // First teammate: split the leader surface to the right.
+                    if tmuxSurfaceExists(lastColumn, workspaceId: wsId, client: client) {
+                        target = (wsId, nil, lastColumn)
+                        direction = "down"
+                    } else if tmuxSurfaceExists(callerSurface, workspaceId: wsId, client: client) {
+                        // Column surface gone but leader alive; start a new column.
+                        target = (wsId, nil, callerSurface)
+                        direction = "right"
+                        // Clear stale layout state.
+                        var updatedStore = store
+                        updatedStore.mainVerticalLayouts.removeValue(forKey: wsId)
+                        try? saveTmuxCompatStore(updatedStore)
+                    }
+                    // else: both stale — fall through to default resolution
+                } else if tmuxSurfaceExists(callerSurface, workspaceId: wsId, client: client) {
                     target = (wsId, nil, callerSurface)
                     direction = "right"
                 }

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -646,12 +646,44 @@ func findExecutableInPath(name string, pathEnv string, skipDir string) string {
 
 // --- Claude Teams launch args ---
 
+const paneToolsPrompt = `You have pane management shell scripts on PATH for running commands in split terminal panes.
+
+One-shot (run, capture, close):
+  OUTPUT=$(run-in-pane "your-command")
+  OUTPUT=$(run-in-pane -v -t 60 "npm run build")  # vertical split, 60s timeout
+
+Long-lived pane (interactive, SSH, etc.):
+  PANE=$(tmux split-window -d -h -P -F "#{pane_id}")
+  tmux send-keys -t "$PANE" "ssh remote-host" Enter
+  SIG="/tmp/done-$$.sig"
+  tmux send-keys -t "$PANE" "your-command; touch $SIG" Enter
+  tmux wait-for "done-$$" --timeout=30
+  tmux capture-pane -t "$PANE" -p
+  tmux kill-pane -t "$PANE"
+
+Poll pane output for a pattern:
+  poll-pane -t "$PANE" -p "ready|error" --timeout 60`
+
 func claudeTeamsLaunchArgs(args []string) []string {
-	// Check if --teammate-mode is already specified
+	var result []string
+	hasPaneTools := false
+	hasTeammateMode := false
+	// Strip --pane-tools from args (it's a cmux flag, not a claude flag)
 	for _, arg := range args {
-		if arg == "--teammate-mode" || strings.HasPrefix(arg, "--teammate-mode=") {
-			return args
+		if arg == "--pane-tools" {
+			hasPaneTools = true
+			continue
 		}
+		if arg == "--teammate-mode" || strings.HasPrefix(arg, "--teammate-mode=") {
+			hasTeammateMode = true
+		}
+		result = append(result, arg)
 	}
-	return append([]string{"--teammate-mode", "auto"}, args...)
+	if !hasTeammateMode {
+		result = append([]string{"--teammate-mode", "auto"}, result...)
+	}
+	if hasPaneTools {
+		result = append(result, "--append-system-prompt", paneToolsPrompt)
+	}
+	return result
 }

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -17,7 +17,7 @@ import (
 func runClaudeTeamsRelay(socketPath string, args []string, refreshAddr func() string) int {
 	rc := &rpcContext{socketPath: socketPath, refreshAddr: refreshAddr}
 
-	shimDir, err := createTmuxShimDir("claude-teams-bin", claudeTeamsShimScript)
+	shimDir, err := createClaudeTeamsShimDir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmux claude-teams: failed to create shim directory: %v\n", err)
 		return 1
@@ -126,6 +126,63 @@ set -euo pipefail
 exec "${CMUX_CLAUDE_TEAMS_CMUX_BIN:-cmux}" __tmux-compat "$@"
 `
 
+const runInPaneScript = `#!/usr/bin/env bash
+set -euo pipefail
+# Usage: run-in-pane [-h|-v] [-t timeout] [--] <command...>
+# Splits a pane, runs a command, waits for completion, captures output, cleans up.
+DIR="-h"; TIMEOUT=30
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|-v) DIR="$1"; shift ;;
+    -t)    TIMEOUT="$2"; shift 2 ;;
+    --)    shift; break ;;
+    *)     break ;;
+  esac
+done
+[[ $# -eq 0 ]] && { echo "run-in-pane: no command specified" >&2; exit 1; }
+SIGNAL="rip-$$-$RANDOM"
+SIG_PATH="/tmp/cmux-wait-for-${SIGNAL}.sig"
+PANE=$(tmux split-window -d "$DIR" -P)
+trap 'tmux kill-pane -t "$PANE" 2>/dev/null || true; rm -f "$SIG_PATH"' EXIT
+tmux send-keys -t "$PANE" "$*; touch $SIG_PATH" Enter
+# Poll for signal file
+DEADLINE=$(($(date +%s) + TIMEOUT))
+while [[ $(date +%s) -lt $DEADLINE ]]; do
+  [[ -f "$SIG_PATH" ]] && break
+  sleep 0.05
+done
+tmux capture-pane -t "$PANE" -p
+`
+
+const pollPaneScript = `#!/usr/bin/env bash
+set -euo pipefail
+# Usage: poll-pane -t <pane> -p <pattern> [--timeout <secs>] [--interval <secs>]
+# Polls pane output until a regex pattern matches or timeout.
+PANE=""; PATTERN=""; TIMEOUT=30; INTERVAL=0.2
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t)         PANE="$2"; shift 2 ;;
+    -p)         PATTERN="$2"; shift 2 ;;
+    --timeout)  TIMEOUT="$2"; shift 2 ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    *)          shift ;;
+  esac
+done
+[[ -z "$PANE" ]] && { echo "poll-pane: -t <pane> required" >&2; exit 1; }
+[[ -z "$PATTERN" ]] && { echo "poll-pane: -p <pattern> required" >&2; exit 1; }
+DEADLINE=$(($(date +%s) + TIMEOUT))
+while [[ $(date +%s) -lt $DEADLINE ]]; do
+  OUTPUT=$(tmux capture-pane -t "$PANE" -p 2>/dev/null || true)
+  if echo "$OUTPUT" | grep -qE "$PATTERN"; then
+    echo "$OUTPUT"
+    exit 0
+  fi
+  sleep "$INTERVAL"
+done
+echo "poll-pane: timeout waiting for pattern: $PATTERN" >&2
+exit 1
+`
+
 const omoTmuxShimScript = `#!/usr/bin/env bash
 set -euo pipefail
 # Only match -V/-v as the first arg (top-level tmux flag).
@@ -161,6 +218,22 @@ func createTmuxShimDir(dirName string, tmuxScript string) (string, error) {
 	tmuxPath := filepath.Join(dir, "tmux")
 	if err := writeShimIfChanged(tmuxPath, tmuxScript); err != nil {
 		return "", err
+	}
+	return dir, nil
+}
+
+func createClaudeTeamsShimDir() (string, error) {
+	dir, err := createTmuxShimDir("claude-teams-bin", claudeTeamsShimScript)
+	if err != nil {
+		return "", err
+	}
+	for name, script := range map[string]string{
+		"run-in-pane": runInPaneScript,
+		"poll-pane":   pollPaneScript,
+	} {
+		if err := writeShimIfChanged(filepath.Join(dir, name), script); err != nil {
+			return "", err
+		}
 	}
 	return dir, nil
 }

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -124,6 +124,26 @@ func parseTmuxArgs(args []string, valueFlags, boolFlags []string) *tmuxParsed {
 			continue
 		}
 		if strings.HasPrefix(arg, "--") {
+			// Handle --key=value and --key value for long flags
+			key := arg
+			val := ""
+			if eqIdx := strings.IndexByte(arg, '='); eqIdx >= 0 {
+				key = arg[:eqIdx]
+				val = arg[eqIdx+1:]
+			}
+			if vSet[key] {
+				if val != "" {
+					p.options[key] = append(p.options[key], val)
+				} else if i+1 < len(args) {
+					i++
+					p.options[key] = append(p.options[key], args[i])
+				}
+				continue
+			}
+			if bSet[key] {
+				p.flags[key] = true
+				continue
+			}
 			p.positional = append(p.positional, arg)
 			continue
 		}
@@ -381,6 +401,25 @@ func tmuxCallerWorkspaceHandle() string {
 
 func tmuxCallerSurfaceHandle() string {
 	return strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID"))
+}
+
+// tmuxSurfaceExists returns true if the given surface ID is present in the workspace.
+func tmuxSurfaceExists(rc *rpcContext, workspaceId, surfaceId string) bool {
+	payload, err := rc.call("surface.list", map[string]any{"workspace_id": workspaceId})
+	if err != nil {
+		return false
+	}
+	surfs, _ := payload["surfaces"].([]any)
+	for _, s := range surfs {
+		surf, _ := s.(map[string]any)
+		if id, _ := surf["id"].(string); id == surfaceId {
+			return true
+		}
+		if ref, _ := surf["ref"].(string); ref == surfaceId {
+			return true
+		}
+	}
+	return false
 }
 
 func tmuxCallerPaneHandle() string {
@@ -722,9 +761,10 @@ func tmuxResolveSurfaceTarget(rc *rpcContext, raw string) (workspaceId string, p
 	}
 
 	// When no explicit target and caller workspace matches, use caller's surface
+	// (only if that surface still exists — it may have been closed by kill-pane)
 	if winSel == "" {
 		if callerWs := tmuxCallerWorkspaceHandle(); callerWs == workspaceId {
-			if callerSurface := tmuxCallerSurfaceHandle(); callerSurface != "" {
+			if callerSurface := tmuxCallerSurfaceHandle(); callerSurface != "" && tmuxSurfaceExists(rc, workspaceId, callerSurface) {
 				surfaceId = callerSurface
 				return
 			}
@@ -1069,17 +1109,30 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 		direction = "up"
 	}
 
-	// Anchor splits to the leader surface for agent teams
+	// Anchor splits to the leader surface for agent teams.
+	// Validate that the target surface still exists before using it;
+	// a prior kill-pane may have made CMUX_SURFACE_ID stale.
 	callerSurface := tmuxCallerSurfaceHandle()
 	callerWorkspace := tmuxCallerWorkspaceHandle()
 	if callerSurface != "" && callerWorkspace != "" {
 		if wsId, err := tmuxResolveWorkspaceId(rc, callerWorkspace); err == nil {
 			store := loadTmuxCompatStore()
 			if mvState, ok := store.MainVerticalLayouts[wsId]; ok && mvState.LastColumnSurfaceId != "" {
-				targetWs = wsId
-				targetSurface = mvState.LastColumnSurfaceId
-				direction = "down"
-			} else {
+				if tmuxSurfaceExists(rc, wsId, mvState.LastColumnSurfaceId) {
+					targetWs = wsId
+					targetSurface = mvState.LastColumnSurfaceId
+					direction = "down"
+				} else if tmuxSurfaceExists(rc, wsId, callerSurface) {
+					// Column surface is gone but leader is still alive; start a new column.
+					targetWs = wsId
+					targetSurface = callerSurface
+					direction = "right"
+					// Clear stale layout state.
+					delete(store.MainVerticalLayouts, wsId)
+					saveTmuxCompatStore(store)
+				}
+				// else: both stale — fall through to default resolution
+			} else if tmuxSurfaceExists(rc, wsId, callerSurface) {
 				targetWs = wsId
 				targetSurface = callerSurface
 				direction = "right"

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -391,6 +391,25 @@ func TestClaudeTeamsLaunchArgs(t *testing.T) {
 	if args[0] != "--teammate-mode" || args[1] != "off" {
 		t.Errorf("args = %v, should not prepend when already present", args)
 	}
+
+	// --pane-tools should be stripped and --append-system-prompt added
+	args = claudeTeamsLaunchArgs([]string{"--pane-tools", "--verbose"})
+	foundPaneTools := false
+	foundAppend := false
+	for i, a := range args {
+		if a == "--pane-tools" {
+			foundPaneTools = true
+		}
+		if a == "--append-system-prompt" && i+1 < len(args) {
+			foundAppend = true
+		}
+	}
+	if foundPaneTools {
+		t.Error("--pane-tools should be stripped from args")
+	}
+	if !foundAppend {
+		t.Error("--append-system-prompt should be added when --pane-tools is specified")
+	}
 }
 
 func TestTmuxWaitForSignalRoundTrip(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSplitTmuxCmd(t *testing.T) {
@@ -427,5 +429,33 @@ func TestTmuxShowBuffer(t *testing.T) {
 	})
 	if strings.TrimSpace(output) != "hello world" {
 		t.Errorf("output = %q, want %q", output, "hello world")
+	}
+}
+
+func TestWaitForSignalPathUniqueness(t *testing.T) {
+	// Verify that signal names with distinct inputs produce distinct paths
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		signal := fmt.Sprintf("rip-%d-%d-%d", os.Getpid(), time.Now().UnixNano(), i)
+		path := tmuxWaitForSignalPath(signal)
+		if seen[path] {
+			t.Fatalf("duplicate signal path: %s", path)
+		}
+		seen[path] = true
+	}
+}
+
+func TestWaitForSignalPathSanitization(t *testing.T) {
+	// Signal names with special chars should be sanitized to safe characters
+	path := tmuxWaitForSignalPath("rip-123-456/../../etc/passwd")
+	// Slashes and dots are converted to underscores, preventing directory traversal
+	if !strings.HasPrefix(path, "/tmp/cmux-wait-for-") {
+		t.Errorf("signal path should be in /tmp: %s", path)
+	}
+	// The sanitized name should not contain actual slash characters
+	name := strings.TrimPrefix(path, "/tmp/cmux-wait-for-")
+	name = strings.TrimSuffix(name, ".sig")
+	if strings.Contains(name, "/") {
+		t.Errorf("signal name should not contain slashes: %s", name)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix "Surface not found" after `kill-pane` by validating surface existence before using stale `CMUX_SURFACE_ID` or `tmux-compat-store.json` entries (#2319)
- Fix `parseTmuxArguments` (Swift/Go) to handle `--long-flag=value` syntax
- Add `run-in-pane` and `poll-pane` shell scripts to shim directory (tmux-compatible)
- Add `--pane-tools` flag to `cmux claude-teams` that injects pane management patterns into Claude's system prompt

## Test plan

- [x] Go unit tests pass
- [x] Swift builds clean
- [x] 3 rounds of split → kill → split (no "Surface not found")
- [x] 3 simultaneous panes
- [x] `run-in-pane` captures output and cleans up
- [x] `--pane-tools` stripped and `--append-system-prompt` injected
- [ ] CI / E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)