### PR TITLE
Add R2 dual-write for nightly appcast and DMGs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -503,6 +503,41 @@ jobs:
           # installs to migrate onto the unified nightly appcast.
           cp appcast.xml appcast-universal.xml
 
+      - name: Generate R2-targeted appcast
+        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          DOWNLOAD_URL_PREFIX: "https://files.cmux.com/nightly/"
+          RELEASE_NOTES_URL: "https://github.com/manaflow-ai/cmux/releases/tag/nightly"
+        run: |
+          ./scripts/sparkle_generate_appcast.sh "$NIGHTLY_DMG_IMMUTABLE" nightly appcast-r2.xml
+
+      - name: Upload nightly assets to R2
+        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          BUCKET=cmux-binaries
+
+          # Upload DMGs first so the appcast never references a missing file.
+          aws s3 cp "$NIGHTLY_DMG_IMMUTABLE" \
+            "s3://${BUCKET}/nightly/${NIGHTLY_DMG_IMMUTABLE}" \
+            --endpoint-url "$R2_ENDPOINT"
+          aws s3 cp cmux-nightly-macos.dmg \
+            "s3://${BUCKET}/nightly/cmux-nightly-macos.dmg" \
+            --endpoint-url "$R2_ENDPOINT"
+
+          # Upload appcast last (atomic PutObject, no 404 window).
+          aws s3 cp appcast-r2.xml \
+            "s3://${BUCKET}/nightly/appcast.xml" \
+            --endpoint-url "$R2_ENDPOINT"
+
+          echo "R2 upload complete: https://files.cmux.com/nightly/appcast.xml"
+
       - name: Attest remote daemon nightly assets
         if: needs.decide.outputs.should_publish != 'true' || (steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true')
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -505,6 +505,7 @@ jobs:
 
       - name: Generate R2-targeted appcast
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        continue-on-error: true
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           DOWNLOAD_URL_PREFIX: "https://files.cmux.com/nightly/"
@@ -514,6 +515,7 @@ jobs:
 
       - name: Upload nightly assets to R2
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -503,16 +503,6 @@ jobs:
           # installs to migrate onto the unified nightly appcast.
           cp appcast.xml appcast-universal.xml
 
-      - name: Generate R2-targeted appcast
-        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
-        continue-on-error: true
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          DOWNLOAD_URL_PREFIX: "https://files.cmux.com/nightly/"
-          RELEASE_NOTES_URL: "https://github.com/manaflow-ai/cmux/releases/tag/nightly"
-        run: |
-          ./scripts/sparkle_generate_appcast.sh "$NIGHTLY_DMG_IMMUTABLE" nightly appcast-r2.xml
-
       - name: Upload nightly assets to R2
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
         continue-on-error: true
@@ -523,20 +513,30 @@ jobs:
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
+          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
           BUCKET=cmux-binaries
 
-          # Upload DMGs first so the appcast never references a missing file.
+          # Derive R2 appcast from the GitHub one by replacing the download URL prefix.
+          # EdDSA signature is over the DMG content, not the URL, so this is safe.
+          sed 's|https://github.com/manaflow-ai/cmux/releases/download/nightly/|https://files.cmux.com/nightly/|g' \
+            appcast.xml > appcast-r2.xml
+
+          # Upload immutable versioned DMG (cacheable forever).
           aws s3 cp "$NIGHTLY_DMG_IMMUTABLE" \
             "s3://${BUCKET}/nightly/${NIGHTLY_DMG_IMMUTABLE}" \
-            --endpoint-url "$R2_ENDPOINT"
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "max-age=31536000, immutable"
+          # Upload mutable latest DMG (no cache).
           aws s3 cp cmux-nightly-macos.dmg \
             "s3://${BUCKET}/nightly/cmux-nightly-macos.dmg" \
-            --endpoint-url "$R2_ENDPOINT"
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
 
           # Upload appcast last (atomic PutObject, no 404 window).
           aws s3 cp appcast-r2.xml \
             "s3://${BUCKET}/nightly/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT"
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
 
           echo "R2 upload complete: https://files.cmux.com/nightly/appcast.xml"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,40 @@ jobs:
           fi
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
+      - name: Generate R2-targeted appcast
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        continue-on-error: true
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          DOWNLOAD_URL_PREFIX: "https://files.cmux.com/stable/"
+          RELEASE_NOTES_URL: "https://github.com/manaflow-ai/cmux/releases/tag/${{ github.ref_name }}"
+        run: |
+          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast-r2.xml
+
+      - name: Upload release assets to R2
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          BUCKET=cmux-binaries
+
+          # Upload DMG first so the appcast never references a missing file.
+          aws s3 cp cmux-macos.dmg \
+            "s3://${BUCKET}/stable/cmux-macos.dmg" \
+            --endpoint-url "$R2_ENDPOINT"
+
+          # Upload appcast last (atomic PutObject, no 404 window).
+          aws s3 cp appcast-r2.xml \
+            "s3://${BUCKET}/stable/appcast.xml" \
+            --endpoint-url "$R2_ENDPOINT"
+
+          echo "R2 upload complete: https://files.cmux.com/stable/appcast.xml"
+
       - name: Attest remote daemon release assets
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,16 +336,6 @@ jobs:
           fi
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
-      - name: Generate R2-targeted appcast
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
-        continue-on-error: true
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          DOWNLOAD_URL_PREFIX: "https://files.cmux.com/stable/"
-          RELEASE_NOTES_URL: "https://github.com/manaflow-ai/cmux/releases/tag/${{ github.ref_name }}"
-        run: |
-          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast-r2.xml
-
       - name: Upload release assets to R2
         if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         continue-on-error: true
@@ -356,17 +346,24 @@ jobs:
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
+          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
           BUCKET=cmux-binaries
+
+          # Derive R2 appcast by replacing the download URL prefix.
+          sed "s|https://github.com/manaflow-ai/cmux/releases/download/${GITHUB_REF_NAME}/|https://files.cmux.com/stable/|g" \
+            appcast.xml > appcast-r2.xml
 
           # Upload DMG first so the appcast never references a missing file.
           aws s3 cp cmux-macos.dmg \
             "s3://${BUCKET}/stable/cmux-macos.dmg" \
-            --endpoint-url "$R2_ENDPOINT"
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
 
           # Upload appcast last (atomic PutObject, no 404 window).
           aws s3 cp appcast-r2.xml \
             "s3://${BUCKET}/stable/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT"
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
 
           echo "R2 upload complete: https://files.cmux.com/stable/appcast.xml"
 


### PR DESCRIPTION
## Summary

- Uploads nightly DMGs and appcast.xml to Cloudflare R2 (`files.cmux.com/nightly/`) alongside existing GitHub Release assets
- R2 uses atomic PutObject, so the appcast never 404s during replacement (fixes the transient `SUDownloadError 2001` race condition)
- DMGs uploaded before appcast so the feed never references a missing file
- Existing GitHub Release upload is unchanged, no client-side changes

## How it works

1. Existing appcast generation (GitHub URLs) runs as before
2. New step generates a second appcast with `DOWNLOAD_URL_PREFIX=https://files.cmux.com/nightly/`
3. New step uploads immutable DMG, latest DMG, then appcast to R2 via AWS CLI (S3-compatible)

## Secrets required

- `CF_R2_ACCOUNT_ID` ✅
- `CF_R2_ACCESS_KEY_ID` ✅
- `CF_R2_SECRET_ACCESS_KEY` ✅

## Verification

After merge, confirm:
- `curl -I https://files.cmux.com/nightly/appcast.xml` returns 200
- Appcast XML contains R2 DMG URLs
- DMG downloads work from R2

## Follow-up

Separate PR will switch `SUFeedURL` in the app bundle from GitHub Releases to R2 after manual verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dual-write nightly and stable DMGs and appcasts to Cloudflare R2 (https://files.cmux.com/nightly/, https://files.cmux.com/stable/) alongside GitHub Releases to eliminate transient feed 404s. DMGs upload first, then the appcast; atomic writes prevent `SUDownloadError 2001`, and failures won’t block GitHub publishing.

- **New Features**
  - Derive R2 `appcast.xml` by URL-replacing the GitHub download prefix (via `sed`); signatures remain valid.
  - Set Cache-Control headers: nightly versioned DMG is immutable (1 year), appcasts and “latest” DMGs are no-cache; upload via `aws s3` with `continue-on-error` and AWS CLI auto-install. GitHub Release uploads are unchanged. A follow-up will switch `SUFeedURL` to R2.

- **Migration**
  - Set secrets: `CF_R2_ACCOUNT_ID`, `CF_R2_ACCESS_KEY_ID`, `CF_R2_SECRET_ACCESS_KEY`.

<sup>Written for commit 7ba3ea0aa50da6b49fcbdcc5ea4cf4b740386b0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Publish nightly installers and feed to an additional Cloudflare R2 hosting path; immutable build artifact kept versioned, feed and latest DMG published with no-cache headers. Uploads are non-blocking.
  * Publish release installers and feed to the same R2 target; installer uploaded before the feed to ensure feed references existing files, uploads are non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->