### PR TITLE
Add New Window to Dock menu

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5510,6 +5510,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         mainWindowContexts.values.first(where: { $0.windowId == windowId })?.sidebarState.isVisible
     }
 
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let menu = NSMenu(title: "")
+        let newWindowItem = NSMenuItem(
+            title: String(localized: "menu.file.newWindow", defaultValue: "New Window"),
+            action: #selector(openNewMainWindow(_:)),
+            keyEquivalent: ""
+        )
+        newWindowItem.target = self
+        menu.addItem(newWindowItem)
+        return menu
+    }
+
     @objc func openNewMainWindow(_ sender: Any?) {
         _ = createMainWindow()
     }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -197,6 +197,44 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Cmd+N should still route by event window metadata when object-key lookup misses")
     }
 
+    func testDockMenuNewWindowItemCreatesMainWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let existingWindowId = appDelegate.createMainWindow()
+        var createdWindowId: UUID?
+        defer {
+            if let createdWindowId {
+                closeWindow(withId: createdWindowId)
+            }
+            closeWindow(withId: existingWindowId)
+        }
+
+        let existingWindowIds = mainWindowIds()
+
+        let delegate: NSApplicationDelegate = appDelegate
+        guard let dockMenu = delegate.applicationDockMenu?(NSApp) else {
+            XCTFail("Expected Dock menu")
+            return
+        }
+
+        let expectedTitle = String(localized: "menu.file.newWindow", defaultValue: "New Window")
+        guard let item = dockMenu.items.first(where: { $0.action == #selector(AppDelegate.openNewMainWindow(_:)) }) else {
+            XCTFail("Expected New Window item in Dock menu")
+            return
+        }
+
+        XCTAssertEqual(item.title, expectedTitle)
+        XCTAssertTrue(NSApp.sendAction(#selector(AppDelegate.openNewMainWindow(_:)), to: item.target, from: item))
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        let newWindowIds = mainWindowIds().subtracting(existingWindowIds)
+        XCTAssertEqual(newWindowIds.count, 1, "Dock menu New Window should create one main window")
+        createdWindowId = newWindowIds.first
+    }
+
     func testAddWorkspaceInPreferredMainWindowUsesKeyWindowWhenObjectKeyLookupIsMismatched() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")


### PR DESCRIPTION
## Summary
- add a Dock-menu `New Window` item via `applicationDockMenu(_:)` in `AppDelegate`
- route the Dock menu item to the existing `openNewMainWindow(_:)` path so it matches the app's normal window creation flow
- add a regression test covering Dock menu selection creating a new main window

Fixes #2240.

## Testing
- did not run local tests per repo policy
- `./scripts/reload.sh --tag dock-new-window --launch`
- `./scripts/reload.sh --tag dock-new-window`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "New Window" item to the macOS Dock menu that opens a new main window using the same flow as the app’s normal window creation. Fixes #2240.

- **New Features**
  - Adds Dock menu via `applicationDockMenu` in `AppDelegate` with a localized “New Window” item that calls `openNewMainWindow(_:)`.
  - Adds a regression test to ensure the Dock menu item creates exactly one new main window.

<sup>Written for commit ea551e0634ef21694e543e538852b913257dabb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dock menu with a "New Window" option, enabling users to quickly create new main windows directly from the app's dock icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->