### PR TITLE
fix: preserve horizontal tab bar in fullscreen with minimal mode

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2378,6 +2378,7 @@ struct ContentView: View {
                         workspace: tab,
                         isWorkspaceVisible: presentation.isPanelVisible,
                         isWorkspaceInputActive: isInputActive,
+                        isFullScreen: isFullScreen,
                         workspacePortalPriority: portalPriority,
                         onThemeRefreshRequest: { reason, eventId, source, payloadHex in
                             scheduleTitlebarThemeRefreshFromWorkspace(

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -225,6 +225,7 @@ struct WorkspaceContentView: View {
     @ObservedObject var workspace: Workspace
     let isWorkspaceVisible: Bool
     let isWorkspaceInputActive: Bool
+    let isFullScreen: Bool
     let workspacePortalPriority: Int
     let onThemeRefreshRequest: ((
         _ reason: String,
@@ -377,7 +378,7 @@ struct WorkspaceContentView: View {
         }
 
         Group {
-            if isMinimalMode {
+            if isMinimalMode && !isFullScreen {
                 bonsplitView
                     .ignoresSafeArea(.container, edges: .top)
             } else {


### PR DESCRIPTION
Fixes #2317 — Horizontal tab bar (Bonsplit tabs) disappears when minimal mode is enabled and the window enters fullscreen.

**Problem**

In `WorkspaceContentView`, `.ignoresSafeArea(.container, edges: .top)` is applied unconditionally whenever minimal mode is active. In fullscreen, the safe area computation changes, causing the Bonsplit tab bar to be pushed out of view.

```swift
// Before (bug): always ignores safe area in minimal mode
if isMinimalMode {
    bonsplitView
        .ignoresSafeArea(.container, edges: .top)
}
```

**Fix**

Pass `isFullScreen` from `ContentView` to `WorkspaceContentView` and skip the `.ignoresSafeArea` modifier when fullscreen is active. This preserves the intended minimal mode behavior in windowed mode while keeping tabs visible in fullscreen.

```swift
// After: only ignore safe area in windowed minimal mode
if isMinimalMode && !isFullScreen {
    bonsplitView
        .ignoresSafeArea(.container, edges: .top)
}
```

**Changes**

- `Sources/WorkspaceContentView.swift`: Add `isFullScreen` property; guard `.ignoresSafeArea` with `!isFullScreen`
- `Sources/ContentView.swift`: Pass `isFullScreen` to `WorkspaceContentView` at the call site

**Testing**

1. Enable minimal mode
2. Open 2+ tabs so tab bar is visible
3. Enter fullscreen (⌘⌃F or ⌘↩)
4. Tab bar remains visible

Also verified windowed minimal mode still hides the titlebar area correctly (no regression).

**Regression test: skipped (intentional)**

Per `CLAUDE.md` test quality policy: this fix changes how a SwiftUI layout modifier (`.ignoresSafeArea`) is conditionally applied based on window fullscreen state. The bug is purely visual — it depends on AppKit's safe area computation during fullscreen transitions, which cannot be exercised through unit or integration tests. No meaningful behavioral or artifact-level test is practical for this change.