### PR TITLE
Fix fullscreen new windows opening in current Space

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5993,6 +5993,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             backing: .buffered,
             defer: false
         )
+        // Match Terminal.app: when a cmux window is in native fullscreen, keep
+        // newly created windows out of that fullscreen tile so they open on a
+        // separate Space/Desktop instead of overlaying the fullscreen window.
+        window.collectionBehavior.insert(.fullScreenDisallowsTiling)
         window.title = ""
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2147,6 +2147,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isFirstResponder: Bool
     }
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
+    var debugCreateMainWindowSourceIsNativeFullScreenOverride: Bool?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
     private var debugDetachedContextWindows: [NSWindow] = []
 
@@ -5980,8 +5981,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         let sourceWindow = sourceContext.flatMap { resolvedWindow(for: $0) }
         let existingFrame = sourceWindow?.frame
+        let sourceWindowIsNativeFullScreen: Bool = {
+#if DEBUG
+            if let debugCreateMainWindowSourceIsNativeFullScreenOverride {
+                return debugCreateMainWindowSourceIsNativeFullScreenOverride
+            }
+#endif
+            return sourceWindow?.styleMask.contains(.fullScreen) == true
+        }()
         let shouldTemporarilyDisallowFullScreenTiling =
-            sessionWindowSnapshot == nil && (sourceWindow?.styleMask.contains(.fullScreen) == true)
+            sessionWindowSnapshot == nil && sourceWindowIsNativeFullScreen
         let initialRect: NSRect
         if sessionWindowSnapshot == nil, let existingFrame {
             // Convert frame rect to content rect so the new window matches the

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5975,9 +5975,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.
         let styleMask: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
-        let existingFrame = preferredMainWindowContextForWorkspaceCreation(
+        let sourceContext = preferredMainWindowContextForWorkspaceCreation(
             debugSource: "createMainWindow.initialGeometry"
-        ).flatMap { resolvedWindow(for: $0)?.frame }
+        )
+        let sourceWindow = sourceContext.flatMap { resolvedWindow(for: $0) }
+        let existingFrame = sourceWindow?.frame
+        let shouldTemporarilyDisallowFullScreenTiling =
+            sessionWindowSnapshot == nil && (sourceWindow?.styleMask.contains(.fullScreen) == true)
         let initialRect: NSRect
         if sessionWindowSnapshot == nil, let existingFrame {
             // Convert frame rect to content rect so the new window matches the
@@ -5993,10 +5997,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             backing: .buffered,
             defer: false
         )
-        // Match Terminal.app: when a cmux window is in native fullscreen, keep
-        // newly created windows out of that fullscreen tile so they open on a
-        // separate Space/Desktop instead of overlaying the fullscreen window.
-        window.collectionBehavior.insert(.fullScreenDisallowsTiling)
+        // When creating a new window from an existing native fullscreen window,
+        // temporarily opt out of fullscreen tiling so AppKit doesn't place the
+        // new window into the active fullscreen Space.
+        if shouldTemporarilyDisallowFullScreenTiling {
+            window.collectionBehavior.insert(.fullScreenDisallowsTiling)
+        }
         window.title = ""
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
@@ -6048,6 +6054,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             window.makeKeyAndOrderFront(nil)
             setActiveMainWindow(window)
             NSApp.activate(ignoringOtherApps: true)
+        }
+        if shouldTemporarilyDisallowFullScreenTiling {
+            DispatchQueue.main.async { [weak window] in
+                window?.collectionBehavior.remove(.fullScreenDisallowsTiling)
+            }
         }
         if let restoredFrame {
             window.setFrame(restoredFrame, display: true)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -98,6 +98,28 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Cmd+N should add workspace to the event's window")
     }
 
+    func testCreateMainWindowDisallowsFullScreenTiling() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        XCTAssertTrue(
+            window.collectionBehavior.contains(.fullScreenDisallowsTiling),
+            "Main windows should opt out of fullscreen tiling so new windows do not join an existing fullscreen Space"
+        )
+    }
+
     func testAddWorkspaceInPreferredMainWindowIgnoresStaleTabManagerPointer() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -98,7 +98,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(secondManager.tabs.count, secondCount + 1, "Cmd+N should add workspace to the event's window")
     }
 
-    func testCreateMainWindowDisallowsFullScreenTiling() {
+    func testCreateMainWindowDoesNotDisallowFullScreenTilingByDefault() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -114,9 +114,50 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(
+        XCTAssertFalse(
             window.collectionBehavior.contains(.fullScreenDisallowsTiling),
-            "Main windows should opt out of fullscreen tiling so new windows do not join an existing fullscreen Space"
+            "Main windows should still support standard macOS Split View when not created from a fullscreen source"
+        )
+    }
+
+    func testCreateMainWindowTemporarilyDisallowsFullScreenTilingFromFullscreenSource() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let sourceWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: sourceWindowId)
+        }
+
+        guard let sourceWindow = window(withId: sourceWindowId) else {
+            XCTFail("Expected fullscreen source window")
+            return
+        }
+
+        sourceWindow.styleMask.insert(.fullScreen)
+
+        let newWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: newWindowId)
+        }
+
+        guard let newWindow = window(withId: newWindowId) else {
+            XCTFail("Expected new window")
+            return
+        }
+
+        XCTAssertTrue(
+            newWindow.collectionBehavior.contains(.fullScreenDisallowsTiling),
+            "New windows should temporarily opt out of fullscreen tiling while opening from a fullscreen source"
+        )
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertFalse(
+            newWindow.collectionBehavior.contains(.fullScreenDisallowsTiling),
+            "The fullscreen tiling opt-out should be cleared after initial presentation so Split View keeps working"
         )
     }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -33,6 +33,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
     override func tearDown() {
         AppDelegate.shared?.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
         AppDelegate.shared?.debugCloseMainWindowConfirmationHandler = nil
+        AppDelegate.shared?.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
         AppDelegate.shared?.dismissNotificationsPopoverIfShown()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         for action in KeyboardShortcutSettings.Action.allCases {
@@ -126,17 +127,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        let sourceWindowId = appDelegate.createMainWindow()
-        defer {
-            closeWindow(withId: sourceWindowId)
-        }
-
-        guard let sourceWindow = window(withId: sourceWindowId) else {
-            XCTFail("Expected fullscreen source window")
-            return
-        }
-
-        sourceWindow.styleMask.insert(.fullScreen)
+        appDelegate.debugCreateMainWindowSourceIsNativeFullScreenOverride = true
 
         let newWindowId = appDelegate.createMainWindow()
         defer {
@@ -153,6 +144,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             "New windows should temporarily opt out of fullscreen tiling while opening from a fullscreen source"
         )
 
+        appDelegate.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
 
         XCTAssertFalse(


### PR DESCRIPTION
## Summary
- prevent newly created main windows from joining an existing native fullscreen Space
- add a regression test asserting created main windows disallow fullscreen tiling

## Testing
- ./scripts/reload.sh --tag issue-2315-fullscreen-new-window --launch

Fixes #2315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New main windows created from a native fullscreen window no longer join that Space. We temporarily disable fullscreen tiling during creation (when not restoring a session) so they open on a separate Space, then restore normal Split View support. Fixes #2315.

- **Bug Fixes**
  - Temporarily set `.fullScreenDisallowsTiling` only when opened from a native fullscreen source and no session restore is in progress; remove it on the next run loop tick after the window appears.
  - Added and stabilized tests using a debug-only override to simulate a fullscreen source; confirmed default windows still allow Split View and the temporary opt-out is cleared.

<sup>Written for commit ab476733e5f3a9467841a7bfadf58b33d5d34eee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created main windows opened from a native macOS fullscreen window now temporarily opt out of fullscreen tiling to avoid layout interference; the restriction is removed shortly after the window appears.

* **Tests**
  * Added automated tests verifying the temporary exclusion from fullscreen tiling is applied when appropriate, is cleared afterward, and that test-state overrides are reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->