### PR TITLE
Enable macOS window tiling and add dock menu New Window

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -84898,6 +84898,125 @@
           }
         }
       }
+    },
+    "dock.newWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ウインドウ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增視窗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 윈도우"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neues Fenster"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuova finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyt vindue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowe okno"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новое окно"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novi prozor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نافذة جديدة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nytt vindu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "หน้าต่างใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni Pencere"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нове вікно"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -15,6 +15,7 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
+    override var mouseDownCanMoveWindow: Bool { false }
 
     required init(rootView: Content) {
         super.init(rootView: rootView)
@@ -2754,6 +2755,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             NSApp.reply(toApplicationShouldTerminate: shouldQuit)
         }
         return .terminateLater
+    }
+
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let menu = NSMenu()
+        let newWindowItem = NSMenuItem(
+            title: String(localized: "dock.newWindow", defaultValue: "New Window"),
+            action: #selector(openNewMainWindow(_:)),
+            keyEquivalent: ""
+        )
+        menu.addItem(newWindowItem)
+        return menu
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -5997,7 +6009,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.isMovable = false
+        window.isMovable = true
+        window.collectionBehavior.insert(.managed)
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3130,12 +3130,14 @@ struct ContentView: View {
         view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
-            // Keep window immovable; the sidebar's WindowDragHandleView handles
-            // drag-to-move via performDrag with temporary movable override.
-            // isMovableByWindowBackground=true breaks tab reordering, and
-            // isMovable=true blocks clicks on sidebar buttons in minimal mode.
+            // isMovableByWindowBackground=false prevents background drags from
+            // interfering with sidebar tab reordering.
+            // isMovable=true enables macOS window tiling (Move & Resize menu).
+            // The sidebar's WindowDragHandleView handles drag-to-move via
+            // performDrag with temporary movable override.
             window.isMovableByWindowBackground = false
-            window.isMovable = false
+            window.isMovable = true
+            window.collectionBehavior.insert(.managed)
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications


### PR DESCRIPTION
## Problem

cmux windows have `isMovable = false`, which disables:
- macOS Sequoia "Move & Resize" / "Fill & Arrange" tiling from the green traffic-light button menu
- Window arrangement keyboard shortcuts (fn+Control+Arrow)
- Third-party window managers (Swish, Rectangle, etc.)

Additionally, right-clicking the dock icon has no "New Window" option.

## Fix

**Window tiling:**
- Set `window.isMovable = true` so macOS recognizes the window as tileable
- Add `window.collectionBehavior.insert(.managed)` so the window participates in window management
- Add `mouseDownCanMoveWindow = false` on `MainWindowHostingView` to prevent the root hosting view from triggering accidental window drags

**Dock menu:**
- Implement `applicationDockMenu(_:)` returning a menu with a localized "New Window" item
- Add `dock.newWindow` key to `Localizable.xcstrings` for all 19 supported languages

## Companion change required (bonsplit)

This PR requires a small change in `vendor/bonsplit` (not included in this commit since it's a separate submodule repo):

- `TabBarView.swift` `DragNSView.mouseDownCanMoveWindow`: change from conditional (`true` in minimal mode) to always `false` — the old behavior was designed for `isMovable = false` and is now redundant
- `TabBarView.swift` `TabBarBackgroundNSView.mouseDown`: replace `performDrag` with `super.mouseDown(with: event)` in minimal mode — `performDrag` enters a modal drag loop that swallows button clicks; window dragging now works natively via `isMovable = true`

## Testing

- [x] Green button menu shows "Move & Resize" and "Fill & Arrange" tiling options
- [x] Window tiling via menu and keyboard shortcuts works
- [x] Right-click dock icon shows "New Window"
- [x] Tab reordering in sidebar still works
- [x] Window dragging from titlebar still works
- [x] Window dragging in minimal mode still works (via DragNSView)
- [x] Minimal mode tab bar buttons — pre-existing issue, not a regression

Fixes #1613, fixes #1765, fixes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable macOS window tiling and add a Dock “New Window” menu item. Users can tile via the green button or keyboard shortcuts and open new windows from the Dock. Fixes #1613, #1765, #1383.

- **New Features**
  - Enable tiling by setting windows movable and managed; prevent accidental drags by disabling mouseDownCanMoveWindow on the hosting view.
  - Add Dock menu with localized “New Window” (`dock.newWindow`) across 19 languages.

- **Migration**
  - Requires a companion update in `vendor/bonsplit`:
    - Set `DragNSView.mouseDownCanMoveWindow = false` unconditionally.
    - In `TabBarBackgroundNSView` (minimal mode), replace `performDrag` with `super.mouseDown(with:)`.

<sup>Written for commit 0dbae6522af3b6eae832aeb37609a9c881a52af1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "New Window" option to the dock menu for quick window creation
  * Expanded localization support across multiple languages

* **Improvements**
  * Windows are now movable and properly managed by the operating system's window management features
  * Enhanced window dragging behavior for better interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->