### PR TITLE
Notification management: mute, hide, bookmark, and snooze

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -30814,6 +30814,91 @@
         }
       }
     },
+    "contextMenu.bookmarkNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmark Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知をブックマーク"
+          }
+        }
+      }
+    },
+    "contextMenu.hideNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知を非表示"
+          }
+        }
+      }
+    },
+    "contextMenu.muteNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知をミュート"
+          }
+        }
+      }
+    },
+    "contextMenu.snoozeNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snooze Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知をスヌーズ"
+          }
+        }
+      }
+    },
+    "contextMenu.unmuteNotifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmute Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知のミュートを解除"
+          }
+        }
+      }
+    },
     "contextMenu.moveDown": {
       "extractionState": "manual",
       "localizations": {
@@ -44871,6 +44956,278 @@
         }
       }
     },
+    "notifications.action.bookmark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmark"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマーク"
+          }
+        }
+      }
+    },
+    "notifications.action.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Permanently"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完全に削除"
+          }
+        }
+      }
+    },
+    "notifications.action.hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide from Inbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受信箱から非表示"
+          }
+        }
+      }
+    },
+    "notifications.action.markRead": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark Read"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既読にする"
+          }
+        }
+      }
+    },
+    "notifications.action.markUnread": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mark Unread"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未読にする"
+          }
+        }
+      }
+    },
+    "notifications.action.more": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More Actions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "その他の操作"
+          }
+        }
+      }
+    },
+    "notifications.action.muteProcess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスをミュート"
+          }
+        }
+      }
+    },
+    "notifications.action.muteWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mute Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースをミュート"
+          }
+        }
+      }
+    },
+    "notifications.action.open": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開く"
+          }
+        }
+      }
+    },
+    "notifications.action.removeBookmark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Bookmark"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマークを解除"
+          }
+        }
+      }
+    },
+    "notifications.action.restore": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore to Inbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受信箱に戻す"
+          }
+        }
+      }
+    },
+    "notifications.action.snooze15m": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snooze 15 Minutes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15分スヌーズ"
+          }
+        }
+      }
+    },
+    "notifications.action.snooze1h": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snooze 1 Hour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1時間スヌーズ"
+          }
+        }
+      }
+    },
+    "notifications.action.snooze4h": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snooze 4 Hours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4時間スヌーズ"
+          }
+        }
+      }
+    },
+    "notifications.action.unmuteProcess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmute Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスのミュートを解除"
+          }
+        }
+      }
+    },
+    "notifications.action.unmuteWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unmute Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのミュートを解除"
+          }
+        }
+      }
+    },
     "notifications.clearAll": {
       "extractionState": "manual",
       "localizations": {
@@ -44990,6 +45347,40 @@
         }
       }
     },
+    "notifications.empty.bookmarked.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmark important notifications to keep them easy to revisit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重要な通知をブックマークすると、あとで見返しやすくなります。"
+          }
+        }
+      }
+    },
+    "notifications.empty.bookmarked.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No bookmarked notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマークした通知はありません"
+          }
+        }
+      }
+    },
     "notifications.empty.description": {
       "extractionState": "manual",
       "localizations": {
@@ -45105,6 +45496,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сповіщення робочого столу з'являтимуться тут для швидкого перегляду."
+          }
+        }
+      }
+    },
+    "notifications.empty.hidden.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hidden, muted, and snoozed notifications will collect here until you restore them."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示、ミュート、スヌーズした通知は、復元するまでここに表示されます。"
+          }
+        }
+      }
+    },
+    "notifications.empty.hidden.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hidden notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示の通知はありません"
+          }
+        }
+      }
+    },
+    "notifications.empty.inboxCleared.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hidden, snoozed, and bookmarked notifications are still available from the filters above."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示、スヌーズ、ブックマークした通知は上のフィルタから確認できます。"
+          }
+        }
+      }
+    },
+    "notifications.empty.inboxCleared.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inbox is clear"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受信箱は空です"
           }
         }
       }
@@ -45489,6 +45948,210 @@
         }
       }
     },
+    "notifications.filter.bookmarked": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmarked"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマーク"
+          }
+        }
+      }
+    },
+    "notifications.filter.hidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hidden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示"
+          }
+        }
+      }
+    },
+    "notifications.filter.inbox": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inbox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受信箱"
+          }
+        }
+      }
+    },
+    "notifications.filter.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification Filter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知フィルタ"
+          }
+        }
+      }
+    },
+    "notifications.muted.processes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muted Processes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミュート中のプロセス"
+          }
+        }
+      }
+    },
+    "notifications.muted.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muted"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミュート中"
+          }
+        }
+      }
+    },
+    "notifications.muted.workspaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muted Workspaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミュート中のワークスペース"
+          }
+        }
+      }
+    },
+    "notifications.status.hidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hidden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非表示"
+          }
+        }
+      }
+    },
+    "notifications.status.mutedProcess": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muted Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミュート中のプロセス"
+          }
+        }
+      }
+    },
+    "notifications.status.mutedWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muted Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミュート中のワークスペース"
+          }
+        }
+      }
+    },
+    "notifications.status.snoozed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snoozed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スヌーズ中"
+          }
+        }
+      }
+    },
+    "notifications.status.snoozedUntil": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snoozed until %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@までスヌーズ"
+          }
+        }
+      }
+    },
     "notifications.title": {
       "extractionState": "manual",
       "localizations": {
@@ -45604,6 +46267,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сповіщення"
+          }
+        }
+      }
+    },
+    "notifications.workspace.fallback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8735,11 +8735,13 @@ struct VerticalTabsSidebar: View {
                                     selectedTabIds: $selectedTabIds,
                                     lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                                     showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
+                                    notificationStatus: notificationStore.workspaceNotificationSidebarStatus(forTabId: tab.id),
                                     dragAutoScrollController: dragAutoScrollController,
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                                    contextMenuAllWorkspacesMuted: notificationStore.areAllWorkspacesMuted(contextMenuWorkspaceIds),
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
                                     settings: tabItemSettings
@@ -11123,6 +11125,36 @@ enum SidebarTrailingAccessoryWidthPolicy {
 // and bridge its objectWillChange into local state instead.
 // Do NOT add @EnvironmentObject or new @Binding without updating ==.
 // Do NOT remove .equatable() from the ForEach call site in VerticalTabsSidebar.
+private enum WorkspaceNotificationSnoozeOption: CaseIterable, Identifiable {
+    case fifteenMinutes
+    case oneHour
+    case fourHours
+
+    var id: Self { self }
+
+    var duration: TimeInterval {
+        switch self {
+        case .fifteenMinutes:
+            return 15 * 60
+        case .oneHour:
+            return 60 * 60
+        case .fourHours:
+            return 4 * 60 * 60
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .fifteenMinutes:
+            return String(localized: "notifications.action.snooze15m", defaultValue: "Snooze 15 Minutes")
+        case .oneHour:
+            return String(localized: "notifications.action.snooze1h", defaultValue: "Snooze 1 Hour")
+        case .fourHours:
+            return String(localized: "notifications.action.snooze4h", defaultValue: "Snooze 4 Hours")
+        }
+    }
+}
+
 private struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
 
@@ -11140,8 +11172,10 @@ private struct TabItemView: View, Equatable {
         lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
+        lhs.notificationStatus == rhs.notificationStatus &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
+        lhs.contextMenuAllWorkspacesMuted == rhs.contextMenuAllWorkspacesMuted &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
         lhs.settings == rhs.settings
@@ -11167,11 +11201,13 @@ private struct TabItemView: View, Equatable {
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
     let showsModifierShortcutHints: Bool
+    let notificationStatus: WorkspaceNotificationSidebarStatus
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
     let contextMenuWorkspaceIds: [UUID]
     let remoteContextMenuWorkspaceIds: [UUID]
+    let contextMenuAllWorkspacesMuted: Bool
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
     let settings: SidebarTabItemSettingsSnapshot
@@ -11402,6 +11438,83 @@ private struct TabItemView: View, Equatable {
         settings.visibleAuxiliaryDetails
     }
 
+    private var notificationStatusForegroundColor: Color {
+        usesInvertedActiveForeground ? activeSecondaryColor(0.8) : .secondary
+    }
+
+    private func notificationStatusItem(
+        systemImage: String,
+        text: String? = nil,
+        helpText: String
+    ) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+                .font(.system(size: 9, weight: .semibold))
+            if let text {
+                Text(text)
+                    .font(.system(size: 10, weight: .medium))
+                    .monospacedDigit()
+            }
+        }
+        .foregroundColor(notificationStatusForegroundColor)
+        .safeHelp(helpText)
+    }
+
+    @ViewBuilder
+    private var workspaceNotificationStatusRow: some View {
+        if notificationStatus.hasVisibleStatus {
+            HStack(spacing: 6) {
+                if notificationStatus.isMuted {
+                    notificationStatusItem(
+                        systemImage: "bell.slash.fill",
+                        text: String(
+                            localized: "notifications.muted.title",
+                            defaultValue: "Muted"
+                        ),
+                        helpText: String(
+                            localized: "notifications.status.mutedWorkspace",
+                            defaultValue: "Muted Workspace"
+                        )
+                    )
+                }
+
+                if notificationStatus.bookmarkedCount > 0 {
+                    notificationStatusItem(
+                        systemImage: "bookmark.fill",
+                        text: "\(notificationStatus.bookmarkedCount)",
+                        helpText: String(
+                            localized: "notifications.filter.bookmarked",
+                            defaultValue: "Bookmarked"
+                        )
+                    )
+                }
+
+                if notificationStatus.snoozedCount > 0 {
+                    notificationStatusItem(
+                        systemImage: "clock.fill",
+                        text: "\(notificationStatus.snoozedCount)",
+                        helpText: String(
+                            localized: "notifications.status.snoozed",
+                            defaultValue: "Snoozed"
+                        )
+                    )
+                }
+
+                if notificationStatus.hiddenCount > 0 {
+                    notificationStatusItem(
+                        systemImage: "eye.slash",
+                        text: "\(notificationStatus.hiddenCount)",
+                        helpText: String(
+                            localized: "notifications.status.hidden",
+                            defaultValue: "Hidden"
+                        )
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
     var body: some View {
         let _ = workspaceObservationGeneration
         let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
@@ -11531,6 +11644,8 @@ private struct TabItemView: View, Equatable {
                     .truncationMode(.tail)
                     .multilineTextAlignment(.leading)
             }
+
+            workspaceNotificationStatusRow
 
             remoteWorkspaceSection
 
@@ -11850,6 +11965,9 @@ private struct TabItemView: View, Equatable {
             multi: String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread"),
             single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
             isMulti: isMulti)
+        let muteNotificationsLabel = contextMenuAllWorkspacesMuted
+            ? String(localized: "contextMenu.unmuteNotifications", defaultValue: "Unmute Notifications")
+            : String(localized: "contextMenu.muteNotifications", defaultValue: "Mute Notifications")
         let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
         let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
         Button(pinLabel) {
@@ -12017,6 +12135,40 @@ private struct TabItemView: View, Equatable {
             markTabsUnread(targetIds)
         }
         .disabled(!hasReadNotifications(in: targetIds))
+
+        Button(muteNotificationsLabel) {
+            for id in targetIds {
+                if contextMenuAllWorkspacesMuted {
+                    notificationStore.unmuteWorkspace(tabId: id)
+                } else {
+                    let workspaceLabel = tabManager.tabs.first(where: { $0.id == id })?.title
+                    notificationStore.muteWorkspace(tabId: id, label: workspaceLabel)
+                }
+            }
+        }
+        .disabled(targetIds.isEmpty)
+
+        Button(String(localized: "contextMenu.hideNotifications", defaultValue: "Hide Notifications")) {
+            for id in targetIds {
+                notificationStore.hideNotifications(forTabId: id)
+            }
+        }
+
+        Button(String(localized: "contextMenu.bookmarkNotifications", defaultValue: "Bookmark Notifications")) {
+            for id in targetIds {
+                notificationStore.bookmarkNotifications(forTabId: id)
+            }
+        }
+
+        Menu(String(localized: "contextMenu.snoozeNotifications", defaultValue: "Snooze Notifications")) {
+            ForEach(WorkspaceNotificationSnoozeOption.allCases) { option in
+                Button(option.title) {
+                    for id in targetIds {
+                        notificationStore.snoozeNotifications(forTabId: id, for: option.duration)
+                    }
+                }
+            }
+        }
     }
 
     private var selectionBackgroundColor: NSColor {

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -1,43 +1,79 @@
 import Bonsplit
 import SwiftUI
 
+private enum NotificationListFilter: String, CaseIterable, Identifiable {
+    case inbox
+    case bookmarked
+    case hidden
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .inbox:
+            return String(localized: "notifications.filter.inbox", defaultValue: "Inbox")
+        case .bookmarked:
+            return String(localized: "notifications.filter.bookmarked", defaultValue: "Bookmarked")
+        case .hidden:
+            return String(localized: "notifications.filter.hidden", defaultValue: "Hidden")
+        }
+    }
+}
+
+private enum NotificationSnoozeOption: CaseIterable, Identifiable {
+    case fifteenMinutes
+    case oneHour
+    case fourHours
+
+    var id: Self { self }
+
+    var duration: TimeInterval {
+        switch self {
+        case .fifteenMinutes:
+            return 15 * 60
+        case .oneHour:
+            return 60 * 60
+        case .fourHours:
+            return 4 * 60 * 60
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .fifteenMinutes:
+            return String(localized: "notifications.action.snooze15m", defaultValue: "Snooze 15 Minutes")
+        case .oneHour:
+            return String(localized: "notifications.action.snooze1h", defaultValue: "Snooze 1 Hour")
+        case .fourHours:
+            return String(localized: "notifications.action.snooze4h", defaultValue: "Snooze 4 Hours")
+        }
+    }
+}
+
 struct NotificationsPage: View {
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @EnvironmentObject var tabManager: TabManager
     @Binding var selection: SidebarSelection
     @FocusState private var focusedNotificationId: UUID?
     @AppStorage(KeyboardShortcutSettings.Action.jumpToUnread.defaultsKey) private var jumpToUnreadShortcutData = Data()
+    @State private var filter: NotificationListFilter = .inbox
 
     var body: some View {
         VStack(spacing: 0) {
             header
             Divider()
 
-            if notificationStore.notifications.isEmpty {
+            if displayNotifications.isEmpty {
                 emptyState
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 8) {
-                        ForEach(notificationStore.notifications) { notification in
+                    LazyVStack(spacing: 10) {
+                        ForEach(displayNotifications) { notification in
                             NotificationRow(
                                 notification: notification,
                                 tabTitle: tabTitle(for: notification.tabId),
-                                onOpen: {
-                                    // SwiftUI action closures are not guaranteed to run on the main actor.
-                                    // Ensure window focus + tab selection happens on the main thread.
-                                    DispatchQueue.main.async {
-                                        _ = AppDelegate.shared?.openNotification(
-                                            tabId: notification.tabId,
-                                            surfaceId: notification.surfaceId,
-                                            notificationId: notification.id
-                                        )
-                                        selection = .tabs
-                                    }
-                                },
-                                onClear: {
-                                    notificationStore.remove(id: notification.id)
-                                },
-                                focusedNotificationId: $focusedNotificationId
+                                focusedNotificationId: $focusedNotificationId,
+                                selection: $selection
                             )
                         }
                     }
@@ -48,16 +84,31 @@ struct NotificationsPage: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
         .onAppear(perform: setInitialFocus)
-        .onChange(of: notificationStore.notifications.first?.id) { _ in
+        .onChange(of: selection) { _, _ in
+            setInitialFocus()
+        }
+        .onChange(of: filter) { _, _ in
+            setInitialFocus()
+        }
+        .onChange(of: displayNotifications.first?.id) { _ in
             setInitialFocus()
         }
     }
 
+    private var displayNotifications: [TerminalNotification] {
+        switch filter {
+        case .inbox:
+            return notificationStore.notifications
+        case .bookmarked:
+            return notificationStore.bookmarkedNotifications()
+        case .hidden:
+            return notificationStore.archivedNotifications
+        }
+    }
+
     private func setInitialFocus() {
-        // Only set focus when the notifications page is visible
-        // to avoid stealing focus from the terminal when notifications arrive
         guard selection == .notifications else { return }
-        guard let firstId = notificationStore.notifications.first?.id else {
+        guard let firstId = displayNotifications.first?.id else {
             focusedNotificationId = nil
             return
         }
@@ -67,38 +118,104 @@ struct NotificationsPage: View {
     }
 
     private var header: some View {
-        HStack {
-            Text(String(localized: "notifications.title", defaultValue: "Notifications"))
-                .font(.title2)
-                .fontWeight(.semibold)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Text(String(localized: "notifications.title", defaultValue: "Notifications"))
+                    .font(.title2)
+                    .fontWeight(.semibold)
 
-            Spacer()
+                Spacer()
 
-            if !notificationStore.notifications.isEmpty {
-                jumpToUnreadButton
-
-                Button(String(localized: "notifications.clearAll", defaultValue: "Clear All")) {
-                    notificationStore.clearAll()
+                if notificationStore.hasMutedSources {
+                    mutedSourcesMenu
                 }
-                .buttonStyle(.bordered)
+
+                if !notificationStore.notifications.isEmpty {
+                    jumpToUnreadButton
+                }
+
+                if hasAnyNotifications {
+                    Button(String(localized: "notifications.clearAll", defaultValue: "Clear All")) {
+                        notificationStore.clearAll()
+                    }
+                    .buttonStyle(.bordered)
+                }
             }
+
+            Picker(
+                String(localized: "notifications.filter.title", defaultValue: "Notification Filter"),
+                selection: $filter
+            ) {
+                ForEach(NotificationListFilter.allCases) { filter in
+                    Text(filter.title).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
     }
 
+    private var hasAnyNotifications: Bool {
+        !notificationStore.notifications.isEmpty || !notificationStore.archivedNotifications.isEmpty
+    }
+
     private var emptyState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "bell.slash")
+        VStack(spacing: 10) {
+            Image(systemName: emptyStateImageName)
                 .font(.system(size: 32))
                 .foregroundColor(.secondary)
-            Text(String(localized: "notifications.empty.title", defaultValue: "No notifications yet"))
+
+            Text(emptyStateTitle)
                 .font(.headline)
-            Text(String(localized: "notifications.empty.description", defaultValue: "Desktop notifications will appear here for quick review."))
+
+            Text(emptyStateDescription)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    private var emptyStateImageName: String {
+        switch filter {
+        case .inbox:
+            return "bell.slash"
+        case .bookmarked:
+            return "bookmark.slash"
+        case .hidden:
+            return "eye.slash"
+        }
+    }
+
+    private var emptyStateTitle: String {
+        switch filter {
+        case .inbox:
+            if hasAnyNotifications {
+                return String(localized: "notifications.empty.inboxCleared.title", defaultValue: "Inbox is clear")
+            }
+            return String(localized: "notifications.empty.title", defaultValue: "No notifications yet")
+        case .bookmarked:
+            return String(localized: "notifications.empty.bookmarked.title", defaultValue: "No bookmarked notifications")
+        case .hidden:
+            return String(localized: "notifications.empty.hidden.title", defaultValue: "No hidden notifications")
+        }
+    }
+
+    private var emptyStateDescription: String {
+        switch filter {
+        case .inbox:
+            if hasAnyNotifications {
+                return String(localized: "notifications.empty.inboxCleared.description", defaultValue: "Hidden, snoozed, and bookmarked notifications are still available from the filters above.")
+            }
+            return String(localized: "notifications.empty.description", defaultValue: "Desktop notifications will appear here for quick review.")
+        case .bookmarked:
+            return String(localized: "notifications.empty.bookmarked.description", defaultValue: "Bookmark important notifications to keep them easy to revisit.")
+        case .hidden:
+            return String(localized: "notifications.empty.hidden.description", defaultValue: "Hidden, muted, and snoozed notifications will collect here until you restore them.")
+        }
     }
 
     @ViewBuilder
@@ -129,6 +246,46 @@ struct NotificationsPage: View {
             .safeHelp(KeyboardShortcutSettings.Action.jumpToUnread.tooltip(String(localized: "notifications.jumpToLatestUnread", defaultValue: "Jump to Latest Unread")))
             .disabled(!hasUnreadNotifications)
         }
+    }
+
+    private var mutedSourcesMenu: some View {
+        Menu {
+            if !notificationStore.mutedWorkspaceLabelsById.isEmpty {
+                Section(String(localized: "notifications.muted.workspaces", defaultValue: "Muted Workspaces")) {
+                    ForEach(sortedMutedWorkspaces, id: \.id) { item in
+                        Button(item.label) {
+                            notificationStore.unmuteWorkspace(tabId: item.id)
+                        }
+                    }
+                }
+            }
+
+            if !notificationStore.mutedProcessLabelsById.isEmpty {
+                Section(String(localized: "notifications.muted.processes", defaultValue: "Muted Processes")) {
+                    ForEach(sortedMutedProcesses, id: \.id) { item in
+                        Button(item.label) {
+                            notificationStore.unmuteProcess(identifier: item.id)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label(String(localized: "notifications.muted.title", defaultValue: "Muted"), systemImage: "bell.slash")
+        }
+        .menuStyle(BorderlessButtonMenuStyle())
+        .fixedSize()
+    }
+
+    private var sortedMutedWorkspaces: [(id: UUID, label: String)] {
+        notificationStore.mutedWorkspaceLabelsById
+            .map { (id: $0.key, label: $0.value) }
+            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+    }
+
+    private var sortedMutedProcesses: [(id: String, label: String)] {
+        notificationStore.mutedProcessLabelsById
+            .map { (id: $0.key, label: $0.value) }
+            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
     }
 
     private var jumpToUnreadShortcut: StoredShortcut {
@@ -182,45 +339,104 @@ struct ShortcutAnnotation: View {
 }
 
 private struct NotificationRow: View {
+    @EnvironmentObject private var notificationStore: TerminalNotificationStore
+
     let notification: TerminalNotification
     let tabTitle: String?
-    let onOpen: () -> Void
-    let onClear: () -> Void
     let focusedNotificationId: FocusState<UUID?>.Binding
+    @Binding var selection: SidebarSelection
+
+    private var detailText: String {
+        let detail = notification.body.isEmpty ? notification.subtitle : notification.body
+        return detail.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var metadataText: String? {
+        var parts: [String] = []
+        if let tabTitle, !tabTitle.isEmpty {
+            parts.append(tabTitle)
+        }
+        if let processDisplayName = notification.processDisplayName,
+           !processDisplayName.isEmpty,
+           processDisplayName != notification.title {
+            parts.append(processDisplayName)
+        }
+        let result = parts.joined(separator: " · ")
+        return result.isEmpty ? nil : result
+    }
+
+    private var isArchived: Bool {
+        notification.isArchived
+    }
+
+    private var bookmarkHelpText: String {
+        notification.isBookmarked
+            ? String(localized: "notifications.action.removeBookmark", defaultValue: "Remove Bookmark")
+            : String(localized: "notifications.action.bookmark", defaultValue: "Bookmark")
+    }
+
+    private var archiveHelpText: String {
+        isArchived
+            ? String(localized: "notifications.action.restore", defaultValue: "Restore to Inbox")
+            : String(localized: "notifications.action.hide", defaultValue: "Hide from Inbox")
+    }
+
+    private var processIdentifier: String? {
+        notification.processIdentifier
+    }
+
+    private var shouldShowProcessMute: Bool {
+        processIdentifier != nil
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            Button(action: onOpen) {
+            Button(action: openNotification) {
                 HStack(alignment: .top, spacing: 12) {
-                    Circle()
-                        .fill(notification.isRead ? Color.clear : cmuxAccentColor())
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(cmuxAccentColor().opacity(notification.isRead ? 0.2 : 1), lineWidth: 1)
-                        )
-                        .padding(.top, 6)
+                    unreadIndicator
 
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(alignment: .top, spacing: 8) {
                             Text(notification.title)
                                 .font(.headline)
                                 .foregroundColor(.primary)
-                            Spacer()
+                                .multilineTextAlignment(.leading)
+
+                            if notification.isBookmarked {
+                                Image(systemName: "bookmark.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(.yellow)
+                                    .padding(.top, 2)
+                            }
+
+                            Spacer(minLength: 8)
+
                             Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
 
-                        if !notification.body.isEmpty {
-                            Text(notification.body)
+                        if !detailText.isEmpty {
+                            Text(detailText)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                                 .lineLimit(3)
                         }
 
-                        if let tabTitle {
-                            Text(tabTitle)
+                        if !statusChips.isEmpty {
+                            HStack(spacing: 6) {
+                                ForEach(statusChips, id: \.title) { chip in
+                                    NotificationStatusChip(
+                                        title: chip.title,
+                                        systemImage: chip.systemImage,
+                                        tint: chip.tint
+                                    )
+                                }
+                            }
+                        }
+
+                        if let metadataText {
+                            Text(metadataText)
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -228,7 +444,7 @@ private struct NotificationRow: View {
 
                     Spacer(minLength: 0)
                 }
-                .padding(.trailing, 6)
+                .padding(.trailing, 4)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
             }
@@ -238,17 +454,220 @@ private struct NotificationRow: View {
             .focused(focusedNotificationId, equals: notification.id)
             .modifier(DefaultActionModifier(isActive: focusedNotificationId.wrappedValue == notification.id))
 
-            Button(action: onClear) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
+            VStack(spacing: 10) {
+                iconButton(
+                    systemImage: notification.isBookmarked ? "bookmark.fill" : "bookmark",
+                    helpText: bookmarkHelpText
+                ) {
+                    notificationStore.toggleBookmark(id: notification.id)
+                }
+                .foregroundStyle(notification.isBookmarked ? .yellow : .secondary)
+
+                iconButton(
+                    systemImage: isArchived ? "arrow.uturn.backward.circle" : "eye.slash",
+                    helpText: archiveHelpText
+                ) {
+                    if isArchived {
+                        notificationStore.restore(id: notification.id)
+                    } else {
+                        notificationStore.hide(id: notification.id)
+                    }
+                }
+
+                Menu {
+                    notificationActionMenu
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                .menuStyle(BorderlessButtonMenuStyle())
+                .safeHelp(String(localized: "notifications.action.more", defaultValue: "More Actions"))
             }
-            .buttonStyle(.plain)
+            .padding(.top, 2)
         }
         .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: 12)
                 .fill(Color(nsColor: .controlBackgroundColor))
         )
+        .contextMenu {
+            notificationActionMenu
+        }
+    }
+
+    private var unreadIndicator: some View {
+        Circle()
+            .fill(notification.isRead ? Color.clear : cmuxAccentColor())
+            .frame(width: 8, height: 8)
+            .overlay(
+                Circle()
+                    .stroke(cmuxAccentColor().opacity(notification.isRead ? 0.2 : 1), lineWidth: 1)
+            )
+            .padding(.top, 6)
+    }
+
+    private func iconButton(
+        systemImage: String,
+        helpText: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 14, weight: .medium))
+        }
+        .buttonStyle(.plain)
+        .safeHelp(helpText)
+    }
+
+    @ViewBuilder
+    private var notificationActionMenu: some View {
+        Button(String(localized: "notifications.action.open", defaultValue: "Open")) {
+            openNotification()
+        }
+
+        Button(notification.isRead
+               ? String(localized: "notifications.action.markUnread", defaultValue: "Mark Unread")
+               : String(localized: "notifications.action.markRead", defaultValue: "Mark Read")) {
+            if notification.isRead {
+                notificationStore.markUnread(id: notification.id)
+            } else {
+                notificationStore.markRead(id: notification.id)
+            }
+        }
+
+        Button(notification.isBookmarked
+               ? String(localized: "notifications.action.removeBookmark", defaultValue: "Remove Bookmark")
+               : String(localized: "notifications.action.bookmark", defaultValue: "Bookmark")) {
+            notificationStore.toggleBookmark(id: notification.id)
+        }
+
+        Button(isArchived
+               ? String(localized: "notifications.action.restore", defaultValue: "Restore to Inbox")
+               : String(localized: "notifications.action.hide", defaultValue: "Hide from Inbox")) {
+            if isArchived {
+                notificationStore.restore(id: notification.id)
+            } else {
+                notificationStore.hide(id: notification.id)
+            }
+        }
+
+        if !isArchived {
+            Divider()
+
+            ForEach(NotificationSnoozeOption.allCases) { option in
+                Button(option.title) {
+                    notificationStore.snooze(id: notification.id, for: option.duration)
+                }
+            }
+        }
+
+        Divider()
+
+        Button(notificationStore.isWorkspaceMuted(notification.tabId)
+               ? String(localized: "notifications.action.unmuteWorkspace", defaultValue: "Unmute Workspace")
+               : String(localized: "notifications.action.muteWorkspace", defaultValue: "Mute Workspace")) {
+            if notificationStore.isWorkspaceMuted(notification.tabId) {
+                notificationStore.unmuteWorkspace(tabId: notification.tabId)
+            } else {
+                notificationStore.muteWorkspace(tabId: notification.tabId, label: tabTitle)
+            }
+        }
+
+        if shouldShowProcessMute, let processIdentifier {
+            Button(notificationStore.isProcessMuted(processIdentifier)
+                   ? String(localized: "notifications.action.unmuteProcess", defaultValue: "Unmute Process")
+                   : String(localized: "notifications.action.muteProcess", defaultValue: "Mute Process")) {
+                if notificationStore.isProcessMuted(processIdentifier) {
+                    notificationStore.unmuteProcess(identifier: processIdentifier)
+                } else {
+                    notificationStore.muteProcess(
+                        identifier: processIdentifier,
+                        label: notification.processDisplayName
+                    )
+                }
+            }
+        }
+
+        Divider()
+
+        Button(
+            String(localized: "notifications.action.delete", defaultValue: "Delete Permanently"),
+            role: .destructive
+        ) {
+            notificationStore.remove(id: notification.id)
+        }
+    }
+
+    private func openNotification() {
+        DispatchQueue.main.async {
+            _ = AppDelegate.shared?.openNotification(
+                tabId: notification.tabId,
+                surfaceId: notification.surfaceId,
+                notificationId: notification.id
+            )
+            selection = .tabs
+        }
+    }
+
+    private var statusChips: [(title: String, systemImage: String, tint: Color)] {
+        var chips: [(title: String, systemImage: String, tint: Color)] = []
+        if let archivedReason = notification.archivedReason {
+            switch archivedReason {
+            case .hidden:
+                chips.append((
+                    title: String(localized: "notifications.status.hidden", defaultValue: "Hidden"),
+                    systemImage: "eye.slash",
+                    tint: .secondary
+                ))
+            case .snoozed:
+                let dateText = notification.snoozedUntil?.formatted(date: .omitted, time: .shortened)
+                    ?? String(localized: "notifications.status.snoozed", defaultValue: "Snoozed")
+                chips.append((
+                    title: String(
+                        format: String(
+                            localized: "notifications.status.snoozedUntil",
+                            defaultValue: "Snoozed until %@"
+                        ),
+                        locale: .current,
+                        dateText
+                    ),
+                    systemImage: "clock",
+                    tint: .blue
+                ))
+            case .mutedWorkspace:
+                chips.append((
+                    title: String(localized: "notifications.status.mutedWorkspace", defaultValue: "Muted Workspace"),
+                    systemImage: "bell.slash",
+                    tint: .orange
+                ))
+            case .mutedProcess:
+                chips.append((
+                    title: String(localized: "notifications.status.mutedProcess", defaultValue: "Muted Process"),
+                    systemImage: "bell.slash",
+                    tint: .orange
+                ))
+            }
+        }
+        return chips
+    }
+}
+
+private struct NotificationStatusChip: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.12))
+            )
     }
 }
 

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -459,7 +459,9 @@ private struct NotificationRow: View {
                     systemImage: notification.isBookmarked ? "bookmark.fill" : "bookmark",
                     helpText: bookmarkHelpText
                 ) {
-                    notificationStore.toggleBookmark(id: notification.id)
+                    performNotificationAction {
+                        notificationStore.toggleBookmark(id: notification.id)
+                    }
                 }
                 .foregroundStyle(notification.isBookmarked ? .yellow : .secondary)
 
@@ -467,10 +469,12 @@ private struct NotificationRow: View {
                     systemImage: isArchived ? "arrow.uturn.backward.circle" : "eye.slash",
                     helpText: archiveHelpText
                 ) {
-                    if isArchived {
-                        notificationStore.restore(id: notification.id)
-                    } else {
-                        notificationStore.hide(id: notification.id)
+                    performNotificationAction {
+                        if isArchived {
+                            notificationStore.restore(id: notification.id)
+                        } else {
+                            notificationStore.hide(id: notification.id)
+                        }
                     }
                 }
 
@@ -485,6 +489,7 @@ private struct NotificationRow: View {
                 .safeHelp(String(localized: "notifications.action.more", defaultValue: "More Actions"))
             }
             .padding(.top, 2)
+            .zIndex(1)
         }
         .padding(12)
         .background(
@@ -529,26 +534,32 @@ private struct NotificationRow: View {
         Button(notification.isRead
                ? String(localized: "notifications.action.markUnread", defaultValue: "Mark Unread")
                : String(localized: "notifications.action.markRead", defaultValue: "Mark Read")) {
-            if notification.isRead {
-                notificationStore.markUnread(id: notification.id)
-            } else {
-                notificationStore.markRead(id: notification.id)
+            performNotificationAction {
+                if notification.isRead {
+                    notificationStore.markUnread(id: notification.id)
+                } else {
+                    notificationStore.markRead(id: notification.id)
+                }
             }
         }
 
         Button(notification.isBookmarked
                ? String(localized: "notifications.action.removeBookmark", defaultValue: "Remove Bookmark")
                : String(localized: "notifications.action.bookmark", defaultValue: "Bookmark")) {
-            notificationStore.toggleBookmark(id: notification.id)
+            performNotificationAction {
+                notificationStore.toggleBookmark(id: notification.id)
+            }
         }
 
         Button(isArchived
                ? String(localized: "notifications.action.restore", defaultValue: "Restore to Inbox")
                : String(localized: "notifications.action.hide", defaultValue: "Hide from Inbox")) {
-            if isArchived {
-                notificationStore.restore(id: notification.id)
-            } else {
-                notificationStore.hide(id: notification.id)
+            performNotificationAction {
+                if isArchived {
+                    notificationStore.restore(id: notification.id)
+                } else {
+                    notificationStore.hide(id: notification.id)
+                }
             }
         }
 
@@ -557,7 +568,9 @@ private struct NotificationRow: View {
 
             ForEach(NotificationSnoozeOption.allCases) { option in
                 Button(option.title) {
-                    notificationStore.snooze(id: notification.id, for: option.duration)
+                    performNotificationAction {
+                        notificationStore.snooze(id: notification.id, for: option.duration)
+                    }
                 }
             }
         }
@@ -567,10 +580,12 @@ private struct NotificationRow: View {
         Button(notificationStore.isWorkspaceMuted(notification.tabId)
                ? String(localized: "notifications.action.unmuteWorkspace", defaultValue: "Unmute Workspace")
                : String(localized: "notifications.action.muteWorkspace", defaultValue: "Mute Workspace")) {
-            if notificationStore.isWorkspaceMuted(notification.tabId) {
-                notificationStore.unmuteWorkspace(tabId: notification.tabId)
-            } else {
-                notificationStore.muteWorkspace(tabId: notification.tabId, label: tabTitle)
+            performNotificationAction {
+                if notificationStore.isWorkspaceMuted(notification.tabId) {
+                    notificationStore.unmuteWorkspace(tabId: notification.tabId)
+                } else {
+                    notificationStore.muteWorkspace(tabId: notification.tabId, label: tabTitle)
+                }
             }
         }
 
@@ -578,13 +593,15 @@ private struct NotificationRow: View {
             Button(notificationStore.isProcessMuted(processIdentifier)
                    ? String(localized: "notifications.action.unmuteProcess", defaultValue: "Unmute Process")
                    : String(localized: "notifications.action.muteProcess", defaultValue: "Mute Process")) {
-                if notificationStore.isProcessMuted(processIdentifier) {
-                    notificationStore.unmuteProcess(identifier: processIdentifier)
-                } else {
-                    notificationStore.muteProcess(
-                        identifier: processIdentifier,
-                        label: notification.processDisplayName
-                    )
+                performNotificationAction {
+                    if notificationStore.isProcessMuted(processIdentifier) {
+                        notificationStore.unmuteProcess(identifier: processIdentifier)
+                    } else {
+                        notificationStore.muteProcess(
+                            identifier: processIdentifier,
+                            label: notification.processDisplayName
+                        )
+                    }
                 }
             }
         }
@@ -595,8 +612,14 @@ private struct NotificationRow: View {
             String(localized: "notifications.action.delete", defaultValue: "Delete Permanently"),
             role: .destructive
         ) {
-            notificationStore.remove(id: notification.id)
+            performNotificationAction {
+                notificationStore.remove(id: notification.id)
+            }
         }
+    }
+
+    private func performNotificationAction(_ action: @escaping () -> Void) {
+        DispatchQueue.main.async(execute: action)
     }
 
     private func openNotification() {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -655,6 +655,22 @@ enum NotificationAuthorizationState: Equatable {
     }
 }
 
+enum NotificationArchiveReason: String, Hashable {
+    case hidden
+    case snoozed
+    case mutedWorkspace
+    case mutedProcess
+
+    var isMuted: Bool {
+        switch self {
+        case .mutedWorkspace, .mutedProcess:
+            return true
+        case .hidden, .snoozed:
+            return false
+        }
+    }
+}
+
 struct TerminalNotification: Identifiable, Hashable {
     let id: UUID
     let tabId: UUID
@@ -662,8 +678,29 @@ struct TerminalNotification: Identifiable, Hashable {
     let title: String
     let subtitle: String
     let body: String
+    let processIdentifier: String? = nil
+    let processDisplayName: String? = nil
     let createdAt: Date
     var isRead: Bool
+    var isBookmarked: Bool = false
+    var archivedReason: NotificationArchiveReason? = nil
+    var archivedAt: Date? = nil
+    var snoozedUntil: Date? = nil
+
+    var isArchived: Bool {
+        archivedReason != nil
+    }
+}
+
+struct WorkspaceNotificationSidebarStatus: Equatable {
+    let isMuted: Bool
+    let bookmarkedCount: Int
+    let hiddenCount: Int
+    let snoozedCount: Int
+
+    var hasVisibleStatus: Bool {
+        isMuted || bookmarkedCount > 0 || hiddenCount > 0 || snoozedCount > 0
+    }
 }
 
 @MainActor
@@ -679,12 +716,23 @@ final class TerminalNotificationStore: ObservableObject {
         var unreadByTabSurface = Set<TabSurfaceKey>()
         var latestUnreadByTabId: [UUID: TerminalNotification] = [:]
         var latestByTabId: [UUID: TerminalNotification] = [:]
+        var activeCountByTabId: [UUID: Int] = [:]
+        var bookmarkedCountByTabId: [UUID: Int] = [:]
+    }
+
+    private struct ArchivedNotificationIndexes {
+        var countByTabId: [UUID: Int] = [:]
+        var hiddenCountByTabId: [UUID: Int] = [:]
+        var snoozedCountByTabId: [UUID: Int] = [:]
+        var bookmarkedCountByTabId: [UUID: Int] = [:]
     }
 
     static let shared = TerminalNotificationStore()
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
+    private static let mutedWorkspacesDefaultsKey = "notifications.mutedWorkspaces"
+    private static let mutedProcessesDefaultsKey = "notifications.mutedProcesses"
     private enum AuthorizationRequestOrigin: String {
         case notificationDelivery = "notification_delivery"
         case settingsButton = "settings_button"
@@ -697,10 +745,18 @@ final class TerminalNotificationStore: ObservableObject {
             refreshDockBadge()
         }
     }
+    @Published private(set) var archivedNotifications: [TerminalNotification] = [] {
+        didSet {
+            archivedIndexes = Self.buildArchivedIndexes(for: archivedNotifications)
+        }
+    }
+    @Published private(set) var mutedWorkspaceLabelsById: [UUID: String] = [:]
+    @Published private(set) var mutedProcessLabelsById: [String: String] = [:]
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
 
     private let center = UNUserNotificationCenter.current()
+    private let defaults = UserDefaults.standard
     private var hasRequestedAutomaticAuthorization = false
     private var hasDeferredAuthorizationRequest = false
     private var hasPromptedForSettings = false
@@ -734,9 +790,13 @@ final class TerminalNotificationStore: ObservableObject {
         store.playSuppressedNotificationFeedback(for: notification)
     }
     private var lastNotificationDateByCooldownKey: [String: Date] = [:]
+    private var snoozeResurfaceWorkItems: [UUID: DispatchWorkItem] = [:]
     private var indexes = NotificationIndexes()
+    private var archivedIndexes = ArchivedNotificationIndexes()
 
     private init() {
+        mutedWorkspaceLabelsById = Self.loadMutedWorkspaceLabels(defaults: defaults)
+        mutedProcessLabelsById = Self.loadMutedProcessLabels(defaults: defaults)
         indexes = Self.buildIndexes(for: notifications)
         userDefaultsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
@@ -776,6 +836,37 @@ final class TerminalNotificationStore: ObservableObject {
 
     var unreadCount: Int {
         indexes.unreadCount
+    }
+
+    var hasMutedSources: Bool {
+        !mutedWorkspaceLabelsById.isEmpty || !mutedProcessLabelsById.isEmpty
+    }
+
+    var bookmarkedCount: Int {
+        notifications.lazy.filter { $0.isBookmarked }.count +
+            archivedNotifications.lazy.filter { $0.isBookmarked }.count
+    }
+
+    func bookmarkedNotifications() -> [TerminalNotification] {
+        notifications.filter { $0.isBookmarked } + archivedNotifications.filter { $0.isBookmarked }
+    }
+
+    func isWorkspaceMuted(_ tabId: UUID) -> Bool {
+        mutedWorkspaceLabelsById[tabId] != nil
+    }
+
+    func mutedWorkspaceLabel(for tabId: UUID) -> String? {
+        mutedWorkspaceLabelsById[tabId]
+    }
+
+    func isProcessMuted(_ identifier: String?) -> Bool {
+        guard let identifier else { return false }
+        return mutedProcessLabelsById[identifier] != nil
+    }
+
+    func mutedProcessLabel(for identifier: String?) -> String? {
+        guard let identifier else { return nil }
+        return mutedProcessLabelsById[identifier]
     }
 
     private func logAuthorization(_ message: String) {
@@ -878,6 +969,36 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.unreadByTabSurface.contains(TabSurfaceKey(tabId: tabId, surfaceId: surfaceId))
     }
 
+    func hasActiveNotifications(forTabId tabId: UUID) -> Bool {
+        indexes.activeCountByTabId[tabId, default: 0] > 0
+    }
+
+    func hasAnyNotifications(forTabId tabId: UUID) -> Bool {
+        hasActiveNotifications(forTabId: tabId) || archivedIndexes.countByTabId[tabId, default: 0] > 0
+    }
+
+    func hasActiveNotifications(forTabIds tabIds: [UUID]) -> Bool {
+        tabIds.contains { hasActiveNotifications(forTabId: $0) }
+    }
+
+    func hasAnyNotifications(forTabIds tabIds: [UUID]) -> Bool {
+        tabIds.contains { hasAnyNotifications(forTabId: $0) }
+    }
+
+    func areAllWorkspacesMuted(_ tabIds: [UUID]) -> Bool {
+        !tabIds.isEmpty && tabIds.allSatisfy(isWorkspaceMuted)
+    }
+
+    func workspaceNotificationSidebarStatus(forTabId tabId: UUID) -> WorkspaceNotificationSidebarStatus {
+        WorkspaceNotificationSidebarStatus(
+            isMuted: isWorkspaceMuted(tabId),
+            bookmarkedCount: indexes.bookmarkedCountByTabId[tabId, default: 0]
+                + archivedIndexes.bookmarkedCountByTabId[tabId, default: 0],
+            hiddenCount: archivedIndexes.hiddenCountByTabId[tabId, default: 0],
+            snoozedCount: archivedIndexes.snoozedCountByTabId[tabId, default: 0]
+        )
+    }
+
     func hasVisibleNotificationIndicator(forTabId tabId: UUID, surfaceId: UUID?) -> Bool {
         hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) ||
             focusedReadIndicatorByTabId[tabId] == surfaceId
@@ -917,7 +1038,9 @@ final class TerminalNotificationStore: ObservableObject {
         var updated = notifications
         var idsToClear: [String] = []
         updated.removeAll { existing in
-            guard existing.tabId == tabId, existing.surfaceId == surfaceId else { return false }
+            guard existing.tabId == tabId,
+                  existing.surfaceId == surfaceId,
+                  !existing.isBookmarked else { return false }
             idsToClear.append(existing.id.uuidString)
             return true
         }
@@ -933,11 +1056,26 @@ final class TerminalNotificationStore: ObservableObject {
         let isFocusedPanel = isActiveTab && isFocusedSurface
         let isAppFocused = AppFocusState.isAppFocused()
         let shouldSuppressExternalDelivery = isAppFocused && isFocusedPanel
+        let processDescriptor = resolveProcessDescriptor(
+            tabId: tabId,
+            surfaceId: surfaceId,
+            title: title,
+            subtitle: subtitle
+        )
+        let mutedReason: NotificationArchiveReason? = {
+            if isWorkspaceMuted(tabId) {
+                return .mutedWorkspace
+            }
+            if isProcessMuted(processDescriptor.identifier) {
+                return .mutedProcess
+            }
+            return nil
+        }()
         if shouldSuppressExternalDelivery {
             setFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         }
 
-        if WorkspaceAutoReorderSettings.isEnabled() {
+        if WorkspaceAutoReorderSettings.isEnabled(), mutedReason == nil {
             AppDelegate.shared?.tabManager?.moveTabToTopForNotification(tabId)
         }
 
@@ -948,11 +1086,11 @@ final class TerminalNotificationStore: ObservableObject {
             title: title,
             subtitle: subtitle,
             body: body,
+            processIdentifier: processDescriptor.identifier,
+            processDisplayName: processDescriptor.label,
             createdAt: now,
             isRead: false
         )
-        updated.insert(notification, at: 0)
-        notifications = updated
         if let cooldownKey, resolvedCooldownInterval != nil {
             lastNotificationDateByCooldownKey[cooldownKey] = now
         }
@@ -960,6 +1098,13 @@ final class TerminalNotificationStore: ObservableObject {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
+        if let mutedReason {
+            notifications = updated
+            archiveIncomingNotification(notification, reason: mutedReason)
+            return
+        }
+        updated.insert(notification, at: 0)
+        notifications = updated
         if shouldSuppressExternalDelivery {
             suppressedNotificationFeedbackHandler(self, notification)
         } else {
@@ -968,16 +1113,21 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func markRead(id: UUID) {
-        var updated = notifications
-        guard let index = updated.firstIndex(where: { $0.id == id }) else { return }
-        guard !updated[index].isRead else { return }
-        updated[index].isRead = true
-        notifications = updated
+        guard updateNotification(id: id, update: { notification in
+            notification.isRead = true
+        }) else { return }
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
+    }
+
+    func markUnread(id: UUID) {
+        _ = updateNotification(id: id, update: { notification in
+            notification.isRead = false
+        })
     }
 
     func markRead(forTabId tabId: UUID) {
         var updated = notifications
+        var archivedUpdated = archivedNotifications
         var idsToClear: [String] = []
         for index in updated.indices {
             if updated[index].tabId == tabId && !updated[index].isRead {
@@ -985,14 +1135,22 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        for index in archivedUpdated.indices {
+            if archivedUpdated[index].tabId == tabId && !archivedUpdated[index].isRead {
+                archivedUpdated[index].isRead = true
+                idsToClear.append(archivedUpdated[index].id.uuidString)
+            }
+        }
         if !idsToClear.isEmpty {
             notifications = updated
+            archivedNotifications = archivedUpdated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         }
     }
 
     func markRead(forTabId tabId: UUID, surfaceId: UUID?) {
         var updated = notifications
+        var archivedUpdated = archivedNotifications
         var idsToClear: [String] = []
         for index in updated.indices {
             if updated[index].tabId == tabId,
@@ -1002,8 +1160,17 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        for index in archivedUpdated.indices {
+            if archivedUpdated[index].tabId == tabId,
+               archivedUpdated[index].surfaceId == surfaceId,
+               !archivedUpdated[index].isRead {
+                archivedUpdated[index].isRead = true
+                idsToClear.append(archivedUpdated[index].id.uuidString)
+            }
+        }
         if !idsToClear.isEmpty {
             notifications = updated
+            archivedNotifications = archivedUpdated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
@@ -1011,6 +1178,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     func markUnread(forTabId tabId: UUID) {
         var updated = notifications
+        var archivedUpdated = archivedNotifications
         var didChange = false
         for index in updated.indices {
             if updated[index].tabId == tabId, updated[index].isRead {
@@ -1018,8 +1186,15 @@ final class TerminalNotificationStore: ObservableObject {
                 didChange = true
             }
         }
+        for index in archivedUpdated.indices {
+            if archivedUpdated[index].tabId == tabId, archivedUpdated[index].isRead {
+                archivedUpdated[index].isRead = false
+                didChange = true
+            }
+        }
         if didChange {
             notifications = updated
+            archivedNotifications = archivedUpdated
         }
     }
 
@@ -1043,6 +1218,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     func markAllRead() {
         var updated = notifications
+        var archivedUpdated = archivedNotifications
         var idsToClear: [String] = []
         for index in updated.indices {
             if !updated[index].isRead {
@@ -1050,31 +1226,145 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        for index in archivedUpdated.indices {
+            if !archivedUpdated[index].isRead {
+                archivedUpdated[index].isRead = true
+                idsToClear.append(archivedUpdated[index].id.uuidString)
+            }
+        }
         if !idsToClear.isEmpty {
             notifications = updated
+            archivedNotifications = archivedUpdated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
     }
 
+    func setBookmarked(id: UUID, isBookmarked: Bool) {
+        _ = updateNotification(id: id, update: { notification in
+            notification.isBookmarked = isBookmarked
+        })
+    }
+
+    func setBookmarked(forTabId tabId: UUID, isBookmarked: Bool) {
+        var updated = notifications
+        var archivedUpdated = archivedNotifications
+        var didChange = false
+        for index in updated.indices {
+            guard updated[index].tabId == tabId,
+                  updated[index].isBookmarked != isBookmarked else { continue }
+            updated[index].isBookmarked = isBookmarked
+            didChange = true
+        }
+        for index in archivedUpdated.indices {
+            guard archivedUpdated[index].tabId == tabId,
+                  archivedUpdated[index].isBookmarked != isBookmarked else { continue }
+            archivedUpdated[index].isBookmarked = isBookmarked
+            didChange = true
+        }
+        guard didChange else { return }
+        notifications = updated
+        archivedNotifications = archivedUpdated
+    }
+
+    func toggleBookmark(id: UUID) {
+        _ = updateNotification(id: id, update: { notification in
+            notification.isBookmarked.toggle()
+        })
+    }
+
+    func bookmarkNotifications(forTabId tabId: UUID) {
+        setBookmarked(forTabId: tabId, isBookmarked: true)
+    }
+
+    func hide(id: UUID) {
+        archive(id: id, reason: .hidden)
+    }
+
+    func hideNotifications(forTabId tabId: UUID) {
+        archiveNotifications(
+            matching: { $0.tabId == tabId },
+            reason: .hidden
+        )
+    }
+
+    func restore(id: UUID) {
+        guard let notification = removeArchivedNotification(id: id) else { return }
+        cancelSnoozeResurface(id: id)
+        insertArchivedNotificationIntoInbox(notification)
+    }
+
+    func snooze(id: UUID, for duration: TimeInterval) {
+        guard duration.isFinite, duration > 0 else { return }
+        archive(id: id, reason: .snoozed, snoozedUntil: Date().addingTimeInterval(duration))
+    }
+
+    func snoozeNotifications(forTabId tabId: UUID, for duration: TimeInterval) {
+        guard duration.isFinite, duration > 0 else { return }
+        archiveNotifications(
+            matching: { $0.tabId == tabId },
+            reason: .snoozed,
+            snoozedUntil: Date().addingTimeInterval(duration)
+        )
+    }
+
+    func muteWorkspace(tabId: UUID, label: String? = nil) {
+        mutedWorkspaceLabelsById[tabId] = resolvedWorkspaceLabel(for: tabId, fallback: label)
+        persistMutedSettings()
+        archiveActiveNotifications(
+            matching: { $0.tabId == tabId },
+            reason: .mutedWorkspace
+        )
+    }
+
+    func unmuteWorkspace(tabId: UUID) {
+        guard mutedWorkspaceLabelsById.removeValue(forKey: tabId) != nil else { return }
+        persistMutedSettings()
+    }
+
+    func muteProcess(identifier: String, label: String? = nil) {
+        let resolvedLabel = resolvedProcessLabel(label, fallbackIdentifier: identifier)
+        mutedProcessLabelsById[identifier] = resolvedLabel
+        persistMutedSettings()
+        archiveActiveNotifications(
+            matching: { $0.processIdentifier == identifier },
+            reason: .mutedProcess
+        )
+    }
+
+    func unmuteProcess(identifier: String) {
+        guard mutedProcessLabelsById.removeValue(forKey: identifier) != nil else { return }
+        persistMutedSettings()
+    }
+
     func remove(id: UUID) {
         var updated = notifications
-        let removed = updated.first(where: { $0.id == id })
-        let originalCount = updated.count
+        let removed = updated.first(where: { $0.id == id }) ?? archivedNotifications.first(where: { $0.id == id })
+        let activeOriginalCount = updated.count
         updated.removeAll { $0.id == id }
-        guard updated.count != originalCount else { return }
+        var archivedUpdated = archivedNotifications
+        let archivedOriginalCount = archivedUpdated.count
+        archivedUpdated.removeAll { $0.id == id }
+        guard updated.count != activeOriginalCount || archivedUpdated.count != archivedOriginalCount else { return }
         notifications = updated
+        archivedNotifications = archivedUpdated
+        cancelSnoozeResurface(id: id)
         if let removed {
             clearFocusedReadIndicator(forTabId: removed.tabId, surfaceId: removed.surfaceId)
         }
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
+        center.removePendingNotificationRequestsOffMain(withIdentifiers: [id.uuidString])
     }
 
     func clearAll() {
-        guard !notifications.isEmpty || !focusedReadIndicatorByTabId.isEmpty else { return }
-        let ids = notifications.map { $0.id.uuidString }
+        guard !notifications.isEmpty
+                || !archivedNotifications.isEmpty
+                || !focusedReadIndicatorByTabId.isEmpty else { return }
+        let ids = (notifications + archivedNotifications).map { $0.id.uuidString }
         notifications.removeAll()
+        archivedNotifications.removeAll()
         focusedReadIndicatorByTabId.removeAll()
+        cancelAllSnoozeResurfaces()
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: ids)
     }
@@ -1082,6 +1372,8 @@ final class TerminalNotificationStore: ObservableObject {
     func clearNotifications(forTabId tabId: UUID, surfaceId: UUID?) {
         var updated: [TerminalNotification] = []
         updated.reserveCapacity(notifications.count)
+        var archivedUpdated: [TerminalNotification] = []
+        archivedUpdated.reserveCapacity(archivedNotifications.count)
         var idsToClear: [String] = []
         for notification in notifications {
             if notification.tabId == tabId, notification.surfaceId == surfaceId {
@@ -1090,8 +1382,17 @@ final class TerminalNotificationStore: ObservableObject {
                 updated.append(notification)
             }
         }
+        for notification in archivedNotifications {
+            if notification.tabId == tabId, notification.surfaceId == surfaceId {
+                idsToClear.append(notification.id.uuidString)
+                cancelSnoozeResurface(id: notification.id)
+            } else {
+                archivedUpdated.append(notification)
+            }
+        }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
+        archivedNotifications = archivedUpdated
         clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
@@ -1100,6 +1401,8 @@ final class TerminalNotificationStore: ObservableObject {
     func clearNotifications(forTabId tabId: UUID) {
         var updated: [TerminalNotification] = []
         updated.reserveCapacity(notifications.count)
+        var archivedUpdated: [TerminalNotification] = []
+        archivedUpdated.reserveCapacity(archivedNotifications.count)
         var idsToClear: [String] = []
         for notification in notifications {
             if notification.tabId == tabId {
@@ -1108,8 +1411,17 @@ final class TerminalNotificationStore: ObservableObject {
                 updated.append(notification)
             }
         }
+        for notification in archivedNotifications {
+            if notification.tabId == tabId {
+                idsToClear.append(notification.id.uuidString)
+                cancelSnoozeResurface(id: notification.id)
+            } else {
+                archivedUpdated.append(notification)
+            }
+        }
         guard !idsToClear.isEmpty else { return }
         notifications = updated
+        archivedNotifications = archivedUpdated
         clearFocusedReadIndicator(forTabId: tabId)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
@@ -1326,9 +1638,266 @@ final class TerminalNotificationStore: ObservableObject {
         return shouldDeferAutomaticAuthorizationRequest(status: status, isAppActive: isAppActive)
     }
 
+    private func updateNotification(
+        id: UUID,
+        update: (inout TerminalNotification) -> Void
+    ) -> Bool {
+        if let index = notifications.firstIndex(where: { $0.id == id }) {
+            var updated = notifications
+            update(&updated[index])
+            notifications = updated
+            return true
+        }
+        if let index = archivedNotifications.firstIndex(where: { $0.id == id }) {
+            var updated = archivedNotifications
+            update(&updated[index])
+            archivedNotifications = updated
+            return true
+        }
+        return false
+    }
+
+    private func archive(id: UUID, reason: NotificationArchiveReason, snoozedUntil: Date? = nil) {
+        guard let notification = removeActiveNotification(id: id) ?? removeArchivedNotification(id: id) else {
+            return
+        }
+        archiveIncomingNotification(notification, reason: reason, snoozedUntil: snoozedUntil)
+    }
+
+    private func archiveIncomingNotification(
+        _ notification: TerminalNotification,
+        reason: NotificationArchiveReason,
+        snoozedUntil: Date? = nil
+    ) {
+        var archived = archivedNotifications
+        var archivedNotification = notification
+        archivedNotification.archivedReason = reason
+        archivedNotification.archivedAt = Date()
+        archivedNotification.snoozedUntil = reason == .snoozed ? snoozedUntil : nil
+        archived.insert(archivedNotification, at: 0)
+        archivedNotifications = archived
+        clearFocusedReadIndicator(forTabId: notification.tabId, surfaceId: notification.surfaceId)
+        center.removeDeliveredNotificationsOffMain(withIdentifiers: [notification.id.uuidString])
+        center.removePendingNotificationRequestsOffMain(withIdentifiers: [notification.id.uuidString])
+        if reason == .snoozed, let snoozedUntil {
+            scheduleSnoozeResurface(for: archivedNotification, at: snoozedUntil)
+        } else {
+            cancelSnoozeResurface(id: archivedNotification.id)
+        }
+    }
+
+    private func insertArchivedNotificationIntoInbox(_ notification: TerminalNotification) {
+        var updated = notifications
+        var idsToClear: [String] = []
+        updated.removeAll { existing in
+            guard existing.tabId == notification.tabId,
+                  existing.surfaceId == notification.surfaceId,
+                  !existing.isBookmarked else { return false }
+            idsToClear.append(existing.id.uuidString)
+            return true
+        }
+        var restored = notification
+        restored.archivedReason = nil
+        restored.archivedAt = nil
+        restored.snoozedUntil = nil
+        updated.insert(restored, at: 0)
+        notifications = updated
+        if !idsToClear.isEmpty {
+            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
+            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+        }
+    }
+
+    private func archiveActiveNotifications(
+        matching predicate: (TerminalNotification) -> Bool,
+        reason: NotificationArchiveReason,
+        snoozedUntil: Date? = nil
+    ) {
+        let matchingNotifications = notifications.filter(predicate)
+        guard !matchingNotifications.isEmpty else { return }
+        notifications.removeAll(where: predicate)
+        for notification in matchingNotifications.reversed() {
+            archiveIncomingNotification(
+                notification,
+                reason: reason,
+                snoozedUntil: snoozedUntil
+            )
+        }
+    }
+
+    private func archiveNotifications(
+        matching predicate: (TerminalNotification) -> Bool,
+        reason: NotificationArchiveReason,
+        snoozedUntil: Date? = nil
+    ) {
+        let activeIds = notifications.filter(predicate).map(\.id)
+        let archivedIds = archivedNotifications.filter(predicate).map(\.id)
+        let ids = activeIds + archivedIds
+        guard !ids.isEmpty else { return }
+        for id in ids {
+            archive(id: id, reason: reason, snoozedUntil: snoozedUntil)
+        }
+    }
+
+    private func removeActiveNotification(id: UUID) -> TerminalNotification? {
+        guard let index = notifications.firstIndex(where: { $0.id == id }) else { return nil }
+        var updated = notifications
+        let removed = updated.remove(at: index)
+        notifications = updated
+        return removed
+    }
+
+    private func removeArchivedNotification(id: UUID) -> TerminalNotification? {
+        guard let index = archivedNotifications.firstIndex(where: { $0.id == id }) else { return nil }
+        var updated = archivedNotifications
+        let removed = updated.remove(at: index)
+        archivedNotifications = updated
+        return removed
+    }
+
+    private func scheduleSnoozeResurface(for notification: TerminalNotification, at date: Date) {
+        cancelSnoozeResurface(id: notification.id)
+        let delay = max(0, date.timeIntervalSinceNow)
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                self?.resurfaceSnoozedNotification(id: notification.id)
+            }
+        }
+        snoozeResurfaceWorkItems[notification.id] = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func cancelSnoozeResurface(id: UUID) {
+        snoozeResurfaceWorkItems.removeValue(forKey: id)?.cancel()
+    }
+
+    private func cancelAllSnoozeResurfaces() {
+        for (_, workItem) in snoozeResurfaceWorkItems {
+            workItem.cancel()
+        }
+        snoozeResurfaceWorkItems.removeAll()
+    }
+
+    private func resurfaceSnoozedNotification(id: UUID) {
+        cancelSnoozeResurface(id: id)
+        guard let notification = removeArchivedNotification(id: id) else { return }
+        guard notification.archivedReason == .snoozed else {
+            archivedNotifications.insert(notification, at: 0)
+            return
+        }
+        if isWorkspaceMuted(notification.tabId) {
+            archiveIncomingNotification(notification, reason: .mutedWorkspace)
+            return
+        }
+        if isProcessMuted(notification.processIdentifier) {
+            archiveIncomingNotification(notification, reason: .mutedProcess)
+            return
+        }
+        insertArchivedNotificationIntoInbox(notification)
+    }
+
+    private func resolveProcessDescriptor(
+        tabId: UUID,
+        surfaceId: UUID?,
+        title: String,
+        subtitle: String
+    ) -> (identifier: String?, label: String?) {
+        let workspaceTitle = AppDelegate.shared?.tabTitle(for: tabId)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let surfaceId,
+           let workspace = AppDelegate.shared?.workspaceFor(tabId: tabId),
+           let panel = workspace.panels[surfaceId] {
+            let candidate = panel.displayTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !candidate.isEmpty, candidate != workspaceTitle {
+                return (Self.normalizedProcessIdentifier(candidate), candidate)
+            }
+        }
+        let fallbackTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !fallbackTitle.isEmpty, fallbackTitle != workspaceTitle {
+            return (Self.normalizedProcessIdentifier(fallbackTitle), fallbackTitle)
+        }
+        let fallbackSubtitle = subtitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !fallbackSubtitle.isEmpty, fallbackSubtitle != workspaceTitle {
+            return (Self.normalizedProcessIdentifier(fallbackSubtitle), fallbackSubtitle)
+        }
+        return (nil, nil)
+    }
+
+    private func resolvedWorkspaceLabel(for tabId: UUID, fallback: String?) -> String {
+        let trimmedFallback = fallback?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedFallback.isEmpty {
+            return trimmedFallback
+        }
+        let resolvedTitle = AppDelegate.shared?.tabTitle(for: tabId)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !resolvedTitle.isEmpty {
+            return resolvedTitle
+        }
+        return String(localized: "notifications.workspace.fallback", defaultValue: "Workspace")
+    }
+
+    private func resolvedProcessLabel(_ label: String?, fallbackIdentifier: String) -> String {
+        let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? fallbackIdentifier : trimmed
+    }
+
+    private static func normalizedProcessIdentifier(_ label: String) -> String? {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let collapsedWhitespace = trimmed.replacingOccurrences(
+            of: "\\s+",
+            with: " ",
+            options: .regularExpression
+        )
+        return collapsedWhitespace.lowercased()
+    }
+
+    private static func loadMutedWorkspaceLabels(
+        defaults: UserDefaults
+    ) -> [UUID: String] {
+        guard let raw = defaults.dictionary(forKey: mutedWorkspacesDefaultsKey) as? [String: String] else {
+            return [:]
+        }
+        var resolved: [UUID: String] = [:]
+        for (key, value) in raw {
+            guard let id = UUID(uuidString: key) else { continue }
+            let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolved[id] = trimmedValue.isEmpty ? key : trimmedValue
+        }
+        return resolved
+    }
+
+    private static func loadMutedProcessLabels(
+        defaults: UserDefaults
+    ) -> [String: String] {
+        guard let raw = defaults.dictionary(forKey: mutedProcessesDefaultsKey) as? [String: String] else {
+            return [:]
+        }
+        var resolved: [String: String] = [:]
+        for (key, value) in raw {
+            let trimmedKey = key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedKey.isEmpty else { continue }
+            let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolved[trimmedKey] = trimmedValue.isEmpty ? trimmedKey : trimmedValue
+        }
+        return resolved
+    }
+
+    private func persistMutedSettings() {
+        let workspaceValues = mutedWorkspaceLabelsById.reduce(into: [String: String]()) { result, entry in
+            result[entry.key.uuidString] = entry.value
+        }
+        defaults.set(workspaceValues, forKey: Self.mutedWorkspacesDefaultsKey)
+        defaults.set(mutedProcessLabelsById, forKey: Self.mutedProcessesDefaultsKey)
+    }
+
     private static func buildIndexes(for notifications: [TerminalNotification]) -> NotificationIndexes {
         var indexes = NotificationIndexes()
         for notification in notifications {
+            indexes.activeCountByTabId[notification.tabId, default: 0] += 1
+            if notification.isBookmarked {
+                indexes.bookmarkedCountByTabId[notification.tabId, default: 0] += 1
+            }
             if indexes.latestByTabId[notification.tabId] == nil {
                 indexes.latestByTabId[notification.tabId] = notification
             }
@@ -1343,6 +1912,25 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         return indexes
+    }
+
+    private static func buildArchivedIndexes(
+        for notifications: [TerminalNotification]
+    ) -> ArchivedNotificationIndexes {
+        notifications.reduce(into: ArchivedNotificationIndexes()) { result, notification in
+            result.countByTabId[notification.tabId, default: 0] += 1
+            if notification.isBookmarked {
+                result.bookmarkedCountByTabId[notification.tabId, default: 0] += 1
+            }
+            switch notification.archivedReason {
+            case .hidden:
+                result.hiddenCountByTabId[notification.tabId, default: 0] += 1
+            case .snoozed:
+                result.snoozedCountByTabId[notification.tabId, default: 0] += 1
+            case .mutedWorkspace, .mutedProcess, nil:
+                break
+            }
+        }
     }
 
 #if DEBUG
@@ -1403,7 +1991,9 @@ final class TerminalNotificationStore: ObservableObject {
 
     func replaceNotificationsForTesting(_ notifications: [TerminalNotification]) {
         self.notifications = notifications
+        archivedNotifications.removeAll()
         focusedReadIndicatorByTabId.removeAll()
+        cancelAllSnoozeResurfaces()
     }
 #endif
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -678,8 +678,8 @@ struct TerminalNotification: Identifiable, Hashable {
     let title: String
     let subtitle: String
     let body: String
-    let processIdentifier: String? = nil
-    let processDisplayName: String? = nil
+    let processIdentifier: String?
+    let processDisplayName: String?
     let createdAt: Date
     var isRead: Bool
     var isBookmarked: Bool = false
@@ -689,6 +689,38 @@ struct TerminalNotification: Identifiable, Hashable {
 
     var isArchived: Bool {
         archivedReason != nil
+    }
+
+    init(
+        id: UUID,
+        tabId: UUID,
+        surfaceId: UUID?,
+        title: String,
+        subtitle: String,
+        body: String,
+        processIdentifier: String? = nil,
+        processDisplayName: String? = nil,
+        createdAt: Date,
+        isRead: Bool,
+        isBookmarked: Bool = false,
+        archivedReason: NotificationArchiveReason? = nil,
+        archivedAt: Date? = nil,
+        snoozedUntil: Date? = nil
+    ) {
+        self.id = id
+        self.tabId = tabId
+        self.surfaceId = surfaceId
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.processIdentifier = processIdentifier
+        self.processDisplayName = processDisplayName
+        self.createdAt = createdAt
+        self.isRead = isRead
+        self.isBookmarked = isBookmarked
+        self.archivedReason = archivedReason
+        self.archivedAt = archivedAt
+        self.snoozedUntil = snoozedUntil
     }
 }
 
@@ -1035,16 +1067,6 @@ final class TerminalNotificationStore: ObservableObject {
             return
         }
 
-        var updated = notifications
-        var idsToClear: [String] = []
-        updated.removeAll { existing in
-            guard existing.tabId == tabId,
-                  existing.surfaceId == surfaceId,
-                  !existing.isBookmarked else { return false }
-            idsToClear.append(existing.id.uuidString)
-            return true
-        }
-
         if let existingIndicatorSurfaceId = focusedReadIndicatorByTabId[tabId],
            existingIndicatorSurfaceId != surfaceId {
             focusedReadIndicatorByTabId.removeValue(forKey: tabId)
@@ -1094,17 +1116,11 @@ final class TerminalNotificationStore: ObservableObject {
         if let cooldownKey, resolvedCooldownInterval != nil {
             lastNotificationDateByCooldownKey[cooldownKey] = now
         }
-        if !idsToClear.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
-        }
         if let mutedReason {
-            notifications = updated
             archiveIncomingNotification(notification, reason: mutedReason)
             return
         }
-        updated.insert(notification, at: 0)
-        notifications = updated
+        insertNotificationIntoInbox(notification, removingMatchingInboxEntries: true)
         if shouldSuppressExternalDelivery {
             suppressedNotificationFeedbackHandler(self, notification)
         } else {
@@ -1686,26 +1702,41 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
 
-    private func insertArchivedNotificationIntoInbox(_ notification: TerminalNotification) {
+    private func insertNotificationIntoInbox(
+        _ notification: TerminalNotification,
+        removingMatchingInboxEntries: Bool
+    ) {
         var updated = notifications
         var idsToClear: [String] = []
-        updated.removeAll { existing in
-            guard existing.tabId == notification.tabId,
-                  existing.surfaceId == notification.surfaceId,
-                  !existing.isBookmarked else { return false }
-            idsToClear.append(existing.id.uuidString)
-            return true
+
+        if removingMatchingInboxEntries {
+            updated.removeAll { existing in
+                guard existing.tabId == notification.tabId,
+                      existing.surfaceId == notification.surfaceId,
+                      !existing.isBookmarked else { return false }
+                idsToClear.append(existing.id.uuidString)
+                return true
+            }
         }
-        var restored = notification
-        restored.archivedReason = nil
-        restored.archivedAt = nil
-        restored.snoozedUntil = nil
-        updated.insert(restored, at: 0)
+
+        let insertIndex = updated.firstIndex { existing in
+            existing.createdAt < notification.createdAt
+        } ?? updated.endIndex
+        updated.insert(notification, at: insertIndex)
         notifications = updated
+
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
+    }
+
+    private func insertArchivedNotificationIntoInbox(_ notification: TerminalNotification) {
+        var restored = notification
+        restored.archivedReason = nil
+        restored.archivedAt = nil
+        restored.snoozedUntil = nil
+        insertNotificationIntoInbox(restored, removingMatchingInboxEntries: false)
     }
 
     private func archiveActiveNotifications(

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -754,6 +754,187 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: tab), 0)
         XCTAssertNil(store.latestNotification(forTabId: tab))
     }
+
+    func testWorkspaceWideNotificationActionsTrackActiveAndArchivedState() {
+        let tabA = UUID()
+        let tabB = UUID()
+        let notificationA = TerminalNotification(
+            id: UUID(),
+            tabId: tabA,
+            surfaceId: nil,
+            title: "A",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+        let notificationB = TerminalNotification(
+            id: UUID(),
+            tabId: tabB,
+            surfaceId: nil,
+            title: "B",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([notificationA, notificationB])
+        defer {
+            store.unmuteWorkspace(tabId: tabA)
+            store.unmuteWorkspace(tabId: tabB)
+            store.replaceNotificationsForTesting([])
+        }
+
+        XCTAssertTrue(store.hasActiveNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasAnyNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasActiveNotifications(forTabIds: [tabA]))
+        XCTAssertTrue(store.hasAnyNotifications(forTabIds: [tabA]))
+        XCTAssertFalse(store.areAllWorkspacesMuted([tabA, tabB]))
+
+        store.hideNotifications(forTabId: tabA)
+
+        XCTAssertFalse(store.hasActiveNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasAnyNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasActiveNotifications(forTabId: tabB))
+        XCTAssertEqual(
+            store.archivedNotifications.first(where: { $0.id == notificationA.id })?.archivedReason,
+            .hidden
+        )
+        XCTAssertEqual(
+            store.workspaceNotificationSidebarStatus(forTabId: tabA),
+            WorkspaceNotificationSidebarStatus(
+                isMuted: false,
+                bookmarkedCount: 0,
+                hiddenCount: 1,
+                snoozedCount: 0
+            )
+        )
+
+        store.muteWorkspace(tabId: tabA, label: "Workspace A")
+        XCTAssertTrue(store.areAllWorkspacesMuted([tabA]))
+        XCTAssertFalse(store.areAllWorkspacesMuted([tabA, tabB]))
+        XCTAssertEqual(
+            store.workspaceNotificationSidebarStatus(forTabId: tabA),
+            WorkspaceNotificationSidebarStatus(
+                isMuted: true,
+                bookmarkedCount: 0,
+                hiddenCount: 1,
+                snoozedCount: 0
+            )
+        )
+
+        store.muteWorkspace(tabId: tabB, label: "Workspace B")
+        XCTAssertTrue(store.areAllWorkspacesMuted([tabA, tabB]))
+    }
+
+    func testWorkspaceWideBookmarkAndSnoozeTargetOnlySelectedWorkspace() {
+        let tabA = UUID()
+        let tabB = UUID()
+        let notificationA = TerminalNotification(
+            id: UUID(),
+            tabId: tabA,
+            surfaceId: nil,
+            title: "A",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+        let notificationB = TerminalNotification(
+            id: UUID(),
+            tabId: tabB,
+            surfaceId: nil,
+            title: "B",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([notificationA, notificationB])
+        defer {
+            store.replaceNotificationsForTesting([])
+        }
+
+        store.bookmarkNotifications(forTabId: tabA)
+
+        XCTAssertTrue(store.notifications.first(where: { $0.id == notificationA.id })?.isBookmarked ?? false)
+        XCTAssertFalse(store.notifications.first(where: { $0.id == notificationB.id })?.isBookmarked ?? true)
+
+        store.snoozeNotifications(forTabId: tabA, for: 60)
+
+        XCTAssertFalse(store.hasActiveNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasAnyNotifications(forTabId: tabA))
+        XCTAssertTrue(store.hasActiveNotifications(forTabId: tabB))
+        XCTAssertEqual(
+            store.archivedNotifications.first(where: { $0.id == notificationA.id })?.archivedReason,
+            .snoozed
+        )
+        XCTAssertNotNil(store.archivedNotifications.first(where: { $0.id == notificationA.id })?.snoozedUntil)
+        XCTAssertTrue(store.archivedNotifications.first(where: { $0.id == notificationA.id })?.isBookmarked ?? false)
+        XCTAssertEqual(
+            store.workspaceNotificationSidebarStatus(forTabId: tabA),
+            WorkspaceNotificationSidebarStatus(
+                isMuted: false,
+                bookmarkedCount: 1,
+                hiddenCount: 0,
+                snoozedCount: 1
+            )
+        )
+    }
+
+    func testWorkspaceWideHideAndSnoozeAlsoRetargetArchivedNotifications() {
+        let tab = UUID()
+        let firstNotification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: nil,
+            title: "First",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: true
+        )
+        let secondNotification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: nil,
+            title: "Second",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: true
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([firstNotification, secondNotification])
+        defer {
+            store.replaceNotificationsForTesting([])
+        }
+
+        store.hide(id: firstNotification.id)
+
+        XCTAssertEqual(store.archivedNotifications.count, 1)
+        XCTAssertEqual(
+            store.archivedNotifications.first(where: { $0.id == firstNotification.id })?.archivedReason,
+            .hidden
+        )
+        XCTAssertNotNil(store.notifications.first(where: { $0.id == secondNotification.id }))
+
+        store.snoozeNotifications(forTabId: tab, for: 300)
+
+        XCTAssertEqual(store.archivedNotifications.count, 2)
+        XCTAssertTrue(store.archivedNotifications.allSatisfy { $0.archivedReason == .snoozed })
+        XCTAssertTrue(store.archivedNotifications.allSatisfy { $0.snoozedUntil != nil })
+
+        store.hideNotifications(forTabId: tab)
+
+        XCTAssertEqual(store.archivedNotifications.count, 2)
+        XCTAssertTrue(store.archivedNotifications.allSatisfy { $0.archivedReason == .hidden })
+    }
 }
 
 

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -935,6 +935,132 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertEqual(store.archivedNotifications.count, 2)
         XCTAssertTrue(store.archivedNotifications.allSatisfy { $0.archivedReason == .hidden })
     }
+
+    func testRestoreDoesNotEvictNewerActiveNotificationOnSameSurface() throws {
+        let tab = UUID()
+        let surface = UUID()
+        let archivedNotification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: surface,
+            title: "Older",
+            subtitle: "",
+            body: "",
+            createdAt: Date(timeIntervalSince1970: 1),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([archivedNotification])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        defer {
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+        }
+
+        store.hide(id: archivedNotification.id)
+        XCTAssertTrue(store.notifications.isEmpty)
+        XCTAssertEqual(store.archivedNotifications.map(\.id), [archivedNotification.id])
+
+        store.addNotification(
+            tabId: tab,
+            surfaceId: surface,
+            title: "Newer",
+            subtitle: "",
+            body: ""
+        )
+
+        let newerNotificationID = try XCTUnwrap(store.notifications.first?.id)
+
+        store.restore(id: archivedNotification.id)
+
+        XCTAssertEqual(store.notifications.map(\.id), [newerNotificationID, archivedNotification.id])
+        XCTAssertEqual(store.latestNotification(forTabId: tab)?.id, newerNotificationID)
+        XCTAssertFalse(store.archivedNotifications.contains(where: { $0.id == archivedNotification.id }))
+    }
+
+    func testMutedDeliveryDoesNotEvictExistingActiveNotificationOnSameSurface() throws {
+        let tab = UUID()
+        let surface = UUID()
+        let existingActive = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: surface,
+            title: "Visible",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        var deliveredNotificationIDs: [UUID] = []
+
+        store.replaceNotificationsForTesting([existingActive])
+        store.configureNotificationDeliveryHandlerForTesting { _, notification in
+            deliveredNotificationIDs.append(notification.id)
+        }
+        defer {
+            store.unmuteProcess(identifier: "muted process")
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+        }
+
+        store.muteProcess(identifier: "muted process", label: "Muted Process")
+        store.addNotification(
+            tabId: tab,
+            surfaceId: surface,
+            title: "Muted Process",
+            subtitle: "",
+            body: ""
+        )
+
+        XCTAssertEqual(store.notifications.map(\.id), [existingActive.id])
+        XCTAssertEqual(store.latestNotification(forTabId: tab)?.id, existingActive.id)
+        XCTAssertEqual(store.archivedNotifications.count, 1)
+        XCTAssertEqual(store.archivedNotifications.first?.archivedReason, .mutedProcess)
+        XCTAssertEqual(store.archivedNotifications.first?.processIdentifier, "muted process")
+        XCTAssertTrue(deliveredNotificationIDs.isEmpty)
+    }
+
+    func testPerNotificationActionsUpdateBookmarkHideAndSnoozeState() throws {
+        let tab = UUID()
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: tab,
+            surfaceId: nil,
+            title: "Actionable",
+            subtitle: "",
+            body: "",
+            createdAt: Date(),
+            isRead: false
+        )
+
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([notification])
+        defer {
+            store.replaceNotificationsForTesting([])
+        }
+
+        store.toggleBookmark(id: notification.id)
+        XCTAssertTrue(store.notifications.first(where: { $0.id == notification.id })?.isBookmarked ?? false)
+
+        store.hide(id: notification.id)
+        XCTAssertTrue(store.notifications.isEmpty)
+        let hiddenNotification = try XCTUnwrap(
+            store.archivedNotifications.first(where: { $0.id == notification.id })
+        )
+        XCTAssertEqual(hiddenNotification.archivedReason, .hidden)
+        XCTAssertTrue(hiddenNotification.isBookmarked)
+
+        store.snooze(id: notification.id, for: 60)
+        let snoozedNotification = try XCTUnwrap(
+            store.archivedNotifications.first(where: { $0.id == notification.id })
+        )
+        XCTAssertEqual(snoozedNotification.archivedReason, .snoozed)
+        XCTAssertNotNil(snoozedNotification.snoozedUntil)
+        XCTAssertTrue(snoozedNotification.isBookmarked)
+    }
 }
 
 


### PR DESCRIPTION
Closes #2274

## Summary

- add notification inbox filtering plus richer row actions for open, bookmark, hide, snooze, mute, and delete workflows
- persist muted workspaces/processes and surface notification status badges plus bulk actions from the workspace sidebar context menu
- add store coverage for workspace-wide bookmark, hide, snooze, and mute behavior across active and archived notifications

## Testing

- Added `cmuxTests/NotificationAndMenuBarTests.swift` coverage for workspace-wide active vs archived notification state
- `git diff --check`
- Attempted `./scripts/reload.sh --tag issue-2274-notification-management`, but local build was blocked on March 30, 2026 because `/System/Volumes/Data` only had about 104 MiB free and `xcodebuild` failed while extracting Sentry artifacts into tagged DerivedData

## Demo Video

- Video URL or attachment: pending

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full notification management with inbox filters and row actions, plus workspace-wide controls with sidebar badges and bulk actions. Fixes action handling so state, filters, and badges stay in sync to meet #2274.

- **New Features**
  - Filters: Inbox, Bookmarked, Hidden.
  - Row actions: Open, Bookmark, Hide, Snooze (15m/1h/4h), Mute, Delete.
  - Persisted mutes for workspaces/processes; notifications can be archived with a reason or snoozed-until.
  - Workspace sidebar shows status badges and supports bulk mute/unmute from the context menu.
  - Store tracks bookmarks and archived/snoozed state; tests cover active vs archived behavior.

- **Bug Fixes**
  - Row actions now correctly update active vs archived state; filter counts and sidebar badges stay accurate.
  - Sidebar context menu indicates when all selected workspaces are muted; bulk mute/unmute applies reliably.

<sup>Written for commit 8dce26804c63d6c50a57f4a1cd70b6263595b535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification management: bookmark, hide/restore, snooze (15m/1h/4h), permanent delete, mark read/unread, clear all
  * Workspace/process mute/unmute and bulk actions (bookmark/hide/snooze per workspace)
  * Filters: inbox, bookmarked, hidden; header muted-sources menu and workspace status indicators
  * Context menus, “more actions” and per-row action UI

* **Localization**
  * Added many new localized strings for notification actions, statuses, filters, and empty states

* **Tests**
  * Added tests covering workspace-wide and per-notification actions and state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->