### PR TITLE
Fix #2358 update error details dialog overflow

### DIFF
--- a/Sources/Update/UpdatePopoverView.swift
+++ b/Sources/Update/UpdatePopoverView.swift
@@ -469,11 +469,15 @@ fileprivate struct UpdateErrorView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(String(localized: "update.popover.details", defaultValue: "Details"))
                     .font(.system(size: 11, weight: .semibold))
-                Text(details)
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
+                ScrollView(.vertical) {
+                    Text(details)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .frame(maxHeight: 300)
             }
 
             HStack(spacing: 8) {


### PR DESCRIPTION
## Summary
- wrap update error details in a vertical scroll view
- cap the details region height so long Sparkle errors do not push actions off-screen
- keep the header, message, and buttons always visible

Closes #2358

## Verification
- built and launched the tagged dev app with `./scripts/reload.sh --tag update-dialog-scroll --launch`
- did not run local tests per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix overflow in the update error dialog. The details text is now in a vertical scroll area with a capped height, so long Sparkle errors don’t push the header or action buttons off-screen.

<sup>Written for commit dc0fef1218550d20d0cb58c1fb507c04f7381bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error details section now displays content in a scrollable container with a maximum height constraint, improving visibility and readability of lengthy error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->