### PR TITLE
Simplify R2 to appcast-only (keep DMGs on GitHub)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -503,7 +503,7 @@ jobs:
           # installs to migrate onto the unified nightly appcast.
           cp appcast.xml appcast-universal.xml
 
-      - name: Upload nightly assets to R2
+      - name: Upload nightly appcast to R2
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
         continue-on-error: true
         env:
@@ -514,31 +514,16 @@ jobs:
         run: |
           set -euo pipefail
           command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
-          BUCKET=cmux-binaries
 
-          # Derive R2 appcast from the GitHub one by replacing the download URL prefix.
-          # EdDSA signature is over the DMG content, not the URL, so this is safe.
-          sed 's|https://github.com/manaflow-ai/cmux/releases/download/nightly/|https://files.cmux.com/nightly/|g' \
-            appcast.xml > appcast-r2.xml
-
-          # Upload immutable versioned DMG (cacheable forever).
-          aws s3 cp "$NIGHTLY_DMG_IMMUTABLE" \
-            "s3://${BUCKET}/nightly/${NIGHTLY_DMG_IMMUTABLE}" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --cache-control "max-age=31536000, immutable"
-          # Upload mutable latest DMG (no cache).
-          aws s3 cp cmux-nightly-macos.dmg \
-            "s3://${BUCKET}/nightly/cmux-nightly-macos.dmg" \
+          # Upload the same appcast.xml (GitHub Release DMG URLs).
+          # DMGs are immutable per-build on GitHub Releases, so no race condition.
+          # Only the appcast itself needs atomic replacement (R2 PutObject).
+          aws s3 cp appcast.xml \
+            "s3://cmux-binaries/nightly/appcast.xml" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache, no-store, must-revalidate"
 
-          # Upload appcast last (atomic PutObject, no 404 window).
-          aws s3 cp appcast-r2.xml \
-            "s3://${BUCKET}/nightly/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-          echo "R2 upload complete: https://files.cmux.com/nightly/appcast.xml"
+          echo "R2 appcast upload complete: https://files.cmux.com/nightly/appcast.xml"
 
       - name: Attest remote daemon nightly assets
         if: needs.decide.outputs.should_publish != 'true' || (steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true')

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -503,28 +503,6 @@ jobs:
           # installs to migrate onto the unified nightly appcast.
           cp appcast.xml appcast-universal.xml
 
-      - name: Upload nightly appcast to R2
-        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
-        run: |
-          set -euo pipefail
-          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
-
-          # Upload the same appcast.xml (GitHub Release DMG URLs).
-          # DMGs are immutable per-build on GitHub Releases, so no race condition.
-          # Only the appcast itself needs atomic replacement (R2 PutObject).
-          aws s3 cp appcast.xml \
-            "s3://cmux-binaries/nightly/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-          echo "R2 appcast upload complete: https://files.cmux.com/nightly/appcast.xml"
-
       - name: Attest remote daemon nightly assets
         if: needs.decide.outputs.should_publish != 'true' || (steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true')
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -582,6 +560,28 @@ jobs:
             remote-daemon-assets/cmuxd-remote-*
             appcast-universal.xml
           overwrite_files: true
+
+      - name: Upload nightly appcast to R2
+        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
+
+          # Upload after GitHub Release publish so the appcast never references
+          # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
+          # is either the old version or the new one, never missing.
+          aws s3 cp appcast.xml \
+            "s3://cmux-binaries/nightly/appcast.xml" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+          echo "R2 appcast upload complete: https://files.cmux.com/nightly/appcast.xml"
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,16 @@ jobs:
           set -euo pipefail
           command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
 
+          # Guard: only upload if this tag is the highest semver release.
+          # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from
+          # overwriting the stable appcast with an older version.
+          LATEST=$(gh release list --exclude-drafts --exclude-pre-releases \
+            --json tagName -q '.[].tagName' | sort -V | tail -1)
+          if [ -n "$LATEST" ] && [ "$LATEST" != "$GITHUB_REF_NAME" ]; then
+            echo "Skipping R2 stable upload: $GITHUB_REF_NAME is not the latest release ($LATEST)"
+            exit 0
+          fi
+
           # Upload after GitHub Release publish so the appcast never references
           # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
           # is either the old version or the new one, never missing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,28 +336,6 @@ jobs:
           fi
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
-      - name: Upload release appcast to R2
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
-        run: |
-          set -euo pipefail
-          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
-
-          # Upload the same appcast.xml (GitHub Release DMG URLs).
-          # Stable releases use overwrite_files: false, so no DMG race condition.
-          # Only the appcast needs atomic replacement for future tiered rollouts.
-          aws s3 cp appcast.xml \
-            "s3://cmux-binaries/stable/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-          echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"
-
       - name: Attest remote daemon release assets
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -396,6 +374,28 @@ jobs:
             remote-daemon-assets/cmuxd-remote-manifest.json
           generate_release_notes: true
           overwrite_files: false
+
+      - name: Upload release appcast to R2
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
+
+          # Upload after GitHub Release publish so the appcast never references
+          # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
+          # is either the old version or the new one, never missing.
+          aws s3 cp appcast.xml \
+            "s3://cmux-binaries/stable/appcast.xml" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+          echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
           fi
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
-      - name: Upload release assets to R2
+      - name: Upload release appcast to R2
         if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         continue-on-error: true
         env:
@@ -347,25 +347,16 @@ jobs:
         run: |
           set -euo pipefail
           command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
-          BUCKET=cmux-binaries
 
-          # Derive R2 appcast by replacing the download URL prefix.
-          sed "s|https://github.com/manaflow-ai/cmux/releases/download/${GITHUB_REF_NAME}/|https://files.cmux.com/stable/|g" \
-            appcast.xml > appcast-r2.xml
-
-          # Upload DMG first so the appcast never references a missing file.
-          aws s3 cp cmux-macos.dmg \
-            "s3://${BUCKET}/stable/cmux-macos.dmg" \
+          # Upload the same appcast.xml (GitHub Release DMG URLs).
+          # Stable releases use overwrite_files: false, so no DMG race condition.
+          # Only the appcast needs atomic replacement for future tiered rollouts.
+          aws s3 cp appcast.xml \
+            "s3://cmux-binaries/stable/appcast.xml" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache, no-store, must-revalidate"
 
-          # Upload appcast last (atomic PutObject, no 404 window).
-          aws s3 cp appcast-r2.xml \
-            "s3://${BUCKET}/stable/appcast.xml" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --cache-control "no-cache, no-store, must-revalidate"
-
-          echo "R2 upload complete: https://files.cmux.com/stable/appcast.xml"
+          echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"
 
       - name: Attest remote daemon release assets
         if: steps.guard_release_assets.outputs.skip_all != 'true'


### PR DESCRIPTION
## Summary

- Removes DMG uploads to R2, keeps only appcast.xml
- DMGs stay on GitHub Releases (immutable per-build, no race condition)
- R2 appcast now uploads the original appcast.xml as-is (GitHub Release DMG URLs), no sed URL rewriting needed
- Saves R2 storage/bandwidth (~40MB per nightly)

Follow-up to https://github.com/manaflow-ai/cmux/pull/2335.

## Why

The 404 race condition only affects `appcast.xml` (overwritten every nightly via delete-then-upload). The versioned DMGs (`cmux-nightly-macos-{build}.dmg`) are immutable and never deleted, so GitHub Releases is fine for them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified R2 uploads to appcast-only; DMGs stay on GitHub Releases. Uploads the appcast after publishing to avoid broken links and reduce R2 storage/bandwidth.

- **Refactors**
  - Stop uploading DMGs to R2; upload `appcast.xml` as-is (GitHub Release URLs).
  - Remove URL rewriting and all R2 DMG steps.
  - Saves ~40MB per nightly by not duplicating DMGs.

- **Bug Fixes**
  - Upload `appcast.xml` to R2 after GitHub Release publish so it never references a missing DMG.
  - Atomic upload with a semver guard prevents transient 404s and avoids downgrading the stable appcast from backport tags.

<sup>Written for commit 0adf2b53b3e94ffaf9c9d8962f1cd432d194f5f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nightly and release distribution workflows: the appcast is now uploaded directly to distribution storage and its upload runs later in the publish process.
  * Release binaries (DMG) are no longer uploaded alongside the appcast; binaries are published via the release flow while the appcast is managed separately.
  * Added a semver guard so release appcast uploads only occur for the highest semver tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->