### PR TITLE
Add customizable terminal pane notification ring color

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7400,12 +7400,19 @@ final class GhosttySurfaceScrollView: NSView {
         notificationRingOverlayView.layer?.backgroundColor = NSColor.clear.cgColor
         notificationRingOverlayView.layer?.masksToBounds = false
         notificationRingOverlayView.autoresizingMask = [.width, .height]
+        let ringColor: NSColor = {
+            if let hex = UserDefaults.standard.string(forKey: "paneNotificationRingColorHex"),
+               let custom = NSColor(hex: hex) {
+                return custom
+            }
+            return .systemBlue
+        }()
         notificationRingLayer.fillColor = NSColor.clear.cgColor
-        notificationRingLayer.strokeColor = NSColor.systemBlue.cgColor
+        notificationRingLayer.strokeColor = ringColor.cgColor
         notificationRingLayer.lineWidth = NotificationRingMetrics.lineWidth
         notificationRingLayer.lineJoin = .round
         notificationRingLayer.lineCap = .round
-        notificationRingLayer.shadowColor = NSColor.systemBlue.cgColor
+        notificationRingLayer.shadowColor = ringColor.cgColor
         notificationRingLayer.shadowOpacity = 0.35
         notificationRingLayer.shadowRadius = 3
         notificationRingLayer.shadowOffset = .zero

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3906,6 +3906,7 @@ struct SettingsView: View {
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
     @AppStorage("sidebarSelectionColorHex") private var sidebarSelectionColorHex: String?
     @AppStorage("sidebarNotificationBadgeColorHex") private var sidebarNotificationBadgeColorHex: String?
+    @AppStorage("paneNotificationRingColorHex") private var paneNotificationRingColorHex: String?
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
     @AppStorage("sidebarShowPullRequest") private var sidebarShowPullRequest = true
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
@@ -4058,6 +4059,21 @@ struct SettingsView: View {
             set: { newColor in
                 let nsColor = NSColor(newColor)
                 sidebarNotificationBadgeColorHex = nsColor.hexString()
+            }
+        )
+    }
+
+    private var paneNotificationRingColorBinding: Binding<Color> {
+        Binding(
+            get: {
+                if let hex = paneNotificationRingColorHex, let nsColor = NSColor(hex: hex) {
+                    return Color(nsColor: nsColor)
+                }
+                return Color(nsColor: .systemBlue)
+            },
+            set: { newColor in
+                let nsColor = NSColor(newColor)
+                paneNotificationRingColorHex = nsColor.hexString()
             }
         )
     }
@@ -5003,6 +5019,36 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardRow(
+                            String(localized: "settings.workspaceColors.paneNotificationRingColor", defaultValue: "Notification Ring"),
+                            subtitle: String(localized: "settings.workspaceColors.paneNotificationRingColor.subtitle", defaultValue: "Color of the border flash on terminal panes when a notification fires.")
+                        ) {
+                            HStack(spacing: 8) {
+                                if paneNotificationRingColorHex != nil {
+                                    Button(String(localized: "settings.workspaceColors.paneNotificationRingColor.reset", defaultValue: "Reset")) {
+                                        paneNotificationRingColorHex = nil
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                }
+
+                                ColorPicker(
+                                    "",
+                                    selection: paneNotificationRingColorBinding,
+                                    supportsOpacity: false
+                                )
+                                .labelsHidden()
+                                .frame(width: 38)
+
+                                Text(paneNotificationRingColorHex ?? String(localized: "settings.sidebarAppearance.defaultLabel", defaultValue: "Default"))
+                                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 76, alignment: .trailing)
+                            }
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsCardNote(String(localized: "settings.workspaceColors.paletteNote", defaultValue: "Customize the workspace color palette used by Sidebar > Workspace Color. \"Choose Custom Color...\" entries are persisted below."))
 
                         ForEach(Array(workspaceTabDefaultEntries.enumerated()), id: \.element.name) { index, entry in
@@ -5845,6 +5891,7 @@ struct SettingsView: View {
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
         sidebarSelectionColorHex = nil
         sidebarNotificationBadgeColorHex = nil
+        paneNotificationRingColorHex = nil
         sidebarShowBranchDirectory = true
         sidebarShowPullRequest = true
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser


### PR DESCRIPTION
## Summary
- Add `paneNotificationRingColorHex` user default to override the hardcoded `systemBlue` notification ring on terminal panes
- Add "Notification Ring" color picker in Settings > Workspace Colors, following the same pattern as Selection Highlight and Notification Badge
- Falls back to `systemBlue` when no custom color is set

Follow-up to #1824, completes #1753

## Test plan
- Open Settings > Workspace Colors
- Verify "Notification Ring" color picker appears below "Notification Badge"
- Pick a custom color, trigger a notification on a background pane, confirm the ring flashes in the new color
- Click "Reset" and confirm it reverts to system blue
- Verify new panes pick up the custom color; existing panes update on next creation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customizable color for the terminal pane notification ring with a new picker in Settings > Workspace Colors. Defaults to system blue when unset.

- New Features
  - Introduced `paneNotificationRingColorHex` to override the ring color.
  - Added “Notification Ring” color picker with Reset in Settings > Workspace Colors.
  - Ring stroke and shadow now use the selected color.
  - New panes use the color; existing panes update on recreation.

<sup>Written for commit 5337bfede6bb86757878b991bf7fc6cfa01fccea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customize the notification ring color in workspace color settings with a reset-to-default option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->