### PR TITLE
Switch nightly Sparkle feed to R2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -304,7 +304,7 @@ jobs:
           prepare_variant \
             "$APP_DIR" \
             "com.cmuxterm.app.nightly" \
-            "https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast.xml"
+            "https://files.cmux.com/nightly/appcast.xml"
 
           echo "Nightly app name: cmux NIGHTLY"
           echo "Nightly bundle ID: com.cmuxterm.app.nightly"


### PR DESCRIPTION
## Summary

- Changes the nightly `SUFeedURL` from `github.com/.../nightly/appcast.xml` to `files.cmux.com/nightly/appcast.xml`
- One-line change in `nightly.yml` (the `prepare_variant` call)
- No Swift code changes needed (`isNightly` detection checks for `/nightly/` in URL, which matches both)
- Stable builds unchanged (still use GitHub Releases)
- DMGs still served from GitHub Releases, only the appcast feed moves to R2

## Why

GitHub Release asset replacement (delete-then-upload) causes a brief 404 window for `appcast.xml`, resulting in `SUDownloadError 2001` when a user checks for updates during a nightly publish. R2 uses atomic PutObject, so the appcast is either the old version or the new one, never missing.

## Security

- EdDSA signature verification is the real security boundary. Even with full R2 write access, an attacker can't push malicious updates (signature won't match the private key in GitHub secrets)
- Nightly/release workflows only trigger on `push` to `main` / tag push, never on PRs. Fork PRs cannot access secrets.
- No `pull_request_target` anywhere in the repo
- No user-controlled input in R2 upload commands

## DO NOT MERGE until

Manually verify R2 appcast is serving correctly across multiple nightly builds:
```bash
curl -sL https://files.cmux.com/nightly/appcast.xml
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the nightly Sparkle update feed from GitHub Releases to R2 at https://files.cmux.com/nightly/appcast.xml to remove transient 404s and eliminate SUDownloadError 2001. Stable builds are unchanged; DMGs still come from GitHub Releases.

- **Bug Fixes**
  - Atomic uploads on R2 ensure `appcast.xml` is never missing.
  - Nightly detection still works (URL still contains `/nightly/`).

- **Migration**
  - Before merging, verify the R2 appcast across multiple nightly builds: curl -sL https://files.cmux.com/nightly/appcast.xml

<sup>Written for commit 1516e7c2ab0d766a65e12d4db23a3d5572d795de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly build's update source configuration to use a new server location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->