### PR TITLE
Fix browser.eval and snapshot on sites with strict CSP

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8052,9 +8052,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         })();
         """
 
-        panel.webView.evaluateJavaScript(script) { [weak self] result, _ in
+        panel.webView.evaluateJavaScript(script, in: nil, in: .defaultClient) { [weak self] callResult in
             guard let self else { return }
-            let payload = result as? [String: Any]
+            let payload = (try? callResult.get()) as? [String: Any]
             let focused = (payload?["focused"] as? Bool) ?? false
             let inputId = (payload?["id"] as? String) ?? ""
             let secondaryInputId = (payload?["secondaryId"] as? String) ?? ""
@@ -8260,8 +8260,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         })();
         """
 
-        panel.webView.evaluateJavaScript(script) { result, _ in
-            let payload = result as? [String: Any]
+        panel.webView.evaluateJavaScript(script, in: nil, in: .defaultClient) { callResult in
+            let payload = (try? callResult.get()) as? [String: Any]
             completion([
                 "id": (payload?["id"] as? String) ?? "",
                 "tag": (payload?["tag"] as? String) ?? "",

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2517,7 +2517,8 @@ final class BrowserPanel: Panel, ObservableObject {
             WKUserScript(
                 source: Self.telemetryHookBootstrapScriptSource,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: true
+                forMainFrameOnly: true,
+                in: .defaultClient
             )
         )
         // Track the last editable focused element continuously so omnibar exit can
@@ -2527,7 +2528,8 @@ final class BrowserPanel: Panel, ObservableObject {
             WKUserScript(
                 source: Self.addressBarFocusTrackingBootstrapScript,
                 injectionTime: .atDocumentStart,
-                forMainFrameOnly: true
+                forMainFrameOnly: true,
+                in: .defaultClient
             )
         )
     }
@@ -3540,8 +3542,8 @@ final class BrowserPanel: Panel, ObservableObject {
                 continuation.resume(returning: value)
             }
 
-            webView.evaluateJavaScript(script) { result, _ in
-                let value = result as? String
+            webView.evaluateJavaScript(script, in: nil, in: .defaultClient) { result in
+                let value = (try? result.get()) as? String
                 Task { @MainActor in
                     resume(value)
                 }
@@ -4807,7 +4809,7 @@ extension BrowserPanel {
 
     /// Execute JavaScript
     func evaluateJavaScript(_ script: String) async throws -> Any? {
-        try await webView.evaluateJavaScript(script)
+        try await webView.evaluateJavaScript(script, in: nil, in: .defaultClient)
     }
 
     // MARK: - Find in Page
@@ -4867,7 +4869,7 @@ extension BrowserPanel {
     func findNext() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.nextScript())
+            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.nextScript(), in: nil, in: .defaultClient)
             self.parseFindResult(result)
         }
     }
@@ -4875,7 +4877,7 @@ extension BrowserPanel {
     func findPrevious() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.previousScript())
+            let result = try? await self.webView.evaluateJavaScript(BrowserFindJavaScript.previousScript(), in: nil, in: .defaultClient)
             self.parseFindResult(result)
         }
     }
@@ -4909,7 +4911,7 @@ extension BrowserPanel {
             guard let self else { return }
             let js = BrowserFindJavaScript.searchScript(query: needle)
             do {
-                let result = try await self.webView.evaluateJavaScript(js)
+                let result = try await self.webView.evaluateJavaScript(js, in: nil, in: .defaultClient)
                 self.parseFindResult(result)
             } catch {
                 NSLog("Find: browser JS search error: %@", error.localizedDescription)
@@ -4921,7 +4923,7 @@ extension BrowserPanel {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.webView.evaluateJavaScript(BrowserFindJavaScript.clearScript())
+                _ = try await self.webView.evaluateJavaScript(BrowserFindJavaScript.clearScript(), in: nil, in: .defaultClient)
             } catch {
                 NSLog("Find: browser JS clear error: %@", error.localizedDescription)
             }
@@ -5236,25 +5238,25 @@ extension BrowserPanel {
     }
 
     private func captureAddressBarPageFocusIfNeeded() {
-        webView.evaluateJavaScript(Self.addressBarFocusCaptureScript) { [weak self] result, error in
+        webView.evaluateJavaScript(Self.addressBarFocusCaptureScript, in: nil, in: .defaultClient) { [weak self] callResult in
 #if DEBUG
             guard let self else { return }
-            if let error {
+            switch callResult {
+            case .failure(let error):
                 dlog(
                     "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
                     "result=error message=\(error.localizedDescription)"
                 )
-                return
+            case .success(let result):
+                let resultValue = (result as? String) ?? "unknown"
+                dlog(
+                    "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
+                    "result=\(resultValue)"
+                )
             }
-            let resultValue = (result as? String) ?? "unknown"
-            dlog(
-                "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
-                "result=\(resultValue)"
-            )
 #else
             _ = self
-            _ = result
-            _ = error
+            _ = callResult
 #endif
         }
     }
@@ -5308,7 +5310,14 @@ extension BrowserPanel {
             completion(false)
             return
         }
-        webView.evaluateJavaScript(Self.addressBarFocusRestoreScript) { [weak self] result, error in
+        webView.evaluateJavaScript(Self.addressBarFocusRestoreScript, in: nil, in: .defaultClient) { [weak self] callResult in
+            let result: Any?
+            let error: Error?
+            switch callResult {
+            case .success(let value): result = value; error = nil
+            case .failure(let err): result = nil; error = err
+            }
+
             guard let self else {
                 completion(false)
                 return

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4808,8 +4808,8 @@ extension BrowserPanel {
     }
 
     /// Execute JavaScript
-    func evaluateJavaScript(_ script: String) async throws -> Any? {
-        try await webView.evaluateJavaScript(script, in: nil, in: .defaultClient)
+    func evaluateJavaScript(_ script: String, contentWorld: WKContentWorld = .defaultClient) async throws -> Any? {
+        try await webView.evaluateJavaScript(script, in: nil, in: contentWorld)
     }
 
     // MARK: - Find in Page

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -415,8 +415,8 @@ final class CmuxWebView: WKWebView {
             return '';
         })();
         """
-        evaluateJavaScript(js) { result, _ in
-            guard let href = result as? String, !href.isEmpty,
+        evaluateJavaScript(js, in: nil, in: .defaultClient) { callResult in
+            guard let href = (try? callResult.get()) as? String, !href.isEmpty,
                   let url = URL(string: href) else {
                 completion(nil)
                 return
@@ -860,8 +860,8 @@ final class CmuxWebView: WKWebView {
             return candidateFromElement(single) || '';
         })();
         """
-        evaluateJavaScript(js) { result, _ in
-            guard let src = result as? String, !src.isEmpty,
+        evaluateJavaScript(js, in: nil, in: .defaultClient) { callResult in
+            guard let src = (try? callResult.get()) as? String, !src.isEmpty,
                   let url = URL(string: src) else {
                 completion(nil)
                 return
@@ -940,8 +940,8 @@ final class CmuxWebView: WKWebView {
             return linkFromElement(single) || '';
         })();
         """
-        evaluateJavaScript(js) { result, _ in
-            guard let href = result as? String, !href.isEmpty,
+        evaluateJavaScript(js, in: nil, in: .defaultClient) { callResult in
+            guard let href = (try? callResult.get()) as? String, !href.isEmpty,
                   let url = URL(string: href) else {
                 completion(nil)
                 return
@@ -982,9 +982,9 @@ final class CmuxWebView: WKWebView {
             return JSON.stringify({count: nodes.length, entries});
         })();
         """
-        evaluateJavaScript(js) { [weak self] result, _ in
+        evaluateJavaScript(js, in: nil, in: .defaultClient) { [weak self] callResult in
             guard let self,
-                  let payload = result as? String,
+                  let payload = (try? callResult.get()) as? String,
                   !payload.isEmpty else { return }
             self.debugContextDownload(
                 "browser.ctxdl.inspect trace=\(traceID) kind=\(kind) payload=\(payload)"

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6837,7 +6837,7 @@ class TerminalController {
                     }
                 }
             } else {
-                // macOS < 11.0: contentWorld parameter is ignored; JS runs in .page
+                // macOS < 11.0: WKContentWorld API unavailable; JS always runs in .page world
                 webView.evaluateJavaScript(script) { value, error in
                     if let error {
                         finish(nil, error.localizedDescription)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -9356,6 +9356,7 @@ class TerminalController {
             browserPanel.webView,
             script: BrowserPanel.telemetryHookBootstrapScriptSource,
             timeout: 5.0,
+            preferAsync: true,
             contentWorld: .defaultClient
         )
     }
@@ -9365,6 +9366,7 @@ class TerminalController {
             browserPanel.webView,
             script: BrowserPanel.dialogTelemetryHookBootstrapScriptSource,
             timeout: 5.0,
+            preferAsync: true,
             contentWorld: .defaultClient
         )
     }
@@ -9397,7 +9399,7 @@ class TerminalController {
             })()
             """
 
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, preferAsync: true, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10055,7 +10057,7 @@ class TerminalController {
               return { ok: true, items };
             })()
             """
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, preferAsync: true, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10093,7 +10095,7 @@ class TerminalController {
               return { ok: true, items };
             })()
             """
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, preferAsync: true, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7106,7 +7106,7 @@ class TerminalController {
                 script: asyncFunctionBody,
                 timeout: timeout,
                 preferAsync: true,
-                contentWorld: .page
+                contentWorld: .defaultClient
             )
         } else {
             let evaluateFallback = """
@@ -7114,7 +7114,7 @@ class TerminalController {
               \(asyncFunctionBody)
             })()
             """
-            rawResult = v2RunJavaScript(webView, script: evaluateFallback, timeout: timeout, contentWorld: .page)
+            rawResult = v2RunJavaScript(webView, script: evaluateFallback, timeout: timeout, contentWorld: .defaultClient)
         }
 
         if !useEval, case .failure(let pageMessage) = rawResult, #available(macOS 11.0, *) {
@@ -9373,7 +9373,7 @@ class TerminalController {
             browserPanel.webView,
             script: BrowserPanel.telemetryHookBootstrapScriptSource,
             timeout: 5.0,
-            contentWorld: .page
+            contentWorld: .defaultClient
         )
     }
 
@@ -9382,7 +9382,7 @@ class TerminalController {
             browserPanel.webView,
             script: BrowserPanel.dialogTelemetryHookBootstrapScriptSource,
             timeout: 5.0,
-            contentWorld: .page
+            contentWorld: .defaultClient
         )
     }
 
@@ -9414,7 +9414,7 @@ class TerminalController {
             })()
             """
 
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10072,7 +10072,7 @@ class TerminalController {
               return { ok: true, items };
             })()
             """
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10110,7 +10110,7 @@ class TerminalController {
               return { ok: true, items };
             })()
             """
-            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .page) {
+            switch v2RunJavaScript(browserPanel.webView, script: script, timeout: 5.0, contentWorld: .defaultClient) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
@@ -10287,7 +10287,7 @@ class TerminalController {
             scripts.append(script)
             v2BrowserInitScriptsBySurface[surfaceId] = scripts
 
-            let userScript = WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            let userScript = WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .defaultClient)
             browserPanel.webView.configuration.userContentController.addUserScript(userScript)
             _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: script, timeout: 10.0)
 
@@ -10340,7 +10340,7 @@ class TerminalController {
             })()
             """
 
-            let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            let userScript = WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: .defaultClient)
             browserPanel.webView.configuration.userContentController.addUserScript(userScript)
             _ = v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: source, timeout: 10.0)
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6837,6 +6837,7 @@ class TerminalController {
                     }
                 }
             } else {
+                // macOS < 11.0: contentWorld parameter is ignored; JS runs in .page
                 webView.evaluateJavaScript(script) { value, error in
                     if let error {
                         finish(nil, error.localizedDescription)
@@ -7115,24 +7116,6 @@ class TerminalController {
             })()
             """
             rawResult = v2RunJavaScript(webView, script: evaluateFallback, timeout: timeout, contentWorld: .defaultClient)
-        }
-
-        if !useEval, case .failure(let pageMessage) = rawResult, #available(macOS 11.0, *) {
-            let isolatedResult = v2RunJavaScript(
-                webView,
-                script: asyncFunctionBody,
-                timeout: timeout,
-                preferAsync: true,
-                contentWorld: .defaultClient
-            )
-            switch isolatedResult {
-            case .success:
-                rawResult = isolatedResult
-            case .failure(let isolatedMessage):
-                if isolatedMessage != pageMessage {
-                    rawResult = .failure("\(pageMessage) (isolated-world retry: \(isolatedMessage))")
-                }
-            }
         }
 
         switch rawResult {


### PR DESCRIPTION
`browser.eval` and `snapshot --interactive` return `js_error` on sites with strict CSP (e.g. Airtable, various React SPAs).

The issue is all injected JS runs in `WKContentWorld.page`, which is subject to the page's Content-Security-Policy headers. Strict CSP blocks inline script execution, so any `evaluateJavaScript` call gets rejected.

Switching to `.defaultClient` fixes it. That world is CSP-exempt but still has full DOM access, the same approach Safari extensions use for content scripts.

All `evaluateJavaScript` calls and `WKUserScript` registrations targeting browser panel webviews now use `.defaultClient`. Inspector frontend calls are left alone since those target an internal WebView. Completion handlers updated to match the `Result<Any, Error>` API of the content-world overload.

Telemetry hooks now run in an isolated world so page JS can't see `__cmux*` globals, which should help with CAPTCHA systems detecting environment tampering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how in-page scripts and JavaScript evaluations run across the app to use a consistent execution context, improving reliability of search, address‑bar focus/restore, telemetry hooks, and console/error capture.
  * Removed legacy isolated-context retry behavior for a simpler, more consistent script execution model.
  * No public APIs or user-facing settings were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->