### PR TITLE
feat(ios): offline badge and workspace visibility filtering

### DIFF
--- a/ios/Sources/Terminal/TerminalModels.swift
+++ b/ios/Sources/Terminal/TerminalModels.swift
@@ -18,6 +18,11 @@ enum TerminalConnectionPhase: String, Codable, CaseIterable, Sendable {
     case failed
 }
 
+enum MobileMachineStatus: String, Codable, CaseIterable, Sendable {
+    case online
+    case offline
+}
+
 enum TerminalHostSource: String, Codable, CaseIterable, Sendable {
     case discovered
     case custom
@@ -102,6 +107,9 @@ struct TerminalHost: Identifiable, Codable, Equatable, Sendable {
     var serverID: String?
     var allowsSSHFallback: Bool
     var directTLSPins: [String]
+    /// Runtime-only machine status propagated by the server discovery layer (Unit 6).
+    /// Not persisted. Defaults to nil (treated as online).
+    var machineStatus: MobileMachineStatus?
 
     init(
         id: ID = UUID(),
@@ -122,7 +130,8 @@ struct TerminalHost: Identifiable, Codable, Equatable, Sendable {
         teamID: String? = nil,
         serverID: String? = nil,
         allowsSSHFallback: Bool = true,
-        directTLSPins: [String] = []
+        directTLSPins: [String] = [],
+        machineStatus: MobileMachineStatus? = nil
     ) {
         self.id = id
         self.stableID = stableID ?? id.uuidString
@@ -143,6 +152,7 @@ struct TerminalHost: Identifiable, Codable, Equatable, Sendable {
         self.serverID = serverID
         self.allowsSSHFallback = allowsSSHFallback
         self.directTLSPins = directTLSPins.normalizedTerminalPins
+        self.machineStatus = machineStatus
     }
 
     var subtitle: String {
@@ -246,6 +256,29 @@ struct TerminalHost: Identifiable, Codable, Equatable, Sendable {
             allowsSSHFallback: try container.decodeIfPresent(Bool.self, forKey: .allowsSSHFallback) ?? true,
             directTLSPins: try container.decodeIfPresent([String].self, forKey: .directTLSPins) ?? []
         )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(stableID, forKey: .stableID)
+        try container.encode(name, forKey: .name)
+        try container.encode(hostname, forKey: .hostname)
+        try container.encode(port, forKey: .port)
+        try container.encode(username, forKey: .username)
+        try container.encode(symbolName, forKey: .symbolName)
+        try container.encode(palette, forKey: .palette)
+        try container.encode(bootstrapCommand, forKey: .bootstrapCommand)
+        try container.encodeIfPresent(trustedHostKey, forKey: .trustedHostKey)
+        try container.encodeIfPresent(pendingHostKey, forKey: .pendingHostKey)
+        try container.encode(sortIndex, forKey: .sortIndex)
+        try container.encode(source, forKey: .source)
+        try container.encode(transportPreference, forKey: .transportPreference)
+        try container.encode(sshAuthenticationMethod, forKey: .sshAuthenticationMethod)
+        try container.encodeIfPresent(teamID, forKey: .teamID)
+        try container.encodeIfPresent(serverID, forKey: .serverID)
+        try container.encode(allowsSSHFallback, forKey: .allowsSSHFallback)
+        try container.encode(directTLSPins, forKey: .directTLSPins)
     }
 
     private static func legacyStableID(hostname: String, fallbackID: ID) -> String {

--- a/ios/Sources/Terminal/TerminalSidebarRootView.swift
+++ b/ios/Sources/Terminal/TerminalSidebarRootView.swift
@@ -57,14 +57,51 @@ struct TerminalSidebarRootView: View {
     }
 
     private var filteredWorkspaces: [TerminalWorkspace] {
+        let staleThreshold = Date.now.addingTimeInterval(-24 * 60 * 60)
+
+        let base: [TerminalWorkspace]
         if searchText.isEmpty {
-            return store.workspaces
+            base = store.workspaces
+        } else {
+            let query = searchText.localizedLowercase
+            base = store.workspaces.filter { workspace in
+                guard let host = store.server(for: workspace.hostID) else { return false }
+                return workspace.matches(query: query, host: host)
+            }
         }
 
-        let query = searchText.localizedLowercase
-        return store.workspaces.filter { workspace in
-            guard let host = store.server(for: workspace.hostID) else { return false }
-            return workspace.matches(query: query, host: host)
+        let visible = base.filter { workspace in
+            // Hide stale workspaces: idle with no activity in 24 hours
+            if workspace.phase == .idle, workspace.lastActivity < staleThreshold {
+                return false
+            }
+            return true
+        }
+
+        // Pre-compute sort keys to avoid repeated store lookups during sort.
+        let sortKeys = Dictionary(
+            uniqueKeysWithValues: visible.map { ($0.id, workspaceSortOrder($0)) }
+        )
+        return visible.sorted { lhs, rhs in
+            let lhsOrder = sortKeys[lhs.id] ?? 1
+            let rhsOrder = sortKeys[rhs.id] ?? 1
+            if lhsOrder != rhsOrder {
+                return lhsOrder < rhsOrder
+            }
+            return lhs.lastActivity > rhs.lastActivity
+        }
+    }
+
+    /// Sort priority: connected first (0), disconnected-but-online next (1), offline last (2).
+    private func workspaceSortOrder(_ workspace: TerminalWorkspace) -> Int {
+        if store.server(for: workspace.hostID)?.machineStatus == .offline {
+            return 2
+        }
+        switch workspace.phase {
+        case .connected:
+            return 0
+        default:
+            return 1
         }
     }
 
@@ -327,6 +364,7 @@ private enum TerminalHomeStrings {
         defaultValue: "Reconnecting to cmuxd"
     )
     static let failedLabel = String(localized: "terminal.home.status.failed", defaultValue: "Failed")
+    static let offlineLabel = String(localized: "terminal.home.status.offline", defaultValue: "Offline")
     static let readyToConfigureLabel = String(localized: "terminal.home.status.needs_setup", defaultValue: "Setup Required")
     static let disconnectedLabel = String(localized: "terminal.home.status.disconnected", defaultValue: "Disconnected")
     static let editorNewTitle = String(localized: "terminal.host_editor.new_title", defaultValue: "New Server")
@@ -450,12 +488,22 @@ private struct TerminalServerPinView: View {
     let workspaceCount: Int
     let isConfigured: Bool
 
+    private var isOffline: Bool {
+        host.machineStatus == .offline
+    }
+
     var body: some View {
         VStack(spacing: 6) {
             ZStack(alignment: .topTrailing) {
                 Circle()
                     .fill(host.palette.gradient)
                     .frame(width: 62, height: 62)
+                    .overlay {
+                        if isOffline {
+                            Circle()
+                                .fill(Color.gray.opacity(0.5))
+                        }
+                    }
 
                 Image(systemName: host.symbolName)
                     .font(.title3.weight(.semibold))
@@ -474,14 +522,23 @@ private struct TerminalServerPinView: View {
 
             Text(host.name)
                 .font(.caption.weight(.semibold))
+                .foregroundStyle(isOffline ? .secondary : .primary)
                 .lineLimit(1)
 
-            Text(isConfigured ? host.subtitle : TerminalHomeStrings.notReadyLabel)
-                .font(.caption2)
-                .foregroundStyle(isConfigured ? Color.secondary : Color.orange)
-                .lineLimit(1)
+            if isOffline {
+                Text(TerminalHomeStrings.offlineLabel)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            } else {
+                Text(isConfigured ? host.subtitle : TerminalHomeStrings.notReadyLabel)
+                    .font(.caption2)
+                    .foregroundStyle(isConfigured ? Color.secondary : Color.orange)
+                    .lineLimit(1)
+            }
         }
         .frame(width: 92)
+        .opacity(isOffline ? 0.5 : 1.0)
     }
 }
 
@@ -512,6 +569,10 @@ private struct TerminalWorkspaceConversationRow: View {
     let workspace: TerminalWorkspace
     let host: TerminalHost
 
+    private var isOffline: Bool {
+        host.machineStatus == .offline
+    }
+
     var accessibilityTitle: String {
         workspace.title
     }
@@ -520,13 +581,15 @@ private struct TerminalWorkspaceConversationRow: View {
         let readState = workspace.unread
             ? TerminalHomeStrings.markUnreadAction
             : TerminalHomeStrings.markReadAction
-        return [
-            host.name,
-            previewText(for: workspace, host: host),
-            statusText(for: workspace.phase),
-            readState,
-            relativeTimestamp(for: workspace.lastActivity),
-        ]
+        var parts = [host.name]
+        if isOffline {
+            parts.append(TerminalHomeStrings.offlineLabel)
+        } else {
+            parts.append(previewText(for: workspace, host: host))
+            parts.append(statusText(for: workspace.phase))
+        }
+        parts.append(contentsOf: [readState, relativeTimestamp(for: workspace.lastActivity)])
+        return parts
         .joined(separator: ", ")
     }
 
@@ -557,6 +620,7 @@ private struct TerminalWorkspaceConversationRow: View {
                 HStack(alignment: .firstTextBaseline) {
                     Text(workspace.title)
                         .font(.headline)
+                        .foregroundStyle(isOffline ? .secondary : .primary)
                         .lineLimit(1)
 
                     Spacer(minLength: 10)
@@ -567,35 +631,54 @@ private struct TerminalWorkspaceConversationRow: View {
                         .accessibilityIdentifier("terminal.workspace.timestamp.\(workspace.id.uuidString)")
                 }
 
-                HStack(spacing: 6) {
-                    Text(host.name)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(host.palette.accent)
-                        .lineLimit(1)
-                    Text("•")
-                        .foregroundStyle(.tertiary)
-                    Text(previewText(for: workspace, host: host))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .accessibilityIdentifier("terminal.workspace.preview.\(workspace.id.uuidString)")
+                if isOffline {
+                    HStack(spacing: 6) {
+                        Text(host.name)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        Text("•")
+                            .foregroundStyle(.tertiary)
+                        Text(TerminalHomeStrings.offlineLabel)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .accessibilityIdentifier("terminal.workspace.preview.\(workspace.id.uuidString)")
+                } else {
+                    HStack(spacing: 6) {
+                        Text(host.name)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(host.palette.accent)
+                            .lineLimit(1)
+                        Text("•")
+                            .foregroundStyle(.tertiary)
+                        Text(previewText(for: workspace, host: host))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .accessibilityIdentifier("terminal.workspace.preview.\(workspace.id.uuidString)")
+                    }
                 }
 
-                if let lastError = workspace.lastError, workspace.phase == .failed {
-                    Text(lastError)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(1)
-                } else {
-                    Text(statusText(for: workspace.phase))
-                        .font(.caption)
-                        .foregroundStyle(statusColor(for: workspace.phase))
-                        .lineLimit(1)
-                        .accessibilityIdentifier("terminal.workspace.status.\(workspace.id.uuidString)")
+                if !isOffline {
+                    if let lastError = workspace.lastError, workspace.phase == .failed {
+                        Text(lastError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .lineLimit(1)
+                    } else {
+                        Text(statusText(for: workspace.phase))
+                            .font(.caption)
+                            .foregroundStyle(statusColor(for: workspace.phase))
+                            .lineLimit(1)
+                            .accessibilityIdentifier("terminal.workspace.status.\(workspace.id.uuidString)")
+                    }
                 }
             }
         }
         .padding(.vertical, 2)
+        .opacity(isOffline ? 0.5 : 1.0)
     }
 
     private func relativeTimestamp(for date: Date) -> String {


### PR DESCRIPTION
## Summary
- Add `MobileMachineStatus` enum and `machineStatus` property to `TerminalHost` (runtime-only, not persisted)
- Offline hosts show dimmed server pin circles with gray overlay and "Offline" label
- Workspace rows for offline machines show reduced opacity with secondary-colored text and "host . Offline" in the preview line
- Workspaces sort by connection state: connected first, disconnected next, offline last
- Stale workspaces (idle phase + no activity in 24 hours) are filtered out

## Test plan
- [ ] Verify offline server pins show gray overlay and reduced opacity
- [ ] Verify offline workspace rows show dimmed text with "Offline" badge
- [ ] Verify workspace list sorts connected workspaces above disconnected, above offline
- [ ] Verify idle workspaces older than 24 hours are hidden from the list
- [ ] Verify online hosts and workspaces render unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds offline awareness to the iOS terminal sidebar and improves workspace visibility so active connections surface first. Offline hosts are clearly labeled and dimmed; stale idle workspaces are hidden.

- **New Features**
  - Added `MobileMachineStatus` and a runtime `machineStatus` on `TerminalHost` (not persisted).
  - Server pins show a gray overlay and “Offline” badge; name and row content use secondary styling when offline.
  - Workspace list sorts by state: connected (first), disconnected (next), offline (last); then by most recent activity.
  - Hides stale workspaces: idle with no activity in the last 24 hours.
  - Accessibility text includes the offline state where relevant.

<sup>Written for commit 73fa4d49769810f74528a5f6e52922f11ef5fc7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

