### PR TITLE
Harden iOS RPC client: ID validation, timeout, better errors

### DIFF
--- a/ios/Sources/Terminal/TerminalRemoteDaemonClient.swift
+++ b/ios/Sources/Terminal/TerminalRemoteDaemonClient.swift
@@ -122,6 +122,8 @@ enum TerminalRemoteDaemonClientError: LocalizedError, Equatable {
     case invalidJSON(String)
     case missingResult
     case rpc(code: String, message: String)
+    case responseMismatch
+    case rpcTimeout
 
     var errorDescription: String? {
         switch self {
@@ -131,6 +133,10 @@ enum TerminalRemoteDaemonClientError: LocalizedError, Equatable {
             return "Daemon response was missing a result payload."
         case .rpc(let code, let message):
             return "Daemon RPC failed (\(code)): \(message)"
+        case .responseMismatch:
+            return "Response ID did not match request ID."
+        case .rpcTimeout:
+            return "RPC call timed out waiting for a response."
         }
     }
 }
@@ -138,10 +144,12 @@ enum TerminalRemoteDaemonClientError: LocalizedError, Equatable {
 actor TerminalRemoteDaemonClient {
     private let transport: any TerminalRemoteDaemonTransport
     private let decoder: JSONDecoder
+    private let rpcTimeoutSeconds: TimeInterval
     private var nextRequestID = 1
 
-    init(transport: any TerminalRemoteDaemonTransport) {
+    init(transport: any TerminalRemoteDaemonTransport, rpcTimeoutSeconds: TimeInterval = 30) {
         self.transport = transport
+        self.rpcTimeoutSeconds = rpcTimeoutSeconds
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         self.decoder = decoder
@@ -276,8 +284,21 @@ actor TerminalRemoteDaemonClient {
         nextRequestID += 1
 
         try await transport.writeLine(try encodeRequestLine(id: requestID, method: method, params: params))
-        let responseLine = try await transport.readLine()
-        return try Self.decodeResponse(from: responseLine, decoder: decoder, as: responseType)
+
+        let responseLine: String = try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask { [transport] in
+                try await transport.readLine()
+            }
+            group.addTask { [rpcTimeoutSeconds] in
+                try await Task.sleep(nanoseconds: UInt64(rpcTimeoutSeconds * 1_000_000_000))
+                throw TerminalRemoteDaemonClientError.rpcTimeout
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        return try Self.decodeResponse(from: responseLine, decoder: decoder, expectedID: requestID, as: responseType)
     }
 
     private func encodeRequestLine(id: Int, method: String, params: [String: Any]) throws -> String {
@@ -293,6 +314,7 @@ actor TerminalRemoteDaemonClient {
     private static func decodeResponse<ResponsePayload: Decodable>(
         from line: String,
         decoder: JSONDecoder,
+        expectedID: Int? = nil,
         as responseType: ResponsePayload.Type
     ) throws -> ResponsePayload {
         guard let data = line.data(using: .utf8) else {
@@ -306,6 +328,10 @@ actor TerminalRemoteDaemonClient {
             throw TerminalRemoteDaemonClientError.invalidJSON(line)
         }
 
+        if let expectedID, envelope.id != expectedID {
+            throw TerminalRemoteDaemonClientError.responseMismatch
+        }
+
         if envelope.ok {
             guard let result = envelope.result else {
                 throw TerminalRemoteDaemonClientError.missingResult
@@ -317,13 +343,14 @@ actor TerminalRemoteDaemonClient {
             throw TerminalRemoteDaemonClientError.rpc(code: error.code, message: error.message)
         }
 
-        throw TerminalRemoteDaemonClientError.missingResult
+        throw TerminalRemoteDaemonClientError.rpc(code: "unknown", message: "Server returned an error without details")
     }
 }
 
 extension TerminalRemoteDaemonClient: TerminalRemoteDaemonSessionClient {}
 
 private struct TerminalRemoteDaemonResponseEnvelope<Result: Decodable>: Decodable {
+    let id: Int
     let ok: Bool
     let result: Result?
     let error: TerminalRemoteDaemonRPCErrorPayload?

--- a/ios/cmuxTests/TerminalRemoteDaemonClientTests.swift
+++ b/ios/cmuxTests/TerminalRemoteDaemonClientTests.swift
@@ -78,6 +78,50 @@ final class TerminalRemoteDaemonClientTests: XCTestCase {
         XCTAssertEqual(result.offset, 0)
     }
 
+    func testResponseIDMismatchThrows() async throws {
+        let transport = InMemoryDaemonTransport(
+            responses: [
+                #"{"id":999,"ok":true,"result":{"session_id":"sess-9","attachments":[],"effective_cols":0,"effective_rows":0,"last_known_cols":0,"last_known_rows":0}}"#
+            ]
+        )
+        let client = TerminalRemoteDaemonClient(transport: transport)
+
+        do {
+            _ = try await client.ensureSession(sessionID: "sess-9")
+            XCTFail("Expected responseMismatch error")
+        } catch let error as TerminalRemoteDaemonClientError {
+            XCTAssertEqual(error, .responseMismatch)
+        }
+    }
+
+    func testErrorWithoutPayloadReturnsUnknownRPC() async throws {
+        let transport = InMemoryDaemonTransport(
+            responses: [
+                #"{"id":1,"ok":false}"#
+            ]
+        )
+        let client = TerminalRemoteDaemonClient(transport: transport)
+
+        do {
+            _ = try await client.ensureSession(sessionID: nil)
+            XCTFail("Expected rpc error")
+        } catch let error as TerminalRemoteDaemonClientError {
+            XCTAssertEqual(error, .rpc(code: "unknown", message: "Server returned an error without details"))
+        }
+    }
+
+    func testRPCTimeoutThrows() async throws {
+        let transport = HangingDaemonTransport()
+        let client = TerminalRemoteDaemonClient(transport: transport, rpcTimeoutSeconds: 0.1)
+
+        do {
+            _ = try await client.sendHello()
+            XCTFail("Expected rpcTimeout error")
+        } catch let error as TerminalRemoteDaemonClientError {
+            XCTAssertEqual(error, .rpcTimeout)
+        }
+    }
+
     func testTerminalReadAndWriteUseBase64Payloads() async throws {
         let transport = InMemoryDaemonTransport(
             responses: [
@@ -137,4 +181,14 @@ private actor InMemoryDaemonTransport: TerminalRemoteDaemonTransport {
 
 private enum TestTransportError: Error {
     case noResponseQueued
+}
+
+private actor HangingDaemonTransport: TerminalRemoteDaemonTransport {
+    func writeLine(_ line: String) async throws {}
+
+    func readLine() async throws -> String {
+        // Sleep long enough that the RPC timeout fires first.
+        try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+        return ""
+    }
 }


### PR DESCRIPTION
## Summary

- Add response ID validation to `decodeResponse` so mismatched responses throw `.responseMismatch` instead of silently returning wrong data.
- Add configurable RPC timeout (default 30s) using a task group race in `sendRequest`. Throws `.rpcTimeout` if the transport stalls.
- Improve the `ok: false` without error payload path to throw `.rpc(code: "unknown", message: "Server returned an error without details")` instead of the generic `.missingResult`.

## Test plan

- [ ] `testResponseIDMismatchThrows` verifies mismatched IDs are caught
- [ ] `testErrorWithoutPayloadReturnsUnknownRPC` verifies the improved error message
- [ ] `testRPCTimeoutThrows` verifies timeout fires with a hanging transport
- [ ] Existing tests pass (all response fixtures already include `id` field)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds response ID validation, a configurable RPC timeout (default 30s), and clearer error mapping in the iOS `TerminalRemoteDaemonClient`. This prevents mismatched responses, avoids hangs, and returns more useful errors.

- **Bug Fixes**
  - Validate response `id` and throw `.responseMismatch` on mismatch.
  - Add RPC timeout using a task-group race; throw `.rpcTimeout` on stall.
  - Map `ok: false` without an error payload to `.rpc(code: "unknown", message: "Server returned an error without details")` instead of `.missingResult`.

<sup>Written for commit 7c6a4b0171b46281422f21641fb519ced8499747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

