### PR TITLE
Add tests for Ghostty surface and remote daemon RPC edge cases

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
+					D3A1B2C300000001E5F60718 /* GhosttySurfaceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C300000002E5F60718 /* GhosttySurfaceContractTests.swift */; };
+					D3A1B2C300000003E5F60718 /* RemoteDaemonRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C300000004E5F60718 /* RemoteDaemonRPCTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -324,6 +326,8 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
+				D3A1B2C300000002E5F60718 /* GhosttySurfaceContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceContractTests.swift; sourceTree = "<group>"; };
+				D3A1B2C300000004E5F60718 /* RemoteDaemonRPCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDaemonRPCTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -600,6 +604,8 @@
 					491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */,
 					10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 					C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
+					D3A1B2C300000002E5F60718 /* GhosttySurfaceContractTests.swift */,
+					D3A1B2C300000004E5F60718 /* RemoteDaemonRPCTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -896,6 +902,8 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
+					D3A1B2C300000001E5F60718 /* GhosttySurfaceContractTests.swift in Sources */,
+					D3A1B2C300000003E5F60718 /* RemoteDaemonRPCTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/cmuxTests/GhosttySurfaceContractTests.swift
+++ b/cmuxTests/GhosttySurfaceContractTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests for Ghostty surface edge cases: nil surface handling, empty text input,
+/// and sendText guards.
+@MainActor
+final class GhosttySurfaceContractTests: XCTestCase {
+
+    // MARK: - Empty text input
+
+    /// insertText("") via NSTextInputClient should not crash and should not
+    /// attempt to send data to the surface.
+    func testEmptyTextInputViaInsertTextIsIgnored() {
+        let view = GhosttyNSView(frame: .zero)
+        view.insertText("", replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    /// The single-argument insertText override (responder chain) should also
+    /// handle empty strings gracefully.
+    func testEmptyTextInputViaSingleArgInsertTextIsIgnored() {
+        let view = GhosttyNSView(frame: .zero)
+        view.insertText("")
+    }
+
+    /// NSAttributedString with empty content should also be handled.
+    func testEmptyAttributedStringInputIsIgnored() {
+        let view = GhosttyNSView(frame: .zero)
+        view.insertText(NSAttributedString(string: ""), replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    // MARK: - Marked text state with nil surface
+
+    /// Setting and clearing marked text when no surface exists should not crash.
+    /// This can happen when a view is being torn down while the IME is composing.
+    func testMarkedTextLifecycleWithNilSurface() {
+        let view = GhosttyNSView(frame: .zero)
+
+        XCTAssertFalse(view.hasMarkedText())
+
+        view.setMarkedText("a", selectedRange: NSRange(location: 0, length: 1), replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertTrue(view.hasMarkedText())
+        XCTAssertEqual(view.markedRange(), NSRange(location: 0, length: 1))
+
+        view.unmarkText()
+        XCTAssertFalse(view.hasMarkedText())
+        XCTAssertEqual(view.markedRange(), NSRange(location: NSNotFound, length: 0))
+    }
+
+    // MARK: - insertText clears marked text even for empty payload
+
+    /// IME flush: insertText("") should still clear any active marked text,
+    /// even though no text is sent to the terminal.
+    func testInsertEmptyTextClearsMarkedText() {
+        let view = GhosttyNSView(frame: .zero)
+
+        view.setMarkedText("ni", selectedRange: NSRange(location: 2, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertTrue(view.hasMarkedText())
+
+        view.insertText("", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        XCTAssertFalse(view.hasMarkedText(), "insertText(\"\") should still clear marked text via unmarkText")
+    }
+}

--- a/cmuxTests/RemoteDaemonRPCTests.swift
+++ b/cmuxTests/RemoteDaemonRPCTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests for WorkspaceRemoteDaemonPendingCallRegistry: request/response ID
+/// matching, timeout cleanup, and transport failure propagation.
+final class RemoteDaemonPendingCallRegistryTests: XCTestCase {
+
+    // MARK: - Basic register/resolve cycle
+
+    func testRegisterAndResolveReturnsResponse() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        XCTAssertEqual(call.id, 1)
+
+        let payload: [String: Any] = ["ok": true, "result": ["version": "1.0"]]
+        XCTAssertTrue(registry.resolve(id: call.id, payload: payload))
+
+        let outcome = registry.wait(for: call, timeout: 1.0)
+        guard case .response(let response) = outcome else {
+            return XCTFail("Expected .response, got \(outcome)")
+        }
+        XCTAssertEqual(response["ok"] as? Bool, true)
+    }
+
+    // MARK: - Response ID mismatch
+
+    /// Resolving with a non-matching ID returns false; the real call times out.
+    func testResponseIDMismatchDropsResponse() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        XCTAssertFalse(registry.resolve(id: call.id + 999, payload: ["ok": true]))
+
+        let outcome = registry.wait(for: call, timeout: 0.1)
+        guard case .timedOut = outcome else {
+            return XCTFail("Expected .timedOut, got \(outcome)")
+        }
+    }
+
+    // MARK: - ok:false response handling
+
+    /// {"ok": false} with no "error" field should fall through to default error
+    /// strings in the RPC client's response parsing.
+    func testOkFalseWithoutErrorPayloadUsesDefaults() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        registry.resolve(id: call.id, payload: ["id": call.id, "ok": false])
+
+        guard case .response(let response) = registry.wait(for: call, timeout: 1.0) else {
+            return XCTFail("Expected .response")
+        }
+
+        // Replicate the extraction logic from WorkspaceRemoteDaemonRPCClient.call
+        XCTAssertEqual((response["ok"] as? Bool) ?? false, false)
+        let errorObject = (response["error"] as? [String: Any]) ?? [:]
+        XCTAssertEqual(
+            (errorObject["code"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "rpc_error",
+            "rpc_error"
+        )
+        XCTAssertEqual(
+            (errorObject["message"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "daemon RPC call failed",
+            "daemon RPC call failed"
+        )
+    }
+
+    /// {"ok": false, "error": {...}} should surface the actual code and message.
+    func testOkFalseWithErrorPayloadExtractsFields() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        registry.resolve(id: call.id, payload: [
+            "id": call.id,
+            "ok": false,
+            "error": ["code": "auth_failed", "message": "authentication rejected"],
+        ])
+
+        guard case .response(let response) = registry.wait(for: call, timeout: 1.0) else {
+            return XCTFail("Expected .response")
+        }
+
+        let errorObject = (response["error"] as? [String: Any]) ?? [:]
+        XCTAssertEqual(errorObject["code"] as? String, "auth_failed")
+        XCTAssertEqual(errorObject["message"] as? String, "authentication rejected")
+    }
+
+    // MARK: - failAll
+
+    /// failAll should signal every pending call so none hang when the transport dies.
+    func testFailAllSignalsAllPendingCalls() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call1 = registry.register()
+        let call2 = registry.register()
+        registry.failAll("transport closed")
+
+        for (label, call) in [("call1", call1), ("call2", call2)] {
+            guard case .failure(let msg) = registry.wait(for: call, timeout: 1.0) else {
+                XCTFail("Expected .failure for \(label)")
+                continue
+            }
+            XCTAssertEqual(msg, "transport closed")
+        }
+    }
+
+    // MARK: - Reset
+
+    func testResetClearsStateAndRestartsIDs() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+        _ = registry.register()
+        registry.reset()
+        XCTAssertEqual(registry.register().id, 1)
+    }
+
+    // MARK: - Timeout cleanup
+
+    func testTimeoutRemovesPendingCall() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        guard case .timedOut = registry.wait(for: call, timeout: 0.05) else {
+            return XCTFail("Expected .timedOut")
+        }
+
+        XCTAssertFalse(
+            registry.resolve(id: call.id, payload: ["ok": true]),
+            "Resolve after timeout should return false"
+        )
+    }
+
+    // MARK: - Sequential IDs
+
+    func testSequentialIDAssignment() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let calls = (0..<3).map { _ in registry.register() }
+        XCTAssertEqual(calls.map(\.id), [1, 2, 3])
+
+        calls.forEach { registry.remove($0) }
+    }
+
+    // MARK: - Double resolve safety
+
+    func testDoubleResolveDoesNotCrash() {
+        let registry = WorkspaceRemoteDaemonPendingCallRegistry()
+
+        let call = registry.register()
+        XCTAssertTrue(registry.resolve(id: call.id, payload: ["ok": true, "attempt": 1]))
+        // Second resolve: should not crash regardless of outcome.
+        _ = registry.resolve(id: call.id, payload: ["ok": true, "attempt": 2])
+
+        guard case .response = registry.wait(for: call, timeout: 1.0) else {
+            return XCTFail("Expected .response after resolve")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GhosttySurfaceContractTests`: tests for empty text input via `insertText` (NSTextInputClient and responder chain), marked text lifecycle with nil surface, and IME flush clearing marked text.
- Adds `RemoteDaemonPendingCallRegistryTests`: tests for request/response ID matching, response ID mismatch (dropped + timeout), `ok:false` with and without error payload, `failAll` propagation, timeout cleanup, reset, sequential IDs, and double-resolve safety.

## Test plan

- [ ] CI passes `cmux-unit` scheme (the tests are new additions, no production code changed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for the Ghostty text input surface and the remote daemon RPC pending-call registry to lock down edge cases. Covers empty and attributed-empty insertText paths, marked text with nil surface, IME flush clearing, response ID matching and mismatches, ok:false with/without error payload, failAll propagation, timeout cleanup, reset, sequential IDs, and double-resolve safety.

<sup>Written for commit cec0bfdaad218676c0a279b8637597b9ce518097. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites to improve code reliability and stability for text input handling and inter-process communication mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->