### PR TITLE
Add sidebar multi-selection edge case tests

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12222,6 +12222,27 @@ private struct TabItemView: View, Equatable {
         let wasSelected = tabManager.selectedTabId == tab.id
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
+        #if DEBUG
+        let debugWorkspaceId: (UUID?) -> String = { workspaceId in
+            guard let workspaceId else { return "nil" }
+            return String(workspaceId.uuidString.prefix(5))
+        }
+        let debugSelectedWorkspaceIds: (Set<UUID>) -> String = { workspaceIds in
+            let orderedIds = tabManager.tabs.enumerated().compactMap { tabIndex, workspace in
+                workspaceIds.contains(workspace.id) ? "\(tabIndex):\(workspace.id.uuidString.prefix(5))" : nil
+            }
+            return orderedIds.isEmpty ? "[]" : "[\(orderedIds.joined(separator: ", "))]"
+        }
+        let debugPivot = lastSidebarSelectionIndex.map { anchorIndex -> String in
+            guard tabManager.tabs.indices.contains(anchorIndex) else { return "\(anchorIndex):invalid" }
+            return "\(anchorIndex):\(tabManager.tabs[anchorIndex].id.uuidString.prefix(5))"
+        } ?? "nil"
+        if isShift {
+            dlog(
+                "sidebar.select shift before clicked=\(index):\(tab.id.uuidString.prefix(5)) active=\(debugWorkspaceId(tabManager.selectedTabId)) pivot=\(debugPivot) selected=\(debugSelectedWorkspaceIds(selectedTabIds)) command=\(isCommand)"
+            )
+        }
+        #endif
         guard let update = SidebarWorkspaceSelectionPolicy.update(
             workspaceIds: tabManager.tabs.map(\.id),
             selectedWorkspaceIds: selectedTabIds,
@@ -12232,6 +12253,16 @@ private struct TabItemView: View, Equatable {
         ) else {
             return
         }
+        #if DEBUG
+        if isShift {
+            let debugNextPivot = tabManager.tabs.indices.contains(update.nextAnchorIndex)
+                ? "\(update.nextAnchorIndex):\(tabManager.tabs[update.nextAnchorIndex].id.uuidString.prefix(5))"
+                : "\(update.nextAnchorIndex):invalid"
+            dlog(
+                "sidebar.select shift after clicked=\(index):\(tab.id.uuidString.prefix(5)) active=\(debugWorkspaceId(update.nextActiveWorkspaceId)) pivot=\(debugNextPivot) selected=\(debugSelectedWorkspaceIds(update.selectedWorkspaceIds)) command=\(isCommand)"
+            )
+        }
+        #endif
 
         selectedTabIds = update.selectedWorkspaceIds
         lastSidebarSelectionIndex = update.nextAnchorIndex

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11155,10 +11155,11 @@ enum SidebarWorkspaceSelectionPolicy {
         let isShift = modifiers.contains(.shift)
         var nextSelectedWorkspaceIds = selectedWorkspaceIds
         var nextActiveWorkspaceId = clickedWorkspaceId
+        var nextAnchorIndex = clickedIndex
+        let hasSelectionAnchor = isShift &&
+            lastSelectionAnchorIndex.map(workspaceIds.indices.contains) == true
 
-        if isShift,
-           let lastSelectionAnchorIndex,
-           workspaceIds.indices.contains(lastSelectionAnchorIndex) {
+        if hasSelectionAnchor, let lastSelectionAnchorIndex {
             let lower = min(lastSelectionAnchorIndex, clickedIndex)
             let upper = max(lastSelectionAnchorIndex, clickedIndex)
             let rangeIds = workspaceIds[lower...upper]
@@ -11167,6 +11168,7 @@ enum SidebarWorkspaceSelectionPolicy {
             } else {
                 nextSelectedWorkspaceIds = Set(rangeIds)
             }
+            nextAnchorIndex = lastSelectionAnchorIndex
         } else if isCommand {
             if nextSelectedWorkspaceIds.contains(clickedWorkspaceId) {
                 if nextSelectedWorkspaceIds.count == 1 {
@@ -11191,7 +11193,7 @@ enum SidebarWorkspaceSelectionPolicy {
         return SidebarWorkspaceSelectionUpdate(
             selectedWorkspaceIds: nextSelectedWorkspaceIds,
             nextActiveWorkspaceId: nextActiveWorkspaceId,
-            nextAnchorIndex: clickedIndex
+            nextAnchorIndex: nextAnchorIndex
         )
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11155,20 +11155,21 @@ enum SidebarWorkspaceSelectionPolicy {
         let isShift = modifiers.contains(.shift)
         var nextSelectedWorkspaceIds = selectedWorkspaceIds
         var nextActiveWorkspaceId = clickedWorkspaceId
-        var nextAnchorIndex = clickedIndex
-        let hasSelectionAnchor = isShift &&
-            lastSelectionAnchorIndex.map(workspaceIds.indices.contains) == true
+        let validAnchorIndex = lastSelectionAnchorIndex.flatMap { index in
+            workspaceIds.indices.contains(index) ? index : nil
+        }
+        var nextAnchorIndex = validAnchorIndex ?? clickedIndex
 
-        if hasSelectionAnchor, let lastSelectionAnchorIndex {
-            let lower = min(lastSelectionAnchorIndex, clickedIndex)
-            let upper = max(lastSelectionAnchorIndex, clickedIndex)
+        if isShift, let validAnchorIndex {
+            let lower = min(validAnchorIndex, clickedIndex)
+            let upper = max(validAnchorIndex, clickedIndex)
             let rangeIds = workspaceIds[lower...upper]
             if isCommand {
                 nextSelectedWorkspaceIds.formUnion(rangeIds)
             } else {
                 nextSelectedWorkspaceIds = Set(rangeIds)
             }
-            nextAnchorIndex = lastSelectionAnchorIndex
+            nextAnchorIndex = validAnchorIndex
         } else if isCommand {
             if nextSelectedWorkspaceIds.contains(clickedWorkspaceId) {
                 if nextSelectedWorkspaceIds.count == 1 {
@@ -11188,6 +11189,7 @@ enum SidebarWorkspaceSelectionPolicy {
             }
         } else {
             nextSelectedWorkspaceIds = [clickedWorkspaceId]
+            nextAnchorIndex = clickedIndex
         }
 
         return SidebarWorkspaceSelectionUpdate(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11133,6 +11133,56 @@ enum SidebarTrailingAccessoryWidthPolicy {
     }
 }
 
+struct SidebarWorkspaceSelectionUpdate: Equatable {
+    let selectedWorkspaceIds: Set<UUID>
+    let nextActiveWorkspaceId: UUID
+    let nextAnchorIndex: Int
+}
+
+enum SidebarWorkspaceSelectionPolicy {
+    static func update(
+        workspaceIds: [UUID],
+        selectedWorkspaceIds: Set<UUID>,
+        lastSelectionAnchorIndex: Int?,
+        clickedIndex: Int,
+        modifiers: NSEvent.ModifierFlags
+    ) -> SidebarWorkspaceSelectionUpdate? {
+        guard workspaceIds.indices.contains(clickedIndex) else { return nil }
+
+        let clickedWorkspaceId = workspaceIds[clickedIndex]
+        let isCommand = modifiers.contains(.command)
+        let isShift = modifiers.contains(.shift)
+        var nextSelectedWorkspaceIds = selectedWorkspaceIds
+
+        if isShift,
+           let lastSelectionAnchorIndex,
+           workspaceIds.indices.contains(lastSelectionAnchorIndex) {
+            let lower = min(lastSelectionAnchorIndex, clickedIndex)
+            let upper = max(lastSelectionAnchorIndex, clickedIndex)
+            let rangeIds = workspaceIds[lower...upper]
+            if isCommand {
+                nextSelectedWorkspaceIds.formUnion(rangeIds)
+            } else {
+                nextSelectedWorkspaceIds = Set(rangeIds)
+            }
+        } else if isCommand {
+            if nextSelectedWorkspaceIds.contains(clickedWorkspaceId) {
+                nextSelectedWorkspaceIds.remove(clickedWorkspaceId)
+            } else {
+                nextSelectedWorkspaceIds.insert(clickedWorkspaceId)
+            }
+        } else {
+            nextSelectedWorkspaceIds = [clickedWorkspaceId]
+        }
+
+        return SidebarWorkspaceSelectionUpdate(
+            selectedWorkspaceIds: nextSelectedWorkspaceIds,
+            nextActiveWorkspaceId: clickedWorkspaceId,
+            nextAnchorIndex: clickedIndex
+        )
+    }
+}
+
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
 // the parent rebuilds with unchanged values. Without this, every TabManager
 // or NotificationStore publish causes ALL tab items to re-evaluate (~18% of
@@ -12132,30 +12182,21 @@ private struct TabItemView: View, Equatable {
         dlog("sidebar.select workspace=\(tab.id.uuidString.prefix(5)) modifiers=\(modStr.isEmpty ? "none" : modStr.trimmingCharacters(in: .whitespaces))")
         #endif
         let modifiers = NSEvent.modifierFlags
+        let wasSelected = tabManager.selectedTabId == tab.id
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
-        let wasSelected = tabManager.selectedTabId == tab.id
-
-        if isShift, let lastIndex = lastSidebarSelectionIndex {
-            let lower = min(lastIndex, index)
-            let upper = max(lastIndex, index)
-            let rangeIds = tabManager.tabs[lower...upper].map { $0.id }
-            if isCommand {
-                selectedTabIds.formUnion(rangeIds)
-            } else {
-                selectedTabIds = Set(rangeIds)
-            }
-        } else if isCommand {
-            if selectedTabIds.contains(tab.id) {
-                selectedTabIds.remove(tab.id)
-            } else {
-                selectedTabIds.insert(tab.id)
-            }
-        } else {
-            selectedTabIds = [tab.id]
+        guard let update = SidebarWorkspaceSelectionPolicy.update(
+            workspaceIds: tabManager.tabs.map(\.id),
+            selectedWorkspaceIds: selectedTabIds,
+            lastSelectionAnchorIndex: lastSidebarSelectionIndex,
+            clickedIndex: index,
+            modifiers: modifiers
+        ) else {
+            return
         }
 
-        lastSidebarSelectionIndex = index
+        selectedTabIds = update.selectedWorkspaceIds
+        lastSidebarSelectionIndex = update.nextAnchorIndex
         tabManager.selectTab(tab)
         if wasSelected, !isCommand, !isShift {
             tabManager.dismissNotificationOnDirectInteraction(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11158,6 +11158,7 @@ enum SidebarWorkspaceSelectionPolicy {
         let validAnchorIndex = lastSelectionAnchorIndex.flatMap { index in
             workspaceIds.indices.contains(index) ? index : nil
         }
+        let anchorWorkspaceId = validAnchorIndex.map { workspaceIds[$0] }
         var nextAnchorIndex = validAnchorIndex ?? clickedIndex
 
         if isShift, let validAnchorIndex {
@@ -11169,7 +11170,9 @@ enum SidebarWorkspaceSelectionPolicy {
             } else {
                 nextSelectedWorkspaceIds = Set(rangeIds)
             }
-            nextAnchorIndex = validAnchorIndex
+            // Once a range starts from a singleton selection, keep the first
+            // shift-clicked edge as the pivot while later shift clicks resize.
+            nextAnchorIndex = selectedWorkspaceIds.count <= 1 ? clickedIndex : validAnchorIndex
         } else if isCommand {
             if nextSelectedWorkspaceIds.contains(clickedWorkspaceId) {
                 if nextSelectedWorkspaceIds.count == 1 {
@@ -11186,6 +11189,16 @@ enum SidebarWorkspaceSelectionPolicy {
                 }
             } else {
                 nextSelectedWorkspaceIds.insert(clickedWorkspaceId)
+            }
+
+            if let anchorWorkspaceId,
+               !nextSelectedWorkspaceIds.contains(anchorWorkspaceId),
+               let replacementAnchorIndex = preferredSelectionAnchorIndex(
+                   workspaceIds: workspaceIds,
+                   selectedWorkspaceIds: nextSelectedWorkspaceIds,
+                   referenceIndex: validAnchorIndex ?? clickedIndex
+               ) {
+                nextAnchorIndex = replacementAnchorIndex
             }
         } else {
             nextSelectedWorkspaceIds = [clickedWorkspaceId]
@@ -11217,6 +11230,32 @@ enum SidebarWorkspaceSelectionPolicy {
 
         let leadingIds = workspaceIds.prefix(clickedIndex).reversed()
         return leadingIds.first(where: selectedWorkspaceIds.contains)
+    }
+
+    private static func preferredSelectionAnchorIndex(
+        workspaceIds: [UUID],
+        selectedWorkspaceIds: Set<UUID>,
+        referenceIndex: Int
+    ) -> Int? {
+        let safeReferenceIndex = min(max(referenceIndex, 0), workspaceIds.count - 1)
+
+        for index in workspaceIds.indices.dropFirst(safeReferenceIndex + 1) {
+            if selectedWorkspaceIds.contains(workspaceIds[index]) {
+                return index
+            }
+        }
+
+        for index in workspaceIds.indices.prefix(safeReferenceIndex).reversed() {
+            if selectedWorkspaceIds.contains(workspaceIds[index]) {
+                return index
+            }
+        }
+
+        if selectedWorkspaceIds.contains(workspaceIds[safeReferenceIndex]) {
+            return safeReferenceIndex
+        }
+
+        return nil
     }
 }
 
@@ -12222,27 +12261,6 @@ private struct TabItemView: View, Equatable {
         let wasSelected = tabManager.selectedTabId == tab.id
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
-        #if DEBUG
-        let debugWorkspaceId: (UUID?) -> String = { workspaceId in
-            guard let workspaceId else { return "nil" }
-            return String(workspaceId.uuidString.prefix(5))
-        }
-        let debugSelectedWorkspaceIds: (Set<UUID>) -> String = { workspaceIds in
-            let orderedIds = tabManager.tabs.enumerated().compactMap { tabIndex, workspace in
-                workspaceIds.contains(workspace.id) ? "\(tabIndex):\(workspace.id.uuidString.prefix(5))" : nil
-            }
-            return orderedIds.isEmpty ? "[]" : "[\(orderedIds.joined(separator: ", "))]"
-        }
-        let debugPivot = lastSidebarSelectionIndex.map { anchorIndex -> String in
-            guard tabManager.tabs.indices.contains(anchorIndex) else { return "\(anchorIndex):invalid" }
-            return "\(anchorIndex):\(tabManager.tabs[anchorIndex].id.uuidString.prefix(5))"
-        } ?? "nil"
-        if isShift {
-            dlog(
-                "sidebar.select shift before clicked=\(index):\(tab.id.uuidString.prefix(5)) active=\(debugWorkspaceId(tabManager.selectedTabId)) pivot=\(debugPivot) selected=\(debugSelectedWorkspaceIds(selectedTabIds)) command=\(isCommand)"
-            )
-        }
-        #endif
         guard let update = SidebarWorkspaceSelectionPolicy.update(
             workspaceIds: tabManager.tabs.map(\.id),
             selectedWorkspaceIds: selectedTabIds,
@@ -12253,16 +12271,6 @@ private struct TabItemView: View, Equatable {
         ) else {
             return
         }
-        #if DEBUG
-        if isShift {
-            let debugNextPivot = tabManager.tabs.indices.contains(update.nextAnchorIndex)
-                ? "\(update.nextAnchorIndex):\(tabManager.tabs[update.nextAnchorIndex].id.uuidString.prefix(5))"
-                : "\(update.nextAnchorIndex):invalid"
-            dlog(
-                "sidebar.select shift after clicked=\(index):\(tab.id.uuidString.prefix(5)) active=\(debugWorkspaceId(update.nextActiveWorkspaceId)) pivot=\(debugNextPivot) selected=\(debugSelectedWorkspaceIds(update.selectedWorkspaceIds)) command=\(isCommand)"
-            )
-        }
-        #endif
 
         selectedTabIds = update.selectedWorkspaceIds
         lastSidebarSelectionIndex = update.nextAnchorIndex

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11143,6 +11143,7 @@ enum SidebarWorkspaceSelectionPolicy {
     static func update(
         workspaceIds: [UUID],
         selectedWorkspaceIds: Set<UUID>,
+        currentActiveWorkspaceId: UUID?,
         lastSelectionAnchorIndex: Int?,
         clickedIndex: Int,
         modifiers: NSEvent.ModifierFlags
@@ -11153,6 +11154,7 @@ enum SidebarWorkspaceSelectionPolicy {
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
         var nextSelectedWorkspaceIds = selectedWorkspaceIds
+        var nextActiveWorkspaceId = clickedWorkspaceId
 
         if isShift,
            let lastSelectionAnchorIndex,
@@ -11167,7 +11169,18 @@ enum SidebarWorkspaceSelectionPolicy {
             }
         } else if isCommand {
             if nextSelectedWorkspaceIds.contains(clickedWorkspaceId) {
-                nextSelectedWorkspaceIds.remove(clickedWorkspaceId)
+                if nextSelectedWorkspaceIds.count == 1 {
+                    nextSelectedWorkspaceIds = [clickedWorkspaceId]
+                    nextActiveWorkspaceId = clickedWorkspaceId
+                } else {
+                    nextSelectedWorkspaceIds.remove(clickedWorkspaceId)
+                    nextActiveWorkspaceId = preferredActiveWorkspaceId(
+                        workspaceIds: workspaceIds,
+                        selectedWorkspaceIds: nextSelectedWorkspaceIds,
+                        currentActiveWorkspaceId: currentActiveWorkspaceId,
+                        clickedIndex: clickedIndex
+                    ) ?? clickedWorkspaceId
+                }
             } else {
                 nextSelectedWorkspaceIds.insert(clickedWorkspaceId)
             }
@@ -11177,9 +11190,29 @@ enum SidebarWorkspaceSelectionPolicy {
 
         return SidebarWorkspaceSelectionUpdate(
             selectedWorkspaceIds: nextSelectedWorkspaceIds,
-            nextActiveWorkspaceId: clickedWorkspaceId,
+            nextActiveWorkspaceId: nextActiveWorkspaceId,
             nextAnchorIndex: clickedIndex
         )
+    }
+
+    private static func preferredActiveWorkspaceId(
+        workspaceIds: [UUID],
+        selectedWorkspaceIds: Set<UUID>,
+        currentActiveWorkspaceId: UUID?,
+        clickedIndex: Int
+    ) -> UUID? {
+        if let currentActiveWorkspaceId,
+           selectedWorkspaceIds.contains(currentActiveWorkspaceId) {
+            return currentActiveWorkspaceId
+        }
+
+        let trailingIds = workspaceIds.suffix(from: min(clickedIndex + 1, workspaceIds.count))
+        if let nextId = trailingIds.first(where: selectedWorkspaceIds.contains) {
+            return nextId
+        }
+
+        let leadingIds = workspaceIds.prefix(clickedIndex).reversed()
+        return leadingIds.first(where: selectedWorkspaceIds.contains)
     }
 }
 
@@ -12188,6 +12221,7 @@ private struct TabItemView: View, Equatable {
         guard let update = SidebarWorkspaceSelectionPolicy.update(
             workspaceIds: tabManager.tabs.map(\.id),
             selectedWorkspaceIds: selectedTabIds,
+            currentActiveWorkspaceId: tabManager.selectedTabId,
             lastSelectionAnchorIndex: lastSidebarSelectionIndex,
             clickedIndex: index,
             modifiers: modifiers
@@ -12197,7 +12231,9 @@ private struct TabItemView: View, Equatable {
 
         selectedTabIds = update.selectedWorkspaceIds
         lastSidebarSelectionIndex = update.nextAnchorIndex
-        tabManager.selectTab(tab)
+        if let nextActiveWorkspace = tabManager.tabs.first(where: { $0.id == update.nextActiveWorkspaceId }) {
+            tabManager.selectTab(nextActiveWorkspace)
+        }
         if wasSelected, !isCommand, !isShift {
             tabManager.dismissNotificationOnDirectInteraction(
                 tabId: tab.id,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1109,7 +1109,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(result.nextAnchorIndex, 4)
+        XCTAssertEqual(result.nextAnchorIndex, 1)
     }
 
     func testShiftClickSelectsBackwardInclusiveRange() throws {
@@ -1128,7 +1128,61 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[1])
-        XCTAssertEqual(result.nextAnchorIndex, 1)
+        XCTAssertEqual(result.nextAnchorIndex, 4)
+    }
+
+    func testRepeatedShiftClicksPreserveOriginalAnchorWhileShrinkingRange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let firstResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1]]),
+            currentActiveWorkspaceId: workspaceIds[1],
+            lastSelectionAnchorIndex: 1,
+            clickedIndex: 4,
+            modifiers: [.shift]
+        )
+
+        let secondResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: firstResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: firstResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: firstResult.nextAnchorIndex,
+            clickedIndex: 2,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(firstResult.nextAnchorIndex, 1)
+        XCTAssertEqual(secondResult.selectedWorkspaceIds, Set([workspaceIds[1], workspaceIds[2]]))
+        XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(secondResult.nextAnchorIndex, 1)
+    }
+
+    func testRepeatedShiftClicksPreserveOriginalAnchorAcrossDirectionChange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let firstResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[3]]),
+            currentActiveWorkspaceId: workspaceIds[3],
+            lastSelectionAnchorIndex: 3,
+            clickedIndex: 1,
+            modifiers: [.shift]
+        )
+
+        let secondResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: firstResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: firstResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: firstResult.nextAnchorIndex,
+            clickedIndex: 4,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(firstResult.nextAnchorIndex, 3)
+        XCTAssertEqual(secondResult.selectedWorkspaceIds, Set([workspaceIds[3], workspaceIds[4]]))
+        XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(secondResult.nextAnchorIndex, 3)
     }
 
     func testShiftClickWithoutAnchorFallsBackToSingleSelection() throws {
@@ -1215,7 +1269,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[0], workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[3])
-        XCTAssertEqual(result.nextAnchorIndex, 3)
+        XCTAssertEqual(result.nextAnchorIndex, 1)
     }
 
     func testCommandShiftClickWithoutAnchorFallsBackToCommandToggle() throws {
@@ -1235,6 +1289,33 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[2])
         XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+
+    func testCommandClickSetsAnchorForSubsequentShiftClickRange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let commandResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[0]]),
+            currentActiveWorkspaceId: workspaceIds[0],
+            lastSelectionAnchorIndex: 0,
+            clickedIndex: 3,
+            modifiers: [.command]
+        )
+
+        let shiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: commandResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: commandResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: commandResult.nextAnchorIndex,
+            clickedIndex: 4,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(commandResult.nextAnchorIndex, 3)
+        XCTAssertEqual(shiftResult.selectedWorkspaceIds, Set([workspaceIds[3], workspaceIds[4]]))
+        XCTAssertEqual(shiftResult.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(shiftResult.nextAnchorIndex, 3)
     }
 
     func testCommandClickOnOnlySelectedWorkspaceKeepsActiveWorkspaceSelected() throws {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1217,7 +1217,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[1], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(result.nextAnchorIndex, 4)
+        XCTAssertEqual(result.nextAnchorIndex, 3)
     }
 
     func testRepeatedCommandClicksAccumulateDifferentWorkspaces() throws {
@@ -1239,7 +1239,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         )
     }
 
-    func testRepeatedCommandClicksMoveFocusAndAnchorToEachClickedWorkspace() throws {
+    func testRepeatedCommandClicksMoveFocusWhilePreservingOriginalPivot() throws {
         let workspaceIds = makeWorkspaceIds()
 
         let updates = try applyCommandClickSequence(
@@ -1250,7 +1250,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         )
 
         XCTAssertEqual(updates.map(\.nextActiveWorkspaceId), [workspaceIds[3], workspaceIds[1], workspaceIds[4]])
-        XCTAssertEqual(updates.map(\.nextAnchorIndex), [3, 1, 4])
+        XCTAssertEqual(updates.map(\.nextAnchorIndex), [0, 0, 0])
     }
 
     func testCommandShiftClickUnionsContiguousRangeIntoExistingSelection() throws {
@@ -1291,7 +1291,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(result.nextAnchorIndex, 2)
     }
 
-    func testCommandClickSetsAnchorForSubsequentShiftClickRange() throws {
+    func testCommandClickPreservesPivotForSubsequentShiftClickRange() throws {
         let workspaceIds = makeWorkspaceIds()
 
         let commandResult = try update(
@@ -1312,10 +1312,41 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             modifiers: [.shift]
         )
 
-        XCTAssertEqual(commandResult.nextAnchorIndex, 3)
-        XCTAssertEqual(shiftResult.selectedWorkspaceIds, Set([workspaceIds[3], workspaceIds[4]]))
+        XCTAssertEqual(commandResult.nextAnchorIndex, 0)
+        XCTAssertEqual(
+            shiftResult.selectedWorkspaceIds,
+            Set([workspaceIds[0], workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
         XCTAssertEqual(shiftResult.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(shiftResult.nextAnchorIndex, 3)
+        XCTAssertEqual(shiftResult.nextAnchorIndex, 0)
+    }
+
+    func testInitialCommandClickEstablishesPivotForSubsequentShiftClickRange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let commandResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: [],
+            lastSelectionAnchorIndex: nil,
+            clickedIndex: 2,
+            modifiers: [.command]
+        )
+
+        let shiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: commandResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: commandResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: commandResult.nextAnchorIndex,
+            clickedIndex: 4,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(commandResult.selectedWorkspaceIds, Set([workspaceIds[2]]))
+        XCTAssertEqual(commandResult.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(commandResult.nextAnchorIndex, 2)
+        XCTAssertEqual(shiftResult.selectedWorkspaceIds, Set([workspaceIds[2], workspaceIds[3], workspaceIds[4]]))
+        XCTAssertEqual(shiftResult.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(shiftResult.nextAnchorIndex, 2)
     }
 
     func testCommandClickOnOnlySelectedWorkspaceKeepsActiveWorkspaceSelected() throws {
@@ -1356,7 +1387,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             "Command-click can shrink a multi-selection, but the focused workspace should still be part of the resulting selected set."
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(result.nextAnchorIndex, 2)
+        XCTAssertEqual(result.nextAnchorIndex, 4)
     }
 
     func testCommandClickRemovingNonActiveWorkspacePreservesCurrentActiveWorkspace() throws {
@@ -1373,7 +1404,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
 
         XCTAssertEqual(result.selectedWorkspaceIds, Set([workspaceIds[1], workspaceIds[4]]))
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(result.nextAnchorIndex, 2)
+        XCTAssertEqual(result.nextAnchorIndex, 4)
     }
 }
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1109,7 +1109,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(result.nextAnchorIndex, 1)
+        XCTAssertEqual(result.nextAnchorIndex, 4)
     }
 
     func testShiftClickSelectsBackwardInclusiveRange() throws {
@@ -1128,10 +1128,10 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[1])
-        XCTAssertEqual(result.nextAnchorIndex, 4)
+        XCTAssertEqual(result.nextAnchorIndex, 1)
     }
 
-    func testRepeatedShiftClicksPreserveOriginalAnchorWhileShrinkingRange() throws {
+    func testRepeatedShiftClicksKeepFirstShiftClickedWorkspaceAsPivotWhileShrinkingOppositeEdge() throws {
         let workspaceIds = makeWorkspaceIds()
 
         let firstResult = try update(
@@ -1152,21 +1152,21 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             modifiers: [.shift]
         )
 
-        XCTAssertEqual(firstResult.nextAnchorIndex, 1)
-        XCTAssertEqual(secondResult.selectedWorkspaceIds, Set([workspaceIds[1], workspaceIds[2]]))
+        XCTAssertEqual(firstResult.nextAnchorIndex, 4)
+        XCTAssertEqual(secondResult.selectedWorkspaceIds, Set([workspaceIds[2], workspaceIds[3], workspaceIds[4]]))
         XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[2])
-        XCTAssertEqual(secondResult.nextAnchorIndex, 1)
+        XCTAssertEqual(secondResult.nextAnchorIndex, 4)
     }
 
-    func testRepeatedShiftClicksPreserveOriginalAnchorAcrossDirectionChange() throws {
-        let workspaceIds = makeWorkspaceIds()
+    func testRepeatedShiftClicksUseFirstShiftClickedWorkspaceAsPivotAcrossDirectionChange() throws {
+        let workspaceIds = makeWorkspaceIds(count: 7)
 
         let firstResult = try update(
             workspaceIds: workspaceIds,
-            selectedWorkspaceIds: Set([workspaceIds[3]]),
-            currentActiveWorkspaceId: workspaceIds[3],
-            lastSelectionAnchorIndex: 3,
-            clickedIndex: 1,
+            selectedWorkspaceIds: Set([workspaceIds[2]]),
+            currentActiveWorkspaceId: workspaceIds[2],
+            lastSelectionAnchorIndex: 2,
+            clickedIndex: 5,
             modifiers: [.shift]
         )
 
@@ -1175,14 +1175,20 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             selectedWorkspaceIds: firstResult.selectedWorkspaceIds,
             currentActiveWorkspaceId: firstResult.nextActiveWorkspaceId,
             lastSelectionAnchorIndex: firstResult.nextAnchorIndex,
-            clickedIndex: 4,
+            clickedIndex: 0,
             modifiers: [.shift]
         )
 
-        XCTAssertEqual(firstResult.nextAnchorIndex, 3)
-        XCTAssertEqual(secondResult.selectedWorkspaceIds, Set([workspaceIds[3], workspaceIds[4]]))
-        XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(secondResult.nextAnchorIndex, 3)
+        XCTAssertEqual(firstResult.nextAnchorIndex, 5)
+        XCTAssertEqual(
+            secondResult.selectedWorkspaceIds,
+            Set([
+                workspaceIds[0], workspaceIds[1], workspaceIds[2],
+                workspaceIds[3], workspaceIds[4], workspaceIds[5]
+            ])
+        )
+        XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[0])
+        XCTAssertEqual(secondResult.nextAnchorIndex, 5)
     }
 
     func testShiftClickWithoutAnchorFallsBackToSingleSelection() throws {
@@ -1346,7 +1352,85 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(commandResult.nextAnchorIndex, 2)
         XCTAssertEqual(shiftResult.selectedWorkspaceIds, Set([workspaceIds[2], workspaceIds[3], workspaceIds[4]]))
         XCTAssertEqual(shiftResult.nextActiveWorkspaceId, workspaceIds[4])
-        XCTAssertEqual(shiftResult.nextAnchorIndex, 2)
+        XCTAssertEqual(shiftResult.nextAnchorIndex, 4)
+    }
+
+    func testInitialCommandShiftRangePromotesClickedWorkspaceToPivotForLaterShiftClick() throws {
+        let workspaceIds = makeWorkspaceIds(count: 6)
+
+        let firstResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1]]),
+            currentActiveWorkspaceId: workspaceIds[1],
+            lastSelectionAnchorIndex: 1,
+            clickedIndex: 4,
+            modifiers: [.command, .shift]
+        )
+
+        let secondResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: firstResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: firstResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: firstResult.nextAnchorIndex,
+            clickedIndex: 0,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(
+            firstResult.selectedWorkspaceIds,
+            Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(firstResult.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(firstResult.nextAnchorIndex, 4)
+        XCTAssertEqual(
+            secondResult.selectedWorkspaceIds,
+            Set([workspaceIds[0], workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(secondResult.nextActiveWorkspaceId, workspaceIds[0])
+        XCTAssertEqual(secondResult.nextAnchorIndex, 4)
+    }
+
+    func testCommandClickPreservesFirstShiftClickedPivotForLaterShiftRange() throws {
+        let workspaceIds = makeWorkspaceIds(count: 7)
+
+        let firstShiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[3]]),
+            currentActiveWorkspaceId: workspaceIds[3],
+            lastSelectionAnchorIndex: 3,
+            clickedIndex: 1,
+            modifiers: [.shift]
+        )
+
+        let commandResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: firstShiftResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: firstShiftResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: firstShiftResult.nextAnchorIndex,
+            clickedIndex: 5,
+            modifiers: [.command]
+        )
+
+        let secondShiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: commandResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: commandResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: commandResult.nextAnchorIndex,
+            clickedIndex: 6,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(firstShiftResult.nextAnchorIndex, 1)
+        XCTAssertEqual(commandResult.nextAnchorIndex, 1)
+        XCTAssertEqual(
+            secondShiftResult.selectedWorkspaceIds,
+            Set([
+                workspaceIds[1], workspaceIds[2], workspaceIds[3],
+                workspaceIds[4], workspaceIds[5], workspaceIds[6]
+            ])
+        )
+        XCTAssertEqual(secondShiftResult.nextActiveWorkspaceId, workspaceIds[6])
+        XCTAssertEqual(secondShiftResult.nextAnchorIndex, 1)
     }
 
     func testCommandClickOnOnlySelectedWorkspaceKeepsActiveWorkspaceSelected() throws {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1043,6 +1043,32 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         )
     }
 
+    private func applyCommandClickSequence(
+        workspaceIds: [UUID],
+        initialSelectedWorkspaceIds: Set<UUID>,
+        initialAnchorIndex: Int?,
+        clickedIndexes: [Int]
+    ) throws -> [SidebarWorkspaceSelectionUpdate] {
+        var selectedWorkspaceIds = initialSelectedWorkspaceIds
+        var anchorIndex = initialAnchorIndex
+        var updates: [SidebarWorkspaceSelectionUpdate] = []
+
+        for clickedIndex in clickedIndexes {
+            let result = try update(
+                workspaceIds: workspaceIds,
+                selectedWorkspaceIds: selectedWorkspaceIds,
+                lastSelectionAnchorIndex: anchorIndex,
+                clickedIndex: clickedIndex,
+                modifiers: [.command]
+            )
+            updates.append(result)
+            selectedWorkspaceIds = result.selectedWorkspaceIds
+            anchorIndex = result.nextAnchorIndex
+        }
+
+        return updates
+    }
+
     func testPlainClickReplacesExistingSelectionAndMovesAnchor() throws {
         let workspaceIds = makeWorkspaceIds()
 
@@ -1130,6 +1156,39 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         )
         XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
         XCTAssertEqual(result.nextAnchorIndex, 4)
+    }
+
+    func testRepeatedCommandClicksAccumulateDifferentWorkspaces() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let updates = try applyCommandClickSequence(
+            workspaceIds: workspaceIds,
+            initialSelectedWorkspaceIds: Set([workspaceIds[0]]),
+            initialAnchorIndex: 0,
+            clickedIndexes: [2, 4, 1]
+        )
+
+        XCTAssertEqual(updates.count, 3)
+        XCTAssertEqual(updates[0].selectedWorkspaceIds, Set([workspaceIds[0], workspaceIds[2]]))
+        XCTAssertEqual(updates[1].selectedWorkspaceIds, Set([workspaceIds[0], workspaceIds[2], workspaceIds[4]]))
+        XCTAssertEqual(
+            updates[2].selectedWorkspaceIds,
+            Set([workspaceIds[0], workspaceIds[1], workspaceIds[2], workspaceIds[4]])
+        )
+    }
+
+    func testRepeatedCommandClicksMoveFocusAndAnchorToEachClickedWorkspace() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let updates = try applyCommandClickSequence(
+            workspaceIds: workspaceIds,
+            initialSelectedWorkspaceIds: Set([workspaceIds[0]]),
+            initialAnchorIndex: 0,
+            clickedIndexes: [3, 1, 4]
+        )
+
+        XCTAssertEqual(updates.map(\.nextActiveWorkspaceId), [workspaceIds[3], workspaceIds[1], workspaceIds[4]])
+        XCTAssertEqual(updates.map(\.nextAnchorIndex), [3, 1, 4])
     }
 
     func testCommandShiftClickUnionsContiguousRangeIntoExistingSelection() throws {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1028,6 +1028,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
     private func update(
         workspaceIds: [UUID],
         selectedWorkspaceIds: Set<UUID>,
+        currentActiveWorkspaceId: UUID? = nil,
         lastSelectionAnchorIndex: Int?,
         clickedIndex: Int,
         modifiers: NSEvent.ModifierFlags
@@ -1036,6 +1037,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             SidebarWorkspaceSelectionPolicy.update(
                 workspaceIds: workspaceIds,
                 selectedWorkspaceIds: selectedWorkspaceIds,
+                currentActiveWorkspaceId: currentActiveWorkspaceId,
                 lastSelectionAnchorIndex: lastSelectionAnchorIndex,
                 clickedIndex: clickedIndex,
                 modifiers: modifiers
@@ -1047,16 +1049,21 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         workspaceIds: [UUID],
         initialSelectedWorkspaceIds: Set<UUID>,
         initialAnchorIndex: Int?,
+        initialActiveWorkspaceId: UUID? = nil,
         clickedIndexes: [Int]
     ) throws -> [SidebarWorkspaceSelectionUpdate] {
         var selectedWorkspaceIds = initialSelectedWorkspaceIds
         var anchorIndex = initialAnchorIndex
+        var currentActiveWorkspaceId = initialActiveWorkspaceId ?? (
+            initialSelectedWorkspaceIds.count == 1 ? initialSelectedWorkspaceIds.first : nil
+        )
         var updates: [SidebarWorkspaceSelectionUpdate] = []
 
         for clickedIndex in clickedIndexes {
             let result = try update(
                 workspaceIds: workspaceIds,
                 selectedWorkspaceIds: selectedWorkspaceIds,
+                currentActiveWorkspaceId: currentActiveWorkspaceId,
                 lastSelectionAnchorIndex: anchorIndex,
                 clickedIndex: clickedIndex,
                 modifiers: [.command]
@@ -1064,6 +1071,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             updates.append(result)
             selectedWorkspaceIds = result.selectedWorkspaceIds
             anchorIndex = result.nextAnchorIndex
+            currentActiveWorkspaceId = result.nextActiveWorkspaceId
         }
 
         return updates
@@ -1235,6 +1243,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         let result = try update(
             workspaceIds: workspaceIds,
             selectedWorkspaceIds: Set([workspaceIds[2]]),
+            currentActiveWorkspaceId: workspaceIds[2],
             lastSelectionAnchorIndex: 2,
             clickedIndex: 2,
             modifiers: [.command]
@@ -1255,6 +1264,7 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         let result = try update(
             workspaceIds: workspaceIds,
             selectedWorkspaceIds: Set([workspaceIds[1], workspaceIds[2], workspaceIds[4]]),
+            currentActiveWorkspaceId: workspaceIds[2],
             lastSelectionAnchorIndex: 4,
             clickedIndex: 2,
             modifiers: [.command]
@@ -1264,6 +1274,24 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
             result.selectedWorkspaceIds.contains(result.nextActiveWorkspaceId),
             "Command-click can shrink a multi-selection, but the focused workspace should still be part of the resulting selected set."
         )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+
+    func testCommandClickRemovingNonActiveWorkspacePreservesCurrentActiveWorkspace() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1], workspaceIds[2], workspaceIds[4]]),
+            currentActiveWorkspaceId: workspaceIds[4],
+            lastSelectionAnchorIndex: 4,
+            clickedIndex: 2,
+            modifiers: [.command]
+        )
+
+        XCTAssertEqual(result.selectedWorkspaceIds, Set([workspaceIds[1], workspaceIds[4]]))
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
         XCTAssertEqual(result.nextAnchorIndex, 2)
     }
 }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1433,6 +1433,48 @@ final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(secondShiftResult.nextAnchorIndex, 1)
     }
 
+    func testCommandClickRemovingShiftPivotMovesPivotToNearestRemainingWorkspace() throws {
+        let workspaceIds = makeWorkspaceIds(count: 6)
+
+        let firstShiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[3]]),
+            currentActiveWorkspaceId: workspaceIds[3],
+            lastSelectionAnchorIndex: 3,
+            clickedIndex: 1,
+            modifiers: [.shift]
+        )
+
+        let commandResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: firstShiftResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: firstShiftResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: firstShiftResult.nextAnchorIndex,
+            clickedIndex: 1,
+            modifiers: [.command]
+        )
+
+        let secondShiftResult = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: commandResult.selectedWorkspaceIds,
+            currentActiveWorkspaceId: commandResult.nextActiveWorkspaceId,
+            lastSelectionAnchorIndex: commandResult.nextAnchorIndex,
+            clickedIndex: 5,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(firstShiftResult.nextAnchorIndex, 1)
+        XCTAssertEqual(commandResult.selectedWorkspaceIds, Set([workspaceIds[2], workspaceIds[3]]))
+        XCTAssertEqual(commandResult.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(commandResult.nextAnchorIndex, 2)
+        XCTAssertEqual(
+            secondShiftResult.selectedWorkspaceIds,
+            Set([workspaceIds[2], workspaceIds[3], workspaceIds[4], workspaceIds[5]])
+        )
+        XCTAssertEqual(secondShiftResult.nextActiveWorkspaceId, workspaceIds[5])
+        XCTAssertEqual(secondShiftResult.nextAnchorIndex, 2)
+    }
+
     func testCommandClickOnOnlySelectedWorkspaceKeepsActiveWorkspaceSelected() throws {
         let workspaceIds = makeWorkspaceIds()
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1020,6 +1020,195 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
     }
 }
 
+final class SidebarWorkspaceSelectionPolicyTests: XCTestCase {
+    private func makeWorkspaceIds(count: Int = 5) -> [UUID] {
+        (0..<count).map { _ in UUID() }
+    }
+
+    private func update(
+        workspaceIds: [UUID],
+        selectedWorkspaceIds: Set<UUID>,
+        lastSelectionAnchorIndex: Int?,
+        clickedIndex: Int,
+        modifiers: NSEvent.ModifierFlags
+    ) throws -> SidebarWorkspaceSelectionUpdate {
+        try XCTUnwrap(
+            SidebarWorkspaceSelectionPolicy.update(
+                workspaceIds: workspaceIds,
+                selectedWorkspaceIds: selectedWorkspaceIds,
+                lastSelectionAnchorIndex: lastSelectionAnchorIndex,
+                clickedIndex: clickedIndex,
+                modifiers: modifiers
+            )
+        )
+    }
+
+    func testPlainClickReplacesExistingSelectionAndMovesAnchor() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[0], workspaceIds[3]]),
+            lastSelectionAnchorIndex: 3,
+            clickedIndex: 2,
+            modifiers: []
+        )
+
+        XCTAssertEqual(result.selectedWorkspaceIds, Set([workspaceIds[2]]))
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+
+    func testShiftClickSelectsForwardInclusiveRange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1]]),
+            lastSelectionAnchorIndex: 1,
+            clickedIndex: 4,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(result.nextAnchorIndex, 4)
+    }
+
+    func testShiftClickSelectsBackwardInclusiveRange() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[4]]),
+            lastSelectionAnchorIndex: 4,
+            clickedIndex: 1,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[1])
+        XCTAssertEqual(result.nextAnchorIndex, 1)
+    }
+
+    func testShiftClickWithoutAnchorFallsBackToSingleSelection() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[0], workspaceIds[1]]),
+            lastSelectionAnchorIndex: nil,
+            clickedIndex: 3,
+            modifiers: [.shift]
+        )
+
+        XCTAssertEqual(result.selectedWorkspaceIds, Set([workspaceIds[3]]))
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[3])
+        XCTAssertEqual(result.nextAnchorIndex, 3)
+    }
+
+    func testCommandClickAddsWorkspaceToExistingSelection() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1], workspaceIds[3]]),
+            lastSelectionAnchorIndex: 3,
+            clickedIndex: 4,
+            modifiers: [.command]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[1], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[4])
+        XCTAssertEqual(result.nextAnchorIndex, 4)
+    }
+
+    func testCommandShiftClickUnionsContiguousRangeIntoExistingSelection() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[0], workspaceIds[4]]),
+            lastSelectionAnchorIndex: 1,
+            clickedIndex: 3,
+            modifiers: [.command, .shift]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[0], workspaceIds[1], workspaceIds[2], workspaceIds[3], workspaceIds[4]])
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[3])
+        XCTAssertEqual(result.nextAnchorIndex, 3)
+    }
+
+    func testCommandShiftClickWithoutAnchorFallsBackToCommandToggle() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1], workspaceIds[3]]),
+            lastSelectionAnchorIndex: nil,
+            clickedIndex: 2,
+            modifiers: [.command, .shift]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[1], workspaceIds[2], workspaceIds[3]])
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+
+    func testCommandClickOnOnlySelectedWorkspaceKeepsActiveWorkspaceSelected() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[2]]),
+            lastSelectionAnchorIndex: 2,
+            clickedIndex: 2,
+            modifiers: [.command]
+        )
+
+        XCTAssertEqual(
+            result.selectedWorkspaceIds,
+            Set([workspaceIds[2]]),
+            "The sidebar always has an active workspace, so command-click should not leave the current workspace visually active but absent from the multi-selection set."
+        )
+        XCTAssertEqual(result.nextActiveWorkspaceId, workspaceIds[2])
+        XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+
+    func testCommandClickRemovingActiveWorkspaceKeepsActiveWorkspaceInsideSelection() throws {
+        let workspaceIds = makeWorkspaceIds()
+
+        let result = try update(
+            workspaceIds: workspaceIds,
+            selectedWorkspaceIds: Set([workspaceIds[1], workspaceIds[2], workspaceIds[4]]),
+            lastSelectionAnchorIndex: 4,
+            clickedIndex: 2,
+            modifiers: [.command]
+        )
+
+        XCTAssertTrue(
+            result.selectedWorkspaceIds.contains(result.nextActiveWorkspaceId),
+            "Command-click can shrink a multi-selection, but the focused workspace should still be part of the resulting selected set."
+        )
+        XCTAssertEqual(result.nextAnchorIndex, 2)
+    }
+}
+
 
 @MainActor
 final class TabManagerNotificationFocusTests: XCTestCase {


### PR DESCRIPTION
## Summary
- extract sidebar workspace multi-selection into a small testable helper
- add coverage for plain click, shift-click, repeated shift-click sequences, cmd-click, repeated cmd-click sequences, and cmd-shift-click in the workspace sidebar
- fix sidebar selection so shift-click keeps a persistent pivot until a plain click resets it
- fix cmd-click so it toggles membership without moving the stored shift pivot
- fix cmd-click so the active workspace always remains inside the sidebar selection set

## Behavior
- plain click replaces a multi-selection and resets the pivot to the clicked workspace
- shift-click selects an inclusive range from the existing pivot without moving that pivot
- repeated shift-clicks shrink or extend from the same original pivot, even when direction changes
- cmd-click adds or removes a workspace and preserves the existing shift pivot
- the first cmd-click with no pivot establishes one for later shift ranges
- cmd-shift-click unions the pivoted contiguous range into an existing non-contiguous selection
- shift-click without a pivot falls back to a single selection
- cmd-click on the only selected workspace keeps the active workspace selected
- cmd-click removing the active workspace moves focus to a remaining selected workspace

## Testing
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-cmd-click-sidebar-multi-workspace-selection test -only-testing:cmuxTests/SidebarWorkspaceSelectionPolicyTests`
- 16 passed
- 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified sidebar workspace multi-selection behavior: consistent Shift-range and Cmd-toggle interactions, preserved selection anchor across range changes, and smarter active-workspace selection when selections change.

* **Tests**
  * Added comprehensive unit tests covering click, Shift, Cmd, and Cmd+Shift flows, anchor/pivot preservation, selection shrinking/expansion, and active-workspace outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
