### PR TITLE
Fix minimal mode pane tab clicks

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -15,6 +15,9 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
+    // Minimal mode pulls pane tabs into the titlebar band; keep the root host
+    // non-draggable so left-clicks stay routed to interactive SwiftUI content.
+    override var mouseDownCanMoveWindow: Bool { false }
 
     required init(rootView: Content) {
         super.init(rootView: rootView)


### PR DESCRIPTION
## Summary
- keep the main window root hosting view non-draggable
- prevent minimal-mode pane tab clicks from being treated as titlebar drag candidates

Fixes #2390

## Verification
- built and launched with `./scripts/reload.sh --tag minimal-pane-click --launch`
- ran the required final build command `./scripts/reload.sh --tag minimal-pane-click`
- did not run local tests (per repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops minimal-mode pane tab clicks from being treated as titlebar drags (fixes #2390). Makes the root `NSHostingView` non-draggable by overriding `mouseDownCanMoveWindow` to `false`.

<sup>Written for commit c8d31ce50dff6181528216a8da1e9629006bcbcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clicking interactive UI elements would inadvertently trigger window dragging, preventing normal interaction with those elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->