### PR TITLE
fix: use ghostty_surface_text for large cmux send payloads

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13552,6 +13552,14 @@ class TerminalController {
         return success ? "OK" : "ERROR: Failed to send input"
     }
 
+    /// Threshold (in characters) above which text chunks use the direct PTY
+    /// text path (`ghostty_surface_text`) instead of key-event simulation.
+    /// Ghostty's text path handles bracketed paste mode internally — it adds
+    /// `\e[200~` / `\e[201~` markers only when the running program has enabled
+    /// mode 2004, so this is safe for vim, REPLs, and other non-shell surfaces.
+    /// See #2396.
+    private static let pasteTextThreshold = 256
+
     private func sendSocketText(_ text: String, surface: ghostty_surface_t) {
         let chunks = Self.socketTextChunks(text)
 #if DEBUG
@@ -13560,7 +13568,11 @@ class TerminalController {
         for chunk in chunks {
             switch chunk {
             case .text(let value):
-                sendTextEvent(surface: surface, text: value)
+                if value.count >= Self.pasteTextThreshold {
+                    writePTYText(value, surface: surface)
+                } else {
+                    sendTextEvent(surface: surface, text: value)
+                }
             case .control(let scalar):
                 _ = handleControlScalar(scalar, surface: surface)
             }
@@ -13573,6 +13585,26 @@ class TerminalController {
             )
         }
 #endif
+    }
+
+    /// Write text directly to the PTY via `ghostty_surface_text` (Ghostty's
+    /// paste/text path), bypassing key-event simulation.
+    private func writePTYText(_ text: String, surface: ghostty_surface_t) {
+        guard let data = text.data(using: .utf8), !data.isEmpty else {
+#if DEBUG
+            dlog("writePTYText: failed to convert text to UTF-8 or text is empty")
+#endif
+            return
+        }
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else {
+#if DEBUG
+                dlog("writePTYText: nil baseAddress for UTF-8 data")
+#endif
+                return
+            }
+            ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+        }
     }
 
     private func sendInputToWorkspace(_ args: String) -> String {


### PR DESCRIPTION
Fixes #2396 — `cmux send` freezes the terminal when injecting large text (2000+ characters) because text is sent through `ghostty_surface_key()` as individual key events, causing O(n²) shell processing.

## Problem

`sendSocketText()` routes all text chunks through `sendTextEvent()` → `ghostty_surface_key()`. For a 2000-character input, the shell's line editor (zsh ZLE, readline, etc.) re-runs syntax highlighting after each character insertion, creating ~4 million operations that peg the CPU and freeze the terminal.

## Fix

Text chunks ≥ 256 characters now use `ghostty_surface_text()` (Ghostty's paste/text path) instead of key-event simulation via `ghostty_surface_key()`. Ghostty internally handles bracketed paste mode — it wraps text in `\e[200~` / `\e[201~` markers **only when the running program has enabled mode 2004** (verified via [Ghostty source](https://github.com/ghostty-org/ghostty/blob/main/src/input/paste.zig#L93-L99)), so this is safe for vim, REPLs, and other non-shell PTY consumers.

Short text (< 256 chars) continues to use the existing key-event path for full compatibility with shell features like tab completion and history.

## Changes

- `Sources/TerminalController.swift`: Add `pasteTextThreshold` constant (256), update `sendSocketText()` to use `ghostty_surface_text()` for large text chunks, add `writePTYText()` helper with debug logging

## Testing

1. `cmux send --workspace ... --surface ... $'<2000+ char text>\n'` — terminal should remain responsive
2. Short commands (`ls`, `echo hello`) — unchanged behavior via key-event path
3. `cmux send` to vim in insert mode — should insert correctly (Ghostty only adds bracketed paste markers if mode 2004 is active)

**Regression test: skipped (intentional)**

Per `CLAUDE.md` test quality policy: this fix changes how text is routed to the PTY based on length. The bug is a terminal freeze caused by shell-side O(n²) processing of key events, which depends on the shell's line editor behavior and cannot be meaningfully exercised through unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling and performance when pasting large amounts of text into terminal sessions; large pastes are now injected via a more direct path for reliability and efficiency, while small inputs retain the previous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->