### PR TITLE
Hide punctuation-only cmd+p metadata matches

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7876,6 +7876,10 @@ enum CommandPaletteFuzzyMatcher {
         var isEmpty: Bool {
             tokens.isEmpty
         }
+
+        var hasAlphanumericCharacter: Bool {
+            normalizedText.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+        }
     }
 
     static func preparedQuery(_ query: String) -> PreparedQuery {
@@ -8683,6 +8687,12 @@ enum CommandPaletteSearchEngine {
                 preparedQuery: preparedQuery,
                 normalizedCandidates: [entry.normalizedTitle]
               ) else {
+            // Hidden metadata matches like workspace cwd are useful for queries such as
+            // "/Users" or ":3000", but punctuation-only probes like "/" are too noisy
+            // when the row text gives no visible reason for the match.
+            if !preparedQuery.hasAlphanumericCharacter {
+                return nil
+            }
             return fuzzyScore
         }
         return max(fuzzyScore, titleScore + titleMatchBonus)

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -116,6 +116,31 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         ]
     }
 
+    private func makeWorkspaceMetadataEntry(
+        id: String,
+        rank: Int = 0,
+        title: String,
+        directory: String? = nil,
+        branch: String? = nil,
+        ports: [Int] = []
+    ) -> FixtureEntry {
+        let keywords = CommandPaletteSwitcherSearchIndexer.keywords(
+            baseKeywords: ["workspace", "switch", "go", "open", title],
+            metadata: CommandPaletteSwitcherSearchMetadata(
+                directories: directory.map { [$0] } ?? [],
+                branches: branch.map { [$0] } ?? [],
+                ports: ports
+            ),
+            detail: .workspace
+        )
+        return FixtureEntry(
+            id: id,
+            rank: rank,
+            title: title,
+            searchableTexts: [title, "Workspace"] + keywords
+        )
+    }
+
     private func makeUpdateCommandEntries() -> [FixtureEntry] {
         [
             FixtureEntry(
@@ -203,19 +228,30 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         query: String,
         entry: FixtureEntry
     ) -> Int? {
+        let preparedQuery = CommandPaletteFuzzyMatcher.preparedQuery(query)
         guard let fuzzyScore = CommandPaletteFuzzyMatcher.score(
-            query: query,
-            candidates: entry.searchableTexts
+            preparedQuery: preparedQuery,
+            normalizedCandidates: entry.searchableTexts.map(CommandPaletteFuzzyMatcher.normalizeForSearch)
         ) else {
             return nil
         }
         guard let titleScore = CommandPaletteFuzzyMatcher.score(
-            query: query,
-            candidate: entry.title
+            preparedQuery: preparedQuery,
+            normalizedCandidates: [CommandPaletteFuzzyMatcher.normalizeForSearch(entry.title)]
         ) else {
+            if !queryHasAlphanumericCharacter(query) {
+                return nil
+            }
             return fuzzyScore
         }
         return max(fuzzyScore, titleScore + 2000)
+    }
+
+    private func queryHasAlphanumericCharacter(_ query: String) -> Bool {
+        CommandPaletteFuzzyMatcher
+            .normalizeForSearch(query)
+            .unicodeScalars
+            .contains { CharacterSet.alphanumerics.contains($0) }
     }
 
     private func benchmarkElapsedMs(operation: () -> Void) -> Double {
@@ -237,6 +273,9 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
             "rename tab",
             "workspace",
             "feature-12",
+            "/",
+            "~/dev",
+            ":3004",
             "3004",
             "toggle side",
             "open dir",
@@ -371,6 +410,142 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         XCTAssertEqual(
             results.prefix(2).map(\.id),
             ["command.checkForUpdates", "command.attemptUpdate"]
+        )
+    }
+
+    func testSlashQueryDoesNotMatchHiddenWorkspacePathMetadataOnly() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs",
+                branch: "feature/skibs"
+            )
+        ]
+
+        XCTAssertTrue(optimizedResults(entries: entries, query: "/").isEmpty)
+    }
+
+    func testSlashQueryStillMatchesVisibleSlashInTitle() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs"
+            ),
+            makeWorkspaceMetadataEntry(
+                id: "workspace.visible",
+                rank: 1,
+                title: "foo/bar",
+                directory: "/tmp/other"
+            ),
+        ]
+
+        let results = optimizedResults(entries: entries, query: "/")
+
+        XCTAssertEqual(results.map(\.id), ["workspace.visible"])
+        XCTAssertFalse(results[0].titleMatchIndices.isEmpty)
+    }
+
+    func testHiddenWorkspacePathMatchStillWorksForPathQueryWithLetters() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs"
+            )
+        ]
+
+        XCTAssertEqual(
+            optimizedResults(entries: entries, query: "/Users").first?.id,
+            "workspace.skibs"
+        )
+    }
+
+    func testHiddenWorkspacePathMatchStillWorksForAbbreviatedHomeQueryWithLetters() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs"
+            )
+        ]
+
+        XCTAssertEqual(
+            optimizedResults(entries: entries, query: "~/dev").first?.id,
+            "workspace.skibs"
+        )
+    }
+
+    func testTildeOnlyQueryDoesNotMatchHiddenWorkspacePathMetadataOnly() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs"
+            )
+        ]
+
+        XCTAssertTrue(optimizedResults(entries: entries, query: "~").isEmpty)
+    }
+
+    func testDashOnlyQueryDoesNotMatchHiddenWorkspaceBranchMetadataOnly() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                branch: "feature/skibs-hidden-match"
+            )
+        ]
+
+        XCTAssertTrue(optimizedResults(entries: entries, query: "-").isEmpty)
+    }
+
+    func testSlashOnlyQueryDoesNotMatchHiddenWorkspaceBranchMetadataOnly() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                branch: "feature/skibs"
+            )
+        ]
+
+        XCTAssertTrue(optimizedResults(entries: entries, query: "/").isEmpty)
+    }
+
+    func testColonPortQueryStillMatchesHiddenWorkspacePortMetadata() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.skibs",
+                title: "skibs",
+                ports: [3000]
+            )
+        ]
+
+        XCTAssertEqual(
+            optimizedResults(entries: entries, query: ":3000").first?.id,
+            "workspace.skibs"
+        )
+    }
+
+    func testVisiblePunctuationTitleOutranksHiddenMetadataMatch() {
+        let entries = [
+            makeWorkspaceMetadataEntry(
+                id: "workspace.hidden",
+                title: "skibs",
+                directory: "/Users/example/dev/skibs"
+            ),
+            makeWorkspaceMetadataEntry(
+                id: "workspace.visible",
+                rank: 1,
+                title: "slash/workspace",
+                directory: "/tmp/other"
+            ),
+        ]
+
+        XCTAssertEqual(
+            optimizedResults(entries: entries, query: "/w").first?.id,
+            "workspace.visible"
         )
     }
 


### PR DESCRIPTION
## Summary
- stop punctuation-only hidden metadata hits from surfacing unexplained workspace rows in cmd+p
- add a broader switcher matcher regression matrix for path, branch, port, and visible-title punctuation edge cases
- mirror the label-vs-path test style from VS Code fuzzy scorer coverage: https://github.com/microsoft/vscode/blob/main/src/vs/base/test/common/fuzzyScorer.test.ts

## Testing
- ./scripts/reload.sh --tag issue-2402-cmd-p-slash-hidden-metadata (build succeeded)
- local test suite not run, per repo policy

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/2402


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide punctuation-only hidden metadata matches in the cmd+p switcher to prevent unexplained workspace rows. Queries with letters or digits like '/Users', '~/dev', or ':3000' still work, and visible punctuation in titles continues to match.

- **Bug Fixes**
  - Suppress hidden metadata hits when the query has no alphanumerics; keep title-based punctuation matches and scoring intact.
  - Added regression tests for path, branch, and port queries, plus visible-title punctuation, mirroring VS Code label-vs-path coverage.

<sup>Written for commit 8a498d221b87d5ecc61002df3872d74cdd16ccc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result accuracy by preventing punctuation-only queries (e.g., "/" or "-") from matching irrelevant entries
  * Enhanced search filtering for specialized queries involving paths and ports to deliver more relevant results

* **Tests**
  * Added comprehensive test coverage for punctuation-based and special character queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->