### PR TITLE
Dim inactive bonsplit tab bars

### DIFF
--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -220,6 +220,25 @@ struct TmuxWorkspacePaneOverlayView: View {
     }
 }
 
+struct UnfocusedBonsplitTabBarOverlayView: View {
+    let rects: [CGRect]
+    let color: NSColor
+    let opacity: Double
+
+    var body: some View {
+        Canvas { context, _ in
+            guard opacity > 0.0001 else { return }
+            let fill = Color(nsColor: color).opacity(opacity)
+
+            for rect in rects where rect.width > 0 && rect.height > 0 {
+                context.fill(Path(rect), with: .color(fill))
+            }
+        }
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
 /// View that renders a Workspace's content using BonsplitView
 struct WorkspaceContentView: View {
     @ObservedObject var workspace: Workspace
@@ -259,6 +278,17 @@ struct WorkspaceContentView: View {
         let isSplit = workspace.bonsplitController.allPaneIds.count > 1 ||
             workspace.panels.count > 1
         let usesWorkspacePaneOverlay = TmuxOverlayExperimentSettings.target().usesWorkspacePaneOverlay
+        let bonsplitLayoutSnapshot = Self.effectiveTmuxLayoutSnapshot(
+            cachedSnapshot: workspace.tmuxLayoutSnapshot,
+            liveSnapshot: workspace.bonsplitController.layoutSnapshot()
+        )
+        let inactiveTabBarRects = Self.inactiveBonsplitTabBarRects(
+            layoutSnapshot: bonsplitLayoutSnapshot,
+            focusedPaneId: workspace.bonsplitController.focusedPaneId,
+            zoomedPaneId: workspace.bonsplitController.zoomedPaneId,
+            isWorkspaceInputActive: isWorkspaceInputActive,
+            shouldDimInactivePanes: isSplit
+        )
 
         // Inactive workspaces are kept alive in a ZStack (for state preservation) but their
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
@@ -377,12 +407,23 @@ struct WorkspaceContentView: View {
             )
         }
 
+        let decoratedBonsplitView = bonsplitView
+            .overlay(alignment: .topLeading) {
+                if !inactiveTabBarRects.isEmpty {
+                    UnfocusedBonsplitTabBarOverlayView(
+                        rects: inactiveTabBarRects,
+                        color: appearance.unfocusedOverlayNSColor,
+                        opacity: appearance.unfocusedOverlayOpacity
+                    )
+                }
+            }
+
         Group {
             if isMinimalMode && !isFullScreen {
-                bonsplitView
+                decoratedBonsplitView
                     .ignoresSafeArea(.container, edges: .top)
             } else {
-                bonsplitView
+                decoratedBonsplitView
             }
         }
     }
@@ -426,6 +467,17 @@ struct WorkspaceContentView: View {
         case windowContent
     }
 
+    private static func tmuxWorkspacePaneTopChromeRect(_ rect: CGRect) -> CGRect? {
+        let topInset = min(tmuxWorkspacePaneTopChromeHeight, max(0, rect.height - 1))
+        guard topInset > 0 else { return nil }
+        return CGRect(
+            x: rect.origin.x,
+            y: rect.origin.y,
+            width: rect.width,
+            height: topInset
+        )
+    }
+
     private static func tmuxWorkspacePaneContentRect(
         _ rect: CGRect,
         trimMode: TmuxWorkspacePaneOverlayTrimMode
@@ -442,11 +494,10 @@ struct WorkspaceContentView: View {
         }
     }
 
-    private static func tmuxWorkspacePaneRect(
+    private static func tmuxWorkspacePaneLocalRect(
         layoutSnapshot: LayoutSnapshot?,
         paneId: PaneID?,
-        includeContainerOffset: Bool,
-        trimMode: TmuxWorkspacePaneOverlayTrimMode
+        includeContainerOffset: Bool
     ) -> CGRect? {
         guard let layoutSnapshot,
               let paneId,
@@ -469,7 +520,68 @@ struct WorkspaceContentView: View {
                 dy: -CGFloat(layoutSnapshot.containerFrame.y)
             )
         }
+        return rect
+    }
+
+    private static func tmuxWorkspacePaneRect(
+        layoutSnapshot: LayoutSnapshot?,
+        paneId: PaneID?,
+        includeContainerOffset: Bool,
+        trimMode: TmuxWorkspacePaneOverlayTrimMode
+    ) -> CGRect? {
+        guard let rect = tmuxWorkspacePaneLocalRect(
+            layoutSnapshot: layoutSnapshot,
+            paneId: paneId,
+            includeContainerOffset: includeContainerOffset
+        ) else {
+            return nil
+        }
         return tmuxWorkspacePaneContentRect(rect, trimMode: trimMode)
+    }
+
+    static func tmuxWorkspacePaneTabBarRect(
+        layoutSnapshot: LayoutSnapshot?,
+        paneId: PaneID?
+    ) -> CGRect? {
+        guard let rect = tmuxWorkspacePaneLocalRect(
+            layoutSnapshot: layoutSnapshot,
+            paneId: paneId,
+            includeContainerOffset: false
+        ) else {
+            return nil
+        }
+        return tmuxWorkspacePaneTopChromeRect(rect)
+    }
+
+    static func inactiveBonsplitTabBarRects(
+        layoutSnapshot: LayoutSnapshot?,
+        focusedPaneId: PaneID?,
+        zoomedPaneId: PaneID?,
+        isWorkspaceInputActive: Bool,
+        shouldDimInactivePanes: Bool
+    ) -> [CGRect] {
+        guard shouldDimInactivePanes,
+              let layoutSnapshot else { return [] }
+
+        let zoomedPaneUUID = zoomedPaneId?.id.uuidString
+
+        return layoutSnapshot.panes.compactMap { pane in
+            if let zoomedPaneUUID, pane.paneId != zoomedPaneUUID {
+                return nil
+            }
+
+            if isWorkspaceInputActive,
+               let focusedPaneId,
+               pane.paneId == focusedPaneId.id.uuidString {
+                return nil
+            }
+
+            guard let paneUUID = UUID(uuidString: pane.paneId) else { return nil }
+            return tmuxWorkspacePaneTabBarRect(
+                layoutSnapshot: layoutSnapshot,
+                paneId: PaneID(id: paneUUID)
+            )
+        }
     }
 
     private static func tmuxWorkspacePaneRects(

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -104,6 +104,101 @@ final class WorkspaceContentViewVisibilityTests: XCTestCase {
         )
     }
 
+    func testTmuxWorkspacePaneTabBarRectReturnsTopChromeFrame() {
+        let paneID = PaneID(id: UUID())
+        let snapshot = LayoutSnapshot(
+            containerFrame: PixelRect(x: 200, y: 32, width: 1200, height: 800),
+            panes: [
+                PaneGeometry(
+                    paneId: paneID.id.uuidString,
+                    frame: PixelRect(x: 877.5, y: 32, width: 500, height: 320),
+                    selectedTabId: nil,
+                    tabIds: []
+                )
+            ],
+            focusedPaneId: paneID.id.uuidString,
+            timestamp: 0
+        )
+
+        XCTAssertEqual(
+            WorkspaceContentView.tmuxWorkspacePaneTabBarRect(
+                layoutSnapshot: snapshot,
+                paneId: paneID
+            ),
+            CGRect(x: 677.5, y: 0, width: 500, height: 30)
+        )
+    }
+
+    func testInactiveBonsplitTabBarRectsExcludeFocusedPaneWhenWorkspaceInputActive() {
+        let focusedPaneID = PaneID(id: UUID())
+        let unfocusedPaneID = PaneID(id: UUID())
+        let snapshot = LayoutSnapshot(
+            containerFrame: PixelRect(x: 200, y: 32, width: 1200, height: 800),
+            panes: [
+                PaneGeometry(
+                    paneId: focusedPaneID.id.uuidString,
+                    frame: PixelRect(x: 200, y: 32, width: 500, height: 320),
+                    selectedTabId: nil,
+                    tabIds: []
+                ),
+                PaneGeometry(
+                    paneId: unfocusedPaneID.id.uuidString,
+                    frame: PixelRect(x: 700, y: 32, width: 500, height: 320),
+                    selectedTabId: nil,
+                    tabIds: []
+                )
+            ],
+            focusedPaneId: focusedPaneID.id.uuidString,
+            timestamp: 0
+        )
+
+        XCTAssertEqual(
+            WorkspaceContentView.inactiveBonsplitTabBarRects(
+                layoutSnapshot: snapshot,
+                focusedPaneId: focusedPaneID,
+                zoomedPaneId: nil,
+                isWorkspaceInputActive: true,
+                shouldDimInactivePanes: true
+            ),
+            [CGRect(x: 500, y: 0, width: 500, height: 30)]
+        )
+    }
+
+    func testInactiveBonsplitTabBarRectsIncludeOnlyZoomedPaneWhenWorkspaceInactive() {
+        let firstPaneID = PaneID(id: UUID())
+        let zoomedPaneID = PaneID(id: UUID())
+        let snapshot = LayoutSnapshot(
+            containerFrame: PixelRect(x: 200, y: 32, width: 1200, height: 800),
+            panes: [
+                PaneGeometry(
+                    paneId: firstPaneID.id.uuidString,
+                    frame: PixelRect(x: 200, y: 32, width: 500, height: 320),
+                    selectedTabId: nil,
+                    tabIds: []
+                ),
+                PaneGeometry(
+                    paneId: zoomedPaneID.id.uuidString,
+                    frame: PixelRect(x: 700, y: 32, width: 500, height: 320),
+                    selectedTabId: nil,
+                    tabIds: []
+                )
+            ],
+            focusedPaneId: firstPaneID.id.uuidString,
+            timestamp: 0
+        )
+
+        XCTAssertEqual(
+            WorkspaceContentView.inactiveBonsplitTabBarRects(
+                layoutSnapshot: snapshot,
+                focusedPaneId: firstPaneID,
+                zoomedPaneId: zoomedPaneID,
+                isWorkspaceInputActive: false,
+                shouldDimInactivePanes: true
+            ),
+            [CGRect(x: 500, y: 0, width: 500, height: 30)]
+        )
+    }
+
     @MainActor
     func testTmuxWorkspacePaneUnreadRectsIncludeFocusedReadIndicator() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()


### PR DESCRIPTION
## Summary
- dim bonsplit pane tab bars for inactive panes with the same Ghostty unfocused split overlay color and opacity used for terminal content
- add geometry tests for inactive pane tab bar rect selection in normal and zoomed tmux layouts

## Testing
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-dim-unfocused-bonsplit-tabbar test -only-testing:cmuxTests/WorkspaceContentViewVisibilityTests` (`** TEST SUCCEEDED **`)
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag task-dim-unfocused-bonsplit-tabbar` (`** BUILD SUCCEEDED **`)

## Task
- dim the bonsplit tab bar when the pane is unfocused, matching the existing Ghostty inactive split dimming behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dim the bonsplit tab bars for unfocused panes using the same Ghostty unfocused split overlay color and opacity used for terminal content. Adds geometry helpers and unit tests to compute and validate inactive tab bar rects in normal and zoomed tmux layouts, respecting focus and input state.

<sup>Written for commit 1fb4807e0134cee604ef6768ed43bdfa8e4db0dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual dimming overlay for inactive tab bar regions in the workspace view; overlay respects pane focus and zoom states, and adapts based on workspace input activity.

* **Tests**
  * Added test coverage for tab bar rectangle geometry calculations and inactive pane dimming selection logic in various focus and zoom scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->