### PR TITLE
Bump unit test CI runner to 8x to fix OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: bun tsc --noEmit
 
   tests:
-    runs-on: warp-macos-15-arm64-6x
+    runs-on: warp-macos-15-arm64-8x
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- The `TerminalControllerSocketSecurityTests` added in https://github.com/manaflow-ai/cmux/pull/2355 cause ghostty surface allocation to OOM on the 6-core WarpBuild runner (`error.OutOfMemory`), failing 3 socket tests that were previously passing.
- Bumps the `tests` job runner from `warp-macos-15-arm64-6x` to `warp-macos-15-arm64-8x` for more memory headroom.

## Test plan
- CI on this PR should show the 3 `TerminalControllerSocketSecurityTests` passing (or at least no longer OOM-ing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump CI unit test runner from `warp-macos-15-arm64-6x` to `warp-macos-15-arm64-8x` to stop OOM failures in TerminalControllerSocketSecurityTests. This adds memory headroom for ghostty surface allocation so the three socket tests no longer fail.

<sup>Written for commit a2647e6f5536cbef59859685bb799ef273119dd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure configuration to optimize test job execution environment.

**Note:** This is an internal infrastructure change with no impact on product features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->