### PR TITLE
Use bracketed paste for large cmux send payloads

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13552,11 +13552,37 @@ class TerminalController {
         return success ? "OK" : "ERROR: Failed to send input"
     }
 
+    /// Threshold above which we use the paste path (`ghostty_surface_text`)
+    /// instead of simulating individual key events.  The paste path triggers
+    /// bracketed paste mode so the shell buffers the entire input at once,
+    /// avoiding O(n²) redraws from per-character processing.
+    private static let pasteThreshold = 256
+
     private func sendSocketText(_ text: String, surface: ghostty_surface_t) {
-        let chunks = Self.socketTextChunks(text)
 #if DEBUG
         let startedAt = ProcessInfo.processInfo.systemUptime
 #endif
+        if text.count >= Self.pasteThreshold {
+            // Use the paste path for large payloads.  ghostty_surface_text()
+            // routes through completeClipboardPaste() which wraps with
+            // bracketed paste sequences when the terminal has mode 2004 on,
+            // and converts \n → \r otherwise.
+            if let data = text.data(using: .utf8), !data.isEmpty {
+                data.withUnsafeBytes { rawBuffer in
+                    guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+                    ghostty_surface_text(surface, baseAddress, UInt(rawBuffer.count))
+                }
+            }
+#if DEBUG
+            let elapsedMs = (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0
+            dlog(
+                "socket.send_text.paste chars=\(text.count) ms=\(String(format: "%.2f", elapsedMs))"
+            )
+#endif
+            return
+        }
+
+        let chunks = Self.socketTextChunks(text)
         for chunk in chunks {
             switch chunk {
             case .text(let value):


### PR DESCRIPTION
## Summary
- Route `cmux send` / `surface.send_text` payloads >= 256 chars through `ghostty_surface_text()` (paste path) instead of `ghostty_surface_key()` (key event path)
- The paste path triggers bracketed paste mode (`ESC[200~` / `ESC[201~`), so the shell buffers the entire input at once — avoiding O(n²) redraws from per-character syntax highlighting, completion lookups, and prompt redraws that froze terminals with 2000+ char payloads
- Short text (< 256 chars) continues to use the key event path for precise control character handling

Closes #2396

## Test plan
- [ ] Send a ~2000 character command via `cmux send` to a terminal surface — verify the terminal does not freeze and the text is inserted as a paste
- [ ] Send a short (<256 char) command via `cmux send` — verify it still works as individual keystrokes (control characters like `\n`, `\t` handled correctly)
- [ ] Verify bracketed paste markers appear in terminal output for large payloads (when shell has bracketed paste mode enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route large `cmux send`/`surface.send_text` payloads (>=256 chars) through `ghostty_surface_text()` to use bracketed paste, preventing freezes and speeding up insertion. Small payloads still use `ghostty_surface_key()` for precise control character handling.

- **Bug Fixes**
  - Send texts >= 256 chars via `ghostty_surface_text()` to trigger bracketed paste and batch the input.
  - Eliminates per-character O(n²) redraws that caused freezes on 2k+ char sends (fixes #2396).

<sup>Written for commit 5ed62a9282b7998c2b27b775f5a8427917000d19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized terminal text input handling to improve performance when pasting large amounts of text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->