### PR TITLE
Skip zig Ghostty helper builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Validate unit-test SwiftPM retry guard
         run: ./tests/test_ci_unit_test_spm_retry.sh
 
+      - name: Validate CI skips zig Ghostty helper builds on macOS
+        run: ./tests/test_ci_skip_zig_build_guard.sh
+
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 
@@ -77,6 +80,8 @@ jobs:
   tests:
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 30
+    env:
+      CMUX_SKIP_ZIG_BUILD: 1
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -241,6 +246,8 @@ jobs:
     # still run via test-e2e.yml on GitHub-hosted runners.
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 20
+    env:
+      CMUX_SKIP_ZIG_BUILD: 1
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -403,6 +410,8 @@ jobs:
   ui-regressions:
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 25
+    env:
+      CMUX_SKIP_ZIG_BUILD: 1
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/tests/test_ci_skip_zig_build_guard.sh
+++ b/tests/test_ci_skip_zig_build_guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regression test to keep CI macOS jobs from live-building the Ghostty helper.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
+
+check_job() {
+  local job_name="$1"
+  if ! awk -v job_name="$job_name" '
+    $0 == "  " job_name ":" {
+      in_job = 1
+      next
+    }
+    in_job && $0 ~ /^  [^ ]/ {
+      exit found ? 0 : 1
+    }
+    in_job && $0 ~ /CMUX_SKIP_ZIG_BUILD: 1/ {
+      found = 1
+    }
+    END {
+      if (!in_job || !found) {
+        exit 1
+      }
+    }
+  ' "$WORKFLOW_FILE"; then
+    echo "FAIL: $job_name in ci.yml must set CMUX_SKIP_ZIG_BUILD: 1" >&2
+    exit 1
+  fi
+}
+
+check_job "tests"
+check_job "tests-build-and-lag"
+check_job "ui-regressions"
+
+echo "PASS: CI macOS jobs skip zig Ghostty helper builds"


### PR DESCRIPTION
Fixes the current main CI failure from https://github.com/manaflow-ai/cmux/actions/runs/23787431354.

This sets `CMUX_SKIP_ZIG_BUILD` on the macOS CI jobs that already download the prebuilt `GhosttyKit.xcframework`, and adds a workflow guard test so the skip does not regress.

Validation:
- `./tests/test_ci_skip_zig_build_guard.sh`
- `./tests/test_ci_ghosttykit_checksum_verification.sh`
- download prebuilt GhosttyKit + `CMUX_SKIP_ZIG_BUILD=1` `xcodebuild ... build-for-testing`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip building the Zig Ghostty helper on macOS CI by setting CMUX_SKIP_ZIG_BUILD=1 for jobs that use prebuilt `GhosttyKit`, fixing the current main CI failure. Adds a guard test to ensure this skip stays in place.

- **Bug Fixes**
  - Set CMUX_SKIP_ZIG_BUILD: 1 in tests, tests-build-and-lag, and ui-regressions jobs.
  - Added tests/test_ci_skip_zig_build_guard.sh to verify the env is set in ci.yml.

<sup>Written for commit c23f1fc2cd6916229a450761a08b08e880489b2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI build configuration with validation testing to ensure macOS builds properly skip unnecessary compilation steps, improving build efficiency.
  * Strengthened CI infrastructure reliability through automated configuration validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->