### PR TITLE
Remove copy-on-select setting and override

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -47988,57 +47988,6 @@
         }
       }
     },
-    "settings.app.copyOnSelect": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy on Select"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択時にコピー"
-          }
-        }
-      }
-    },
-    "settings.app.copyOnSelect.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecting terminal text does not copy it to the system clipboard."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ターミナルテキストを選択してもシステムのクリップボードにはコピーしません。"
-          }
-        }
-      }
-    },
-    "settings.app.copyOnSelect.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatically copy selected terminal text to the system clipboard."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したターミナルテキストをシステムのクリップボードに自動でコピーします。"
-          }
-        }
-      }
-    },
     "settings.app.paneFirstClickFocus": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1379,21 +1379,11 @@ class GhosttyApp {
         }
     }
 
-    private func loadCopyOnSelectOverride(_ config: ghostty_config_t) {
-        loadInlineGhosttyConfig(
-            TerminalCopyOnSelectSettings.overrideConfigLine(),
-            into: config,
-            prefix: "cmux-copy-on-select",
-            logLabel: "copy-on-select override"
-        )
-    }
-
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
         ghostty_config_load_default_files(config)
         loadLegacyGhosttyConfigIfNeeded(config)
         ghostty_config_load_recursive_files(config)
         loadCmuxAppSupportGhosttyConfigIfNeeded(config)
-        loadCopyOnSelectOverride(config)
         loadCJKFontFallbackIfNeeded(config)
         // cmux provides the terminal background via backgroundView (CALayer)
         // instead of the GPU full-screen bg pass, so the layer can provide

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3906,22 +3906,6 @@ enum CommandPaletteRenameSelectionSettings {
     }
 }
 
-enum TerminalCopyOnSelectSettings {
-    static let enabledKey = "terminalCopyOnSelectEnabled"
-    static let defaultEnabled = false
-
-    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
-        if defaults.object(forKey: enabledKey) == nil {
-            return defaultEnabled
-        }
-        return defaults.bool(forKey: enabledKey)
-    }
-
-    static func overrideConfigLine(defaults: UserDefaults = .standard) -> String {
-        isEnabled(defaults: defaults) ? "copy-on-select = clipboard" : "copy-on-select = false"
-    }
-}
-
 enum CommandPaletteSwitcherSearchSettings {
     static let searchAllSurfacesKey = "commandPalette.switcherSearchAllSurfaces"
     static let defaultSearchAllSurfaces = false
@@ -4052,8 +4036,6 @@ struct SettingsView: View {
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
-    @AppStorage(TerminalCopyOnSelectSettings.enabledKey)
-    private var terminalCopyOnSelectEnabled = TerminalCopyOnSelectSettings.defaultEnabled
     @AppStorage(CommandPaletteSwitcherSearchSettings.searchAllSurfacesKey)
     private var commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey)
@@ -4172,19 +4154,6 @@ struct SettingsView: View {
         return String(
             localized: "settings.app.paneFirstClickFocus.subtitleOff",
             defaultValue: "When cmux is inactive, the first click only activates the window. Click again to focus the pane."
-        )
-    }
-
-    private var terminalCopyOnSelectSubtitle: String {
-        if terminalCopyOnSelectEnabled {
-            return String(
-                localized: "settings.app.copyOnSelect.subtitleOn",
-                defaultValue: "Automatically copy selected terminal text to the system clipboard."
-            )
-        }
-        return String(
-            localized: "settings.app.copyOnSelect.subtitleOff",
-            defaultValue: "Selecting terminal text does not copy it to the system clipboard."
         )
     }
 
@@ -4704,20 +4673,6 @@ struct SettingsView: View {
                                 .controlSize(.small)
                                 .accessibilityLabel(
                                     String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click")
-                                )
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            String(localized: "settings.app.copyOnSelect", defaultValue: "Copy on Select"),
-                            subtitle: terminalCopyOnSelectSubtitle
-                        ) {
-                            Toggle("", isOn: $terminalCopyOnSelectEnabled)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityLabel(
-                                    String(localized: "settings.app.copyOnSelect", defaultValue: "Copy on Select")
                                 )
                         }
 
@@ -5893,9 +5848,6 @@ struct SettingsView: View {
         .onChange(of: notificationSoundCustomFilePath) { _, _ in
             refreshNotificationCustomSoundStatus()
         }
-        .onChange(of: terminalCopyOnSelectEnabled) { _, _ in
-            GhosttyApp.shared.reloadConfiguration(source: "settings.copy_on_select")
-        }
         .onChange(of: browserInsecureHTTPAllowlist) { oldValue, newValue in
             // Keep draft in sync with external changes unless the user has local unsaved edits.
             if browserInsecureHTTPAllowlistDraft == oldValue {
@@ -6020,7 +5972,6 @@ struct SettingsView: View {
         showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
         warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
-        terminalCopyOnSelectEnabled = TerminalCopyOnSelectSettings.defaultEnabled
         commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces
         ShortcutHintDebugSettings.resetVisibilityDefaults()
         alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -584,44 +584,6 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertFalse(TelemetrySettings.isEnabled(defaults: defaults))
     }
 
-    func testTerminalCopyOnSelectDefaultsToDisabledWhenUnset() {
-        let suiteName = "cmux.tests.copy-on-select.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            XCTFail("Failed to create isolated user defaults suite")
-            return
-        }
-        defer {
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-
-        defaults.removeObject(forKey: TerminalCopyOnSelectSettings.enabledKey)
-
-        XCTAssertFalse(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
-        XCTAssertEqual(
-            TerminalCopyOnSelectSettings.overrideConfigLine(defaults: defaults),
-            "copy-on-select = false"
-        )
-    }
-
-    func testTerminalCopyOnSelectUsesClipboardOverrideWhenEnabled() {
-        let suiteName = "cmux.tests.copy-on-select.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            XCTFail("Failed to create isolated user defaults suite")
-            return
-        }
-        defer {
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-
-        defaults.set(true, forKey: TerminalCopyOnSelectSettings.enabledKey)
-
-        XCTAssertTrue(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
-        XCTAssertEqual(
-            TerminalCopyOnSelectSettings.overrideConfigLine(defaults: defaults),
-            "copy-on-select = clipboard"
-        )
-    }
-
     private func rgb255(_ color: NSColor) -> RGB {
         let srgb = color.usingColorSpace(.sRGB)!
         var red: CGFloat = 0


### PR DESCRIPTION
## Summary
- remove the Settings toggle and localized copy for copy on select
- stop injecting a cmux `copy-on-select` override so Ghostty config controls the behavior again
- delete the unit tests that only covered the removed override mapping

## Testing
- `./scripts/reload.sh --tag task-remove-copy-on-select-ui` (build succeeded)

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/2282


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Copy on Select setting and the `cmux` override so Ghostty’s native `copy-on-select` controls behavior again. Configure it directly in your Ghostty config.

- **Refactors**
  - Removed the Settings toggle and localized strings for “Copy on Select”.
  - Deleted `TerminalCopyOnSelectSettings` and stopped injecting a `copy-on-select` override during config load.
  - Removed related unit tests tied to the override mapping.

- **Migration**
  - Set `copy-on-select` in your Ghostty config (e.g., `copy-on-select = clipboard` or `copy-on-select = false`). The in-app toggle is gone.

<sup>Written for commit acd45bbd9e775452906b2d9fd8a6930d95cfa174. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the "Copy on Select" setting option from application preferences and its associated configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->