### PR TITLE
feat: WKWebView-based markdown renderer for multi-line text selection

### DIFF
--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import MarkdownUI
+import WebKit
 
 /// SwiftUI view that renders a MarkdownPanel's content using MarkdownUI.
 struct MarkdownPanelView: View {
@@ -13,11 +14,15 @@ struct MarkdownPanelView: View {
     @State private var focusFlashOpacity: Double = 0.0
     @State private var focusFlashAnimationGeneration: Int = 0
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(MarkdownRendererSettings.useWebViewKey)
+    private var useWebView = MarkdownRendererSettings.defaultUseWebView
 
     var body: some View {
         Group {
             if panel.isFileUnavailable {
                 fileUnavailableView
+            } else if useWebView {
+                markdownWebViewContent
             } else {
                 markdownContentView
             }
@@ -43,7 +48,26 @@ struct MarkdownPanelView: View {
         }
     }
 
-    // MARK: - Content
+    // MARK: - WebView Content
+
+    private var markdownWebViewContent: some View {
+        VStack(spacing: 0) {
+            filePathHeader
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+                .padding(.bottom, 8)
+
+            Divider()
+                .padding(.horizontal, 16)
+
+            MarkdownWebViewRepresentable(
+                content: panel.content,
+                colorScheme: colorScheme
+            )
+        }
+    }
+
+    // MARK: - Native MarkdownUI Content
 
     private var markdownContentView: some View {
         ScrollView {
@@ -289,6 +313,140 @@ struct MarkdownPanelView: View {
         }
     }
 }
+
+// MARK: - WebView-based Markdown Renderer
+
+/// Renders markdown as HTML in a WKWebView for full multi-line text selection support.
+struct MarkdownWebViewRepresentable: NSViewRepresentable {
+    let content: String
+    let colorScheme: ColorScheme
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.setValue(false, forKey: "drawsBackground")
+        loadHTML(into: webView)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        loadHTML(into: webView)
+    }
+
+    private func loadHTML(into webView: WKWebView) {
+        let isDark = colorScheme == .dark
+        let html = Self.wrapInHTML(markdown: content, isDark: isDark)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    private static func escapeForJS(_ text: String) -> String {
+        text.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "`", with: "\\`")
+            .replacingOccurrences(of: "$", with: "\\$")
+    }
+
+    static func wrapInHTML(markdown: String, isDark: Bool) -> String {
+        let escapedMarkdown = escapeForJS(markdown)
+        let bg = isDark ? "#1e1e1e" : "#fafafa"
+        let fg = isDark ? "rgba(255,255,255,0.9)" : "#1a1a1a"
+        let mutedFg = isDark ? "rgba(255,255,255,0.6)" : "#666"
+        let codeBg = isDark ? "#141414" : "#ededed"
+        let codeFg = isDark ? "#e6e6e6" : "#333"
+        let inlineCodeFg = isDark ? "rgb(217,153,242)" : "rgb(153,51,179)"
+        let inlineCodeBg = isDark ? "#2e2e2e" : "#eaeaea"
+        let borderColor = isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.12)"
+        let tableBgEven = isDark ? "#1a1a1a" : "#fff"
+        let tableBgOdd = isDark ? "#242424" : "#f5f5f5"
+        let linkColor = isDark ? "#58a6ff" : "#0969da"
+        let blockquoteBorder = isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.2)"
+
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="color-scheme" content="\(isDark ? "dark" : "light")">
+        <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            color: \(fg);
+            background: \(bg);
+            padding: 16px 24px;
+            margin: 0;
+            -webkit-font-smoothing: antialiased;
+        }
+        h1 { font-size: 28px; font-weight: 700; margin: 24px 0 16px; padding-bottom: 8px; border-bottom: 1px solid \(borderColor); }
+        h2 { font-size: 22px; font-weight: 700; margin: 20px 0 12px; padding-bottom: 6px; border-bottom: 1px solid \(borderColor); }
+        h3 { font-size: 18px; font-weight: 600; margin: 16px 0 8px; }
+        h4 { font-size: 16px; font-weight: 600; margin: 12px 0 6px; }
+        h5 { font-size: 14px; font-weight: 500; margin: 10px 0 4px; }
+        h6 { font-size: 13px; font-weight: 500; margin: 8px 0 4px; color: \(mutedFg); }
+        p { margin: 4px 0 8px; }
+        a { color: \(linkColor); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        strong { font-weight: 600; }
+        code {
+            font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;
+            font-size: 13px;
+            color: \(inlineCodeFg);
+            background: \(inlineCodeBg);
+            padding: 2px 5px;
+            border-radius: 3px;
+        }
+        pre {
+            background: \(codeBg);
+            border-radius: 6px;
+            padding: 12px;
+            overflow-x: auto;
+            margin: 8px 0;
+        }
+        pre code {
+            color: \(codeFg);
+            background: none;
+            padding: 0;
+            font-size: 13px;
+        }
+        blockquote {
+            border-left: 3px solid \(blockquoteBorder);
+            margin: 8px 0;
+            padding-left: 12px;
+            color: \(mutedFg);
+        }
+        hr { border: none; border-top: 1px solid \(borderColor); margin: 16px 0; }
+        ul, ol { padding-left: 24px; }
+        li { margin: 4px 0; }
+        table { border-collapse: collapse; margin: 8px 0; width: 100%; }
+        th, td {
+            border: 1px solid \(borderColor);
+            padding: 6px 12px;
+            text-align: left;
+        }
+        tr:nth-child(odd) td { background: \(tableBgOdd); }
+        tr:nth-child(even) td { background: \(tableBgEven); }
+        th { font-weight: 600; background: \(tableBgOdd); }
+        img { max-width: 100%; }
+        input[type="checkbox"] { margin-right: 6px; }
+        </style>
+        <script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+        </head>
+        <body>
+        <div id="content"></div>
+        <script>
+        const md = `\(escapedMarkdown)`;
+        marked.setOptions({ gfm: true, breaks: false });
+        document.getElementById('content').innerHTML = marked.parse(md);
+        </script>
+        </body>
+        </html>
+        """
+    }
+}
+
+// MARK: - Pointer Observer
 
 private struct MarkdownPointerObserver: NSViewRepresentable {
     let onPointerDown: () -> Void

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3946,6 +3946,18 @@ enum ClaudeCodeIntegrationSettings {
     }
 }
 
+enum MarkdownRendererSettings {
+    static let useWebViewKey = "markdownRenderer.useWebView"
+    static let defaultUseWebView = true
+
+    static func useWebView(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: useWebViewKey) == nil {
+            return defaultUseWebView
+        }
+        return defaults.bool(forKey: useWebViewKey)
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }
@@ -4063,6 +4075,8 @@ struct SettingsView: View {
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(PaneFirstClickFocusSettings.enabledKey)
     private var paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+    @AppStorage(MarkdownRendererSettings.useWebViewKey)
+    private var markdownUseWebView = MarkdownRendererSettings.defaultUseWebView
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
@@ -4733,6 +4747,18 @@ struct SettingsView: View {
                             )
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            "Markdown WebView Renderer",
+                            subtitle: "Use a web-based renderer for markdown panels. Supports multi-line text selection. Disable to use the native SwiftUI renderer."
+                        ) {
+                            Toggle("", isOn: $markdownUseWebView)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityLabel("Markdown WebView Renderer")
                         }
 
                         SettingsCardDivider()
@@ -6033,6 +6059,7 @@ struct SettingsView: View {
         defaults.removeObject(forKey: WorkspaceButtonFadeSettings.legacyPaneTabBarControlsVisibilityModeKey)
         closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
         paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+        markdownUseWebView = MarkdownRendererSettings.defaultUseWebView
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
         sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage


### PR DESCRIPTION
## Summary

- Adds an alternative WKWebView-based markdown renderer that enables full multi-line text selection in markdown panels (the native SwiftUI MarkdownUI renderer only allows selection within a single block due to a SwiftUI limitation)
- New setting "Markdown WebView Renderer" (default: on) with toggle in Settings
- CSS theme matches the existing MarkdownUI dark/light theme colors exactly

## Test plan

- [ ] Open a markdown file with `cmux markdown open <file>`
- [ ] Verify text can be selected across multiple paragraphs/headings
- [ ] Verify Cmd+A selects all text
- [ ] Verify Cmd+C copies selected text
- [ ] Toggle the setting off in Settings and verify the native renderer still works
- [ ] Test with both dark and light mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `WKWebView`-based markdown renderer to enable full multi-line text selection in markdown panels. It’s on by default and can be toggled off to use the native `MarkdownUI` renderer.

- **New Features**
  - Multi-line selection across blocks; Cmd+A selects all; Cmd+C copies selection.
  - New Settings toggle: "Markdown WebView Renderer" (key `markdownRenderer.useWebView`), default on.
  - HTML is rendered via `marked` (CDN) with CSS matching current dark/light themes.
  - Falls back to the native `MarkdownUI` renderer when the toggle is off.

<sup>Written for commit 64da50200d507cd5fccd8b04f226764616f95d3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a markdown renderer preference in settings, allowing users to choose between native and web-based rendering modes.
  * Web-based renderer supports dynamic markdown conversion with automatic light and dark theme styling.
  * Default renderer is web-based; users can switch back to native rendering in preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->