### PR TITLE
Cache Zig package downloads in CI to prevent TLS flakes

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -65,8 +65,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/zig
-          key: zig-cache-ghosttykit-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-cache-ghosttykit-
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
 
       - name: Build GhosttyKit.xcframework
         if: steps.check-release.outputs.exists == 'false'

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -60,6 +60,14 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Cache Zig packages
+        if: steps.check-release.outputs.exists == 'false'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-ghosttykit-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-cache-ghosttykit-
+
       - name: Build GhosttyKit.xcframework
         if: steps.check-release.outputs.exists == 'false'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/zig
-          key: zig-cache-tests-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-cache-tests-
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
 
       - name: Cache DerivedData
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -304,8 +304,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/zig
-          key: zig-cache-build-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-cache-build-
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
 
       - name: Cache DerivedData
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -465,8 +465,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cache/zig
-          key: zig-cache-ui-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-cache-ui-
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
 
       - name: Cache Swift packages
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,13 @@ jobs:
             zig version
           fi
 
+      - name: Cache Zig packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-tests-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-cache-tests-
+
       - name: Cache DerivedData
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
@@ -293,6 +300,13 @@ jobs:
             zig version
           fi
 
+      - name: Cache Zig packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-build-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-cache-build-
+
       - name: Cache DerivedData
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
@@ -446,6 +460,13 @@ jobs:
             export PATH="/usr/local/bin:$PATH"
             zig version
           fi
+
+      - name: Cache Zig packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/zig
+          key: zig-cache-ui-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-cache-ui-
 
       - name: Cache Swift packages
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4


### PR DESCRIPTION
## Summary
- Add `~/.cache/zig` cache steps to all four Zig-using CI jobs (`tests`, `tests-build-and-lag`, `ui-regressions` in `ci.yml`, and `build-ghosttykit.yml`)
- Cache key is based on `ghostty/build.zig.zon` + `ghostty/build.zig.zon.json` hashes, with restore-keys fallback

## Root cause
The `ui-regressions` job fails intermittently with `TlsInitializationFailed` when `xcodebuild build-for-testing` triggers a Zig build phase that fetches dependencies from `deps.files.ghostty.org`. Unlike Swift packages (which have both caching and 3-attempt retry), Zig package downloads had no caching at all. The `tests` and `tests-build-and-lag` jobs survived because they cache DerivedData (which includes compiled Zig artifacts), but `ui-regressions` does not cache DerivedData.

Example failure: https://github.com/manaflow-ai/cmux/actions/runs/23787431354

## Testing
- CI will validate on this PR's own run (first run populates the cache, subsequent runs use it)
- No app behavior change, CI-only fix

## Related
- Task: Fix CI ui-regressions TLS flake on Zig dependency fetch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Zig package downloads in CI to prevent TLS flakes in `ui-regressions` and cut redundant downloads. Uses a shared `zig-packages-` cache so the first job warms it for all Zig jobs.

- **Bug Fixes**
  - Added `actions/cache@v4` steps caching `~/.cache/zig` in `tests`, `tests-build-and-lag`, `ui-regressions`, and `build-ghosttykit.yml`.
  - Cache key: `zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}` with a shared `zig-packages-` restore prefix across jobs.
  - Satisfies the task to stabilize `ui-regressions` by caching Zig dependency fetches.

<sup>Written for commit 24b455c97e89c772019dbe75ebdde48e9cfba995. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline performance by implementing caching for build artifacts across multiple workflows, reducing build times for development and testing cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->