### PR TITLE
fix: auto-scroll sidebar to follow workspace selection

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8724,6 +8724,7 @@ struct VerticalTabsSidebar: View {
 
         VStack(spacing: 0) {
             GeometryReader { proxy in
+                ScrollViewReader { scrollProxy in
                 ScrollView {
                     VStack(spacing: 0) {
                         // Space for traffic lights / fullscreen controls
@@ -8827,6 +8828,13 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(Color.clear)
                 .modifier(ClearScrollBackground())
+                .onChange(of: tabManager.selectedTabId) { newId in
+                    guard let newId else { return }
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        scrollProxy.scrollTo(newId, anchor: nil)
+                    }
+                }
+                }
             }
             SidebarFooter(updateViewModel: updateViewModel, onSendFeedback: onSendFeedback)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8828,8 +8828,11 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(Color.clear)
                 .modifier(ClearScrollBackground())
-                .onChange(of: tabManager.selectedTabId) { newId in
+                .onChange(of: tabManager.selectedTabId) { _, newId in
                     guard let newId else { return }
+                    #if DEBUG
+                    dlog("sidebar.scroll.selectedTab id=\(newId.uuidString.prefix(5))")
+                    #endif
                     withAnimation(.easeOut(duration: 0.15)) {
                         scrollProxy.scrollTo(newId, anchor: nil)
                     }


### PR DESCRIPTION
## Summary

- Wrap the sidebar `ScrollView` in `ScrollViewReader` and add `.onChange(of: tabManager.selectedTabId)` to scroll to the active tab
- When switching workspaces with Ctrl+Cmd+[ / Ctrl+Cmd+], the sidebar now auto-scrolls to keep the selected tab visible when sessions exceed the screen height
- Uses `anchor: nil` for minimal scrolling — no scroll when the tab is already visible

## Testing

- Built and launched tagged debug app (`reload.sh --tag fix-sidebar-scroll --launch`)
- Created 20+ workspaces to exceed sidebar height
- Verified Ctrl+Cmd+] scrolls sidebar down to follow selection
- Verified Ctrl+Cmd+[ scrolls sidebar up to follow selection
- Verified no unnecessary scrolling when selected tab is already visible

## Demo Video

https://github.com/user-attachments/assets/9d9ce4c9-67a2-4b4b-a70d-524ebe6fbd78

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sidebar now auto-scrolls to keep the selected tab visible when switching workspaces with Ctrl+Cmd+[ / Ctrl+Cmd+], even when the list exceeds screen height. Implemented with `ScrollViewReader` and the two-argument `.onChange` to scroll to `tabManager.selectedTabId` with a short ease-out animation (anchor: nil); adds a DEBUG log for scroll events.

<sup>Written for commit 86bf7560f1b68e19f578b74c42f2179e48a99cef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar now automatically scrolls the selected tab into view with a short ease-out animation and includes debug logging for selection changes.
* **Refactor**
  * Sidebar view hierarchy and scroll handling reorganized to ensure reliable programmatic scrolling and consistent overlays/background behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->