### PR TITLE
issue-2418-browser-input-keyboard use NSEvent to input text

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5896,12 +5896,33 @@ struct CMUXCLI {
                 throw CLIError(message: "browser input requires mouse|keyboard|touch")
             }
             let remainder = Array(subArgs.dropFirst())
+
+            if inputVerb == "keyboard" {
+                let (selector, args1) = parseOption(remainder, name: "--selector")
+                let (text, args2) = parseOption(args1, name: "--text")
+                let (key, args3) = parseOption(args2, name: "--key")
+                let snapshotAfter = hasFlag(args3, name: "--snapshot-after")
+                let leftover = args3.filter { $0 != "--snapshot-after" }
+                if let unknown = leftover.first {
+                    throw CLIError(message: "Unknown keyboard flag: \(unknown)")
+                }
+                guard (text == nil) != (key == nil) else {
+                    throw CLIError(message: "Exactly one of --text or --key must be provided")
+                }
+                var params: [String: Any] = ["surface_id": sid]
+                if let selector { params["selector"] = selector }
+                if let text { params["text"] = text }
+                if let key { params["key"] = key }
+                if snapshotAfter { params["snapshot_after"] = true }
+                let payload = try client.sendV2(method: "browser.input_keyboard", params: params)
+                output(payload, fallback: "OK")
+                return
+            }
+
             let method: String
             switch inputVerb {
             case "mouse":
                 method = "browser.input_mouse"
-            case "keyboard":
-                method = "browser.input_keyboard"
             case "touch":
                 method = "browser.input_touch"
             default:
@@ -13099,6 +13120,8 @@ struct CMUXCLI {
           browser type <selector> <text> [--snapshot-after]
           browser fill <selector> [text] [--snapshot-after]   (empty text clears input)
           browser press|keydown|keyup <key> [--snapshot-after]
+          browser input keyboard [--selector <css>] (--text <text> | --key <key>) [--snapshot-after]
+                               (native keyboard injection via NSEvent; compatible with React/Vue/Angular controlled inputs)
           browser select <selector> <value> [--snapshot-after]
           browser scroll [--selector <css>] [--dx <n>] [--dy <n>] [--snapshot-after]
           browser screenshot [--out <path>] [--json]

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3273,6 +3273,57 @@ final class BrowserPanel: Panel, ObservableObject {
         }
     }
 
+    /// Prepares the webView for a batch of native key events: suppresses omnibar autofocus and
+    /// makes webView first responder once, avoiding redundant setup per-character in text loops.
+    func prepareForKeyInjection() {
+        guard let window = webView.window else { return }
+        suppressOmnibarAutofocus(for: 0.5)
+        if !Self.responderChainContains(window.firstResponder, target: webView) {
+            window.makeFirstResponder(webView)
+        }
+    }
+
+    func injectNativeKeyEvent(
+        keyCode: UInt16,
+        characters: String,
+        charactersIgnoringModifiers: String,
+        modifierFlags: NSEvent.ModifierFlags
+    ) {
+        guard let window = webView.window else { return }
+
+        let timestamp = ProcessInfo.processInfo.systemUptime
+
+        guard let keyDown = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: timestamp,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        ) else { return }
+
+        webView.keyDown(with: keyDown)
+
+        guard let keyUp = NSEvent.keyEvent(
+            with: .keyUp,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: timestamp + 0.00005, // 50µs after keyDown
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        ) else { return }
+
+        webView.keyUp(with: keyUp)
+    }
+
     func unfocus() {
         invalidateSearchFocusRequests(reason: "panelUnfocus")
         guard let window = webView.window else { return }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10411,8 +10411,69 @@ class TerminalController {
         v2BrowserNotSupported("browser.input_mouse", details: "Raw CDP mouse injection is unavailable; use browser.click/hover/scroll")
     }
 
-    private func v2BrowserInputKeyboard(params _: [String: Any]) -> V2CallResult {
-        v2BrowserNotSupported("browser.input_keyboard", details: "Raw CDP keyboard injection is unavailable; use browser.press/keydown/keyup")
+    private func v2BrowserInputKeyboard(params: [String: Any]) -> V2CallResult {
+        let text = v2String(params, "text")
+        let keyRaw = v2String(params, "key")
+        let selector = v2String(params, "selector")
+
+        guard (text == nil) != (keyRaw == nil) else {
+            return .err(code: "invalid_params", message: "Exactly one of 'text' or 'key' must be provided", data: nil)
+        }
+
+        return v2BrowserWithPanel(params: params) { _, ws, surfaceId, browserPanel in
+            if let selector = selector {
+                let selectorLiteral = v2JSONLiteral(selector)
+                let focusScript = """
+                (() => {
+                  const el = document.querySelector(\(selectorLiteral));
+                  if (!el) return { ok: false, error: 'not_found' };
+                  el.focus();
+                  return { ok: true };
+                })()
+                """
+                switch v2RunBrowserJavaScript(browserPanel.webView, surfaceId: surfaceId, script: focusScript) {
+                case .failure(let message):
+                    return .err(code: "js_error", message: message, data: nil)
+                case .success:
+                    break
+                }
+            }
+
+            browserPanel.prepareForKeyInjection()
+
+            if let textToType = text {
+                for char in textToType {
+                    guard let parsed = parseBrowserKey(String(char)) else {
+                        return .err(code: "invalid_key", message: "Cannot parse character: \(char)", data: nil)
+                    }
+                    browserPanel.injectNativeKeyEvent(
+                        keyCode: parsed.keyCode,
+                        characters: parsed.characters,
+                        charactersIgnoringModifiers: parsed.charactersIgnoringModifiers,
+                        modifierFlags: parsed.modifierFlags
+                    )
+                }
+            } else if let keyRaw = keyRaw {
+                guard let parsed = parseBrowserKey(keyRaw) else {
+                    return .err(code: "invalid_key", message: "Unknown key: \(keyRaw)", data: nil)
+                }
+                browserPanel.injectNativeKeyEvent(
+                    keyCode: parsed.keyCode,
+                    characters: parsed.characters,
+                    charactersIgnoringModifiers: parsed.charactersIgnoringModifiers,
+                    modifierFlags: parsed.modifierFlags
+                )
+            }
+
+            var payload: [String: Any] = [
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId)
+            ]
+            v2BrowserAppendPostSnapshot(params: params, surfaceId: surfaceId, payload: &payload)
+            return .ok(payload)
+        }
     }
 
     private func v2BrowserInputTouch(params _: [String: Any]) -> V2CallResult {
@@ -12073,6 +12134,32 @@ class TerminalController {
         }
     }
 #endif
+
+    private func parseBrowserKey(_ rawKey: String) -> ParsedShortcutCombo? {
+        // Bare uppercase letter (e.g. 'H' from --text "Hello"): normalize to "Shift+h"
+        // so parseShortcutCombo produces the correct keyCode and modifierFlags.
+        let raw = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = (raw.count == 1 && raw.first?.isLetter == true && raw.first?.isUppercase == true)
+            ? "Shift+" + raw.lowercased()
+            : raw
+
+        guard let combo = parseShortcutCombo(normalized) else { return nil }
+
+        // parseShortcutCombo sets characters=storedKey (always lowercase for letters).
+        // For browser injection, characters must reflect the actual glyph the key produces:
+        // Shift+letter → uppercase; everything else → as-is.
+        guard combo.modifierFlags.contains(.shift),
+              combo.storedKey.count == 1,
+              combo.storedKey.first?.isLetter == true else { return combo }
+
+        return ParsedShortcutCombo(
+            storedKey: combo.storedKey,
+            keyCode: combo.keyCode,
+            modifierFlags: combo.modifierFlags,
+            characters: combo.storedKey.uppercased(),
+            charactersIgnoringModifiers: combo.storedKey
+        )
+    }
 
     #if !DEBUG
     private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {

--- a/tests_v2/test_browser_api_unsupported_matrix.py
+++ b/tests_v2/test_browser_api_unsupported_matrix.py
@@ -112,7 +112,6 @@ WKWEBVIEW_NOT_SUPPORTED = {
     "browser.screencast.start": {},
     "browser.screencast.stop": {},
     "browser.input_mouse": {"args": ["move", "10", "10"]},
-    "browser.input_keyboard": {"args": ["type", "hello"]},
     "browser.input_touch": {"args": ["tap", "10", "10"]},
 }
 


### PR DESCRIPTION
## Summary

cmux browser type and cmux browser fill inject text via JavaScript (dispatchEvent),
which does not work reliably with React controlled inputs. React's internal value tracking
does not recognize the synthetic event, causing it to overwrite the field with the previous
state value on the next render. The same issue affects Vue, Angular, and any framework that
relies on native browser input events.

cmux browser input keyboard exists in the CLI but is currently marked as not supported.


## Implementation
Use NSEvents to reliably create the correkt events. No more workarounds for react and similar frameworks required.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native keyboard input to the browser panel using macOS `NSEvent` so typing works reliably with controlled inputs (React/Vue/Angular). Introduces a new CLI path to send text or keys without JS dispatch.

- **New Features**
  - Adds `v2 browser.input_keyboard`: focuses an optional `--selector`, prepares the webview once, and injects native keyDown/keyUp for `--text` or a single `--key`; supports `--snapshot-after`.
  - New CLI: `browser input keyboard [--selector <css>] (--text <text> | --key <key>) [--snapshot-after]`; validates flags and updates help output.
  - `BrowserPanel` gains `prepareForKeyInjection` and `injectNativeKeyEvent` for `NSEvent`-based typing and proper first-responder handling.
  - Removes `browser.input_keyboard` from the unsupported API matrix tests.

<sup>Written for commit 7283ca32764b13924570d853c22b2a03fb2cd459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keyboard input is now fully functional for browser automation, supporting both text input and special key sequences
  * Enables optional DOM element selection for targeted keyboard events

* **Bug Fixes**
  * Resolved keyboard input operations that were previously marked as unsupported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->