### PR TITLE
fix: route new-workspace --command through workspace.create initial_command

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1703,17 +1703,15 @@ struct CMUXCLI {
                 let resolved = resolvePath(cwdOpt)
                 params["cwd"] = resolved
             }
+            if let commandOpt, !commandOpt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                params["initial_command"] = commandOpt
+            }
             if let nameOpt {
                 params["title"] = nameOpt
             }
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
             print("OK \(wsId)")
-            if let commandText = commandOpt, !wsId.isEmpty {
-                let text = unescapeSendText(commandText + "\\n")
-                let sendParams: [String: Any] = ["text": text, "workspace_id": wsId]
-                _ = try client.sendV2(method: "surface.send_text", params: sendParams)
-            }
 
         case "new-split":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
@@ -6409,7 +6407,7 @@ struct CMUXCLI {
             Flags:
               --name <title>    Set a custom name for the new workspace
               --cwd <path>      Set the working directory for the new workspace
-              --command <text>   Send text+Enter to the new workspace after creation
+              --command <text>  Run this as the new workspace's initial terminal command
 
             Example:
               cmux new-workspace

--- a/tests/test_cli_new_workspace_initial_command.py
+++ b/tests/test_cli_new_workspace_initial_command.py
@@ -20,22 +20,24 @@ WORKSPACE_REF = "workspace:1"
 
 class FakeCmuxState:
     def __init__(self) -> None:
+        self.lock = threading.Lock()
         self.requests: list[tuple[str, dict[str, object]]] = []
         self.workspace_create_params: dict[str, object] | None = None
         self.surface_send_text_params: dict[str, object] | None = None
 
     def handle(self, method: str, params: dict[str, object]) -> dict[str, object]:
-        self.requests.append((method, dict(params)))
-        if method == "workspace.create":
-            self.workspace_create_params = dict(params)
-            return {
-                "workspace_id": WORKSPACE_ID,
-                "workspace_ref": WORKSPACE_REF,
-            }
-        if method == "surface.send_text":
-            self.surface_send_text_params = dict(params)
-            return {"ok": True}
-        raise RuntimeError(f"Unsupported fake cmux method: {method}")
+        with self.lock:
+            self.requests.append((method, dict(params)))
+            if method == "workspace.create":
+                self.workspace_create_params = dict(params)
+                return {
+                    "workspace_id": WORKSPACE_ID,
+                    "workspace_ref": WORKSPACE_REF,
+                }
+            if method == "surface.send_text":
+                self.surface_send_text_params = dict(params)
+                return {"ok": True}
+            raise RuntimeError(f"Unsupported fake cmux method: {method}")
 
 
 class FakeCmuxUnixServer(socketserver.ThreadingUnixStreamServer):

--- a/tests/test_cli_new_workspace_initial_command.py
+++ b/tests/test_cli_new_workspace_initial_command.py
@@ -135,10 +135,17 @@ def main() -> int:
             "cwd": str(cwd),
             "initial_command": command_text,
         }
-        if state.workspace_create_params != expected_params:
+        observed_params = state.workspace_create_params
+        missing_or_mismatched = {
+            key: (expected_params[key], observed_params.get(key))
+            for key in expected_params
+            if observed_params.get(key) != expected_params[key]
+        }
+        if missing_or_mismatched:
             print(
                 "FAIL: workspace.create params mismatch "
-                f"expected={expected_params!r} observed={state.workspace_create_params!r}"
+                f"expected_subset={expected_params!r} observed={observed_params!r} "
+                f"diff={missing_or_mismatched!r}"
             )
             return 1
 

--- a/tests/test_cli_new_workspace_initial_command.py
+++ b/tests/test_cli_new_workspace_initial_command.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Regression: `new-workspace --command` should use `workspace.create.initial_command`."""
+
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+WORKSPACE_ID = "11111111-1111-4111-8111-111111111111"
+WORKSPACE_REF = "workspace:1"
+
+
+class FakeCmuxState:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, object]]] = []
+        self.workspace_create_params: dict[str, object] | None = None
+        self.surface_send_text_params: dict[str, object] | None = None
+
+    def handle(self, method: str, params: dict[str, object]) -> dict[str, object]:
+        self.requests.append((method, dict(params)))
+        if method == "workspace.create":
+            self.workspace_create_params = dict(params)
+            return {
+                "workspace_id": WORKSPACE_ID,
+                "workspace_ref": WORKSPACE_REF,
+            }
+        if method == "surface.send_text":
+            self.surface_send_text_params = dict(params)
+            return {"ok": True}
+        raise RuntimeError(f"Unsupported fake cmux method: {method}")
+
+
+class FakeCmuxUnixServer(socketserver.ThreadingUnixStreamServer):
+    allow_reuse_address = True
+
+    def __init__(self, socket_path: str, state: FakeCmuxState) -> None:
+        self.state = state
+        super().__init__(socket_path, FakeCmuxHandler)
+
+
+class FakeCmuxHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        while True:
+            line = self.rfile.readline()
+            if not line:
+                return
+            request = json.loads(line.decode("utf-8"))
+            response = {
+                "ok": True,
+                "result": self.server.state.handle(  # type: ignore[attr-defined]
+                    request["method"],
+                    request.get("params", {}),
+                ),
+                "id": request.get("id"),
+            }
+            self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
+            self.wfile.flush()
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-newws-cmd-") as td:
+        tmp = Path(td)
+        socket_path = tmp / "fake.sock"
+        cwd = tmp / "workspace"
+        cwd.mkdir(parents=True, exist_ok=True)
+
+        state = FakeCmuxState()
+        server = FakeCmuxUnixServer(str(socket_path), state)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        command_text = "echo hello > /tmp/cmux-1900-check.txt"
+        env = os.environ.copy()
+        env.pop("CMUX_WORKSPACE_ID", None)
+        env.pop("CMUX_SURFACE_ID", None)
+        env.pop("CMUX_TAB_ID", None)
+
+        try:
+            proc = subprocess.run(
+                [
+                    cli_path,
+                    "--socket",
+                    str(socket_path),
+                    "new-workspace",
+                    "--cwd",
+                    str(cwd),
+                    "--command",
+                    command_text,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            print("FAIL: `cmux new-workspace --command` timed out")
+            return 1
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        if proc.returncode != 0:
+            print("FAIL: `cmux new-workspace --command` exited non-zero")
+            print(f"exit={proc.returncode}")
+            print(f"stdout={proc.stdout.strip()}")
+            print(f"stderr={proc.stderr.strip()}")
+            return 1
+
+        output = (proc.stdout or "").strip()
+        if output != f"OK {WORKSPACE_REF}":
+            print(f"FAIL: expected workspace ref output, got {output!r}")
+            return 1
+
+        if state.workspace_create_params is None:
+            print("FAIL: CLI never called workspace.create")
+            return 1
+
+        expected_params = {
+            "cwd": str(cwd),
+            "initial_command": command_text,
+        }
+        if state.workspace_create_params != expected_params:
+            print(
+                "FAIL: workspace.create params mismatch "
+                f"expected={expected_params!r} observed={state.workspace_create_params!r}"
+            )
+            return 1
+
+        if state.surface_send_text_params is not None:
+            print(
+                "FAIL: new-workspace --command should not call surface.send_text "
+                f"observed={state.surface_send_text_params!r}"
+            )
+            return 1
+
+    print("PASS: new-workspace --command uses workspace.create initial_command")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`cmux new-workspace --command` currently creates the workspace first and then injects the command with `surface.send_text`.

This PR routes `--command` through `workspace.create.initial_command` instead.

## Why

`workspace.create` already supports `initial_command`, and cmux already threads that through the terminal startup path.

Using `surface.send_text` here is the wrong primitive:
- it depends on shell/editor keybinding state
- it breaks in vi-mode shells like fish with `fish_vi_key_bindings`
- it adds an avoidable second step after workspace creation

## Scope

This PR only changes `cmux new-workspace --command`.

It does not change:
- tmux compat
- `new-surface`
- `new-split`
- the broader direct-command work discussed in #1884

## Implementation

- populate `initial_command` in the `workspace.create` params for `new-workspace`
- remove the follow-up `surface.send_text` call for this path
- update the CLI help text so `--command` is described as an initial terminal command
- add a focused fake-socket CLI regression that verifies `workspace.create` receives `initial_command` and `surface.send_text` is not used

The existing runtime coverage in `tests_v2/test_cli_new_workspace_command_queue.py` still exercises the user-visible behavior that the command runs without selecting the new workspace.

Fixes #1900

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `cmux new-workspace --command` through `workspace.create.initial_command` to run the initial command reliably across shells, including vi-mode. Fixes #1900 and ignores empty/whitespace commands.

- **Bug Fixes**
  - Set `initial_command` in `workspace.create` only when `--command` is non-empty; stop calling `surface.send_text`.
  - Update CLI help to describe `--command` as the initial terminal command.
  - Add a fake-socket regression test with subset-based assertions and thread-safe state; verifies `workspace.create` includes `initial_command` and `surface.send_text` is not used.

<sup>Written for commit 1a0708846c836d285dc723f278acf74d41f08074. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now runs the provided --command as the new workspace’s initial terminal command during creation; help text for --command updated to reflect this behavior.
* **Tests**
  * Added a regression test ensuring the CLI includes the initial command in workspace creation and does not send the command as a separate post-creation "send text" action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->