### PR TITLE
Fix clipboard manager paste failing during focus transitions

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12948,8 +12948,9 @@ private extension NSWindow {
         var menuBypassGhosttyView = firstResponderGhosttyView
         if menuBypassGhosttyView == nil, self.firstResponder is NSWindow {
             if let terminalPanel = AppDelegate.shared?.tabManager?.selectedWorkspace?.focusedTerminalPanel,
-               let ghosttyNSView = Self.findGhosttyNSView(in: terminalPanel.hostedView) {
-                self.makeFirstResponder(ghosttyNSView)
+               let ghosttyNSView = Self.findGhosttyNSView(in: terminalPanel.hostedView),
+               ghosttyNSView.window === self,
+               self.makeFirstResponder(ghosttyNSView) {
                 menuBypassGhosttyView = ghosttyNSView
 #if DEBUG
                 dlog("  → focus-transition recovery: restored terminal as firstResponder")

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12939,7 +12939,25 @@ private extension NSWindow {
         // When the terminal is focused, skip the full NSWindow.performKeyEquivalent
         // (which walks the SwiftUI content view hierarchy) and dispatch Command-key
         // events directly to the main menu. This avoids the broken SwiftUI focus path.
-        if firstResponderGhosttyView != nil,
+        //
+        // When the first responder is the window itself (focus transition after
+        // a clipboard-manager overlay like Raycast/Tuna dismisses), restore the
+        // terminal as first responder before dispatching. Without this, the main
+        // menu can't validate items (no responder handles paste:/copy:) and the
+        // original performKeyEquivalent walks the broken SwiftUI focus path.
+        var menuBypassGhosttyView = firstResponderGhosttyView
+        if menuBypassGhosttyView == nil, self.firstResponder is NSWindow {
+            if let terminalPanel = AppDelegate.shared?.tabManager?.selectedWorkspace?.focusedTerminalPanel,
+               let ghosttyNSView = Self.findGhosttyNSView(in: terminalPanel.hostedView) {
+                self.makeFirstResponder(ghosttyNSView)
+                menuBypassGhosttyView = ghosttyNSView
+#if DEBUG
+                dlog("  → focus-transition recovery: restored terminal as firstResponder")
+#endif
+            }
+        }
+
+        if menuBypassGhosttyView != nil,
            shouldRouteCommandEquivalentDirectlyToMainMenu(event),
            let mainMenu = NSApp.mainMenu {
             let consumedByMenu = mainMenu.performKeyEquivalent(with: event)
@@ -12956,9 +12974,7 @@ private extension NSWindow {
                 )
             }
 #endif
-            if !consumedByMenu {
-                // Fall through to the original performKeyEquivalent path below.
-            } else {
+            if consumedByMenu {
 #if DEBUG
                 dlog("  → consumed by mainMenu (bypassed SwiftUI)")
 #endif
@@ -12971,6 +12987,18 @@ private extension NSWindow {
         if result { dlog("  → consumed by original performKeyEquivalent") }
 #endif
         return result
+    }
+
+    /// Walk the subview tree downward to find the GhosttyNSView inside a hosted view.
+    /// Unlike `cmuxOwningGhosttyView(for:)` which walks upward through superviews,
+    /// this walks downward — needed when starting from the GhosttySurfaceScrollView
+    /// container whose surfaceView property is private.
+    static func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
+        if let ghosttyView = view as? GhosttyNSView { return ghosttyView }
+        for subview in view.subviews {
+            if let found = findGhosttyNSView(in: subview) { return found }
+        }
+        return nil
     }
 
     static func keyDescription(_ event: NSEvent) -> String {


### PR DESCRIPTION
## Human Summary

Text below the horizontal line is written by Claude. This is my human summary: I've had issues with raycast clipboard history not working ( #2415 ). This PR was made by Claude, but I've verified that it actually fixes the issue, AND that `cmd-+ / − / 0` shortcuts to change zoom still work (commit making them work was the one that broke pasting). Feel free to reject / rewrite that, it is only as a proof of concept how this might be fixed.

----------

## Summary

- Fix clipboard manager paste (Cmd+V) failing when overlays like Raycast or Tuna dismiss and send a synthetic key event during a focus transition
- When the first responder is briefly the window itself (not the terminal), the main menu bypass doesn't fire — this detects that state and restores the terminal as first responder before dispatching

## Problem

When a clipboard manager overlay dismisses and sends a synthetic Cmd+V, the window regains key status before the terminal view becomes first responder. The first responder is briefly the `NSWindow` itself, so:
1. The main menu bypass doesn't fire (no terminal in the responder chain to validate `paste:`)
2. The event falls through to the SwiftUI view hierarchy which swallows it

## Fix

Detect when `firstResponder` is the window during a Command key equivalent, look up the focused terminal panel's `GhosttyNSView`, restore it as first responder, then dispatch to the main menu as usual.

Fixes #2415, related to #700

## Test plan

- [ ] Open cmux with a terminal focused
- [ ] Use Raycast/Tuna clipboard manager to paste — verify Cmd+V works
- [ ] Verify normal paste (without clipboard manager) still works
- [ ] Verify other Command shortcuts (Cmd+C, Cmd+T, etc.) are unaffected

🤖 *Posted by Claude Code*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable Command-key shortcut handling and menu navigation when a terminal is focused.

* **Behavior Changes**
  * Copy-on-select no longer forces an inline startup override.
  * Split terminals now defer working-directory inheritance to configuration (no forced split cwd).
  * Non-release app variants skip the automatic updater.
  * App variants with certain bundle IDs use variant-specific socket paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->