### PR TITLE
fix: stop swallowing ABC-QWERTZ / and ? in terminal input

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5600,6 +5600,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         }
 
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+
+        // Printable text without Command/Control should stay on the normal keyDown
+        // path. AppKit can still route layout-dependent punctuation through
+        // performKeyEquivalent first, and probing bindings here can misclassify
+        // keys such as ABC-QWERTZ Shift+7 ("/") or Shift+- ("?") as shortcuts.
+        if !flags.contains(.command),
+           !flags.contains(.control),
+           let text = textForKeyEvent(event),
+           shouldSendText(text) {
+            lastPerformKeyEvent = nil
+            return false
+        }
+
 #if DEBUG
         recordKeyLatency(path: "performKeyEquivalent", event: event)
 #endif

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1146,6 +1146,99 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
 }
 
 @MainActor
+final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
+    private func makeHostedTerminalWindow() throws -> (window: NSWindow, hostedView: GhosttySurfaceScrollView, surfaceView: GhosttyNSView) {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        let contentView = try XCTUnwrap(window.contentView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        let surfaceView = try XCTUnwrap(findGhosttyNSView(in: hostedView))
+        return (window, hostedView, surfaceView)
+    }
+
+    func testShiftSlashPrintableKeyEquivalentBypassesShortcutPath() throws {
+        let (window, _, surfaceView) = try makeHostedTerminalWindow()
+        defer { window.orderOut(nil) }
+
+        window.makeFirstResponder(surfaceView)
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "/",
+            charactersIgnoringModifiers: "/",
+            isARepeat: false,
+            keyCode: 26 // ABC-QWERTZ Shift+7
+        ) else {
+            XCTFail("Failed to construct Shift+/ event")
+            return
+        }
+
+        XCTAssertFalse(
+            window.performKeyEquivalent(with: event),
+            "Printable Shift+/ should continue through keyDown instead of being consumed as a key equivalent"
+        )
+    }
+
+    func testShiftQuestionMarkPrintableKeyEquivalentBypassesShortcutPath() throws {
+        let (window, _, surfaceView) = try makeHostedTerminalWindow()
+        defer { window.orderOut(nil) }
+
+        window.makeFirstResponder(surfaceView)
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "?",
+            charactersIgnoringModifiers: "?",
+            isARepeat: false,
+            keyCode: 27 // ABC-QWERTZ Shift+-
+        ) else {
+            XCTFail("Failed to construct Shift+? event")
+            return
+        }
+
+        XCTAssertFalse(
+            window.performKeyEquivalent(with: event),
+            "Printable Shift+? should continue through keyDown instead of being consumed as a key equivalent"
+        )
+    }
+}
+
+@MainActor
 final class GhosttyOptionDeleteRegressionTests: XCTestCase {
     func testOptionDeletePreservesAltAsModifierForWordDelete() {
         _ = NSApplication.shared

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1147,7 +1147,14 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
 
 @MainActor
 final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
-    private func makeHostedTerminalWindow() throws -> (window: NSWindow, hostedView: GhosttySurfaceScrollView, surfaceView: GhosttyNSView) {
+    private struct HostedTerminalWindow {
+        let surface: TerminalSurface
+        let window: NSWindow
+        let hostedView: GhosttySurfaceScrollView
+        let surfaceView: GhosttyNSView
+    }
+
+    private func makeHostedTerminalWindow() throws -> HostedTerminalWindow {
         _ = NSApplication.shared
 
         let surface = TerminalSurface(
@@ -1178,14 +1185,22 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         let surfaceView = try XCTUnwrap(findGhosttyNSView(in: hostedView))
-        return (window, hostedView, surfaceView)
+        return HostedTerminalWindow(
+            surface: surface,
+            window: window,
+            hostedView: hostedView,
+            surfaceView: surfaceView
+        )
     }
 
     func testShiftSlashPrintableKeyEquivalentBypassesShortcutPath() throws {
-        let (window, _, surfaceView) = try makeHostedTerminalWindow()
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
         defer { window.orderOut(nil) }
 
         window.makeFirstResponder(surfaceView)
+        XCTAssertNotNil(surfaceView.terminalSurface)
 
         guard let event = NSEvent.keyEvent(
             with: .keyDown,
@@ -1203,17 +1218,22 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(
-            window.performKeyEquivalent(with: event),
-            "Printable Shift+/ should continue through keyDown instead of being consumed as a key equivalent"
-        )
+        withExtendedLifetime(hostedTerminal.surface) {
+            XCTAssertFalse(
+                window.performKeyEquivalent(with: event),
+                "Printable Shift+/ should continue through keyDown instead of being consumed as a key equivalent"
+            )
+        }
     }
 
     func testShiftQuestionMarkPrintableKeyEquivalentBypassesShortcutPath() throws {
-        let (window, _, surfaceView) = try makeHostedTerminalWindow()
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
         defer { window.orderOut(nil) }
 
         window.makeFirstResponder(surfaceView)
+        XCTAssertNotNil(surfaceView.terminalSurface)
 
         guard let event = NSEvent.keyEvent(
             with: .keyDown,
@@ -1231,10 +1251,12 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(
-            window.performKeyEquivalent(with: event),
-            "Printable Shift+? should continue through keyDown instead of being consumed as a key equivalent"
-        )
+        withExtendedLifetime(hostedTerminal.surface) {
+            XCTAssertFalse(
+                window.performKeyEquivalent(with: event),
+                "Printable Shift+? should continue through keyDown instead of being consumed as a key equivalent"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/2432

## Summary
- add a regression covering printable shifted punctuation reaching the terminal key path
- bypass `performKeyEquivalent` for printable non-Command/non-Control text so layout-sensitive input stays on normal `keyDown` dispatch
- keep app-level shortcuts and control-key equivalents on the existing path

## Testing
- not run locally (per repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2432. Prevents ABC‑QWERTZ Shift+/ and Shift+? from being intercepted as shortcuts so they reach the terminal as text.

- **Bug Fixes**
  - In `performKeyEquivalent`, skip key-equivalent handling for printable text without Command/Control so it routes to `keyDown` (covers ABC‑QWERTZ Shift+7 "/" and Shift+- "?").
  - Added regression tests and fixed the terminal test host lifetime to ensure Shift+/ and Shift+? reliably bypass key equivalents.

<sup>Written for commit 67961d4b31fcf4ca41128d20f66e1f4a7317becc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Printable Shift key combinations (e.g., Shift+/ and Shift+?) are no longer intercepted by app shortcuts and are correctly delivered to the terminal.

* **Tests**
  * Added regression tests to ensure Shift-modified printable keys bypass shortcut handling and reach the terminal input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->