### PR TITLE
Add remote SSH Codex hook support

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -121,6 +121,23 @@
         }
       }
     },
+    "workspace.remoteDaemon.missingRequiredCapability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote daemon missing required capability %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートデーモンに必要な機能 %@ がありません"
+          }
+        }
+      }
+    },
     "cli.claude-teams.usage": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3219,6 +3219,19 @@ final class WorkspaceRemoteSessionController {
 
     private static let requiredCodexHooksCapability = "cli.codex.hooks"
 
+    private var requiresCodexHooksCapability: Bool {
+        guard let relayPort = configuration.relayPort, relayPort > 0,
+              let relayID = configuration.relayID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !relayID.isEmpty,
+              let relayToken = configuration.relayToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !relayToken.isEmpty,
+              let localSocketPath = configuration.localSocketPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !localSocketPath.isEmpty else {
+            return false
+        }
+        return true
+    }
+
     private var isStopping = false
     private var proxyLease: WorkspaceRemoteProxyBroker.Lease?
     private var proxyEndpoint: BrowserProxyEndpoint?
@@ -3354,9 +3367,15 @@ final class WorkspaceRemoteSessionController {
         publishDaemonStatus(.bootstrapping, detail: bootstrapDetail)
         do {
             let hello = try bootstrapDaemonLocked()
-            if let missingCapability = Self.firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) {
+            if let missingCapability = firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) {
                 throw NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
-                    NSLocalizedDescriptionKey: "remote daemon missing required capability \(missingCapability)",
+                    NSLocalizedDescriptionKey: String(
+                        format: String(
+                            localized: "workspace.remoteDaemon.missingRequiredCapability",
+                            defaultValue: "Remote daemon missing required capability %@"
+                        ),
+                        missingCapability
+                    ),
                 ])
             }
             daemonReady = true
@@ -3994,7 +4013,7 @@ final class WorkspaceRemoteSessionController {
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, remotePath: remotePath)
             hello = try helloRemoteDaemonLocked(remotePath: remotePath)
         }
-        if hadExistingBinary, Self.firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) != nil {
+        if hadExistingBinary, firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) != nil {
             debugLog("remote.bootstrap.capabilityMissing remotePath=\(remotePath) capabilities=\(hello.capabilities.joined(separator: ","))")
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, remotePath: remotePath)
@@ -4598,11 +4617,11 @@ final class WorkspaceRemoteSessionController {
         "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
-    private static func firstMissingRequiredRemoteDaemonCapability(in capabilities: [String]) -> String? {
-        let requiredCapabilities = [
-            WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability,
-            requiredCodexHooksCapability,
-        ]
+    private func firstMissingRequiredRemoteDaemonCapability(in capabilities: [String]) -> String? {
+        var requiredCapabilities = [WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability]
+        if requiresCodexHooksCapability {
+            requiredCapabilities.append(Self.requiredCodexHooksCapability)
+        }
         for capability in requiredCapabilities where !capabilities.contains(capability) {
             return capability
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3217,6 +3217,8 @@ final class WorkspaceRemoteSessionController {
     private let configuration: WorkspaceRemoteConfiguration
     private let controllerID: UUID
 
+    private static let requiredCodexHooksCapability = "cli.codex.hooks"
+
     private var isStopping = false
     private var proxyLease: WorkspaceRemoteProxyBroker.Lease?
     private var proxyEndpoint: BrowserProxyEndpoint?
@@ -3352,9 +3354,9 @@ final class WorkspaceRemoteSessionController {
         publishDaemonStatus(.bootstrapping, detail: bootstrapDetail)
         do {
             let hello = try bootstrapDaemonLocked()
-            guard hello.capabilities.contains(WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability) else {
+            if let missingCapability = Self.firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) {
                 throw NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
-                    NSLocalizedDescriptionKey: "remote daemon missing required capability \(WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability)",
+                    NSLocalizedDescriptionKey: "remote daemon missing required capability \(missingCapability)",
                 ])
             }
             daemonReady = true
@@ -3992,7 +3994,7 @@ final class WorkspaceRemoteSessionController {
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, remotePath: remotePath)
             hello = try helloRemoteDaemonLocked(remotePath: remotePath)
         }
-        if hadExistingBinary, !hello.capabilities.contains(WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability) {
+        if hadExistingBinary, Self.firstMissingRequiredRemoteDaemonCapability(in: hello.capabilities) != nil {
             debugLog("remote.bootstrap.capabilityMissing remotePath=\(remotePath) capabilities=\(hello.capabilities.joined(separator: ","))")
             let localBinary = try buildLocalDaemonBinary(goOS: platform.goOS, goArch: platform.goArch, version: version)
             try uploadRemoteDaemonBinaryLocked(localBinary: localBinary, remotePath: remotePath)
@@ -4596,6 +4598,17 @@ final class WorkspaceRemoteSessionController {
         "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
+    private static func firstMissingRequiredRemoteDaemonCapability(in capabilities: [String]) -> String? {
+        let requiredCapabilities = [
+            WorkspaceRemoteDaemonRPCClient.requiredProxyStreamCapability,
+            requiredCodexHooksCapability,
+        ]
+        for capability in requiredCapabilities where !capabilities.contains(capability) {
+            return capability
+        }
+        return nil
+    }
+
     static func remoteCLIWrapperScript() -> String {
         """
         #!/usr/bin/env bash
@@ -4657,6 +4670,7 @@ final class WorkspaceRemoteSessionController {
         CMUXRELAYAUTH
         chmod 600 "$HOME/.cmux/relay/\(relayPort).auth"
         printf '%s' '127.0.0.1:\(relayPort)' > "$HOME/.cmux/socket_addr"
+        CMUX_SOCKET_PATH='127.0.0.1:\(relayPort)' "$HOME/.cmux/bin/cmux" codex install-hooks --yes >/dev/null 2>&1 || true
         """
     }
 

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -176,6 +176,48 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: daemonPathURL.path))
     }
 
+    func testRemoteRelayMetadataInstallScriptRunsRemoteCodexHookInstall() throws {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory.appendingPathComponent("cmux-relay-install-\(UUID().uuidString)")
+        let fakeBinDir = home.appendingPathComponent("bin")
+        let fakeDaemonURL = fakeBinDir.appendingPathComponent("fake-cmuxd")
+        let daemonLogURL = home.appendingPathComponent("daemon.log")
+        defer { try? fileManager.removeItem(at: home) }
+
+        try fileManager.createDirectory(at: fakeBinDir, withIntermediateDirectories: true)
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '%s\\n' "$@" >> "\(daemonLogURL.path)"
+        """.write(to: fakeDaemonURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeDaemonURL.path)
+
+        let script = WorkspaceRemoteSessionController.remoteRelayMetadataInstallScript(
+            daemonRemotePath: "bin/fake-cmuxd",
+            relayPort: 64021,
+            relayID: "relay-id",
+            relayToken: String(repeating: "a", count: 64)
+        )
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: [
+                "HOME=\(home.path)",
+                "/bin/sh",
+                "-c",
+                script,
+            ],
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            try String(contentsOf: daemonLogURL, encoding: .utf8),
+            "codex\ninstall-hooks\n--yes\n"
+        )
+    }
+
     func testRelayZshBootstrapUsesRealHomeHistoryByDefault() throws {
         let histfile = try runRelayZshHistfile { home in
             try ":\n".write(to: home.appendingPathComponent(".zshenv"), atomically: true, encoding: .utf8)

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -124,6 +124,13 @@ doneFlags:
 		cliUsage()
 		return 0
 	}
+	if cmdName == "codex" {
+		return runCodexCommand(cmdArgs)
+	}
+	if cmdName == "codex-hook" && strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID")) == "" {
+		fmt.Println("{}")
+		return 0
+	}
 
 	// refreshAddr is set when the address came from socket_addr file (not env/flag),
 	// allowing one stale-address refresh if another workspace has replaced socket_addr.
@@ -153,6 +160,9 @@ doneFlags:
 	}
 	if cmdName == "omo" {
 		return runOMORelay(socketPath, cmdArgs, refreshAddr)
+	}
+	if cmdName == "codex-hook" {
+		return runCodexHookCommand(socketPath, cmdArgs, refreshAddr)
 	}
 
 	// Tmux compatibility layer (used by agent shims)
@@ -770,5 +780,7 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  browser <sub>             Browser commands (open, navigate, back, forward, reload, get-url)")
 	fmt.Fprintln(os.Stderr, "  claude-teams [args...]     Launch Claude Code in teammate mode")
 	fmt.Fprintln(os.Stderr, "  omo [args...]              Launch OpenCode with cmux integration")
+	fmt.Fprintln(os.Stderr, "  codex <sub>                Manage Codex hooks on this remote host")
+	fmt.Fprintln(os.Stderr, "  codex-hook <event>         Handle a Codex lifecycle hook")
 	fmt.Fprintln(os.Stderr, "  rpc <method> [json-params] Send arbitrary JSON-RPC")
 }

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -43,6 +43,33 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(output)
 }
 
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = original
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(output)
+}
+
 func withStdin(t *testing.T, input string, fn func()) {
 	t.Helper()
 	original := os.Stdin
@@ -619,7 +646,7 @@ func TestCLICodexInstallHooksDoesNotRequireSocket(t *testing.T) {
 	t.Setenv("CODEX_HOME", codexHome)
 	t.Setenv("CMUX_SOCKET_PATH", "")
 
-	code := runCLI([]string{"codex", "install-hooks"})
+	code := runCLI([]string{"codex", "install-hooks", "--yes"})
 	if code != 0 {
 		t.Fatalf("codex install-hooks should return 0, got %d", code)
 	}
@@ -638,6 +665,28 @@ func TestCLICodexInstallHooksDoesNotRequireSocket(t *testing.T) {
 	}
 	if !strings.Contains(string(configContent), "codex_hooks = true") {
 		t.Fatalf("expected config.toml to enable codex_hooks, got %q", string(configContent))
+	}
+
+	hooksInfo, err := os.Stat(filepath.Join(codexHome, "hooks.json"))
+	if err != nil {
+		t.Fatalf("stat hooks.json: %v", err)
+	}
+	if hooksInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("expected hooks.json mode 0600, got %#o", hooksInfo.Mode().Perm())
+	}
+	configInfo, err := os.Stat(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("stat config.toml: %v", err)
+	}
+	if configInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("expected config.toml mode 0600, got %#o", configInfo.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(codexHome)
+	if err != nil {
+		t.Fatalf("stat codex home: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("expected codex home mode 0700, got %#o", dirInfo.Mode().Perm())
 	}
 }
 
@@ -769,6 +818,97 @@ func TestCLICodexHookStopNotifiesTargetSurfaceAndSetsIdleStatus(t *testing.T) {
 	}
 	if statusPayload != "set_status codex Idle --icon=pause.circle.fill --color=#8E8E93 --tab=workspace-1" {
 		t.Fatalf("unexpected status payload: %q", statusPayload)
+	}
+}
+
+func TestCLICodexHookHelpDoesNotReadStdin(t *testing.T) {
+	t.Setenv("CMUX_SURFACE_ID", "surface-1")
+	stderr := captureStderr(t, func() {
+		code := runCLI([]string{"codex-hook", "--help"})
+		if code != 0 {
+			t.Fatalf("codex-hook help should return 0, got %d", code)
+		}
+	})
+	if !strings.Contains(stderr, "Usage: cmux codex-hook") {
+		t.Fatalf("expected help output, got %q", stderr)
+	}
+}
+
+func TestBuildCodexHooksContentRejectsMalformedJSON(t *testing.T) {
+	if _, err := buildCodexHooksContent("{not-json"); err == nil {
+		t.Fatal("expected malformed hooks.json to return an error")
+	}
+}
+
+func TestBuildCodexHooksContentPreservesUserManagedCompoundHooks(t *testing.T) {
+	existing := `{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmux codex-hook stop && my-notifier"
+          }
+        ]
+      }
+    ]
+  }
+}`
+	updated, err := buildCodexHooksContent(existing)
+	if err != nil {
+		t.Fatalf("build hooks content: %v", err)
+	}
+	if !strings.Contains(updated, "cmux codex-hook stop && my-notifier") {
+		t.Fatalf("expected user-managed hook to be preserved, got %q", updated)
+	}
+}
+
+func TestBuildConfigWithCodexHooksRemoteTouchesOnlyFeaturesSection(t *testing.T) {
+	content := strings.Join([]string{
+		"[model]",
+		`codex_hooks = false`,
+		"",
+		"[features]",
+		`other = true`,
+		"",
+	}, "\n")
+	updated := buildConfigWithCodexHooksRemote(content)
+	if !strings.Contains(updated, "[model]\ncodex_hooks = false") {
+		t.Fatalf("expected non-features codex_hooks to stay unchanged, got %q", updated)
+	}
+	if !strings.Contains(updated, "[features]\ncodex_hooks = true\nother = true") {
+		t.Fatalf("expected features section to gain codex_hooks, got %q", updated)
+	}
+}
+
+func TestBuildConfigWithoutCodexHooksRemoteTouchesOnlyFeaturesSection(t *testing.T) {
+	content := strings.Join([]string{
+		"[model]",
+		`codex_hooks = false`,
+		"",
+		"[features]",
+		`codex_hooks = true`,
+		`other = true`,
+		"",
+	}, "\n")
+	updated := buildConfigWithoutCodexHooksRemote(content)
+	if !strings.Contains(updated, "[model]\ncodex_hooks = false") {
+		t.Fatalf("expected non-features codex_hooks to stay unchanged, got %q", updated)
+	}
+	if strings.Contains(updated, "[features]\ncodex_hooks = true") {
+		t.Fatalf("expected features codex_hooks to be removed, got %q", updated)
+	}
+}
+
+func TestCodexHookSessionStoreLoadRejectsCorruptJSON(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "codex-hook-sessions.json")
+	if err := os.WriteFile(statePath, []byte("{oops"), 0o600); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+	store := &codexHookSessionStore{statePath: statePath}
+	if _, err := store.load(); err == nil {
+		t.Fatal("expected corrupt state to return an error")
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -43,6 +43,28 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(output)
 }
 
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	original := os.Stdin
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := writer.WriteString(input); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	os.Stdin = reader
+	defer func() {
+		os.Stdin = original
+		_ = reader.Close()
+	}()
+
+	fn()
+}
+
 func makeShortUnixSocketPath(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "cmuxd-")
@@ -592,6 +614,49 @@ func TestCLINoSocket(t *testing.T) {
 	}
 }
 
+func TestCLICodexInstallHooksDoesNotRequireSocket(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CMUX_SOCKET_PATH", "")
+
+	code := runCLI([]string{"codex", "install-hooks"})
+	if code != 0 {
+		t.Fatalf("codex install-hooks should return 0, got %d", code)
+	}
+
+	hooksContent, err := os.ReadFile(filepath.Join(codexHome, "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+	if !strings.Contains(string(hooksContent), "cmux codex-hook stop") {
+		t.Fatalf("expected hooks.json to install cmux-owned stop hook, got %q", string(hooksContent))
+	}
+
+	configContent, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if !strings.Contains(string(configContent), "codex_hooks = true") {
+		t.Fatalf("expected config.toml to enable codex_hooks, got %q", string(configContent))
+	}
+}
+
+func TestCLICodexHookWithoutSurfaceNoOpsWithoutSocket(t *testing.T) {
+	t.Setenv("CMUX_SURFACE_ID", "")
+	t.Setenv("CMUX_SOCKET_PATH", "")
+
+	output := captureStdout(t, func() {
+		code := runCLI([]string{"codex-hook", "stop"})
+		if code != 0 {
+			t.Fatalf("codex-hook should no-op outside cmux, got %d", code)
+		}
+	})
+
+	if strings.TrimSpace(output) != "{}" {
+		t.Fatalf("expected codex-hook no-op output, got %q", output)
+	}
+}
+
 func TestCLISocketEnvVar(t *testing.T) {
 	sockPath := startMockSocket(t, "pong")
 	os.Setenv("CMUX_SOCKET_PATH", sockPath)
@@ -600,6 +665,110 @@ func TestCLISocketEnvVar(t *testing.T) {
 	code := runCLI([]string{"ping"})
 	if code != 0 {
 		t.Fatalf("ping with env socket should return 0, got %d", code)
+	}
+}
+
+func TestCLICodexHookStopNotifiesTargetSurfaceAndSetsIdleStatus(t *testing.T) {
+	sockPath := makeShortUnixSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	received := make(chan string, 4)
+	go func() {
+		for i := 0; i < 2; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				buf := make([]byte, 4096)
+				n, _ := conn.Read(buf)
+				payload := strings.TrimSpace(string(buf[:n]))
+				received <- payload
+
+				if strings.HasPrefix(payload, "{") {
+					var req map[string]any
+					_ = json.Unmarshal(buf[:n], &req)
+					resp := map[string]any{"id": req["id"], "ok": true, "result": map[string]any{}}
+					encoded, _ := json.Marshal(resp)
+					_, _ = conn.Write(append(encoded, '\n'))
+					return
+				}
+
+				_, _ = conn.Write([]byte("OK\n"))
+			}(conn)
+		}
+	}()
+
+	t.Setenv("CMUX_SOCKET_PATH", sockPath)
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace-1")
+	t.Setenv("CMUX_SURFACE_ID", "surface-1")
+
+	withStdin(t, `{"session_id":"sess-1","cwd":"/tmp/research-proj","last_assistant_message":"Need your approval on the final patch."}`, func() {
+		output := captureStdout(t, func() {
+			code := runCLI([]string{"codex-hook", "stop"})
+			if code != 0 {
+				t.Fatalf("codex-hook stop should return 0, got %d", code)
+			}
+		})
+		if strings.TrimSpace(output) != "{}" {
+			t.Fatalf("expected codex-hook stop to print {}, got %q", output)
+		}
+	})
+
+	readReceived := func() string {
+		t.Helper()
+		select {
+		case payload := <-received:
+			return payload
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for codex-hook socket payload")
+			return ""
+		}
+	}
+
+	first := readReceived()
+	second := readReceived()
+
+	var requestPayload string
+	var statusPayload string
+	if strings.HasPrefix(first, "{") {
+		requestPayload = first
+		statusPayload = second
+	} else {
+		requestPayload = second
+		statusPayload = first
+	}
+
+	var request map[string]any
+	if err := json.Unmarshal([]byte(requestPayload), &request); err != nil {
+		t.Fatalf("decode notification request: %v", err)
+	}
+	if got := request["method"]; got != "notification.create_for_target" {
+		t.Fatalf("expected notification.create_for_target, got %v", got)
+	}
+	params, _ := request["params"].(map[string]any)
+	if got := params["workspace_id"]; got != "workspace-1" {
+		t.Fatalf("expected workspace_id workspace-1, got %v", got)
+	}
+	if got := params["surface_id"]; got != "surface-1" {
+		t.Fatalf("expected surface_id surface-1, got %v", got)
+	}
+	if got := params["title"]; got != "Codex" {
+		t.Fatalf("expected title Codex, got %v", got)
+	}
+	if got := params["subtitle"]; got != "Completed in research-proj" {
+		t.Fatalf("expected project subtitle, got %v", got)
+	}
+	if got := params["body"]; got != "Need your approval on the final patch." {
+		t.Fatalf("expected last assistant message body, got %v", got)
+	}
+	if statusPayload != "set_status codex Idle --icon=pause.circle.fill --color=#8E8E93 --tab=workspace-1" {
+		t.Fatalf("unexpected status payload: %q", statusPayload)
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/codex.go
+++ b/daemon/remote/cmd/cmuxd-remote/codex.go
@@ -1,0 +1,789 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type codexHookParsedInput struct {
+	rawInput   string
+	object     map[string]any
+	sessionID  string
+	cwd        string
+	transcript string
+}
+
+type codexHookSessionRecord struct {
+	SessionID    string  `json:"sessionId"`
+	WorkspaceID  string  `json:"workspaceId"`
+	SurfaceID    string  `json:"surfaceId"`
+	CWD          string  `json:"cwd,omitempty"`
+	LastSubtitle string  `json:"lastSubtitle,omitempty"`
+	LastBody     string  `json:"lastBody,omitempty"`
+	StartedAt    float64 `json:"startedAt"`
+	UpdatedAt    float64 `json:"updatedAt"`
+}
+
+type codexHookSessionStoreFile struct {
+	Version  int                               `json:"version"`
+	Sessions map[string]codexHookSessionRecord `json:"sessions"`
+}
+
+type codexHookSessionStore struct {
+	statePath string
+}
+
+const (
+	defaultCodexHookStatePath = "~/.cmuxterm/codex-hook-sessions.json"
+	codexHookMaxStateAge      = 7 * 24 * time.Hour
+)
+
+func runCodexCommand(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "cmux codex: requires a subcommand (install-hooks, uninstall-hooks)")
+		return 2
+	}
+
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "install-hooks":
+		if err := installCodexHooks(); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux codex: %v\n", err)
+			return 1
+		}
+		return 0
+	case "uninstall-hooks":
+		if err := uninstallCodexHooks(); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux codex: %v\n", err)
+			return 1
+		}
+		return 0
+	case "help", "--help", "-h":
+		fmt.Fprintln(os.Stderr, "Usage: cmux codex <install-hooks|uninstall-hooks>")
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "cmux codex: unknown subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func runCodexHookCommand(socketPath string, args []string, refreshAddr func() string) int {
+	if strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID")) == "" {
+		fmt.Println("{}")
+		return 0
+	}
+
+	subcommand := "help"
+	if len(args) > 0 {
+		subcommand = strings.ToLower(strings.TrimSpace(args[0]))
+	}
+
+	rawInputBytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux codex-hook: failed to read stdin: %v\n", err)
+		return 1
+	}
+	parsed := parseCodexHookInput(string(rawInputBytes))
+	store := newCodexHookSessionStore()
+
+	switch subcommand {
+	case "session-start":
+		workspaceID, surfaceID := codexHookContext(parsed.sessionID, store)
+		if parsed.sessionID != "" && workspaceID != "" {
+			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, parsed.cwd, "", ""); err != nil {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
+				return 1
+			}
+		}
+		fmt.Println("{}")
+		return 0
+
+	case "prompt-submit":
+		workspaceID, _ := codexHookContext(parsed.sessionID, store)
+		if workspaceID != "" {
+			if err := sendV1CommandRemote(socketPath, fmt.Sprintf("clear_notifications --tab=%s", workspaceID), refreshAddr); err != nil && !shouldIgnoreCodexHookError(err) {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
+				return 1
+			}
+			if err := setCodexStatusRemote(socketPath, workspaceID, "Running", "bolt.fill", "#4C8DFF", refreshAddr); err != nil && !shouldIgnoreCodexHookError(err) {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
+				return 1
+			}
+		}
+		fmt.Println("{}")
+		return 0
+
+	case "stop":
+		record, _ := store.lookup(parsed.sessionID)
+		workspaceID, surfaceID := codexHookContext(parsed.sessionID, store)
+		if record != nil {
+			if workspaceID == "" {
+				workspaceID = record.WorkspaceID
+			}
+			if surfaceID == "" {
+				surfaceID = record.SurfaceID
+			}
+		}
+
+		lastMessage := codexLastAssistantMessage(parsed.object)
+		if lastMessage != "" {
+			lastMessage = truncateCodexHook(normalizedSingleLineCodex(lastMessage), 200)
+		}
+		cwd := normalizeCodexHookString(parsed.cwd)
+		if cwd == "" && record != nil {
+			cwd = record.CWD
+		}
+
+		subtitle := "Completed"
+		if projectName := codexProjectName(cwd); projectName != "" {
+			subtitle = "Completed in " + projectName
+		}
+		body := lastMessage
+		if body == "" {
+			body = "Codex session completed"
+		}
+
+		if parsed.sessionID != "" && workspaceID != "" {
+			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, cwd, "Completed", lastMessage); err != nil {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
+				return 1
+			}
+		}
+
+		if workspaceID != "" {
+			var notifyErr error
+			if surfaceID != "" {
+				_, notifyErr = socketRoundTripV2(socketPath, "notification.create_for_target", map[string]any{
+					"workspace_id": workspaceID,
+					"surface_id":   surfaceID,
+					"title":        "Codex",
+					"subtitle":     subtitle,
+					"body":         body,
+				}, refreshAddr)
+			} else {
+				_, notifyErr = socketRoundTripV2(socketPath, "notification.create", map[string]any{
+					"workspace_id": workspaceID,
+					"title":        "Codex",
+					"subtitle":     subtitle,
+					"body":         body,
+				}, refreshAddr)
+			}
+			if notifyErr != nil && !shouldIgnoreCodexHookError(notifyErr) {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", notifyErr)
+				return 1
+			}
+
+			if err := setCodexStatusRemote(socketPath, workspaceID, "Idle", "pause.circle.fill", "#8E8E93", refreshAddr); err != nil && !shouldIgnoreCodexHookError(err) {
+				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
+				return 1
+			}
+		}
+		fmt.Println("{}")
+		return 0
+
+	case "help", "--help", "-h":
+		fmt.Fprintln(os.Stderr, "Usage: cmux codex-hook <session-start|prompt-submit|stop>")
+		return 0
+
+	default:
+		fmt.Fprintf(os.Stderr, "cmux codex-hook: unknown subcommand %q\n", subcommand)
+		return 2
+	}
+}
+
+func installCodexHooks() error {
+	codexHome := os.Getenv("CODEX_HOME")
+	if strings.TrimSpace(codexHome) == "" {
+		codexHome = "~/.codex"
+	}
+	codexHome = expandTildeCodex(codexHome)
+	hooksPath := filepath.Join(codexHome, "hooks.json")
+	configPath := filepath.Join(codexHome, "config.toml")
+
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		return err
+	}
+
+	existingHooksContent := readFileIfExists(hooksPath)
+	newHooksContent, err := buildCodexHooksContent(existingHooksContent)
+	if err != nil {
+		return err
+	}
+
+	existingConfigContent := readFileIfExists(configPath)
+	newConfigContent := buildConfigWithCodexHooksRemote(existingConfigContent)
+
+	hooksChanged := existingHooksContent != newHooksContent
+	configChanged := existingConfigContent != newConfigContent
+	if !hooksChanged && !configChanged {
+		fmt.Println("cmux hooks are already installed. Nothing to change.")
+		return nil
+	}
+
+	if hooksChanged {
+		if err := os.WriteFile(hooksPath, []byte(newHooksContent), 0o644); err != nil {
+			return err
+		}
+	}
+	if configChanged {
+		if err := os.WriteFile(configPath, []byte(newConfigContent), 0o644); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Installed. Hooks activate inside cmux and silently no-op elsewhere.")
+	return nil
+}
+
+func uninstallCodexHooks() error {
+	codexHome := os.Getenv("CODEX_HOME")
+	if strings.TrimSpace(codexHome) == "" {
+		codexHome = "~/.codex"
+	}
+	codexHome = expandTildeCodex(codexHome)
+	hooksPath := filepath.Join(codexHome, "hooks.json")
+	configPath := filepath.Join(codexHome, "config.toml")
+
+	existingHooksContent := readFileIfExists(hooksPath)
+	if existingHooksContent == "" && readFileIfExists(configPath) == "" {
+		fmt.Printf("No hooks.json found at %s\n", hooksPath)
+		return nil
+	}
+
+	newHooksContent, removedCount, err := buildCodexHooksContentWithoutCmux(existingHooksContent)
+	if err != nil {
+		return err
+	}
+	existingConfigContent := readFileIfExists(configPath)
+	newConfigContent := buildConfigWithoutCodexHooksRemote(existingConfigContent)
+	configChanged := existingConfigContent != newConfigContent
+	if removedCount == 0 && !configChanged {
+		fmt.Println("No cmux hooks found.")
+		return nil
+	}
+
+	if removedCount > 0 {
+		if err := os.WriteFile(hooksPath, []byte(newHooksContent), 0o644); err != nil {
+			return err
+		}
+	}
+	if configChanged {
+		if err := os.WriteFile(configPath, []byte(newConfigContent), 0o644); err != nil {
+			return err
+		}
+	}
+	fmt.Println("Removed cmux Codex hooks.")
+	return nil
+}
+
+func buildCodexHooksContent(existingContent string) (string, error) {
+	existing := map[string]any{}
+	if strings.TrimSpace(existingContent) != "" {
+		_ = json.Unmarshal([]byte(existingContent), &existing)
+	}
+
+	hooks, _ := existing["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	for eventName, cmuxGroups := range codexHooksDefinition() {
+		var eventGroups []map[string]any
+		if rawGroups, ok := hooks[eventName]; ok {
+			eventGroups = anySliceToMapSlice(rawGroups)
+		}
+		filtered := make([]map[string]any, 0, len(eventGroups)+len(cmuxGroups))
+		for _, group := range eventGroups {
+			if !codexGroupOwnedByCmux(group) {
+				filtered = append(filtered, group)
+			}
+		}
+		filtered = append(filtered, cmuxGroups...)
+		hooks[eventName] = filtered
+	}
+	existing["hooks"] = hooks
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
+}
+
+func buildCodexHooksContentWithoutCmux(existingContent string) (string, int, error) {
+	if strings.TrimSpace(existingContent) == "" {
+		return "", 0, nil
+	}
+
+	existing := map[string]any{}
+	if err := json.Unmarshal([]byte(existingContent), &existing); err != nil {
+		return "", 0, err
+	}
+	hooks, _ := existing["hooks"].(map[string]any)
+	if hooks == nil {
+		return existingContent, 0, nil
+	}
+
+	removedCount := 0
+	for eventName, rawGroups := range hooks {
+		groups := anySliceToMapSlice(rawGroups)
+		filtered := make([]map[string]any, 0, len(groups))
+		for _, group := range groups {
+			if codexGroupOwnedByCmux(group) {
+				removedCount++
+				continue
+			}
+			filtered = append(filtered, group)
+		}
+		if len(filtered) == 0 {
+			delete(hooks, eventName)
+			continue
+		}
+		hooks[eventName] = filtered
+	}
+	existing["hooks"] = hooks
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return "", 0, err
+	}
+	return string(data) + "\n", removedCount, nil
+}
+
+func codexHooksDefinition() map[string][]map[string]any {
+	return map[string][]map[string]any{
+		"SessionStart": {
+			{
+				"hooks": []map[string]any{{
+					"type":    "command",
+					"command": codexHookCommandRemote("session-start"),
+					"timeout": 10,
+				}},
+			},
+		},
+		"UserPromptSubmit": {
+			{
+				"hooks": []map[string]any{{
+					"type":    "command",
+					"command": codexHookCommandRemote("prompt-submit"),
+					"timeout": 10,
+				}},
+			},
+		},
+		"Stop": {
+			{
+				"hooks": []map[string]any{{
+					"type":    "command",
+					"command": codexHookCommandRemote("stop"),
+					"timeout": 10,
+				}},
+			},
+		},
+	}
+}
+
+func codexHookCommandRemote(event string) string {
+	return fmt.Sprintf(`[ -n "$CMUX_SURFACE_ID" ] && command -v cmux >/dev/null 2>&1 && cmux codex-hook %s || echo '{}'`, event)
+}
+
+func codexGroupOwnedByCmux(group map[string]any) bool {
+	rawHooks, ok := group["hooks"]
+	if !ok {
+		return false
+	}
+	hooks := anySliceToMapSlice(rawHooks)
+	if len(hooks) == 0 {
+		return false
+	}
+	for _, hook := range hooks {
+		command, _ := hook["command"].(string)
+		if !strings.Contains(command, "cmux codex-hook") {
+			return false
+		}
+	}
+	return true
+}
+
+func anySliceToMapSlice(value any) []map[string]any {
+	rawSlice, ok := value.([]any)
+	if !ok {
+		if typed, ok := value.([]map[string]any); ok {
+			return typed
+		}
+		return nil
+	}
+	result := make([]map[string]any, 0, len(rawSlice))
+	for _, item := range rawSlice {
+		if typed, ok := item.(map[string]any); ok {
+			result = append(result, typed)
+		}
+	}
+	return result
+}
+
+func buildConfigWithCodexHooksRemote(content string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if isTOMLKeyRemote(line, "codex_hooks") {
+			lines[i] = "codex_hooks = true"
+			return strings.Join(lines, "\n")
+		}
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "[features]" {
+			updated := append([]string{}, lines[:i+1]...)
+			updated = append(updated, "codex_hooks = true")
+			updated = append(updated, lines[i+1:]...)
+			return strings.Join(updated, "\n")
+		}
+	}
+	result := content
+	if result != "" && !strings.HasSuffix(result, "\n") {
+		result += "\n"
+	}
+	result += "\n[features]\ncodex_hooks = true\n"
+	return result
+}
+
+func buildConfigWithoutCodexHooksRemote(content string) string {
+	lines := strings.Split(content, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if !isTOMLKeyRemote(line, "codex_hooks") {
+			filtered = append(filtered, line)
+		}
+	}
+	for i, line := range filtered {
+		if strings.TrimSpace(line) != "[features]" {
+			continue
+		}
+		nextNonEmpty := -1
+		for j := i + 1; j < len(filtered); j++ {
+			if strings.TrimSpace(filtered[j]) != "" {
+				nextNonEmpty = j
+				break
+			}
+		}
+		if nextNonEmpty == -1 || strings.HasPrefix(strings.TrimSpace(filtered[nextNonEmpty]), "[") {
+			return strings.Join(append(filtered[:i], filtered[i+1:]...), "\n")
+		}
+		break
+	}
+	return strings.Join(filtered, "\n")
+}
+
+func isTOMLKeyRemote(line, key string) bool {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "#") || !strings.HasPrefix(trimmed, key) {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
+	return strings.HasPrefix(rest, "=")
+}
+
+func parseCodexHookInput(rawInput string) codexHookParsedInput {
+	trimmed := strings.TrimSpace(rawInput)
+	if trimmed == "" {
+		return codexHookParsedInput{rawInput: rawInput}
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &object); err != nil {
+		return codexHookParsedInput{rawInput: rawInput}
+	}
+	return codexHookParsedInput{
+		rawInput:   rawInput,
+		object:     object,
+		sessionID:  extractCodexSessionID(object),
+		cwd:        extractCodexCWD(object),
+		transcript: firstCodexString(object, "transcript_path", "transcriptPath"),
+	}
+}
+
+func extractCodexSessionID(object map[string]any) string {
+	if object == nil {
+		return ""
+	}
+	if id := firstCodexString(object, "session_id", "sessionId"); id != "" {
+		return id
+	}
+	if nested, ok := object["notification"].(map[string]any); ok {
+		if id := firstCodexString(nested, "session_id", "sessionId"); id != "" {
+			return id
+		}
+	}
+	if nested, ok := object["data"].(map[string]any); ok {
+		if id := firstCodexString(nested, "session_id", "sessionId"); id != "" {
+			return id
+		}
+	}
+	if session, ok := object["session"].(map[string]any); ok {
+		if id := firstCodexString(session, "id", "session_id", "sessionId"); id != "" {
+			return id
+		}
+	}
+	if context, ok := object["context"].(map[string]any); ok {
+		if id := firstCodexString(context, "session_id", "sessionId"); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func extractCodexCWD(object map[string]any) string {
+	cwdKeys := []string{"cwd", "working_directory", "workingDirectory", "project_dir", "projectDir"}
+	if object == nil {
+		return ""
+	}
+	if cwd := firstCodexString(object, cwdKeys...); cwd != "" {
+		return cwd
+	}
+	if nested, ok := object["notification"].(map[string]any); ok {
+		if cwd := firstCodexString(nested, cwdKeys...); cwd != "" {
+			return cwd
+		}
+	}
+	if nested, ok := object["data"].(map[string]any); ok {
+		if cwd := firstCodexString(nested, cwdKeys...); cwd != "" {
+			return cwd
+		}
+	}
+	if context, ok := object["context"].(map[string]any); ok {
+		if cwd := firstCodexString(context, cwdKeys...); cwd != "" {
+			return cwd
+		}
+	}
+	return ""
+}
+
+func codexLastAssistantMessage(object map[string]any) string {
+	if object == nil {
+		return ""
+	}
+	if message := firstCodexString(object, "last_assistant_message", "lastAssistantMessage"); message != "" {
+		return message
+	}
+	if nested, ok := object["data"].(map[string]any); ok {
+		if message := firstCodexString(nested, "last_assistant_message", "lastAssistantMessage"); message != "" {
+			return message
+		}
+	}
+	return ""
+}
+
+func firstCodexString(object map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := object[key]
+		if !ok {
+			continue
+		}
+		if typed, ok := value.(string); ok {
+			if trimmed := strings.TrimSpace(typed); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func newCodexHookSessionStore() *codexHookSessionStore {
+	override := strings.TrimSpace(os.Getenv("CMUX_CLAUDE_HOOK_STATE_PATH"))
+	if override != "" {
+		return &codexHookSessionStore{statePath: expandTildeCodex(override)}
+	}
+	return &codexHookSessionStore{statePath: expandTildeCodex(defaultCodexHookStatePath)}
+}
+
+func (s *codexHookSessionStore) lookup(sessionID string) (*codexHookSessionRecord, error) {
+	normalized := normalizeCodexHookString(sessionID)
+	if normalized == "" {
+		return nil, nil
+	}
+	state, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	record, ok := state.Sessions[normalized]
+	if !ok {
+		return nil, nil
+	}
+	return &record, nil
+}
+
+func (s *codexHookSessionStore) upsert(sessionID, workspaceID, surfaceID, cwd, lastSubtitle, lastBody string) error {
+	normalized := normalizeCodexHookString(sessionID)
+	if normalized == "" {
+		return nil
+	}
+	state, err := s.load()
+	if err != nil {
+		return err
+	}
+	now := float64(time.Now().Unix())
+	record, ok := state.Sessions[normalized]
+	if !ok {
+		record = codexHookSessionRecord{
+			SessionID:   normalized,
+			WorkspaceID: normalizeCodexHookString(workspaceID),
+			SurfaceID:   normalizeCodexHookString(surfaceID),
+			StartedAt:   now,
+			UpdatedAt:   now,
+		}
+	}
+	record.WorkspaceID = normalizeCodexHookString(workspaceID)
+	if normalizedSurfaceID := normalizeCodexHookString(surfaceID); normalizedSurfaceID != "" {
+		record.SurfaceID = normalizedSurfaceID
+	}
+	if normalizedCWD := normalizeCodexHookString(cwd); normalizedCWD != "" {
+		record.CWD = normalizedCWD
+	}
+	if normalizedSubtitle := normalizeCodexHookString(lastSubtitle); normalizedSubtitle != "" {
+		record.LastSubtitle = normalizedSubtitle
+	}
+	if normalizedBody := normalizeCodexHookString(lastBody); normalizedBody != "" {
+		record.LastBody = normalizedBody
+	}
+	record.UpdatedAt = now
+	state.Sessions[normalized] = record
+	return s.save(state)
+}
+
+func (s *codexHookSessionStore) load() (*codexHookSessionStoreFile, error) {
+	state := &codexHookSessionStoreFile{
+		Version:  1,
+		Sessions: map[string]codexHookSessionRecord{},
+	}
+	data, err := os.ReadFile(s.statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return nil, err
+	}
+	_ = json.Unmarshal(data, state)
+	if state.Sessions == nil {
+		state.Sessions = map[string]codexHookSessionRecord{}
+	}
+	now := time.Now().Add(-codexHookMaxStateAge).Unix()
+	for sessionID, record := range state.Sessions {
+		if int64(record.UpdatedAt) < now {
+			delete(state.Sessions, sessionID)
+		}
+	}
+	return state, nil
+}
+
+func (s *codexHookSessionStore) save(state *codexHookSessionStoreFile) error {
+	parentDir := filepath.Dir(s.statePath)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.statePath, append(data, '\n'), 0o644)
+}
+
+func codexHookContext(sessionID string, store *codexHookSessionStore) (string, string) {
+	var workspaceID string
+	var surfaceID string
+	if record, err := store.lookup(sessionID); err == nil && record != nil {
+		workspaceID = record.WorkspaceID
+		surfaceID = record.SurfaceID
+	}
+	if workspaceID == "" {
+		workspaceID = normalizeCodexHookString(os.Getenv("CMUX_WORKSPACE_ID"))
+	}
+	if surfaceID == "" {
+		surfaceID = normalizeCodexHookString(os.Getenv("CMUX_SURFACE_ID"))
+	}
+	return workspaceID, surfaceID
+}
+
+func setCodexStatusRemote(socketPath, workspaceID, value, icon, color string, refreshAddr func() string) error {
+	command := fmt.Sprintf("set_status codex %s --icon=%s --color=%s --tab=%s", value, icon, color, workspaceID)
+	return sendV1CommandRemote(socketPath, command, refreshAddr)
+}
+
+func sendV1CommandRemote(socketPath, command string, refreshAddr func() string) error {
+	response, err := socketRoundTrip(socketPath, command, refreshAddr)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(response, "ERROR:") {
+		return fmt.Errorf("%s", response)
+	}
+	return nil
+}
+
+func shouldIgnoreCodexHookError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "tabmanager not available") ||
+		strings.Contains(lower, "server error [unavailable]") ||
+		strings.Contains(lower, "workspace not found") ||
+		strings.Contains(lower, "surface not found")
+}
+
+func codexProjectName(cwd string) string {
+	normalized := normalizeCodexHookString(cwd)
+	if normalized == "" {
+		return ""
+	}
+	expanded := expandTildeCodex(normalized)
+	base := filepath.Base(expanded)
+	if base == "." || base == string(filepath.Separator) {
+		return expanded
+	}
+	return base
+}
+
+func normalizedSingleLineCodex(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func truncateCodexHook(value string, maxLength int) string {
+	runes := []rune(value)
+	if len(runes) <= maxLength {
+		return value
+	}
+	if maxLength <= 1 {
+		return "…"
+	}
+	return string(runes[:maxLength-1]) + "…"
+}
+
+func normalizeCodexHookString(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func expandTildeCodex(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || trimmed[0] != '~' {
+		return trimmed
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return trimmed
+	}
+	if trimmed == "~" {
+		return home
+	}
+	if strings.HasPrefix(trimmed, "~/") {
+		return filepath.Join(home, strings.TrimPrefix(trimmed, "~/"))
+	}
+	return trimmed
+}
+
+func readFileIfExists(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/daemon/remote/cmd/cmuxd-remote/codex.go
+++ b/daemon/remote/cmd/cmuxd-remote/codex.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -19,14 +20,12 @@ type codexHookParsedInput struct {
 }
 
 type codexHookSessionRecord struct {
-	SessionID    string  `json:"sessionId"`
-	WorkspaceID  string  `json:"workspaceId"`
-	SurfaceID    string  `json:"surfaceId"`
-	CWD          string  `json:"cwd,omitempty"`
-	LastSubtitle string  `json:"lastSubtitle,omitempty"`
-	LastBody     string  `json:"lastBody,omitempty"`
-	StartedAt    float64 `json:"startedAt"`
-	UpdatedAt    float64 `json:"updatedAt"`
+	SessionID   string  `json:"sessionId"`
+	WorkspaceID string  `json:"workspaceId"`
+	SurfaceID   string  `json:"surfaceId"`
+	CWD         string  `json:"cwd,omitempty"`
+	StartedAt   float64 `json:"startedAt"`
+	UpdatedAt   float64 `json:"updatedAt"`
 }
 
 type codexHookSessionStoreFile struct {
@@ -43,6 +42,8 @@ const (
 	codexHookMaxStateAge      = 7 * 24 * time.Hour
 )
 
+var codexHookEvents = []string{"session-start", "prompt-submit", "stop"}
+
 func runCodexCommand(args []string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "cmux codex: requires a subcommand (install-hooks, uninstall-hooks)")
@@ -51,7 +52,7 @@ func runCodexCommand(args []string) int {
 
 	switch strings.ToLower(strings.TrimSpace(args[0])) {
 	case "install-hooks":
-		if err := installCodexHooks(); err != nil {
+		if err := installCodexHooks(args[1:]); err != nil {
 			fmt.Fprintf(os.Stderr, "cmux codex: %v\n", err)
 			return 1
 		}
@@ -82,6 +83,16 @@ func runCodexHookCommand(socketPath string, args []string, refreshAddr func() st
 		subcommand = strings.ToLower(strings.TrimSpace(args[0]))
 	}
 
+	switch subcommand {
+	case "session-start", "prompt-submit", "stop":
+	case "help", "--help", "-h":
+		fmt.Fprintln(os.Stderr, "Usage: cmux codex-hook <session-start|prompt-submit|stop>")
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "cmux codex-hook: unknown subcommand %q\n", subcommand)
+		return 2
+	}
+
 	rawInputBytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmux codex-hook: failed to read stdin: %v\n", err)
@@ -94,7 +105,7 @@ func runCodexHookCommand(socketPath string, args []string, refreshAddr func() st
 	case "session-start":
 		workspaceID, surfaceID := codexHookContext(parsed.sessionID, store)
 		if parsed.sessionID != "" && workspaceID != "" {
-			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, parsed.cwd, "", ""); err != nil {
+			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, parsed.cwd); err != nil {
 				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
 				return 1
 			}
@@ -148,7 +159,7 @@ func runCodexHookCommand(socketPath string, args []string, refreshAddr func() st
 		}
 
 		if parsed.sessionID != "" && workspaceID != "" {
-			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, cwd, "Completed", lastMessage); err != nil {
+			if err := store.upsert(parsed.sessionID, workspaceID, surfaceID, cwd); err != nil {
 				fmt.Fprintf(os.Stderr, "cmux codex-hook: %v\n", err)
 				return 1
 			}
@@ -184,18 +195,22 @@ func runCodexHookCommand(socketPath string, args []string, refreshAddr func() st
 		}
 		fmt.Println("{}")
 		return 0
-
-	case "help", "--help", "-h":
-		fmt.Fprintln(os.Stderr, "Usage: cmux codex-hook <session-start|prompt-submit|stop>")
-		return 0
-
-	default:
-		fmt.Fprintf(os.Stderr, "cmux codex-hook: unknown subcommand %q\n", subcommand)
-		return 2
 	}
+
+	return 0
 }
 
-func installCodexHooks() error {
+func installCodexHooks(args []string) error {
+	for _, arg := range args {
+		trimmed := strings.TrimSpace(arg)
+		switch trimmed {
+		case "", "--yes":
+			continue
+		default:
+			return fmt.Errorf("unknown flag %q", arg)
+		}
+	}
+
 	codexHome := os.Getenv("CODEX_HOME")
 	if strings.TrimSpace(codexHome) == "" {
 		codexHome = "~/.codex"
@@ -204,7 +219,7 @@ func installCodexHooks() error {
 	hooksPath := filepath.Join(codexHome, "hooks.json")
 	configPath := filepath.Join(codexHome, "config.toml")
 
-	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+	if err := os.MkdirAll(codexHome, 0o700); err != nil {
 		return err
 	}
 
@@ -225,12 +240,12 @@ func installCodexHooks() error {
 	}
 
 	if hooksChanged {
-		if err := os.WriteFile(hooksPath, []byte(newHooksContent), 0o644); err != nil {
+		if err := writeFileAtomic(hooksPath, []byte(newHooksContent), 0o600); err != nil {
 			return err
 		}
 	}
 	if configChanged {
-		if err := os.WriteFile(configPath, []byte(newConfigContent), 0o644); err != nil {
+		if err := writeFileAtomic(configPath, []byte(newConfigContent), 0o600); err != nil {
 			return err
 		}
 	}
@@ -267,12 +282,12 @@ func uninstallCodexHooks() error {
 	}
 
 	if removedCount > 0 {
-		if err := os.WriteFile(hooksPath, []byte(newHooksContent), 0o644); err != nil {
+		if err := writeFileAtomic(hooksPath, []byte(newHooksContent), 0o600); err != nil {
 			return err
 		}
 	}
 	if configChanged {
-		if err := os.WriteFile(configPath, []byte(newConfigContent), 0o644); err != nil {
+		if err := writeFileAtomic(configPath, []byte(newConfigContent), 0o600); err != nil {
 			return err
 		}
 	}
@@ -283,7 +298,9 @@ func uninstallCodexHooks() error {
 func buildCodexHooksContent(existingContent string) (string, error) {
 	existing := map[string]any{}
 	if strings.TrimSpace(existingContent) != "" {
-		_ = json.Unmarshal([]byte(existingContent), &existing)
+		if err := json.Unmarshal([]byte(existingContent), &existing); err != nil {
+			return "", fmt.Errorf("invalid hooks.json: %w", err)
+		}
 	}
 
 	hooks, _ := existing["hooks"].(map[string]any)
@@ -359,7 +376,7 @@ func codexHooksDefinition() map[string][]map[string]any {
 			{
 				"hooks": []map[string]any{{
 					"type":    "command",
-					"command": codexHookCommandRemote("session-start"),
+					"command": codexOwnedHookCommandRemote("session-start"),
 					"timeout": 10,
 				}},
 			},
@@ -368,7 +385,7 @@ func codexHooksDefinition() map[string][]map[string]any {
 			{
 				"hooks": []map[string]any{{
 					"type":    "command",
-					"command": codexHookCommandRemote("prompt-submit"),
+					"command": codexOwnedHookCommandRemote("prompt-submit"),
 					"timeout": 10,
 				}},
 			},
@@ -377,7 +394,7 @@ func codexHooksDefinition() map[string][]map[string]any {
 			{
 				"hooks": []map[string]any{{
 					"type":    "command",
-					"command": codexHookCommandRemote("stop"),
+					"command": codexOwnedHookCommandRemote("stop"),
 					"timeout": 10,
 				}},
 			},
@@ -387,6 +404,10 @@ func codexHooksDefinition() map[string][]map[string]any {
 
 func codexHookCommandRemote(event string) string {
 	return fmt.Sprintf(`[ -n "$CMUX_SURFACE_ID" ] && command -v cmux >/dev/null 2>&1 && cmux codex-hook %s || echo '{}'`, event)
+}
+
+func codexOwnedHookCommandRemote(event string) string {
+	return codexHookCommandRemote(event) + " # cmux-managed"
 }
 
 func codexGroupOwnedByCmux(group map[string]any) bool {
@@ -400,11 +421,27 @@ func codexGroupOwnedByCmux(group map[string]any) bool {
 	}
 	for _, hook := range hooks {
 		command, _ := hook["command"].(string)
-		if !strings.Contains(command, "cmux codex-hook") {
+		if !codexCommandOwnedByCmux(command) {
 			return false
 		}
 	}
 	return true
+}
+
+func codexCommandOwnedByCmux(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasSuffix(trimmed, "# cmux-managed") {
+		return true
+	}
+	for _, event := range codexHookEvents {
+		if trimmed == codexHookCommandRemote(event) {
+			return true
+		}
+	}
+	return false
 }
 
 func anySliceToMapSlice(value any) []map[string]any {
@@ -426,19 +463,19 @@ func anySliceToMapSlice(value any) []map[string]any {
 
 func buildConfigWithCodexHooksRemote(content string) string {
 	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		if isTOMLKeyRemote(line, "codex_hooks") {
-			lines[i] = "codex_hooks = true"
-			return strings.Join(lines, "\n")
+	sectionRanges := tomlSectionRanges(lines)
+	if featuresRange, ok := sectionRanges["features"]; ok {
+		for i := featuresRange.start; i < featuresRange.end; i++ {
+			if isTOMLKeyRemote(lines[i], "codex_hooks") {
+				lines[i] = "codex_hooks = true"
+				return strings.Join(lines, "\n")
+			}
 		}
-	}
-	for i, line := range lines {
-		if strings.TrimSpace(line) == "[features]" {
-			updated := append([]string{}, lines[:i+1]...)
-			updated = append(updated, "codex_hooks = true")
-			updated = append(updated, lines[i+1:]...)
-			return strings.Join(updated, "\n")
-		}
+		insertAt := featuresRange.end
+		updated := append([]string{}, lines[:insertAt]...)
+		updated = append(updated, "codex_hooks = true")
+		updated = append(updated, lines[insertAt:]...)
+		return strings.Join(updated, "\n")
 	}
 	result := content
 	if result != "" && !strings.HasSuffix(result, "\n") {
@@ -450,27 +487,39 @@ func buildConfigWithCodexHooksRemote(content string) string {
 
 func buildConfigWithoutCodexHooksRemote(content string) string {
 	lines := strings.Split(content, "\n")
-	filtered := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if !isTOMLKeyRemote(line, "codex_hooks") {
-			filtered = append(filtered, line)
-		}
+	sectionRanges := tomlSectionRanges(lines)
+	featuresRange, ok := sectionRanges["features"]
+	if !ok {
+		return content
 	}
-	for i, line := range filtered {
-		if strings.TrimSpace(line) != "[features]" {
-			continue
-		}
-		nextNonEmpty := -1
-		for j := i + 1; j < len(filtered); j++ {
-			if strings.TrimSpace(filtered[j]) != "" {
-				nextNonEmpty = j
-				break
+
+	featuresHasContent := false
+	for i, line := range lines {
+		if i >= featuresRange.start && i < featuresRange.end {
+			trimmed := strings.TrimSpace(line)
+			if isTOMLKeyRemote(line, "codex_hooks") {
+				continue
+			}
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				featuresHasContent = true
 			}
 		}
-		if nextNonEmpty == -1 || strings.HasPrefix(strings.TrimSpace(filtered[nextNonEmpty]), "[") {
-			return strings.Join(append(filtered[:i], filtered[i+1:]...), "\n")
+	}
+
+	filtered := make([]string, 0, len(lines))
+	removingFeaturesHeader := !featuresHasContent
+	for i, line := range lines {
+		if removingFeaturesHeader && i == featuresRange.headerIndex {
+			continue
 		}
-		break
+		if i >= featuresRange.start && i < featuresRange.end && isTOMLKeyRemote(line, "codex_hooks") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	if featuresHasContent {
+		return strings.Join(filtered, "\n")
 	}
 	return strings.Join(filtered, "\n")
 }
@@ -482,6 +531,55 @@ func isTOMLKeyRemote(line, key string) bool {
 	}
 	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
 	return strings.HasPrefix(rest, "=")
+}
+
+type tomlSectionRange struct {
+	headerIndex int
+	start       int
+	end         int
+}
+
+func tomlSectionRanges(lines []string) map[string]tomlSectionRange {
+	ranges := map[string]tomlSectionRange{}
+	currentName := ""
+	currentHeader := -1
+	currentStart := -1
+	for i, line := range lines {
+		sectionName, ok := parseTOMLSectionName(line)
+		if !ok {
+			continue
+		}
+		if currentName != "" {
+			ranges[currentName] = tomlSectionRange{
+				headerIndex: currentHeader,
+				start:       currentStart,
+				end:         i,
+			}
+		}
+		currentName = sectionName
+		currentHeader = i
+		currentStart = i + 1
+	}
+	if currentName != "" {
+		ranges[currentName] = tomlSectionRange{
+			headerIndex: currentHeader,
+			start:       currentStart,
+			end:         len(lines),
+		}
+	}
+	return ranges
+}
+
+func parseTOMLSectionName(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "[[") || !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+		return "", false
+	}
+	name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	if name == "" || strings.Contains(name, ".") {
+		return "", false
+	}
+	return name, true
 }
 
 func parseCodexHookInput(rawInput string) codexHookParsedInput {
@@ -601,53 +699,47 @@ func (s *codexHookSessionStore) lookup(sessionID string) (*codexHookSessionRecor
 	if normalized == "" {
 		return nil, nil
 	}
-	state, err := s.load()
-	if err != nil {
-		return nil, err
-	}
-	record, ok := state.Sessions[normalized]
-	if !ok {
-		return nil, nil
-	}
-	return &record, nil
+	var record *codexHookSessionRecord
+	err := s.withLockedState(true, func(state *codexHookSessionStoreFile) error {
+		stored, ok := state.Sessions[normalized]
+		if !ok {
+			return nil
+		}
+		copyRecord := stored
+		record = &copyRecord
+		return nil
+	})
+	return record, err
 }
 
-func (s *codexHookSessionStore) upsert(sessionID, workspaceID, surfaceID, cwd, lastSubtitle, lastBody string) error {
+func (s *codexHookSessionStore) upsert(sessionID, workspaceID, surfaceID, cwd string) error {
 	normalized := normalizeCodexHookString(sessionID)
 	if normalized == "" {
 		return nil
 	}
-	state, err := s.load()
-	if err != nil {
-		return err
-	}
-	now := float64(time.Now().Unix())
-	record, ok := state.Sessions[normalized]
-	if !ok {
-		record = codexHookSessionRecord{
-			SessionID:   normalized,
-			WorkspaceID: normalizeCodexHookString(workspaceID),
-			SurfaceID:   normalizeCodexHookString(surfaceID),
-			StartedAt:   now,
-			UpdatedAt:   now,
+	return s.withLockedState(false, func(state *codexHookSessionStoreFile) error {
+		now := float64(time.Now().Unix())
+		record, ok := state.Sessions[normalized]
+		if !ok {
+			record = codexHookSessionRecord{
+				SessionID:   normalized,
+				WorkspaceID: normalizeCodexHookString(workspaceID),
+				SurfaceID:   normalizeCodexHookString(surfaceID),
+				StartedAt:   now,
+				UpdatedAt:   now,
+			}
 		}
-	}
-	record.WorkspaceID = normalizeCodexHookString(workspaceID)
-	if normalizedSurfaceID := normalizeCodexHookString(surfaceID); normalizedSurfaceID != "" {
-		record.SurfaceID = normalizedSurfaceID
-	}
-	if normalizedCWD := normalizeCodexHookString(cwd); normalizedCWD != "" {
-		record.CWD = normalizedCWD
-	}
-	if normalizedSubtitle := normalizeCodexHookString(lastSubtitle); normalizedSubtitle != "" {
-		record.LastSubtitle = normalizedSubtitle
-	}
-	if normalizedBody := normalizeCodexHookString(lastBody); normalizedBody != "" {
-		record.LastBody = normalizedBody
-	}
-	record.UpdatedAt = now
-	state.Sessions[normalized] = record
-	return s.save(state)
+		record.WorkspaceID = normalizeCodexHookString(workspaceID)
+		if normalizedSurfaceID := normalizeCodexHookString(surfaceID); normalizedSurfaceID != "" {
+			record.SurfaceID = normalizedSurfaceID
+		}
+		if normalizedCWD := normalizeCodexHookString(cwd); normalizedCWD != "" {
+			record.CWD = normalizedCWD
+		}
+		record.UpdatedAt = now
+		state.Sessions[normalized] = record
+		return nil
+	})
 }
 
 func (s *codexHookSessionStore) load() (*codexHookSessionStoreFile, error) {
@@ -662,7 +754,12 @@ func (s *codexHookSessionStore) load() (*codexHookSessionStoreFile, error) {
 		}
 		return nil, err
 	}
-	_ = json.Unmarshal(data, state)
+	if len(data) == 0 {
+		return state, nil
+	}
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, fmt.Errorf("decode hook state: %w", err)
+	}
 	if state.Sessions == nil {
 		state.Sessions = map[string]codexHookSessionRecord{}
 	}
@@ -677,14 +774,82 @@ func (s *codexHookSessionStore) load() (*codexHookSessionStoreFile, error) {
 
 func (s *codexHookSessionStore) save(state *codexHookSessionStoreFile) error {
 	parentDir := filepath.Dir(s.statePath)
-	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+	if err := os.MkdirAll(parentDir, 0o700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.statePath, append(data, '\n'), 0o644)
+	return writeFileAtomic(s.statePath, append(data, '\n'), 0o600)
+}
+
+func (s *codexHookSessionStore) withLockedState(readOnly bool, fn func(state *codexHookSessionStoreFile) error) error {
+	lockFile, err := s.lock()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = lockFile.Close()
+	}()
+
+	state, err := s.load()
+	if err != nil {
+		return err
+	}
+	if err := fn(state); err != nil {
+		return err
+	}
+	if readOnly {
+		return nil
+	}
+	return s.save(state)
+}
+
+func (s *codexHookSessionStore) lock() (*os.File, error) {
+	parentDir := filepath.Dir(s.statePath)
+	if err := os.MkdirAll(parentDir, 0o700); err != nil {
+		return nil, err
+	}
+	lockPath := s.statePath + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lockFile.Close()
+		return nil, err
+	}
+	return lockFile, nil
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	parentDir := filepath.Dir(path)
+	if err := os.MkdirAll(parentDir, 0o700); err != nil {
+		return err
+	}
+	tempFile, err := os.CreateTemp(parentDir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := tempFile.Chmod(mode); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
 }
 
 func codexHookContext(sessionID string, store *codexHookSessionStore) (string, string) {

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -313,6 +313,7 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 				"capabilities": []string{
 					"session.basic",
 					"session.resize.min",
+					"cli.codex.hooks",
 					"proxy.http_connect",
 					"proxy.socks5",
 					"proxy.stream",

--- a/daemon/remote/cmd/cmuxd-remote/main_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/main_test.go
@@ -159,14 +159,20 @@ func TestRunStdioHelloAndPing(t *testing.T) {
 		t.Fatalf("hello should return capabilities: %v", firstResult)
 	}
 	var sawPushCapability bool
+	var sawCodexHooksCapability bool
 	for _, capability := range capabilities {
 		if capability == "proxy.stream.push" {
 			sawPushCapability = true
-			break
+		}
+		if capability == "cli.codex.hooks" {
+			sawCodexHooksCapability = true
 		}
 	}
 	if !sawPushCapability {
 		t.Fatalf("hello should advertise proxy.stream.push: %v", firstResult)
+	}
+	if !sawCodexHooksCapability {
+		t.Fatalf("hello should advertise cli.codex.hooks: %v", firstResult)
 	}
 
 	var second map[string]any

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,220 @@
+# Docker + Codex over `cmux ssh`
+
+This document explains how to keep local cmux notifications working when `Codex` runs inside a Docker container on a remote host reached through `cmux ssh`.
+
+## Short Answer
+
+- Running `codex` directly in the remote shell started by `cmux ssh` works automatically.
+- Running `codex` inside a Docker container does not work automatically.
+- To make it work inside a container, the container must:
+  - reach the relay address published by `cmux ssh`
+  - receive `CMUX_SOCKET_PATH`, `CMUX_WORKSPACE_ID`, and `CMUX_SURFACE_ID`
+  - have the `cmux` wrapper available in `PATH`
+  - have Codex hooks installed in the container's `~/.codex`
+
+## Recommended Approach
+
+The simplest and most reliable setup is:
+
+1. Start the remote workspace with `cmux ssh <host>`.
+2. Run `codex` in that remote shell.
+3. Let Codex call `docker exec` or `docker run` only for the commands that actually need the container.
+
+This keeps notifications working without extra container plumbing.
+
+## When You Must Run `codex` Inside a Container
+
+### Recommended: `docker run --network host` on Linux
+
+On Linux remote hosts, `--network host` is the easiest way to preserve the relay path created by `cmux ssh`.
+
+```bash
+docker run --rm -it \
+  --network host \
+  -e CMUX_SOCKET_PATH \
+  -e CMUX_WORKSPACE_ID \
+  -e CMUX_SURFACE_ID \
+  -v "$HOME/.cmux:$HOME/.cmux" \
+  -v "$HOME/.codex:$HOME/.codex" \
+  -v "$PWD:$PWD" \
+  -w "$PWD" \
+  <image> bash
+```
+
+Inside the container:
+
+```bash
+export PATH="$HOME/.cmux/bin:$PATH"
+cmux codex install-hooks
+codex
+```
+
+Notes:
+
+- Mounting `~/.cmux` makes the remote `cmux` wrapper and relay metadata visible inside the container.
+- Mounting `~/.codex` shares the already-installed Codex hook config with the container.
+- Re-running `cmux codex install-hooks` is safe. If nothing changed, it becomes a no-op.
+
+### Bridge-Network Containers Need a Rewritten Relay Address
+
+In a normal bridge-network container, the inherited:
+
+```bash
+CMUX_SOCKET_PATH=127.0.0.1:<relay-port>
+```
+
+points to the container itself, not the remote host. In that case, `cmux codex-hook` will not be able to reach the relay.
+
+Use one of these options:
+
+1. Prefer `--network host`.
+2. Or expose the host gateway to the container and rewrite `CMUX_SOCKET_PATH`.
+
+Example:
+
+```bash
+relay_port="${CMUX_SOCKET_PATH##*:}"
+
+docker run --rm -it \
+  --add-host host.docker.internal:host-gateway \
+  -e CMUX_WORKSPACE_ID \
+  -e CMUX_SURFACE_ID \
+  -e CMUX_SOCKET_PATH="host.docker.internal:${relay_port}" \
+  -v "$HOME/.cmux:$HOME/.cmux" \
+  -v "$HOME/.codex:$HOME/.codex" \
+  -v "$PWD:$PWD" \
+  -w "$PWD" \
+  <image> bash
+```
+
+Inside the container:
+
+```bash
+export PATH="$HOME/.cmux/bin:$PATH"
+cmux codex install-hooks
+codex
+```
+
+If your Docker setup does not support `host.docker.internal` on Linux, use the remote host's reachable bridge/gateway IP instead and rewrite `CMUX_SOCKET_PATH` to that address.
+
+## Attaching to an Existing Container
+
+`docker exec` only works if the container already has the right network path and mounted state.
+
+Example for a container that was started with host networking and the required mounts:
+
+```bash
+docker exec -it \
+  -e CMUX_SOCKET_PATH="$CMUX_SOCKET_PATH" \
+  -e CMUX_WORKSPACE_ID="$CMUX_WORKSPACE_ID" \
+  -e CMUX_SURFACE_ID="$CMUX_SURFACE_ID" \
+  <container> bash
+```
+
+Inside the container:
+
+```bash
+export PATH="$HOME/.cmux/bin:$PATH"
+cmux codex install-hooks
+codex
+```
+
+If the container was created without host networking and without mounted `~/.cmux` and `~/.codex`, `docker exec` alone is not enough. Recreate the container with the required settings.
+
+## Compose Example
+
+For Docker Compose on a Linux remote host:
+
+```yaml
+services:
+  codex:
+    network_mode: host
+    environment:
+      CMUX_SOCKET_PATH: ${CMUX_SOCKET_PATH}
+      CMUX_WORKSPACE_ID: ${CMUX_WORKSPACE_ID}
+      CMUX_SURFACE_ID: ${CMUX_SURFACE_ID}
+    volumes:
+      - ${HOME}/.cmux:${HOME}/.cmux
+      - ${HOME}/.codex:${HOME}/.codex
+      - ${PWD}:${PWD}
+    working_dir: ${PWD}
+```
+
+Then inside the service container:
+
+```bash
+export PATH="$HOME/.cmux/bin:$PATH"
+cmux codex install-hooks
+codex
+```
+
+Adjust `HOME`, user IDs, and mount paths if the container runs as a different user.
+
+## Verification
+
+Inside the container, verify the required state first:
+
+```bash
+echo "$CMUX_SOCKET_PATH"
+echo "$CMUX_WORKSPACE_ID"
+echo "$CMUX_SURFACE_ID"
+command -v cmux
+grep -n "cmux codex-hook" ~/.codex/hooks.json
+grep -n "codex_hooks = true" ~/.codex/config.toml
+```
+
+Then run a smoke test:
+
+```bash
+printf '{"session_id":"docker-smoke-1","cwd":"%s"}\n' "$PWD" | cmux codex-hook session-start
+printf '{"session_id":"docker-smoke-1","cwd":"%s"}\n' "$PWD" | cmux codex-hook prompt-submit
+printf '{"session_id":"docker-smoke-1","cwd":"%s","last_assistant_message":"docker smoke test"}\n' "$PWD" | cmux codex-hook stop
+```
+
+Expected result:
+
+- the local cmux workspace status changes for Codex
+- a macOS notification appears on the local machine
+
+## Troubleshooting
+
+### `cmux codex-hook ...` prints `{}` and nothing happens
+
+Usually one of these is missing inside the container:
+
+- `CMUX_SURFACE_ID`
+- `CMUX_WORKSPACE_ID`
+- the `cmux` wrapper in `PATH`
+
+It can also mean the hook is running outside a shell started by `cmux ssh`.
+
+### `cmux: unknown command "codex"`
+
+The container is likely using a different or older `cmux` binary instead of the wrapper from the mounted `~/.cmux/bin`.
+
+Check:
+
+```bash
+command -v cmux
+ls -la "$HOME/.cmux/bin/cmux"
+```
+
+### Hook commands exit successfully but no notification appears
+
+The most common cause is bridge networking with an unchanged:
+
+```bash
+CMUX_SOCKET_PATH=127.0.0.1:<relay-port>
+```
+
+Inside a bridge-network container, that address points at the container, not the remote host. Use `--network host` or rewrite `CMUX_SOCKET_PATH` to a host-reachable address.
+
+### `docker exec` still does not work
+
+`docker exec` cannot fix missing container startup state. If the existing container lacks:
+
+- host networking or a host-reachable relay address
+- mounted `~/.cmux`
+- mounted `~/.codex`
+
+recreate the container instead of trying to patch it after the fact.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -130,6 +130,10 @@ Then use:
 notify = ["bash", "~/.local/bin/codex-notify.sh"]
 ```
 
+For remote shells launched with `cmux ssh`, cmux now installs the Codex hook config on the remote host automatically so `codex-hook` events route back to the local workspace over the relay. Plain `ssh user@host` sessions still do not carry the `CMUX_*` context automatically.
+
+If Codex runs inside a Docker container on the remote host, see [docker.md](../docker.md) for the required network, environment, and mount setup.
+
 ### OpenCode Plugin
 
 Create `.opencode/plugins/cmux-notify.js`:

--- a/docs/remote-daemon-spec.md
+++ b/docs/remote-daemon-spec.md
@@ -51,6 +51,7 @@ This is a **living implementation spec** (also called an **execution spec**): a 
 - `DONE` `cmux ssh` startup exports session-local `CMUX_SOCKET_PATH=127.0.0.1:<relay_port>` so parallel sessions pin to their own relay instead of racing on shared socket_addr.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.daemon_path`; remote `cmux` wrapper uses this to select the right daemon binary per session, including mixed local cmux versions.
 - `DONE` relay startup writes `~/.cmux/relay/<relay_port>.auth` with a relay ID and token; the local relay requires HMAC-SHA256 challenge-response before forwarding any command to the real local socket.
+- `DONE` relay metadata install now runs `cmux codex install-hooks --yes` on the remote so Codex hook events flow back to the local workspace by default in `cmux ssh` sessions.
 - `DONE` ephemeral port range (49152-65535) filtered from probe results to exclude relay ports from other workspaces.
 - `DONE` multi-workspace port conflict detection uses TCP connect check (`isLoopbackPortReachable`) so ports already forwarded by another workspace are silently skipped instead of flagged as conflicts.
 - `DONE` orphaned relay SSH processes from previous app sessions are cleaned up before starting a new relay.

--- a/scripts/install-release-cli.sh
+++ b/scripts/install-release-cli.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/install-release-cli.sh [--launch] [--no-install-app]
+
+Build the Release cmux.app, find the newest build product, and symlink the
+bundled CLI to ~/.local/bin/cmux.
+
+Options:
+  --launch          Launch the installed Release app after installation.
+  --no-install-app  Do not copy the built app into /Applications/cmux.app.
+  -h, --help        Show this help message.
+EOF
+}
+
+LAUNCH="false"
+INSTALL_APP="true"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --launch)
+      LAUNCH="true"
+      shift
+      ;;
+    --no-install-app)
+      INSTALL_APP="false"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "Building Release app..."
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -destination 'platform=macOS' build
+
+APP_PATH="$(
+  find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Release/cmux.app" -print0 \
+  | xargs -0 /usr/bin/stat -f "%m %N" 2>/dev/null \
+  | sort -nr \
+  | head -n 1 \
+  | cut -d' ' -f2-
+)"
+if [[ -z "${APP_PATH}" ]]; then
+  echo "error: cmux.app not found in DerivedData" >&2
+  exit 1
+fi
+
+CLI_PATH="${APP_PATH}/Contents/Resources/bin/cmux"
+if [[ ! -x "${CLI_PATH}" ]]; then
+  echo "error: bundled cmux CLI not found at ${CLI_PATH}" >&2
+  exit 1
+fi
+
+INSTALL_DIR="${HOME}/.local/bin"
+mkdir -p "${INSTALL_DIR}"
+ln -sfn "${CLI_PATH}" "${INSTALL_DIR}/cmux"
+
+INSTALLED_APP_PATH="${APP_PATH}"
+if [[ "${INSTALL_APP}" == "true" ]]; then
+  INSTALLED_APP_PATH="/Applications/cmux.app"
+  rm -rf "${INSTALLED_APP_PATH}"
+  cp -R "${APP_PATH}" "${INSTALLED_APP_PATH}"
+fi
+
+echo "Release app:"
+echo "  ${APP_PATH}"
+if [[ "${INSTALL_APP}" == "true" ]]; then
+  echo "Installed app:"
+  echo "  ${INSTALLED_APP_PATH}"
+fi
+echo "Installed CLI:"
+echo "  ${INSTALL_DIR}/cmux -> ${INSTALLED_APP_PATH}/Contents/Resources/bin/cmux"
+echo ""
+echo "Verify:"
+echo "  command -v cmux"
+echo "  cmux version"
+if [[ "${INSTALL_APP}" == "true" ]]; then
+  echo "  /Applications/cmux.app/Contents/Resources/bin/cmux version"
+fi
+echo ""
+echo "If your shell still resolves an older path, run:"
+echo "  rehash"
+
+if [[ "${LAUNCH}" == "true" ]]; then
+  echo ""
+  echo "Launching app..."
+  env -u GIT_PAGER -u GH_PAGER open -g "${INSTALLED_APP_PATH}"
+fi

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -47,6 +47,15 @@ set -euo pipefail
 
 CLI_PATH_FILE="/tmp/cmux-last-cli-path"
 CLI_PATH_OWNER="\$(stat -f '%u' "\$CLI_PATH_FILE" 2>/dev/null || stat -c '%u' "\$CLI_PATH_FILE" 2>/dev/null || echo -1)"
+SOCKET_PATH_FILE="/tmp/cmux-last-socket-path"
+SOCKET_PATH_OWNER="\$(stat -f '%u' "\$SOCKET_PATH_FILE" 2>/dev/null || stat -c '%u' "\$SOCKET_PATH_FILE" 2>/dev/null || echo -1)"
+if [[ -r "\$SOCKET_PATH_FILE" ]] && [[ ! -L "\$SOCKET_PATH_FILE" ]] && [[ "\$SOCKET_PATH_OWNER" == "\$(id -u)" ]]; then
+  SOCKET_PATH="\$(cat "\$SOCKET_PATH_FILE")"
+  if [[ -n "\$SOCKET_PATH" ]]; then
+    export CMUX_SOCKET_PATH="\$SOCKET_PATH"
+    unset CMUX_WORKSPACE_ID CMUX_SURFACE_ID CMUX_TAB_ID CMUX_PANEL_ID CMUX_SOCKET || true
+  fi
+fi
 if [[ -r "\$CLI_PATH_FILE" ]] && [[ ! -L "\$CLI_PATH_FILE" ]] && [[ "\$CLI_PATH_OWNER" == "\$(id -u)" ]]; then
   CLI_PATH="\$(cat "\$CLI_PATH_FILE")"
   if [[ -x "\$CLI_PATH" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,13 +9,6 @@ cd "$PROJECT_DIR"
 echo "==> Initializing submodules..."
 git submodule update --init --recursive
 
-echo "==> Checking for zig..."
-if ! command -v zig &> /dev/null; then
-    echo "Error: zig is not installed."
-    echo "Install via: brew install zig"
-    exit 1
-fi
-
 GHOSTTY_SHA="$(git -C ghostty rev-parse HEAD)"
 CACHE_ROOT="${CMUX_GHOSTTYKIT_CACHE_DIR:-$HOME/.cache/cmux/ghosttykit}"
 CACHE_DIR="$CACHE_ROOT/$GHOSTTY_SHA"
@@ -54,6 +47,12 @@ download_prebuilt_ghosttykit() {
 }
 
 build_local_ghosttykit() {
+    echo "==> Checking for zig..."
+    if ! command -v zig >/dev/null 2>&1; then
+        echo "Error: zig is required to build GhosttyKit.xcframework locally."
+        echo "Install via: brew install zig"
+        return 1
+    fi
     echo "==> Building GhosttyKit.xcframework locally (this may take a few minutes)..."
     (
         cd ghostty
@@ -87,7 +86,7 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
     echo "==> Waiting for GhosttyKit cache lock for $GHOSTTY_SHA..."
     sleep 1
 done
-trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true; rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
+trap 'if [ -n "$TMP_ROOT" ]; then rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true; fi; rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
 
 if [ -d "$CACHE_XCFRAMEWORK" ]; then
     echo "==> Reusing cached GhosttyKit.xcframework"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,10 +23,58 @@ CACHE_XCFRAMEWORK="$CACHE_DIR/GhosttyKit.xcframework"
 LOCAL_XCFRAMEWORK="$PROJECT_DIR/ghostty/macos/GhosttyKit.xcframework"
 LOCAL_SHA_STAMP="$LOCAL_XCFRAMEWORK/.ghostty_sha"
 LOCK_DIR="$CACHE_ROOT/$GHOSTTY_SHA.lock"
+CHECKSUMS_FILE="$SCRIPT_DIR/ghosttykit-checksums.txt"
+PREFER_PREBUILT="${CMUX_GHOSTTYKIT_PREFER_PREBUILT:-1}"
+TMP_ROOT=""
 
 mkdir -p "$CACHE_ROOT"
 
 echo "==> Ghostty submodule commit: $GHOSTTY_SHA"
+
+has_pinned_prebuilt() {
+    [ -f "$CHECKSUMS_FILE" ] || return 1
+    awk -v sha="$GHOSTTY_SHA" '
+        $1 == sha {
+            found = 1
+            exit 0
+        }
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "$CHECKSUMS_FILE"
+}
+
+download_prebuilt_ghosttykit() {
+    local download_dir="$1"
+    echo "==> Downloading prebuilt GhosttyKit.xcframework for $GHOSTTY_SHA..."
+    (
+        cd "$download_dir"
+        GHOSTTY_SHA="$GHOSTTY_SHA" "$SCRIPT_DIR/download-prebuilt-ghosttykit.sh"
+    )
+}
+
+build_local_ghosttykit() {
+    echo "==> Building GhosttyKit.xcframework locally (this may take a few minutes)..."
+    (
+        cd ghostty
+        zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+    )
+}
+
+print_local_build_help() {
+    cat <<'EOF'
+Error: Failed to build GhosttyKit.xcframework locally.
+
+If the error mentions a missing Metal Toolchain, install it once with:
+  xcodebuild -downloadComponent MetalToolchain
+
+Then rerun:
+  ./scripts/setup.sh
+
+If you want to avoid a local Ghostty build, try the pinned prebuilt bundle:
+  ./scripts/download-prebuilt-ghosttykit.sh
+EOF
+}
 
 LOCK_TIMEOUT=300
 LOCK_START=$SECONDS
@@ -39,11 +87,16 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
     echo "==> Waiting for GhosttyKit cache lock for $GHOSTTY_SHA..."
     sleep 1
 done
-trap 'rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true; rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
 
 if [ -d "$CACHE_XCFRAMEWORK" ]; then
     echo "==> Reusing cached GhosttyKit.xcframework"
 else
+    TMP_ROOT="$(mktemp -d "$CACHE_ROOT/.ghosttykit-tmp.XXXXXX")"
+    DOWNLOAD_DIR="$TMP_ROOT/download"
+    STAGE_DIR="$TMP_ROOT/stage"
+    mkdir -p "$DOWNLOAD_DIR" "$STAGE_DIR"
+
     # Only reuse local xcframework if its SHA stamp matches the current ghostty commit.
     # Without this check, a stale build from a previous commit could be cached under
     # the wrong SHA, producing ABI mismatches.
@@ -52,29 +105,41 @@ else
         LOCAL_SHA="$(cat "$LOCAL_SHA_STAMP")"
     fi
 
+    SOURCE_XCFRAMEWORK=""
     if [ -d "$LOCAL_XCFRAMEWORK" ] && [ "$LOCAL_SHA" = "$GHOSTTY_SHA" ]; then
         echo "==> Seeding cache from existing local GhosttyKit.xcframework (SHA matches)"
+        SOURCE_XCFRAMEWORK="$LOCAL_XCFRAMEWORK"
     else
-        echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
-        (
-            cd ghostty
-            zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
-        )
-        # Stamp the build output with the SHA it was built from
-        echo "$GHOSTTY_SHA" > "$LOCAL_SHA_STAMP"
+        if [ "$PREFER_PREBUILT" != "0" ] && has_pinned_prebuilt; then
+            if download_prebuilt_ghosttykit "$DOWNLOAD_DIR"; then
+                SOURCE_XCFRAMEWORK="$DOWNLOAD_DIR/GhosttyKit.xcframework"
+            else
+                echo "==> Prebuilt GhosttyKit download failed; falling back to local build."
+            fi
+        else
+            echo "==> No pinned prebuilt GhosttyKit for $GHOSTTY_SHA; building locally."
+        fi
+
+        if [ -z "$SOURCE_XCFRAMEWORK" ]; then
+            if ! build_local_ghosttykit; then
+                print_local_build_help
+                exit 1
+            fi
+            # Stamp the build output with the SHA it was built from.
+            echo "$GHOSTTY_SHA" > "$LOCAL_SHA_STAMP"
+            SOURCE_XCFRAMEWORK="$LOCAL_XCFRAMEWORK"
+        fi
     fi
 
-    if [ ! -d "$LOCAL_XCFRAMEWORK" ]; then
-        echo "Error: GhosttyKit.xcframework not found at $LOCAL_XCFRAMEWORK"
+    if [ ! -d "$SOURCE_XCFRAMEWORK" ]; then
+        echo "Error: GhosttyKit.xcframework not found at $SOURCE_XCFRAMEWORK"
         exit 1
     fi
 
-    TMP_DIR="$(mktemp -d "$CACHE_ROOT/.ghosttykit-tmp.XXXXXX")"
     mkdir -p "$CACHE_DIR"
-    cp -R "$LOCAL_XCFRAMEWORK" "$TMP_DIR/GhosttyKit.xcframework"
+    cp -R "$SOURCE_XCFRAMEWORK" "$STAGE_DIR/GhosttyKit.xcframework"
     rm -rf "$CACHE_XCFRAMEWORK"
-    mv "$TMP_DIR/GhosttyKit.xcframework" "$CACHE_XCFRAMEWORK"
-    rmdir "$TMP_DIR"
+    mv "$STAGE_DIR/GhosttyKit.xcframework" "$CACHE_XCFRAMEWORK"
     echo "==> Cached GhosttyKit.xcframework at $CACHE_XCFRAMEWORK"
 fi
 


### PR DESCRIPTION
## Summary

  - Added remote Codex hook support for `cmux ssh` sessions so Codex lifecycle events on the remote host can update local cmux status and trigger local
  notifications.
  - Added automatic remote hook installation during SSH relay/bootstrap, plus a remote capability gate so stale `cmuxd-remote` binaries get replaced.
  - Improved dev setup/build behavior by making `scripts/setup.sh` prefer prebuilt `GhosttyKit.xcframework` and surfacing clearer fallback guidance.
  - Fixed the `cmux-dev` shim so tagged Debug builds reliably target the selected dev socket instead of inheriting stale `CMUX_*` context from an older cmux
  session.
  - Added docs for remote notifications and Docker-based Codex usage.

  - Why?
  - The original remote SSH flow did not notify the local macOS cmux app when remote Codex needed attention.
  - Older remote daemons could stay in place and miss the new hook commands/capabilities.
  - Local testing was confusing because `cmux-dev` could accidentally talk to the wrong app socket.
  - Docker usage on the remote host needed explicit documentation because it does not work automatically like a plain `cmux ssh` shell.

  ## Testing

  - How did you test this change?
  - Built and launched a tagged Debug app with `./scripts/reload.sh --tag ssh-notify --launch`.
  - Verified the tagged CLI shim resolved to the tagged socket instead of the installed app socket.
  - Established a remote workspace with `cmux-dev ssh gpuserver13` and confirmed the remote daemon was rebuilt, uploaded, bootstrapped, and reported the new
  capability.
  - Verified remote Codex hook installation on the remote host by checking `~/.codex/hooks.json` and `~/.codex/config.toml`.
  - Used `cmux-dev list-workspaces`, `current-workspace`, `tree`, and `read-screen` to confirm the remote workspace was connected and interactive.
  - Ran manual Codex hook smoke tests in the remote shell to verify end-to-end notification routing behavior.

  - What did you verify manually?
  - `cmux ssh` sessions now auto-install Codex hooks on the remote host.
  - Remote `cmuxd-remote` upgrades when the new Codex hook capability is required.
  - The tagged Debug app receives the SSH workspace instead of the main installed app.
  - `cmux codex-hook session-start`, `prompt-submit`, and `stop` execute successfully in the remote cmux shell and route back through the relay.
  - The new Docker documentation matches the actual constraints of running Codex inside containers.

  ## Demo Video

  For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

  - Video URL or attachment:
    - Not attached yet. I can record a short demo showing `cmux ssh` -> remote `codex` / `cmux codex-hook stop` -> local notification if needed.

  ## Review Trigger (Copy/Paste as PR comment)

  ```text
  @codex review
  @coderabbitai review
  @greptile-apps review
  @cubic-dev-ai review

  ## Checklist

  - [x] I tested the change locally
  - [x] I added or updated tests for behavior changes
  - [x] I updated docs/changelog if needed
  - [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
  - [ ] All code review bot comments are resolved
  - [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote Codex hook support for `cmux ssh` so remote Codex events update local status and send notifications. Hooks auto-install on the remote and are gated by the new `cli.codex.hooks` capability, with remotes upgraded as needed.

- **New Features**
  - Auto-install Codex hooks during SSH bootstrap by running `cmux codex install-hooks --yes`.
  - New `codex` and `codex-hook` subcommands in `cmuxd-remote`; hooks no-op outside cmux and route events over the relay, updating status (Running/Idle) and creating targeted notifications.
  - Capability gate `cli.codex.hooks`; bootstrap rebuilds/uploads `cmuxd-remote` when missing and surfaces a localized “missing required capability” error.
  - Added Docker guide for running Codex in containers (env: `CMUX_SOCKET_PATH`, `CMUX_WORKSPACE_ID`, `CMUX_SURFACE_ID`; mounts: `~/.cmux`, `~/.codex`; networking tips).
  - New `scripts/install-release-cli.sh` to build Release and symlink the bundled CLI to `~/.local/bin/cmux`.

- **Bug Fixes**
  - `cmux-dev` shim reliably binds tagged Debug builds to the selected socket; `scripts/reload.sh` restores `CMUX_SOCKET_PATH` and clears stale `CMUX_*`.
  - `scripts/setup.sh` prefers pinned prebuilt `GhosttyKit.xcframework` with clearer local-build fallback and guidance.

<sup>Written for commit d15f69f4a0e4f222d77cb20f89f2afbdb4703c2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex hook support for remote shells and new codex/codex-hook CLI for hook handling
  * Socket path restoration for improved session continuity
  * New installer script to install the built CLI into ~/.local/bin (optional app install/launch)

* **Bug Fixes**
  * Remote bootstrap now enforces required capabilities and re-triggers rebuild/upload when missing; clearer missing-capability message

* **Documentation**
  * Docker guide for Codex-in-container remote workflows; updated remote notifications docs

* **Tests**
  * Added tests covering hook install/run and CLI behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->