### PR TITLE
Fix sidebar workspace title truncation

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11136,6 +11136,7 @@ enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 
     static func width(
+        canCloseWorkspace: Bool,
         showsWorkspaceShortcutHint: Bool,
         workspaceShortcutLabel: String?,
         debugXOffset: Double
@@ -11147,7 +11148,7 @@ enum SidebarTrailingAccessoryWidthPolicy {
             )
         }
 
-        return 0
+        return canCloseWorkspace ? closeButtonWidth : 0
     }
 }
 
@@ -11348,14 +11349,6 @@ private struct TabItemView: View, Equatable {
         (showsModifierShortcutHints || alwaysShowShortcutHints) && workspaceShortcutLabel != nil
     }
 
-    private var trailingAccessoryWidth: CGFloat {
-        SidebarTrailingAccessoryWidthPolicy.width(
-            showsWorkspaceShortcutHint: showsWorkspaceShortcutHint,
-            workspaceShortcutLabel: workspaceShortcutLabel,
-            debugXOffset: sidebarShortcutHintXOffset
-        )
-    }
-
     private var remoteWorkspaceSidebarText: String? {
         guard tab.hasActiveRemoteTerminalSessions else { return nil }
         let trimmedTarget = tab.remoteDisplayTarget?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -11519,29 +11512,6 @@ private struct TabItemView: View, Equatable {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: .infinity, alignment: .leading)
-
-                if trailingAccessoryWidth > 0 {
-                    ZStack(alignment: .trailing) {
-                        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-                            Text(workspaceShortcutLabel)
-                                .lineLimit(1)
-                                .fixedSize(horizontal: true, vertical: false)
-                                .font(.system(size: 10, weight: .semibold, design: .rounded))
-                                .monospacedDigit()
-                                .foregroundColor(activePrimaryTextColor)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
-                                .offset(
-                                    x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
-                                    y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
-                                )
-                                .transition(.opacity)
-                        }
-                    }
-                    .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
-                    .frame(width: trailingAccessoryWidth, height: 16, alignment: .trailing)
-                }
             }
 
             if let subtitle = effectiveSubtitle {
@@ -11742,23 +11712,43 @@ private struct TabItemView: View, Equatable {
                 }
         )
         .overlay(alignment: .topTrailing) {
-            Button(action: {
-                #if DEBUG
-                dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                #endif
-                tabManager.closeWorkspaceWithConfirmation(tab)
-            }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundColor(activeSecondaryColor(0.7))
+            if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
+                Text(workspaceShortcutLabel)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(activePrimaryTextColor)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
+                    .offset(
+                        x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
+                        y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
+                    )
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
+                    .padding(.top, 6)
+                    .padding(.trailing, 6)
+            } else {
+                Button(action: {
+                    #if DEBUG
+                    dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                    #endif
+                    tabManager.closeWorkspaceWithConfirmation(tab)
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(activeSecondaryColor(0.7))
+                }
+                .buttonStyle(.plain)
+                .safeHelp(closeButtonTooltip)
+                .frame(width: 20, height: 20, alignment: .center)
+                .padding(.top, 2)
+                .padding(.trailing, 2)
+                .opacity(showCloseButton ? 1 : 0)
+                .allowsHitTesting(showCloseButton)
             }
-            .buttonStyle(.plain)
-            .safeHelp(closeButtonTooltip)
-            .frame(width: 20, height: 20, alignment: .center)
-            .padding(.top, 2)
-            .padding(.trailing, 2)
-            .opacity(showCloseButton && !showsWorkspaceShortcutHint ? 1 : 0)
-            .allowsHitTesting(showCloseButton && !showsWorkspaceShortcutHint)
         }
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .padding(.horizontal, 6)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11136,7 +11136,6 @@ enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 
     static func width(
-        canCloseWorkspace: Bool,
         showsWorkspaceShortcutHint: Bool,
         workspaceShortcutLabel: String?,
         debugXOffset: Double
@@ -11148,7 +11147,7 @@ enum SidebarTrailingAccessoryWidthPolicy {
             )
         }
 
-        return canCloseWorkspace ? closeButtonWidth : 0
+        return 0
     }
 }
 
@@ -11351,7 +11350,6 @@ private struct TabItemView: View, Equatable {
 
     private var trailingAccessoryWidth: CGFloat {
         SidebarTrailingAccessoryWidthPolicy.width(
-            canCloseWorkspace: canCloseWorkspace,
             showsWorkspaceShortcutHint: showsWorkspaceShortcutHint,
             workspaceShortcutLabel: workspaceShortcutLabel,
             debugXOffset: sidebarShortcutHintXOffset
@@ -11520,46 +11518,30 @@ private struct TabItemView: View, Equatable {
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .layoutPriority(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                Spacer(minLength: 0)
-
-                ZStack(alignment: .trailing) {
-                    Button(action: {
-                        #if DEBUG
-                        dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                        #endif
-                        tabManager.closeWorkspaceWithConfirmation(tab)
-                    }) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(activeSecondaryColor(0.7))
+                if trailingAccessoryWidth > 0 {
+                    ZStack(alignment: .trailing) {
+                        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
+                            Text(workspaceShortcutLabel)
+                                .lineLimit(1)
+                                .fixedSize(horizontal: true, vertical: false)
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundColor(activePrimaryTextColor)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
+                                .offset(
+                                    x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
+                                    y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
+                                )
+                                .transition(.opacity)
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .safeHelp(closeButtonTooltip)
-                    .frame(width: SidebarTrailingAccessoryWidthPolicy.closeButtonWidth, height: 16, alignment: .center)
-                    .opacity(showCloseButton && !showsWorkspaceShortcutHint ? 1 : 0)
-                    .allowsHitTesting(showCloseButton && !showsWorkspaceShortcutHint)
-
-                    if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-                        Text(workspaceShortcutLabel)
-                            .lineLimit(1)
-                            .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
-                            .monospacedDigit()
-                            .foregroundColor(activePrimaryTextColor)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
-                            .offset(
-                                x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
-                                y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
-                            )
-                            .transition(.opacity)
-                    }
+                    .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
+                    .frame(width: trailingAccessoryWidth, height: 16, alignment: .trailing)
                 }
-                .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
-                .frame(width: trailingAccessoryWidth, height: 16, alignment: .trailing)
             }
 
             if let subtitle = effectiveSubtitle {
@@ -11759,6 +11741,26 @@ private struct TabItemView: View, Equatable {
                     }
                 }
         )
+        .overlay(alignment: .topTrailing) {
+            Button(action: {
+                #if DEBUG
+                dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                #endif
+                tabManager.closeWorkspaceWithConfirmation(tab)
+            }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(activeSecondaryColor(0.7))
+            }
+            .buttonStyle(.plain)
+            .safeHelp(closeButtonTooltip)
+            .frame(width: 20, height: 20, alignment: .center)
+            .padding(.top, 2)
+            .padding(.trailing, 2)
+            .opacity(showCloseButton && !showsWorkspaceShortcutHint ? 1 : 0)
+            .allowsHitTesting(showCloseButton && !showsWorkspaceShortcutHint)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
         .padding(.horizontal, 6)
         .background {
             GeometryReader { proxy in

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11132,25 +11132,6 @@ enum SidebarWorkspaceShortcutHintMetrics {
     #endif
 }
 
-enum SidebarTrailingAccessoryWidthPolicy {
-    static let closeButtonWidth: CGFloat = 16
-
-    static func width(
-        canCloseWorkspace: Bool,
-        showsWorkspaceShortcutHint: Bool,
-        workspaceShortcutLabel: String?,
-        debugXOffset: Double
-    ) -> CGFloat {
-        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-            return SidebarWorkspaceShortcutHintMetrics.slotWidth(
-                label: workspaceShortcutLabel,
-                debugXOffset: debugXOffset
-            )
-        }
-
-        return canCloseWorkspace ? closeButtonWidth : 0
-    }
-}
 
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
 // the parent rebuilds with unchanged values. Without this, every TabManager
@@ -11712,43 +11693,45 @@ private struct TabItemView: View, Equatable {
                 }
         )
         .overlay(alignment: .topTrailing) {
-            if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-                Text(workspaceShortcutLabel)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .font(.system(size: 10, weight: .semibold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundColor(activePrimaryTextColor)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
-                    .offset(
-                        x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
-                        y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
-                    )
-                    .transition(.opacity)
-                    .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
-                    .padding(.top, 6)
-                    .padding(.trailing, 6)
-            } else {
-                Button(action: {
-                    #if DEBUG
-                    dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                    #endif
-                    tabManager.closeWorkspaceWithConfirmation(tab)
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(activeSecondaryColor(0.7))
+            Group {
+                if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
+                    Text(workspaceShortcutLabel)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(activePrimaryTextColor)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(ShortcutHintPillBackground(emphasis: shortcutHintEmphasis))
+                        .offset(
+                            x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
+                            y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
+                        )
+                        .transition(.opacity)
+                        .padding(.top, 6)
+                        .padding(.trailing, 6)
+                } else {
+                    Button(action: {
+                        #if DEBUG
+                        dlog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                        #endif
+                        tabManager.closeWorkspaceWithConfirmation(tab)
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(activeSecondaryColor(0.7))
+                    }
+                    .buttonStyle(.plain)
+                    .safeHelp(closeButtonTooltip)
+                    .frame(width: 20, height: 20, alignment: .center)
+                    .padding(.top, 2)
+                    .padding(.trailing, 2)
+                    .opacity(showCloseButton ? 1 : 0)
+                    .allowsHitTesting(showCloseButton)
                 }
-                .buttonStyle(.plain)
-                .safeHelp(closeButtonTooltip)
-                .frame(width: 20, height: 20, alignment: .center)
-                .padding(.top, 2)
-                .padding(.trailing, 2)
-                .opacity(showCloseButton ? 1 : 0)
-                .allowsHitTesting(showCloseButton)
             }
+            .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
         }
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .padding(.horizontal, 6)


### PR DESCRIPTION
## Summary
Addresses #2897 

I've been bothered by how little space the title gets before it truncates, so I took at shot at adjusting the UI as little as possible to still fix the issue.

- Workspace titles in the sidebar now extend to the full row width instead of truncating ~24pt early
- The close button moved from in-flow layout to an overlay, so it no longer reserves space when hidden
- Shortcut hints remain in-flow and only appear when a modifier key is held

## What changed
The trailing ZStack (close button + shortcut hints) always reserved 16pt + 8pt HStack spacing even when the close button was invisible (opacity 0, not hovering). This caused titles to truncate well before the trailing edge of the workspace row.

Now the title uses `frame(maxWidth: .infinity)` to fill the row, the close button floats as an overlay on hover, and the shortcut hint ZStack is only inserted when active (`trailingAccessoryWidth > 0`).

I'll note that I did consider using a background for the `x` button but ultimately it didn't seem like it really needed it.  I tried some gradients as well as a circle or rounded rect to match the rounded rects of the workspaces themselves but none of them felt necessary in the end.  Happy to add one back in though.

## Test plan
- [x] Long workspace titles extend close to the trailing edge of the row
- [x] Close button appears on hover (requires 2+ workspaces)
- [x] Shortcut hints appear when holding modifier key
- [x] Short titles still left-align normally
- [x] No layout jumping when hovering

https://github.com/user-attachments/assets/1f7d351c-2ac8-4f1a-9c12-d3ef0a6cb1ec

<img width="383" height="202" alt="Screenshot 2026-04-01 at 10 05 52 AM" src="https://github.com/user-attachments/assets/855f3ae9-9efc-4e09-8b9f-6a36eaa1b2b2" />
<img width="511" height="211" alt="Screenshot 2026-04-01 at 10 06 09 AM" src="https://github.com/user-attachments/assets/adc18717-9ca8-4cda-9c50-91cd4dfeecdc" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar workspace title truncation by letting titles use the full row width and moving the close button to an overlay. Titles no longer cut off early, and hover/shortcut hints no longer shift the layout.

- **Bug Fixes**
  - Title now uses `frame(maxWidth: .infinity)` to fill the row.
  - Close button floats as an overlay on hover, so it doesn’t reserve space when hidden.
  - Shortcut hints render only when active, preventing extra spacing and flicker.

<sup>Written for commit 1ab77eebfa4baaeac50bea24fbbd509cabac1229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated sidebar tab-item layout to better allocate title space and simplify trailing controls.
  * Reworked close button and workspace-shortcut hint presentation: size, visibility, hit area, and rounded clipping improved for more consistent appearance and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->