### PR TITLE
Fix web header overlap

### DIFF
--- a/web/app/[locale]/components/download-button.tsx
+++ b/web/app/[locale]/components/download-button.tsx
@@ -6,9 +6,11 @@ import posthog from "posthog-js";
 export function DownloadButton({
   size = "default",
   location = "hero",
+  className,
 }: {
   size?: "default" | "sm";
   location?: string;
+  className?: string;
 }) {
   const t = useTranslations("common");
   const isSmall = size === "sm";
@@ -18,7 +20,7 @@ export function DownloadButton({
       onClick={() => posthog.capture("cmuxterm_download_clicked", { location })}
       className={`inline-flex items-center whitespace-nowrap rounded-full font-medium bg-foreground hover:opacity-85 transition-opacity ${
         isSmall ? "gap-2 px-4 py-1.5 text-xs" : "gap-2.5 px-5 py-2.5 text-[15px]"
-      }`}
+      } ${className ?? ""}`}
       style={{ color: "var(--background)", textDecoration: "none" }}
     >
       <svg

--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -31,6 +31,7 @@ export function GitHubStarsBadge({
   className?: string;
 } = {}) {
   const [stars, setStars] = useState<number | null>(null);
+  const classes = `${className ?? "inline-flex"} items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in`;
 
   useEffect(() => {
     fetch("/api/github-stars")
@@ -51,7 +52,7 @@ export function GitHubStarsBadge({
       onClick={() =>
         posthog.capture("cmuxterm_github_clicked", { location })
       }
-      className={className ?? "inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in"}
+      className={classes}
     >
       {GITHUB_ICON}
       <span className="text-xs tabular-nums">{formatStars(stars)}</span>

--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -31,7 +31,7 @@ export function GitHubStarsBadge({
   className?: string;
 } = {}) {
   const [stars, setStars] = useState<number | null>(null);
-  const classes = `${className ?? "inline-flex"} items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in`;
+  const classes = `inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in ${className ?? ""}`;
 
   useEffect(() => {
     fetch("/api/github-stars")

--- a/web/app/[locale]/components/mobile-drawer.tsx
+++ b/web/app/[locale]/components/mobile-drawer.tsx
@@ -55,7 +55,7 @@ export function useMobileDrawer() {
   // Lock body scroll on mobile
   useEffect(() => {
     if (!open) return;
-    const mq = window.matchMedia("(min-width: 768px)");
+    const mq = window.matchMedia("(min-width: 810px)");
     if (mq.matches) return;
     document.body.style.overflow = "hidden";
     return () => {
@@ -70,7 +70,7 @@ export function MobileDrawerOverlay({ open, onClose }: { open: boolean; onClose:
   if (!open) return null;
   return (
     <div
-      className="fixed inset-0 z-40 bg-black/50 md:hidden"
+      className="fixed inset-0 z-40 bg-black/50 min-[810px]:hidden"
       aria-hidden="true"
       onClick={onClose}
     />
@@ -96,7 +96,7 @@ export function MobileDrawerToggle({
       aria-expanded={open}
       className={
         className ??
-        "md:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
+        "min-[810px]:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
       }
       aria-label={open ? "Close menu" : "Open menu"}
     >

--- a/web/app/[locale]/components/mobile-drawer.tsx
+++ b/web/app/[locale]/components/mobile-drawer.tsx
@@ -55,7 +55,7 @@ export function useMobileDrawer() {
   // Lock body scroll on mobile
   useEffect(() => {
     if (!open) return;
-    const mq = window.matchMedia("(min-width: 840px)");
+    const mq = window.matchMedia("(min-width: 940px)");
     if (mq.matches) return;
     document.body.style.overflow = "hidden";
     return () => {
@@ -70,7 +70,7 @@ export function MobileDrawerOverlay({ open, onClose }: { open: boolean; onClose:
   if (!open) return null;
   return (
     <div
-      className="fixed inset-0 z-40 bg-black/50 min-[840px]:hidden"
+      className="fixed inset-0 z-40 bg-black/50 min-[940px]:hidden"
       aria-hidden="true"
       onClick={onClose}
     />
@@ -96,7 +96,7 @@ export function MobileDrawerToggle({
       aria-expanded={open}
       className={
         className ??
-        "min-[840px]:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
+        "min-[940px]:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
       }
       aria-label={open ? "Close menu" : "Open menu"}
     >

--- a/web/app/[locale]/components/mobile-drawer.tsx
+++ b/web/app/[locale]/components/mobile-drawer.tsx
@@ -55,7 +55,7 @@ export function useMobileDrawer() {
   // Lock body scroll on mobile
   useEffect(() => {
     if (!open) return;
-    const mq = window.matchMedia("(min-width: 810px)");
+    const mq = window.matchMedia("(min-width: 840px)");
     if (mq.matches) return;
     document.body.style.overflow = "hidden";
     return () => {
@@ -70,7 +70,7 @@ export function MobileDrawerOverlay({ open, onClose }: { open: boolean; onClose:
   if (!open) return null;
   return (
     <div
-      className="fixed inset-0 z-40 bg-black/50 min-[810px]:hidden"
+      className="fixed inset-0 z-40 bg-black/50 min-[840px]:hidden"
       aria-hidden="true"
       onClick={onClose}
     />
@@ -96,7 +96,7 @@ export function MobileDrawerToggle({
       aria-expanded={open}
       className={
         className ??
-        "min-[810px]:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
+        "min-[840px]:hidden w-8 h-8 flex items-center justify-center text-muted hover:text-foreground transition-colors"
       }
       aria-label={open ? "Close menu" : "Open menu"}
     >

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -37,7 +37,7 @@ export function NavLinks() {
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => posthog.capture("cmuxterm_github_clicked", { location: "navbar" })}
-        className="hidden xl:inline hover:text-foreground transition-colors"
+        className="hover:text-foreground transition-colors"
       >
         {t("github")}
       </a>

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -37,7 +37,7 @@ export function NavLinks() {
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => posthog.capture("cmuxterm_github_clicked", { location: "navbar" })}
-        className="hover:text-foreground transition-colors"
+        className="hidden xl:inline hover:text-foreground transition-colors"
       >
         {t("github")}
       </a>

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -60,7 +60,7 @@ export function SiteHeader({
 
           {/* Right: GitHub stars + Download + theme + mobile */}
           <div className="flex flex-1 items-center justify-end gap-3 min-w-0">
-            <GitHubStarsBadge className="hidden xl:inline-flex" />
+            <GitHubStarsBadge />
             <div className="hidden md:block">
               <DownloadButton size="sm" location="navbar" />
             </div>

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,7 +26,7 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 px-6">
+        <div className="w-full max-w-6xl mx-auto grid h-12 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-6 lg:gap-4">
           {/* Left: logo + section */}
           <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
@@ -54,15 +54,19 @@ export function SiteHeader({
           </div>
 
           {/* Center: nav links */}
-          <nav className="hidden min-w-0 items-center justify-center gap-4 text-sm text-muted md:flex">
+          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted md:flex lg:gap-4 lg:text-sm">
             <NavLinks />
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="flex min-w-0 items-center justify-end gap-3">
-            <GitHubStarsBadge />
+          <div className="flex min-w-0 items-center justify-end gap-1.5 lg:gap-3">
+            <GitHubStarsBadge className="gap-1 pr-0 lg:gap-1.5 lg:pr-1" />
             <div className="hidden md:block">
-              <DownloadButton size="sm" location="navbar" />
+              <DownloadButton
+                size="sm"
+                location="navbar"
+                className="gap-1.5 px-3 text-[11px] lg:gap-2 lg:px-4 lg:text-xs"
+              />
             </div>
             <ThemeToggle />
             <MobileDrawerToggle

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -60,7 +60,7 @@ export function SiteHeader({
 
           {/* Right: GitHub stars + Download + theme + mobile */}
           <div className="flex flex-1 items-center justify-end gap-3 min-w-0">
-            <GitHubStarsBadge />
+            <GitHubStarsBadge className="hidden xl:inline-flex" />
             <div className="hidden md:block">
               <DownloadButton size="sm" location="navbar" />
             </div>

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,7 +26,7 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 min-[810px]:grid min-[810px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[810px]:gap-2 lg:gap-4">
+        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 min-[840px]:grid min-[840px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[840px]:gap-2 lg:gap-4">
           {/* Left: logo + section */}
           <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
@@ -54,14 +54,14 @@ export function SiteHeader({
           </div>
 
           {/* Center: nav links */}
-          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted min-[810px]:flex lg:gap-4 lg:text-sm">
+          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted min-[840px]:flex lg:gap-4 lg:text-sm">
             <NavLinks />
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 min-[810px]:ml-0 lg:gap-3">
+          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 min-[840px]:ml-0 lg:gap-3">
             <GitHubStarsBadge className="gap-1 pr-0 lg:gap-1.5 lg:pr-1" />
-            <div className="hidden min-[810px]:block">
+            <div className="hidden min-[840px]:block">
               <DownloadButton
                 size="sm"
                 location="navbar"
@@ -84,7 +84,7 @@ export function SiteHeader({
         ref={drawerRef}
         role="navigation"
         aria-label="Main navigation"
-        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform min-[810px]:hidden ${
+        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform min-[840px]:hidden ${
           open ? "translate-x-0" : "translate-x-full invisible"
         }`}
       >

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,7 +26,7 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 min-[840px]:grid min-[840px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[840px]:gap-2 lg:gap-4">
+        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 min-[940px]:grid min-[940px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[940px]:gap-4">
           {/* Left: logo + section */}
           <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
@@ -54,19 +54,15 @@ export function SiteHeader({
           </div>
 
           {/* Center: nav links */}
-          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted min-[840px]:flex lg:gap-4 lg:text-sm">
+          <nav className="hidden min-w-0 items-center justify-center gap-4 text-sm text-muted min-[940px]:flex">
             <NavLinks />
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 min-[840px]:ml-0 lg:gap-3">
-            <GitHubStarsBadge className="gap-1 pr-0 lg:gap-1.5 lg:pr-1" />
-            <div className="hidden min-[840px]:block">
-              <DownloadButton
-                size="sm"
-                location="navbar"
-                className="gap-1.5 px-3 text-[11px] lg:gap-2 lg:px-4 lg:text-xs"
-              />
+          <div className="ml-auto flex min-w-0 items-center justify-end gap-3 min-[940px]:ml-0">
+            <GitHubStarsBadge />
+            <div className="hidden min-[940px]:block">
+              <DownloadButton size="sm" location="navbar" />
             </div>
             <ThemeToggle />
             <MobileDrawerToggle
@@ -84,7 +80,7 @@ export function SiteHeader({
         ref={drawerRef}
         role="navigation"
         aria-label="Main navigation"
-        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform min-[840px]:hidden ${
+        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform min-[940px]:hidden ${
           open ? "translate-x-0" : "translate-x-full invisible"
         }`}
       >

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,7 +26,7 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 md:grid md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:gap-2 lg:gap-4">
+        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 min-[810px]:grid min-[810px]:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] min-[810px]:gap-2 lg:gap-4">
           {/* Left: logo + section */}
           <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
@@ -54,14 +54,14 @@ export function SiteHeader({
           </div>
 
           {/* Center: nav links */}
-          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted md:flex lg:gap-4 lg:text-sm">
+          <nav className="hidden min-w-0 items-center justify-center gap-2 text-[13px] text-muted min-[810px]:flex lg:gap-4 lg:text-sm">
             <NavLinks />
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 md:ml-0 lg:gap-3">
+          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 min-[810px]:ml-0 lg:gap-3">
             <GitHubStarsBadge className="gap-1 pr-0 lg:gap-1.5 lg:pr-1" />
-            <div className="hidden md:block">
+            <div className="hidden min-[810px]:block">
               <DownloadButton
                 size="sm"
                 location="navbar"
@@ -84,7 +84,7 @@ export function SiteHeader({
         ref={drawerRef}
         role="navigation"
         aria-label="Main navigation"
-        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform md:hidden ${
+        className={`fixed inset-y-0 right-0 z-50 w-56 bg-background border-l border-border overflow-y-auto transition-transform min-[810px]:hidden ${
           open ? "translate-x-0" : "translate-x-full invisible"
         }`}
       >

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,9 +26,9 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto flex items-center px-6 h-12">
+        <div className="w-full max-w-6xl mx-auto grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 px-6">
           {/* Left: logo + section */}
-          <div className="flex flex-1 items-center gap-3 min-w-0">
+          <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
               <>
                 <Link href="/" className="flex items-center gap-2.5">
@@ -54,12 +54,12 @@ export function SiteHeader({
           </div>
 
           {/* Center: nav links */}
-          <nav className="hidden md:flex items-center justify-center gap-4 text-sm text-muted shrink-0">
+          <nav className="hidden min-w-0 items-center justify-center gap-4 text-sm text-muted md:flex">
             <NavLinks />
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="flex flex-1 items-center justify-end gap-3 min-w-0">
+          <div className="flex min-w-0 items-center justify-end gap-3">
             <GitHubStarsBadge />
             <div className="hidden md:block">
               <DownloadButton size="sm" location="navbar" />

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -26,7 +26,7 @@ export function SiteHeader({
   return (
     <>
       <header className="sticky top-0 z-30 w-full bg-background">
-        <div className="w-full max-w-6xl mx-auto grid h-12 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-6 lg:gap-4">
+        <div className="w-full max-w-6xl mx-auto flex h-12 items-center px-6 md:grid md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:gap-2 lg:gap-4">
           {/* Left: logo + section */}
           <div className="flex min-w-0 items-center gap-3">
             {!hideLogo && (
@@ -59,7 +59,7 @@ export function SiteHeader({
           </nav>
 
           {/* Right: GitHub stars + Download + theme + mobile */}
-          <div className="flex min-w-0 items-center justify-end gap-1.5 lg:gap-3">
+          <div className="ml-auto flex min-w-0 items-center justify-end gap-1.5 md:ml-0 lg:gap-3">
             <GitHubStarsBadge className="gap-1 pr-0 lg:gap-1.5 lg:pr-1" />
             <div className="hidden md:block">
               <DownloadButton


### PR DESCRIPTION
## Summary
- hide the header GitHub stars badge until extra-large screens so the desktop nav no longer collides at narrower widths
- let the badge component accept additive classes so responsive visibility can be controlled from the header

## Testing
- `SKIP_ENV_VALIDATION=1 npm run build`
- `npx eslint 'app/[locale]/components/github-stars.tsx' 'app/[locale]/components/site-header.tsx'` (passes with one pre-existing `<img>` warning in `site-header.tsx`)
- manual browser check at `860px` and `1400px` viewport widths on `http://localhost:3778`

## Issues
- Task: user request "fix overlap" with attached header screenshot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes header overlap by centering the nav and preventing collisions. Uses a 3‑column grid from 940px and tighter spacing so the header stays balanced on all screens.

- **Bug Fixes**
  - Move the responsive breakpoint to 940px across the header and mobile drawer (grid/nav visibility, toggle/overlay, and body scroll lock).
  - Tighten gaps and text sizes, add `min-w-0`, and refine badge/button spacing; keep GitHub stars visible. Allow additive `className` on `GitHubStarsBadge` and `DownloadButton` for responsive sizing.

<sup>Written for commit aa7ce62fcbbf9be9541041b81f841b300d63f383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GitHub stars badge and download button now support caller-provided styling to allow targeted layout adjustments.
  * Site header converted to a three-column responsive grid for more consistent alignment and behavior across screen sizes.

* **Style**
  * Updated spacing, gaps, and typography across header, badge, and download controls for improved visual balance and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->