### PR TITLE
Make sidebar PR lookups event-driven

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -62,8 +62,6 @@ _CMUX_PR_POLL_PWD="${_CMUX_PR_POLL_PWD:-}"
 _CMUX_PR_LAST_BRANCH="${_CMUX_PR_LAST_BRANCH:-}"
 _CMUX_PR_NO_PR_BRANCH="${_CMUX_PR_NO_PR_BRANCH:-}"
 _CMUX_PR_POLL_INTERVAL="${_CMUX_PR_POLL_INTERVAL:-45}"
-_CMUX_PR_RESULT_TTL="${_CMUX_PR_RESULT_TTL:-300}"
-_CMUX_PR_NO_PR_TTL="${_CMUX_PR_NO_PR_TTL:-300}"
 _CMUX_PR_FORCE="${_CMUX_PR_FORCE:-0}"
 _CMUX_PR_DEBUG="${_CMUX_PR_DEBUG:-0}"
 _CMUX_ASYNC_JOB_TIMEOUT="${_CMUX_ASYNC_JOB_TIMEOUT:-20}"
@@ -380,31 +378,6 @@ _cmux_pr_request_probe() {
     : >| "$signal_path"
 }
 
-_cmux_pr_emit_cached_result() {
-    local branch="$1"
-    local result_line="$2"
-    local kind="" number="" state="" url="" status_opt=""
-
-    if [[ "$result_line" == "none" ]]; then
-        _cmux_clear_pr_for_panel
-        return 0
-    fi
-
-    IFS=$'\t' read -r kind number state url <<< "$result_line"
-    [[ "$kind" == "pr" ]] || return 1
-    [[ -n "$number" && -n "$url" ]] || return 1
-
-    case "$state" in
-        MERGED) status_opt="--state=merged" ;;
-        OPEN) status_opt="--state=open" ;;
-        CLOSED) status_opt="--state=closed" ;;
-        *) return 1 ;;
-    esac
-
-    local quoted_branch="${branch//\"/\\\"}"
-    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-}
-
 _cmux_report_pr_for_path() {
     local repo_path="$1"
     local force_probe="${2:-0}"
@@ -424,7 +397,7 @@ _cmux_report_pr_for_path() {
 
     local branch repo_slug="" gh_output="" gh_error="" err_file="" gh_status number state url status_opt=""
     local now prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
-    local cache_branch="" cache_repo_path="" cache_result="" cache_timestamp="" cache_no_pr_branch="" cache_ttl=0 cache_age=0
+    local cache_branch="" cache_result="" cache_no_pr_branch=""
     local -a gh_repo_args=()
     now="$(_cmux_now)"
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
@@ -443,31 +416,17 @@ _cmux_report_pr_for_path() {
         timestamp_file="${prefix}.timestamp"
         no_pr_branch_file="${prefix}.no-pr-branch"
         [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
-        [[ -r "$repo_file" ]] && cache_repo_path="$(<"$repo_file")"
         [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
-        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
         [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
     fi
 
     _CMUX_PR_LAST_BRANCH="$cache_branch"
     _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
-
-    if [[ "$cache_no_pr_branch" == "$branch" ]] || [[ "$cache_result" == "none" ]]; then
-        cache_ttl="${_CMUX_PR_NO_PR_TTL:-300}"
+    if [[ "$cache_branch" == "$branch" && -n "$cache_result" ]]; then
+        _cmux_pr_debug_log "$branch" "cache-refresh"
     else
-        cache_ttl="${_CMUX_PR_RESULT_TTL:-300}"
+        _cmux_pr_debug_log "$branch" "cache-miss"
     fi
-
-    if [[ "$force_probe" != "1" && -n "$cache_branch" && -n "$cache_result" && -n "$cache_timestamp" ]] \
-        && [[ "$cache_branch" == "$branch" && "$cache_repo_path" == "$repo_path" ]]; then
-        cache_age=$(( now - cache_timestamp ))
-        if (( cache_age >= 0 && cache_age < cache_ttl )); then
-            _cmux_pr_debug_log "$branch" "cache-hit"
-            _cmux_pr_emit_cached_result "$branch" "$cache_result"
-            return $?
-        fi
-    fi
-    _cmux_pr_debug_log "$branch" "cache-miss"
 
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -44,6 +44,10 @@ _cmux_restore_scrollback_once() {
 }
 _cmux_restore_scrollback_once
 
+_cmux_now() {
+    printf '%s\n' "${EPOCHSECONDS:-$SECONDS}"
+}
+
 # Throttle heavy work to avoid prompt latency.
 _CMUX_PWD_LAST_PWD="${_CMUX_PWD_LAST_PWD:-}"
 _CMUX_GIT_LAST_PWD="${_CMUX_GIT_LAST_PWD:-}"
@@ -55,8 +59,13 @@ _CMUX_GIT_HEAD_PATH="${_CMUX_GIT_HEAD_PATH:-}"
 _CMUX_GIT_HEAD_SIGNATURE="${_CMUX_GIT_HEAD_SIGNATURE:-}"
 _CMUX_PR_POLL_PID="${_CMUX_PR_POLL_PID:-}"
 _CMUX_PR_POLL_PWD="${_CMUX_PR_POLL_PWD:-}"
+_CMUX_PR_LAST_BRANCH="${_CMUX_PR_LAST_BRANCH:-}"
+_CMUX_PR_NO_PR_BRANCH="${_CMUX_PR_NO_PR_BRANCH:-}"
 _CMUX_PR_POLL_INTERVAL="${_CMUX_PR_POLL_INTERVAL:-45}"
+_CMUX_PR_RESULT_TTL="${_CMUX_PR_RESULT_TTL:-300}"
+_CMUX_PR_NO_PR_TTL="${_CMUX_PR_NO_PR_TTL:-300}"
 _CMUX_PR_FORCE="${_CMUX_PR_FORCE:-0}"
+_CMUX_PR_DEBUG="${_CMUX_PR_DEBUG:-0}"
 _CMUX_ASYNC_JOB_TIMEOUT="${_CMUX_ASYNC_JOB_TIMEOUT:-20}"
 
 _CMUX_PORTS_LAST_RUN="${_CMUX_PORTS_LAST_RUN:-0}"
@@ -327,13 +336,85 @@ _cmux_github_repo_slug_for_path() {
     printf '%s\n' "$path_part"
 }
 
+_cmux_pr_cache_prefix() {
+    [[ -n "$CMUX_PANEL_ID" ]] || return 1
+    printf '%s\n' "/tmp/cmux-pr-cache-${CMUX_PANEL_ID}"
+}
+
+_cmux_pr_force_signal_path() {
+    [[ -n "$CMUX_PANEL_ID" ]] || return 1
+    printf '%s\n' "/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
+}
+
+_cmux_pr_debug_log() {
+    (( _CMUX_PR_DEBUG )) || return 0
+
+    local branch="$1"
+    local event="$2"
+    local now
+    now="$(_cmux_now)"
+    printf '%s\tbranch=%s\tevent=%s\n' "$now" "$branch" "$event" >> /tmp/cmux-pr-debug.log
+}
+
+_cmux_pr_cache_clear() {
+    local prefix=""
+    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+        /bin/rm -f -- \
+            "${prefix}.branch" \
+            "${prefix}.repo" \
+            "${prefix}.result" \
+            "${prefix}.timestamp" \
+            "${prefix}.no-pr-branch" \
+            >/dev/null 2>&1 || true
+    fi
+
+    _CMUX_PR_LAST_BRANCH=""
+    _CMUX_PR_NO_PR_BRANCH=""
+}
+
+_cmux_pr_request_probe() {
+    local signal_path=""
+    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+    [[ -n "$signal_path" ]] || return 0
+    : >| "$signal_path"
+}
+
+_cmux_pr_emit_cached_result() {
+    local branch="$1"
+    local result_line="$2"
+    local kind="" number="" state="" url="" status_opt=""
+
+    if [[ "$result_line" == "none" ]]; then
+        _cmux_clear_pr_for_panel
+        return 0
+    fi
+
+    IFS=$'\t' read -r kind number state url <<< "$result_line"
+    [[ "$kind" == "pr" ]] || return 1
+    [[ -n "$number" && -n "$url" ]] || return 1
+
+    case "$state" in
+        MERGED) status_opt="--state=merged" ;;
+        OPEN) status_opt="--state=open" ;;
+        CLOSED) status_opt="--state=closed" ;;
+        *) return 1 ;;
+    esac
+
+    local quoted_branch="${branch//\"/\\\"}"
+    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+}
+
 _cmux_report_pr_for_path() {
     local repo_path="$1"
+    local force_probe="${2:-0}"
     [[ -n "$repo_path" ]] || {
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     }
     [[ -d "$repo_path" ]] || {
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     }
@@ -342,12 +423,52 @@ _cmux_report_pr_for_path() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
     local branch repo_slug="" gh_output="" gh_error="" err_file="" gh_status number state url status_opt=""
+    local now prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
+    local cache_branch="" cache_repo_path="" cache_result="" cache_timestamp="" cache_no_pr_branch="" cache_ttl=0 cache_age=0
     local -a gh_repo_args=()
+    now="$(_cmux_now)"
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
+        _cmux_pr_debug_log "$branch" "cache-miss:clear"
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     fi
+
+    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+        branch_file="${prefix}.branch"
+        repo_file="${prefix}.repo"
+        result_file="${prefix}.result"
+        timestamp_file="${prefix}.timestamp"
+        no_pr_branch_file="${prefix}.no-pr-branch"
+        [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
+        [[ -r "$repo_file" ]] && cache_repo_path="$(<"$repo_file")"
+        [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
+        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+        [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
+    fi
+
+    _CMUX_PR_LAST_BRANCH="$cache_branch"
+    _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
+
+    if [[ "$cache_no_pr_branch" == "$branch" ]] || [[ "$cache_result" == "none" ]]; then
+        cache_ttl="${_CMUX_PR_NO_PR_TTL:-300}"
+    else
+        cache_ttl="${_CMUX_PR_RESULT_TTL:-300}"
+    fi
+
+    if [[ "$force_probe" != "1" && -n "$cache_branch" && -n "$cache_result" && -n "$cache_timestamp" ]] \
+        && [[ "$cache_branch" == "$branch" && "$cache_repo_path" == "$repo_path" ]]; then
+        cache_age=$(( now - cache_timestamp ))
+        if (( cache_age >= 0 && cache_age < cache_ttl )); then
+            _cmux_pr_debug_log "$branch" "cache-hit"
+            _cmux_pr_emit_cached_result "$branch" "$cache_result"
+            return $?
+        fi
+    fi
+    _cmux_pr_debug_log "$branch" "cache-miss"
+
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then
         gh_repo_args=(--repo "$repo_slug")
@@ -371,10 +492,28 @@ _cmux_report_pr_for_path() {
 
     if (( gh_status != 0 )) || [[ -z "$gh_output" ]]; then
         if (( gh_status == 0 )) && [[ -z "$gh_output" ]]; then
+            if [[ -n "$prefix" ]]; then
+                printf '%s\n' "$branch" >| "$branch_file"
+                printf '%s\n' "$repo_path" >| "$repo_file"
+                printf '%s\n' "$now" >| "$timestamp_file"
+                printf '%s\n' "none" >| "$result_file"
+                printf '%s\n' "$branch" >| "$no_pr_branch_file"
+            fi
+            _CMUX_PR_LAST_BRANCH="$branch"
+            _CMUX_PR_NO_PR_BRANCH="$branch"
             _cmux_clear_pr_for_panel
             return 0
         fi
         if _cmux_pr_output_indicates_no_pull_request "$gh_error"; then
+            if [[ -n "$prefix" ]]; then
+                printf '%s\n' "$branch" >| "$branch_file"
+                printf '%s\n' "$repo_path" >| "$repo_file"
+                printf '%s\n' "$now" >| "$timestamp_file"
+                printf '%s\n' "none" >| "$result_file"
+                printf '%s\n' "$branch" >| "$no_pr_branch_file"
+            fi
+            _CMUX_PR_LAST_BRANCH="$branch"
+            _CMUX_PR_NO_PR_BRANCH="$branch"
             _cmux_clear_pr_for_panel
             return 0
         fi
@@ -396,6 +535,16 @@ _cmux_report_pr_for_path() {
         CLOSED) status_opt="--state=closed" ;;
         *) return 1 ;;
     esac
+
+    if [[ -n "$prefix" ]]; then
+        printf '%s\n' "$branch" >| "$branch_file"
+        printf '%s\n' "$repo_path" >| "$repo_file"
+        printf '%s\n' "$now" >| "$timestamp_file"
+        printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
+        /bin/rm -f -- "$no_pr_branch_file" >/dev/null 2>&1 || true
+    fi
+    _CMUX_PR_LAST_BRANCH="$branch"
+    _CMUX_PR_NO_PR_BRANCH=""
 
     local quoted_branch="${branch//\"/\\\"}"
     _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
@@ -424,18 +573,21 @@ _cmux_kill_process_tree() {
 
 _cmux_run_pr_probe_with_timeout() {
     local repo_path="$1"
+    local force_probe="${2:-0}"
     local probe_pid=""
-    local started_at=$SECONDS
-    local now=$started_at
+    local started_at=""
+    local now=""
+    started_at="$(_cmux_now)"
+    now=$started_at
 
     (
-        _cmux_report_pr_for_path "$repo_path"
+        _cmux_report_pr_for_path "$repo_path" "$force_probe"
     ) &
     probe_pid=$!
 
     while kill -0 "$probe_pid" >/dev/null 2>&1; do
         sleep 1
-        now=$SECONDS
+        now="$(_cmux_now)"
         if (( _CMUX_ASYNC_JOB_TIMEOUT > 0 )) && (( now - started_at >= _CMUX_ASYNC_JOB_TIMEOUT )); then
             _cmux_kill_process_tree "$probe_pid" TERM
             sleep 0.2
@@ -459,8 +611,13 @@ _cmux_stop_pr_poll_loop() {
         # negative PID kills the loop + all descendants (gh, sleep) without
         # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
         kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
-        _CMUX_PR_POLL_PID=""
     fi
+    local signal_path=""
+    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+    [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+    _CMUX_PR_POLL_PID=""
+    _CMUX_PR_POLL_PWD=""
+    _cmux_pr_cache_clear
 }
 
 _cmux_start_pr_poll_loop() {
@@ -478,14 +635,34 @@ _cmux_start_pr_poll_loop() {
         return 0
     fi
 
-    _cmux_stop_pr_poll_loop
+    if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
+        _cmux_stop_pr_poll_loop
+    else
+        _CMUX_PR_POLL_PID=""
+    fi
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
     {
+        local signal_path=""
+        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while :; do
             kill -0 "$watch_shell_pid" 2>/dev/null || break
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" || true
-            sleep "$interval"
+            local force_probe=0
+            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                force_probe=1
+                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+            fi
+            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
+
+            local slept=0
+            while (( slept < interval )); do
+                kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
+                if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                    break
+                fi
+                sleep 1
+                slept=$(( slept + 1 ))
+            done
         done
     } >/dev/null 2>&1 &
     _CMUX_PR_POLL_PID=$!
@@ -513,7 +690,6 @@ _cmux_preexec_command() {
     _cmux_report_shell_activity_state running
     _cmux_report_tty_once
     _cmux_ports_kick
-    _cmux_stop_pr_poll_loop
 }
 
 _cmux_bash_preexec_hook() {
@@ -528,7 +704,8 @@ _cmux_prompt_command() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     _cmux_report_shell_activity_state prompt
 
-    local now=$SECONDS
+    local now
+    now="$(_cmux_now)"
     local pwd="$PWD"
 
     # Post-wake socket writes can occasionally leave a probe process wedged.
@@ -625,6 +802,7 @@ _cmux_prompt_command() {
     # Pull request metadata is remote state. Keep polling while the shell sits
     # at a prompt so newly created or merged PRs appear without another command.
     local should_restart_pr_poll=0
+    local should_signal_pr_probe=0
     local pr_context_changed=0
     if [[ -n "$_CMUX_PR_POLL_PWD" && "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
         pr_context_changed=1
@@ -634,16 +812,27 @@ _cmux_prompt_command() {
     if [[ "$pwd" != "$_CMUX_PR_POLL_PWD" || "$git_head_changed" == "1" ]]; then
         should_restart_pr_poll=1
     elif (( _CMUX_PR_FORCE )); then
-        should_restart_pr_poll=1
+        if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
+            should_signal_pr_probe=1
+        else
+            should_restart_pr_poll=1
+        fi
     elif [[ -z "$_CMUX_PR_POLL_PID" ]] || ! kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
         should_restart_pr_poll=1
     fi
 
+    if (( pr_context_changed )); then
+        _cmux_pr_cache_clear
+        _cmux_clear_pr_for_panel
+    fi
+
+    if (( should_signal_pr_probe )); then
+        _CMUX_PR_FORCE=0
+        _cmux_pr_request_probe
+    fi
+
     if (( should_restart_pr_poll )); then
         _CMUX_PR_FORCE=0
-        if (( pr_context_changed )); then
-            _cmux_clear_pr_for_panel
-        fi
         _cmux_start_pr_poll_loop "$pwd" 1
     fi
 

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -70,8 +70,6 @@ typeset -g _CMUX_PR_POLL_PWD=""
 typeset -g _CMUX_PR_LAST_BRANCH=""
 typeset -g _CMUX_PR_NO_PR_BRANCH=""
 typeset -g _CMUX_PR_POLL_INTERVAL=45
-typeset -g _CMUX_PR_RESULT_TTL=300
-typeset -g _CMUX_PR_NO_PR_TTL=300
 typeset -g _CMUX_PR_FORCE=0
 typeset -g _CMUX_PR_DEBUG=${_CMUX_PR_DEBUG:-0}
 typeset -g _CMUX_ASYNC_JOB_TIMEOUT=20
@@ -497,32 +495,6 @@ _cmux_pr_request_probe() {
     : >| "$signal_path"
 }
 
-_cmux_pr_emit_cached_result() {
-    local branch="$1"
-    local result_line="$2"
-    local kind="" number="" state="" url="" status_opt=""
-
-    if [[ "$result_line" == "none" ]]; then
-        _cmux_clear_pr_for_panel
-        return 0
-    fi
-
-    local IFS=$'\t'
-    read -r kind number state url <<< "$result_line"
-    [[ "$kind" == "pr" ]] || return 1
-    [[ -n "$number" && -n "$url" ]] || return 1
-
-    case "$state" in
-        MERGED) status_opt="--state=merged" ;;
-        OPEN) status_opt="--state=open" ;;
-        CLOSED) status_opt="--state=closed" ;;
-        *) return 1 ;;
-    esac
-
-    local quoted_branch="${branch//\"/\\\"}"
-    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-}
-
 _cmux_report_pr_for_path() {
     local repo_path="$1"
     local force_probe="${2:-0}"
@@ -543,7 +515,7 @@ _cmux_report_pr_for_path() {
     local branch repo_slug="" gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
     local now="${EPOCHSECONDS:-0}"
     local prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
-    local cache_branch="" cache_repo_path="" cache_result="" cache_timestamp="" cache_no_pr_branch="" cache_ttl=0 cache_age=0
+    local cache_branch="" cache_result="" cache_no_pr_branch=""
     local -a gh_repo_args
     gh_repo_args=()
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
@@ -562,31 +534,17 @@ _cmux_report_pr_for_path() {
         timestamp_file="${prefix}.timestamp"
         no_pr_branch_file="${prefix}.no-pr-branch"
         [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
-        [[ -r "$repo_file" ]] && cache_repo_path="$(<"$repo_file")"
         [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
-        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
         [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
     fi
 
     _CMUX_PR_LAST_BRANCH="$cache_branch"
     _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
-
-    if [[ "$cache_no_pr_branch" == "$branch" ]] || [[ "$cache_result" == "none" ]]; then
-        cache_ttl="${_CMUX_PR_NO_PR_TTL:-300}"
+    if [[ "$cache_branch" == "$branch" && -n "$cache_result" ]]; then
+        _cmux_pr_debug_log "$branch" "cache-refresh"
     else
-        cache_ttl="${_CMUX_PR_RESULT_TTL:-300}"
+        _cmux_pr_debug_log "$branch" "cache-miss"
     fi
-
-    if [[ "$force_probe" != "1" && -n "$cache_branch" && -n "$cache_result" && -n "$cache_timestamp" ]] \
-        && [[ "$cache_branch" == "$branch" && "$cache_repo_path" == "$repo_path" ]]; then
-        cache_age=$(( now - cache_timestamp ))
-        if (( cache_age >= 0 && cache_age < cache_ttl )); then
-            _cmux_pr_debug_log "$branch" "cache-hit"
-            _cmux_pr_emit_cached_result "$branch" "$cache_result"
-            return $?
-        fi
-    fi
-    _cmux_pr_debug_log "$branch" "cache-miss"
 
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -467,7 +467,7 @@ _cmux_pr_debug_log() {
 
     local branch="$1"
     local event="$2"
-    local now="${EPOCHSECONDS:-0}"
+    local now="${EPOCHSECONDS:-$SECONDS}"
     printf '%s\tbranch=%s\tevent=%s\n' "$now" "$branch" "$event" >> /tmp/cmux-pr-debug.log
 }
 
@@ -513,7 +513,7 @@ _cmux_report_pr_for_path() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
     local branch repo_slug="" gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
-    local now="${EPOCHSECONDS:-0}"
+    local now="${EPOCHSECONDS:-$SECONDS}"
     local prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
     local cache_branch="" cache_result="" cache_no_pr_branch=""
     local -a gh_repo_args
@@ -653,7 +653,7 @@ _cmux_run_pr_probe_with_timeout() {
     local repo_path="$1"
     local force_probe="${2:-0}"
     local probe_pid=""
-    local started_at=$EPOCHSECONDS
+    local started_at="${EPOCHSECONDS:-$SECONDS}"
     local now=$started_at
 
     (
@@ -663,7 +663,7 @@ _cmux_run_pr_probe_with_timeout() {
 
     while kill -0 "$probe_pid" >/dev/null 2>&1; do
         sleep 1
-        now=$EPOCHSECONDS
+        now="${EPOCHSECONDS:-$SECONDS}"
         if (( _CMUX_ASYNC_JOB_TIMEOUT > 0 )) && (( now - started_at >= _CMUX_ASYNC_JOB_TIMEOUT )); then
             _cmux_kill_process_tree "$probe_pid" TERM
             sleep 0.2

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -67,8 +67,13 @@ typeset -g _CMUX_GIT_HEAD_SIGNATURE=""
 typeset -g _CMUX_GIT_HEAD_WATCH_PID=""
 typeset -g _CMUX_PR_POLL_PID=""
 typeset -g _CMUX_PR_POLL_PWD=""
+typeset -g _CMUX_PR_LAST_BRANCH=""
+typeset -g _CMUX_PR_NO_PR_BRANCH=""
 typeset -g _CMUX_PR_POLL_INTERVAL=45
+typeset -g _CMUX_PR_RESULT_TTL=300
+typeset -g _CMUX_PR_NO_PR_TTL=300
 typeset -g _CMUX_PR_FORCE=0
+typeset -g _CMUX_PR_DEBUG=${_CMUX_PR_DEBUG:-0}
 typeset -g _CMUX_ASYNC_JOB_TIMEOUT=20
 
 typeset -g _CMUX_PORTS_LAST_RUN=0
@@ -449,13 +454,85 @@ _cmux_github_repo_slug_for_path() {
     print -r -- "$path_part"
 }
 
+_cmux_pr_cache_prefix() {
+    [[ -n "$CMUX_PANEL_ID" ]] || return 1
+    print -r -- "/tmp/cmux-pr-cache-${CMUX_PANEL_ID}"
+}
+
+_cmux_pr_force_signal_path() {
+    [[ -n "$CMUX_PANEL_ID" ]] || return 1
+    print -r -- "/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
+}
+
+_cmux_pr_debug_log() {
+    (( _CMUX_PR_DEBUG )) || return 0
+
+    local branch="$1"
+    local event="$2"
+    local now="${EPOCHSECONDS:-0}"
+    printf '%s\tbranch=%s\tevent=%s\n' "$now" "$branch" "$event" >> /tmp/cmux-pr-debug.log
+}
+
+_cmux_pr_cache_clear() {
+    local prefix=""
+    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+        /bin/rm -f -- \
+            "${prefix}.branch" \
+            "${prefix}.repo" \
+            "${prefix}.result" \
+            "${prefix}.timestamp" \
+            "${prefix}.no-pr-branch" \
+            >/dev/null 2>&1 || true
+    fi
+
+    _CMUX_PR_LAST_BRANCH=""
+    _CMUX_PR_NO_PR_BRANCH=""
+}
+
+_cmux_pr_request_probe() {
+    local signal_path=""
+    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+    [[ -n "$signal_path" ]] || return 0
+    : >| "$signal_path"
+}
+
+_cmux_pr_emit_cached_result() {
+    local branch="$1"
+    local result_line="$2"
+    local kind="" number="" state="" url="" status_opt=""
+
+    if [[ "$result_line" == "none" ]]; then
+        _cmux_clear_pr_for_panel
+        return 0
+    fi
+
+    local IFS=$'\t'
+    read -r kind number state url <<< "$result_line"
+    [[ "$kind" == "pr" ]] || return 1
+    [[ -n "$number" && -n "$url" ]] || return 1
+
+    case "$state" in
+        MERGED) status_opt="--state=merged" ;;
+        OPEN) status_opt="--state=open" ;;
+        CLOSED) status_opt="--state=closed" ;;
+        *) return 1 ;;
+    esac
+
+    local quoted_branch="${branch//\"/\\\"}"
+    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+}
+
 _cmux_report_pr_for_path() {
     local repo_path="$1"
+    local force_probe="${2:-0}"
     [[ -n "$repo_path" ]] || {
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     }
     [[ -d "$repo_path" ]] || {
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     }
@@ -464,13 +541,53 @@ _cmux_report_pr_for_path() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
 
     local branch repo_slug="" gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
+    local now="${EPOCHSECONDS:-0}"
+    local prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
+    local cache_branch="" cache_repo_path="" cache_result="" cache_timestamp="" cache_no_pr_branch="" cache_ttl=0 cache_age=0
     local -a gh_repo_args
     gh_repo_args=()
     branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
     if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
+        _cmux_pr_debug_log "$branch" "cache-miss:clear"
+        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
         return 0
     fi
+
+    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+        branch_file="${prefix}.branch"
+        repo_file="${prefix}.repo"
+        result_file="${prefix}.result"
+        timestamp_file="${prefix}.timestamp"
+        no_pr_branch_file="${prefix}.no-pr-branch"
+        [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
+        [[ -r "$repo_file" ]] && cache_repo_path="$(<"$repo_file")"
+        [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
+        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+        [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
+    fi
+
+    _CMUX_PR_LAST_BRANCH="$cache_branch"
+    _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
+
+    if [[ "$cache_no_pr_branch" == "$branch" ]] || [[ "$cache_result" == "none" ]]; then
+        cache_ttl="${_CMUX_PR_NO_PR_TTL:-300}"
+    else
+        cache_ttl="${_CMUX_PR_RESULT_TTL:-300}"
+    fi
+
+    if [[ "$force_probe" != "1" && -n "$cache_branch" && -n "$cache_result" && -n "$cache_timestamp" ]] \
+        && [[ "$cache_branch" == "$branch" && "$cache_repo_path" == "$repo_path" ]]; then
+        cache_age=$(( now - cache_timestamp ))
+        if (( cache_age >= 0 && cache_age < cache_ttl )); then
+            _cmux_pr_debug_log "$branch" "cache-hit"
+            _cmux_pr_emit_cached_result "$branch" "$cache_result"
+            return $?
+        fi
+    fi
+    _cmux_pr_debug_log "$branch" "cache-miss"
+
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then
         gh_repo_args=(--repo "$repo_slug")
@@ -494,10 +611,28 @@ _cmux_report_pr_for_path() {
 
     if (( gh_status != 0 )) || [[ -z "$gh_output" ]]; then
         if (( gh_status == 0 )) && [[ -z "$gh_output" ]]; then
+            if [[ -n "$prefix" ]]; then
+                print -r -- "$branch" >| "$branch_file"
+                print -r -- "$repo_path" >| "$repo_file"
+                print -r -- "$now" >| "$timestamp_file"
+                print -r -- "none" >| "$result_file"
+                print -r -- "$branch" >| "$no_pr_branch_file"
+            fi
+            _CMUX_PR_LAST_BRANCH="$branch"
+            _CMUX_PR_NO_PR_BRANCH="$branch"
             _cmux_clear_pr_for_panel
             return 0
         fi
         if _cmux_pr_output_indicates_no_pull_request "$gh_error"; then
+            if [[ -n "$prefix" ]]; then
+                print -r -- "$branch" >| "$branch_file"
+                print -r -- "$repo_path" >| "$repo_file"
+                print -r -- "$now" >| "$timestamp_file"
+                print -r -- "none" >| "$result_file"
+                print -r -- "$branch" >| "$no_pr_branch_file"
+            fi
+            _CMUX_PR_LAST_BRANCH="$branch"
+            _CMUX_PR_NO_PR_BRANCH="$branch"
             _cmux_clear_pr_for_panel
             return 0
         fi
@@ -520,6 +655,16 @@ _cmux_report_pr_for_path() {
         CLOSED) status_opt="--state=closed" ;;
         *) return 1 ;;
     esac
+
+    if [[ -n "$prefix" ]]; then
+        print -r -- "$branch" >| "$branch_file"
+        print -r -- "$repo_path" >| "$repo_file"
+        print -r -- "$now" >| "$timestamp_file"
+        printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
+        /bin/rm -f -- "$no_pr_branch_file" >/dev/null 2>&1 || true
+    fi
+    _CMUX_PR_LAST_BRANCH="$branch"
+    _CMUX_PR_NO_PR_BRANCH=""
 
     local quoted_branch="${branch//\"/\\\"}"
     _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
@@ -548,12 +693,13 @@ _cmux_kill_process_tree() {
 
 _cmux_run_pr_probe_with_timeout() {
     local repo_path="$1"
+    local force_probe="${2:-0}"
     local probe_pid=""
     local started_at=$EPOCHSECONDS
     local now=$started_at
 
     (
-        _cmux_report_pr_for_path "$repo_path"
+        _cmux_report_pr_for_path "$repo_path" "$force_probe"
     ) &
     probe_pid=$!
 
@@ -583,8 +729,13 @@ _cmux_stop_pr_poll_loop() {
         # negative PID kills the loop + all descendants (gh, sleep) without
         # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
         kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
-        _CMUX_PR_POLL_PID=""
     fi
+    local signal_path=""
+    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+    [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+    _CMUX_PR_POLL_PID=""
+    _CMUX_PR_POLL_PWD=""
+    _cmux_pr_cache_clear
 }
 
 _cmux_start_pr_poll_loop() {
@@ -602,14 +753,34 @@ _cmux_start_pr_poll_loop() {
         return 0
     fi
 
-    _cmux_stop_pr_poll_loop
+    if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
+        _cmux_stop_pr_poll_loop
+    else
+        _CMUX_PR_POLL_PID=""
+    fi
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
     {
+        local signal_path=""
+        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while true; do
             kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" || true
-            sleep "$interval"
+            local force_probe=0
+            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                force_probe=1
+                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
+            fi
+            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
+
+            local slept=0
+            while (( slept < interval )); do
+                kill -0 "$watch_shell_pid" >/dev/null 2>&1 || exit 0
+                if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                    break
+                fi
+                sleep 1
+                slept=$(( slept + 1 ))
+            done
         done
     } >/dev/null 2>&1 &!
     _CMUX_PR_POLL_PID=$!
@@ -649,7 +820,14 @@ _cmux_start_git_head_watch() {
             signature="$(_cmux_git_head_signature "$watch_head_path" 2>/dev/null || true)"
             if [[ -n "$signature" && "$signature" != "$last_signature" ]]; then
                 last_signature="$signature"
+                _cmux_pr_cache_clear
                 _cmux_report_git_branch_for_path "$watch_pwd"
+                _cmux_clear_pr_for_panel
+                if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
+                    _cmux_pr_request_probe
+                else
+                    _cmux_run_pr_probe_with_timeout "$watch_pwd" 1 || true
+                fi
             fi
         done
     } >/dev/null 2>&1 &!
@@ -680,7 +858,6 @@ _cmux_preexec() {
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
     _cmux_ports_kick
-    _cmux_stop_pr_poll_loop
     _cmux_start_git_head_watch
 }
 
@@ -810,6 +987,7 @@ _cmux_precmd() {
     # alive while the shell is idle so gh-created PRs and merge status changes
     # appear even without another prompt.
     local should_restart_pr_poll=0
+    local should_signal_pr_probe=0
     local pr_context_changed=0
     if [[ -n "$_CMUX_PR_POLL_PWD" && "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
         pr_context_changed=1
@@ -819,16 +997,27 @@ _cmux_precmd() {
     if [[ "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
         should_restart_pr_poll=1
     elif (( _CMUX_PR_FORCE )); then
-        should_restart_pr_poll=1
+        if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
+            should_signal_pr_probe=1
+        else
+            should_restart_pr_poll=1
+        fi
     elif [[ -z "$_CMUX_PR_POLL_PID" ]] || ! kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
         should_restart_pr_poll=1
     fi
 
+    if (( pr_context_changed )); then
+        _cmux_pr_cache_clear
+        _cmux_clear_pr_for_panel
+    fi
+
+    if (( should_signal_pr_probe )); then
+        _CMUX_PR_FORCE=0
+        _cmux_pr_request_probe
+    fi
+
     if (( should_restart_pr_poll )); then
         _CMUX_PR_FORCE=0
-        if (( pr_context_changed )); then
-            _cmux_clear_pr_for_panel
-        fi
         _cmux_start_pr_poll_loop "$pwd" 1
     fi
 

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -3,7 +3,7 @@
 Regression coverage for issue #1138.
 
 Validates that shell integration:
-1) keeps a background PR loop alive while reusing cached results on idle branches
+1) keeps polling PR state while idle and recovers after a transient gh failure
 2) resolves the current branch PR via `gh pr view` instead of repository-wide
    branch-name matching
 3) clears stale PR state when the branch changes and the new probe fails
@@ -13,7 +13,6 @@ Validates that shell integration:
 7) falls back to explicit branch lookup when implicit gh branch resolution fails
 8) does not clear an existing PR badge on the first prompt while establishing
    the HEAD baseline
-9) caches negative lookups instead of re-querying `gh pr view` every interval
 """
 
 from __future__ import annotations
@@ -145,10 +144,6 @@ def _gh_stub() -> str:
           prompt_helper_idle)
             printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
             ;;
-          no_pr_cached)
-            printf 'no pull requests found for branch "%s"\\n' "$branch" >&2
-            exit 1
-            ;;
           initial_prompt_preserves_pr_badge)
             printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
             ;;
@@ -213,13 +208,6 @@ def _shell_command(kind: str, scenario: str) -> str:
             '_cmux_cleanup\n'
         ),
         "transient_same_context": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=1\n'
-            '_cmux_prompt_entry\n'
-            'sleep 3\n'
-            '_cmux_cleanup\n'
-        ),
-        "no_pr_cached": (
             'cd "$CMUX_TEST_REPO"\n'
             '_CMUX_PR_POLL_INTERVAL=1\n'
             '_cmux_prompt_entry\n'
@@ -363,8 +351,8 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
         return (1, f"{shell}/{scenario}: expected gh pr view only\n" + "\n".join(gh_args_lines))
 
     if scenario == "prompt_helper_idle":
-        if gh_count != 1:
-            return (1, f"{shell}/{scenario}: expected cached idle branch to hit gh once, saw {gh_count}")
+        if gh_count < 2:
+            return (1, f"{shell}/{scenario}: expected idle polling to survive prompt helpers, saw {gh_count}")
         if _report_line(1138) not in send_lines:
             return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
@@ -391,13 +379,6 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
             return (1, f"{shell}/{scenario}: expected clear_pr after branch change\n" + "\n".join(send_lines))
         if clear_indices[0] <= old_index:
             return (1, f"{shell}/{scenario}: clear_pr happened before old report\n" + "\n".join(send_lines))
-        return (0, f"{shell}/{scenario}: ok")
-
-    if scenario == "no_pr_cached":
-        if gh_count != 1:
-            return (1, f"{shell}/{scenario}: expected one cached negative gh probe, saw {gh_count}")
-        if not any(line.startswith("clear_pr ") for line in send_lines):
-            return (1, f"{shell}/{scenario}: expected clear_pr payload\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
 
     if scenario == "timeout_recovery":
@@ -444,7 +425,6 @@ def main() -> int:
     scenarios = [
         "prompt_helper_idle",
         "transient_same_context",
-        "no_pr_cached",
         "branch_switch_clear",
         "timeout_recovery",
         "explicit_branch_fallback",
@@ -478,7 +458,7 @@ def main() -> int:
                 print(failure)
             return 1
 
-        print("PASS: shell integrations reuse cached PR state while still recovering across transient failures, branch changes, and timeouts")
+        print("PASS: shell integrations poll PR state robustly across transient failures, branch changes, and timeouts")
         return 0
     finally:
         shutil.rmtree(base, ignore_errors=True)

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -3,7 +3,7 @@
 Regression coverage for issue #1138.
 
 Validates that shell integration:
-1) keeps polling PR state while idle and recovers after a transient gh failure
+1) keeps a background PR loop alive while reusing cached results on idle branches
 2) resolves the current branch PR via `gh pr view` instead of repository-wide
    branch-name matching
 3) clears stale PR state when the branch changes and the new probe fails
@@ -13,6 +13,7 @@ Validates that shell integration:
 7) falls back to explicit branch lookup when implicit gh branch resolution fails
 8) does not clear an existing PR badge on the first prompt while establishing
    the HEAD baseline
+9) caches negative lookups instead of re-querying `gh pr view` every interval
 """
 
 from __future__ import annotations
@@ -144,6 +145,10 @@ def _gh_stub() -> str:
           prompt_helper_idle)
             printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
             ;;
+          no_pr_cached)
+            printf 'no pull requests found for branch "%s"\\n' "$branch" >&2
+            exit 1
+            ;;
           initial_prompt_preserves_pr_badge)
             printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
             ;;
@@ -208,6 +213,13 @@ def _shell_command(kind: str, scenario: str) -> str:
             '_cmux_cleanup\n'
         ),
         "transient_same_context": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_CMUX_PR_POLL_INTERVAL=1\n'
+            '_cmux_prompt_entry\n'
+            'sleep 3\n'
+            '_cmux_cleanup\n'
+        ),
+        "no_pr_cached": (
             'cd "$CMUX_TEST_REPO"\n'
             '_CMUX_PR_POLL_INTERVAL=1\n'
             '_cmux_prompt_entry\n'
@@ -351,8 +363,8 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
         return (1, f"{shell}/{scenario}: expected gh pr view only\n" + "\n".join(gh_args_lines))
 
     if scenario == "prompt_helper_idle":
-        if gh_count < 2:
-            return (1, f"{shell}/{scenario}: expected idle polling to survive prompt helpers, saw {gh_count}")
+        if gh_count != 1:
+            return (1, f"{shell}/{scenario}: expected cached idle branch to hit gh once, saw {gh_count}")
         if _report_line(1138) not in send_lines:
             return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
@@ -379,6 +391,13 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
             return (1, f"{shell}/{scenario}: expected clear_pr after branch change\n" + "\n".join(send_lines))
         if clear_indices[0] <= old_index:
             return (1, f"{shell}/{scenario}: clear_pr happened before old report\n" + "\n".join(send_lines))
+        return (0, f"{shell}/{scenario}: ok")
+
+    if scenario == "no_pr_cached":
+        if gh_count != 1:
+            return (1, f"{shell}/{scenario}: expected one cached negative gh probe, saw {gh_count}")
+        if not any(line.startswith("clear_pr ") for line in send_lines):
+            return (1, f"{shell}/{scenario}: expected clear_pr payload\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
 
     if scenario == "timeout_recovery":
@@ -425,6 +444,7 @@ def main() -> int:
     scenarios = [
         "prompt_helper_idle",
         "transient_same_context",
+        "no_pr_cached",
         "branch_switch_clear",
         "timeout_recovery",
         "explicit_branch_fallback",
@@ -458,7 +478,7 @@ def main() -> int:
                 print(failure)
             return 1
 
-        print("PASS: shell integrations poll PR state robustly across transient failures, branch changes, and timeouts")
+        print("PASS: shell integrations reuse cached PR state while still recovering across transient failures, branch changes, and timeouts")
         return 0
     finally:
         shutil.rmtree(base, ignore_errors=True)


### PR DESCRIPTION
## Summary
- replace unconditional sidebar PR polling with per-panel cache files and force-signal files in the zsh/bash shell integrations
- cache both PR and no-PR results so idle workspaces reuse prior state, while branch changes and explicit git/gh activity can trigger immediate reprobes
- extend the existing shell integration regression harness to cover cached idle behavior and cached no-PR lookups

## Validation
- Did not run local tests per repo policy
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `python3 -m py_compile tests/test_issue_1138_sidebar_pr_polling.py`

Closes #2414.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidebar PR lookups event-driven with per-panel caching, a reprobe signal, and a persistent idle poll loop to keep badges fresh while reducing `gh` calls. Restores predictable idle refresh cadence and reduces UI churn, addressing #2414.

- **New Features**
  - Keep the PR poll loop alive between prompts; wake early on branch changes, per-panel reprobe signals, and a `zsh` Git HEAD watcher.
  - Cache PR and no-PR state per panel and reuse it between prompts; optional debug logging to `/tmp/cmux-pr-debug.log`.

- **Bug Fixes**
  - Clear stale PR state and signal files on context changes and when stopping the loop; handle transient `gh` failures and timeouts without stopping the poller.
  - Fix `zsh` timer handling by falling back to `$SECONDS` when `EPOCHSECONDS` is unset; add `_cmux_now` in `bash` for consistent timing.

<sup>Written for commit a00b46ceaa5f5914a496bd88e24fa96257539bb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-panel PR state caching (including “no PR” results) for faster, more accurate PR badges.
  * Force-probe signal to refresh PR information on demand.
  * Optional debug logging for PR detection troubleshooting.

* **Improvements**
  * Polling optimized to wake early on demand and use a monotonic timestamp for prompt timing.
  * Prompt lifecycle now clears stale PR state when context (path/branch/HEAD) changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->