### PR TITLE
Drag bonsplit tabs into sidebar as workspaces

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7643,7 +7643,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         writeBonsplitTabDragUITestData([
             "workspaceCount": String(tabManager.tabs.count),
-            "selectedWorkspaceId": tabManager.selectedTabId?.uuidString ?? "",
+            "selectedWorkspaceId": tabManager.selectedTabId?.uuidString ?? "NONE",
+            "hasSelectedWorkspace": tabManager.selectedTabId != nil ? "1" : "0",
             "trackedPaneId": trackedPaneId.description,
             "trackedPaneTabTitles": titles.joined(separator: "|"),
             "trackedPaneTabCount": String(titles.count),

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4519,6 +4519,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return moved
     }
 
+    func moveBonsplitTabToNewWorkspace(
+        tabId: UUID,
+        in targetTabManager: TabManager,
+        at targetIndex: Int,
+        focus: Bool = true,
+        focusWindow: Bool = true
+    ) -> UUID? {
+        guard let located = locateBonsplitSurface(tabId: tabId) else {
+            return nil
+        }
+
+        let bootstrapWorkspace = targetTabManager.addWorkspace(
+            select: focus,
+            placementOverride: .end,
+            autoWelcomeIfNeeded: false
+        )
+        let bootstrapWorkspaceId = bootstrapWorkspace.id
+        let bootstrapPanelId = bootstrapWorkspace.focusedPanelId
+
+        _ = targetTabManager.reorderWorkspace(
+            tabId: bootstrapWorkspaceId,
+            toIndex: targetIndex
+        )
+
+        guard let destinationPane = bootstrapWorkspace.bonsplitController.focusedPaneId
+            ?? bootstrapWorkspace.bonsplitController.allPaneIds.first else {
+            targetTabManager.closeWorkspace(bootstrapWorkspace)
+            return nil
+        }
+
+        guard moveSurface(
+            panelId: located.panelId,
+            toWorkspace: bootstrapWorkspaceId,
+            targetPane: destinationPane,
+            focus: focus,
+            focusWindow: focusWindow
+        ) else {
+            targetTabManager.closeWorkspace(bootstrapWorkspace)
+            return nil
+        }
+
+        if let bootstrapPanelId,
+           bootstrapPanelId != located.panelId,
+           bootstrapWorkspace.panels[bootstrapPanelId] != nil,
+           bootstrapWorkspace.panels.count > 1 {
+            _ = bootstrapWorkspace.closePanel(bootstrapPanelId, force: true)
+        }
+
+        return bootstrapWorkspaceId
+    }
+
     func tabManagerFor(windowId: UUID) -> TabManager? {
         mainWindowContexts.values.first(where: { $0.windowId == windowId })?.tabManager
     }
@@ -7591,6 +7642,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .flatMap { workspace.panelTitle(panelId: $0) } ?? ""
 
         writeBonsplitTabDragUITestData([
+            "workspaceCount": String(tabManager.tabs.count),
+            "selectedWorkspaceId": tabManager.selectedTabId?.uuidString ?? "",
             "trackedPaneId": trackedPaneId.description,
             "trackedPaneTabTitles": titles.joined(separator: "|"),
             "trackedPaneTabCount": String(titles.count),

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8671,6 +8671,7 @@ struct VerticalTabsSidebar: View {
     @StateObject private var tabItemSettingsStore = SidebarTabItemSettingsStore()
     @State private var draggedTabId: UUID?
     @State private var dropIndicator: SidebarDropIndicator?
+    @State private var dropIndicatorOwnerKey: String?
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(KeyboardShortcutSettings.Action.selectWorkspaceByNumber.defaultsKey)
@@ -8777,6 +8778,7 @@ struct VerticalTabsSidebar: View {
                                     dragAutoScrollController: dragAutoScrollController,
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
+                                    dropIndicatorOwnerKey: $dropIndicatorOwnerKey,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
@@ -8795,7 +8797,8 @@ struct VerticalTabsSidebar: View {
                             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                             dragAutoScrollController: dragAutoScrollController,
                             draggedTabId: $draggedTabId,
-                            dropIndicator: $dropIndicator
+                            dropIndicator: $dropIndicator,
+                            dropIndicatorOwnerKey: $dropIndicatorOwnerKey
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
@@ -8847,6 +8850,7 @@ struct VerticalTabsSidebar: View {
             modifierKeyMonitor.start()
             draggedTabId = nil
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
             SidebarDragLifecycleNotification.postStateDidChange(
                 tabId: nil,
                 reason: "sidebar_appear"
@@ -8858,6 +8862,7 @@ struct VerticalTabsSidebar: View {
             dragFailsafeMonitor.stop()
             draggedTabId = nil
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
             SidebarDragLifecycleNotification.postStateDidChange(
                 tabId: nil,
                 reason: "sidebar_disappear"
@@ -8880,6 +8885,7 @@ struct VerticalTabsSidebar: View {
             dragFailsafeMonitor.stop()
             dragAutoScrollController.stop()
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
         }
         .onReceive(NotificationCenter.default.publisher(for: SidebarDragLifecycleNotification.requestClear)) { notification in
             guard draggedTabId != nil else { return }
@@ -11016,6 +11022,7 @@ private struct SidebarEmptyArea: View {
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
+    @Binding var dropIndicatorOwnerKey: String?
 
     var body: some View {
         Color.clear
@@ -11037,7 +11044,8 @@ private struct SidebarEmptyArea: View {
                 lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                 targetRowHeight: nil,
                 dragAutoScrollController: dragAutoScrollController,
-                dropIndicator: $dropIndicator
+                dropIndicator: $dropIndicator,
+                dropIndicatorOwnerKey: $dropIndicatorOwnerKey
             ))
             .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitWorkspaceDropDelegate(
                 targetTabId: nil,
@@ -11046,7 +11054,8 @@ private struct SidebarEmptyArea: View {
                 lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                 targetRowHeight: nil,
                 dragAutoScrollController: dragAutoScrollController,
-                dropIndicator: $dropIndicator
+                dropIndicator: $dropIndicator,
+                dropIndicatorOwnerKey: $dropIndicatorOwnerKey
             ))
             .overlay(alignment: .top) {
                 if shouldShowTopDropIndicator {
@@ -11218,6 +11227,7 @@ private struct TabItemView: View, Equatable {
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
+    @Binding var dropIndicatorOwnerKey: String?
     let contextMenuWorkspaceIds: [UUID]
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
@@ -11815,6 +11825,7 @@ private struct TabItemView: View, Equatable {
             #endif
             draggedTabId = tab.id
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
             return SidebarTabDragPayload.provider(for: tab.id)
         }
         .internalOnlyTabDrag()
@@ -11826,7 +11837,8 @@ private struct TabItemView: View, Equatable {
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
             targetRowHeight: rowHeight,
             dragAutoScrollController: dragAutoScrollController,
-            dropIndicator: $dropIndicator
+            dropIndicator: $dropIndicator,
+            dropIndicatorOwnerKey: $dropIndicatorOwnerKey
         ))
         .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitWorkspaceDropDelegate(
             targetTabId: tab.id,
@@ -11835,7 +11847,8 @@ private struct TabItemView: View, Equatable {
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
             targetRowHeight: rowHeight,
             dragAutoScrollController: dragAutoScrollController,
-            dropIndicator: $dropIndicator
+            dropIndicator: $dropIndicator,
+            dropIndicatorOwnerKey: $dropIndicatorOwnerKey
         ))
         .onTapGesture {
             updateSelection()
@@ -13436,6 +13449,7 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
     let targetRowHeight: CGFloat?
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var dropIndicator: SidebarDropIndicator?
+    @Binding var dropIndicatorOwnerKey: String?
 
     func validateDrop(info: DropInfo) -> Bool {
         guard info.hasItemsConforming(to: [BonsplitTabDragPayload.typeIdentifier]) else { return false }
@@ -13449,14 +13463,9 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
-        if targetTabId == nil {
-            if dropIndicator?.tabId == nil {
-                dropIndicator = nil
-            }
-            return
-        }
-        if dropIndicator?.tabId == targetTabId {
+        if dropIndicatorOwnerKey == dropIndicatorSourceKey {
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
         }
     }
 
@@ -13470,6 +13479,7 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
     func performDrop(info: DropInfo) -> Bool {
         defer {
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
             dragAutoScrollController.stop()
         }
         guard validateDrop(info: info),
@@ -13492,7 +13502,16 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
     }
 
     private func updateDropIndicator(for info: DropInfo) {
-        dropIndicator = proposedIndicator(for: info)
+        if let indicator = proposedIndicator(for: info) {
+            dropIndicator = indicator
+            dropIndicatorOwnerKey = dropIndicatorSourceKey
+            return
+        }
+
+        if dropIndicatorOwnerKey == dropIndicatorSourceKey {
+            dropIndicator = nil
+            dropIndicatorOwnerKey = nil
+        }
     }
 
     private func proposedIndicator(for info: DropInfo) -> SidebarDropIndicator? {
@@ -13528,6 +13547,10 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
             lastSidebarSelectionIndex = nil
         }
     }
+
+    private var dropIndicatorSourceKey: String {
+        "bonsplit:\(targetTabId?.uuidString ?? "end")"
+    }
 }
 
 private struct SidebarTabDropDelegate: DropDelegate {
@@ -13539,6 +13562,7 @@ private struct SidebarTabDropDelegate: DropDelegate {
     let targetRowHeight: CGFloat?
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var dropIndicator: SidebarDropIndicator?
+    @Binding var dropIndicatorOwnerKey: String?
 
     func validateDrop(info: DropInfo) -> Bool {
         let hasType = info.hasItemsConforming(to: [SidebarTabDragPayload.typeIdentifier])
@@ -13561,8 +13585,9 @@ private struct SidebarTabDropDelegate: DropDelegate {
 #if DEBUG
         dlog("sidebar.dropExited target=\(targetTabId?.uuidString.prefix(5) ?? "end")")
 #endif
-        if dropIndicator?.tabId == targetTabId {
+        if dropIndicatorOwnerKey == dropIndicatorSourceKey {
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
         }
     }
 
@@ -13582,6 +13607,7 @@ private struct SidebarTabDropDelegate: DropDelegate {
         defer {
             draggedTabId = nil
             dropIndicator = nil
+            dropIndicatorOwnerKey = nil
             dragAutoScrollController.stop()
         }
         #if DEBUG
@@ -13641,14 +13667,23 @@ private struct SidebarTabDropDelegate: DropDelegate {
     private func updateDropIndicator(for info: DropInfo) {
         let tabIds = tabManager.tabs.map(\.id)
         let pinnedTabIds = Set(tabManager.tabs.filter(\.isPinned).map(\.id))
-        dropIndicator = SidebarDropPlanner.indicator(
+        if let indicator = SidebarDropPlanner.indicator(
             draggedTabId: draggedTabId,
             targetTabId: targetTabId,
             tabIds: tabIds,
             pinnedTabIds: pinnedTabIds,
             pointerY: targetTabId == nil ? nil : info.location.y,
             targetHeight: targetRowHeight
-        )
+        ) {
+            dropIndicator = indicator
+            dropIndicatorOwnerKey = dropIndicatorSourceKey
+            return
+        }
+
+        if dropIndicatorOwnerKey == dropIndicatorSourceKey {
+            dropIndicator = nil
+            dropIndicatorOwnerKey = nil
+        }
     }
 
     private func syncSidebarSelection(preferredSelectedTabId: UUID? = nil) {
@@ -13664,6 +13699,10 @@ private struct SidebarTabDropDelegate: DropDelegate {
         guard let indicator else { return "nil" }
         let tabText = indicator.tabId.map { String($0.uuidString.prefix(5)) } ?? "end"
         return "\(tabText):\(indicator.edge == .top ? "top" : "bottom")"
+    }
+
+    private var dropIndicatorSourceKey: String {
+        "sidebar:\(targetTabId?.uuidString ?? "end")"
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13453,7 +13453,10 @@ private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
 
     func validateDrop(info: DropInfo) -> Bool {
         guard info.hasItemsConforming(to: [BonsplitTabDragPayload.typeIdentifier]) else { return false }
-        guard BonsplitTabDragPayload.currentTransfer() != nil else { return false }
+        // The live drag pasteboard can report the bonsplit UTI before the
+        // payload is synchronously decodable. Allow hover feedback based on
+        // type plus insertion legality, and require the full transfer only
+        // when the drop is committed.
         return plannedTargetIndex(for: info) != nil
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11039,6 +11039,15 @@ private struct SidebarEmptyArea: View {
                 dragAutoScrollController: dragAutoScrollController,
                 dropIndicator: $dropIndicator
             ))
+            .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitWorkspaceDropDelegate(
+                targetTabId: nil,
+                tabManager: tabManager,
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                targetRowHeight: nil,
+                dragAutoScrollController: dragAutoScrollController,
+                dropIndicator: $dropIndicator
+            ))
             .overlay(alignment: .top) {
                 if shouldShowTopDropIndicator {
                     Rectangle()
@@ -11051,7 +11060,7 @@ private struct SidebarEmptyArea: View {
     }
 
     private var shouldShowTopDropIndicator: Bool {
-        guard draggedTabId != nil, let indicator = dropIndicator else { return false }
+        guard let indicator = dropIndicator else { return false }
         if indicator.tabId == nil {
             return true
         }
@@ -11819,11 +11828,14 @@ private struct TabItemView: View, Equatable {
             dragAutoScrollController: dragAutoScrollController,
             dropIndicator: $dropIndicator
         ))
-        .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitTabDropDelegate(
-            targetWorkspaceId: tab.id,
+        .onDrop(of: BonsplitTabDragPayload.dropContentTypes, delegate: SidebarBonsplitWorkspaceDropDelegate(
+            targetTabId: tab.id,
             tabManager: tabManager,
             selectedTabIds: $selectedTabIds,
-            lastSidebarSelectionIndex: $lastSidebarSelectionIndex
+            lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+            targetRowHeight: rowHeight,
+            dragAutoScrollController: dragAutoScrollController,
+            dropIndicator: $dropIndicator
         ))
         .onTapGesture {
             updateSelection()
@@ -12112,7 +12124,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var showsCenteredTopDropIndicator: Bool {
-        guard draggedTabId != nil, let indicator = dropIndicator else { return false }
+        guard let indicator = dropIndicator else { return false }
         if indicator.tabId == tab.id && indicator.edge == .top {
             return true
         }
@@ -13304,51 +13316,213 @@ private enum BonsplitTabDragPayload {
     }
 }
 
-private struct SidebarBonsplitTabDropDelegate: DropDelegate {
-    let targetWorkspaceId: UUID
+enum SidebarBonsplitWorkspaceInsertPlanner {
+    static func indicator(
+        targetTabId: UUID?,
+        tabIds: [UUID],
+        pinnedTabIds: Set<UUID>,
+        pointerY: CGFloat? = nil,
+        targetHeight: CGFloat? = nil
+    ) -> SidebarDropIndicator? {
+        guard let insertionPosition = resolvedInsertionPosition(
+            targetTabId: targetTabId,
+            indicator: nil,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedTabIds,
+            pointerY: pointerY,
+            targetHeight: targetHeight
+        ) else {
+            return nil
+        }
+        return indicatorForInsertionPosition(insertionPosition, tabIds: tabIds)
+    }
+
+    static func targetIndex(
+        targetTabId: UUID?,
+        indicator: SidebarDropIndicator?,
+        tabIds: [UUID],
+        pinnedTabIds: Set<UUID>,
+        pointerY: CGFloat? = nil,
+        targetHeight: CGFloat? = nil
+    ) -> Int? {
+        resolvedInsertionPosition(
+            targetTabId: targetTabId,
+            indicator: indicator,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedTabIds,
+            pointerY: pointerY,
+            targetHeight: targetHeight
+        )
+    }
+
+    private static func resolvedInsertionPosition(
+        targetTabId: UUID?,
+        indicator: SidebarDropIndicator?,
+        tabIds: [UUID],
+        pinnedTabIds: Set<UUID>,
+        pointerY: CGFloat?,
+        targetHeight: CGFloat?
+    ) -> Int? {
+        let proposedInsertionPosition: Int
+        if let indicator,
+           let indicatorInsertion = insertionPositionForIndicator(indicator, tabIds: tabIds) {
+            proposedInsertionPosition = indicatorInsertion
+        } else if let targetTabId {
+            guard let targetTabIndex = tabIds.firstIndex(of: targetTabId) else { return nil }
+            let edge = (pointerY != nil && targetHeight != nil)
+                ? SidebarDropPlanner.edgeForPointer(
+                    locationY: pointerY ?? 0,
+                    targetHeight: targetHeight ?? 0
+                )
+                : .top
+            proposedInsertionPosition = (edge == .bottom) ? targetTabIndex + 1 : targetTabIndex
+        } else {
+            proposedInsertionPosition = tabIds.count
+        }
+
+        return legalInsertionPosition(
+            proposedInsertionPosition,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedTabIds
+        )
+    }
+
+    private static func legalInsertionPosition(
+        _ proposedInsertionPosition: Int,
+        tabIds: [UUID],
+        pinnedTabIds: Set<UUID>
+    ) -> Int? {
+        let clampedInsertion = max(0, min(proposedInsertionPosition, tabIds.count))
+        guard !pinnedTabIds.isEmpty else { return clampedInsertion }
+
+        let pinnedCount = tabIds.reduce(into: 0) { count, tabId in
+            if pinnedTabIds.contains(tabId) {
+                count += 1
+            }
+        }
+        guard pinnedCount > 0 else { return clampedInsertion }
+        guard clampedInsertion >= pinnedCount else { return nil }
+        return clampedInsertion
+    }
+
+    private static func indicatorForInsertionPosition(
+        _ insertionPosition: Int,
+        tabIds: [UUID]
+    ) -> SidebarDropIndicator {
+        let clampedInsertion = max(0, min(insertionPosition, tabIds.count))
+        if clampedInsertion >= tabIds.count {
+            return SidebarDropIndicator(tabId: nil, edge: .bottom)
+        }
+        return SidebarDropIndicator(tabId: tabIds[clampedInsertion], edge: .top)
+    }
+
+    private static func insertionPositionForIndicator(
+        _ indicator: SidebarDropIndicator,
+        tabIds: [UUID]
+    ) -> Int? {
+        if let tabId = indicator.tabId {
+            guard let targetTabIndex = tabIds.firstIndex(of: tabId) else { return nil }
+            return indicator.edge == .bottom ? targetTabIndex + 1 : targetTabIndex
+        }
+        return tabIds.count
+    }
+}
+
+private struct SidebarBonsplitWorkspaceDropDelegate: DropDelegate {
+    let targetTabId: UUID?
     let tabManager: TabManager
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
+    let targetRowHeight: CGFloat?
+    let dragAutoScrollController: SidebarDragAutoScrollController
+    @Binding var dropIndicator: SidebarDropIndicator?
 
     func validateDrop(info: DropInfo) -> Bool {
         guard info.hasItemsConforming(to: [BonsplitTabDragPayload.typeIdentifier]) else { return false }
-        return BonsplitTabDragPayload.currentTransfer() != nil
+        guard BonsplitTabDragPayload.currentTransfer() != nil else { return false }
+        return plannedTargetIndex(for: info) != nil
+    }
+
+    func dropEntered(info: DropInfo) {
+        dragAutoScrollController.updateFromDragLocation()
+        updateDropIndicator(for: info)
+    }
+
+    func dropExited(info: DropInfo) {
+        if targetTabId == nil {
+            if dropIndicator?.tabId == nil {
+                dropIndicator = nil
+            }
+            return
+        }
+        if dropIndicator?.tabId == targetTabId {
+            dropIndicator = nil
+        }
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
+        dragAutoScrollController.updateFromDragLocation()
+        updateDropIndicator(for: info)
         guard validateDrop(info: info) else { return nil }
         return DropProposal(operation: .move)
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        defer {
+            dropIndicator = nil
+            dragAutoScrollController.stop()
+        }
         guard validateDrop(info: info),
               let transfer = BonsplitTabDragPayload.currentTransfer(),
-              let app = AppDelegate.shared else {
+              let targetIndex = plannedTargetIndex(for: info),
+              let app = AppDelegate.shared,
+              let newWorkspaceId = app.moveBonsplitTabToNewWorkspace(
+                tabId: transfer.tab.id,
+                in: tabManager,
+                at: targetIndex,
+                focus: true,
+                focusWindow: true
+              ) else {
             return false
         }
 
-        if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
-           source.workspaceId == targetWorkspaceId {
-            syncSidebarSelection()
-            return true
-        }
-
-        guard app.moveBonsplitTab(
-            tabId: transfer.tab.id,
-            toWorkspace: targetWorkspaceId,
-            focus: true,
-            focusWindow: true
-        ) else {
-            return false
-        }
-
-        selectedTabIds = [targetWorkspaceId]
-        syncSidebarSelection()
+        selectedTabIds = [newWorkspaceId]
+        syncSidebarSelection(preferredSelectedTabId: newWorkspaceId)
         return true
     }
 
-    private func syncSidebarSelection() {
-        if let selectedId = tabManager.selectedTabId {
+    private func updateDropIndicator(for info: DropInfo) {
+        dropIndicator = proposedIndicator(for: info)
+    }
+
+    private func proposedIndicator(for info: DropInfo) -> SidebarDropIndicator? {
+        let tabIds = tabManager.tabs.map(\.id)
+        let pinnedTabIds = Set(tabManager.tabs.filter(\.isPinned).map(\.id))
+        return SidebarBonsplitWorkspaceInsertPlanner.indicator(
+            targetTabId: targetTabId,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedTabIds,
+            pointerY: targetTabId == nil ? nil : info.location.y,
+            targetHeight: targetRowHeight
+        )
+    }
+
+    private func plannedTargetIndex(for info: DropInfo) -> Int? {
+        let tabIds = tabManager.tabs.map(\.id)
+        let pinnedTabIds = Set(tabManager.tabs.filter(\.isPinned).map(\.id))
+        return SidebarBonsplitWorkspaceInsertPlanner.targetIndex(
+            targetTabId: targetTabId,
+            indicator: proposedIndicator(for: info),
+            tabIds: tabIds,
+            pinnedTabIds: pinnedTabIds,
+            pointerY: targetTabId == nil ? nil : info.location.y,
+            targetHeight: targetRowHeight
+        )
+    }
+
+    private func syncSidebarSelection(preferredSelectedTabId: UUID? = nil) {
+        let selectedId = preferredSelectedTabId ?? tabManager.selectedTabId
+        if let selectedId {
             lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
         } else {
             lastSidebarSelectionIndex = nil

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -803,6 +803,92 @@ final class SidebarDropPlannerTests: XCTestCase {
 
 }
 
+final class SidebarBonsplitWorkspaceInsertPlannerTests: XCTestCase {
+    func testRejectsInsertionIntoPinnedRegion() {
+        let pinnedA = UUID()
+        let pinnedB = UUID()
+        let unpinned = UUID()
+        let tabIds = [pinnedA, pinnedB, unpinned]
+        let pinnedIds: Set<UUID> = [pinnedA, pinnedB]
+
+        XCTAssertNil(
+            SidebarBonsplitWorkspaceInsertPlanner.indicator(
+                targetTabId: pinnedA,
+                tabIds: tabIds,
+                pinnedTabIds: pinnedIds,
+                pointerY: 2,
+                targetHeight: 40
+            )
+        )
+        XCTAssertNil(
+            SidebarBonsplitWorkspaceInsertPlanner.targetIndex(
+                targetTabId: pinnedA,
+                indicator: nil,
+                tabIds: tabIds,
+                pinnedTabIds: pinnedIds,
+                pointerY: 2,
+                targetHeight: 40
+            )
+        )
+    }
+
+    func testAllowsInsertionAtFirstUnpinnedBoundary() {
+        let pinnedA = UUID()
+        let pinnedB = UUID()
+        let unpinnedA = UUID()
+        let unpinnedB = UUID()
+        let tabIds = [pinnedA, pinnedB, unpinnedA, unpinnedB]
+        let pinnedIds: Set<UUID> = [pinnedA, pinnedB]
+
+        let indicator = SidebarBonsplitWorkspaceInsertPlanner.indicator(
+            targetTabId: pinnedB,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedIds,
+            pointerY: 38,
+            targetHeight: 40
+        )
+
+        XCTAssertEqual(indicator?.tabId, unpinnedA)
+        XCTAssertEqual(indicator?.edge, .top)
+        XCTAssertEqual(
+            SidebarBonsplitWorkspaceInsertPlanner.targetIndex(
+                targetTabId: pinnedB,
+                indicator: indicator,
+                tabIds: tabIds,
+                pinnedTabIds: pinnedIds,
+                pointerY: 38,
+                targetHeight: 40
+            ),
+            2
+        )
+    }
+
+    func testEmptyAreaAppendsAfterPinnedWorkspaces() {
+        let pinnedA = UUID()
+        let pinnedB = UUID()
+        let tabIds = [pinnedA, pinnedB]
+        let pinnedIds: Set<UUID> = [pinnedA, pinnedB]
+
+        let indicator = SidebarBonsplitWorkspaceInsertPlanner.indicator(
+            targetTabId: nil,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedIds
+        )
+
+        XCTAssertEqual(indicator?.tabId, nil)
+        XCTAssertEqual(indicator?.edge, .bottom)
+        XCTAssertEqual(
+            SidebarBonsplitWorkspaceInsertPlanner.targetIndex(
+                targetTabId: nil,
+                indicator: indicator,
+                tabIds: tabIds,
+                pinnedTabIds: pinnedIds
+            ),
+            2
+        )
+    }
+}
+
 
 final class SidebarDragAutoScrollPlannerTests: XCTestCase {
     func testAutoScrollPlanTriggersNearTopAndBottomOnly() {

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -104,7 +104,11 @@ final class BonsplitTabDragUITests: XCTestCase {
             return
         }
 
-        let sourceWorkspaceId = ready["workspaceId"] ?? ""
+        guard let sourceWorkspaceId = ready["workspaceId"], !sourceWorkspaceId.isEmpty else {
+            XCTFail("Expected setup to provide a source workspace id. data=\(ready)")
+            return
+        }
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
         let betaTitle = ready["betaTitle"] ?? "UITest Beta"
         let betaTab = app.buttons[betaTitle]
         let sidebar = app.descendants(matching: .any).matching(identifier: "Sidebar").firstMatch
@@ -117,8 +121,8 @@ final class BonsplitTabDragUITests: XCTestCase {
 
         let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
         let destination = CGPoint(
-            x: min(sidebar.frame.maxX - 24, workspaceRow.frame.midX),
-            y: workspaceRow.frame.maxY - max(6, min(14, workspaceRow.frame.height * 0.25))
+            x: min(sidebar.frame.maxX - 24.0, workspaceRow.frame.midX),
+            y: workspaceRow.frame.maxY - max(6.0, min(14.0, workspaceRow.frame.height * 0.25))
         )
         guard let dragSession = beginMouseDrag(
             fromAccessibilityPoint: start,
@@ -140,6 +144,7 @@ final class BonsplitTabDragUITests: XCTestCase {
             return
         }
 
+        XCTAssertEqual(updated["hasSelectedWorkspace"], "1", "Expected a selected workspace after extraction. data=\(updated)")
         XCTAssertEqual(updated["trackedPaneTabCount"], "1", "Expected the source pane to keep only one tab after extraction. data=\(updated)")
         XCTAssertEqual(updated["trackedPaneTabTitles"], alphaTitle, "Expected the source pane to retain only the alpha tab after extraction. data=\(updated)")
         XCTAssertNotEqual(updated["selectedWorkspaceId"], sourceWorkspaceId, "Expected the extracted pane tab to land in a newly selected workspace. data=\(updated)")

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -86,6 +86,60 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected tab drag not to move the window vertically")
     }
 
+    func testDraggingPaneTabIntoSidebarCreatesNewWorkspace() {
+        let (app, dataPath) = launchConfiguredApp()
+
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for pane-tab to sidebar workspace conversion UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let sourceWorkspaceId = ready["workspaceId"] ?? ""
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let betaTab = app.buttons[betaTitle]
+        let sidebar = app.descendants(matching: .any).matching(identifier: "Sidebar").firstMatch
+
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 5.0), "Expected sidebar to exist")
+
+        let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
+        let destination = CGPoint(x: sidebar.frame.midX, y: sidebar.frame.midY)
+        guard let dragSession = beginMouseDrag(
+            fromAccessibilityPoint: start,
+            holdDuration: 0.20
+        ) else {
+            XCTFail("Expected raw mouse drag session to start")
+            return
+        }
+        continueMouseDrag(
+            dragSession,
+            toAccessibilityPoint: destination,
+            steps: 28,
+            dragDuration: 0.45
+        )
+        endMouseDrag(dragSession, atAccessibilityPoint: destination)
+
+        guard let updated = waitForJSONKey("workspaceCount", equals: "2", atPath: dataPath, timeout: 5.0) else {
+            XCTFail("Expected workspace count to become 2 after dragging a pane tab into the sidebar. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        XCTAssertEqual(updated["trackedPaneTabCount"], "1", "Expected the source pane to keep only one tab after extraction. data=\(updated)")
+        XCTAssertEqual(updated["trackedPaneTabTitles"], alphaTitle, "Expected the source pane to retain only the alpha tab after extraction. data=\(updated)")
+        XCTAssertNotEqual(updated["selectedWorkspaceId"], sourceWorkspaceId, "Expected the extracted pane tab to land in a newly selected workspace. data=\(updated)")
+    }
+
     func testMinimalModePlacesPaneTabBarAtTopEdge() {
         let (app, dataPath) = launchConfiguredApp()
 

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -105,16 +105,21 @@ final class BonsplitTabDragUITests: XCTestCase {
         }
 
         let sourceWorkspaceId = ready["workspaceId"] ?? ""
-        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
         let betaTitle = ready["betaTitle"] ?? "UITest Beta"
         let betaTab = app.buttons[betaTitle]
         let sidebar = app.descendants(matching: .any).matching(identifier: "Sidebar").firstMatch
+        let workspaceRowIdentifier = "sidebarWorkspace.\(sourceWorkspaceId)"
+        let workspaceRow = app.descendants(matching: .any).matching(identifier: workspaceRowIdentifier).firstMatch
 
         XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
         XCTAssertTrue(sidebar.waitForExistence(timeout: 5.0), "Expected sidebar to exist")
+        XCTAssertTrue(workspaceRow.waitForExistence(timeout: 5.0), "Expected source workspace row to exist")
 
         let start = CGPoint(x: betaTab.frame.midX, y: betaTab.frame.midY)
-        let destination = CGPoint(x: sidebar.frame.midX, y: sidebar.frame.midY)
+        let destination = CGPoint(
+            x: min(sidebar.frame.maxX - 24, workspaceRow.frame.midX),
+            y: workspaceRow.frame.maxY - max(6, min(14, workspaceRow.frame.height * 0.25))
+        )
         guard let dragSession = beginMouseDrag(
             fromAccessibilityPoint: start,
             holdDuration: 0.20


### PR DESCRIPTION
## Summary
- drag bonsplit pane tabs into the sidebar to extract them into new workspaces
- reuse sidebar insertion indicators and block drops into the pinned workspace region
- add planner coverage plus a UI test for pane-tab-to-sidebar workspace conversion

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-drag-bonsplit-tabs-to-sidebar-workspaces build-for-testing`
- `./scripts/reload.sh --tag task-drag-bonsplit-tabs-to-sidebar-workspaces`

## Issues
- Task: make it possible to drag bonsplit tabs into the sidebar to convert them into workspaces, respecting pinned regions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drag bonsplit pane tabs into the sidebar to create new workspaces with precise insertion guides that respect pinned regions, now with hover indicators shown even before the payload fully decodes. Satisfies the task to convert pane tabs into workspaces while protecting pinned areas.

- New Features
  - Dragging a bonsplit tab over the sidebar creates and focuses a new workspace at a valid index.
  - Shows sidebar hover indicators for bonsplit drags without requiring full payload decode; reuses insertion indicators with auto-scroll; blocks pinned regions and supports row-edge and empty-area drops.
  - Adds `SidebarBonsplitWorkspaceInsertPlanner` and `SidebarBonsplitWorkspaceDropDelegate` to plan and handle sidebar drops.
  - Introduces `moveBonsplitTabToNewWorkspace`; adds unit tests for pinned-boundary and empty-area cases, plus a UI test validating workspace creation and selection.

- Bug Fixes
  - Fixes sidebar drop indicator cleanup by tracking ownership via `dropIndicatorOwnerKey`, preventing stale or wrong indicators when entering/exiting targets.

<sup>Written for commit 9eea901075a161f8d58eec3c44a4b2c690ee26e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar drag-and-drop can extract a pane into a newly created workspace; improved drop indicators and auto-scroll for more reliable reordering and insertion-at-end over empty sidebar areas.

* **Behavior**
  * Insertion planning respects pinned workspaces and yields predictable insertion positions at boundaries and in empty areas.

* **Tests**
  * Added unit tests for insertion planning and a UI test verifying dragging a pane tab into the sidebar creates a new workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->