### PR TITLE
Add SSH Docker sandbox workspace mode

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3590,8 +3590,61 @@ struct CMUXCLI {
         let noFocus: Bool
         let sshOptions: [String]
         let extraArguments: [String]
+        let dockerSandbox: SSHDockerSandboxOptions?
         let localSocketPath: String
         let remoteRelayPort: Int
+    }
+
+    struct SSHDockerSandboxOptions: Equatable {
+        let workspacePath: String?
+        let name: String?
+        let mounts: [String]
+        let shellArguments: [String]
+
+        var suggestedWorkspaceTitle: String? {
+            if let name = normalized(name) {
+                return name
+            }
+            guard let workspacePath = normalized(workspacePath) else {
+                return nil
+            }
+            let candidate = URL(fileURLWithPath: workspacePath).lastPathComponent
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return candidate.isEmpty || candidate == "/" ? nil : candidate
+        }
+
+        var writableWorkspacePaths: [String] {
+            var seen: Set<String> = []
+            var ordered: [String] = []
+
+            func append(_ rawValue: String?) {
+                guard let value = normalized(rawValue) else { return }
+                if seen.insert(value).inserted {
+                    ordered.append(value)
+                }
+            }
+
+            append(workspacePath)
+            for mount in mounts {
+                let trimmed = mount.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { continue }
+                let lower = trimmed.lowercased()
+                if lower.hasSuffix(":ro") || lower.hasSuffix(":readonly") {
+                    continue
+                }
+                append(trimmed)
+            }
+
+            return ordered
+        }
+
+        private func normalized(_ value: String?) -> String? {
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else {
+                return nil
+            }
+            return trimmed
+        }
     }
 
     private struct RemoteDaemonManifest: Decodable {
@@ -3660,14 +3713,24 @@ struct CMUXCLI {
             "source=\(terminfoSource == nil ? 0 : 1)"
         )
         let shellFeaturesValue = scopedGhosttyShellFeaturesValue()
-        let initialSSHCommand = buildSSHCommandText(sshOptions)
-        let remoteTerminalBootstrapScript = sshOptions.extraArguments.isEmpty
-            ? buildInteractiveRemoteShellScript(
-                remoteRelayPort: sshOptions.remoteRelayPort,
-                shellFeatures: shellFeaturesValue,
-                terminfoSource: terminfoSource
-            )
-            : nil
+        let remoteTerminalBootstrapScript: String? =
+            if let dockerSandbox = sshOptions.dockerSandbox {
+                buildDockerSandboxRemoteBootstrapScript(dockerSandbox)
+            } else if sshOptions.extraArguments.isEmpty {
+                buildInteractiveRemoteShellScript(
+                    remoteRelayPort: sshOptions.remoteRelayPort,
+                    shellFeatures: shellFeaturesValue,
+                    terminfoSource: terminfoSource
+                )
+            } else {
+                nil
+            }
+        let initialSSHCommand =
+            if sshOptions.dockerSandbox != nil {
+                buildSSHCommandText(sshOptions, remoteBootstrapScript: remoteTerminalBootstrapScript)
+            } else {
+                buildSSHCommandText(sshOptions)
+            }
         let remoteTerminalSSHCommand = buildSSHCommandText(
             sshOptions,
             remoteBootstrapScript: remoteTerminalBootstrapScript
@@ -3705,7 +3768,7 @@ struct CMUXCLI {
             "relayPort=\(sshOptions.remoteRelayPort) localSocket=\(sshOptions.localSocketPath) " +
             "controlPath=\(sshOptionValue(named: "ControlPath", in: remoteSSHOptions) ?? "nil") " +
             "workspaceName=\(sshOptions.workspaceName?.replacingOccurrences(of: " ", with: "_") ?? "nil") " +
-            "extraArgs=\(sshOptions.extraArguments.count)"
+            "extraArgs=\(sshOptions.extraArguments.count) dockerSandbox=\(sshOptions.dockerSandbox == nil ? 0 : 1)"
         )
 
         let workspaceCreateParams: [String: Any] = [
@@ -3808,6 +3871,20 @@ struct CMUXCLI {
             "GHOSTTY_SHELL_FEATURES": shellFeaturesValue,
         ]
         payload["remote_relay_port"] = remoteRelayPort
+        if let dockerSandbox = sshOptions.dockerSandbox {
+            var dockerSandboxPayload: [String: Any] = [
+                "mounts": dockerSandbox.mounts,
+                "shell_arguments": dockerSandbox.shellArguments,
+                "run_command": buildDockerSandboxRunCommand(dockerSandbox),
+            ]
+            if let workspacePath = dockerSandbox.workspacePath {
+                dockerSandboxPayload["workspace_path"] = workspacePath
+            }
+            if let name = dockerSandbox.name {
+                dockerSandboxPayload["name"] = name
+            }
+            payload["docker_sandbox"] = dockerSandboxPayload
+        }
         logSSHTiming("complete", extra: "workspace=\(String(workspaceId.prefix(8)))")
         if jsonOutput {
             print(jsonString(formatIDs(payload, mode: idFormat)))
@@ -3827,6 +3904,10 @@ struct CMUXCLI {
         var noFocus = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
+        var dockerSandboxEnabled = false
+        var dockerSandboxWorkspacePath: String?
+        var dockerSandboxName: String?
+        var dockerSandboxMounts: [String] = []
 
         var passthrough = false
         var index = 0
@@ -3863,6 +3944,33 @@ struct CMUXCLI {
                 }
                 workspaceName = commandArgs[index + 1]
                 index += 2
+            case "--docker-sandbox":
+                dockerSandboxEnabled = true
+                index += 1
+            case "--docker-sandbox-workspace":
+                guard index + 1 < commandArgs.count else {
+                    throw CLIError(message: "ssh: --docker-sandbox-workspace requires a path")
+                }
+                dockerSandboxEnabled = true
+                dockerSandboxWorkspacePath = commandArgs[index + 1]
+                index += 2
+            case "--docker-sandbox-name":
+                guard index + 1 < commandArgs.count else {
+                    throw CLIError(message: "ssh: --docker-sandbox-name requires a value")
+                }
+                dockerSandboxEnabled = true
+                dockerSandboxName = commandArgs[index + 1]
+                index += 2
+            case "--docker-sandbox-mount":
+                guard index + 1 < commandArgs.count else {
+                    throw CLIError(message: "ssh: --docker-sandbox-mount requires a path")
+                }
+                dockerSandboxEnabled = true
+                let value = commandArgs[index + 1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty {
+                    dockerSandboxMounts.append(value)
+                }
+                index += 2
             case "--no-focus":
                 noFocus = true
                 index += 1
@@ -3896,14 +4004,26 @@ struct CMUXCLI {
         guard let destination else {
             throw CLIError(message: "ssh requires a destination (example: cmux ssh user@host)")
         }
+        let dockerSandbox: SSHDockerSandboxOptions? =
+            if dockerSandboxEnabled {
+                SSHDockerSandboxOptions(
+                    workspacePath: dockerSandboxWorkspacePath,
+                    name: dockerSandboxName,
+                    mounts: dockerSandboxMounts,
+                    shellArguments: extraArguments
+                )
+            } else {
+                nil
+            }
         return SSHCommandOptions(
             destination: destination,
             port: port,
             identityFile: identityFile,
-            workspaceName: workspaceName,
+            workspaceName: workspaceName ?? dockerSandbox?.suggestedWorkspaceTitle,
             noFocus: noFocus,
             sshOptions: sshOptions,
-            extraArguments: extraArguments,
+            extraArguments: dockerSandbox == nil ? extraArguments : [],
+            dockerSandbox: dockerSandbox,
             localSocketPath: localSocketPath,
             remoteRelayPort: remoteRelayPort
         )
@@ -4114,6 +4234,51 @@ struct CMUXCLI {
             terminfoSource: terminfoSource
         )
         return "/bin/sh -c \(shellQuote(script))"
+    }
+
+    func buildDockerSandboxRunCommand(_ options: SSHDockerSandboxOptions) -> String {
+        var parts = ["docker", "sandbox", "run"]
+        if let name = options.name?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !name.isEmpty {
+            parts.append("--name")
+            parts.append(shellQuote(name))
+        }
+        parts.append("shell")
+        if let workspacePath = options.workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workspacePath.isEmpty {
+            parts.append(dockerSandboxPathShellToken(workspacePath))
+        }
+        for mount in options.mounts {
+            let trimmed = mount.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            parts.append(dockerSandboxPathShellToken(trimmed))
+        }
+        if !options.shellArguments.isEmpty {
+            parts.append("--")
+            parts.append(contentsOf: options.shellArguments.map(shellQuote))
+        }
+        return parts.joined(separator: " ")
+    }
+
+    func buildDockerSandboxRemoteBootstrapScript(_ options: SSHDockerSandboxOptions) -> String {
+        var lines = [
+            "if ! command -v docker >/dev/null 2>&1; then",
+            "  echo 'cmux ssh: docker CLI not found on the remote host.' >&2",
+            "  exit 127",
+            "fi",
+            "cmux_docker_sandbox_probe_err=\"$(docker sandbox ls 2>&1 >/dev/null)\"",
+            "cmux_docker_sandbox_probe_status=$?",
+            "if [ \"$cmux_docker_sandbox_probe_status\" -ne 0 ]; then",
+            "  if [ -n \"$cmux_docker_sandbox_probe_err\" ]; then printf '%s\\n' \"$cmux_docker_sandbox_probe_err\" >&2; fi",
+            "  echo 'cmux ssh: docker sandbox is unavailable on the remote host. Docker Desktop 4.58+ required.' >&2",
+            "  exit 127",
+            "fi",
+        ]
+        for workspacePath in options.writableWorkspacePaths {
+            lines.append("mkdir -p -- \(dockerSandboxPathShellToken(workspacePath)) || exit $?")
+        }
+        lines.append("exec \(buildDockerSandboxRunCommand(options))")
+        return lines.joined(separator: "\n")
     }
 
     private func interactiveRemoteTerminalSetupLines(terminfoSource: String?) -> [String] {
@@ -4556,6 +4721,30 @@ struct CMUXCLI {
             }
         }
         return trimmed
+    }
+
+    private func dockerSandboxPathShellToken(_ rawValue: String) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return shellQuote(trimmed) }
+
+        let lower = trimmed.lowercased()
+        if lower.hasSuffix(":readonly") {
+            let path = String(trimmed.dropLast(9))
+            return dockerSandboxPathShellToken(path) + ":readonly"
+        }
+        if lower.hasSuffix(":ro") {
+            let path = String(trimmed.dropLast(3))
+            return dockerSandboxPathShellToken(path) + ":ro"
+        }
+
+        if trimmed == "~" || trimmed == "~/" {
+            return "\"$HOME\""
+        }
+        if trimmed.hasPrefix("~/") {
+            let suffix = String(trimmed.dropFirst(2))
+            return suffix.isEmpty ? "\"$HOME\"" : "\"$HOME\"/\(shellQuote(suffix))"
+        }
+        return shellQuote(trimmed)
     }
 
     private func shellQuote(_ value: String) -> String {
@@ -6428,22 +6617,32 @@ struct CMUXCLI {
             """
         case "ssh":
             return """
-            Usage: cmux ssh <destination> [flags] [-- <remote-command-args>]
+            Usage: cmux ssh <destination> [flags] [-- <remote-command-args-or-sandbox-shell-args>]
 
             Create a new workspace, mark it as remote-SSH, and start an SSH session in that workspace.
             cmux will also establish a local SSH proxy endpoint so browser traffic can egress from the remote host.
 
             Flags:
-              --name <title>          Optional workspace title
-              --port <n>              SSH port
-              --identity <path>       SSH identity file path
-              --ssh-option <opt>      Extra SSH -o option (repeatable)
-              --no-focus              Create workspace without switching to it
+              --name <title>                   Optional workspace title
+              --port <n>                       SSH port
+              --identity <path>                SSH identity file path
+              --ssh-option <opt>               Extra SSH -o option (repeatable)
+              --docker-sandbox                 Run `docker sandbox run shell` on the remote host after connect
+              --docker-sandbox-workspace <p>   Primary remote workspace path to mount/create
+              --docker-sandbox-name <name>     Reuse a named Docker sandbox on the remote host
+              --docker-sandbox-mount <path>    Extra remote workspace mount, supports :ro / :readonly
+              --no-focus                       Create workspace without switching to it
+
+            Notes:
+              When Docker sandbox mode is enabled, args after `--` are passed through to
+              `docker sandbox run ... -- ...` inside the remote host.
 
             Example:
               cmux ssh dev@my-host
               cmux ssh dev@my-host --name "gpu-box" --port 2222 --identity ~/.ssh/id_ed25519
               cmux ssh dev@my-host --ssh-option UserKnownHostsFile=/dev/null --ssh-option StrictHostKeyChecking=no
+              cmux ssh dev@my-host --docker-sandbox --docker-sandbox-workspace ~/src/cmux
+              cmux ssh dev@my-host --docker-sandbox --docker-sandbox-name cmux-dev --docker-sandbox-mount ~/docs/cmux:ro
             """
         case "remote-daemon-status":
             return """
@@ -13026,7 +13225,7 @@ struct CMUXCLI {
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>]
           list-workspaces
           new-workspace [--name <title>] [--cwd <path>] [--command <text>]
-          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
+          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--docker-sandbox] [--docker-sandbox-workspace <path>] [--docker-sandbox-name <name>] [--docker-sandbox-mount <path[:ro]>] [--no-focus] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
           list-panes [--workspace <id|ref>]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Sidebar shows git branch, linked PR status/number, working directory, listening 
 <td width="40%" valign="middle">
 <h3>SSH</h3>
 <code>cmux ssh user@remote</code> creates a workspace for a remote machine. Browser panes route through the remote network so localhost just works. Drag an image into a remote session to upload via scp.
+<br /><br />
+<code>cmux ssh user@remote --docker-sandbox --docker-sandbox-workspace ~/src/app</code> lands that remote workspace inside Docker Desktop sandboxes on the remote host, so you keep cmux’s SSH UX while isolating the shell.
 </td>
 <td width="60%">
 <img src="./docs/assets/ssh.png" alt="cmux SSH" width="100%" />

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2147,41 +2147,4 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         )
     }
 
-    func testDockerSandboxRunCommandBuildsExpectedRemoteInvocation() {
-        let cli = CMUXCLI(args: ["cmux"])
-        let options = CMUXCLI.SSHDockerSandboxOptions(
-            workspacePath: "~/src/cmux",
-            name: "cmux-dev",
-            mounts: ["~/docs/cmux:ro", "./notes"],
-            shellArguments: ["-lc", "echo hi"]
-        )
-
-        let command = cli.buildDockerSandboxRunCommand(options)
-
-        XCTAssertEqual(
-            command,
-            "docker sandbox run --name cmux-dev shell \"$HOME\"/'src/cmux' \"$HOME\"/'docs/cmux':ro ./notes -- -lc 'echo hi'"
-        )
-    }
-
-    func testDockerSandboxBootstrapCreatesWritablePathsAndSkipsReadonlyMounts() {
-        let cli = CMUXCLI(args: ["cmux"])
-        let options = CMUXCLI.SSHDockerSandboxOptions(
-            workspacePath: "~/src/cmux",
-            name: nil,
-            mounts: ["~/docs/cmux:ro", "./notes"],
-            shellArguments: []
-        )
-
-        let script = cli.buildDockerSandboxRemoteBootstrapScript(options)
-
-        XCTAssertTrue(script.contains("docker sandbox ls"))
-        XCTAssertTrue(script.contains("mkdir -p -- \"$HOME\"/'src/cmux' || exit $?"), script)
-        XCTAssertTrue(script.contains("mkdir -p -- ./notes || exit $?"), script)
-        XCTAssertFalse(script.contains("mkdir -p -- \"$HOME\"/'docs/cmux':ro"), script)
-        XCTAssertTrue(
-            script.contains("exec docker sandbox run shell \"$HOME\"/'src/cmux' \"$HOME\"/'docs/cmux':ro ./notes"),
-            script
-        )
-    }
 }

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2146,4 +2146,42 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             "Stale env surface should not win inside tmux, saw \(state.commands)"
         )
     }
+
+    func testDockerSandboxRunCommandBuildsExpectedRemoteInvocation() {
+        let cli = CMUXCLI(args: ["cmux"])
+        let options = CMUXCLI.SSHDockerSandboxOptions(
+            workspacePath: "~/src/cmux",
+            name: "cmux-dev",
+            mounts: ["~/docs/cmux:ro", "./notes"],
+            shellArguments: ["-lc", "echo hi"]
+        )
+
+        let command = cli.buildDockerSandboxRunCommand(options)
+
+        XCTAssertEqual(
+            command,
+            "docker sandbox run --name cmux-dev shell \"$HOME\"/'src/cmux' \"$HOME\"/'docs/cmux':ro ./notes -- -lc 'echo hi'"
+        )
+    }
+
+    func testDockerSandboxBootstrapCreatesWritablePathsAndSkipsReadonlyMounts() {
+        let cli = CMUXCLI(args: ["cmux"])
+        let options = CMUXCLI.SSHDockerSandboxOptions(
+            workspacePath: "~/src/cmux",
+            name: nil,
+            mounts: ["~/docs/cmux:ro", "./notes"],
+            shellArguments: []
+        )
+
+        let script = cli.buildDockerSandboxRemoteBootstrapScript(options)
+
+        XCTAssertTrue(script.contains("docker sandbox ls"))
+        XCTAssertTrue(script.contains("mkdir -p -- \"$HOME\"/'src/cmux' || exit $?"), script)
+        XCTAssertTrue(script.contains("mkdir -p -- ./notes || exit $?"), script)
+        XCTAssertFalse(script.contains("mkdir -p -- \"$HOME\"/'docs/cmux':ro"), script)
+        XCTAssertTrue(
+            script.contains("exec docker sandbox run shell \"$HOME\"/'src/cmux' \"$HOME\"/'docs/cmux':ro ./notes"),
+            script
+        )
+    }
 }

--- a/web/app/[locale]/blog/cmux-ssh/page.tsx
+++ b/web/app/[locale]/blog/cmux-ssh/page.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
+import { CodeBlock } from "../../components/code-block";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
@@ -73,6 +74,25 @@ export default function CmuxSshPage() {
         <li><code>cmux claude-teams</code> and <code>cmux omo</code> work over SSH, spawning teammate panes locally while computation runs remote</li>
         <li>The sidebar shows connection state and detected listening ports</li>
       </ul>
+
+      <h2 className="mt-10">SSH Sandboxes</h2>
+      <p className="mt-4">
+        The new SSH sandbox mode keeps the same remote workspace UX, but starts the shell
+        inside Docker Sandboxes on the remote host. That gives you the browser proxying,
+        notifications, and reconnect flow from <code>cmux ssh</code>, while moving the
+        actual shell into an isolated Docker sandbox.
+      </p>
+
+      <CodeBlock lang="bash">{`cmux ssh dev@macmini --docker-sandbox --docker-sandbox-workspace ~/src/cmux
+cmux ssh dev@macmini --docker-sandbox --docker-sandbox-name cmux-dev
+cmux ssh dev@macmini --docker-sandbox --docker-sandbox-workspace ~/src/cmux --docker-sandbox-mount ~/docs/cmux:ro`}</CodeBlock>
+
+      <p className="mt-4">
+        This is built for Docker Desktop&apos;s <code>docker sandbox</code> integration on
+        the remote machine. cmux checks for that command before the workspace finishes
+        connecting, creates missing writable workspace directories, and then runs
+        <code>docker sandbox run shell</code> for you.
+      </p>
 
       <iframe
         className="my-6 rounded-lg w-full aspect-video"

--- a/web/app/[locale]/docs/ssh/page.tsx
+++ b/web/app/[locale]/docs/ssh/page.tsx
@@ -53,6 +53,32 @@ cmux ssh user@remote -i ~/.ssh/id_ed25519`}</CodeBlock>
         </tbody>
       </table>
 
+      <h2>SSH Sandboxes</h2>
+      <p>
+        Use cmux SSH to land inside Docker Sandboxes on the remote host. This keeps the
+        normal cmux SSH workspace model, but starts the terminal inside Docker&apos;s
+        shell sandbox instead of the host login shell.
+      </p>
+      <CodeBlock lang="bash">{`cmux ssh dev@macmini --docker-sandbox --docker-sandbox-workspace ~/src/cmux
+cmux ssh dev@macmini --docker-sandbox --docker-sandbox-name cmux-dev
+cmux ssh dev@macmini --docker-sandbox --docker-sandbox-workspace ~/src/cmux --docker-sandbox-mount ~/docs/cmux:ro
+cmux ssh dev@macmini --docker-sandbox --docker-sandbox-workspace ~/src/cmux -- -lc "git status && exec bash -il"`}</CodeBlock>
+      <p>
+        cmux checks for <code>docker sandbox</code> on the remote host, creates writable
+        workspace directories when needed, and then runs <code>docker sandbox run shell</code>
+        for you. The primary workspace path becomes the main sandbox mount. Additional
+        <code>--docker-sandbox-mount</code>
+        paths are passed through directly, and args after <code>--</code> become shell
+        args inside the sandbox.
+      </p>
+      <p>
+        This targets Docker Desktop&apos;s built-in <code>docker sandbox</code> command on
+        the remote host. Docker documents that integration as requiring Docker Desktop
+        4.58 or later, and it also notes that the standalone <code>sbx</code> CLI is the
+        fuller option. cmux surfaces a preflight error if the remote machine does not
+        expose <code>docker sandbox</code>.
+      </p>
+
       <h2>{t("browserTitle")}</h2>
       <p>{t("browserDesc")}</p>
 


### PR DESCRIPTION
## Summary
- add Docker Sandbox flags to `cmux ssh` so a remote SSH workspace can start inside `docker sandbox run shell`
- preflight `docker sandbox` availability, create writable workspace directories, and add focused unit coverage for the sandbox command/bootstrap builders
- document SSH Sandboxes in the README plus the SSH docs and blog pages

## Testing
- `./scripts/reload.sh --tag task-cmux-ssh-sandboxed-workspace`
- `RESEND_API_KEY=test CMUX_FEEDBACK_FROM_EMAIL=test@example.com CMUX_FEEDBACK_RATE_LIMIT_ID=test npm run build` (in `web/`)
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-cmux-ssh-sandboxed-workspace-unit CMUX_SKIP_ZIG_BUILD=1 build`

## Issues
- Related: https://docs.docker.com/ai/sandboxes/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docker Sandbox mode to `cmux ssh` so remote workspaces start inside `docker sandbox run shell` on the remote host. This keeps the SSH UX while isolating the shell in Docker Desktop Sandboxes.

- **New Features**
  - New flags: `--docker-sandbox`, `--docker-sandbox-workspace <path>`, `--docker-sandbox-name <name>`, `--docker-sandbox-mount <path[:ro]>`.
  - Remote preflight checks `docker`/`docker sandbox`, shows clear errors, and creates missing writable dirs; `:ro`/`:readonly` mounts are skipped.
  - With sandbox enabled, args after `--` are passed to the sandbox shell; workspace title defaults from sandbox name or workspace path.
  - Updated CLI help, README, and SSH docs/blog with examples.

<sup>Written for commit 8d2bbe2c52a6c8591a770281b13c31b4774e6a92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker sandbox mode for cmux ssh: run shells inside remote Docker Sandboxes while preserving SSH proxying, notifications, and reconnects.
  * New flags: --docker-sandbox, --docker-sandbox-workspace, --docker-sandbox-name, repeatable --docker-sandbox-mount.
  * Remote preflight checks and automatic preparation of writable workspace paths; sandbox run invoked remotely.

* **Documentation**
  * Usage examples and docs updated (README, blog, SSH docs) and CLI help updated to document sandbox behavior and flag semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->