### PR TITLE
Fix shell integration review regressions

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -277,7 +277,7 @@ _cmux_ports_kick() {
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    _CMUX_PORTS_LAST_RUN=$SECONDS
+    _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     {
         _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     } >/dev/null 2>&1 & disown
@@ -649,6 +649,7 @@ _cmux_preexec_command() {
     _cmux_report_shell_activity_state running
     _cmux_report_tty_once
     _cmux_ports_kick
+    _cmux_stop_pr_poll_loop
 }
 
 _cmux_bash_preexec_hook() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -564,7 +564,7 @@ _cmux_run_pr_probe_with_timeout() {
     wait "$probe_pid"
 }
 
-_cmux_stop_pr_poll_loop() {
+_cmux_halt_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
         # Process-group kill: background jobs are process-group leaders, so
         # negative PID kills the loop + all descendants (gh, sleep) without
@@ -576,6 +576,10 @@ _cmux_stop_pr_poll_loop() {
     [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
     _CMUX_PR_POLL_PID=""
     _CMUX_PR_POLL_PWD=""
+}
+
+_cmux_stop_pr_poll_loop() {
+    _cmux_halt_pr_poll_loop
     _cmux_pr_cache_clear
 }
 
@@ -595,7 +599,7 @@ _cmux_start_pr_poll_loop() {
     fi
 
     if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        _cmux_stop_pr_poll_loop
+        _cmux_halt_pr_poll_loop
     else
         _CMUX_PR_POLL_PID=""
     fi
@@ -649,7 +653,7 @@ _cmux_preexec_command() {
     _cmux_report_shell_activity_state running
     _cmux_report_tty_once
     _cmux_ports_kick
-    _cmux_stop_pr_poll_loop
+    _cmux_halt_pr_poll_loop
 }
 
 _cmux_bash_preexec_hook() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -636,7 +636,58 @@ _cmux_bash_cleanup() {
     _cmux_stop_pr_poll_loop
 }
 
+_cmux_command_starts_nested_shell() {
+    local cmd="$1"
+    local -a words=()
+    read -r -a words <<< "$cmd"
+
+    local index=0
+    local word base
+    while (( index < ${#words[@]} )); do
+        word="${words[index]}"
+
+        case "$word" in
+            *=*)
+                index=$(( index + 1 ))
+                continue ;;
+            exec|command|builtin|noglob|time)
+                index=$(( index + 1 ))
+                continue ;;
+            env)
+                index=$(( index + 1 ))
+                while (( index < ${#words[@]} )); do
+                    word="${words[index]}"
+                    case "$word" in
+                        -*|*=*)
+                            index=$(( index + 1 ))
+                            continue ;;
+                    esac
+                    break
+                done
+                continue ;;
+        esac
+
+        base="${word##*/}"
+        case "$base" in
+            bash|zsh|sh|fish|nu|nix-shell)
+                return 0 ;;
+            nix)
+                local next_index=$(( index + 1 ))
+                local next_word="${words[next_index]:-}"
+                case "$next_word" in
+                    develop|shell)
+                        return 0 ;;
+                esac ;;
+        esac
+
+        return 1
+    done
+
+    return 1
+}
+
 _cmux_preexec_command() {
+    local cmd="${1:-${BASH_COMMAND:-}}"
     _cmux_tmux_sync_cmux_environment
 
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
@@ -654,10 +705,13 @@ _cmux_preexec_command() {
     _cmux_report_tty_once
     _cmux_ports_kick
     _cmux_halt_pr_poll_loop
+    if _cmux_command_starts_nested_shell "$cmd"; then
+        return 0
+    fi
 }
 
 _cmux_bash_preexec_hook() {
-    _cmux_preexec_command
+    _cmux_preexec_command "$@"
 }
 
 _cmux_prompt_command() {
@@ -834,11 +888,11 @@ _cmux_install_prompt_command() {
         esac
     fi
 
-    if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )); then
+        if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )); then
         if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3) )); then
-            builtin readonly _CMUX_BASH_PS0='${ _cmux_bash_preexec_hook; }'
+            builtin readonly _CMUX_BASH_PS0='${ _cmux_bash_preexec_hook "$BASH_COMMAND"; }'
         else
-            builtin readonly _CMUX_BASH_PS0='$(_cmux_bash_preexec_hook >/dev/null)'
+            builtin readonly _CMUX_BASH_PS0='$(_cmux_bash_preexec_hook "$BASH_COMMAND" >/dev/null)'
         fi
         if [[ "$PS0" != *"${_CMUX_BASH_PS0}"* ]]; then
             PS0=$PS0"${_CMUX_BASH_PS0}"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -792,6 +792,56 @@ _cmux_start_git_head_watch() {
     _CMUX_GIT_HEAD_WATCH_PID=$!
 }
 
+_cmux_command_starts_nested_shell() {
+    local cmd="$1"
+    local -a words
+    words=("${(z)cmd}")
+
+    local index=1
+    local word base
+    while (( index <= ${#words} )); do
+        word="${words[index]}"
+
+        case "$word" in
+            *=*)
+                index=$(( index + 1 ))
+                continue ;;
+            exec|command|builtin|noglob|time)
+                index=$(( index + 1 ))
+                continue ;;
+            env)
+                index=$(( index + 1 ))
+                while (( index <= ${#words} )); do
+                    word="${words[index]}"
+                    case "$word" in
+                        -*|*=*)
+                            index=$(( index + 1 ))
+                            continue ;;
+                    esac
+                    break
+                done
+                continue ;;
+        esac
+
+        base="${word:t}"
+        case "$base" in
+            bash|zsh|sh|fish|nu|nix-shell)
+                return 0 ;;
+            nix)
+                local next_index=$(( index + 1 ))
+                local next_word="${words[next_index]}"
+                case "$next_word" in
+                    develop|shell)
+                        return 0 ;;
+                esac ;;
+        esac
+
+        return 1
+    done
+
+    return 1
+}
+
 _cmux_preexec() {
     _cmux_tmux_sync_cmux_environment
 
@@ -817,6 +867,10 @@ _cmux_preexec() {
     _cmux_report_tty_once
     _cmux_ports_kick
     _cmux_stop_pr_poll_loop
+    _cmux_stop_git_head_watch
+    if _cmux_command_starts_nested_shell "$cmd"; then
+        return 0
+    fi
     _cmux_start_git_head_watch
 }
 

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -681,7 +681,7 @@ _cmux_run_pr_probe_with_timeout() {
     wait "$probe_pid"
 }
 
-_cmux_stop_pr_poll_loop() {
+_cmux_halt_pr_poll_loop() {
     if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
         # Process-group kill: background jobs are process-group leaders, so
         # negative PID kills the loop + all descendants (gh, sleep) without
@@ -693,6 +693,10 @@ _cmux_stop_pr_poll_loop() {
     [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
     _CMUX_PR_POLL_PID=""
     _CMUX_PR_POLL_PWD=""
+}
+
+_cmux_stop_pr_poll_loop() {
+    _cmux_halt_pr_poll_loop
     _cmux_pr_cache_clear
 }
 
@@ -712,7 +716,7 @@ _cmux_start_pr_poll_loop() {
     fi
 
     if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        _cmux_stop_pr_poll_loop
+        _cmux_halt_pr_poll_loop
     else
         _CMUX_PR_POLL_PID=""
     fi
@@ -866,7 +870,7 @@ _cmux_preexec() {
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
     _cmux_ports_kick
-    _cmux_stop_pr_poll_loop
+    _cmux_halt_pr_poll_loop
     _cmux_stop_git_head_watch
     if _cmux_command_starts_nested_shell "$cmd"; then
         return 0

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -816,6 +816,7 @@ _cmux_preexec() {
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
     _cmux_ports_kick
+    _cmux_stop_pr_poll_loop
     _cmux_start_git_head_watch
 }
 

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -13,7 +13,7 @@ Validates that shell integration:
 7) falls back to explicit branch lookup when implicit gh branch resolution fails
 8) does not clear an existing PR badge on the first prompt while establishing
    the HEAD baseline
-9) stops a parent PR poller before nested shells start in the same panel
+9) stops parent-shell PR tracking before nested shells start in the same panel
 10) preserves ports polling throttling after an explicit ports kick
 """
 
@@ -259,6 +259,11 @@ def _shell_command(kind: str, scenario: str) -> str:
             'if kill -0 "$parent_pid" 2>/dev/null; then\n'
             '  echo "parent poller still running" >&2\n'
             '  exit 42\n'
+            'fi\n'
+            'parent_watch_pid="${_CMUX_GIT_HEAD_WATCH_PID:-}"\n'
+            'if [ -n "$parent_watch_pid" ] && kill -0 "$parent_watch_pid" 2>/dev/null; then\n'
+            '  echo "parent HEAD watcher still running" >&2\n'
+            '  exit 43\n'
             'fi\n'
             '_cmux_cleanup\n'
         ),

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -15,6 +15,7 @@ Validates that shell integration:
    the HEAD baseline
 9) stops parent-shell PR tracking before nested shells start in the same panel
 10) preserves ports polling throttling after an explicit ports kick
+11) preserves cached PR results across ordinary preexec cycles
 """
 
 from __future__ import annotations
@@ -276,6 +277,16 @@ def _shell_command(kind: str, scenario: str) -> str:
             '_cmux_prompt_entry\n'
             '_cmux_cleanup\n'
         ),
+        "preexec_preserves_pr_cache": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_CMUX_PR_POLL_INTERVAL=10\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_regular_command_entry\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_cleanup\n'
+        ),
     }[scenario]
 
     if kind == "zsh":
@@ -285,6 +296,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             _cmux_send() {{ print -r -- "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_precmd; }}
             _cmux_nested_shell_entry() {{ _cmux_preexec zsh; }}
+            _cmux_regular_command_entry() {{ _cmux_preexec "echo hi"; }}
             _cmux_cleanup() {{ _cmux_zshexit; }}
             {shared}"""
         )
@@ -296,6 +308,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             _cmux_send() {{ printf '%s\\n' "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_prompt_command; }}
             _cmux_nested_shell_entry() {{ _cmux_bash_preexec_hook; }}
+            _cmux_regular_command_entry() {{ _cmux_bash_preexec_hook; }}
             _cmux_cleanup() {{ type _cmux_bash_cleanup >/dev/null 2>&1 && _cmux_bash_cleanup; }}
             {shared}"""
         )
@@ -458,6 +471,17 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
     if scenario == "nested_shell_stops_parent_poll":
         return (0, f"{shell}/{scenario}: ok")
 
+    if scenario == "preexec_preserves_pr_cache":
+        if gh_count != 1:
+            return (
+                1,
+                f"{shell}/{scenario}: expected cached PR result to survive ordinary preexec, saw {gh_count} gh calls\n"
+                + "\n".join(gh_args_lines),
+            )
+        if _report_line(1138) not in send_lines:
+            return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
+        return (0, f"{shell}/{scenario}: ok")
+
     return (1, f"{shell}/{scenario}: unhandled scenario")
 
 
@@ -476,6 +500,7 @@ def main() -> int:
         "initial_prompt_preserves_pr_badge",
         "nested_shell_stops_parent_poll",
         "ports_kick_throttle",
+        "preexec_preserves_pr_cache",
     ]
 
     base = Path("/tmp") / f"cmux_issue_1138_pr_poll_{os.getpid()}"

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -307,8 +307,8 @@ def _shell_command(kind: str, scenario: str) -> str:
             source "$CMUX_TEST_SCRIPT"
             _cmux_send() {{ printf '%s\\n' "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_prompt_command; }}
-            _cmux_nested_shell_entry() {{ _cmux_bash_preexec_hook; }}
-            _cmux_regular_command_entry() {{ _cmux_bash_preexec_hook; }}
+            _cmux_nested_shell_entry() {{ _cmux_bash_preexec_hook bash; }}
+            _cmux_regular_command_entry() {{ _cmux_bash_preexec_hook "echo hi"; }}
             _cmux_cleanup() {{ type _cmux_bash_cleanup >/dev/null 2>&1 && _cmux_bash_cleanup; }}
             {shared}"""
         )
@@ -390,10 +390,21 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
     gh_args_lines = _read_lines(gh_args_log)
     gh_count = int((gh_count_file.read_text(encoding="utf-8").strip() or "0")) if gh_count_file.exists() else 0
 
-    if not gh_args_lines:
-        return (1, f"{shell}/{scenario}: expected at least one gh invocation")
-    if any(not line.startswith("pr view ") for line in gh_args_lines):
-        return (1, f"{shell}/{scenario}: expected gh pr view only\n" + "\n".join(gh_args_lines))
+    scenarios_requiring_gh = {
+        "prompt_helper_idle",
+        "transient_same_context",
+        "branch_switch_clear",
+        "timeout_recovery",
+        "explicit_branch_fallback",
+        "initial_prompt_preserves_pr_badge",
+        "ports_kick_throttle",
+        "preexec_preserves_pr_cache",
+    }
+    if scenario in scenarios_requiring_gh:
+        if not gh_args_lines:
+            return (1, f"{shell}/{scenario}: expected at least one gh invocation")
+        if any(not line.startswith("pr view ") for line in gh_args_lines):
+            return (1, f"{shell}/{scenario}: expected gh pr view only\n" + "\n".join(gh_args_lines))
 
     if scenario == "prompt_helper_idle":
         if gh_count < 2:

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -13,6 +13,8 @@ Validates that shell integration:
 7) falls back to explicit branch lookup when implicit gh branch resolution fails
 8) does not clear an existing PR badge on the first prompt while establishing
    the HEAD baseline
+9) stops a parent PR poller before nested shells start in the same panel
+10) preserves ports polling throttling after an explicit ports kick
 """
 
 from __future__ import annotations
@@ -246,6 +248,29 @@ def _shell_command(kind: str, scenario: str) -> str:
             'sleep 2\n'
             '_cmux_cleanup\n'
         ),
+        "nested_shell_stops_parent_poll": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_CMUX_PR_POLL_INTERVAL=10\n'
+            '_cmux_prompt_entry\n'
+            'parent_pid="$_CMUX_PR_POLL_PID"\n'
+            '[ -n "$parent_pid" ] || { echo "missing parent poll pid" >&2; exit 41; }\n'
+            '_cmux_nested_shell_entry\n'
+            'sleep 1\n'
+            'if kill -0 "$parent_pid" 2>/dev/null; then\n'
+            '  echo "parent poller still running" >&2\n'
+            '  exit 42\n'
+            'fi\n'
+            '_cmux_cleanup\n'
+        ),
+        "ports_kick_throttle": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_CMUX_PR_POLL_INTERVAL=10\n'
+            '_cmux_ports_kick\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_prompt_entry\n'
+            '_cmux_cleanup\n'
+        ),
     }[scenario]
 
     if kind == "zsh":
@@ -254,6 +279,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             source "$CMUX_TEST_SCRIPT"
             _cmux_send() {{ print -r -- "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_precmd; }}
+            _cmux_nested_shell_entry() {{ _cmux_preexec zsh; }}
             _cmux_cleanup() {{ _cmux_zshexit; }}
             {shared}"""
         )
@@ -264,6 +290,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             source "$CMUX_TEST_SCRIPT"
             _cmux_send() {{ printf '%s\\n' "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_prompt_command; }}
+            _cmux_nested_shell_entry() {{ _cmux_bash_preexec_hook; }}
             _cmux_cleanup() {{ type _cmux_bash_cleanup >/dev/null 2>&1 && _cmux_bash_cleanup; }}
             {shared}"""
         )
@@ -413,6 +440,19 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
             )
         return (0, f"{shell}/{scenario}: ok")
 
+    if scenario == "ports_kick_throttle":
+        ports_kicks = [line for line in send_lines if line.startswith("ports_kick ")]
+        if len(ports_kicks) != 1:
+            return (
+                1,
+                f"{shell}/{scenario}: expected exactly one ports_kick across explicit kick + throttled prompts\n"
+                + "\n".join(send_lines),
+            )
+        return (0, f"{shell}/{scenario}: ok")
+
+    if scenario == "nested_shell_stops_parent_poll":
+        return (0, f"{shell}/{scenario}: ok")
+
     return (1, f"{shell}/{scenario}: unhandled scenario")
 
 
@@ -429,6 +469,8 @@ def main() -> int:
         "timeout_recovery",
         "explicit_branch_fallback",
         "initial_prompt_preserves_pr_badge",
+        "nested_shell_stops_parent_poll",
+        "ports_kick_throttle",
     ]
 
     base = Path("/tmp") / f"cmux_issue_1138_pr_poll_{os.getpid()}"


### PR DESCRIPTION
## Summary
- stop the parent shell PR poller before nested shells start so stale `report_pr` updates cannot keep mutating the same panel
- keep bash prompt timing on the same clock for `ports_kick` throttling so explicit kicks still suppress repeated prompt scans
- extend the shell integration regression harness with nested-shell poller shutdown and ports-throttle scenarios

## Validation
- Did not run local tests per repo policy
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `python3 -m py_compile tests/test_issue_1138_sidebar_pr_polling.py`

Supersedes #2453.
Closes #2414.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shell integration review regressions. Stops PR polling (bash/zsh) and the zsh HEAD watcher before nested shells, keeps `ports_kick` throttling, preserves PR cache, and tightens bash nested-shell handling. Addresses #2414.

- **Bug Fixes**
  - On preexec, halt the PR poll loop in bash and zsh; in zsh also stop the HEAD watcher and don’t restart it when a nested shell is detected.
  - Detect nested shells from the command string in both shells (handles env/exec and `nix` develop/shell). In bash, pass `$BASH_COMMAND` into the preexec hook via `PS0` for reliable detection.
  - Preserve cached PR results across ordinary preexecs by splitting “halt” (no cache clear) from “stop” (clears cache). Keep `ports_kick` throttling by setting `_CMUX_PORTS_LAST_RUN` via `_cmux_now`.
  - Extend the regression harness and harden bash nested-shell coverage with `nested_shell_stops_parent_poll`, `ports_kick_throttle`, and `preexec_preserves_pr_cache`.

<sup>Written for commit 00b4810ed6b74eea8b5736a4158ba73cd7a08356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust stopping and restarting of PR polling and git HEAD watches when launching commands or entering nested shells.
  * Ports-kick timestamping and throttling improved to avoid duplicate port-scan triggers.
  * Pre-execution handling now halts background polling promptly while preserving PR cache when appropriate.

* **Tests**
  * Added regression scenarios covering nested-shell behavior, poll/head shutdown, ports-kick throttling, and PR-cache preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->