### PR TITLE
Fix paste from Raycast and apps using alternate plain-text UTIs

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -101,14 +101,14 @@ enum GhosttyPasteboardHelper {
                 .joined(separator: " ")
         }
 
-        if let value = plainTextContents(from: pasteboard) {
-            return value
-        }
-
         if hasImageData(in: pasteboard),
            let html = pasteboard.string(forType: .html),
            htmlHasNoVisibleText(html) {
             return nil
+        }
+
+        if let value = plainTextContents(from: pasteboard) {
+            return value
         }
 
         if let htmlText = attributedStringContents(from: pasteboard, type: .html, documentType: .html) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -101,25 +101,29 @@ enum GhosttyPasteboardHelper {
                 .joined(separator: " ")
         }
 
+        let htmlText = attributedStringContents(from: pasteboard, type: .html, documentType: .html)
+        let rtfText = attributedStringContents(from: pasteboard, type: .rtf, documentType: .rtf)
+        let rtfdText = attributedStringContents(from: pasteboard, type: .rtfd, documentType: .rtfd)
+
         if hasImageData(in: pasteboard),
            let html = pasteboard.string(forType: .html),
            htmlHasNoVisibleText(html) {
             return nil
         }
 
+        if hasImageData(in: pasteboard) {
+            if let htmlText { return htmlText }
+            if let rtfText { return rtfText }
+            return rtfdText
+        }
+
         if let value = plainTextContents(from: pasteboard) {
             return value
         }
 
-        if let htmlText = attributedStringContents(from: pasteboard, type: .html, documentType: .html) {
-            return htmlText
-        }
-
-        if let rtfText = attributedStringContents(from: pasteboard, type: .rtf, documentType: .rtf) {
-            return rtfText
-        }
-
-        return attributedStringContents(from: pasteboard, type: .rtfd, documentType: .rtfd)
+        if let htmlText { return htmlText }
+        if let rtfText { return rtfText }
+        return rtfdText
     }
 
     static func hasString(for location: ghostty_clipboard_e) -> Bool {
@@ -201,7 +205,7 @@ enum GhosttyPasteboardHelper {
               type != .fileURL,
               let utType = UTType(type.rawValue) else { return false }
 
-        return utType.conforms(to: .plainText) || utType.conforms(to: .text)
+        return utType.conforms(to: .plainText)
     }
 
     private static func attributedString(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -101,11 +101,7 @@ enum GhosttyPasteboardHelper {
                 .joined(separator: " ")
         }
 
-        if let value = pasteboard.string(forType: .string) {
-            return value
-        }
-
-        if let value = pasteboard.string(forType: utf8PlainTextType) {
+        if let value = plainTextContents(from: pasteboard) {
             return value
         }
 
@@ -128,12 +124,7 @@ enum GhosttyPasteboardHelper {
 
     static func hasString(for location: ghostty_clipboard_e) -> Bool {
         guard let pasteboard = pasteboard(for: location) else { return false }
-        let types = pasteboard.types ?? []
-        if types.contains(.fileURL) || types.contains(.string) || types.contains(utf8PlainTextType)
-            || types.contains(.html) || types.contains(.rtf) || types.contains(.rtfd) {
-            return true
-        }
-        return hasImageData(in: pasteboard)
+        return hasPasteableContents(in: pasteboard)
     }
 
     static func writeString(_ string: String, to location: ghostty_clipboard_e) {
@@ -176,6 +167,41 @@ enum GhosttyPasteboardHelper {
 
         guard let sanitized, !sanitized.isEmpty else { return nil }
         return sanitized
+    }
+
+    private static func plainTextContents(from pasteboard: NSPasteboard) -> String? {
+        for type in pasteboard.types ?? [] {
+            guard isPlainTextType(type) else { continue }
+            guard let value = pasteboard.string(forType: type), !value.isEmpty else { continue }
+            return value
+        }
+
+        return nil
+    }
+
+    private static func hasPasteableContents(in pasteboard: NSPasteboard) -> Bool {
+        let types = pasteboard.types ?? []
+        if types.contains(.fileURL) || types.contains(.html) || types.contains(.rtf) || types.contains(.rtfd) {
+            return true
+        }
+        if types.contains(where: isPlainTextType) {
+            return true
+        }
+        return hasImageData(in: pasteboard)
+    }
+
+    private static func isPlainTextType(_ type: NSPasteboard.PasteboardType) -> Bool {
+        if type == .string || type == utf8PlainTextType {
+            return true
+        }
+
+        guard type != .html,
+              type != .rtf,
+              type != .rtfd,
+              type != .fileURL,
+              let utType = UTType(type.rawValue) else { return false }
+
+        return utType.conforms(to: .plainText) || utType.conforms(to: .text)
     }
 
     private static func attributedString(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -91,6 +91,34 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: imagePath))
     }
 
+    func testImageHTMLClipboardWithGenericPlainTextStillFallsBackToImagePath() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-image-html-generic-text-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString("<meta charset='utf-8'><img src=\"https://example.com/keyboard.png\">", forType: .html)
+        pasteboard.setString(
+            "https://example.com/keyboard.png",
+            forType: NSPasteboard.PasteboardType(UTType.plainText.identifier)
+        )
+
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        image.unlockFocus()
+        let tiffData = try XCTUnwrap(image.tiffRepresentation)
+        let bitmap = try XCTUnwrap(NSBitmapImageRep(data: tiffData))
+        let pngData = try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+        pasteboard.setData(pngData, forType: .png)
+
+        XCTAssertNil(cmuxPasteboardStringContentsForTesting(pasteboard))
+
+        let imagePath = try XCTUnwrap(cmuxPasteboardImagePathForTesting(pasteboard))
+        defer { try? FileManager.default.removeItem(atPath: imagePath) }
+
+        XCTAssertTrue(imagePath.hasSuffix(".png"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: imagePath))
+    }
+
     func testImageHTMLClipboardWithVisibleTextPrefersText() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-image-html-text-\(UUID().uuidString)"))
         pasteboard.clearContents()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -67,6 +67,45 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         )
     }
 
+    func testXHTMLTypeFallsBackToRenderedHTMLText() {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-xhtml-html-fallback-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(
+            "<div>Hello <strong>world</strong></div>",
+            forType: NSPasteboard.PasteboardType("public.xhtml")
+        )
+        pasteboard.setString("<p>Hello <strong>world</strong></p>", forType: .html)
+
+        XCTAssertEqual(cmuxPasteboardStringContentsForTesting(pasteboard), "Hello world")
+    }
+
+    func testImageClipboardWithPlainTextFallbackStillFallsBackToImagePath() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-image-plain-text-fallback-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(
+            "https://example.com/keyboard.png",
+            forType: NSPasteboard.PasteboardType(UTType.plainText.identifier)
+        )
+
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        NSColor.orange.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        image.unlockFocus()
+        let tiffData = try XCTUnwrap(image.tiffRepresentation)
+        let bitmap = try XCTUnwrap(NSBitmapImageRep(data: tiffData))
+        let pngData = try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+        pasteboard.setData(pngData, forType: .png)
+
+        XCTAssertNil(cmuxPasteboardStringContentsForTesting(pasteboard))
+
+        let imagePath = try XCTUnwrap(cmuxPasteboardImagePathForTesting(pasteboard))
+        defer { try? FileManager.default.removeItem(atPath: imagePath) }
+
+        XCTAssertTrue(imagePath.hasSuffix(".png"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: imagePath))
+    }
+
     func testImageHTMLClipboardFallsBackToImagePath() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-image-html-\(UUID().uuidString)"))
         pasteboard.clearContents()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -35,6 +35,38 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         XCTAssertNil(cmuxPasteboardImagePathForTesting(pasteboard))
     }
 
+    func testAlternatePlainTextUTIExtractsPlainText() {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-plain-text-uti-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(
+            "hello from public.plain-text",
+            forType: NSPasteboard.PasteboardType(UTType.plainText.identifier)
+        )
+
+        XCTAssertEqual(
+            cmuxPasteboardStringContentsForTesting(pasteboard),
+            "hello from public.plain-text"
+        )
+    }
+
+    func testEmptyPlainTextFallsBackToRichTextPayload() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-empty-plain-rich-fallback-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString("", forType: .string)
+
+        let attributed = NSAttributedString(string: "hello from rtf fallback")
+        let rtfData = try attributed.data(
+            from: NSRange(location: 0, length: attributed.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        pasteboard.setData(rtfData, forType: .rtf)
+
+        XCTAssertEqual(
+            cmuxPasteboardStringContentsForTesting(pasteboard),
+            "hello from rtf fallback"
+        )
+    }
+
     func testImageHTMLClipboardFallsBackToImagePath() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-image-html-\(UUID().uuidString)"))
         pasteboard.clearContents()


### PR DESCRIPTION
## Summary
- Apps like Raycast place clipboard content under UTIs such as `public.plain-text` rather than `NSPasteboardType.string`, causing paste to silently fail
- Generalize pasteboard reading to iterate declared types and match any UTI conforming to `.plainText` or `.text`, so paste works regardless of which plain-text variant the source app uses
- Refactor `hasString` check to use the same unified logic

## Test plan
- [x] Unit test: alternate plain-text UTI (`public.plain-text`) extracts content correctly
- [x] Unit test: empty plain-text with RTF payload falls back to rich text extraction
- [ ] Manual: copy text in Raycast, paste into cmux terminal — should paste correctly

Closes #2415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes paste failures from Raycast and similar apps by reading any pasteboard type that conforms to `UTType.plainText`. Keeps rich text and image fallbacks working as expected.

- **Bug Fixes**
  - Extract plain text from any conforming UTI (e.g., `public.plain-text`); no dependency on `.string`.
  - Replace `hasString` with unified `hasPasteableContents` for file URLs, plain text, rich text, and images.
  - Preserve fallbacks: with images, prefer HTML/RTF/RTFD over generic plain text; if HTML has no visible text, fall back to the image path; if plain text is empty, fall back to RTF.
  - Handle XHTML (`public.xhtml`) by using rendered HTML text.

<sup>Written for commit d725fd7dc2db68e65198dca75e522a569e899caf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard handling: better recognition of alternate plain-text types, richer handling of HTML/RTF/RTFD vs. plain text, and correct fallback when clipboards contain images or mixed HTML+image content (avoids returning misleading empty text and surfaces image data instead).

* **Tests**
  * Added unit tests covering alternate plain-text formats, empty plain-text fallback to rich text, HTML rendering fallbacks, and image-clipboard/materialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->