### PR TITLE
Fix macOS 26 glass background gating (#2459)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -175,6 +175,7 @@ struct ShortcutHintPillBackground: View {
 /// Applies NSGlassEffectView (macOS 26+) to a window, falling back to NSVisualEffectView
 enum WindowGlassEffect {
     private static var glassViewKey: UInt8 = 0
+    private static var originalContentViewKey: UInt8 = 0
     private static var tintOverlayKey: UInt8 = 0
 
     static var isAvailable: Bool {
@@ -226,6 +227,7 @@ enum WindowGlassEffect {
 
         if usingGlassEffectView {
             // NSGlassEffectView is a full replacement for the contentView.
+            objc_setAssociatedObject(window, &originalContentViewKey, originalContentView, .OBJC_ASSOCIATION_RETAIN)
             window.contentView = glassView
 
             // Re-add the original SwiftUI hosting view on top of the glass, filling entire area.
@@ -297,9 +299,24 @@ enum WindowGlassEffect {
     }
 
     static func remove(from window: NSWindow) {
-        // Note: Removing would require restoring original contentView structure
-        // For now, just clear the reference
+        guard let glassView = objc_getAssociatedObject(window, &glassViewKey) as? NSView else {
+            return
+        }
+
+        if glassView.className == "NSGlassEffectView" {
+            if let originalContentView = objc_getAssociatedObject(window, &originalContentViewKey) as? NSView {
+                originalContentView.removeFromSuperview()
+                originalContentView.translatesAutoresizingMaskIntoConstraints = true
+                originalContentView.autoresizingMask = [.width, .height]
+                originalContentView.frame = glassView.bounds
+                window.contentView = originalContentView
+            }
+        } else {
+            glassView.removeFromSuperview()
+        }
+
         objc_setAssociatedObject(window, &glassViewKey, nil, .OBJC_ASSOCIATION_RETAIN)
+        objc_setAssociatedObject(window, &originalContentViewKey, nil, .OBJC_ASSOCIATION_RETAIN)
         objc_setAssociatedObject(window, &tintOverlayKey, nil, .OBJC_ASSOCIATION_RETAIN)
     }
 }
@@ -3201,6 +3218,8 @@ struct ContentView: View {
                 // Apply liquid glass effect to the window with tint from settings
                 let tintColor = (NSColor(hex: bgGlassTintHex) ?? .black).withAlphaComponent(bgGlassTintOpacity)
                 WindowGlassEffect.apply(to: window, tintColor: tintColor)
+            } else {
+                WindowGlassEffect.remove(from: window)
             }
             AppDelegate.shared?.attachUpdateAccessory(to: window)
             AppDelegate.shared?.applyWindowDecorations(to: window)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3169,16 +3169,17 @@ struct ContentView: View {
                 UpdateLogStore.shared.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
             }
 #endif
-            // Background glass: skip on macOS 26+ where NSGlassEffectView can cause blank
-            // or incorrectly tinted SwiftUI content. Keep native window rendering there so
-            // Ghostty theme colors remain authoritative.
+            // User settings decide whether window glass is active. The native Tahoe
+            // NSGlassEffectView path vs the older NSVisualEffectView fallback is chosen
+            // inside WindowGlassEffect.apply.
             let currentThemeBackground = GhosttyBackgroundTheme.currentColor()
-            let shouldApplyWindowGlassFallback =
-                sidebarBlendMode == SidebarBlendModeOption.behindWindow.rawValue
-                && bgGlassEnabled
-                && !WindowGlassEffect.isAvailable
+            let shouldApplyWindowGlass = cmuxShouldApplyWindowGlass(
+                sidebarBlendMode: sidebarBlendMode,
+                bgGlassEnabled: bgGlassEnabled,
+                glassEffectAvailable: WindowGlassEffect.isAvailable
+            )
             let shouldForceTransparentHosting =
-                shouldApplyWindowGlassFallback || currentThemeBackground.alphaComponent < 0.999
+                shouldApplyWindowGlass || currentThemeBackground.alphaComponent < 0.999
 
             if shouldForceTransparentHosting {
                 window.isOpaque = false
@@ -3196,7 +3197,7 @@ struct ContentView: View {
                 window.isOpaque = currentThemeBackground.alphaComponent >= 0.999
             }
 
-            if shouldApplyWindowGlassFallback {
+            if shouldApplyWindowGlass {
                 // Apply liquid glass effect to the window with tint from settings
                 let tintColor = (NSColor(hex: bgGlassTintHex) ?? .black).withAlphaComponent(bgGlassTintOpacity)
                 WindowGlassEffect.apply(to: window, tintColor: tintColor)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12,11 +12,25 @@ import IOSurface
 import UniformTypeIdentifiers
 
 #if os(macOS)
+func cmuxShouldApplyWindowGlass(
+    sidebarBlendMode: String,
+    bgGlassEnabled: Bool,
+    glassEffectAvailable _: Bool
+) -> Bool {
+    // Native NSGlassEffectView vs NSVisualEffectView fallback is chosen inside
+    // WindowGlassEffect.apply. User settings alone decide whether glass is on.
+    sidebarBlendMode == "behindWindow" && bgGlassEnabled
+}
+
 func cmuxShouldUseTransparentBackgroundWindow() -> Bool {
     let defaults = UserDefaults.standard
     let sidebarBlendMode = defaults.string(forKey: "sidebarBlendMode") ?? "withinWindow"
     let bgGlassEnabled = defaults.object(forKey: "bgGlassEnabled") as? Bool ?? false
-    return sidebarBlendMode == "behindWindow" && bgGlassEnabled && !WindowGlassEffect.isAvailable
+    return cmuxShouldApplyWindowGlass(
+        sidebarBlendMode: sidebarBlendMode,
+        bgGlassEnabled: bgGlassEnabled,
+        glassEffectAvailable: WindowGlassEffect.isAvailable
+    )
 }
 
 func cmuxShouldUseClearWindowBackground(for opacity: Double) -> Bool {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -738,18 +738,45 @@ final class WindowTransparencyDecisionTests: XCTestCase {
         }
     }
 
-    func testBehindWindowGlassPathStillControlsTransparentWindowFallback() {
+    func testGlassEnabledDecisionIgnoresGlassImplementationAvailability() {
+        XCTAssertTrue(
+            cmuxShouldApplyWindowGlass(
+                sidebarBlendMode: "behindWindow",
+                bgGlassEnabled: true,
+                glassEffectAvailable: false
+            )
+        )
+        XCTAssertTrue(
+            cmuxShouldApplyWindowGlass(
+                sidebarBlendMode: "behindWindow",
+                bgGlassEnabled: true,
+                glassEffectAvailable: true
+            )
+        )
+        XCTAssertFalse(
+            cmuxShouldApplyWindowGlass(
+                sidebarBlendMode: "withinWindow",
+                bgGlassEnabled: true,
+                glassEffectAvailable: true
+            )
+        )
+        XCTAssertFalse(
+            cmuxShouldApplyWindowGlass(
+                sidebarBlendMode: "behindWindow",
+                bgGlassEnabled: false,
+                glassEffectAvailable: true
+            )
+        )
+    }
+
+    func testBehindWindowGlassPathKeepsTransparentWindowEnabled() {
         withTemporaryWindowBackgroundDefaults {
             let defaults = UserDefaults.standard
             defaults.set("behindWindow", forKey: sidebarBlendModeKey)
             defaults.set(true, forKey: bgGlassEnabledKey)
 
-            let expectedTransparentFallback = !WindowGlassEffect.isAvailable
-            XCTAssertEqual(cmuxShouldUseTransparentBackgroundWindow(), expectedTransparentFallback)
-            XCTAssertEqual(
-                cmuxShouldUseClearWindowBackground(for: 1.0),
-                expectedTransparentFallback
-            )
+            XCTAssertTrue(cmuxShouldUseTransparentBackgroundWindow())
+            XCTAssertTrue(cmuxShouldUseClearWindowBackground(for: 1.0))
         }
     }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -14,6 +14,37 @@ import UserNotifications
 #endif
 
 @MainActor
+final class WindowGlassEffectTests: XCTestCase {
+    func testRemoveRestoresOriginalContentHierarchy() {
+        _ = NSApplication.shared
+
+        let originalContentView = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        let window = NSWindow(
+            contentRect: originalContentView.bounds,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = originalContentView
+
+        WindowGlassEffect.apply(to: window, tintColor: .systemBlue)
+
+        if WindowGlassEffect.isAvailable {
+            XCTAssertFalse(window.contentView === originalContentView)
+            XCTAssertTrue(window.contentView?.subviews.contains(where: { $0 === originalContentView }) == true)
+        } else {
+            XCTAssertTrue(window.contentView === originalContentView)
+            XCTAssertTrue(originalContentView.subviews.contains(where: { $0 is NSVisualEffectView }))
+        }
+
+        WindowGlassEffect.remove(from: window)
+
+        XCTAssertTrue(window.contentView === originalContentView)
+        XCTAssertFalse(originalContentView.subviews.contains(where: { $0 is NSVisualEffectView }))
+    }
+}
+
+@MainActor
 final class AppDelegateWindowContextRoutingTests: XCTestCase {
     private func makeMainWindow(id: UUID) -> NSWindow {
         let window = NSWindow(


### PR DESCRIPTION
## Summary
- fix the window glass gating so behind-window glass stays enabled on macOS 26 and older macOS paths
- make Tahoe glass teardown reversible by restoring the original window content view when glass is turned off
- add runtime coverage for glass apply/remove behavior and decision coverage for glass-enabled transparency

## Verification
- did not run local tests per repo policy
- `Vercel` commit status is passing for `7a2e9b68`
- built and launched tagged dev app with `./scripts/reload.sh --tag macos26-glass --launch`
- ran required final build command: `./scripts/reload.sh --tag macos26-glass`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix glass background gating so “behind window” glass stays enabled on macOS 26 and older, and make teardown reversible by restoring the original content view. Adds tests for decision logic and apply/remove behavior.

- **Bug Fixes**
  - Route all glass decisions through cmuxShouldApplyWindowGlass (based on user settings only).
  - Keep implementation choice internal: `NSGlassEffectView` on macOS 26+ or `NSVisualEffectView` fallback.
  - Implement WindowGlassEffect.remove to restore the original content view or clean up the fallback view.
  - Align window opacity/transparency with theme alpha and glass setting; remove glass when disabled.

<sup>Written for commit 7a2e9b680fe52c0fa0f63b201bcba903318a56f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window glass effect behavior on macOS with improved state management and consistency.
  * Fixed restoration of window state when disabling the glass effect.

* **Tests**
  * Added comprehensive test coverage for glass effect application and removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->