### PR TITLE
Fix session restore suppression on relaunch

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -457,7 +457,7 @@ enum FinderServicePathResolver {
         var directories: [String] = []
 
         for url in pathURLs {
-            let directoryURL = normalizedComparisonURL(resolvedDirectoryURL(from: url))
+            let directoryURL = resolvedDirectoryURL(from: url)
             guard !excludedRootURLs.contains(where: { isSameOrDescendant(directoryURL, of: $0) }) else {
                 continue
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -426,6 +426,17 @@ enum FinderServicePathResolver {
         return canonical
     }
 
+    private static func normalizedComparisonURL(_ url: URL) -> URL {
+        url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private static func isSameOrDescendant(_ url: URL, of rootURL: URL) -> Bool {
+        let urlPathComponents = normalizedComparisonURL(url).pathComponents
+        let rootPathComponents = normalizedComparisonURL(rootURL).pathComponents
+        guard urlPathComponents.count >= rootPathComponents.count else { return false }
+        return Array(urlPathComponents.prefix(rootPathComponents.count)) == rootPathComponents
+    }
+
     private static func resolvedDirectoryURL(from url: URL) -> URL {
         let standardized = url.standardizedFileURL
         if standardized.hasDirectoryPath {
@@ -438,12 +449,18 @@ enum FinderServicePathResolver {
         return standardized.deletingLastPathComponent()
     }
 
-    static func orderedUniqueDirectories(from pathURLs: [URL]) -> [String] {
+    static func orderedUniqueDirectories(
+        from pathURLs: [URL],
+        excludingDescendantsOf excludedRootURLs: [URL] = []
+    ) -> [String] {
         var seen: Set<String> = []
         var directories: [String] = []
 
         for url in pathURLs {
-            let directoryURL = resolvedDirectoryURL(from: url)
+            let directoryURL = normalizedComparisonURL(resolvedDirectoryURL(from: url))
+            guard !excludedRootURLs.contains(where: { isSameOrDescendant(directoryURL, of: $0) }) else {
+                continue
+            }
             let path = canonicalDirectoryPath(directoryURL.path(percentEncoded: false))
             guard !path.isEmpty else { continue }
             if seen.insert(path).inserted {
@@ -5687,8 +5704,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         target: ServiceOpenTarget,
         error: AutoreleasingUnsafeMutablePointer<NSString>
     ) {
-        prepareForExplicitOpenIntentAtStartup()
-
         let pathURLs = servicePathURLs(from: pasteboard)
         guard !pathURLs.isEmpty else {
             error.pointee = Self.serviceErrorNoPath
@@ -5701,6 +5716,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
 
+        prepareForExplicitOpenIntentAtStartup()
         for directory in directories {
             switch target {
             case .window:
@@ -5755,7 +5771,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func externalOpenDirectories(from urls: [URL]) -> [String] {
-        FinderServicePathResolver.orderedUniqueDirectories(from: urls.filter { $0.isFileURL })
+        // LaunchServices can surface the running app bundle on relaunch; ignore self paths so
+        // they do not get treated as explicit folder opens and suppress session restore.
+        FinderServicePathResolver.orderedUniqueDirectories(
+            from: urls.filter { $0.isFileURL },
+            excludingDescendantsOf: [Bundle.main.bundleURL]
+        )
     }
 
     private func openWorkspaceForExternalDirectory(

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -49,6 +49,50 @@ final class FinderServicePathResolverTests: XCTestCase {
             ]
         )
     }
+
+    func testOrderedUniqueDirectoriesSkipsBundleAndEmbeddedPathsWhenExcludingBundleRoot() {
+        let bundleURL = URL(fileURLWithPath: "/Applications/Tools/../cmux.app", isDirectory: true)
+        let input: [URL] = [
+            bundleURL,
+            URL(fileURLWithPath: "/Applications/cmux.app/Contents/MacOS/cmux", isDirectory: false),
+            URL(fileURLWithPath: "/Applications/cmux.app/Contents/Resources/bin/cmux", isDirectory: false),
+            URL(fileURLWithPath: "/Users/tester/Projects/cmux", isDirectory: true),
+            URL(fileURLWithPath: "/Users/tester/Projects/cmux/README.md", isDirectory: false),
+        ]
+
+        let directories = FinderServicePathResolver.orderedUniqueDirectories(
+            from: input,
+            excludingDescendantsOf: [bundleURL]
+        )
+
+        XCTAssertEqual(
+            directories,
+            [
+                "/Users/tester/Projects/cmux",
+            ]
+        )
+    }
+
+    func testOrderedUniqueDirectoriesExclusionDoesNotFilterSiblingPaths() {
+        let bundleURL = URL(fileURLWithPath: "/Applications/cmux.app", isDirectory: true)
+        let input: [URL] = [
+            URL(fileURLWithPath: "/Applications/cmux.app backup/project", isDirectory: true),
+            URL(fileURLWithPath: "/Applications/cmux.app.beta/project/file.txt", isDirectory: false),
+        ]
+
+        let directories = FinderServicePathResolver.orderedUniqueDirectories(
+            from: input,
+            excludingDescendantsOf: [bundleURL]
+        )
+
+        XCTAssertEqual(
+            directories,
+            [
+                "/Applications/cmux.app backup/project",
+                "/Applications/cmux.app.beta/project",
+            ]
+        )
+    }
 }
 
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -14,6 +14,16 @@ import UserNotifications
 #endif
 
 final class FinderServicePathResolverTests: XCTestCase {
+    private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-finder-service-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        return try body(root)
+    }
+
     func testOrderedUniqueDirectoriesUsesParentForFilesAndDedupes() {
         let input: [URL] = [
             URL(fileURLWithPath: "/tmp/cmux-services/project", isDirectory: true),
@@ -92,6 +102,55 @@ final class FinderServicePathResolverTests: XCTestCase {
                 "/Applications/cmux.app.beta/project",
             ]
         )
+    }
+
+    func testOrderedUniqueDirectoriesPreservesSymlinkAliasPaths() throws {
+        try withTemporaryDirectory { root in
+            let actualDirectory = root.appendingPathComponent("actual/project", isDirectory: true)
+            let aliasDirectory = root.appendingPathComponent("alias-project", isDirectory: true)
+            let actualFile = actualDirectory.appendingPathComponent("README.md", isDirectory: false)
+            let aliasFile = aliasDirectory.appendingPathComponent("README.md", isDirectory: false)
+
+            try FileManager.default.createDirectory(at: actualDirectory, withIntermediateDirectories: true)
+            FileManager.default.createFile(atPath: actualFile.path, contents: Data())
+            try FileManager.default.createSymbolicLink(at: aliasDirectory, withDestinationURL: actualDirectory)
+
+            let directories = FinderServicePathResolver.orderedUniqueDirectories(
+                from: [aliasDirectory, aliasFile]
+            )
+
+            XCTAssertEqual(directories, [aliasDirectory.standardizedFileURL.path])
+            XCTAssertNotEqual(directories, [actualDirectory.standardizedFileURL.path])
+        }
+    }
+
+    func testOrderedUniqueDirectoriesResolvesSymlinksOnlyForExcludedRootComparison() throws {
+        try withTemporaryDirectory { root in
+            let applicationsDirectory = root.appendingPathComponent("Applications", isDirectory: true)
+            let actualBundle = applicationsDirectory.appendingPathComponent("cmux.app", isDirectory: true)
+            let actualBinary = actualBundle.appendingPathComponent("Contents/MacOS/cmux", isDirectory: false)
+            let aliasApplications = root.appendingPathComponent("Launcher", isDirectory: true)
+            let aliasWorkspace = aliasApplications.appendingPathComponent("workspace", isDirectory: true)
+
+            try FileManager.default.createDirectory(at: actualBinary.deletingLastPathComponent(), withIntermediateDirectories: true)
+            FileManager.default.createFile(atPath: actualBinary.path, contents: Data())
+            try FileManager.default.createDirectory(
+                at: applicationsDirectory.appendingPathComponent("workspace", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createSymbolicLink(at: aliasApplications, withDestinationURL: applicationsDirectory)
+
+            let directories = FinderServicePathResolver.orderedUniqueDirectories(
+                from: [
+                    aliasApplications.appendingPathComponent("cmux.app", isDirectory: true),
+                    aliasApplications.appendingPathComponent("cmux.app/Contents/MacOS/cmux", isDirectory: false),
+                    aliasWorkspace,
+                ],
+                excludingDescendantsOf: [actualBundle]
+            )
+
+            XCTAssertEqual(directories, [aliasWorkspace.standardizedFileURL.path])
+        }
     }
 }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -229,6 +229,39 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         XCTAssertNotNil(createdWorkspace)
         XCTAssertEqual(createdWorkspace?.currentDirectory, droppedDirectory.path)
     }
+
+    func testApplicationOpenURLsIgnoresBundleSelfPaths() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+
+        let windowId = UUID()
+        let window = makeMainWindow(id: windowId)
+        defer { window.orderOut(nil) }
+
+        let manager = TabManager()
+        app.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState()
+        )
+
+        window.makeKeyAndOrderFront(nil)
+        _ = app.synchronizeActiveMainWindowContext(preferredWindow: window)
+
+        let existingWorkspaceIds = Set(manager.tabs.map(\.id))
+        let embeddedExecutableURL = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/MacOS/cmux", isDirectory: false)
+
+        app.application(
+            NSApplication.shared,
+            open: [embeddedExecutableURL]
+        )
+
+        let createdWorkspace = manager.tabs.first { !existingWorkspaceIds.contains($0.id) }
+        XCTAssertNil(createdWorkspace)
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- ignore LaunchServices self-bundle opens during relaunch so they do not suppress session restore
- add regression coverage for external open routing, including symlinked Finder aliases
- preserve symlink aliases for workspace creation while still resolving symlinks for bundle exclusion comparisons

## Verification
- ./scripts/reload.sh --tag fix-finder-symlink
- tests not run locally per repo policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session restore being suppressed on relaunch by ignoring self-bundle URLs surfaced by LaunchServices. Preserves symlink alias paths while still excluding bundle paths. (Addresses issue-2387.)

- **Bug Fixes**
  - Ignore the app bundle and its descendants when routing external opens; prevents false explicit opens on relaunch and restores previous session as expected.
  - Resolve symlinks only for excluded-root comparisons; keep alias paths when creating workspaces.
  - Added regression tests for bundle exclusions and symlinked Finder aliases.

<sup>Written for commit 8258459aabef76e32c2eba8e98af2d315312cc65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where the app would incorrectly open folders on relaunch
  * Improved directory resolution to properly handle symlinked directory aliases
  * Enhanced path filtering to prevent app bundle resources from interfering with directory operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->