### PR TITLE
Fix terminal output rendering perf regression vs Ghostty

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4671,6 +4671,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // bursts don't spend main-thread time updating AppKit scroll state faster than
     // the user can see.
     private static let scrollbarFlushInterval: CFTimeInterval = 1.0 / 120.0
+    private enum ScrollbarPriorityState {
+        case normal
+        case awaitingExplicitAfterWheel
+        case holdingExplicitAfterWheel
+    }
     internal enum DropPlan: Equatable {
         case insertText(String)
         case uploadFiles([URL])
@@ -4706,10 +4711,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var _pendingScrollbar: GhosttyScrollbar?
     private var _scrollbarFlushScheduled = false
     private var _lastScrollbarFlushAt: CFTimeInterval = 0
+    private var _committedScrollbar: GhosttyScrollbar?
+    private var _scrollbarPriorityState: ScrollbarPriorityState = .normal
     private let _scrollbarLock = NSLock()
     var cellSize: CGSize = .zero
     var onScrollbarUpdate: ((GhosttyScrollbar) -> Void)?
     var onCellSizeUpdate: (() -> Void)?
+
+    /// Preserve the first post-wheel scrollbar movement that actually changes
+    /// position so later coalesced packets cannot overwrite it before flush.
+    func markNextScrollbarUpdateExplicit() {
+        _scrollbarLock.lock()
+        if _scrollbarPriorityState == .normal {
+            _scrollbarPriorityState = .awaitingExplicitAfterWheel
+        }
+        _scrollbarLock.unlock()
+    }
 
     /// Coalesce high-frequency scrollbar updates into a single main-thread
     /// dispatch.  The action callback (which may fire thousands of times per
@@ -4717,9 +4734,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// and schedules a flush no faster than the display can present it.
     func enqueueScrollbarUpdate(_ newValue: GhosttyScrollbar) {
         _scrollbarLock.lock()
-        // Store the latest value (always overwrites — only the newest matters).
-        _pendingScrollbar = newValue
-        let needsSchedule = !_scrollbarFlushScheduled
+        switch _scrollbarPriorityState {
+        case .normal:
+            // Duplicate packets against the last committed viewport do not change
+            // any visible state, so keep any newer pending update instead.
+            if newValue != _committedScrollbar {
+                _pendingScrollbar = newValue
+            }
+        case .awaitingExplicitAfterWheel:
+            // Ignore duplicate bottom packets while waiting for the first
+            // actual wheel-driven movement.
+            if newValue != _committedScrollbar {
+                _pendingScrollbar = newValue
+                _scrollbarPriorityState = .holdingExplicitAfterWheel
+            }
+        case .holdingExplicitAfterWheel:
+            // Keep the first non-duplicate wheel packet until it reaches the
+            // scroll view; later coalesced packets can be passive output.
+            break
+        }
+        let needsSchedule = _pendingScrollbar != nil && !_scrollbarFlushScheduled
         if needsSchedule { _scrollbarFlushScheduled = true }
         let earliestNextFlush = _lastScrollbarFlushAt + Self.scrollbarFlushInterval
         let delay = max(0, earliestNextFlush - CACurrentMediaTime())
@@ -4745,15 +4779,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _scrollbarFlushScheduled = false
         let pending = _pendingScrollbar
         _pendingScrollbar = nil
-        if pending != nil {
+        let isDuplicate = pending == _committedScrollbar
+        if let pending, !isDuplicate {
+            _committedScrollbar = pending
             _lastScrollbarFlushAt = CACurrentMediaTime()
+        }
+        if _scrollbarPriorityState == .holdingExplicitAfterWheel {
+            _scrollbarPriorityState = isDuplicate ? .awaitingExplicitAfterWheel : .normal
         }
         _scrollbarLock.unlock()
 
-        guard let pending else { return }
-        if pending != scrollbar {
-            scrollbar = pending
-        }
+        guard let pending, !isDuplicate else { return }
+        scrollbar = pending
         onScrollbarUpdate?(pending)
     }
 
@@ -8049,8 +8086,11 @@ final class GhosttySurfaceScrollView: NSView {
         observers.append(NotificationCenter.default.addObserver(
             forName: .ghosttyDidReceiveWheelScroll,
             object: surfaceView,
-            queue: .main
+            // Arm explicit-wheel state synchronously so the very next scrollbar
+            // packet cannot arrive before we mark it as user initiated.
+            queue: nil
         ) { [weak self] _ in
+            self?.surfaceView.markNextScrollbarUpdateExplicit()
             self?.pendingExplicitWheelScroll = true
         })
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4751,8 +4751,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _scrollbarLock.unlock()
 
         guard let pending else { return }
-        guard pending != scrollbar else { return }
-        scrollbar = pending
+        if pending != scrollbar {
+            scrollbar = pending
+        }
         onScrollbarUpdate?(pending)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2621,12 +2621,9 @@ class GhosttyApp {
                 height: CGFloat(action.action.cell_size.height)
             )
             DispatchQueue.main.async {
+                guard surfaceView.cellSize != cellSize else { return }
                 surfaceView.cellSize = cellSize
-                NotificationCenter.default.post(
-                    name: .ghosttyDidUpdateCellSize,
-                    object: surfaceView,
-                    userInfo: [GhosttyNotificationKey.cellSize: cellSize]
-                )
+                surfaceView.onCellSizeUpdate?()
             }
             return true
         case GHOSTTY_ACTION_START_SEARCH:
@@ -4670,6 +4667,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         return UserDefaults.standard.bool(forKey: "cmuxFocusDebug")
     }()
+    // Keep viewport synchronization bounded to display cadence so terminal output
+    // bursts don't spend main-thread time updating AppKit scroll state faster than
+    // the user can see.
+    private static let scrollbarFlushInterval: CFTimeInterval = 1.0 / 120.0
     internal enum DropPlan: Equatable {
         case insertText(String)
         case uploadFiles([URL])
@@ -4704,25 +4705,37 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// fires on Ghostty's I/O thread while the flush runs on main.
     private var _pendingScrollbar: GhosttyScrollbar?
     private var _scrollbarFlushScheduled = false
+    private var _lastScrollbarFlushAt: CFTimeInterval = 0
     private let _scrollbarLock = NSLock()
     var cellSize: CGSize = .zero
+    var onScrollbarUpdate: ((GhosttyScrollbar) -> Void)?
+    var onCellSizeUpdate: (() -> Void)?
 
     /// Coalesce high-frequency scrollbar updates into a single main-thread
     /// dispatch.  The action callback (which may fire thousands of times per
     /// second during bulk output like `seq 1 100000`) stores the latest value
-    /// and schedules exactly one async flush.
+    /// and schedules a flush no faster than the display can present it.
     func enqueueScrollbarUpdate(_ newValue: GhosttyScrollbar) {
         _scrollbarLock.lock()
-        defer { _scrollbarLock.unlock() }
         // Store the latest value (always overwrites — only the newest matters).
         _pendingScrollbar = newValue
         let needsSchedule = !_scrollbarFlushScheduled
         if needsSchedule { _scrollbarFlushScheduled = true }
+        let earliestNextFlush = _lastScrollbarFlushAt + Self.scrollbarFlushInterval
+        let delay = max(0, earliestNextFlush - CACurrentMediaTime())
+        _scrollbarLock.unlock()
 
         // If a flush is already scheduled, skip the dispatch — the scheduled
         // block will pick up the latest value.
         guard needsSchedule else { return }
-        DispatchQueue.main.async { [weak self] in
+        guard delay > 0 else {
+            DispatchQueue.main.async { [weak self] in
+                self?.flushPendingScrollbar()
+            }
+            return
+        }
+        let delayMilliseconds = Int((delay * 1000).rounded(.up))
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMilliseconds)) { [weak self] in
             self?.flushPendingScrollbar()
         }
     }
@@ -4732,15 +4745,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _scrollbarFlushScheduled = false
         let pending = _pendingScrollbar
         _pendingScrollbar = nil
+        if pending != nil {
+            _lastScrollbarFlushAt = CACurrentMediaTime()
+        }
         _scrollbarLock.unlock()
 
         guard let pending else { return }
+        guard pending != scrollbar else { return }
         scrollbar = pending
-        NotificationCenter.default.post(
-            name: .ghosttyDidUpdateScrollbar,
-            object: self,
-            userInfo: [GhosttyNotificationKey.scrollbar: pending]
-        )
+        onScrollbarUpdate?(pending)
     }
 
     var desiredFocus: Bool = false
@@ -7429,7 +7442,7 @@ private extension NSScreen {
     }
 }
 
-struct GhosttyScrollbar {
+struct GhosttyScrollbar: Equatable {
     let total: UInt64
     let offset: UInt64
     let len: UInt64
@@ -7442,8 +7455,6 @@ struct GhosttyScrollbar {
 }
 
 enum GhosttyNotificationKey {
-    static let scrollbar = "ghostty.scrollbar"
-    static let cellSize = "ghostty.cellSize"
     static let tabId = "ghostty.tabId"
     static let surfaceId = "ghostty.surfaceId"
     static let title = "ghostty.title"
@@ -7454,8 +7465,6 @@ enum GhosttyNotificationKey {
 }
 
 extension Notification.Name {
-    static let ghosttyDidUpdateScrollbar = Notification.Name("ghosttyDidUpdateScrollbar")
-    static let ghosttyDidUpdateCellSize = Notification.Name("ghosttyDidUpdateCellSize")
     static let ghosttyDidReceiveWheelScroll = Notification.Name("ghosttyDidReceiveWheelScroll")
     static let ghosttySearchFocus = Notification.Name("ghosttySearchFocus")
     static let ghosttyConfigDidReload = Notification.Name("ghosttyConfigDidReload")
@@ -7969,6 +7978,13 @@ final class GhosttySurfaceScrollView: NSView {
             imageTransferIndicatorContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ])
 
+        surfaceView.onScrollbarUpdate = { [weak self] scrollbar in
+            self?.handleScrollbarUpdate(scrollbar)
+        }
+        surfaceView.onCellSizeUpdate = { [weak self] in
+            self?.synchronizeScrollView()
+        }
+
         scrollView.contentView.postsBoundsChangedNotifications = true
         observers.append(NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
@@ -8004,13 +8020,12 @@ final class GhosttySurfaceScrollView: NSView {
             self?.handleLiveScroll()
         })
 
-        observers.append(NotificationCenter.default.addObserver(
-            forName: .ghosttyDidUpdateScrollbar,
-            object: surfaceView,
-            queue: .main
-        ) { [weak self] notification in
-            self?.handleScrollbarUpdate(notification)
-        })
+        surfaceView.onScrollbarUpdate = { [weak self] scrollbar in
+            self?.handleScrollbarUpdate(scrollbar)
+        }
+        surfaceView.onCellSizeUpdate = { [weak self] in
+            self?.synchronizeScrollView()
+        }
 
         observers.append(NotificationCenter.default.addObserver(
             forName: .terminalSurfaceDidBecomeReady,
@@ -8050,14 +8065,6 @@ final class GhosttySurfaceScrollView: NSView {
             // Explicitly unfocus the terminal so the cursor stops blinking
             // when the search field takes over.
             surface.setFocus(false)
-        })
-
-        observers.append(NotificationCenter.default.addObserver(
-            forName: .ghosttyDidUpdateCellSize,
-            object: surfaceView,
-            queue: .main
-        ) { [weak self] _ in
-            self?.synchronizeScrollView()
         })
 
         observers.append(NotificationCenter.default.addObserver(
@@ -10164,10 +10171,7 @@ final class GhosttySurfaceScrollView: NSView {
         _ = surfaceView.performBindingAction("scroll_to_row:\(row)")
     }
 
-    private func handleScrollbarUpdate(_ notification: Notification) {
-        guard let scrollbar = notification.userInfo?[GhosttyNotificationKey.scrollbar] as? GhosttyScrollbar else {
-            return
-        }
+    private func handleScrollbarUpdate(_ scrollbar: GhosttyScrollbar) {
         if pendingExplicitWheelScroll {
             userScrolledAwayFromBottom = scrollbar.offset + scrollbar.len < scrollbar.total
             allowExplicitScrollbarSync = true

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2149,11 +2149,18 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             return
         }
 
-        surfaceView.enqueueScrollbarUpdate(makeScrollbar(total: 100, offset: 90, len: 10))
-        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        let bottomScrollbar = makeScrollbar(total: 100, offset: 90, len: 10)
+        let scrollbackScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
+
+        surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
+        guard waitUntil(description: "initial bottom scrollbar packet") {
+            surfaceView.scrollbar == bottomScrollbar
+        } else {
+            return
+        }
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
 
-        surfaceView.nextScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
+        surfaceView.nextScrollbar = scrollbackScrollbar
 
         guard let cgEvent = CGEvent(
             scrollWheelEvent2Source: nil,
@@ -2168,11 +2175,19 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         }
 
         scrollView.scrollWheel(with: scrollEvent)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        guard waitUntil(description: "wheel-driven scrollback packet") {
+            abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
+        } else {
+            return
+        }
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 500, accuracy: 0.01)
 
-        surfaceView.enqueueScrollbarUpdate(makeScrollbar(total: 100, offset: 90, len: 10))
-        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
+        guard waitUntil(description: "later passive bottom packet") {
+            surfaceView.scrollbar == bottomScrollbar
+        } else {
+            return
+        }
 
         XCTAssertEqual(
             scrollView.contentView.bounds.origin.y,
@@ -2180,6 +2195,84 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             accuracy: 0.01,
             "A passive bottom packet should not yank the viewport after an explicit wheel scroll into scrollback"
         )
+    }
+
+    func testExplicitWheelScrollPreservesFirstScrollbackPacketThroughCoalescedPackets() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surfaceView = ScrollbarPostingSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 120))
+        surfaceView.cellSize = CGSize(width: 10, height: 10)
+        let hostedView = GhosttySurfaceScrollView(surfaceView: surfaceView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let scrollView = hostedView.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView else {
+            XCTFail("Expected hosted terminal scroll view")
+            return
+        }
+
+        let bottomScrollbar = makeScrollbar(total: 100, offset: 90, len: 10)
+        let scrollbackScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
+
+        surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
+        guard waitUntil(description: "initial bottom scrollbar packet") {
+            surfaceView.scrollbar == bottomScrollbar
+        } else {
+            return
+        }
+        XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
+
+        // The scroll handler emits a duplicate bottom packet first; the later
+        // scrollback packet must still win, and a coalesced passive bottom packet
+        // must not overwrite it before the flush runs.
+        surfaceView.nextScrollbar = bottomScrollbar
+
+        guard let cgEvent = CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: 0,
+            wheel2: -12,
+            wheel3: 0
+        ), let scrollEvent = NSEvent(cgEvent: cgEvent) else {
+            XCTFail("Expected scroll wheel event")
+            return
+        }
+
+        scrollView.scrollWheel(with: scrollEvent)
+        surfaceView.enqueueScrollbarUpdate(scrollbackScrollbar)
+        surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
+
+        guard waitUntil(description: "first non-duplicate wheel packet to win") {
+            abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
+        } else {
+            return
+        }
+
+        XCTAssertEqual(
+            surfaceView.scrollbar,
+            scrollbackScrollbar,
+            "Duplicate and later passive packets should not consume the first real wheel-driven scrollback update"
+        )
+        XCTAssertEqual(scrollView.contentView.bounds.origin.y, 500, accuracy: 0.01)
     }
 
     func testInactiveOverlayVisibilityTracksRequestedState() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1993,11 +1993,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         override func scrollWheel(with event: NSEvent) {
             super.scrollWheel(with: event)
             guard let nextScrollbar else { return }
-            NotificationCenter.default.post(
-                name: .ghosttyDidUpdateScrollbar,
-                object: self,
-                userInfo: [GhosttyNotificationKey.scrollbar: nextScrollbar]
-            )
+            enqueueScrollbarUpdate(nextScrollbar)
         }
     }
 
@@ -2153,11 +2149,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             return
         }
 
-        NotificationCenter.default.post(
-            name: .ghosttyDidUpdateScrollbar,
-            object: surfaceView,
-            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 100, offset: 90, len: 10)]
-        )
+        surfaceView.enqueueScrollbarUpdate(makeScrollbar(total: 100, offset: 90, len: 10))
         RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
 
@@ -2179,11 +2171,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 500, accuracy: 0.01)
 
-        NotificationCenter.default.post(
-            name: .ghosttyDidUpdateScrollbar,
-            object: surfaceView,
-            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 100, offset: 90, len: 10)]
-        )
+        surfaceView.enqueueScrollbarUpdate(makeScrollbar(total: 100, offset: 90, len: 10))
         RunLoop.current.run(until: Date().addingTimeInterval(0.01))
 
         XCTAssertEqual(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2153,9 +2153,12 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         let scrollbackScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
 
         surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
-        guard waitUntil(description: "initial bottom scrollbar packet") {
-            surfaceView.scrollbar == bottomScrollbar
-        } else {
+        guard waitUntil(
+            description: "initial bottom scrollbar packet",
+            {
+                surfaceView.scrollbar == bottomScrollbar
+            }
+        ) else {
             return
         }
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
@@ -2175,17 +2178,23 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         }
 
         scrollView.scrollWheel(with: scrollEvent)
-        guard waitUntil(description: "wheel-driven scrollback packet") {
-            abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
-        } else {
+        guard waitUntil(
+            description: "wheel-driven scrollback packet",
+            {
+                abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
+            }
+        ) else {
             return
         }
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 500, accuracy: 0.01)
 
         surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
-        guard waitUntil(description: "later passive bottom packet") {
-            surfaceView.scrollbar == bottomScrollbar
-        } else {
+        guard waitUntil(
+            description: "later passive bottom packet",
+            {
+                surfaceView.scrollbar == bottomScrollbar
+            }
+        ) else {
             return
         }
 
@@ -2233,9 +2242,12 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         let scrollbackScrollbar = makeScrollbar(total: 100, offset: 40, len: 10)
 
         surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
-        guard waitUntil(description: "initial bottom scrollbar packet") {
-            surfaceView.scrollbar == bottomScrollbar
-        } else {
+        guard waitUntil(
+            description: "initial bottom scrollbar packet",
+            {
+                surfaceView.scrollbar == bottomScrollbar
+            }
+        ) else {
             return
         }
         XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
@@ -2261,9 +2273,12 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         surfaceView.enqueueScrollbarUpdate(scrollbackScrollbar)
         surfaceView.enqueueScrollbarUpdate(bottomScrollbar)
 
-        guard waitUntil(description: "first non-duplicate wheel packet to win") {
-            abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
-        } else {
+        guard waitUntil(
+            description: "first non-duplicate wheel packet to win",
+            {
+                abs(scrollView.contentView.bounds.origin.y - 500) <= 0.01
+            }
+        ) else {
             return
         }
 


### PR DESCRIPTION
## Summary
- throttle Ghostty scrollbar packets to display cadence before cmux syncs AppKit viewport state
- replace NotificationCenter on the hot scrollbar/cell-size path with direct callbacks inside the surface wrapper
- skip redundant cell-size and scrollbar applications so burst output does less main-thread work

## Verification
- built and launched the tagged dev app with `./scripts/reload.sh --tag text-rendering-perf --launch`
- did not run local tests per repo policy

Closes #2444

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a terminal rendering perf regression by rate-limiting viewport/scrollbar sync to display cadence, replacing `NotificationCenter` with direct callbacks, and deduping updates. Scrolling is smoother under burst output and the first explicit wheel scroll is preserved even with duplicate/coalesced packets; addresses #2444.

- **Bug Fixes**
  - Throttle scrollbar/viewport flushes to ~120 Hz; skip flushes that match the last committed value.
  - Replace `NotificationCenter` hot-path updates with direct callbacks (`onScrollbarUpdate`, `onCellSizeUpdate`) and arm wheel-scroll state synchronously.
  - Preserve explicit wheel intent: ignore duplicate bottom packets and hold the first non-duplicate wheel packet through coalesced output; tests updated via `enqueueScrollbarUpdate` and CI `waitUntil` guard parsing fixed.

<sup>Written for commit 48188dafc5f445fc73e110d1debe2350d87e840a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Rate-limited scrollbar flushes tied to display cadence to reduce redundant updates and improve responsiveness.
  * Coalescing/suppression of duplicate cell-size and scrollbar signals for smoother rendering.

* **Bug Fixes**
  * More reliable scrollbar behavior and content positioning by preserving explicit wheel-driven updates and preventing unwanted overrides.

* **Tests**
  * Updated and added tests validating explicit wheel-scroll behavior, scrollbar coalescing, and stable content positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->