### PR TITLE
Fix GitHub star badge k formatting

### DIFF
--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -5,8 +5,8 @@ import posthog from "posthog-js";
 
 function formatStars(count: number): string {
   if (count >= 1000) {
-    const k = count / 1000;
-    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
+    const k = Number((count / 1000).toFixed(1));
+    return `${k}k`;
   }
   return String(count);
 }


### PR DESCRIPTION
## Summary
- drop the trailing `.0` from whole-number GitHub star counts in the site header badge
- keep one decimal for non-round `k` counts such as `12.1k`

## Testing
- `cd web && node -e 'const formatStars = (count) => count >= 1000 ? `${Number((count / 1000).toFixed(1))}k` : String(count); const cases = [[999, "999"], [1000, "1k"], [12000, "12k"], [12100, "12.1k"], [12999, "13k"]]; for (const [input, expected] of cases) { const actual = formatStars(input); if (actual !== expected) { throw new Error(`${input}: expected ${expected}, got ${actual}`); } } console.log("formatStars cases passed");'` (passed)
- `cd web && SKIP_ENV_VALIDATION=1 npm run build` (passed)
- `cd web && npm run lint` (fails on existing unrelated web lint errors in `web/app/[locale]/components/spacing-control.tsx` and `web/app/[locale]/page.tsx`)

## Issues
- Related: task 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GitHub star badge formatting in the site header: whole-thousand counts now render without trailing .0 (1k, 12k) and non-round values keep one decimal (12.1k). Aligns with Linear task-0 GitHub star count format.

<sup>Written for commit e136db1f7ecb8c6076437a89205014a43e5c08d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized GitHub star count display formatting. Counts of 1,000 or more now consistently render with one decimal place (e.g., "2.5k"), ensuring uniform presentation across the interface instead of variable formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->