### PR TITLE
Add editable workspace descriptions

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1694,9 +1694,10 @@ struct CMUXCLI {
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
             let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
-            let (nameOpt, remaining) = parseOption(rem1, name: "--name")
+            let (nameOpt, rem2) = parseOption(rem1, name: "--name")
+            let (descriptionOpt, remaining) = parseOption(rem2, name: "--description")
             if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --command <text>, --cwd <path>")
+                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>")
             }
             var params: [String: Any] = [:]
             if let cwdOpt {
@@ -1705,6 +1706,9 @@ struct CMUXCLI {
             }
             if let nameOpt {
                 params["title"] = nameOpt
+            }
+            if let descriptionOpt {
+                params["description"] = descriptionOpt
             }
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
@@ -2016,11 +2020,14 @@ struct CMUXCLI {
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
 
         case "current-workspace":
-            let response = try sendV1Command("current_workspace", client: client)
+            let response = try client.sendV2(method: "workspace.current")
             if jsonOutput {
-                print(jsonString(["workspace_id": response]))
+                print(jsonString(formatIDs(response, mode: idFormat)))
             } else {
-                print(response)
+                let handle = formatHandle(response, kind: "workspace", idFormat: idFormat)
+                    ?? (response["workspace_id"] as? String)
+                    ?? ""
+                print(handle)
             }
 
         case "read-screen":
@@ -3383,8 +3390,9 @@ struct CMUXCLI {
         let (actionOpt, rem1) = parseOption(rem0, name: "--action")
         let (titleOpt, rem2) = parseOption(rem1, name: "--title")
         let (colorOpt, rem3) = parseOption(rem2, name: "--color")
+        let (descriptionOpt, rem4) = parseOption(rem3, name: "--description")
 
-        var positional = rem3
+        var positional = rem4
         let actionRaw: String
         if let actionOpt {
             actionRaw = actionOpt
@@ -3403,7 +3411,8 @@ struct CMUXCLI {
         let workspaceArg = workspaceOpt ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
         let workspaceId = try normalizeWorkspaceHandle(workspaceArg, client: client, allowCurrent: true)
 
-        let inferredPositional = positional.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        let inferredPositionalRaw = positional.joined(separator: " ")
+        let inferredPositional = inferredPositionalRaw.trimmingCharacters(in: .whitespacesAndNewlines)
         let title = (titleOpt ?? (action == "rename" && !inferredPositional.isEmpty ? inferredPositional : nil))?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if action == "rename", (title?.isEmpty ?? true) {
@@ -3417,6 +3426,13 @@ struct CMUXCLI {
             throw CLIError(message: "workspace-action set-color requires --color <name|#hex> (or a trailing color)")
         }
 
+        let description = (
+            descriptionOpt ?? (action == "set_description" && !inferredPositional.isEmpty ? inferredPositionalRaw : nil)
+        )?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if action == "set_description", (description?.isEmpty ?? true) {
+            throw CLIError(message: "workspace-action set-description requires --description <text> (or trailing text)")
+        }
+
         var params: [String: Any] = ["action": action]
         if let workspaceId {
             params["workspace_id"] = workspaceId
@@ -3426,6 +3442,9 @@ struct CMUXCLI {
         }
         if let color, !color.isEmpty {
             params["color"] = color
+        }
+        if let description, !description.isEmpty {
+            params["description"] = description
         }
 
         let payload = try client.sendV2(method: "workspace.action", params: params)
@@ -6326,6 +6345,7 @@ struct CMUXCLI {
             Actions:
               pin | unpin
               rename | clear-name
+              set-description | clear-description
               move-up | move-down | move-top
               close-others | close-above | close-below
               mark-read | mark-unread
@@ -6336,6 +6356,7 @@ struct CMUXCLI {
               --workspace <id|ref|index>   Target workspace (default: current/$CMUX_WORKSPACE_ID)
               --title <text>               Title for rename
               --color <name|#hex>          Color for set-color (name or #RRGGBB hex)
+              --description <text>         Description for set-description
 
             Named colors:
               Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua,
@@ -6348,6 +6369,8 @@ struct CMUXCLI {
               cmux workspace-action --action set-color --color blue
               cmux workspace-action --action set-color --color "#C0392B"
               cmux workspace-action set-color Amber
+              cmux workspace-action --action set-description --description "Ship checklist"
+              cmux workspace-action --action set-description $'Ship checklist\n- verify build\n- post notes'
               cmux workspace-action clear-color
             """
         case "tab-action":
@@ -6402,18 +6425,20 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--name <title>] [--cwd <path>] [--command <text>]
+            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>]
 
             Create a new workspace in the current window.
 
             Flags:
-              --name <title>    Set a custom name for the new workspace
-              --cwd <path>      Set the working directory for the new workspace
+              --name <title>     Set a custom name for the new workspace
+              --description <text> Set a custom description for the new workspace
+              --cwd <path>       Set the working directory for the new workspace
               --command <text>   Send text+Enter to the new workspace after creation
 
             Example:
               cmux new-workspace
               cmux new-workspace --name "Build Server"
+              cmux new-workspace --name "Launch" --description "Ship checklist"
               cmux new-workspace --cwd ~/projects/myapp
               cmux new-workspace --cwd . --command "npm test"
             """
@@ -13270,9 +13295,9 @@ struct CMUXCLI {
           close-window --window <id>
           move-workspace-to-window --workspace <id|ref> --window <id|ref>
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>]
-          workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>]
+          workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>]
           list-workspaces
-          new-workspace [--name <title>] [--cwd <path>] [--command <text>]
+          new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
 			C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
+			E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 					B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */; };
 					B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 					B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */; };
@@ -273,6 +274,7 @@
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
+		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 							818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */,
 							B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */,
 							B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
+							E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
 							D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
 							D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
 							FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
@@ -857,6 +860,7 @@
 							B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */,
 							B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */,
 							B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
+							E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 							D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,
 							D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */,
 							FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -86660,6 +86660,142 @@
           }
         }
       }
+    },
+    "shortcut.editWorkspaceDescription.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Workspace Description"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を編集"
+          }
+        }
+      }
+    },
+    "menu.view.editWorkspaceDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Workspace Description…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を編集…"
+          }
+        }
+      }
+    },
+    "command.editWorkspaceDescription.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Workspace Description…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を編集…"
+          }
+        }
+      }
+    },
+    "command.clearWorkspaceDescription.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Workspace Description"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を消去"
+          }
+        }
+      }
+    },
+    "commandPalette.description.workspacePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace description"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明"
+          }
+        }
+      }
+    },
+    "commandPalette.description.workspaceInputHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to save. Press Shift-Enter for a new line, or Escape to cancel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter で保存します。Shift-Enter で改行、Escape でキャンセルします。"
+          }
+        }
+      }
+    },
+    "contextMenu.editWorkspaceDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Workspace Description…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を編集…"
+          }
+        }
+      }
+    },
+    "contextMenu.clearWorkspaceDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Workspace Description"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの説明を消去"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5360,6 +5360,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return isCommandPaletteResponder(responder)
     }
 
+    private func isCommandPaletteMultilineTextResponderActive(in window: NSWindow) -> Bool {
+        guard let textView = window.firstResponder as? NSTextView,
+              !textView.isFieldEditor else {
+            return false
+        }
+        return isCommandPaletteResponder(textView)
+    }
+
     private func commandPaletteMarkedTextInput(in window: NSWindow) -> NSTextView? {
         if let textView = window.firstResponder as? NSTextView,
            isCommandPaletteResponder(textView),
@@ -9613,6 +9621,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            let paletteWindow = commandPaletteShortcutWindow {
             let paletteFieldEditorHasMarkedText = commandPaletteFieldEditorHasMarkedText(in: paletteWindow)
             let paletteSnapshot = mainWindowId(for: paletteWindow).map(commandPaletteSnapshot(windowId:)) ?? .empty
+            let paletteUsesInlineReturnHandling = isCommandPaletteMultilineTextResponderActive(in: paletteWindow)
             if normalizedFlags.isEmpty, event.keyCode == 53 {
                 if paletteFieldEditorHasMarkedText {
                     return false
@@ -9631,12 +9640,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 dlog(
                     "shortcut.palette.return target={\(debugWindowToken(paletteWindow))} " +
                     "mode=\(paletteSnapshot.mode) " +
+                    "inline=\(paletteUsesInlineReturnHandling ? 1 : 0) " +
                     "submit=\(shouldSubmitPalette ? 1 : 0) " +
                     "marked=\(paletteFieldEditorHasMarkedText ? 1 : 0) " +
                     "\(debugShortcutRouteSnapshot(event: event))"
                 )
             }
 #endif
+            if paletteUsesInlineReturnHandling,
+               event.keyCode == 36 || event.keyCode == 76 {
+                return false
+            }
             if shouldSubmitPalette {
                 if paletteFieldEditorHasMarkedText {
                     return false

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9520,6 +9520,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             commandPaletteInteractiveInTargetWindow
             || commandPalettePendingOpenInTargetWindow
 
+#if DEBUG
+        if event.keyCode == 36 || event.keyCode == 76 {
+            dlog(
+                "shortcut.return.raw " +
+                "interactive=\(commandPaletteInteractiveInTargetWindow ? 1 : 0) " +
+                "effective=\(commandPaletteEffectiveInTargetWindow ? 1 : 0) " +
+                "target={\(debugWindowToken(commandPaletteTargetWindow))} " +
+                "shortcutWindow={\(debugWindowToken(commandPaletteShortcutWindow))} " +
+                "responderTarget=\(commandPaletteResponderActiveInTargetWindow ? 1 : 0) " +
+                "overlayTarget=\(commandPaletteOverlayVisibleInTargetWindow ? 1 : 0) " +
+                "pendingTarget=\(commandPalettePendingOpenInTargetWindow ? 1 : 0) " +
+                "\(debugShortcutRouteSnapshot(event: event))"
+            )
+        }
+#endif
+
         if normalizedFlags.isEmpty, event.keyCode == 53 {
             let activePaletteWindow = activeCommandPaletteWindow()
             let escapePaletteWindow: NSWindow? = {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2930,7 +2930,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // The automation socket is a core testing primitive, so ensure it's started here when
         // we detect XCTest, even if the main view lifecycle is flaky.
         let env = ProcessInfo.processInfo.environment
-        if isRunningUnderXCTest(env) || env.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) {
+        if isRunningUnderXCTest(env) {
             let raw = UserDefaults.standard.string(forKey: SocketControlSettings.appStorageKey)
                 ?? SocketControlSettings.defaultMode.rawValue
             let userMode = SocketControlSettings.migrateMode(raw)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4884,6 +4884,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return commandPaletteVisibilityByWindowId[windowId] ?? false
     }
 
+    func isCommandPaletteEffectivelyVisible(for window: NSWindow) -> Bool {
+        isCommandPaletteEffectivelyVisible(in: window)
+    }
+
     func shouldBlockFirstResponderChangeWhileCommandPaletteVisible(
         window: NSWindow,
         responder: NSResponder?

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2930,7 +2930,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // The automation socket is a core testing primitive, so ensure it's started here when
         // we detect XCTest, even if the main view lifecycle is flaky.
         let env = ProcessInfo.processInfo.environment
-        if isRunningUnderXCTest(env) {
+        if isRunningUnderXCTest(env) || env.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) {
             let raw = UserDefaults.standard.string(forKey: SocketControlSettings.appStorageKey)
                 ?? SocketControlSettings.defaultMode.rawValue
             let userMode = SocketControlSettings.migrateMode(raw)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1691,13 +1691,20 @@ func shouldConsumeShortcutWhileCommandPaletteVisible(
 
 func shouldSubmitCommandPaletteWithReturn(
     keyCode: UInt16,
-    flags: NSEvent.ModifierFlags
+    flags: NSEvent.ModifierFlags,
+    mode: String
 ) -> Bool {
     guard keyCode == 36 || keyCode == 76 else { return false }
     let normalizedFlags = flags
         .intersection(.deviceIndependentFlagsMask)
         .subtracting([.numericPad, .function, .capsLock])
-    return normalizedFlags == [] || normalizedFlags == [.shift]
+    if normalizedFlags.isEmpty {
+        return true
+    }
+    if normalizedFlags == [.shift] {
+        return mode != "workspace_description_input"
+    }
+    return false
 }
 
 func commandPaletteFieldEditorHasMarkedText(in window: NSWindow) -> Bool {
@@ -9605,6 +9612,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if commandPaletteInteractiveInTargetWindow,
            let paletteWindow = commandPaletteShortcutWindow {
             let paletteFieldEditorHasMarkedText = commandPaletteFieldEditorHasMarkedText(in: paletteWindow)
+            let paletteSnapshot = mainWindowId(for: paletteWindow).map(commandPaletteSnapshot(windowId:)) ?? .empty
             if normalizedFlags.isEmpty, event.keyCode == 53 {
                 if paletteFieldEditorHasMarkedText {
                     return false
@@ -9613,10 +9621,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return true
             }
 
-            if shouldSubmitCommandPaletteWithReturn(
+            let shouldSubmitPalette = shouldSubmitCommandPaletteWithReturn(
                 keyCode: event.keyCode,
-                flags: event.modifierFlags
-            ) {
+                flags: event.modifierFlags,
+                mode: paletteSnapshot.mode
+            )
+#if DEBUG
+            if event.keyCode == 36 || event.keyCode == 76 {
+                dlog(
+                    "shortcut.palette.return target={\(debugWindowToken(paletteWindow))} " +
+                    "mode=\(paletteSnapshot.mode) " +
+                    "submit=\(shouldSubmitPalette ? 1 : 0) " +
+                    "marked=\(paletteFieldEditorHasMarkedText ? 1 : 0) " +
+                    "\(debugShortcutRouteSnapshot(event: event))"
+                )
+            }
+#endif
+            if shouldSubmitPalette {
                 if paletteFieldEditorHasMarkedText {
                     return false
                 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4703,6 +4703,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    func requestCommandPaletteEditWorkspaceDescription(
+        preferredWindow: NSWindow? = nil,
+        source: String = "api.commandPaletteEditWorkspaceDescription"
+    ) {
+        postCommandPaletteRequest(
+            name: .commandPaletteEditWorkspaceDescriptionRequested,
+            preferredWindow: preferredWindow,
+            source: source,
+            markPending: true
+        )
+    }
+
     private func clearCommandPalettePendingOpen(for window: NSWindow?) {
         guard let window,
               let windowId = mainWindowId(for: window) else { return }
@@ -9906,6 +9918,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
 
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)) {
+            return requestEditWorkspaceDescriptionViaCommandPalette(
+                preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            )
+        }
+
         if matchShortcut(
             event: event,
             shortcut: StoredShortcut(key: "t", command: true, shift: false, option: true, control: false)
@@ -10875,6 +10893,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         requestCommandPaletteRenameWorkspace(
             preferredWindow: targetWindow,
             source: "shortcut.renameWorkspace"
+        )
+        return true
+    }
+
+    @discardableResult
+    func requestEditWorkspaceDescriptionViaCommandPalette(preferredWindow: NSWindow? = nil) -> Bool {
+        let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        requestCommandPaletteEditWorkspaceDescription(
+            preferredWindow: targetWindow,
+            source: "shortcut.editWorkspaceDescription"
         )
         return true
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9922,6 +9922,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)) {
+#if DEBUG
+            dlog(
+                "shortcut.editWorkspaceDescription matched target={\(debugWindowToken(commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow))} " +
+                "\(debugShortcutRouteSnapshot(event: event))"
+            )
+#endif
             return requestEditWorkspaceDescriptionViaCommandPalette(
                 preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             )
@@ -10903,6 +10909,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @discardableResult
     func requestEditWorkspaceDescriptionViaCommandPalette(preferredWindow: NSWindow? = nil) -> Bool {
         let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+#if DEBUG
+        dlog(
+            "shortcut.editWorkspaceDescription request target={\(debugWindowToken(targetWindow))} " +
+            "fr=\(targetWindow?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil")"
+        )
+#endif
         requestCommandPaletteEditWorkspaceDescription(
             preferredWindow: targetWindow,
             source: "shortcut.editWorkspaceDescription"

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1701,11 +1701,14 @@ func shouldSubmitCommandPaletteWithReturn(
 }
 
 func commandPaletteFieldEditorHasMarkedText(in window: NSWindow) -> Bool {
-    guard let editor = window.firstResponder as? NSTextView,
-          editor.isFieldEditor else {
-        return false
+    if let editor = window.firstResponder as? NSTextView {
+        return editor.hasMarkedText()
     }
-    return editor.hasMarkedText()
+    if let textField = window.firstResponder as? NSTextField,
+       let editor = textField.currentEditor() as? NSTextView {
+        return editor.hasMarkedText()
+    }
+    return false
 }
 
 func shouldHandleCommandPaletteShortcutEvent(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1646,6 +1646,15 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
     return nil
 }
 
+func shouldRouteCommandPaletteSelectionNavigation(
+    delta: Int?,
+    isInteractive: Bool,
+    usesInlineTextHandling: Bool
+) -> Bool {
+    guard delta != nil, isInteractive else { return false }
+    return !usesInlineTextHandling
+}
+
 func shouldConsumeShortcutWhileCommandPaletteVisible(
     isCommandPaletteVisible: Bool,
     normalizedFlags: NSEvent.ModifierFlags,
@@ -9618,12 +9627,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
         }
 
-        if let delta = commandPaletteSelectionDeltaForKeyboardNavigation(
+        let paletteUsesInlineTextHandling = commandPaletteShortcutWindow.map {
+            isCommandPaletteMultilineTextResponderActive(in: $0)
+        } ?? false
+
+        let paletteSelectionDelta = commandPaletteSelectionDeltaForKeyboardNavigation(
             flags: event.modifierFlags,
             chars: chars,
             keyCode: event.keyCode
+        )
+
+        if shouldRouteCommandPaletteSelectionNavigation(
+            delta: paletteSelectionDelta,
+            isInteractive: commandPaletteInteractiveInTargetWindow,
+            usesInlineTextHandling: paletteUsesInlineTextHandling
         ),
-           commandPaletteInteractiveInTargetWindow,
+           let delta = paletteSelectionDelta,
            let paletteWindow = commandPaletteShortcutWindow {
             NotificationCenter.default.post(
                 name: .commandPaletteMoveSelection,
@@ -9637,7 +9656,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            let paletteWindow = commandPaletteShortcutWindow {
             let paletteFieldEditorHasMarkedText = commandPaletteFieldEditorHasMarkedText(in: paletteWindow)
             let paletteSnapshot = mainWindowId(for: paletteWindow).map(commandPaletteSnapshot(windowId:)) ?? .empty
-            let paletteUsesInlineReturnHandling = isCommandPaletteMultilineTextResponderActive(in: paletteWindow)
+            let paletteUsesInlineReturnHandling = paletteUsesInlineTextHandling
             if normalizedFlags.isEmpty, event.keyCode == 53 {
                 if paletteFieldEditorHasMarkedText {
                     return false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13927,7 +13927,7 @@ enum SidebarMarkdownRenderer {
     static func renderWorkspaceDescription(_ markdown: String) -> AttributedString? {
         try? AttributedString(
             markdown: markdown,
-            options: .init(interpretedSyntax: .full)
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         )
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4516,6 +4516,16 @@ struct ContentView: View {
         var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
         var onDidBecomeFirstResponder: (() -> Void)?
 
+        override func flagsChanged(with event: NSEvent) {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.flagsChanged " +
+                "\(debugCommandPaletteKeyEventSummary(event))"
+            )
+#endif
+            super.flagsChanged(with: event)
+        }
+
         override func becomeFirstResponder() -> Bool {
             let becameFirstResponder = super.becomeFirstResponder()
 #if DEBUG
@@ -4583,6 +4593,50 @@ struct ContentView: View {
             )
 #endif
             return result
+        }
+
+        override func doCommand(by commandSelector: Selector) {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.doCommand selector=\(NSStringFromSelector(commandSelector)) " +
+                "len=\((string as NSString).length) " +
+                "sel=\(selectedRange().location):\(selectedRange().length)"
+            )
+#endif
+            super.doCommand(by: commandSelector)
+        }
+
+        override func insertNewline(_ sender: Any?) {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.insertNewline " +
+                "len=\((string as NSString).length) " +
+                "sel=\(selectedRange().location):\(selectedRange().length)"
+            )
+#endif
+            super.insertNewline(sender)
+        }
+
+        override func insertLineBreak(_ sender: Any?) {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.insertLineBreak " +
+                "len=\((string as NSString).length) " +
+                "sel=\(selectedRange().location):\(selectedRange().length)"
+            )
+#endif
+            super.insertLineBreak(sender)
+        }
+
+        override func insertNewlineIgnoringFieldEditor(_ sender: Any?) {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.insertNewlineIgnoringFieldEditor " +
+                "len=\((string as NSString).length) " +
+                "sel=\(selectedRange().location):\(selectedRange().length)"
+            )
+#endif
+            super.insertNewlineIgnoringFieldEditor(sender)
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4083,7 +4083,7 @@ struct ContentView: View {
         style: CommandPaletteEditorFieldStyle,
         placeholder: String,
         text: Binding<String>,
-        onSubmit: @escaping () -> Void,
+        onSubmit: @escaping (String) -> Void,
         onEscape: @escaping () -> Void,
         onInteraction: (() -> Void)? = nil
     ) -> some View {
@@ -4099,7 +4099,7 @@ struct ContentView: View {
                     onDeleteBackward?(modifiers) ?? .ignored
                 }
                 .onSubmit {
-                    onSubmit()
+                    onSubmit(text.wrappedValue)
                 }
                 .onTapGesture {
                     onInteraction?()
@@ -4129,7 +4129,7 @@ struct ContentView: View {
                 ),
                 placeholder: target.placeholder,
                 text: $commandPaletteRenameDraft,
-                onSubmit: { continueRenameFlow(target: target) },
+                onSubmit: { _ in continueRenameFlow(target: target) },
                 onEscape: { dismissCommandPalette() },
                 onInteraction: handleCommandPaletteRenameInputInteraction
             )
@@ -4216,11 +4216,8 @@ struct ContentView: View {
                 ),
                 placeholder: target.placeholder,
                 text: $commandPaletteWorkspaceDescriptionDraft,
-                onSubmit: {
-                    applyWorkspaceDescriptionFlow(
-                        target: target,
-                        proposedDescription: commandPaletteWorkspaceDescriptionDraft
-                    )
+                onSubmit: { proposedDescription in
+                    applyWorkspaceDescriptionFlow(target: target, proposedDescription: proposedDescription)
                 },
                 onEscape: { dismissCommandPalette() }
             )
@@ -4757,7 +4754,7 @@ struct ContentView: View {
         @Binding var text: String
         @Binding var isFocused: Bool
         @Binding var measuredHeight: CGFloat
-        let onSubmit: () -> Void
+        let onSubmit: (String) -> Void
         let onEscape: () -> Void
 
         final class Coordinator: NSObject, NSTextViewDelegate {
@@ -4838,7 +4835,11 @@ struct ContentView: View {
 #if DEBUG
                         dlog("palette.wsDescription.editor.handleKeyEvent action=submit")
 #endif
-                        parent.onSubmit()
+                        let currentText = editor?.string ?? parent.text
+                        if parent.text != currentText {
+                            parent.text = currentText
+                        }
+                        parent.onSubmit(currentText)
                         return true
                     }
                     if normalizedFlags == [.shift] {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13908,6 +13908,8 @@ private struct SidebarWorkspaceDescriptionText: View {
         .multilineTextAlignment(.leading)
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("SidebarWorkspaceDescriptionText")
+        .accessibilityLabel(accessibilityText)
         .onAppear(perform: renderMarkdown)
         .onChange(of: markdown) { _ in
             renderMarkdown()
@@ -13916,6 +13918,13 @@ private struct SidebarWorkspaceDescriptionText: View {
 
     private var foregroundColor: Color {
         isActive ? .white.opacity(0.84) : .secondary.opacity(0.95)
+    }
+
+    private var accessibilityText: String {
+        if let renderedMarkdown {
+            return String(renderedMarkdown.characters)
+        }
+        return markdown
     }
 
     private func renderMarkdown() {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1603,6 +1603,8 @@ struct ContentView: View {
     @State private var commandPaletteQuery: String = ""
     @State private var commandPaletteMode: CommandPaletteMode = .commands
     @State private var commandPaletteRenameDraft: String = ""
+    @State private var commandPaletteWorkspaceDescriptionDraft: String = ""
+    @State private var commandPaletteWorkspaceDescriptionHeight: CGFloat = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
     @State private var commandPaletteSelectedResultIndex: Int = 0
     @State private var commandPaletteSelectionAnchorCommandID: String?
     @State private var commandPaletteHoveredResultIndex: Int?
@@ -1639,6 +1641,7 @@ struct ContentView: View {
     private var commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
     private var openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
+    @State private var commandPaletteShouldFocusWorkspaceDescriptionEditor = false
     @FocusState private var isCommandPaletteSearchFocused: Bool
     @FocusState private var isCommandPaletteRenameFocused: Bool
 
@@ -1646,6 +1649,7 @@ struct ContentView: View {
         case commands
         case renameInput(CommandPaletteRenameTarget)
         case renameConfirm(CommandPaletteRenameTarget, proposedName: String)
+        case workspaceDescriptionInput(CommandPaletteWorkspaceDescriptionTarget)
     }
 
     private enum CommandPaletteListScope: String {
@@ -1697,6 +1701,25 @@ struct ContentView: View {
             case .tab:
                 return String(localized: "commandPalette.rename.tabPlaceholder", defaultValue: "Tab name")
             }
+        }
+    }
+
+    private struct CommandPaletteWorkspaceDescriptionTarget: Equatable {
+        let workspaceId: UUID
+        let currentDescription: String
+
+        var placeholder: String {
+            String(
+                localized: "commandPalette.description.workspacePlaceholder",
+                defaultValue: "Workspace description"
+            )
+        }
+
+        var inputHint: String {
+            String(
+                localized: "commandPalette.description.workspaceInputHint",
+                defaultValue: "Press Enter to save. Press Shift-Enter for a new line, or Escape to cancel."
+            )
         }
     }
 
@@ -1926,6 +1949,7 @@ struct ContentView: View {
         static let hasWorkspace = "workspace.hasSelection"
         static let workspaceName = "workspace.name"
         static let workspaceHasCustomName = "workspace.hasCustomName"
+        static let workspaceHasCustomDescription = "workspace.hasCustomDescription"
         static let workspaceMinimalModeEnabled = "workspace.minimalModeEnabled"
         static let workspaceShouldPin = "workspace.shouldPin"
         static let workspaceHasPullRequests = "workspace.hasPullRequests"
@@ -2997,6 +3021,17 @@ struct ContentView: View {
             openCommandPaletteRenameWorkspaceInput()
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteEditWorkspaceDescriptionRequested)) { notification in
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ) else { return }
+            openCommandPaletteWorkspaceDescriptionInput()
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteMoveSelection)) { notification in
             guard isCommandPalettePresented else { return }
             guard case .commands = commandPaletteMode else { return }
@@ -3616,6 +3651,8 @@ struct ContentView: View {
                         commandPaletteRenameInputView(target: target)
                     case let .renameConfirm(target, proposedName):
                         commandPaletteRenameConfirmView(target: target, proposedName: proposedName)
+                    case .workspaceDescriptionInput(let target):
+                        commandPaletteWorkspaceDescriptionInputView(target: target)
                     }
                 }
                 .frame(width: targetWidth)
@@ -3807,25 +3844,77 @@ struct ContentView: View {
         }
     }
 
-    private func commandPaletteRenameInputView(target: CommandPaletteRenameTarget) -> some View {
-        VStack(spacing: 0) {
-            TextField(target.placeholder, text: $commandPaletteRenameDraft)
+    private enum CommandPaletteEditorFieldStyle {
+        case singleLine(
+            accessibilityIdentifier: String,
+            focus: FocusState<Bool>.Binding,
+            onDeleteBackward: ((EventModifiers) -> BackportKeyPressResult)?
+        )
+        case multiline(
+            accessibilityIdentifier: String,
+            accessibilityLabel: String,
+            focus: Binding<Bool>,
+            measuredHeight: Binding<CGFloat>
+        )
+    }
+
+    @ViewBuilder
+    private func commandPaletteEditorField(
+        style: CommandPaletteEditorFieldStyle,
+        placeholder: String,
+        text: Binding<String>,
+        onSubmit: @escaping () -> Void,
+        onEscape: @escaping () -> Void,
+        onInteraction: (() -> Void)? = nil
+    ) -> some View {
+        switch style {
+        case .singleLine(let accessibilityIdentifier, let focus, let onDeleteBackward):
+            TextField(placeholder, text: text)
                 .textFieldStyle(.plain)
                 .font(.system(size: 13, weight: .regular))
                 .tint(Color(nsColor: sidebarActiveForegroundNSColor(opacity: 1.0)))
-                .focused($isCommandPaletteRenameFocused)
-                .accessibilityIdentifier("CommandPaletteRenameField")
+                .focused(focus)
+                .accessibilityIdentifier(accessibilityIdentifier)
                 .backport.onKeyPress(.delete) { modifiers in
-                    handleCommandPaletteRenameDeleteBackward(modifiers: modifiers)
+                    onDeleteBackward?(modifiers) ?? .ignored
                 }
                 .onSubmit {
-                    continueRenameFlow(target: target)
+                    onSubmit()
                 }
                 .onTapGesture {
-                    handleCommandPaletteRenameInputInteraction()
+                    onInteraction?()
                 }
-                .padding(.horizontal, 9)
-                .padding(.vertical, 7)
+        case .multiline(let accessibilityIdentifier, let accessibilityLabel, let focus, let measuredHeight):
+            CommandPaletteMultilineTextEditorRepresentable(
+                placeholder: placeholder,
+                accessibilityLabel: accessibilityLabel,
+                accessibilityIdentifier: accessibilityIdentifier,
+                text: text,
+                isFocused: focus,
+                measuredHeight: measuredHeight,
+                onSubmit: onSubmit,
+                onEscape: onEscape
+            )
+            .frame(height: measuredHeight.wrappedValue)
+        }
+    }
+
+    private func commandPaletteRenameInputView(target: CommandPaletteRenameTarget) -> some View {
+        VStack(spacing: 0) {
+            commandPaletteEditorField(
+                style: .singleLine(
+                    accessibilityIdentifier: "CommandPaletteRenameField",
+                    focus: $isCommandPaletteRenameFocused,
+                    onDeleteBackward: handleCommandPaletteRenameDeleteBackward(modifiers:)
+                ),
+                placeholder: target.placeholder,
+                text: $commandPaletteRenameDraft,
+                onSubmit: { continueRenameFlow(target: target) },
+                onEscape: { dismissCommandPalette() },
+                onInteraction: handleCommandPaletteRenameInputInteraction
+            )
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
 
             Divider()
 
@@ -3888,6 +3977,48 @@ struct ContentView: View {
             .frame(width: 0, height: 0)
             .opacity(0)
             .accessibilityHidden(true)
+        }
+    }
+
+    private func commandPaletteWorkspaceDescriptionInputView(
+        target: CommandPaletteWorkspaceDescriptionTarget
+    ) -> some View {
+        VStack(spacing: 0) {
+            commandPaletteEditorField(
+                style: .multiline(
+                    accessibilityIdentifier: "CommandPaletteWorkspaceDescriptionEditor",
+                    accessibilityLabel: String(
+                        localized: "command.editWorkspaceDescription.title",
+                        defaultValue: "Edit Workspace Description…"
+                    ),
+                    focus: $commandPaletteShouldFocusWorkspaceDescriptionEditor,
+                    measuredHeight: $commandPaletteWorkspaceDescriptionHeight
+                ),
+                placeholder: target.placeholder,
+                text: $commandPaletteWorkspaceDescriptionDraft,
+                onSubmit: {
+                    applyWorkspaceDescriptionFlow(
+                        target: target,
+                        proposedDescription: commandPaletteWorkspaceDescriptionDraft
+                    )
+                },
+                onEscape: { dismissCommandPalette() }
+            )
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+
+            Divider()
+
+            Text(target.inputHint)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 6)
+        }
+        .onAppear {
+            resetCommandPaletteWorkspaceDescriptionFocus()
         }
     }
 
@@ -4125,6 +4256,318 @@ struct ContentView: View {
             nsView.onHandleKeyEvent = nil
             coordinator.detachEditorTextDidChangeObserver()
             coordinator.parentField = nil
+        }
+    }
+
+    private final class CommandPalettePassthroughLabel: NSTextField {
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
+
+    private final class CommandPaletteMultilineTextView: NSTextView {
+        var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
+        var onDidBecomeFirstResponder: (() -> Void)?
+
+        override func becomeFirstResponder() -> Bool {
+            let becameFirstResponder = super.becomeFirstResponder()
+            if becameFirstResponder {
+                onDidBecomeFirstResponder?()
+            }
+            return becameFirstResponder
+        }
+
+        override func keyDown(with event: NSEvent) {
+            if hasMarkedText() {
+                super.keyDown(with: event)
+                return
+            }
+            if onHandleKeyEvent?(event, self) == true {
+                return
+            }
+            super.keyDown(with: event)
+        }
+
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            if hasMarkedText() {
+                return super.performKeyEquivalent(with: event)
+            }
+            if onHandleKeyEvent?(event, self) == true {
+                return true
+            }
+            return super.performKeyEquivalent(with: event)
+        }
+    }
+
+    private final class CommandPaletteMultilineTextEditorView: NSView {
+        private static let font = NSFont.systemFont(ofSize: 13)
+        private static let textInset = NSSize(width: 0, height: 2)
+        static let defaultMinimumHeight: CGFloat = {
+            let lineHeight = ceil(font.ascender - font.descender + font.leading)
+            return lineHeight * 5 + textInset.height * 2
+        }()
+
+        let textView = CommandPaletteMultilineTextView(frame: .zero)
+        private let placeholderField = CommandPalettePassthroughLabel(labelWithString: "")
+        var onMeasuredHeightChange: ((CGFloat) -> Void)?
+        private var lastReportedHeight: CGFloat?
+
+        var placeholder: String = "" {
+            didSet {
+                placeholderField.stringValue = placeholder
+                updatePlaceholderVisibility()
+            }
+        }
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+
+            textView.translatesAutoresizingMaskIntoConstraints = false
+            textView.isEditable = true
+            textView.isSelectable = true
+            textView.isRichText = false
+            textView.importsGraphics = false
+            textView.isHorizontallyResizable = false
+            textView.isVerticallyResizable = false
+            textView.backgroundColor = .clear
+            textView.drawsBackground = false
+            textView.font = Self.font
+            textView.textColor = .labelColor
+            textView.insertionPointColor = .labelColor
+            textView.textContainerInset = Self.textInset
+            textView.textContainer?.lineFragmentPadding = 0
+            textView.textContainer?.widthTracksTextView = true
+            textView.textContainer?.heightTracksTextView = false
+            textView.maxSize = NSSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            addSubview(textView)
+
+            placeholderField.translatesAutoresizingMaskIntoConstraints = false
+            placeholderField.font = Self.font
+            placeholderField.textColor = .secondaryLabelColor
+            placeholderField.lineBreakMode = .byWordWrapping
+            placeholderField.maximumNumberOfLines = 0
+            addSubview(placeholderField)
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(textDidChange(_:)),
+                name: NSText.didChangeNotification,
+                object: textView
+            )
+
+            NSLayoutConstraint.activate([
+                textView.topAnchor.constraint(equalTo: topAnchor),
+                textView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                textView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                textView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+                placeholderField.topAnchor.constraint(equalTo: topAnchor, constant: Self.textInset.height),
+                placeholderField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.textInset.width),
+                placeholderField.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -Self.textInset.width),
+            ])
+
+            updatePlaceholderVisibility()
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+
+        override func layout() {
+            super.layout()
+            textView.textContainer?.containerSize = NSSize(
+                width: bounds.width,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            reportMeasuredHeightIfNeeded()
+        }
+
+        func refreshMetrics() {
+            updatePlaceholderVisibility()
+            needsLayout = true
+            layoutSubtreeIfNeeded()
+            reportMeasuredHeightIfNeeded()
+        }
+
+        func focusIfNeeded() {
+            guard let window, window.firstResponder !== textView else { return }
+            window.makeFirstResponder(textView)
+            let length = (textView.string as NSString).length
+            textView.setSelectedRange(NSRange(location: length, length: 0))
+        }
+
+        private func fittingHeight() -> CGFloat {
+            guard let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else {
+                return Self.defaultMinimumHeight
+            }
+            layoutManager.ensureLayout(for: textContainer)
+            let usedRect = layoutManager.usedRect(for: textContainer)
+            let lineHeight = ceil(Self.font.ascender - Self.font.descender + Self.font.leading)
+            let contentHeight = max(lineHeight, ceil(usedRect.height))
+            return max(
+                Self.defaultMinimumHeight,
+                ceil(contentHeight + Self.textInset.height * 2)
+            )
+        }
+
+        private func reportMeasuredHeightIfNeeded() {
+            let height = fittingHeight()
+            guard lastReportedHeight == nil || abs((lastReportedHeight ?? height) - height) > 0.5 else { return }
+            lastReportedHeight = height
+            onMeasuredHeightChange?(height)
+        }
+
+        @objc
+        private func textDidChange(_ notification: Notification) {
+            updatePlaceholderVisibility()
+            reportMeasuredHeightIfNeeded()
+        }
+
+        private func updatePlaceholderVisibility() {
+            placeholderField.isHidden = textView.string.isEmpty == false
+        }
+    }
+
+    private struct CommandPaletteMultilineTextEditorRepresentable: NSViewRepresentable {
+        static let defaultMinimumHeight = CommandPaletteMultilineTextEditorView.defaultMinimumHeight
+
+        let placeholder: String
+        let accessibilityLabel: String
+        let accessibilityIdentifier: String
+        @Binding var text: String
+        @Binding var isFocused: Bool
+        @Binding var measuredHeight: CGFloat
+        let onSubmit: () -> Void
+        let onEscape: () -> Void
+
+        final class Coordinator: NSObject, NSTextViewDelegate {
+            var parent: CommandPaletteMultilineTextEditorRepresentable
+            var isProgrammaticMutation = false
+            var pendingFocusRequest = false
+
+            init(parent: CommandPaletteMultilineTextEditorRepresentable) {
+                self.parent = parent
+            }
+
+            func textDidBeginEditing(_ notification: Notification) {
+                if !parent.isFocused {
+                    DispatchQueue.main.async {
+                        self.parent.isFocused = true
+                    }
+                }
+            }
+
+            func textDidChange(_ notification: Notification) {
+                guard !isProgrammaticMutation,
+                      let textView = notification.object as? NSTextView else { return }
+                parent.text = textView.string
+            }
+
+            func handleDidBecomeFirstResponder() {
+                if !parent.isFocused {
+                    parent.isFocused = true
+                }
+            }
+
+            func handleMeasuredHeight(_ height: CGFloat) {
+                guard abs(parent.measuredHeight - height) > 0.5 else { return }
+                DispatchQueue.main.async {
+                    self.parent.measuredHeight = height
+                }
+            }
+
+            func handleKeyEvent(_ event: NSEvent, editor: NSTextView?) -> Bool {
+                guard !(editor?.hasMarkedText() ?? false) else { return false }
+
+                let normalizedFlags = event.modifierFlags
+                    .intersection(.deviceIndependentFlagsMask)
+                    .subtracting([.numericPad, .function, .capsLock])
+
+                if event.keyCode == 36 || event.keyCode == 76 {
+                    if normalizedFlags.isEmpty {
+                        parent.onSubmit()
+                        return true
+                    }
+                    if normalizedFlags == [.shift] {
+                        return false
+                    }
+                }
+
+                if event.keyCode == 53, normalizedFlags.isEmpty {
+                    parent.onEscape()
+                    return true
+                }
+
+                return false
+            }
+        }
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(parent: self)
+        }
+
+        func makeNSView(context: Context) -> CommandPaletteMultilineTextEditorView {
+            let view = CommandPaletteMultilineTextEditorView(frame: .zero)
+            view.placeholder = placeholder
+            view.textView.string = text
+            view.textView.delegate = context.coordinator
+            view.textView.setAccessibilityLabel(accessibilityLabel)
+            view.textView.setAccessibilityIdentifier(accessibilityIdentifier)
+            view.setAccessibilityIdentifier(accessibilityIdentifier)
+            view.textView.onHandleKeyEvent = { [weak coordinator = context.coordinator] event, editor in
+                coordinator?.handleKeyEvent(event, editor: editor) ?? false
+            }
+            view.textView.onDidBecomeFirstResponder = { [weak coordinator = context.coordinator] in
+                coordinator?.handleDidBecomeFirstResponder()
+            }
+            view.onMeasuredHeightChange = { [weak coordinator = context.coordinator] height in
+                coordinator?.handleMeasuredHeight(height)
+            }
+            view.refreshMetrics()
+            return view
+        }
+
+        func updateNSView(_ nsView: CommandPaletteMultilineTextEditorView, context: Context) {
+            context.coordinator.parent = self
+            nsView.placeholder = placeholder
+            nsView.textView.setAccessibilityLabel(accessibilityLabel)
+            nsView.textView.setAccessibilityIdentifier(accessibilityIdentifier)
+            nsView.setAccessibilityIdentifier(accessibilityIdentifier)
+
+            if nsView.textView.string != text {
+                context.coordinator.isProgrammaticMutation = true
+                nsView.textView.string = text
+                context.coordinator.isProgrammaticMutation = false
+            }
+            nsView.onMeasuredHeightChange = { [weak coordinator = context.coordinator] height in
+                coordinator?.handleMeasuredHeight(height)
+            }
+            nsView.refreshMetrics()
+
+            guard let window = nsView.window else { return }
+            let isFirstResponder = window.firstResponder === nsView.textView
+            if isFocused, !isFirstResponder, !context.coordinator.pendingFocusRequest {
+                context.coordinator.pendingFocusRequest = true
+                DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
+                    guard let coordinator else { return }
+                    coordinator.pendingFocusRequest = false
+                    guard coordinator.parent.isFocused, let nsView else { return }
+                    nsView.focusIfNeeded()
+                }
+            }
+        }
+
+        static func dismantleNSView(_ nsView: CommandPaletteMultilineTextEditorView, coordinator: Coordinator) {
+            nsView.textView.delegate = nil
+            nsView.textView.onHandleKeyEvent = nil
+            nsView.textView.onDidBecomeFirstResponder = nil
+            nsView.onMeasuredHeightChange = nil
         }
     }
 
@@ -5045,7 +5488,8 @@ struct ContentView: View {
         return CommandPaletteSwitcherSearchMetadata(
             directories: directories,
             branches: branches,
-            ports: ports
+            ports: ports,
+            description: workspace.customDescription
         )
     }
 
@@ -5191,6 +5635,8 @@ struct ContentView: View {
             return .renameTab
         case "palette.renameWorkspace":
             return .renameWorkspace
+        case "palette.editWorkspaceDescription":
+            return .editWorkspaceDescription
         case "palette.nextWorkspace":
             return .nextSidebarTab
         case "palette.previousWorkspace":
@@ -5273,6 +5719,7 @@ struct ContentView: View {
             snapshot.setBool(CommandPaletteContextKeys.hasWorkspace, true)
             snapshot.setString(CommandPaletteContextKeys.workspaceName, workspaceDisplayName(workspace))
             snapshot.setBool(CommandPaletteContextKeys.workspaceHasCustomName, workspace.customTitle != nil)
+            snapshot.setBool(CommandPaletteContextKeys.workspaceHasCustomDescription, workspace.hasCustomDescription)
             snapshot.setBool(CommandPaletteContextKeys.workspaceShouldPin, !workspace.isPinned)
             snapshot.setBool(
                 CommandPaletteContextKeys.workspaceHasPullRequests,
@@ -5588,6 +6035,16 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.editWorkspaceDescription",
+                title: constant(String(localized: "command.editWorkspaceDescription.title", defaultValue: "Edit Workspace Description…")),
+                subtitle: workspaceSubtitle,
+                keywords: ["edit", "workspace", "description", "notes", "markdown"],
+                dismissOnRun: false,
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.clearWorkspaceName",
                 title: constant(String(localized: "command.clearWorkspaceName.title", defaultValue: "Clear Workspace Name")),
                 subtitle: workspaceSubtitle,
@@ -5595,6 +6052,18 @@ struct ContentView: View {
                 when: {
                     $0.bool(CommandPaletteContextKeys.hasWorkspace)
                         && $0.bool(CommandPaletteContextKeys.workspaceHasCustomName)
+                }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.clearWorkspaceDescription",
+                title: constant(String(localized: "command.clearWorkspaceDescription.title", defaultValue: "Clear Workspace Description")),
+                subtitle: workspaceSubtitle,
+                keywords: ["clear", "workspace", "description", "notes"],
+                when: {
+                    $0.bool(CommandPaletteContextKeys.hasWorkspace)
+                        && $0.bool(CommandPaletteContextKeys.workspaceHasCustomDescription)
                 }
             )
         )
@@ -6214,12 +6683,22 @@ struct ContentView: View {
         registry.register(commandId: "palette.renameWorkspace") {
             beginRenameWorkspaceFlow()
         }
+        registry.register(commandId: "palette.editWorkspaceDescription") {
+            beginWorkspaceDescriptionFlow()
+        }
         registry.register(commandId: "palette.clearWorkspaceName") {
             guard let workspace = tabManager.selectedWorkspace else {
                 NSSound.beep()
                 return
             }
             tabManager.clearCustomTitle(tabId: workspace.id)
+        }
+        registry.register(commandId: "palette.clearWorkspaceDescription") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            tabManager.clearCustomDescription(tabId: workspace.id)
         }
         registry.register(commandId: "palette.toggleWorkspacePin") {
             guard let workspace = tabManager.selectedWorkspace else {
@@ -6605,6 +7084,7 @@ struct ContentView: View {
         for port in metadata.ports {
             hasher.combine(port)
         }
+        hasher.combine(metadata.description ?? "")
     }
 
     static func commandPaletteScrollPositionAnchor(
@@ -6796,6 +7276,11 @@ struct ContentView: View {
             continueRenameFlow(target: target)
         case .renameConfirm(let target, let proposedName):
             applyRenameFlow(target: target, proposedName: proposedName)
+        case .workspaceDescriptionInput(let target):
+            applyWorkspaceDescriptionFlow(
+                target: target,
+                proposedDescription: commandPaletteWorkspaceDescriptionDraft
+            )
         }
     }
 
@@ -6856,6 +7341,13 @@ struct ContentView: View {
         beginRenameWorkspaceFlow()
     }
 
+    private func openCommandPaletteWorkspaceDescriptionInput() {
+        if !isCommandPalettePresented {
+            presentCommandPalette(initialQuery: Self.commandPaletteCommandsPrefix)
+        }
+        beginWorkspaceDescriptionFlow()
+    }
+
     private func presentFeedbackComposer() {
         DispatchQueue.main.async {
             isFeedbackComposerPresented = true
@@ -6909,6 +7401,8 @@ struct ContentView: View {
             mode = "rename_input"
         case .renameConfirm:
             mode = "rename_confirm"
+        case .workspaceDescriptionInput:
+            mode = "workspace_description_input"
         }
 
         let rows = Array(commandPaletteVisibleResults.prefix(20)).map { result in
@@ -6947,11 +7441,14 @@ struct ContentView: View {
         commandPaletteMode = .commands
         commandPaletteQuery = initialQuery
         commandPaletteRenameDraft = ""
+        commandPaletteWorkspaceDescriptionDraft = ""
+        commandPaletteWorkspaceDescriptionHeight = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
         commandPaletteSelectedResultIndex = 0
         commandPaletteSelectionAnchorCommandID = nil
         commandPaletteHoveredResultIndex = nil
         commandPaletteScrollTargetIndex = nil
         commandPaletteScrollTargetAnchor = nil
+        commandPaletteShouldFocusWorkspaceDescriptionEditor = false
         scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
         resetCommandPaletteSearchFocus()
         syncCommandPaletteDebugStateForObservedWindow()
@@ -6972,11 +7469,14 @@ struct ContentView: View {
         commandPaletteMode = .commands
         commandPaletteQuery = ""
         commandPaletteRenameDraft = ""
+        commandPaletteWorkspaceDescriptionDraft = ""
+        commandPaletteWorkspaceDescriptionHeight = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
         commandPaletteSelectedResultIndex = 0
         commandPaletteSelectionAnchorCommandID = nil
         commandPaletteHoveredResultIndex = nil
         commandPaletteScrollTargetIndex = nil
         commandPaletteScrollTargetAnchor = nil
+        commandPaletteShouldFocusWorkspaceDescriptionEditor = false
         isCommandPaletteSearchFocused = false
         isCommandPaletteRenameFocused = false
         commandPaletteRestoreFocusTarget = nil
@@ -7203,6 +7703,15 @@ struct ContentView: View {
         applyCommandPaletteInputFocusPolicy(commandPaletteRenameInputFocusPolicy())
     }
 
+    private func resetCommandPaletteWorkspaceDescriptionFocus() {
+        DispatchQueue.main.async {
+            isCommandPaletteSearchFocused = false
+            isCommandPaletteRenameFocused = false
+            commandPaletteShouldFocusWorkspaceDescriptionEditor = true
+            commandPalettePendingTextSelectionBehavior = nil
+        }
+    }
+
     private func handleCommandPaletteRenameInputInteraction() {
         guard isCommandPalettePresented else { return }
         guard case .renameInput = commandPaletteMode else { return }
@@ -7222,6 +7731,7 @@ struct ContentView: View {
 
     private func applyCommandPaletteInputFocusPolicy(_ policy: CommandPaletteInputFocusPolicy) {
         DispatchQueue.main.async {
+            commandPaletteShouldFocusWorkspaceDescriptionEditor = false
             switch policy.focusTarget {
             case .search:
                 isCommandPaletteRenameFocused = false
@@ -7253,6 +7763,8 @@ struct ContentView: View {
             case .commands, .renameInput:
                 break
             case .renameConfirm:
+                return
+            case .workspaceDescriptionInput:
                 return
             }
         }
@@ -7407,6 +7919,18 @@ struct ContentView: View {
         startRenameFlow(target)
     }
 
+    private func beginWorkspaceDescriptionFlow() {
+        guard let workspace = tabManager.selectedWorkspace else {
+            NSSound.beep()
+            return
+        }
+        let target = CommandPaletteWorkspaceDescriptionTarget(
+            workspaceId: workspace.id,
+            currentDescription: workspace.customDescription ?? ""
+        )
+        startWorkspaceDescriptionFlow(target)
+    }
+
     private func beginRenameTabFlow() {
         guard let panelContext = focusedPanelContext else {
             NSSound.beep()
@@ -7426,8 +7950,18 @@ struct ContentView: View {
 
     private func startRenameFlow(_ target: CommandPaletteRenameTarget) {
         commandPaletteRenameDraft = target.currentName
+        commandPaletteShouldFocusWorkspaceDescriptionEditor = false
         commandPaletteMode = .renameInput(target)
         resetCommandPaletteRenameFocus()
+        syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func startWorkspaceDescriptionFlow(_ target: CommandPaletteWorkspaceDescriptionTarget) {
+        commandPaletteWorkspaceDescriptionDraft = target.currentDescription
+        commandPaletteWorkspaceDescriptionHeight = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
+        commandPalettePendingTextSelectionBehavior = nil
+        commandPaletteMode = .workspaceDescriptionInput(target)
+        resetCommandPaletteWorkspaceDescriptionFocus()
         syncCommandPaletteDebugStateForObservedWindow()
     }
 
@@ -7452,6 +7986,18 @@ struct ContentView: View {
             workspace.setPanelCustomTitle(panelId: panelId, title: normalizedName)
         }
 
+        dismissCommandPalette()
+    }
+
+    private func applyWorkspaceDescriptionFlow(
+        target: CommandPaletteWorkspaceDescriptionTarget,
+        proposedDescription: String
+    ) {
+        guard tabManager.tabs.contains(where: { $0.id == target.workspaceId }) else {
+            NSSound.beep()
+            return
+        }
+        tabManager.setCustomDescription(tabId: target.workspaceId, description: proposedDescription)
         dismissCommandPalette()
     }
 
@@ -7574,15 +8120,18 @@ struct CommandPaletteSwitcherSearchMetadata: Equatable, Sendable {
     let directories: [String]
     let branches: [String]
     let ports: [Int]
+    let description: String?
 
     init(
         directories: [String] = [],
         branches: [String] = [],
-        ports: [Int] = []
+        ports: [Int] = [],
+        description: String? = nil
     ) {
         self.directories = directories
         self.branches = branches
         self.ports = ports
+        self.description = description
     }
 }
 
@@ -7610,6 +8159,7 @@ enum CommandPaletteSwitcherSearchIndexer {
         let directoryTokens = metadata.directories.flatMap { directoryTokensForSearch($0, detail: detail) }
         let branchTokens = metadata.branches.flatMap { branchTokensForSearch($0, detail: detail) }
         let portTokens = metadata.ports.flatMap(portTokensForSearch)
+        let descriptionTokens = descriptionTokensForSearch(metadata.description)
 
         var contextKeywords: [String] = []
         if !directoryTokens.isEmpty {
@@ -7621,8 +8171,11 @@ enum CommandPaletteSwitcherSearchIndexer {
         if !portTokens.isEmpty {
             contextKeywords.append(contentsOf: ["port", "ports"])
         }
+        if !descriptionTokens.isEmpty {
+            contextKeywords.append(contentsOf: ["description", "descriptions", "notes", "note"])
+        }
 
-        return contextKeywords + directoryTokens + branchTokens + portTokens
+        return contextKeywords + directoryTokens + branchTokens + portTokens + descriptionTokens
     }
 
     private static func directoryTokensForSearch(
@@ -7666,6 +8219,18 @@ enum CommandPaletteSwitcherSearchIndexer {
         guard (1...65535).contains(port) else { return [] }
         let portText = String(port)
         return [portText, ":\(portText)"]
+    }
+
+    private static func descriptionTokensForSearch(_ rawDescription: String?) -> [String] {
+        let trimmed = rawDescription?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return [] }
+        let normalizedWhitespace = trimmed.replacingOccurrences(
+            of: "\\s+",
+            with: " ",
+            options: .regularExpression
+        )
+        let components = normalizedWhitespace.components(separatedBy: metadataDelimiters).filter { !$0.isEmpty }
+        return uniqueNormalizedPreservingOrder([trimmed, normalizedWhitespace] + components)
     }
 
     private static func uniqueNormalizedPreservingOrder(_ values: [String]) -> [String] {
@@ -11582,6 +12147,13 @@ private struct TabItemView: View, Equatable {
                 .frame(width: trailingAccessoryWidth, height: 16, alignment: .trailing)
             }
 
+            if let description = tab.customDescription {
+                SidebarWorkspaceDescriptionText(
+                    markdown: description,
+                    isActive: usesInvertedActiveForeground
+                )
+            }
+
             if let subtitle = effectiveSubtitle {
                 Text(subtitle)
                     .font(.system(size: 10))
@@ -11910,6 +12482,7 @@ private struct TabItemView: View, Equatable {
             single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
             isMulti: isMulti)
         let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
+        let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
         let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
         Button(pinLabel) {
             for id in targetIds {
@@ -11934,6 +12507,25 @@ private struct TabItemView: View, Equatable {
         if tab.hasCustomTitle {
             Button(String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name")) {
                 tabManager.clearCustomTitle(tabId: tab.id)
+            }
+        }
+
+        if !isMulti {
+            if let key = editWorkspaceDescriptionShortcut.keyEquivalent {
+                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
+                    beginWorkspaceDescriptionEditFromContextMenu()
+                }
+                .keyboardShortcut(key, modifiers: editWorkspaceDescriptionShortcut.eventModifiers)
+            } else {
+                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
+                    beginWorkspaceDescriptionEditFromContextMenu()
+                }
+            }
+
+            if tab.hasCustomDescription {
+                Button(String(localized: "contextMenu.clearWorkspaceDescription", defaultValue: "Clear Workspace Description")) {
+                    tabManager.clearCustomDescription(tabId: tab.id)
+                }
             }
         }
 
@@ -12708,6 +13300,51 @@ private struct TabItemView: View, Equatable {
         let response = alert.runModal()
         guard response == .alertFirstButtonReturn else { return }
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
+    }
+
+    private func beginWorkspaceDescriptionEditFromContextMenu() {
+        selectedTabIds = [tab.id]
+        lastSidebarSelectionIndex = index
+        tabManager.selectTab(tab)
+        setSelectionToTabs()
+        _ = AppDelegate.shared?.requestEditWorkspaceDescriptionViaCommandPalette()
+    }
+}
+
+private struct SidebarWorkspaceDescriptionText: View {
+    let markdown: String
+    let isActive: Bool
+
+    @State private var renderedMarkdown: AttributedString?
+
+    var body: some View {
+        Group {
+            if let renderedMarkdown {
+                Text(renderedMarkdown)
+            } else {
+                Text(markdown)
+            }
+        }
+        .font(.system(size: 10.5))
+        .foregroundColor(foregroundColor)
+        .multilineTextAlignment(.leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear(perform: renderMarkdown)
+        .onChange(of: markdown) { _ in
+            renderMarkdown()
+        }
+    }
+
+    private var foregroundColor: Color {
+        isActive ? .white.opacity(0.84) : .secondary.opacity(0.95)
+    }
+
+    private func renderMarkdown() {
+        renderedMarkdown = try? AttributedString(
+            markdown: markdown,
+            options: .init(interpretedSyntax: .full)
+        )
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4381,7 +4381,8 @@ struct ContentView: View {
 
                 if shouldSubmitCommandPaletteWithReturn(
                     keyCode: event.keyCode,
-                    flags: event.modifierFlags
+                    flags: event.modifierFlags,
+                    mode: "single_line"
                 ) {
                     parent.onSubmit()
                     return true
@@ -7666,6 +7667,16 @@ struct ContentView: View {
         case .renameConfirm(let target, let proposedName):
             applyRenameFlow(target: target, proposedName: proposedName)
         case .workspaceDescriptionInput(let target):
+#if DEBUG
+            let newlineCount = commandPaletteWorkspaceDescriptionDraft.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "palette.wsDescription.submit.request workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+                "draftLen=\((commandPaletteWorkspaceDescriptionDraft as NSString).length) " +
+                "newlines=\(newlineCount)"
+            )
+#endif
             applyWorkspaceDescriptionFlow(
                 target: target,
                 proposedDescription: commandPaletteWorkspaceDescriptionDraft
@@ -7866,6 +7877,20 @@ struct ContentView: View {
         preferredFocusTarget: CommandPaletteRestoreFocusTarget?
     ) {
         let focusTarget = preferredFocusTarget ?? commandPaletteRestoreFocusTarget
+#if DEBUG
+        if case .workspaceDescriptionInput(let target) = commandPaletteMode {
+            let newlineCount = commandPaletteWorkspaceDescriptionDraft.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "palette.wsDescription.dismiss workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+                "restoreFocus=\(restoreFocus ? 1 : 0) " +
+                "draftLen=\((commandPaletteWorkspaceDescriptionDraft as NSString).length) " +
+                "newlines=\(newlineCount) " +
+                "window={\(debugCommandPaletteWindowSummary(observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow))}"
+            )
+        }
+#endif
         cancelCommandPaletteSearch()
         commandPaletteSearchRequestID &+= 1
         isCommandPalettePresented = false
@@ -8452,7 +8477,30 @@ struct ContentView: View {
             NSSound.beep()
             return
         }
+#if DEBUG
+        let newlineCount = proposedDescription.reduce(into: 0) { count, character in
+            if character == "\n" { count += 1 }
+        }
+        dlog(
+            "palette.wsDescription.apply.begin workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+            "proposedLen=\((proposedDescription as NSString).length) " +
+            "newlines=\(newlineCount)"
+        )
+#endif
         tabManager.setCustomDescription(tabId: target.workspaceId, description: proposedDescription)
+#if DEBUG
+        if let updatedWorkspace = tabManager.tabs.first(where: { $0.id == target.workspaceId }) {
+            let persisted = updatedWorkspace.customDescription ?? ""
+            let persistedNewlineCount = persisted.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "palette.wsDescription.apply.end workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+                "persistedLen=\((persisted as NSString).length) " +
+                "persistedNewlines=\(persistedNewlineCount)"
+            )
+        }
+#endif
         dismissCommandPalette()
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1018,6 +1018,19 @@ private func debugCommandPaletteKeyEventSummary(_ event: NSEvent) -> String {
         "chars=\(chars) charsIgnoring=\(charsIgnoring)"
 }
 
+private func debugCommandPaletteTextPreview(_ text: String, limit: Int = 120) -> String {
+    let escaped = text
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\t", with: "\\t")
+    if escaped.count <= limit {
+        return escaped
+    }
+    let prefix = escaped.prefix(limit)
+    return "\(prefix)..."
+}
+
 private func debugCommandPaletteResponderSummary(_ responder: NSResponder?) -> String {
     guard let responder else { return "nil" }
 
@@ -4832,10 +4845,15 @@ struct ContentView: View {
 
                 if event.keyCode == 36 || event.keyCode == 76 {
                     if normalizedFlags.isEmpty {
+                        let currentText = editor?.string ?? parent.text
 #if DEBUG
                         dlog("palette.wsDescription.editor.handleKeyEvent action=submit")
+                        dlog(
+                            "palette.wsDescription.editor.handleKeyEvent submitText " +
+                            "len=\((currentText as NSString).length) " +
+                            "text=\"\(debugCommandPaletteTextPreview(currentText))\""
+                        )
 #endif
-                        let currentText = editor?.string ?? parent.text
                         if parent.text != currentText {
                             parent.text = currentText
                         }
@@ -8485,7 +8503,8 @@ struct ContentView: View {
         dlog(
             "palette.wsDescription.apply.begin workspace=\(target.workspaceId.uuidString.prefix(8)) " +
             "proposedLen=\((proposedDescription as NSString).length) " +
-            "newlines=\(newlineCount)"
+            "newlines=\(newlineCount) " +
+            "text=\"\(debugCommandPaletteTextPreview(proposedDescription))\""
         )
 #endif
         tabManager.setCustomDescription(tabId: target.workspaceId, description: proposedDescription)
@@ -8498,7 +8517,8 @@ struct ContentView: View {
             dlog(
                 "palette.wsDescription.apply.end workspace=\(target.workspaceId.uuidString.prefix(8)) " +
                 "persistedLen=\((persisted as NSString).length) " +
-                "persistedNewlines=\(persistedNewlineCount)"
+                "persistedNewlines=\(persistedNewlineCount) " +
+                "text=\"\(debugCommandPaletteTextPreview(persisted))\""
             )
         }
 #endif

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -994,6 +994,30 @@ private func debugCommandPaletteWindowSummary(_ window: NSWindow?) -> String {
     return "num=\(window.windowNumber) ident=\(ident) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
 }
 
+private func debugCommandPaletteNormalizedModifierFlags(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+    flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+}
+
+private func debugCommandPaletteModifierFlagsSummary(_ flags: NSEvent.ModifierFlags) -> String {
+    let normalized = debugCommandPaletteNormalizedModifierFlags(flags)
+    var parts: [String] = []
+    if normalized.contains(.command) { parts.append("cmd") }
+    if normalized.contains(.shift) { parts.append("shift") }
+    if normalized.contains(.option) { parts.append("opt") }
+    if normalized.contains(.control) { parts.append("ctrl") }
+    return parts.isEmpty ? "none" : parts.joined(separator: "+")
+}
+
+private func debugCommandPaletteKeyEventSummary(_ event: NSEvent) -> String {
+    let chars = event.characters.map(String.init(reflecting:)) ?? "nil"
+    let charsIgnoring = event.charactersIgnoringModifiers.map(String.init(reflecting:)) ?? "nil"
+    return
+        "type=\(event.type) keyCode=\(event.keyCode) flags=\(debugCommandPaletteModifierFlagsSummary(event.modifierFlags)) " +
+        "chars=\(chars) charsIgnoring=\(charsIgnoring)"
+}
+
 private func debugCommandPaletteResponderSummary(_ responder: NSResponder?) -> String {
     guard let responder else { return "nil" }
 
@@ -4498,10 +4522,23 @@ struct ContentView: View {
 
         override func keyDown(with event: NSEvent) {
             if hasMarkedText() {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.keyDown markedText=1 " +
+                    "\(debugCommandPaletteKeyEventSummary(event))"
+                )
+#endif
                 super.keyDown(with: event)
                 return
             }
-            if onHandleKeyEvent?(event, self) == true {
+            let handled = onHandleKeyEvent?(event, self) == true
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.keyDown handled=\(handled ? 1 : 0) " +
+                "\(debugCommandPaletteKeyEventSummary(event))"
+            )
+#endif
+            if handled {
                 return
             }
             super.keyDown(with: event)
@@ -4509,12 +4546,32 @@ struct ContentView: View {
 
         override func performKeyEquivalent(with event: NSEvent) -> Bool {
             if hasMarkedText() {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.performKeyEquivalent markedText=1 " +
+                    "\(debugCommandPaletteKeyEventSummary(event))"
+                )
+#endif
                 return super.performKeyEquivalent(with: event)
             }
-            if onHandleKeyEvent?(event, self) == true {
+            let handled = onHandleKeyEvent?(event, self) == true
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.performKeyEquivalent handled=\(handled ? 1 : 0) " +
+                "\(debugCommandPaletteKeyEventSummary(event))"
+            )
+#endif
+            if handled {
                 return true
             }
-            return super.performKeyEquivalent(with: event)
+            let result = super.performKeyEquivalent(with: event)
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.performKeyEquivalent superResult=\(result ? 1 : 0) " +
+                "\(debugCommandPaletteKeyEventSummary(event))"
+            )
+#endif
+            return result
         }
     }
 
@@ -4674,6 +4731,15 @@ struct ContentView: View {
         private func textDidChange(_ notification: Notification) {
             updatePlaceholderVisibility()
             reportMeasuredHeightIfNeeded()
+#if DEBUG
+            let newlineCount = textView.string.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "palette.wsDescription.editor.textDidChange len=\((textView.string as NSString).length) " +
+                "newlines=\(newlineCount)"
+            )
+#endif
         }
 
         private func updatePlaceholderVisibility() {
@@ -4722,6 +4788,17 @@ struct ContentView: View {
                 parent.text = textView.string
             }
 
+            func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.command selector=\(NSStringFromSelector(commandSelector)) " +
+                    "len=\((textView.string as NSString).length) " +
+                    "sel=\(textView.selectedRange().location):\(textView.selectedRange().length)"
+                )
+#endif
+                return false
+            }
+
             func handleDidBecomeFirstResponder() {
 #if DEBUG
                 dlog(
@@ -4747,21 +4824,41 @@ struct ContentView: View {
                     .intersection(.deviceIndependentFlagsMask)
                     .subtracting([.numericPad, .function, .capsLock])
 
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.handleKeyEvent " +
+                    "\(debugCommandPaletteKeyEventSummary(event)) " +
+                    "normalized=\(debugCommandPaletteModifierFlagsSummary(normalizedFlags))"
+                )
+#endif
+
                 if event.keyCode == 36 || event.keyCode == 76 {
                     if normalizedFlags.isEmpty {
+#if DEBUG
+                        dlog("palette.wsDescription.editor.handleKeyEvent action=submit")
+#endif
                         parent.onSubmit()
                         return true
                     }
                     if normalizedFlags == [.shift] {
+#if DEBUG
+                        dlog("palette.wsDescription.editor.handleKeyEvent action=allowShiftReturn")
+#endif
                         return false
                     }
                 }
 
                 if event.keyCode == 53, normalizedFlags.isEmpty {
+#if DEBUG
+                    dlog("palette.wsDescription.editor.handleKeyEvent action=escape")
+#endif
                     parent.onEscape()
                     return true
                 }
 
+#if DEBUG
+                dlog("palette.wsDescription.editor.handleKeyEvent action=passThrough")
+#endif
                 return false
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1089,11 +1089,20 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         return false
     }
 
+    private func isPaletteMultilineTextView(_ textView: NSTextView) -> Bool {
+        guard !textView.isFieldEditor,
+              textView.isEditable,
+              textView.isSelectable,
+              !textView.isHiddenOrHasHiddenAncestor,
+              textView.isDescendant(of: containerView) else { return false }
+        return true
+    }
+
     private func isPaletteTextInputFirstResponder(_ responder: NSResponder?) -> Bool {
         guard let responder else { return false }
 
         if let textView = responder as? NSTextView {
-            return isPaletteFieldEditor(textView)
+            return isPaletteFieldEditor(textView) || isPaletteMultilineTextView(textView)
         }
 
         if let textField = responder as? NSTextField {
@@ -1101,6 +1110,30 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         }
 
         return false
+    }
+
+    private func firstEditableTextInput(in view: NSView) -> NSResponder? {
+        if let textField = view as? NSTextField,
+           textField.isEditable,
+           textField.isEnabled,
+           !textField.isHiddenOrHasHiddenAncestor {
+            return textField
+        }
+
+        if let textView = view as? NSTextView,
+           !textView.isFieldEditor,
+           textView.isEditable,
+           textView.isSelectable,
+           !textView.isHiddenOrHasHiddenAncestor {
+            return textView
+        }
+
+        for subview in view.subviews {
+            if let match = firstEditableTextInput(in: subview) {
+                return match
+            }
+        }
+        return nil
     }
 
     private func firstEditableTextField(in view: NSView) -> NSTextField? {
@@ -1119,6 +1152,22 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         return nil
     }
 
+    private func focusPaletteTextInput(in window: NSWindow) -> Bool {
+        guard let input = firstEditableTextInput(in: hostingView),
+              window.makeFirstResponder(input) else {
+            return false
+        }
+
+        if let textView = input as? NSTextView, !textView.isFieldEditor {
+            let length = (textView.string as NSString).length
+            textView.setSelectedRange(NSRange(location: length, length: 0))
+        } else {
+            normalizeSelectionAfterProgrammaticFocus()
+        }
+
+        return isPaletteTextInputFirstResponder(window.firstResponder)
+    }
+
     private func scheduleFocusIntoPalette(retries: Int = 4) {
         scheduledFocusWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
@@ -1135,18 +1184,12 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             return
         }
 
-        if let textField = firstEditableTextField(in: hostingView),
-           window.makeFirstResponder(textField),
-           isPaletteTextInputFirstResponder(window.firstResponder) {
-            normalizeSelectionAfterProgrammaticFocus()
+        if focusPaletteTextInput(in: window) {
             return
         }
 
         if window.makeFirstResponder(containerView) {
-            if let textField = firstEditableTextField(in: hostingView),
-               window.makeFirstResponder(textField),
-               isPaletteTextInputFirstResponder(window.firstResponder) {
-                normalizeSelectionAfterProgrammaticFocus()
+            if focusPaletteTextInput(in: window) {
                 return
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -987,6 +987,34 @@ private final class PassthroughWindowOverlayContainerView: NSView {
     }
 }
 
+#if DEBUG
+private func debugCommandPaletteWindowSummary(_ window: NSWindow?) -> String {
+    guard let window else { return "nil" }
+    let ident = window.identifier?.rawValue ?? "nil"
+    return "num=\(window.windowNumber) ident=\(ident) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
+}
+
+private func debugCommandPaletteResponderSummary(_ responder: NSResponder?) -> String {
+    guard let responder else { return "nil" }
+
+    let typeName = String(describing: type(of: responder))
+    if let textView = responder as? NSTextView {
+        let selection = textView.selectedRange()
+        return "\(typeName){fieldEditor=\(textView.isFieldEditor ? 1 : 0) editable=\(textView.isEditable ? 1 : 0) selectable=\(textView.isSelectable ? 1 : 0) hidden=\(textView.isHiddenOrHasHiddenAncestor ? 1 : 0) len=\((textView.string as NSString).length) sel=\(selection.location):\(selection.length)}"
+    }
+
+    if let textField = responder as? NSTextField {
+        return "\(typeName){editable=\(textField.isEditable ? 1 : 0) enabled=\(textField.isEnabled ? 1 : 0) hidden=\(textField.isHiddenOrHasHiddenAncestor ? 1 : 0) len=\((textField.stringValue as NSString).length)}"
+    }
+
+    if let view = responder as? NSView {
+        return "\(typeName){hidden=\(view.isHiddenOrHasHiddenAncestor ? 1 : 0)}"
+    }
+
+    return typeName
+}
+#endif
+
 @MainActor
 private final class WindowCommandPaletteOverlayController: NSObject {
     private weak var window: NSWindow?
@@ -1153,8 +1181,30 @@ private final class WindowCommandPaletteOverlayController: NSObject {
     }
 
     private func focusPaletteTextInput(in window: NSWindow) -> Bool {
-        guard let input = firstEditableTextInput(in: hostingView),
-              window.makeFirstResponder(input) else {
+        guard let input = firstEditableTextInput(in: hostingView) else {
+#if DEBUG
+            dlog(
+                "palette.focus.direct missingInput window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
+            return false
+        }
+#if DEBUG
+        dlog(
+            "palette.focus.direct attempt window={\(debugCommandPaletteWindowSummary(window))} " +
+            "input=\(debugCommandPaletteResponderSummary(input)) " +
+            "frBefore=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+        )
+#endif
+        guard window.makeFirstResponder(input) else {
+#if DEBUG
+            dlog(
+                "palette.focus.direct failedMakeFirstResponder window={\(debugCommandPaletteWindowSummary(window))} " +
+                "input=\(debugCommandPaletteResponderSummary(input)) " +
+                "frAfter=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
             return false
         }
 
@@ -1165,10 +1215,28 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             normalizeSelectionAfterProgrammaticFocus()
         }
 
-        return isPaletteTextInputFirstResponder(window.firstResponder)
+        let didSettle = isPaletteTextInputFirstResponder(window.firstResponder)
+#if DEBUG
+        dlog(
+            "palette.focus.direct settled window={\(debugCommandPaletteWindowSummary(window))} " +
+            "didSettle=\(didSettle ? 1 : 0) frAfter=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+        )
+#endif
+        return didSettle
     }
 
     private func scheduleFocusIntoPalette(retries: Int = 4) {
+#if DEBUG
+        if let window {
+            dlog(
+                "palette.focus.schedule retries=\(retries) " +
+                "window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+        } else {
+            dlog("palette.focus.schedule retries=\(retries) window=nil")
+        }
+#endif
         scheduledFocusWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             self?.scheduledFocusWorkItem = nil
@@ -1180,21 +1248,69 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
     private func focusIntoPalette(retries: Int) {
         guard let window else { return }
+#if DEBUG
+        dlog(
+            "palette.focus.retry start retries=\(retries) " +
+            "window={\(debugCommandPaletteWindowSummary(window))} " +
+            "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+        )
+#endif
         if isPaletteTextInputFirstResponder(window.firstResponder) {
+#if DEBUG
+            dlog(
+                "palette.focus.retry alreadyFocused window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
             return
         }
 
         if focusPaletteTextInput(in: window) {
+#if DEBUG
+            dlog(
+                "palette.focus.retry directSuccess retries=\(retries) " +
+                "window={\(debugCommandPaletteWindowSummary(window))}"
+            )
+#endif
             return
         }
 
-        if window.makeFirstResponder(containerView) {
+        let containerFocused = window.makeFirstResponder(containerView)
+#if DEBUG
+        dlog(
+            "palette.focus.retry containerResult retries=\(retries) " +
+            "window={\(debugCommandPaletteWindowSummary(window))} " +
+            "didFocusContainer=\(containerFocused ? 1 : 0) " +
+            "frAfterContainer=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+        )
+#endif
+        if containerFocused {
             if focusPaletteTextInput(in: window) {
+#if DEBUG
+                dlog(
+                    "palette.focus.retry containerAssistedSuccess retries=\(retries) " +
+                    "window={\(debugCommandPaletteWindowSummary(window))}"
+                )
+#endif
                 return
             }
         }
 
-        guard retries > 0 else { return }
+        guard retries > 0 else {
+#if DEBUG
+            dlog(
+                "palette.focus.retry exhausted window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
+            return
+        }
+#if DEBUG
+        dlog(
+            "palette.focus.retry reschedule nextRetries=\(retries - 1) " +
+            "window={\(debugCommandPaletteWindowSummary(window))}"
+        )
+#endif
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { [weak self] in
             self?.focusIntoPalette(retries: retries - 1)
         }
@@ -1228,11 +1344,22 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             return
         }
         guard isPaletteVisible else {
+#if DEBUG
+            dlog(
+                "palette.focus.lock inactive visible=0 window={\(debugCommandPaletteWindowSummary(window))}"
+            )
+#endif
             stopFocusLockTimer()
             return
         }
 
         guard window.isKeyWindow else {
+#if DEBUG
+            dlog(
+                "palette.focus.lock keyWindowMissing window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
             stopFocusLockTimer()
             if isPaletteResponder(window.firstResponder) {
                 _ = window.makeFirstResponder(nil)
@@ -1242,6 +1369,12 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
         startFocusLockTimer()
         if !isPaletteTextInputFirstResponder(window.firstResponder) {
+#if DEBUG
+            dlog(
+                "palette.focus.lock requestRestore window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
             scheduleFocusIntoPalette(retries: 8)
         }
     }
@@ -1296,6 +1429,17 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             previouslyVisible: isPaletteVisible,
             isVisible: isVisible
         )
+#if DEBUG
+        if let window {
+            dlog(
+                "palette.overlay.update visible=\(isVisible ? 1 : 0) promote=\(shouldPromote ? 1 : 0) " +
+                "window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+        } else {
+            dlog("palette.overlay.update visible=\(isVisible ? 1 : 0) promote=\(shouldPromote ? 1 : 0) window=nil")
+        }
+#endif
         isPaletteVisible = isVisible
         if isVisible {
             hostingView.rootView = rootView
@@ -3066,12 +3210,21 @@ struct ContentView: View {
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteEditWorkspaceDescriptionRequested)) { notification in
             let requestedWindow = notification.object as? NSWindow
-            guard Self.shouldHandleCommandPaletteRequest(
+            let shouldHandle = Self.shouldHandleCommandPaletteRequest(
                 observedWindow: observedWindow,
                 requestedWindow: requestedWindow,
                 keyWindow: NSApp.keyWindow,
                 mainWindow: NSApp.mainWindow
-            ) else { return }
+            )
+#if DEBUG
+            dlog(
+                "palette.wsDescription.request observed={\(debugCommandPaletteWindowSummary(observedWindow))} " +
+                "requested={\(debugCommandPaletteWindowSummary(requestedWindow))} " +
+                "shouldHandle=\(shouldHandle ? 1 : 0) presented=\(isCommandPalettePresented ? 1 : 0) " +
+                "mode=\(debugCommandPaletteModeLabel(commandPaletteMode))"
+            )
+#endif
+            guard shouldHandle else { return }
             openCommandPaletteWorkspaceDescriptionInput()
         })
 
@@ -4061,7 +4214,25 @@ struct ContentView: View {
                 .padding(.vertical, 6)
         }
         .onAppear {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.view.appear workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+                "draftLen=\((commandPaletteWorkspaceDescriptionDraft as NSString).length) " +
+                "height=\(String(format: "%.1f", commandPaletteWorkspaceDescriptionHeight)) " +
+                "focusFlag=\(commandPaletteShouldFocusWorkspaceDescriptionEditor ? 1 : 0)"
+            )
+#endif
             resetCommandPaletteWorkspaceDescriptionFocus()
+        }
+        .onChange(of: commandPaletteShouldFocusWorkspaceDescriptionEditor) { _, newValue in
+#if DEBUG
+            dlog(
+                "palette.wsDescription.focus.binding new=\(newValue ? 1 : 0) " +
+                "mode=\(debugCommandPaletteModeLabel(commandPaletteMode)) " +
+                "window={\(debugCommandPaletteWindowSummary(observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow))} " +
+                "fr=\(debugCommandPaletteResponderSummary((observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder))"
+            )
+#endif
         }
     }
 
@@ -4312,6 +4483,13 @@ struct ContentView: View {
 
         override func becomeFirstResponder() -> Bool {
             let becameFirstResponder = super.becomeFirstResponder()
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.textView.becomeFirstResponder success=\(becameFirstResponder ? 1 : 0) " +
+                "window={\(debugCommandPaletteWindowSummary(window))} " +
+                "fr=\(debugCommandPaletteResponderSummary(window?.firstResponder))"
+            )
+#endif
             if becameFirstResponder {
                 onDidBecomeFirstResponder?()
             }
@@ -4438,10 +4616,36 @@ struct ContentView: View {
         }
 
         func focusIfNeeded() {
-            guard let window, window.firstResponder !== textView else { return }
-            window.makeFirstResponder(textView)
+            guard let window else {
+#if DEBUG
+                dlog("palette.wsDescription.editor.focusIfNeeded window=nil")
+#endif
+                return
+            }
+            guard window.firstResponder !== textView else {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.focusIfNeeded alreadyFocused window={\(debugCommandPaletteWindowSummary(window))}"
+                )
+#endif
+                return
+            }
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.focusIfNeeded attempt window={\(debugCommandPaletteWindowSummary(window))} " +
+                "frBefore=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
+            let didFocus = window.makeFirstResponder(textView)
             let length = (textView.string as NSString).length
             textView.setSelectedRange(NSRange(location: length, length: 0))
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.focusIfNeeded result didFocus=\(didFocus ? 1 : 0) " +
+                "window={\(debugCommandPaletteWindowSummary(window))} " +
+                "frAfter=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+            )
+#endif
         }
 
         private func fittingHeight() -> CGFloat {
@@ -4499,6 +4703,12 @@ struct ContentView: View {
             }
 
             func textDidBeginEditing(_ notification: Notification) {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.beginEditing focus=\(parent.isFocused ? 1 : 0) " +
+                    "responder=\(debugCommandPaletteResponderSummary(notification.object as? NSResponder))"
+                )
+#endif
                 if !parent.isFocused {
                     DispatchQueue.main.async {
                         self.parent.isFocused = true
@@ -4513,6 +4723,11 @@ struct ContentView: View {
             }
 
             func handleDidBecomeFirstResponder() {
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.didBecomeFirstResponder focus=\(parent.isFocused ? 1 : 0)"
+                )
+#endif
                 if !parent.isFocused {
                     parent.isFocused = true
                 }
@@ -4573,6 +4788,13 @@ struct ContentView: View {
                 coordinator?.handleMeasuredHeight(height)
             }
             view.refreshMetrics()
+#if DEBUG
+            dlog(
+                "palette.wsDescription.editor.make focus=\(isFocused ? 1 : 0) " +
+                "textLen=\((text as NSString).length) " +
+                "height=\(String(format: "%.1f", measuredHeight))"
+            )
+#endif
             return view
         }
 
@@ -4593,10 +4815,37 @@ struct ContentView: View {
             }
             nsView.refreshMetrics()
 
-            guard let window = nsView.window else { return }
+            guard let window = nsView.window else {
+#if DEBUG
+                if isFocused {
+                    dlog(
+                        "palette.wsDescription.editor.update waitingForWindow focus=1 " +
+                        "pending=\(context.coordinator.pendingFocusRequest ? 1 : 0)"
+                    )
+                }
+#endif
+                return
+            }
             let isFirstResponder = window.firstResponder === nsView.textView
+#if DEBUG
+            if isFocused || context.coordinator.pendingFocusRequest {
+                dlog(
+                    "palette.wsDescription.editor.update focus=\(isFocused ? 1 : 0) " +
+                    "isFirstResponder=\(isFirstResponder ? 1 : 0) " +
+                    "pending=\(context.coordinator.pendingFocusRequest ? 1 : 0) " +
+                    "window={\(debugCommandPaletteWindowSummary(window))} " +
+                    "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+                )
+            }
+#endif
             if isFocused, !isFirstResponder, !context.coordinator.pendingFocusRequest {
                 context.coordinator.pendingFocusRequest = true
+#if DEBUG
+                dlog(
+                    "palette.wsDescription.editor.update scheduleFocus window={\(debugCommandPaletteWindowSummary(window))} " +
+                    "fr=\(debugCommandPaletteResponderSummary(window.firstResponder))"
+                )
+#endif
                 DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
                     guard let coordinator else { return }
                     coordinator.pendingFocusRequest = false
@@ -7385,10 +7634,24 @@ struct ContentView: View {
     }
 
     private func openCommandPaletteWorkspaceDescriptionInput() {
+#if DEBUG
+        dlog(
+            "palette.wsDescription.open begin presented=\(isCommandPalettePresented ? 1 : 0) " +
+            "mode=\(debugCommandPaletteModeLabel(commandPaletteMode)) " +
+            "window={\(debugCommandPaletteWindowSummary(observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow))}"
+        )
+#endif
         if !isCommandPalettePresented {
             presentCommandPalette(initialQuery: Self.commandPaletteCommandsPrefix)
         }
         beginWorkspaceDescriptionFlow()
+#if DEBUG
+        dlog(
+            "palette.wsDescription.open end presented=\(isCommandPalettePresented ? 1 : 0) " +
+            "mode=\(debugCommandPaletteModeLabel(commandPaletteMode)) " +
+            "focusFlag=\(commandPaletteShouldFocusWorkspaceDescriptionEditor ? 1 : 0)"
+        )
+#endif
     }
 
     private func presentFeedbackComposer() {
@@ -7736,6 +7999,19 @@ struct ContentView: View {
             return "browser.findField"
         }
     }
+
+    private func debugCommandPaletteModeLabel(_ mode: CommandPaletteMode) -> String {
+        switch mode {
+        case .commands:
+            return "commands"
+        case .renameInput:
+            return "renameInput"
+        case .renameConfirm:
+            return "renameConfirm"
+        case .workspaceDescriptionInput:
+            return "workspaceDescriptionInput"
+        }
+    }
 #endif
 
     private func resetCommandPaletteSearchFocus() {
@@ -7747,11 +8023,35 @@ struct ContentView: View {
     }
 
     private func resetCommandPaletteWorkspaceDescriptionFocus() {
+#if DEBUG
+        dlog(
+            "palette.wsDescription.focus.reset schedule presented=\(isCommandPalettePresented ? 1 : 0) " +
+            "mode=\(debugCommandPaletteModeLabel(commandPaletteMode)) " +
+            "focusFlag=\(commandPaletteShouldFocusWorkspaceDescriptionEditor ? 1 : 0)"
+        )
+#endif
         DispatchQueue.main.async {
+#if DEBUG
+            dlog(
+                "palette.wsDescription.focus.reset apply.before search=\(isCommandPaletteSearchFocused ? 1 : 0) " +
+                "rename=\(isCommandPaletteRenameFocused ? 1 : 0) " +
+                "editor=\(commandPaletteShouldFocusWorkspaceDescriptionEditor ? 1 : 0) " +
+                "window={\(debugCommandPaletteWindowSummary(observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow))} " +
+                "fr=\(debugCommandPaletteResponderSummary((observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder))"
+            )
+#endif
             isCommandPaletteSearchFocused = false
             isCommandPaletteRenameFocused = false
             commandPaletteShouldFocusWorkspaceDescriptionEditor = true
             commandPalettePendingTextSelectionBehavior = nil
+#if DEBUG
+            dlog(
+                "palette.wsDescription.focus.reset apply.after search=\(isCommandPaletteSearchFocused ? 1 : 0) " +
+                "rename=\(isCommandPaletteRenameFocused ? 1 : 0) " +
+                "editor=\(commandPaletteShouldFocusWorkspaceDescriptionEditor ? 1 : 0) " +
+                "fr=\(debugCommandPaletteResponderSummary((observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder))"
+            )
+#endif
         }
     }
 
@@ -8000,11 +8300,26 @@ struct ContentView: View {
     }
 
     private func startWorkspaceDescriptionFlow(_ target: CommandPaletteWorkspaceDescriptionTarget) {
+#if DEBUG
+        dlog(
+            "palette.wsDescription.flow.start workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+            "descLen=\((target.currentDescription as NSString).length) " +
+            "presented=\(isCommandPalettePresented ? 1 : 0) " +
+            "modeBefore=\(debugCommandPaletteModeLabel(commandPaletteMode))"
+        )
+#endif
         commandPaletteWorkspaceDescriptionDraft = target.currentDescription
         commandPaletteWorkspaceDescriptionHeight = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
         commandPalettePendingTextSelectionBehavior = nil
         commandPaletteMode = .workspaceDescriptionInput(target)
         resetCommandPaletteWorkspaceDescriptionFocus()
+#if DEBUG
+        dlog(
+            "palette.wsDescription.flow.armed workspace=\(target.workspaceId.uuidString.prefix(8)) " +
+            "height=\(String(format: "%.1f", commandPaletteWorkspaceDescriptionHeight)) " +
+            "modeAfter=\(debugCommandPaletteModeLabel(commandPaletteMode))"
+        )
+#endif
         syncCommandPaletteDebugStateForObservedWindow()
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12730,6 +12730,7 @@ private struct TabItemView: View, Equatable {
                     markdown: description,
                     isActive: usesInvertedActiveForeground
                 )
+                .id(description)
             }
 
             if let subtitle = effectiveSubtitle {
@@ -12961,6 +12962,22 @@ private struct TabItemView: View, Equatable {
             }
         }
         .onReceive(
+            tab.sidebarImmediateObservationPublisher
+                .receive(on: RunLoop.main)
+        ) { _ in
+#if DEBUG
+            let description = tab.customDescription ?? ""
+            dlog(
+                "sidebar.row.invalidate workspace=\(tab.id.uuidString.prefix(8)) " +
+                "source=immediate " +
+                "title=\"\(debugCommandPaletteTextPreview(tab.title))\" " +
+                "descLen=\((description as NSString).length) " +
+                "desc=\"\(debugCommandPaletteTextPreview(description))\""
+            )
+#endif
+            workspaceObservationGeneration &+= 1
+        }
+        .onReceive(
             tab.sidebarObservationPublisher
                 .receive(on: RunLoop.main)
                 // Prompt-time sidebar telemetry can arrive as a short burst
@@ -12968,6 +12985,16 @@ private struct TabItemView: View, Equatable {
                 // row redraws once with the settled state instead of blinking.
                 .debounce(for: Self.workspaceObservationCoalesceInterval, scheduler: RunLoop.main)
         ) { _ in
+#if DEBUG
+            let description = tab.customDescription ?? ""
+            dlog(
+                "sidebar.row.invalidate workspace=\(tab.id.uuidString.prefix(8)) " +
+                "source=debounced " +
+                "title=\"\(debugCommandPaletteTextPreview(tab.title))\" " +
+                "descLen=\((description as NSString).length) " +
+                "desc=\"\(debugCommandPaletteTextPreview(description))\""
+            )
+#endif
             workspaceObservationGeneration &+= 1
         }
         .onDrag {
@@ -13893,9 +13920,8 @@ private struct SidebarWorkspaceDescriptionText: View {
     let markdown: String
     let isActive: Bool
 
-    @State private var renderedMarkdown: AttributedString?
-
     var body: some View {
+        let renderedMarkdown = SidebarMarkdownRenderer.renderWorkspaceDescription(markdown)
         Group {
             if let renderedMarkdown {
                 Text(renderedMarkdown)
@@ -13909,10 +13935,32 @@ private struct SidebarWorkspaceDescriptionText: View {
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityIdentifier("SidebarWorkspaceDescriptionText")
-        .accessibilityLabel(accessibilityText)
-        .onAppear(perform: renderMarkdown)
-        .onChange(of: markdown) { _ in
-            renderMarkdown()
+        .accessibilityLabel(accessibilityText(renderedMarkdown: renderedMarkdown))
+        .onAppear {
+#if DEBUG
+            let newlineCount = markdown.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "sidebar.description.render workspaceState=appear " +
+                "len=\((markdown as NSString).length) " +
+                "newlines=\(newlineCount) " +
+                "text=\"\(debugCommandPaletteTextPreview(markdown))\""
+            )
+#endif
+        }
+        .onChange(of: markdown) { newValue in
+#if DEBUG
+            let newlineCount = newValue.reduce(into: 0) { count, character in
+                if character == "\n" { count += 1 }
+            }
+            dlog(
+                "sidebar.description.render workspaceState=change " +
+                "len=\((newValue as NSString).length) " +
+                "newlines=\(newlineCount) " +
+                "text=\"\(debugCommandPaletteTextPreview(newValue))\""
+            )
+#endif
         }
     }
 
@@ -13920,15 +13968,11 @@ private struct SidebarWorkspaceDescriptionText: View {
         isActive ? .white.opacity(0.84) : .secondary.opacity(0.95)
     }
 
-    private var accessibilityText: String {
+    private func accessibilityText(renderedMarkdown: AttributedString?) -> String {
         if let renderedMarkdown {
             return String(renderedMarkdown.characters)
         }
         return markdown
-    }
-
-    private func renderMarkdown() {
-        renderedMarkdown = SidebarMarkdownRenderer.renderWorkspaceDescription(markdown)
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13919,7 +13919,13 @@ private struct SidebarWorkspaceDescriptionText: View {
     }
 
     private func renderMarkdown() {
-        renderedMarkdown = try? AttributedString(
+        renderedMarkdown = SidebarMarkdownRenderer.renderWorkspaceDescription(markdown)
+    }
+}
+
+enum SidebarMarkdownRenderer {
+    static func renderWorkspaceDescription(_ markdown: String) -> AttributedString? {
+        try? AttributedString(
             markdown: markdown,
             options: .init(interpretedSyntax: .full)
         )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3858,6 +3858,10 @@ struct ContentView: View {
         GeometryReader { proxy in
             let maxAllowedWidth = max(340, proxy.size.width - 260)
             let targetWidth = min(560, maxAllowedWidth)
+            let workspaceDescriptionMaxEditorHeight = max(
+                CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight,
+                proxy.size.height - 120
+            )
 
             ZStack(alignment: .top) {
                 Color.clear
@@ -3885,7 +3889,10 @@ struct ContentView: View {
                     case let .renameConfirm(target, proposedName):
                         commandPaletteRenameConfirmView(target: target, proposedName: proposedName)
                     case .workspaceDescriptionInput(let target):
-                        commandPaletteWorkspaceDescriptionInputView(target: target)
+                        commandPaletteWorkspaceDescriptionInputView(
+                            target: target,
+                            maxEditorHeight: workspaceDescriptionMaxEditorHeight
+                        )
                     }
                 }
                 .frame(width: targetWidth)
@@ -4087,7 +4094,8 @@ struct ContentView: View {
             accessibilityIdentifier: String,
             accessibilityLabel: String,
             focus: Binding<Bool>,
-            measuredHeight: Binding<CGFloat>
+            measuredHeight: Binding<CGFloat>,
+            maxHeight: CGFloat
         )
     }
 
@@ -4117,7 +4125,7 @@ struct ContentView: View {
                 .onTapGesture {
                     onInteraction?()
                 }
-        case .multiline(let accessibilityIdentifier, let accessibilityLabel, let focus, let measuredHeight):
+        case .multiline(let accessibilityIdentifier, let accessibilityLabel, let focus, let measuredHeight, let maxHeight):
             CommandPaletteMultilineTextEditorRepresentable(
                 placeholder: placeholder,
                 accessibilityLabel: accessibilityLabel,
@@ -4125,6 +4133,7 @@ struct ContentView: View {
                 text: text,
                 isFocused: focus,
                 measuredHeight: measuredHeight,
+                maxHeight: maxHeight,
                 onSubmit: onSubmit,
                 onEscape: onEscape
             )
@@ -4214,7 +4223,8 @@ struct ContentView: View {
     }
 
     private func commandPaletteWorkspaceDescriptionInputView(
-        target: CommandPaletteWorkspaceDescriptionTarget
+        target: CommandPaletteWorkspaceDescriptionTarget,
+        maxEditorHeight: CGFloat
     ) -> some View {
         VStack(spacing: 0) {
             commandPaletteEditorField(
@@ -4225,7 +4235,8 @@ struct ContentView: View {
                         defaultValue: "Edit Workspace Description…"
                     ),
                     focus: $commandPaletteShouldFocusWorkspaceDescriptionEditor,
-                    measuredHeight: $commandPaletteWorkspaceDescriptionHeight
+                    measuredHeight: $commandPaletteWorkspaceDescriptionHeight,
+                    maxHeight: maxEditorHeight
                 ),
                 placeholder: target.placeholder,
                 text: $commandPaletteWorkspaceDescriptionDraft,
@@ -4648,10 +4659,16 @@ struct ContentView: View {
             return lineHeight * 5 + textInset.height * 2
         }()
 
+        private let scrollView = NSScrollView(frame: .zero)
         let textView = CommandPaletteMultilineTextView(frame: .zero)
         private let placeholderField = CommandPalettePassthroughLabel(labelWithString: "")
         var onMeasuredHeightChange: ((CGFloat) -> Void)?
         private var lastReportedHeight: CGFloat?
+        var maximumHeight: CGFloat = .greatestFiniteMagnitude {
+            didSet {
+                refreshMetrics()
+            }
+        }
 
         var placeholder: String = "" {
             didSet {
@@ -4663,13 +4680,21 @@ struct ContentView: View {
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)
 
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.borderType = .noBorder
+            scrollView.drawsBackground = false
+            scrollView.hasVerticalScroller = true
+            scrollView.autohidesScrollers = true
+            scrollView.scrollerStyle = .overlay
+            addSubview(scrollView)
+
             textView.translatesAutoresizingMaskIntoConstraints = false
             textView.isEditable = true
             textView.isSelectable = true
             textView.isRichText = false
             textView.importsGraphics = false
             textView.isHorizontallyResizable = false
-            textView.isVerticallyResizable = false
+            textView.isVerticallyResizable = true
             textView.backgroundColor = .clear
             textView.drawsBackground = false
             textView.font = Self.font
@@ -4679,11 +4704,12 @@ struct ContentView: View {
             textView.textContainer?.lineFragmentPadding = 0
             textView.textContainer?.widthTracksTextView = true
             textView.textContainer?.heightTracksTextView = false
+            textView.minSize = NSSize(width: 0, height: Self.defaultMinimumHeight)
             textView.maxSize = NSSize(
                 width: CGFloat.greatestFiniteMagnitude,
                 height: CGFloat.greatestFiniteMagnitude
             )
-            addSubview(textView)
+            scrollView.documentView = textView
 
             placeholderField.translatesAutoresizingMaskIntoConstraints = false
             placeholderField.font = Self.font
@@ -4700,10 +4726,10 @@ struct ContentView: View {
             )
 
             NSLayoutConstraint.activate([
-                textView.topAnchor.constraint(equalTo: topAnchor),
-                textView.bottomAnchor.constraint(equalTo: bottomAnchor),
-                textView.leadingAnchor.constraint(equalTo: leadingAnchor),
-                textView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                scrollView.topAnchor.constraint(equalTo: topAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
                 placeholderField.topAnchor.constraint(equalTo: topAnchor, constant: Self.textInset.height),
                 placeholderField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.textInset.width),
@@ -4723,10 +4749,7 @@ struct ContentView: View {
 
         override func layout() {
             super.layout()
-            textView.textContainer?.containerSize = NSSize(
-                width: bounds.width,
-                height: CGFloat.greatestFiniteMagnitude
-            )
+            updateTextViewLayout()
             reportMeasuredHeightIfNeeded()
         }
 
@@ -4770,11 +4793,19 @@ struct ContentView: View {
 #endif
         }
 
-        private func fittingHeight() -> CGFloat {
+        private func cappedMaximumHeight() -> CGFloat {
+            max(Self.defaultMinimumHeight, maximumHeight)
+        }
+
+        private func naturalHeight(for width: CGFloat) -> CGFloat {
             guard let layoutManager = textView.layoutManager,
                   let textContainer = textView.textContainer else {
                 return Self.defaultMinimumHeight
             }
+            textContainer.containerSize = NSSize(
+                width: width,
+                height: CGFloat.greatestFiniteMagnitude
+            )
             layoutManager.ensureLayout(for: textContainer)
             let usedRect = layoutManager.usedRect(for: textContainer)
             let lineHeight = ceil(Self.font.ascender - Self.font.descender + Self.font.leading)
@@ -4783,6 +4814,19 @@ struct ContentView: View {
                 Self.defaultMinimumHeight,
                 ceil(contentHeight + Self.textInset.height * 2)
             )
+        }
+
+        private func updateTextViewLayout() {
+            let availableWidth = max(scrollView.contentSize.width, bounds.width, 1)
+            let naturalHeight = naturalHeight(for: availableWidth)
+            let measuredHeight = min(cappedMaximumHeight(), naturalHeight)
+            let documentHeight = max(naturalHeight, measuredHeight)
+            textView.frame = NSRect(x: 0, y: 0, width: availableWidth, height: documentHeight)
+        }
+
+        private func fittingHeight() -> CGFloat {
+            let availableWidth = max(scrollView.contentSize.width, bounds.width, 1)
+            return min(cappedMaximumHeight(), naturalHeight(for: availableWidth))
         }
 
         private func reportMeasuredHeightIfNeeded() {
@@ -4821,6 +4865,7 @@ struct ContentView: View {
         @Binding var text: String
         @Binding var isFocused: Bool
         @Binding var measuredHeight: CGFloat
+        let maxHeight: CGFloat
         let onSubmit: (String) -> Void
         let onEscape: () -> Void
 
@@ -4944,6 +4989,7 @@ struct ContentView: View {
         func makeNSView(context: Context) -> CommandPaletteMultilineTextEditorView {
             let view = CommandPaletteMultilineTextEditorView(frame: .zero)
             view.placeholder = placeholder
+            view.maximumHeight = maxHeight
             view.textView.string = text
             view.textView.delegate = context.coordinator
             view.textView.setAccessibilityLabel(accessibilityLabel)
@@ -4972,6 +5018,7 @@ struct ContentView: View {
         func updateNSView(_ nsView: CommandPaletteMultilineTextEditorView, context: Context) {
             context.coordinator.parent = self
             nsView.placeholder = placeholder
+            nsView.maximumHeight = maxHeight
             nsView.textView.setAccessibilityLabel(accessibilityLabel)
             nsView.textView.setAccessibilityIdentifier(accessibilityIdentifier)
             nsView.setAccessibilityIdentifier(accessibilityIdentifier)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9194,6 +9194,12 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
             return
         }
+        if AppDelegate.shared?.isCommandPaletteEffectivelyVisible(for: window) == true {
+#if DEBUG
+            dlog("find.applyFirstResponder SKIP surface=\(surfaceShort) reason=commandPaletteVisible")
+#endif
+            return
+        }
         if surfaceView.terminalSurface?.searchState != nil {
             // Find bar is open. Restore focus based on what the user last intended.
             restoreSearchFocus(window: window)

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -27,6 +27,7 @@ enum KeyboardShortcutSettings {
         case selectWorkspaceByNumber
         case renameTab
         case renameWorkspace
+        case editWorkspaceDescription
         case closeWorkspace
         case newSurface
         case toggleTerminalCopyMode
@@ -69,6 +70,7 @@ enum KeyboardShortcutSettings {
             case .selectWorkspaceByNumber: return String(localized: "shortcut.selectWorkspaceByNumber.label", defaultValue: "Select Workspace 1…9")
             case .renameTab: return String(localized: "shortcut.renameTab.label", defaultValue: "Rename Tab")
             case .renameWorkspace: return String(localized: "shortcut.renameWorkspace.label", defaultValue: "Rename Workspace")
+            case .editWorkspaceDescription: return String(localized: "shortcut.editWorkspaceDescription.label", defaultValue: "Edit Workspace Description")
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
@@ -104,6 +106,7 @@ enum KeyboardShortcutSettings {
             case .prevSidebarTab: return "shortcut.prevSidebarTab"
             case .renameTab: return "shortcut.renameTab"
             case .renameWorkspace: return "shortcut.renameWorkspace"
+            case .editWorkspaceDescription: return "shortcut.editWorkspaceDescription"
             case .closeWorkspace: return "shortcut.closeWorkspace"
             case .focusLeft: return "shortcut.focusLeft"
             case .focusRight: return "shortcut.focusRight"
@@ -154,6 +157,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
             case .renameWorkspace:
                 return StoredShortcut(key: "r", command: true, shift: true, option: false, control: false)
+            case .editWorkspaceDescription:
+                return StoredShortcut(key: "e", command: true, shift: true, option: false, control: false)
             case .closeWorkspace:
                 return StoredShortcut(key: "w", command: true, shift: true, option: false, control: false)
             case .focusLeft:

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -330,6 +330,7 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 struct SessionWorkspaceSnapshot: Codable, Sendable {
     var processTitle: String
     var customTitle: String?
+    var customDescription: String?
     var customColor: String?
     var isPinned: Bool
     var currentDirectory: String

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2506,6 +2506,15 @@ class TabManager: ObservableObject {
         setCustomTitle(tabId: tabId, title: nil)
     }
 
+    func setCustomDescription(tabId: UUID, description: String?) {
+        guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
+        tabs[index].setCustomDescription(description)
+    }
+
+    func clearCustomDescription(tabId: UUID) {
+        setCustomDescription(tabId: tabId, description: nil)
+    }
+
     func setTabColor(tabId: UUID, color: String?) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         tab.setCustomColor(color)
@@ -5492,6 +5501,7 @@ extension TabManager {
             hasher.combine(workspace.focusedPanelId)
             hasher.combine(workspace.currentDirectory)
             hasher.combine(workspace.customTitle ?? "")
+            hasher.combine(workspace.customDescription ?? "")
             hasher.combine(workspace.customColor ?? "")
             hasher.combine(workspace.isPinned)
             hasher.combine(workspace.panels.count)
@@ -5703,6 +5713,7 @@ extension Notification.Name {
     static let commandPaletteDismissRequested = Notification.Name("cmux.commandPaletteDismissRequested")
     static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")
     static let commandPaletteRenameWorkspaceRequested = Notification.Name("cmux.commandPaletteRenameWorkspaceRequested")
+    static let commandPaletteEditWorkspaceDescriptionRequested = Notification.Name("cmux.commandPaletteEditWorkspaceDescriptionRequested")
     static let commandPaletteMoveSelection = Notification.Name("cmux.commandPaletteMoveSelection")
     static let commandPaletteRenameInputInteractionRequested = Notification.Name("cmux.commandPaletteRenameInputInteractionRequested")
     static let commandPaletteRenameInputDeleteBackwardRequested = Notification.Name("cmux.commandPaletteRenameInputDeleteBackwardRequested")

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2898,6 +2898,7 @@ class TerminalController {
             "ref": v2Ref(kind: .workspace, uuid: workspace.id),
             "index": index,
             "title": workspace.title,
+            "description": v2OrNull(workspace.customDescription),
             "selected": selected,
             "pinned": workspace.isPinned,
             "panes": panes
@@ -3280,6 +3281,29 @@ class TerminalController {
 
     // MARK: - V2 Workspace Methods
 
+    private func v2WorkspaceSummaryPayload(
+        workspace: Workspace,
+        index: Int?,
+        selected: Bool
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": workspace.id.uuidString,
+            "ref": v2Ref(kind: .workspace, uuid: workspace.id),
+            "title": workspace.title,
+            "description": v2OrNull(workspace.customDescription),
+            "selected": selected,
+            "pinned": workspace.isPinned,
+            "listening_ports": workspace.listeningPorts,
+            "remote": workspace.remoteStatusPayload(),
+            "current_directory": v2OrNull(workspace.currentDirectory),
+            "custom_color": v2OrNull(workspace.customColor)
+        ]
+        if let index {
+            payload["index"] = index
+        }
+        return payload
+    }
+
     private func v2WorkspaceList(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -3288,18 +3312,11 @@ class TerminalController {
         var workspaces: [[String: Any]] = []
         v2MainSync {
             workspaces = tabManager.tabs.enumerated().map { index, ws in
-                return [
-                    "id": ws.id.uuidString,
-                    "ref": v2Ref(kind: .workspace, uuid: ws.id),
-                    "index": index,
-                    "title": ws.title,
-                    "selected": ws.id == tabManager.selectedTabId,
-                    "pinned": ws.isPinned,
-                    "listening_ports": ws.listeningPorts,
-                    "remote": ws.remoteStatusPayload(),
-                    "current_directory": v2OrNull(ws.currentDirectory),
-                    "custom_color": v2OrNull(ws.customColor)
-                ]
+                v2WorkspaceSummaryPayload(
+                    workspace: ws,
+                    index: index,
+                    selected: ws.id == tabManager.selectedTabId
+                )
             }
         }
 
@@ -3341,6 +3358,7 @@ class TerminalController {
 
         let requestedTitle = v2RawString(params, "title")?.trimmingCharacters(in: .whitespacesAndNewlines)
         let title = (requestedTitle?.isEmpty == false) ? requestedTitle : nil
+        let description = v2RawString(params, "description")
 
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
@@ -3353,6 +3371,7 @@ class TerminalController {
                 select: shouldFocus,
                 eagerLoadTerminal: !shouldFocus
             )
+            ws.setCustomDescription(description)
             newId = ws.id
         }
 
@@ -3410,15 +3429,12 @@ class TerminalController {
         v2MainSync {
             wsId = tabManager.selectedTabId
             if let wsId, let workspace = tabManager.tabs.first(where: { $0.id == wsId }) {
-                wsPayload = [
-                    "id": workspace.id.uuidString,
-                    "ref": v2Ref(kind: .workspace, uuid: workspace.id),
-                    "title": workspace.title,
-                    "selected": true,
-                    "pinned": workspace.isPinned,
-                    "listening_ports": workspace.listeningPorts,
-                    "remote": workspace.remoteStatusPayload(),
-                ]
+                let index = tabManager.tabs.firstIndex(where: { $0.id == wsId })
+                wsPayload = v2WorkspaceSummaryPayload(
+                    workspace: workspace,
+                    index: index,
+                    selected: true
+                )
             }
         }
         guard let wsId else {
@@ -4020,6 +4036,7 @@ class TerminalController {
 
         let supportedActions = [
             "pin", "unpin", "rename", "clear_name",
+            "set_description", "clear_description",
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
@@ -4092,6 +4109,19 @@ class TerminalController {
             case "clear_name":
                 tabManager.clearCustomTitle(tabId: workspace.id)
                 finish(["title": workspace.title])
+
+            case "set_description":
+                guard let descriptionRaw = v2String(params, "description"),
+                      !descriptionRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    result = .err(code: "invalid_params", message: "Missing or invalid description", data: nil)
+                    return
+                }
+                tabManager.setCustomDescription(tabId: workspace.id, description: descriptionRaw)
+                finish(["description": v2OrNull(workspace.customDescription)])
+
+            case "clear_description":
+                tabManager.clearCustomDescription(tabId: workspace.id)
+                finish(["description": NSNull()])
 
             case "move_up":
                 guard let currentIndex = tabManager.tabs.firstIndex(where: { $0.id == workspace.id }) else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8,6 +8,21 @@ import Darwin
 import Network
 import CoreText
 
+#if DEBUG
+private func debugWorkspaceDescriptionPreview(_ text: String?, limit: Int = 120) -> String {
+    guard let text else { return "nil" }
+    let escaped = text
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\t", with: "\\t")
+    if escaped.count <= limit {
+        return escaped
+    }
+    return "\(escaped.prefix(limit))..."
+}
+#endif
+
 struct CmuxSurfaceConfigTemplate {
     var fontSize: Float32 = 0
     var workingDirectory: String?
@@ -6475,7 +6490,25 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func setCustomDescription(_ description: String?) {
-        customDescription = Self.normalizedCustomDescription(description)
+        let normalizedDescription = Self.normalizedCustomDescription(description)
+#if DEBUG
+        let inputNewlines = description?.reduce(into: 0) { count, character in
+            if character == "\n" { count += 1 }
+        } ?? 0
+        let normalizedNewlines = normalizedDescription?.reduce(into: 0) { count, character in
+            if character == "\n" { count += 1 }
+        } ?? 0
+        dlog(
+            "workspace.customDescription.update workspace=\(id.uuidString.prefix(8)) " +
+            "inputLen=\((description as NSString?)?.length ?? 0) " +
+            "inputNewlines=\(inputNewlines) " +
+            "normalizedLen=\((normalizedDescription as NSString?)?.length ?? 0) " +
+            "normalizedNewlines=\(normalizedNewlines) " +
+            "input=\"\(debugWorkspaceDescriptionPreview(description))\" " +
+            "normalized=\"\(debugWorkspaceDescriptionPreview(normalizedDescription))\""
+        )
+#endif
+        customDescription = normalizedDescription
     }
 
     // MARK: - Directory Updates

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -280,6 +280,7 @@ extension Workspace {
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
             customTitle: customTitle,
+            customDescription: customDescription,
             customColor: customColor,
             isPinned: isPinned,
             currentDirectory: currentDirectory,
@@ -319,6 +320,7 @@ extension Workspace {
 
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
+        setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
 
@@ -5464,6 +5466,7 @@ final class Workspace: Identifiable, ObservableObject {
     let id: UUID
     @Published var title: String
     @Published var customTitle: String?
+    @Published var customDescription: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var currentDirectory: String
@@ -5604,6 +5607,7 @@ final class Workspace: Identifiable, ObservableObject {
     lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
         let publishers: [AnyPublisher<Void, Never>] = [
             sidebarObservationSignal($title),
+            sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
             sidebarObservationSignal($currentDirectory),
@@ -5795,6 +5799,7 @@ final class Workspace: Identifiable, ObservableObject {
         self.processTitle = title
         self.title = title
         self.customTitle = nil
+        self.customDescription = nil
 
         let trimmedWorkingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let hasWorkingDirectory = !trimmedWorkingDirectory.isEmpty
@@ -6431,6 +6436,10 @@ final class Workspace: Identifiable, ObservableObject {
         return !trimmed.isEmpty
     }
 
+    var hasCustomDescription: Bool {
+        Self.normalizedCustomDescription(customDescription) != nil
+    }
+
     func applyProcessTitle(_ title: String) {
         processTitle = title
         guard customTitle == nil else { return }
@@ -6445,6 +6454,15 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    private static func normalizedCustomDescription(_ description: String?) -> String? {
+        let normalizedLineEndings = description?
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let trimmed = normalizedLineEndings?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
     func setCustomTitle(_ title: String?) {
         let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {
@@ -6454,6 +6472,10 @@ final class Workspace: Identifiable, ObservableObject {
             customTitle = trimmed
             self.title = trimmed
         }
+    }
+
+    func setCustomDescription(_ description: String?) {
+        customDescription = Self.normalizedCustomDescription(description)
     }
 
     // MARK: - Directory Updates

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5619,12 +5619,19 @@ final class Workspace: Identifiable, ObservableObject {
             .eraseToAnyPublisher()
     }
 
-    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
+    lazy var sidebarImmediateObservationPublisher: AnyPublisher<Void, Never> = {
         let publishers: [AnyPublisher<Void, Never>] = [
             sidebarObservationSignal($title),
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
+        ]
+
+        return Publishers.MergeMany(publishers).eraseToAnyPublisher()
+    }()
+
+    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
+        let publishers: [AnyPublisher<Void, Never>] = [
             sidebarObservationSignal($currentDirectory),
             $panels
                 .map(SidebarPanelObservationState.init)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6482,7 +6482,7 @@ final class Workspace: Identifiable, ObservableObject {
             .replacingOccurrences(of: "\r", with: "\n")
         let trimmed = normalizedLineEndings?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return nil }
-        return trimmed
+        return normalizedLineEndings
     }
 
     func setCustomTitle(_ title: String?) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -169,6 +169,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.splitBrowserRight.defaultsKey) private var splitBrowserRightShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.splitBrowserDown.defaultsKey) private var splitBrowserDownShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.renameWorkspace.defaultsKey) private var renameWorkspaceShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.editWorkspaceDescription.defaultsKey) private var editWorkspaceDescriptionShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openFolder.defaultsKey) private var openFolderShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -776,6 +777,10 @@ struct cmuxApp: App {
                     _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
                 }
 
+                splitCommandButton(title: String(localized: "menu.view.editWorkspaceDescription", defaultValue: "Edit Workspace Description…"), shortcut: editWorkspaceDescriptionMenuShortcut) {
+                    _ = AppDelegate.shared?.requestEditWorkspaceDescriptionViaCommandPalette()
+                }
+
                 Divider()
 
                 splitCommandButton(title: String(localized: "menu.view.splitRight", defaultValue: "Split Right"), shortcut: splitRightMenuShortcut) {
@@ -974,6 +979,13 @@ struct cmuxApp: App {
         )
     }
 
+    private var editWorkspaceDescriptionMenuShortcut: StoredShortcut {
+        decodeShortcut(
+            from: editWorkspaceDescriptionShortcutData,
+            fallback: KeyboardShortcutSettings.Action.editWorkspaceDescription.defaultShortcut
+        )
+    }
+
     private var closeWorkspaceMenuShortcut: StoredShortcut {
         decodeShortcut(
             from: closeWorkspaceShortcutData,
@@ -1135,6 +1147,11 @@ struct cmuxApp: App {
 
         Button(String(localized: "menu.view.renameWorkspace", defaultValue: "Rename Workspace…")) {
             _ = AppDelegate.shared?.requestRenameWorkspaceViaCommandPalette()
+        }
+        .disabled(workspace == nil)
+
+        Button(String(localized: "menu.view.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
+            _ = AppDelegate.shared?.requestEditWorkspaceDescriptionViaCommandPalette()
         }
         .disabled(workspace == nil)
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2199,6 +2199,68 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(observedWorkspaceWindow?.windowNumber, window.windowNumber)
     }
 
+    func testCmdShiftERequestsEditWorkspaceDescriptionInCommandPalette() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: windowId)
+        }
+
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        let descriptionExpectation = expectation(description: "Expected command palette edit workspace description notification")
+        var observedWorkspaceWindow: NSWindow?
+        var didObserveDescriptionNotification = false
+        let descriptionToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteEditWorkspaceDescriptionRequested,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard !didObserveDescriptionNotification else { return }
+            didObserveDescriptionNotification = true
+            observedWorkspaceWindow = notification.object as? NSWindow
+            descriptionExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(descriptionToken) }
+
+        let renameWorkspaceExpectation = expectation(description: "Rename workspace notification should not fire for Cmd+Shift+E")
+        renameWorkspaceExpectation.isInverted = true
+        let renameWorkspaceToken = NotificationCenter.default.addObserver(
+            forName: .commandPaletteRenameWorkspaceRequested,
+            object: nil,
+            queue: nil
+        ) { _ in
+            renameWorkspaceExpectation.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(renameWorkspaceToken) }
+
+        guard let event = makeKeyDownEvent(
+            key: "e",
+            modifiers: [.command, .shift],
+            keyCode: 14, // kVK_ANSI_E
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+E event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        wait(for: [descriptionExpectation, renameWorkspaceExpectation], timeout: 1.0)
+        XCTAssertEqual(observedWorkspaceWindow?.windowNumber, window.windowNumber)
+    }
+
     func testEscapeDismissesVisibleCommandPaletteAndIsConsumed() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -302,6 +302,37 @@ final class CommandPaletteKeyboardNavigationTests: XCTestCase {
             )
         )
     }
+
+    func testInlineTextHandlingDisablesPaletteSelectionNavigationRouting() {
+        XCTAssertTrue(
+            shouldRouteCommandPaletteSelectionNavigation(
+                delta: -1,
+                isInteractive: true,
+                usesInlineTextHandling: false
+            )
+        )
+        XCTAssertFalse(
+            shouldRouteCommandPaletteSelectionNavigation(
+                delta: -1,
+                isInteractive: true,
+                usesInlineTextHandling: true
+            )
+        )
+        XCTAssertFalse(
+            shouldRouteCommandPaletteSelectionNavigation(
+                delta: nil,
+                isInteractive: true,
+                usesInlineTextHandling: false
+            )
+        )
+        XCTAssertFalse(
+            shouldRouteCommandPaletteSelectionNavigation(
+                delta: 1,
+                isInteractive: false,
+                usesInlineTextHandling: false
+            )
+        )
+    }
 }
 
 

--- a/cmuxTests/SidebarMarkdownRendererTests.swift
+++ b/cmuxTests/SidebarMarkdownRendererTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SidebarMarkdownRendererTests: XCTestCase {
+    func testRenderWorkspaceDescriptionPreservesLineBreaks() throws {
+        let rendered = try XCTUnwrap(
+            SidebarMarkdownRenderer.renderWorkspaceDescription("First line\nSecond line")
+        )
+
+        XCTAssertEqual(String(rendered.characters), "First line\nSecond line")
+    }
+
+    func testRenderWorkspaceDescriptionPreservesInlineMarkdownAttributes() throws {
+        let rendered = try XCTUnwrap(
+            SidebarMarkdownRenderer.renderWorkspaceDescription("**Bold**\n[Link](https://example.com)")
+        )
+
+        XCTAssertEqual(String(rendered.characters), "Bold\nLink")
+        XCTAssertTrue(rendered.runs.contains { $0.inlinePresentationIntent != nil })
+        XCTAssertTrue(
+            rendered.runs.contains { $0.link == URL(string: "https://example.com") }
+        )
+    }
+}

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -212,6 +212,28 @@ final class WorkspaceShortcutMapperTests: XCTestCase {
     }
 }
 
+@MainActor
+final class WorkspaceCustomDescriptionTests: XCTestCase {
+    func testSetCustomDescriptionPreservesMeaningfulLeadingAndTrailingWhitespace() {
+        let workspace = Workspace()
+        let description = "  line one\n\nline two\n\n"
+
+        workspace.setCustomDescription(description)
+
+        XCTAssertEqual(workspace.customDescription, description)
+        XCTAssertTrue(workspace.hasCustomDescription)
+    }
+
+    func testSetCustomDescriptionClearsWhitespaceOnlyDescriptions() {
+        let workspace = Workspace()
+
+        workspace.setCustomDescription(" \n\t \n")
+
+        XCTAssertNil(workspace.customDescription)
+        XCTAssertFalse(workspace.hasCustomDescription)
+    }
+}
+
 
 final class WorkspacePlacementSettingsTests: XCTestCase {
     func testCurrentPlacementDefaultsToAfterCurrentWhenUnset() {

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -116,12 +116,61 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         assertSavedDescription(description, in: app)
     }
 
+    func testSidebarRendersSavedDescriptionWithLineBreaks() {
+        let app = configuredSidebarApp()
+        launchAndActivate(app)
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 6.0))
+
+        let token = String(UUID().uuidString.prefix(8))
+        let firstLine = "Sidebar first \(token)"
+        let secondLine = "Sidebar second \(token)"
+        let description = "\(firstLine)\n\(secondLine)"
+
+        app.typeKey("e", modifierFlags: [.command, .shift])
+
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor in a simple workspace"
+        )
+
+        app.typeText(firstLine)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [.shift])
+        app.typeText(secondLine)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor after multiline input"
+        )
+
+        let renderedDescription = app
+            .descendants(matching: .staticText)
+            .matching(NSPredicate(format: "label == %@", description))
+            .firstMatch
+
+        XCTAssertTrue(
+            workspaceDescriptionPollUntil(timeout: 5.0) {
+                renderedDescription.exists
+            },
+            "Expected the sidebar to render the saved multiline description with a newline-preserving label"
+        )
+    }
+
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        return app
+    }
+
+    private func configuredSidebarApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_TAG"] = launchTag
         return app
     }
@@ -234,6 +283,24 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         if app.state == .runningBackground { return }
 
         XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func launchAndActivate(_ app: XCUIApplication, activateTimeout: TimeInterval = 2.0) {
+        app.launch()
+        let activated = workspaceDescriptionPollUntil(timeout: activateTimeout) {
+            guard app.state != .runningForeground else {
+                return true
+            }
+            app.activate()
+            return app.state == .runningForeground
+        }
+        if !activated {
+            app.activate()
+        }
+        XCTAssertTrue(
+            workspaceDescriptionPollUntil(timeout: 2.0) { app.state == .runningForeground },
+            "App did not reach runningForeground before UI interactions"
+        )
     }
 
     private func waitForData(keys: [String], timeout: TimeInterval) -> Bool {

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -27,15 +27,15 @@ final class WorkspaceDescriptionUITests: XCTestCase {
     }
 
     private var dataPath = ""
-    private var socketTag = ""
     private var socketPath = ""
+    private var launchTag = ""
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         dataPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).json"
-        socketTag = "ui-tests-workspace-description-\(UUID().uuidString.lowercased())"
-        socketPath = "/tmp/cmux-debug-\(socketTag).sock"
+        launchTag = "ui-tests-workspace-description-\(UUID().uuidString.lowercased())"
+        socketPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).sock"
         try? FileManager.default.removeItem(atPath: dataPath)
         try? FileManager.default.removeItem(atPath: socketPath)
     }
@@ -97,12 +97,13 @@ final class WorkspaceDescriptionUITests: XCTestCase {
 
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments += ["-socketControlMode", "cmuxOnly"]
+        app.launchArguments += ["-socketControlMode", "allowAll"]
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
-        app.launchEnvironment["CMUX_TAG"] = socketTag
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
         return app
     }
 
@@ -124,7 +125,11 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             return nil
         }
 
-        XCTAssertTrue(waitForSocketReady(timeout: 5.0), "Expected control socket to become ready")
+        guard let resolvedSocketPath = resolveSocketPath(timeout: 8.0) else {
+            XCTFail("Expected control socket to become ready")
+            return nil
+        }
+        socketPath = resolvedSocketPath
 
         app.typeKey("h", modifierFlags: [.command, .control])
         XCTAssertTrue(
@@ -219,10 +224,68 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
     }
 
-    private func waitForSocketReady(timeout: TimeInterval) -> Bool {
-        workspaceDescriptionPollUntil(timeout: timeout) {
-            self.socketCommand("ping") == "PONG"
+    private func resolveSocketPath(timeout: TimeInterval) -> String? {
+        let primaryCandidates = expectedSocketCandidates(includeGlobalFallback: false)
+        let fallbackCandidates = expectedSocketCandidates(includeGlobalFallback: true)
+            .filter { !primaryCandidates.contains($0) }
+
+        var resolvedPath: String?
+        _ = workspaceDescriptionPollUntil(timeout: timeout) {
+            for candidate in primaryCandidates where self.socketRespondsToPing(at: candidate) {
+                resolvedPath = candidate
+                return true
+            }
+            for candidate in fallbackCandidates where self.socketRespondsToPing(at: candidate) {
+                resolvedPath = candidate
+                return true
+            }
+            return false
         }
+        return resolvedPath
+    }
+
+    private func expectedSocketCandidates(includeGlobalFallback: Bool) -> [String] {
+        var candidates = [socketPath, "/tmp/cmux-debug-\(launchTag).sock"]
+        if includeGlobalFallback {
+            candidates.append(contentsOf: discoverTmpSocketCandidates(limit: 12))
+            candidates.append("/tmp/cmux-debug.sock")
+        }
+
+        var unique: [String] = []
+        var seen = Set<String>()
+        for candidate in candidates {
+            if seen.insert(candidate).inserted {
+                unique.append(candidate)
+            }
+        }
+        return unique
+    }
+
+    private func discoverTmpSocketCandidates(limit: Int) -> [String] {
+        let tmpPath = "/tmp"
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: tmpPath) else {
+            return []
+        }
+
+        let matches = entries.filter { $0.hasPrefix("cmux") && $0.hasSuffix(".sock") }
+        let sorted = matches.compactMap { entry -> (path: String, mtime: Date)? in
+            let fullPath = (tmpPath as NSString).appendingPathComponent(entry)
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: fullPath) else {
+                return nil
+            }
+            let mtime = (attrs[.modificationDate] as? Date) ?? .distantPast
+            return (fullPath, mtime)
+        }
+        .sorted { $0.mtime > $1.mtime }
+
+        return Array(sorted.prefix(limit)).map(\.path)
+    }
+
+    private func socketRespondsToPing(at path: String) -> Bool {
+        let originalPath = socketPath
+        socketPath = path
+        defer { socketPath = originalPath }
+        return socketCommand("ping") == "PONG"
     }
 
     private func currentWorkspaceContext() -> WorkspaceContext? {

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -80,6 +80,42 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         assertSavedDescription(description, in: app)
     }
 
+    func testShiftEnterInsertsNewlineInsteadOfSubmitting() {
+        let app = configuredApp()
+        launchAndEnsureForeground(app)
+        prepareTerminalFocusedWorkspace(app)
+
+        let token = String(UUID().uuidString.prefix(8))
+        let firstLine = "First line \(token)"
+        let secondLine = "Second line \(token)"
+        let description = "\(firstLine)\n\(secondLine)"
+
+        app.typeKey("e", modifierFlags: [.command, .shift])
+
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor before testing Shift+Enter"
+        )
+
+        app.typeText(firstLine)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [.shift])
+
+        XCTAssertTrue(
+            editor.exists,
+            "Expected Shift+Enter to keep the workspace description editor open for multiline input"
+        )
+
+        app.typeText(secondLine)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor after multiline input"
+        )
+        assertSavedDescription(description, in: app)
+    }
+
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -97,12 +97,13 @@ final class WorkspaceDescriptionUITests: XCTestCase {
 
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments += ["-socketControlMode", "allowAll"]
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = launchTag
         return app

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -102,6 +102,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = launchTag
         return app

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -1,0 +1,131 @@
+import XCTest
+
+private func workspaceDescriptionPollUntil(
+    timeout: TimeInterval,
+    pollInterval: TimeInterval = 0.05,
+    condition: () -> Bool
+) -> Bool {
+    let start = ProcessInfo.processInfo.systemUptime
+    while true {
+        if condition() {
+            return true
+        }
+        if (ProcessInfo.processInfo.systemUptime - start) >= timeout {
+            return false
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+    }
+}
+
+final class WorkspaceDescriptionUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testCmdShiftEAllowsImmediateTypingAndSave() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        launchAndEnsureForeground(app)
+
+        let description = "Cmd Shift E focus note"
+        app.typeKey("e", modifierFlags: [.command, .shift])
+
+        let editor = requireDescriptionEditor(in: app, timeout: 5.0)
+        XCTAssertTrue(editor.exists, "Expected workspace description editor to open")
+
+        app.typeText(description)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor"
+        )
+        XCTAssertTrue(
+            app.staticTexts[description].waitForExistence(timeout: 5.0),
+            "Expected saved workspace description to appear in the sidebar"
+        )
+    }
+
+    func testClickingDescriptionEditorAllowsTypingAndSave() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        launchAndEnsureForeground(app)
+
+        let description = "Clicked description note"
+        app.typeKey("e", modifierFlags: [.command, .shift])
+
+        let editor = requireDescriptionEditor(in: app, timeout: 5.0)
+        XCTAssertTrue(editor.exists, "Expected workspace description editor to open")
+
+        editor.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        app.typeText(description)
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor after clicking it"
+        )
+        XCTAssertTrue(
+            app.staticTexts[description].waitForExistence(timeout: 5.0),
+            "Expected clicked workspace description to appear in the sidebar"
+        )
+    }
+
+    private func requireDescriptionEditor(
+        in app: XCUIApplication,
+        timeout: TimeInterval
+    ) -> XCUIElement {
+        let candidates = descriptionEditorCandidates(in: app)
+        var match: XCUIElement?
+        let found = workspaceDescriptionPollUntil(timeout: timeout) {
+            for candidate in candidates where candidate.exists {
+                match = candidate
+                return true
+            }
+            return false
+        }
+        if let match, found {
+            return match
+        }
+        XCTFail("Expected workspace description editor to appear")
+        return candidates[0]
+    }
+
+    private func descriptionEditorCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.textViews["CommandPaletteWorkspaceDescriptionEditor"],
+            app.scrollViews["CommandPaletteWorkspaceDescriptionEditor"],
+            app.otherElements["CommandPaletteWorkspaceDescriptionEditor"],
+            app.descendants(matching: .any).matching(identifier: "CommandPaletteWorkspaceDescriptionEditor").firstMatch,
+        ]
+    }
+
+    private func waitForNonExistence(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground {
+            return
+        }
+
+        if app.state == .runningBackground {
+            return
+        }
+
+        let activated = workspaceDescriptionPollUntil(timeout: timeout) {
+            app.activate()
+            return app.state == .runningForeground || app.state == .runningBackground
+        }
+        XCTAssertTrue(activated, "App failed to start. state=\(app.state.rawValue)")
+    }
+}

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -52,10 +52,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             waitForNonExistence(editor, timeout: 5.0),
             "Expected Enter to save and dismiss the workspace description editor"
         )
-        XCTAssertTrue(
-            app.staticTexts[description].firstMatch.waitForExistence(timeout: 5.0),
-            "Expected immediate typing to save the workspace description into the sidebar"
-        )
+        assertSavedDescription(description, in: app)
     }
 
     func testClickingDescriptionEditorAllowsTypingAndSave() {
@@ -80,10 +77,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             waitForNonExistence(editor, timeout: 5.0),
             "Expected Enter to save and dismiss the workspace description editor after clicking"
         )
-        XCTAssertTrue(
-            app.staticTexts[description].firstMatch.waitForExistence(timeout: 5.0),
-            "Expected clicking the description editor to allow typing and save the workspace description"
-        )
+        assertSavedDescription(description, in: app)
     }
 
     private func configuredApp() -> XCUIApplication {
@@ -136,6 +130,27 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             return app.textViews["CommandPaletteWorkspaceDescriptionEditor"].firstMatch
         }
         return editor
+    }
+
+    private func assertSavedDescription(_ description: String, in app: XCUIApplication) {
+        app.typeKey("e", modifierFlags: [.command, .shift])
+
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to reopen the workspace description editor for verification"
+        )
+
+        XCTAssertTrue(
+            waitForEditorValue(editor, expected: description, timeout: 5.0),
+            "Expected the saved workspace description to be restored when reopening the editor. value=\(String(describing: editor.value))"
+        )
+
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Escape to dismiss the workspace description editor after verification"
+        )
     }
 
     private func clickDescriptionEditor(_ editor: XCUIElement, in app: XCUIApplication) {
@@ -203,6 +218,15 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         let predicate = NSPredicate(format: "exists == false")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func waitForEditorValue(_ editor: XCUIElement, expected: String, timeout: TimeInterval) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            guard editor.exists else { return false }
+            let value = (editor.value as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return value == expected
+        }
     }
 
     private func loadData() -> [String: String]? {

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -27,13 +27,15 @@ final class WorkspaceDescriptionUITests: XCTestCase {
     }
 
     private var dataPath = ""
+    private var socketTag = ""
     private var socketPath = ""
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         dataPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).json"
-        socketPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).sock"
+        socketTag = "ui-tests-workspace-description-\(UUID().uuidString.lowercased())"
+        socketPath = "/tmp/cmux-debug-\(socketTag).sock"
         try? FileManager.default.removeItem(atPath: dataPath)
         try? FileManager.default.removeItem(atPath: socketPath)
     }
@@ -100,8 +102,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
-        app.launchEnvironment["CMUX_TAG"] = "ui-tests-workspace-description"
+        app.launchEnvironment["CMUX_TAG"] = socketTag
         return app
     }
 

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Foundation
 import CoreGraphics
-import Darwin
 
 private func workspaceDescriptionPollUntil(
     timeout: TimeInterval,
@@ -21,13 +20,7 @@ private func workspaceDescriptionPollUntil(
 }
 
 final class WorkspaceDescriptionUITests: XCTestCase {
-    private struct WorkspaceContext {
-        let workspaceId: String
-        let windowId: String
-    }
-
     private var dataPath = ""
-    private var socketPath = ""
     private var launchTag = ""
 
     override func setUp() {
@@ -35,63 +28,61 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         continueAfterFailure = false
         dataPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).json"
         launchTag = "ui-tests-workspace-description-\(UUID().uuidString.lowercased())"
-        socketPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).sock"
         try? FileManager.default.removeItem(atPath: dataPath)
-        try? FileManager.default.removeItem(atPath: socketPath)
     }
 
     func testCmdShiftEAllowsImmediateTypingAndSave() {
         let app = configuredApp()
         launchAndEnsureForeground(app)
+        prepareTerminalFocusedWorkspace(app)
 
-        guard let context = prepareTerminalFocusedWorkspaceContext(app: app) else { return }
-
-        let description = "Cmd Shift E focus note"
+        let description = "Cmd Shift E focus note \(String(UUID().uuidString.prefix(8)))"
         app.typeKey("e", modifierFlags: [.command, .shift])
 
-        XCTAssertTrue(
-            waitForDescriptionPaletteOpen(windowId: context.windowId, timeout: 5.0),
-            "Expected Cmd+Shift+E to open the workspace description command palette while terminal is focused. snapshot=\(commandPaletteSnapshot(windowId: context.windowId) ?? [:])"
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor while terminal is focused"
         )
 
         app.typeText(description)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
 
         XCTAssertTrue(
-            waitForWorkspaceDescription(workspaceId: context.workspaceId, expectedDescription: description, timeout: 5.0),
-            "Expected immediate typing to save the workspace description. current=\(currentWorkspaceDescription(workspaceId: context.workspaceId) ?? "nil")"
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor"
         )
         XCTAssertTrue(
-            waitForDescriptionPaletteClosed(windowId: context.windowId, timeout: 5.0),
-            "Expected Enter to save and dismiss the workspace description palette"
+            app.staticTexts[description].firstMatch.waitForExistence(timeout: 5.0),
+            "Expected immediate typing to save the workspace description into the sidebar"
         )
     }
 
     func testClickingDescriptionEditorAllowsTypingAndSave() {
         let app = configuredApp()
         launchAndEnsureForeground(app)
+        prepareTerminalFocusedWorkspace(app)
 
-        guard let context = prepareTerminalFocusedWorkspaceContext(app: app) else { return }
-
-        let description = "Clicked description note"
+        let description = "Clicked description note \(String(UUID().uuidString.prefix(8)))"
         app.typeKey("e", modifierFlags: [.command, .shift])
 
-        XCTAssertTrue(
-            waitForDescriptionPaletteOpen(windowId: context.windowId, timeout: 5.0),
-            "Expected Cmd+Shift+E to open the workspace description command palette while terminal is focused. snapshot=\(commandPaletteSnapshot(windowId: context.windowId) ?? [:])"
+        let editor = requireDescriptionEditor(
+            in: app,
+            timeout: 5.0,
+            failureMessage: "Expected Cmd+Shift+E to open the workspace description editor while terminal is focused"
         )
 
-        clickDescriptionEditor(in: app)
+        clickDescriptionEditor(editor, in: app)
         app.typeText(description)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
 
         XCTAssertTrue(
-            waitForWorkspaceDescription(workspaceId: context.workspaceId, expectedDescription: description, timeout: 5.0),
-            "Expected clicking the description editor to allow typing and save the workspace description. current=\(currentWorkspaceDescription(workspaceId: context.workspaceId) ?? "nil")"
+            waitForNonExistence(editor, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description editor after clicking"
         )
         XCTAssertTrue(
-            waitForDescriptionPaletteClosed(windowId: context.windowId, timeout: 5.0),
-            "Expected Enter to save and dismiss the workspace description palette after clicking"
+            app.staticTexts[description].firstMatch.waitForExistence(timeout: 5.0),
+            "Expected clicking the description editor to allow typing and save the workspace description"
         )
     }
 
@@ -101,15 +92,11 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
-        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
-        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = launchTag
         return app
     }
 
-    private func prepareTerminalFocusedWorkspaceContext(app: XCUIApplication) -> WorkspaceContext? {
+    private func prepareTerminalFocusedWorkspace(_ app: XCUIApplication) {
         XCTAssertTrue(
             waitForData(keys: ["terminalPaneId", "webViewFocused"], timeout: 10.0),
             "Expected goto_split setup data to be written"
@@ -117,43 +104,42 @@ final class WorkspaceDescriptionUITests: XCTestCase {
 
         guard let setup = loadData() else {
             XCTFail("Missing goto_split setup data")
-            return nil
+            return
         }
 
         XCTAssertEqual(setup["webViewFocused"], "true", "Expected WKWebView to be first responder for this test")
 
         guard let expectedTerminalPaneId = setup["terminalPaneId"] else {
             XCTFail("Missing terminalPaneId in goto_split setup data")
-            return nil
+            return
         }
-
-        guard let resolvedSocketPath = resolveSocketPath(timeout: 8.0) else {
-            XCTFail("Expected control socket to become ready")
-            return nil
-        }
-        socketPath = resolvedSocketPath
 
         app.typeKey("h", modifierFlags: [.command, .control])
         XCTAssertTrue(
             waitForDataMatch(timeout: 5.0) { data in
                 data["lastMoveDirection"] == "left" && data["focusedPaneId"] == expectedTerminalPaneId
             },
-            "Expected Cmd+Ctrl+H to move focus to the terminal pane before opening the description palette"
+            "Expected Cmd+Ctrl+H to move focus to the terminal pane before opening the description editor"
         )
-
-        guard let context = currentWorkspaceContext() else {
-            XCTFail("Missing workspace context after focusing the terminal pane")
-            return nil
-        }
-
-        return context
     }
 
-    private func clickDescriptionEditor(in app: XCUIApplication) {
-        if let editor = firstExistingElement(
+    private func requireDescriptionEditor(
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        failureMessage: String
+    ) -> XCUIElement {
+        guard let editor = firstExistingElement(
             candidates: descriptionEditorCandidates(in: app),
-            timeout: 1.5
-        ) {
+            timeout: timeout
+        ) else {
+            XCTFail(failureMessage)
+            return app.textViews["CommandPaletteWorkspaceDescriptionEditor"].firstMatch
+        }
+        return editor
+    }
+
+    private func clickDescriptionEditor(_ editor: XCUIElement, in app: XCUIApplication) {
+        if editor.exists {
             editor.click()
             return
         }
@@ -168,7 +154,6 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             app.textViews["CommandPaletteWorkspaceDescriptionEditor"],
             app.scrollViews["CommandPaletteWorkspaceDescriptionEditor"],
             app.otherElements["CommandPaletteWorkspaceDescriptionEditor"],
-            app.staticTexts["Workspace description"],
         ]
     }
 
@@ -190,19 +175,14 @@ final class WorkspaceDescriptionUITests: XCTestCase {
     private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
         let options = XCTExpectedFailure.Options()
         options.isStrict = false
-        XCTExpectFailure("App activation may fail on headless runners", options: options) {
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
             app.launch()
         }
 
-        if app.state == .runningForeground {
-            return
-        }
+        if app.state == .runningForeground { return }
+        if app.state == .runningBackground { return }
 
-        let activated = workspaceDescriptionPollUntil(timeout: timeout) {
-            app.activate()
-            return app.state == .runningForeground || app.state == .runningBackground
-        }
-        XCTAssertTrue(activated, "App failed to start. state=\(app.state.rawValue)")
+        XCTFail("App failed to start. state=\(app.state.rawValue)")
     }
 
     private func waitForData(keys: [String], timeout: TimeInterval) -> Bool {
@@ -219,257 +199,16 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         }
     }
 
+    private func waitForNonExistence(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
     private func loadData() -> [String: String]? {
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: dataPath)) else {
             return nil
         }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
-    }
-
-    private func resolveSocketPath(timeout: TimeInterval) -> String? {
-        let primaryCandidates = expectedSocketCandidates(includeGlobalFallback: false)
-        let fallbackCandidates = expectedSocketCandidates(includeGlobalFallback: true)
-            .filter { !primaryCandidates.contains($0) }
-
-        var resolvedPath: String?
-        _ = workspaceDescriptionPollUntil(timeout: timeout) {
-            for candidate in primaryCandidates where self.socketRespondsToPing(at: candidate) {
-                resolvedPath = candidate
-                return true
-            }
-            for candidate in fallbackCandidates where self.socketRespondsToPing(at: candidate) {
-                resolvedPath = candidate
-                return true
-            }
-            return false
-        }
-        return resolvedPath
-    }
-
-    private func expectedSocketCandidates(includeGlobalFallback: Bool) -> [String] {
-        var candidates = [socketPath, "/tmp/cmux-debug-\(launchTag).sock"]
-        if includeGlobalFallback {
-            candidates.append(contentsOf: discoverTmpSocketCandidates(limit: 12))
-            candidates.append("/tmp/cmux-debug.sock")
-        }
-
-        var unique: [String] = []
-        var seen = Set<String>()
-        for candidate in candidates {
-            if seen.insert(candidate).inserted {
-                unique.append(candidate)
-            }
-        }
-        return unique
-    }
-
-    private func discoverTmpSocketCandidates(limit: Int) -> [String] {
-        let tmpPath = "/tmp"
-        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: tmpPath) else {
-            return []
-        }
-
-        let matches = entries.filter { $0.hasPrefix("cmux") && $0.hasSuffix(".sock") }
-        let sorted = matches.compactMap { entry -> (path: String, mtime: Date)? in
-            let fullPath = (tmpPath as NSString).appendingPathComponent(entry)
-            guard let attrs = try? FileManager.default.attributesOfItem(atPath: fullPath) else {
-                return nil
-            }
-            let mtime = (attrs[.modificationDate] as? Date) ?? .distantPast
-            return (fullPath, mtime)
-        }
-        .sorted { $0.mtime > $1.mtime }
-
-        return Array(sorted.prefix(limit)).map(\.path)
-    }
-
-    private func socketRespondsToPing(at path: String) -> Bool {
-        let originalPath = socketPath
-        socketPath = path
-        defer { socketPath = originalPath }
-        return socketCommand("ping") == "PONG"
-    }
-
-    private func currentWorkspaceContext() -> WorkspaceContext? {
-        guard let envelope = socketJSON(method: "workspace.current", params: [:]),
-              let ok = envelope["ok"] as? Bool,
-              ok,
-              let result = envelope["result"] as? [String: Any],
-              let workspaceId = result["workspace_id"] as? String,
-              let windowId = result["window_id"] as? String else {
-            return nil
-        }
-        return WorkspaceContext(workspaceId: workspaceId, windowId: windowId)
-    }
-
-    private func currentWorkspaceDescription(workspaceId: String) -> String? {
-        guard let envelope = socketJSON(method: "workspace.current", params: [:]),
-              let ok = envelope["ok"] as? Bool,
-              ok,
-              let result = envelope["result"] as? [String: Any],
-              let currentWorkspaceId = result["workspace_id"] as? String,
-              currentWorkspaceId == workspaceId,
-              let workspace = result["workspace"] as? [String: Any] else {
-            return nil
-        }
-        return workspace["description"] as? String
-    }
-
-    private func waitForWorkspaceDescription(
-        workspaceId: String,
-        expectedDescription: String,
-        timeout: TimeInterval
-    ) -> Bool {
-        workspaceDescriptionPollUntil(timeout: timeout) {
-            self.currentWorkspaceDescription(workspaceId: workspaceId) == expectedDescription
-        }
-    }
-
-    private func waitForDescriptionPaletteOpen(windowId: String, timeout: TimeInterval) -> Bool {
-        workspaceDescriptionPollUntil(timeout: timeout) {
-            guard let snapshot = self.commandPaletteSnapshot(windowId: windowId) else { return false }
-            return (snapshot["visible"] as? Bool) == true
-                && (snapshot["mode"] as? String) == "workspace_description_input"
-        }
-    }
-
-    private func waitForDescriptionPaletteClosed(windowId: String, timeout: TimeInterval) -> Bool {
-        workspaceDescriptionPollUntil(timeout: timeout) {
-            guard let snapshot = self.commandPaletteSnapshot(windowId: windowId) else { return false }
-            return (snapshot["visible"] as? Bool) != true
-        }
-    }
-
-    private func commandPaletteSnapshot(windowId: String) -> [String: Any]? {
-        let envelope = socketJSON(
-            method: "debug.command_palette.results",
-            params: [
-                "window_id": windowId,
-                "limit": 20,
-            ]
-        )
-        guard let ok = envelope?["ok"] as? Bool, ok else { return nil }
-        return envelope?["result"] as? [String: Any]
-    }
-
-    private func socketCommand(_ command: String) -> String? {
-        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
-    }
-
-    private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
-        let request: [String: Any] = [
-            "id": UUID().uuidString,
-            "method": method,
-            "params": params,
-        ]
-        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
-    }
-
-    private final class ControlSocketClient {
-        private let path: String
-        private let responseTimeout: TimeInterval
-
-        init(path: String, responseTimeout: TimeInterval) {
-            self.path = path
-            self.responseTimeout = responseTimeout
-        }
-
-        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
-            guard JSONSerialization.isValidJSONObject(object),
-                  let data = try? JSONSerialization.data(withJSONObject: object),
-                  let line = String(data: data, encoding: .utf8),
-                  let response = sendLine(line),
-                  let responseData = response.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
-                return nil
-            }
-            return parsed
-        }
-
-        func sendLine(_ line: String) -> String? {
-            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-            guard fd >= 0 else { return nil }
-            defer { close(fd) }
-
-#if os(macOS)
-            var noSigPipe: Int32 = 1
-            _ = withUnsafePointer(to: &noSigPipe) { ptr in
-                setsockopt(
-                    fd,
-                    SOL_SOCKET,
-                    SO_NOSIGPIPE,
-                    ptr,
-                    socklen_t(MemoryLayout<Int32>.size)
-                )
-            }
-#endif
-
-            var addr = sockaddr_un()
-            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
-            addr.sun_family = sa_family_t(AF_UNIX)
-
-            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
-            let bytes = Array(path.utf8CString)
-            guard bytes.count <= maxLen else { return nil }
-            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-                memset(raw, 0, maxLen)
-                for index in 0..<bytes.count {
-                    raw[index] = bytes[index]
-                }
-            }
-
-            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
-            let addrLen = socklen_t(pathOffset + bytes.count)
-#if os(macOS)
-            addr.sun_len = UInt8(min(Int(addrLen), 255))
-#endif
-
-            let connected = withUnsafePointer(to: &addr) { ptr in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-                    connect(fd, sa, addrLen)
-                }
-            }
-            guard connected == 0 else { return nil }
-
-            let payload = line + "\n"
-            let wrote: Bool = payload.withCString { cString in
-                var remaining = strlen(cString)
-                var pointer = UnsafeRawPointer(cString)
-                while remaining > 0 {
-                    let written = write(fd, pointer, remaining)
-                    if written <= 0 { return false }
-                    remaining -= written
-                    pointer = pointer.advanced(by: written)
-                }
-                return true
-            }
-            guard wrote else { return nil }
-
-            let deadline = Date().addingTimeInterval(responseTimeout)
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            var accumulator = ""
-            while Date() < deadline {
-                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
-                let ready = poll(&pollDescriptor, 1, 100)
-                if ready < 0 {
-                    return nil
-                }
-                if ready == 0 {
-                    continue
-                }
-
-                let count = read(fd, &buffer, buffer.count)
-                if count <= 0 { break }
-                if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
-                    accumulator.append(chunk)
-                    if let newline = accumulator.firstIndex(of: "\n") {
-                        return String(accumulator[..<newline])
-                    }
-                }
-            }
-
-            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
     }
 }

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -1,4 +1,7 @@
 import XCTest
+import Foundation
+import CoreGraphics
+import Darwin
 
 private func workspaceDescriptionPollUntil(
     timeout: TimeInterval,
@@ -18,65 +21,151 @@ private func workspaceDescriptionPollUntil(
 }
 
 final class WorkspaceDescriptionUITests: XCTestCase {
+    private struct WorkspaceContext {
+        let workspaceId: String
+        let windowId: String
+    }
+
+    private var dataPath = ""
+    private var socketPath = ""
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        dataPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).json"
+        socketPath = "/tmp/cmux-ui-test-workspace-description-\(UUID().uuidString).sock"
+        try? FileManager.default.removeItem(atPath: dataPath)
+        try? FileManager.default.removeItem(atPath: socketPath)
     }
 
     func testCmdShiftEAllowsImmediateTypingAndSave() {
-        let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        let app = configuredApp()
         launchAndEnsureForeground(app)
+
+        guard let context = prepareTerminalFocusedWorkspaceContext(app: app) else { return }
 
         let description = "Cmd Shift E focus note"
         app.typeKey("e", modifierFlags: [.command, .shift])
 
-        let editor = requireDescriptionEditor(in: app, timeout: 5.0)
-        XCTAssertTrue(editor.exists, "Expected workspace description editor to open")
+        XCTAssertTrue(
+            waitForDescriptionPaletteOpen(windowId: context.windowId, timeout: 5.0),
+            "Expected Cmd+Shift+E to open the workspace description command palette while terminal is focused. snapshot=\(commandPaletteSnapshot(windowId: context.windowId) ?? [:])"
+        )
 
         app.typeText(description)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
 
         XCTAssertTrue(
-            waitForNonExistence(editor, timeout: 5.0),
-            "Expected Enter to save and dismiss the workspace description editor"
+            waitForWorkspaceDescription(workspaceId: context.workspaceId, expectedDescription: description, timeout: 5.0),
+            "Expected immediate typing to save the workspace description. current=\(currentWorkspaceDescription(workspaceId: context.workspaceId) ?? "nil")"
         )
         XCTAssertTrue(
-            app.staticTexts[description].waitForExistence(timeout: 5.0),
-            "Expected saved workspace description to appear in the sidebar"
+            waitForDescriptionPaletteClosed(windowId: context.windowId, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description palette"
         )
     }
 
     func testClickingDescriptionEditorAllowsTypingAndSave() {
-        let app = XCUIApplication()
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        let app = configuredApp()
         launchAndEnsureForeground(app)
+
+        guard let context = prepareTerminalFocusedWorkspaceContext(app: app) else { return }
 
         let description = "Clicked description note"
         app.typeKey("e", modifierFlags: [.command, .shift])
 
-        let editor = requireDescriptionEditor(in: app, timeout: 5.0)
-        XCTAssertTrue(editor.exists, "Expected workspace description editor to open")
+        XCTAssertTrue(
+            waitForDescriptionPaletteOpen(windowId: context.windowId, timeout: 5.0),
+            "Expected Cmd+Shift+E to open the workspace description command palette while terminal is focused. snapshot=\(commandPaletteSnapshot(windowId: context.windowId) ?? [:])"
+        )
 
-        editor.click()
+        clickDescriptionEditor(in: app)
         app.typeText(description)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
 
         XCTAssertTrue(
-            waitForNonExistence(editor, timeout: 5.0),
-            "Expected Enter to save and dismiss the workspace description editor after clicking it"
+            waitForWorkspaceDescription(workspaceId: context.workspaceId, expectedDescription: description, timeout: 5.0),
+            "Expected clicking the description editor to allow typing and save the workspace description. current=\(currentWorkspaceDescription(workspaceId: context.workspaceId) ?? "nil")"
         )
         XCTAssertTrue(
-            app.staticTexts[description].waitForExistence(timeout: 5.0),
-            "Expected clicked workspace description to appear in the sidebar"
+            waitForDescriptionPaletteClosed(windowId: context.windowId, timeout: 5.0),
+            "Expected Enter to save and dismiss the workspace description palette after clicking"
         )
     }
 
-    private func requireDescriptionEditor(
-        in app: XCUIApplication,
+    private func configuredApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        return app
+    }
+
+    private func prepareTerminalFocusedWorkspaceContext(app: XCUIApplication) -> WorkspaceContext? {
+        XCTAssertTrue(
+            waitForData(keys: ["terminalPaneId", "webViewFocused"], timeout: 10.0),
+            "Expected goto_split setup data to be written"
+        )
+
+        guard let setup = loadData() else {
+            XCTFail("Missing goto_split setup data")
+            return nil
+        }
+
+        XCTAssertEqual(setup["webViewFocused"], "true", "Expected WKWebView to be first responder for this test")
+
+        guard let expectedTerminalPaneId = setup["terminalPaneId"] else {
+            XCTFail("Missing terminalPaneId in goto_split setup data")
+            return nil
+        }
+
+        XCTAssertTrue(waitForSocketReady(timeout: 5.0), "Expected control socket to become ready")
+
+        app.typeKey("h", modifierFlags: [.command, .control])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 5.0) { data in
+                data["lastMoveDirection"] == "left" && data["focusedPaneId"] == expectedTerminalPaneId
+            },
+            "Expected Cmd+Ctrl+H to move focus to the terminal pane before opening the description palette"
+        )
+
+        guard let context = currentWorkspaceContext() else {
+            XCTFail("Missing workspace context after focusing the terminal pane")
+            return nil
+        }
+
+        return context
+    }
+
+    private func clickDescriptionEditor(in app: XCUIApplication) {
+        if let editor = firstExistingElement(
+            candidates: descriptionEditorCandidates(in: app),
+            timeout: 1.5
+        ) {
+            editor.click()
+            return
+        }
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected app window for description editor click target")
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12)).click()
+    }
+
+    private func descriptionEditorCandidates(in app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.textViews["CommandPaletteWorkspaceDescriptionEditor"],
+            app.scrollViews["CommandPaletteWorkspaceDescriptionEditor"],
+            app.otherElements["CommandPaletteWorkspaceDescriptionEditor"],
+            app.staticTexts["Workspace description"],
+        ]
+    }
+
+    private func firstExistingElement(
+        candidates: [XCUIElement],
         timeout: TimeInterval
-    ) -> XCUIElement {
-        let candidates = descriptionEditorCandidates(in: app)
+    ) -> XCUIElement? {
         var match: XCUIElement?
         let found = workspaceDescriptionPollUntil(timeout: timeout) {
             for candidate in candidates where candidate.exists {
@@ -85,29 +174,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             }
             return false
         }
-        if let match, found {
-            return match
-        }
-        XCTFail("Expected workspace description editor to appear")
-        return candidates[0]
-    }
-
-    private func descriptionEditorCandidates(in app: XCUIApplication) -> [XCUIElement] {
-        [
-            app.textViews["CommandPaletteWorkspaceDescriptionEditor"],
-            app.scrollViews["CommandPaletteWorkspaceDescriptionEditor"],
-            app.otherElements["CommandPaletteWorkspaceDescriptionEditor"],
-            app.textViews["Edit Workspace Description…"],
-            app.textViews["Workspace description"],
-            app.staticTexts["Workspace description"],
-            app.descendants(matching: .any).matching(identifier: "CommandPaletteWorkspaceDescriptionEditor").firstMatch,
-        ]
-    }
-
-    private func waitForNonExistence(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
-        let predicate = NSPredicate(format: "exists == false")
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
-        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+        return found ? match : nil
     }
 
     private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
@@ -121,14 +188,220 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             return
         }
 
-        if app.state == .runningBackground {
-            return
-        }
-
         let activated = workspaceDescriptionPollUntil(timeout: timeout) {
             app.activate()
             return app.state == .runningForeground || app.state == .runningBackground
         }
         XCTAssertTrue(activated, "App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func waitForData(keys: [String], timeout: TimeInterval) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            guard let data = self.loadData() else { return false }
+            return keys.allSatisfy { data[$0] != nil }
+        }
+    }
+
+    private func waitForDataMatch(timeout: TimeInterval, predicate: @escaping ([String: String]) -> Bool) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            guard let data = self.loadData() else { return false }
+            return predicate(data)
+        }
+    }
+
+    private func loadData() -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: dataPath)) else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+
+    private func waitForSocketReady(timeout: TimeInterval) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            self.socketCommand("ping") == "PONG"
+        }
+    }
+
+    private func currentWorkspaceContext() -> WorkspaceContext? {
+        guard let envelope = socketJSON(method: "workspace.current", params: [:]),
+              let ok = envelope["ok"] as? Bool,
+              ok,
+              let result = envelope["result"] as? [String: Any],
+              let workspaceId = result["workspace_id"] as? String,
+              let windowId = result["window_id"] as? String else {
+            return nil
+        }
+        return WorkspaceContext(workspaceId: workspaceId, windowId: windowId)
+    }
+
+    private func currentWorkspaceDescription(workspaceId: String) -> String? {
+        guard let envelope = socketJSON(method: "workspace.current", params: [:]),
+              let ok = envelope["ok"] as? Bool,
+              ok,
+              let result = envelope["result"] as? [String: Any],
+              let currentWorkspaceId = result["workspace_id"] as? String,
+              currentWorkspaceId == workspaceId,
+              let workspace = result["workspace"] as? [String: Any] else {
+            return nil
+        }
+        return workspace["description"] as? String
+    }
+
+    private func waitForWorkspaceDescription(
+        workspaceId: String,
+        expectedDescription: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            self.currentWorkspaceDescription(workspaceId: workspaceId) == expectedDescription
+        }
+    }
+
+    private func waitForDescriptionPaletteOpen(windowId: String, timeout: TimeInterval) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            guard let snapshot = self.commandPaletteSnapshot(windowId: windowId) else { return false }
+            return (snapshot["visible"] as? Bool) == true
+                && (snapshot["mode"] as? String) == "workspace_description_input"
+        }
+    }
+
+    private func waitForDescriptionPaletteClosed(windowId: String, timeout: TimeInterval) -> Bool {
+        workspaceDescriptionPollUntil(timeout: timeout) {
+            guard let snapshot = self.commandPaletteSnapshot(windowId: windowId) else { return false }
+            return (snapshot["visible"] as? Bool) != true
+        }
+    }
+
+    private func commandPaletteSnapshot(windowId: String) -> [String: Any]? {
+        let envelope = socketJSON(
+            method: "debug.command_palette.results",
+            params: [
+                "window_id": windowId,
+                "limit": 20,
+            ]
+        )
+        guard let ok = envelope?["ok"] as? Bool, ok else { return nil }
+        return envelope?["result"] as? [String: Any]
+    }
+
+    private func socketCommand(_ command: String) -> String? {
+        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
+    }
+
+    private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
+            guard JSONSerialization.isValidJSONObject(object),
+                  let data = try? JSONSerialization.data(withJSONObject: object),
+                  let line = String(data: data, encoding: .utf8),
+                  let response = sendLine(line),
+                  let responseData = response.data(using: .utf8),
+                  let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+                return nil
+            }
+            return parsed
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+#if os(macOS)
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
+            }
+#endif
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let bytes = Array(path.utf8CString)
+            guard bytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
+                for index in 0..<bytes.count {
+                    raw[index] = bytes[index]
+                }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + bytes.count)
+#if os(macOS)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+#endif
+
+            let connected = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, addrLen)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = line + "\n"
+            let wrote: Bool = payload.withCString { cString in
+                var remaining = strlen(cString)
+                var pointer = UnsafeRawPointer(cString)
+                while remaining > 0 {
+                    let written = write(fd, pointer, remaining)
+                    if written <= 0 { return false }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+                return true
+            }
+            guard wrote else { return nil }
+
+            let deadline = Date().addingTimeInterval(responseTimeout)
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var accumulator = ""
+            while Date() < deadline {
+                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                let ready = poll(&pollDescriptor, 1, 100)
+                if ready < 0 {
+                    return nil
+                }
+                if ready == 0 {
+                    continue
+                }
+
+                let count = read(fd, &buffer, buffer.count)
+                if count <= 0 { break }
+                if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
+                    accumulator.append(chunk)
+                    if let newline = accumulator.firstIndex(of: "\n") {
+                        return String(accumulator[..<newline])
+                    }
+                }
+            }
+
+            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 }

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -95,11 +95,13 @@ final class WorkspaceDescriptionUITests: XCTestCase {
 
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
+        app.launchArguments += ["-socketControlMode", "cmuxOnly"]
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_FOCUS_SHORTCUTS"] = "1"
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = "ui-tests-workspace-description"
         return app
     }
 

--- a/cmuxUITests/WorkspaceDescriptionUITests.swift
+++ b/cmuxUITests/WorkspaceDescriptionUITests.swift
@@ -58,7 +58,7 @@ final class WorkspaceDescriptionUITests: XCTestCase {
         let editor = requireDescriptionEditor(in: app, timeout: 5.0)
         XCTAssertTrue(editor.exists, "Expected workspace description editor to open")
 
-        editor.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        editor.click()
         app.typeText(description)
         app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
 
@@ -97,6 +97,9 @@ final class WorkspaceDescriptionUITests: XCTestCase {
             app.textViews["CommandPaletteWorkspaceDescriptionEditor"],
             app.scrollViews["CommandPaletteWorkspaceDescriptionEditor"],
             app.otherElements["CommandPaletteWorkspaceDescriptionEditor"],
+            app.textViews["Edit Workspace Description…"],
+            app.textViews["Workspace description"],
+            app.staticTexts["Workspace description"],
             app.descendants(matching: .any).matching(identifier: "CommandPaletteWorkspaceDescriptionEditor").firstMatch,
         ]
     }


### PR DESCRIPTION
## Summary
- add a separate editable workspace description field below the sidebar title with multiline markdown rendering
- wire workspace description editing into the command palette, a new Cmd-Shift-E shortcut, the View menu, and the workspace context menu
- expose description read/write support through the socket API and `cmux` CLI, with persistence and focused regression coverage

## Verification
- built with `./scripts/reload.sh --tag task-sidebar-description-notes`
- did not run local test suites

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds editable workspace descriptions with Markdown in the sidebar. Also improves the editor by fixing Shift‑Enter newlines, preventing focus steals, preserving line breaks/whitespace, keeping navigation inside the multiline editor, and capping editor growth.

- **New Features**
  - Sidebar: shows a multiline Markdown description below the workspace title.
  - Command Palette: “Edit Workspace Description” multiline editor with Enter to save, Shift‑Enter for newline, Escape to cancel.
  - Shortcut & Menus: Cmd‑Shift‑E, View menu item, and workspace context menu; “Clear Workspace Description” is available when set.
  - Persistence & Search: description is saved/restored in session snapshots; workspace switcher indexes description text for fuzzy search.
  - API/CLI:
    - Socket API: `workspace.create` accepts `description`; `workspace.action` adds `set_description` and `clear_description`; workspace payloads include `description`.
    - `cmux`: `new-workspace --description <text>`; `workspace-action set-description` supports `--description <text>` or trailing text; `workspace-action clear-description`; `current-workspace` now uses v2 and respects `--id-format`.

- **Bug Fixes**
  - Shift‑Enter inserts a newline in the description editor; prevent terminal focus restore while the command palette is open.
  - Preserve line breaks and leading/trailing whitespace in sidebar Markdown; fix description refresh lag; expose multiline descriptions to accessibility.
  - Keep navigation keys inside the multiline editor (don’t route to palette list).
  - Cap description editor height to prevent runaway growth.

<sup>Written for commit 8e7fc4c07a196074645c7e7ec5efdadfa50357cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add workspace descriptions: create, edit, or clear custom descriptions via CLI, menu, context menu, command palette, or keyboard shortcut (⌘+Shift+E). Descriptions persist across sessions, show in the sidebar, and are indexed for search. Multiline editing supported with refined Return/Shift-Return behavior.

* **Localization**
  * Added localized labels, placeholders, and menu/command text for editing/clearing workspace descriptions.

* **Tests**
  * New tests for shortcut routing, command-palette submission, persistence, and search indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->