### PR TITLE
Keep GitHub stars badge stable across navigation

### DIFF
--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -7,6 +7,7 @@ const STARS_CACHE_TTL_MS = 300_000;
 let cachedStars: number | null = null;
 let cachedStarsFetchedAt = 0;
 let pendingStarsRequest: Promise<number | null> | null = null;
+let hasAnimatedPrimaryStarsBadge = false;
 
 function formatStars(count: number): string {
   if (count >= 1000) {
@@ -71,7 +72,16 @@ export function GitHubStarsBadge({
   className?: string;
 } = {}) {
   const [stars, setStars] = useState<number | null>(() => cachedStars);
-  const classes = `inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors ${className ?? ""}`;
+  const [shouldAnimate] = useState(
+    () => location === "stars_badge" && !hasAnimatedPrimaryStarsBadge
+  );
+  const classes = `inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors ${shouldAnimate ? "animate-fade-in" : ""} ${className ?? ""}`;
+
+  useEffect(() => {
+    if (shouldAnimate) {
+      hasAnimatedPrimaryStarsBadge = true;
+    }
+  }, [shouldAnimate]);
 
   useEffect(() => {
     let cancelled = false;

--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -3,12 +3,52 @@
 import { useEffect, useState } from "react";
 import posthog from "posthog-js";
 
+const STARS_CACHE_TTL_MS = 300_000;
+let cachedStars: number | null = null;
+let cachedStarsFetchedAt = 0;
+let pendingStarsRequest: Promise<number | null> | null = null;
+
 function formatStars(count: number): string {
   if (count >= 1000) {
     const k = Number((count / 1000).toFixed(1));
     return `${k}k`;
   }
   return String(count);
+}
+
+function hasFreshStarsCache() {
+  return (
+    cachedStars !== null &&
+    Date.now() - cachedStarsFetchedAt < STARS_CACHE_TTL_MS
+  );
+}
+
+function loadGitHubStars(): Promise<number | null> {
+  if (hasFreshStarsCache()) {
+    return Promise.resolve(cachedStars);
+  }
+
+  if (pendingStarsRequest) {
+    return pendingStarsRequest;
+  }
+
+  pendingStarsRequest = fetch("/api/github-stars")
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.stars != null) {
+        cachedStars = data.stars;
+        cachedStarsFetchedAt = Date.now();
+        return data.stars;
+      }
+
+      return cachedStars;
+    })
+    .catch(() => cachedStars)
+    .finally(() => {
+      pendingStarsRequest = null;
+    });
+
+  return pendingStarsRequest;
 }
 
 const GITHUB_ICON = (
@@ -30,16 +70,21 @@ export function GitHubStarsBadge({
   location?: string;
   className?: string;
 } = {}) {
-  const [stars, setStars] = useState<number | null>(null);
-  const classes = `inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in ${className ?? ""}`;
+  const [stars, setStars] = useState<number | null>(() => cachedStars);
+  const classes = `inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors ${className ?? ""}`;
 
   useEffect(() => {
-    fetch("/api/github-stars")
-      .then((r) => r.json())
-      .then((d) => {
-        if (d.stars != null) setStars(d.stars);
-      })
-      .catch(() => {});
+    let cancelled = false;
+
+    loadGitHubStars().then((nextStars) => {
+      if (!cancelled && nextStars != null) {
+        setStars(nextStars);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (stars === null) return null;


### PR DESCRIPTION
## Summary
- remove the GitHub stars badge fade-in class so it does not replay on client-side navigation
- cache the fetched star count in the client module so the badge stays visible across header remounts and desktop/mobile copies share one request

## Testing
- `cd web && SKIP_ENV_VALIDATION=1 npm run build` (passed)

## Issues
- Related: GitHub stars badge refades on navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the GitHub stars badge stable across navigation and header remounts, while restoring a one-time fade for the primary badge on its first render. Added a 5‑minute client cache with in‑flight request deduping and shared state so desktop and mobile badges reuse a single fetch and the badge stays visible.

<sup>Written for commit 6088bedecbe2234532eab3052169dcd9b0d2f27f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * GitHub stars now load faster and more reliably, using a shared 5-minute cache to reduce API calls and show stars immediately on load.

* **Style**
  * Fade-in animation for the GitHub stars badge is now applied only to the primary instance for a subtler, less repetitive effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->