### PR TITLE
Fix blank screen: remove occlusion cache that suppresses retries

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7332,7 +7332,6 @@ final class GhosttySurfaceScrollView: NSView {
     private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
-    private var lastRequestedPortalOcclusionVisible: Bool?
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
@@ -8679,10 +8678,10 @@ final class GhosttySurfaceScrollView: NSView {
         let wasVisible = surfaceView.isVisibleInUI
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
-        if wasVisible != visible, lastRequestedPortalOcclusionVisible != visible {
-            lastRequestedPortalOcclusionVisible = visible
-            surfaceView.terminalSurface?.setOcclusion(visible)
-        }
+        // Unconditional: setOcclusion is a cheap mailbox push and the renderer
+        // deduplicates. Gating on a local cache risks permanent desync if
+        // terminalSurface is nil during a visibility transition.
+        surfaceView.terminalSurface?.setOcclusion(visible)
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"


### PR DESCRIPTION
## Summary

Fixes a bug where terminal surfaces permanently go blank after certain transitions (vim exit, tab switching, notification events).

### Root Cause

`setVisibleInUI` gates `ghostty_surface_set_occlusion()` behind a `lastRequestedPortalOcclusionVisible` cache. The cache is updated *before* the optional chain `terminalSurface?.setOcclusion(visible)` — so when `terminalSurface` is nil (transient state during surface creation), the cache records "sent" while Ghostty was never notified. All subsequent calls with the same value are suppressed by the guard. The renderer thread's `if (!self.flags.visible) return` in `drawFrame` drops all draw requests forever — permanent blank screen.

### Fix

Remove the cache entirely. `ghostty_surface_set_occlusion()` is cheap (lock-free mailbox push) and idempotent (renderer thread deduplicates via `if (self.flags.visible == v) break`). The cache optimized away calls that don't need optimization.

`setOcclusion` is now called unconditionally in `setVisibleInUI`. If `terminalSurface` is nil, the optional chain skips, but the next `setVisibleInUI` call retries since there is no cache to suppress it.

### What stays the same

- Notification posting and first responder management remain gated on actual visibility transitions (`wasVisible != visible`)
- No Ghostty fork changes
- No new timers, polling, or callbacks

## Test plan
- [ ] Build passes
- [ ] Multi-tab vim open/close no longer causes blank screen
- [ ] Rapid workspace switching doesn't cause blank surfaces
- [ ] No performance regression during normal terminal use

Fixes #1156
Relates to #2224, #914, #2279


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permanent blank screens after visibility changes by removing the occlusion cache and always sending occlusion updates to the renderer. Fixes #1156; relates to #2224, #914, #2279.

- **Bug Fixes**
  - Removed the `lastRequestedPortalOcclusionVisible` cache and now call `terminalSurface?.setOcclusion(visible)` unconditionally in `setVisibleInUI` to prevent suppressed retries when the surface is nil.
  - Notifications and first-responder logic still trigger only on real visibility changes; the renderer deduplicates occlusion updates, so no performance impact.

<sup>Written for commit 86a2a464bbeab9fe2c0e7dafc79cf408229c882f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal surface visibility handling to ensure consistent occlusion updates during visibility transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->