### PR TITLE
Sync occlusion state on surface creation

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3969,6 +3969,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Ghostty's default.
         ghostty_surface_set_focus(createdSurface, desiredFocusState)
 
+        // Sync occlusion state to the newly created C surface. Ghostty surfaces
+        // default to visible=true, but this surface may be in a background tab
+        // or hidden workspace. Mirrors the focus sync pattern above.
+        if let view = attachedView {
+            setOcclusion(view.isVisibleInUI)
+        }
+
         NotificationCenter.default.post(
             name: .terminalSurfaceDidBecomeReady,
             object: self,


### PR DESCRIPTION
## Summary

Adds `setOcclusion(view.isVisibleInUI)` in `createSurface()` immediately after the existing `ghostty_surface_set_focus` call. This mirrors the focus sync pattern already established in `createSurface`.

### Why

`createSurface` already syncs focus state to newly created Ghostty surfaces because "this surface may have been logically unfocused before the C surface existed." The same applies to occlusion: a surface created in a background tab or hidden workspace should start with the correct visibility state.

Without this, newly created surfaces rely on a subsequent `setVisibleInUI` call from SwiftUI to sync occlusion. If SwiftUI's view state is stable (no re-evaluation triggered), the sync may not happen, leaving the surface with Ghostty's default (visible=true) even when it should be occluded — or vice versa.

### Change

One `if let` block (~4 lines) added after `ghostty_surface_set_focus` in `createSurface()`. No other changes.

## Test plan
- [ ] Build passes
- [ ] Surfaces created in background tabs start correctly occluded
- [ ] Surfaces created in foreground tabs render immediately

Relates to #1156, #2224


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs occlusion on surface creation by calling setOcclusion(view.isVisibleInUI) right after ghostty_surface_set_focus in createSurface(). This ensures new surfaces inherit the correct visibility (e.g., start occluded in background tabs) instead of defaulting to visible until SwiftUI triggers an update.

<sup>Written for commit 8e0fe840a96d2fa49a9dcf063e05543dabc49513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal surfaces now correctly respect their visibility state when first created, ensuring they display or hide appropriately in background tabs and hidden workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->