### PR TITLE
Defense-in-depth: reconcile occlusion state in forceRefresh

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4071,6 +4071,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
         guard let currentSurface = self.surface else { return }
 
+        // Reconcile occlusion: ensure Ghostty's visibility matches the view's.
+        // If a prior setOcclusion call was dropped (e.g. terminalSurface was nil),
+        // the renderer may think this surface is occluded. Re-asserting here
+        // provides a recovery path on focus changes, geometry updates, and
+        // manual cmux refresh-surfaces invocations.
+        setOcclusion(view.isVisibleInUI)
+
         // Re-read self.surface before each ghostty call to guard against the surface
         // being freed during wake-from-sleep geometry reconciliation (issue #432).
         // The surface can be invalidated between calls when AppKit layout triggers


### PR DESCRIPTION
## Summary

Adds `setOcclusion(view.isVisibleInUI)` to `TerminalSurface.forceRefresh()`, following the existing pattern of reconciling display ID and Metal layer size before forcing a surface redraw.

### Why

`forceRefresh` is the established recovery method for rendering issues — it is called on focus changes, geometry reconciliation, surface creation, user input, and via the `cmux refresh-surfaces` CLI command. It already re-asserts the display ID (to restart stuck CVDisplayLinks) and re-syncs the Metal layer size. Adding occlusion reconciliation makes it a recovery point for any occlusion state desync.

This is defense-in-depth: if any code path causes Ghostty's renderer to think a surface is occluded when it should be visible, the next `forceRefresh` call will correct it. `ghostty_surface_set_occlusion` is cheap (lock-free mailbox push) and idempotent (renderer thread deduplicates), so the redundant calls on already-synced surfaces have negligible cost.

### Change

One line added after the guard clauses in `forceRefresh()`. No other changes.

## Test plan
- [ ] Build passes
- [ ] Rapid tab switching shows no increase in jitter/flicker (regression check for #2279)
- [ ] `cmux refresh-surfaces` still works
- [ ] No performance regression during normal use

Relates to #1156, #2224, #914, #2279


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add occlusion reconciliation to `TerminalSurface.forceRefresh()` by calling `setOcclusion(view.isVisibleInUI)` before forcing a redraw. This keeps renderer visibility in sync and makes each refresh a recovery point for occlusion desyncs (on focus changes, geometry updates, input, surface creation, and `cmux refresh-surfaces`) with negligible overhead.

<sup>Written for commit f4b47868c58a007b20ccd9cb85828c956f4bf8bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the terminal view's visibility state was not properly synchronized with the renderer during focus changes and window updates, ensuring consistent display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->