### PR TITLE
fix(claude-hook): handle StopFailure to clear stale Running status

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -256,6 +256,8 @@ fi
 # Build hooks settings JSON.
 # Claude Code merges --settings additively with the user's own settings.json.
 # - SessionStart/Stop/Notification: existing lifecycle hooks
+# - StopFailure: mirrors Stop so the sidebar clears "Running" on abnormal turn exits
+#   (tool-approval timeout, rate-limit error, etc.) — claude-hook stop is idempotent
 # - SessionEnd: cleanup when Claude exits (covers Ctrl+C where Stop doesn't fire)
 # - UserPromptSubmit: clears "Needs input" and sets "Running" on new prompt
 # - PreToolUse: clears "Needs input" and captures AskUserQuestion text for notifications (async status only)
@@ -263,7 +265,7 @@ fi
 #   This is Claude Code's native blocking decision hook. It covers
 #   permissions, ExitPlanMode, and AskUserQuestion without using
 #   PreToolUse denial as a side channel.
-HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":125}]}]}}'
+HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":10,"async":true}]}],"StopFailure":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" feed-hook --source claude","timeout":125}]}]}}'
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" "${CMUX_BYPASS_AVAILABILITY_ARGS[@]}" --settings "$HOOKS_JSON" "$@"


### PR DESCRIPTION
## Summary

- Adds `StopFailure` to the injected `HOOKS_JSON` in `Resources/bin/claude`, pointing to the same `cmux claude-hook stop` handler already used for `Stop`
- `claude-hook stop` is idempotent (sets Idle, does not consume the session or clear the PID), so reusing it for `StopFailure` is safe

## Background

Fixes #2488.

When Claude Code exits a turn via `StopFailure` (tool-approval timeout, rate-limit error, uncaught exception, etc.), the `Stop` hook does not fire. The injected `HOOKS_JSON` had no `StopFailure` entry, so `cmux claude-hook stop` was never called and the sidebar status pill stayed permanently on **Running**.

The existing `sweepStaleAgentPIDs` timer (30 s) only helps if the process has fully exited — if Claude is still alive after a `StopFailure` turn, the PID liveness check passes and the stale **Running** pill is never cleared.

## Test plan

- [ ] Start a Claude Code session in cmux; sidebar shows **Running**
- [ ] Trigger a `StopFailure`: let a tool-use permission request time out (or simulate with `kill -TERM` mid-response)
- [ ] Confirm sidebar transitions to **Idle** instead of staying on **Running**
- [ ] Confirm a subsequent prompt correctly transitions back to **Running**
- [ ] Confirm normal `Stop` flow (clean turn end) still sets **Idle** correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `StopFailure` hook to the injected `HOOKS_JSON`, reusing `cmux claude-hook stop`, so the sidebar clears from "Running" to "Idle" after abnormal exits (tool-approval timeout, rate limit, etc.). Fixes #2488.

<sup>Written for commit 24339b8693bb0fb844fa73ed4d3cb3b6e9262ffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of abnormal session exits so the app reliably clears the “Running” sidebar state and performs proper cleanup.
  * Ensured shutdown/stop behavior runs consistently on failure paths to avoid lingering resource or UI state after unexpected terminations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->