### PR TITLE
fix(claude-hook): show "Stopped" subtitle for StopFailure notifications

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -316,6 +316,13 @@ private struct ClaudeHookParsedInput {
     let sessionId: String?
     let cwd: String?
     let transcriptPath: String?
+    /// `stop_reason` from the Claude Code hook payload (e.g. `"end_turn"`, `"error"`, `"tool_use_limit"`).
+    /// Present when provided by the hook payload (typically for Stop/StopFailure hook events).
+    let stopReason: String?
+    /// `hook_event_name` from the Claude Code hook payload (e.g. `"Stop"`, `"StopFailure"`).
+    let hookEventName: String?
+    /// `error` field from the Claude Code StopFailure hook payload (e.g. `"rate_limit"`, `"server_error"`).
+    let hookError: String?
 }
 
 private struct ClaudeHookSessionRecord: Codable {
@@ -13338,19 +13345,25 @@ struct CMUXCLI {
                 normalizedSingleLine(redactClaudeSensitiveSpans(trimmed)),
                 maxLength: 180
             )
-            return ClaudeHookParsedInput(object: nil, rawFallback: fallback, sessionId: nil, cwd: nil, transcriptPath: nil)
+            return ClaudeHookParsedInput(object: nil, rawFallback: fallback, sessionId: nil, cwd: nil, transcriptPath: nil, stopReason: nil, hookEventName: nil, hookError: nil)
         }
 
         let sessionId = extractClaudeHookSessionId(from: object)
         let cwd = extractClaudeHookCWD(from: object)
         let transcriptPath = firstString(in: object, keys: ["transcript_path", "transcriptPath"])
+        let stopReason = firstString(in: object, keys: ["stop_reason", "stopReason"])
+        let hookEventName = firstString(in: object, keys: ["hook_event_name", "hookEventName"])
+        let hookError = firstString(in: object, keys: ["error"])
         let compactObject = compactClaudeHookObject(object)
         return ClaudeHookParsedInput(
             object: compactObject,
             rawFallback: nil,
             sessionId: sessionId,
             cwd: cwd,
-            transcriptPath: transcriptPath
+            transcriptPath: transcriptPath,
+            stopReason: stopReason,
+            hookEventName: hookEventName,
+            hookError: hookError
         )
     }
 
@@ -13557,13 +13570,26 @@ struct CMUXCLI {
             return tail.isEmpty ? path : tail
         }()
 
+        // Derive the turn verb from hook_event_name / hookError / stop_reason (in that priority order).
+        // StopFailure hook payloads carry hook_event_name="StopFailure" and an error field instead of
+        // stop_reason, so we check those first before falling back to stop_reason for back-compat.
+        let isFailure: Bool = {
+            if parsedInput.hookEventName == "StopFailure" { return true }
+            if parsedInput.hookError != nil { return true }
+            guard let reason = parsedInput.stopReason else { return false }
+            return reason != "end_turn"
+        }()
+        let verb = isFailure
+            ? String(localized: "claude.hook.stop.verb.stopped", defaultValue: "Stopped")
+            : String(localized: "claude.hook.stop.verb.completed", defaultValue: "Completed")
+
         // Try reading the transcript JSONL for a richer summary.
         let transcript = transcriptPath.flatMap { readTranscriptSummary(path: $0) }
 
         if let lastMsg = transcript?.lastAssistantMessage {
-            var subtitle = "Completed"
+            var subtitle = verb
             if let projectName, !projectName.isEmpty {
-                subtitle = "Completed in \(projectName)"
+                subtitle = "\(verb) in \(projectName)"
             }
             return (subtitle, truncate(lastMsg, maxLength: 200))
         }
@@ -13573,14 +13599,21 @@ struct CMUXCLI {
         let hasContext = cwd != nil || lastMessage != nil
         guard hasContext else { return nil }
 
-        var body = "Claude session completed"
+        var subtitle = verb
+        if let projectName, !projectName.isEmpty {
+            subtitle = "\(verb) in \(projectName)"
+        }
+        let sessionState = isFailure
+            ? String(localized: "claude.hook.stop.state.stopped", defaultValue: "stopped")
+            : String(localized: "claude.hook.stop.state.completed", defaultValue: "completed")
+        var body = "Claude session \(sessionState)"
         if let projectName, !projectName.isEmpty {
             body += " in \(projectName)"
         }
         if let lastMessage, !lastMessage.isEmpty {
             body += ". Last: \(lastMessage)"
         }
-        return ("Completed", body)
+        return (subtitle, body)
     }
 
     private struct TranscriptSummary {


### PR DESCRIPTION
## Summary

- Parses `stop_reason` from the Claude Code hook payload in `parseClaudeHookInput`
- Threads it through `summarizeClaudeHookStop` to produce an accurate notification subtitle
- `stop_reason == "end_turn"` (or absent) → **"Completed"** / **"Completed in \<project\>"** (unchanged)
- Any other `stop_reason` (e.g. `"error"`, `"tool_use_limit"`) → **"Stopped"** / **"Stopped in \<project\>"**

## Background

Fixes #2490. Follow-up to #2489.

`summarizeClaudeHookStop` previously hardcoded `subtitle = "Completed"` regardless of how the turn ended. After #2489 wired `StopFailure` to `claude-hook stop`, a turn ending via tool-approval timeout or rate-limit error would send a notification reading "Completed in \<project\>" — misleading for an error exit.

The fix reads `stop_reason` directly from the hook JSON payload (the field Claude Code already includes) and selects the subtitle accordingly.

## Test plan

- [ ] Normal turn (`stop_reason: "end_turn"`): notification subtitle shows **"Completed in \<project\>"**
- [ ] Error exit (`stop_reason: "error"`): notification subtitle shows **"Stopped in \<project\>"**
- [ ] Tool timeout (`stop_reason: "tool_use_limit"`): notification subtitle shows **"Stopped in \<project\>"**
- [ ] No `stop_reason` field in payload: defaults to **"Completed"** (safe fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix notification subtitles for `claude-hook stop` so abnormal exits show "Stopped" and normal turns still show "Completed". Also localizes notification strings, resyncs terminal portal geometry after restore, and stabilizes UI test activation. Fixes #2490 and #1972.

- **Bug Fixes**
  - Parse `hook_event_name`, `error`, and `stop_reason` in `parseClaudeHookInput`; detect failures by preferring `hook_event_name == "StopFailure"` or `error`, then fall back to `stop_reason != "end_turn"`. Localize both the verb ("Stopped"/"Completed") and the session state in the body; include project names in subtitles.
  - Resync terminal portal after bind by scheduling an external geometry sync to capture queued layout shifts during restore; add a unit test to prevent stale hit-testing.
  - Stabilize UI test launch by retrying foreground activation and opening a fallback window if needed; add a targeted CI retry for the display resolution UI test flake.

<sup>Written for commit 0d1c7101fdc6b9d4620b178d75f23aea8b262e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude Code stop state detection with more accurate status reporting
  * Enhanced messaging to distinguish between stopped and completed states using localized text
  * Added project context and session state information to fallback messages for better clarity and context
<!-- end of auto-generated comment: release notes by coderabbit.ai -->