### PR TITLE
Fix bash job completion notifications leaking to terminal

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -380,9 +380,7 @@ _cmux_report_tty_once() {
         payload="$(_cmux_report_tty_payload)"
         [[ -n "$payload" ]] || return 0
         _CMUX_TTY_REPORTED=1
-        {
-            _cmux_send "$payload"
-        } >/dev/null 2>&1 & disown
+        ( _cmux_send "$payload" >/dev/null 2>&1 & )
     else
         [[ -n "$_CMUX_TTY_NAME" ]] || return 0
         # Keep the first relay TTY report synchronous so the server can resolve
@@ -400,9 +398,7 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
-        _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    ( _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" >/dev/null 2>&1 & )
 }
 
 _cmux_ports_kick() {
@@ -416,9 +412,7 @@ _cmux_ports_kick() {
     fi
     _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     if _cmux_socket_is_unix; then
-        {
-            _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
-        } >/dev/null 2>&1 & disown
+        ( _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason" >/dev/null 2>&1 & )
     else
         _cmux_ports_kick_via_relay "$reason"
     fi
@@ -1004,10 +998,10 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
+        (
             local qpwd="${pwd//\"/\\\"}"
-            _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+            _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID" >/dev/null 2>&1 &
+        )
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.


### PR DESCRIPTION
## Summary

Replace `{ cmd; } & disown` with `( cmd & )` subshell pattern in the bash integration script to prevent spurious `[n] Done ...` messages from appearing after every command.

## Problem

After every command in a cmux bash terminal, users see:

```
[2]   Done                       { _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"; } > /dev/null 2>&1
[3]   Done                       { _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"; } > /dev/null 2>&1
```

The `{ ... } & disown` pattern registers a job number at creation time. When these short-lived tasks finish, bash reports completion before the next prompt — even though `disown` was called. This is a known bash behavior.

The zsh integration already handles this correctly via `_cmux_send_bg` using `&!`, but the bash side lacked an equivalent fix.

## Fix

Changed 4 occurrences in `cmux-bash-integration.bash`:

- `_cmux_report_tty_once` — tty name reporting
- `_cmux_report_shell_activity_state` — shell state sync
- `_cmux_ports_kick` — port scanner kick
- `_cmux_prompt_command` — pwd sync

The outer `( ... )` subshell exits immediately. The inner `cmd &` process becomes an orphan that bash no longer tracks, preventing any job notification. Functionality is preserved.

Closes #2494

## Test plan

- [x] Open a cmux terminal with bash, run a command — verify no `[n] Done ...` output
- [x] Verify shell state, port detection, cwd tracking, and git branch detection still work in the sidebar
- [ ] Test in a non-cmux terminal to confirm no regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop bash job-completion messages by launching cmux background tasks in a subshell. Replace `{ cmd; } & disown` with `( cmd & )` so bash doesn’t track and announce jobs.

- **Bug Fixes**
  - Prevent `[n] Done ...` lines after commands in cmux bash sessions using `( _cmux_send ... & )`.
  - Updated: `_cmux_report_tty_once`, `_cmux_report_shell_activity_state`, `_cmux_ports_kick`, `_cmux_prompt_command`.

<sup>Written for commit aabda9113bc7d113836171bf0463f7794022a036. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved shell integration’s background task handling to be quieter and more reliable by changing how asynchronous notifications are launched and output is suppressed.
  * Reduced background noise and likelihood of orphaned processes by simplifying background execution mechanics.
  * No user-facing interfaces changed; behavior and features remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->