### PR TITLE
Fix pane flashing blank during Bonsplit reparenting

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9456,9 +9456,12 @@ final class Workspace: Identifiable, ObservableObject {
         var visiblePanelIds: Set<UUID> = []
 
         for paneId in renderedPaneIds {
-            let selectedTab = bonsplitController.selectedTab(inPane: paneId) ?? bonsplitController.tabs(inPane: paneId).first
-            guard let selectedTab,
-                  let panelId = panelIdFromSurfaceId(selectedTab.id),
+            let selectedTabId = visibleTabIdForPaneSelection(
+                selectedTabId: bonsplitController.selectedTab(inPane: paneId)?.id,
+                tabsInPane: bonsplitController.tabs(inPane: paneId)
+            )
+            guard let selectedTabId,
+                  let panelId = panelIdFromSurfaceId(selectedTabId),
                   panels[panelId] != nil else {
                 continue
             }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -3,6 +3,15 @@ import Foundation
 import AppKit
 import Bonsplit
 
+func visibleTabIdForPaneSelection(
+    selectedTabId: TabID?,
+    tabsInPane: [Bonsplit.Tab]
+) -> TabID? {
+    // Bonsplit can transiently clear selectedTab during pane reparenting/reorganization.
+    // Fall back to the first tab so visible panes don't flash blank while selection settles.
+    selectedTabId ?? tabsInPane.first?.id
+}
+
 enum TmuxOverlayExperimentTarget: String, CaseIterable, Codable, Sendable {
     case surface
     case bonsplitPane
@@ -283,7 +292,10 @@ struct WorkspaceContentView: View {
             let _ = Self.debugPanelLookup(tab: tab, workspace: workspace)
             if let panel = workspace.panel(for: tab.id) {
                 let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
-                let isSelectedInPane = workspace.bonsplitController.selectedTab(inPane: paneId)?.id == tab.id
+                let isSelectedInPane = visibleTabIdForPaneSelection(
+                    selectedTabId: workspace.bonsplitController.selectedTab(inPane: paneId)?.id,
+                    tabsInPane: workspace.bonsplitController.tabs(inPane: paneId)
+                ) == tab.id
                 let isVisibleInUI = Self.panelVisibleInUI(
                     isWorkspaceVisible: isWorkspaceVisible,
                     isSelectedInPane: isSelectedInPane,

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -79,6 +79,41 @@ final class WorkspaceContentViewVisibilityTests: XCTestCase {
         )
     }
 
+    func testVisibleTabIdForPaneSelectionPrefersSelectedTab() {
+        let first = Bonsplit.Tab(id: TabID(), title: "First")
+        let second = Bonsplit.Tab(id: TabID(), title: "Second")
+
+        XCTAssertEqual(
+            visibleTabIdForPaneSelection(
+                selectedTabId: second.id,
+                tabsInPane: [first, second]
+            ),
+            second.id
+        )
+    }
+
+    func testVisibleTabIdForPaneSelectionFallsBackToFirstTabDuringSelectionGap() {
+        let first = Bonsplit.Tab(id: TabID(), title: "First")
+        let second = Bonsplit.Tab(id: TabID(), title: "Second")
+
+        XCTAssertEqual(
+            visibleTabIdForPaneSelection(
+                selectedTabId: nil,
+                tabsInPane: [first, second]
+            ),
+            first.id
+        )
+    }
+
+    func testVisibleTabIdForPaneSelectionReturnsNilForEmptyPane() {
+        XCTAssertNil(
+            visibleTabIdForPaneSelection(
+                selectedTabId: nil,
+                tabsInPane: []
+            )
+        )
+    }
+
     func testTmuxWorkspacePaneOverlayRectReturnsMatchingPaneFrame() {
         let paneID = PaneID(id: UUID())
         let snapshot = LayoutSnapshot(


### PR DESCRIPTION
## Summary
- Bonsplit transiently clears `selectedTab` during pane reorganization, causing visible panes to flash blank
- Extracted `visibleTabIdForPaneSelection` helper that falls back to the first tab when selection is nil, used in both `Workspace.recomputeVisiblePanelIds()` and `WorkspaceContentView`
- Added regression tests covering selected-tab preference, nil-selection fallback, and empty-pane edge case

## Test plan
- [ ] Verify panes no longer flash blank when dragging/splitting panes
- [ ] Unit tests pass for `visibleTabIdForPaneSelection`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes panes flashing blank during `Bonsplit` pane reparenting by ensuring a visible tab is always selected. Panels now stay visible while selection settles.

- **Bug Fixes**
  - Added `visibleTabIdForPaneSelection` to prefer the selected tab and fall back to the first tab (nil if none).
  - Used the helper in `Workspace.recomputeVisiblePanelIds()` and `WorkspaceContentView` to compute the visible tab.
  - Added tests for selected-tab preference, nil-selection fallback, and empty-pane behavior.

<sup>Written for commit b64709fed56102c7ab6ea7d18719d4c132119f3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tab selection resolution logic to prevent panes from being incorrectly treated as unselected during transient state changes, ensuring consistent workspace visibility.

* **Tests**
  * Added comprehensive test coverage for tab selection behavior, including edge cases such as empty pane lists and missing selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->