### PR TITLE
Fix browser panel resize flicker during split drag

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2111,7 +2111,26 @@ final class WindowBrowserPortal: NSObject {
         // WebKit's attached DevTools uses internal NSSplitView instances for the
         // side/bottom inspector layout. Those resizes are local to hosted content
         // and should not trigger a full portal re-sync/refresh pass.
-        return !splitView.isDescendant(of: hostView)
+        guard !splitView.isDescendant(of: hostView) else { return false }
+        // Browser host anchors already emit coalesced geometry callbacks while the
+        // user drags a split divider. Running the portal-wide external-geometry
+        // sync on the same drag frame doubles up WebKit refresh work and shows up
+        // as visible flicker in browser panes.
+        return !isInteractiveSplitDividerDrag(in: window)
+    }
+
+    private static func isInteractiveSplitDividerDrag(in window: NSWindow) -> Bool {
+        guard (NSEvent.pressedMouseButtons & 1) != 0 else { return false }
+        guard let event = NSApp.currentEvent else { return false }
+        let now = ProcessInfo.processInfo.systemUptime
+        guard (now - event.timestamp) < 0.1 else { return false }
+        guard event.window === window else { return false }
+        switch event.type {
+        case .leftMouseDown, .leftMouseDragged:
+            return true
+        default:
+            return false
+        }
     }
 
     private func installGeometryObservers(for window: NSWindow) {


### PR DESCRIPTION
## Summary
- Skip redundant portal-wide geometry sync when an interactive split divider drag is already in progress, since browser host anchors already emit coalesced geometry callbacks
- Adds `isInteractiveSplitDividerDrag` check to prevent double WebKit refresh that caused visible flicker in browser panes

Closes #2503

## Test plan
- [ ] Open a browser panel alongside a terminal split
- [ ] Drag the split divider back and forth — browser pane should resize smoothly without flicker
- [ ] Verify DevTools split views still work correctly (internal NSSplitView bypass unchanged)
- [ ] Confirm no regressions in browser portal sync when not dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser pane flicker during split resize by skipping redundant portal-wide geometry sync while a divider drag is in progress. This prevents double WebKit refresh and makes resizing smooth.

- **Bug Fixes**
  - Skip portal-wide geometry sync during interactive split divider drags to avoid duplicate WebKit refresh.
  - Add `isInteractiveSplitDividerDrag` helper that detects recent left-mouse drag events on the same window.

<sup>Written for commit 2dbb8c2930c2192a0d9fd5564700f8d150fb9def. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window split pane resize behavior during interactive dragging. The application now correctly suppresses external geometry synchronization when a split divider is actively being dragged, preventing unwanted geometry updates that could interfere with the resize operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->