### PR TITLE
Add Claude Binary Path setting

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9697,7 +9697,10 @@ struct CMUXCLI {
             ]
             for raw in candidates {
                 guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
-                      !trimmed.isEmpty,
+                      !trimmed.isEmpty else { continue }
+                var isDir: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: trimmed, isDirectory: &isDir),
+                      !isDir.boolValue,
                       FileManager.default.isExecutableFile(atPath: trimmed),
                       !isCmuxClaudeWrapper(at: trimmed) else { continue }
                 return trimmed

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9688,12 +9688,25 @@ struct CMUXCLI {
             .deletingLastPathComponent()
             .appendingPathComponent("claude", isDirectory: false)
             .path
-        let claudeExecutablePath = resolveClaudeExecutable(searchPath: launcherEnvironment["PATH"])
-            ?? {
-                guard let bundledClaudePath,
-                      FileManager.default.isExecutableFile(atPath: bundledClaudePath) else { return nil }
-                return bundledClaudePath
-            }()
+        let claudeExecutablePath: String? = {
+            // Check custom path from Settings > Automation > Claude Code
+            if let custom = launcherEnvironment["CMUX_CUSTOM_CLAUDE_PATH"],
+               !custom.isEmpty,
+               FileManager.default.isExecutableFile(atPath: custom) {
+                return custom
+            }
+            if let custom = UserDefaults.standard.string(forKey: "claudeCodeCustomClaudePath"),
+               !custom.isEmpty,
+               FileManager.default.isExecutableFile(atPath: custom) {
+                return custom
+            }
+            return resolveClaudeExecutable(searchPath: launcherEnvironment["PATH"])
+                ?? {
+                    guard let bundledClaudePath,
+                          FileManager.default.isExecutableFile(atPath: bundledClaudePath) else { return nil }
+                    return bundledClaudePath
+                }()
+        }()
         configureClaudeTeamsEnvironment(
             processEnvironment: launcherEnvironment,
             shimDirectory: shimDirectory,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9689,16 +9689,18 @@ struct CMUXCLI {
             .appendingPathComponent("claude", isDirectory: false)
             .path
         let claudeExecutablePath: String? = {
-            // Check custom path from Settings > Automation > Claude Code
-            if let custom = launcherEnvironment["CMUX_CUSTOM_CLAUDE_PATH"],
-               !custom.isEmpty,
-               FileManager.default.isExecutableFile(atPath: custom) {
-                return custom
-            }
-            if let custom = UserDefaults.standard.string(forKey: "claudeCodeCustomClaudePath"),
-               !custom.isEmpty,
-               FileManager.default.isExecutableFile(atPath: custom) {
-                return custom
+            // Check custom path from Settings > Automation > Claude Code.
+            // Try env var first (set by the app per-session), then UserDefaults.
+            let candidates = [
+                launcherEnvironment["CMUX_CUSTOM_CLAUDE_PATH"],
+                UserDefaults.standard.string(forKey: "claudeCodeCustomClaudePath"),
+            ]
+            for raw in candidates {
+                guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !trimmed.isEmpty,
+                      FileManager.default.isExecutableFile(atPath: trimmed),
+                      !isCmuxClaudeWrapper(at: trimmed) else { continue }
+                return trimmed
             }
             return resolveClaudeExecutable(searchPath: launcherEnvironment["PATH"])
                 ?? {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53123,6 +53123,57 @@
         }
       }
     },
+    "settings.automation.claudeCode.customPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Binary Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claudeバイナリパス"
+          }
+        }
+      }
+    },
+    "settings.automation.claudeCode.customPath.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. /usr/local/bin/claude"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: /usr/local/bin/claude"
+          }
+        }
+      }
+    },
+    "settings.automation.claudeCode.customPath.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom path to the claude binary. Leave empty to use PATH."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "claudeバイナリのカスタムパス。空欄の場合はPATHを使用します。"
+          }
+        }
+      }
+    },
     "settings.automation.claudeCode.note": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -8,6 +8,11 @@
 
 # Find the real claude binary, skipping our own directory.
 find_real_claude() {
+    # Honor custom path from Settings > Automation > Claude Code > Claude Binary Path
+    if [[ -n "${CMUX_CUSTOM_CLAUDE_PATH:-}" && -x "$CMUX_CUSTOM_CLAUDE_PATH" ]]; then
+        printf '%s' "$CMUX_CUSTOM_CLAUDE_PATH"
+        return 0
+    fi
     local self_dir
     self_dir="$(cd "$(dirname "$0")" && pwd)"
     local IFS=:

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -8,10 +8,19 @@
 
 # Find the real claude binary, skipping our own directory.
 find_real_claude() {
-    # Honor custom path from Settings > Automation > Claude Code > Claude Binary Path
-    if [[ -n "${CMUX_CUSTOM_CLAUDE_PATH:-}" && -x "$CMUX_CUSTOM_CLAUDE_PATH" ]]; then
-        printf '%s' "$CMUX_CUSTOM_CLAUDE_PATH"
-        return 0
+    # Honor custom path from Settings > Automation > Claude Code > Claude Binary Path.
+    # Guard against self-reference (user pointing back to this wrapper).
+    local custom="${CMUX_CUSTOM_CLAUDE_PATH:-}"
+    custom="${custom#"${custom%%[![:space:]]*}"}"  # trim leading whitespace
+    custom="${custom%"${custom##*[![:space:]]}"}"  # trim trailing whitespace
+    if [[ -n "$custom" && -f "$custom" && -x "$custom" ]]; then
+        local custom_real self_real
+        custom_real="$(cd "$(dirname "$custom")" && pwd)/$(basename "$custom")"
+        self_real="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+        if [[ "$custom_real" != "$self_real" ]]; then
+            printf '%s' "$custom"
+            return 0
+        fi
     fi
     local self_dir
     self_dir="$(cd "$(dirname "$0")" && pwd)"

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -14,10 +14,8 @@ find_real_claude() {
     custom="${custom#"${custom%%[![:space:]]*}"}"  # trim leading whitespace
     custom="${custom%"${custom##*[![:space:]]}"}"  # trim trailing whitespace
     if [[ -n "$custom" && -f "$custom" && -x "$custom" ]]; then
-        local custom_real self_real
-        custom_real="$(cd "$(dirname "$custom")" && pwd)/$(basename "$custom")"
-        self_real="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
-        if [[ "$custom_real" != "$self_real" ]]; then
+        # Use -ef to detect same underlying file even through symlinks
+        if [[ ! "$custom" -ef "$0" ]]; then
             printf '%s' "$custom"
             return 0
         fi

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3756,6 +3756,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         if !claudeHooksEnabled {
             setManagedEnvironmentValue("CMUX_CLAUDE_HOOKS_DISABLED", "1")
         }
+        if let customClaudePath = ClaudeCodeIntegrationSettings.customClaudePath() {
+            setManagedEnvironmentValue("CMUX_CUSTOM_CLAUDE_PATH", customClaudePath)
+        }
 
         if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
             let currentPath = env["PATH"]

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5388,6 +5388,10 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardNote(String(localized: "settings.automation.claudeCode.note", defaultValue: "When enabled, cmux wraps the claude command to inject session tracking and notification hooks. Disable if you prefer to manage Claude Code hooks yourself."))
+                    }
+
+                    SettingsCard {
                         SettingsCardRow(
                             String(localized: "settings.automation.claudeCode.customPath", defaultValue: "Claude Binary Path"),
                             subtitle: String(localized: "settings.automation.claudeCode.customPath.subtitle", defaultValue: "Custom path to the claude binary. Leave empty to use PATH.")
@@ -5399,10 +5403,6 @@ struct SettingsView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
                         }
-
-                        SettingsCardDivider()
-
-                        SettingsCardNote(String(localized: "settings.automation.claudeCode.note", defaultValue: "When enabled, cmux wraps the claude command to inject session tracking and notification hooks. Disable if you prefer to manage Claude Code hooks yourself."))
                     }
 
                     SettingsCard {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3931,7 +3931,8 @@ enum ClaudeCodeIntegrationSettings {
     }
 
     static func customClaudePath(defaults: UserDefaults = .standard) -> String? {
-        let value = defaults.string(forKey: customClaudePathKey) ?? ""
+        let value = defaults.string(forKey: customClaudePathKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return value.isEmpty ? nil : value
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3921,12 +3921,18 @@ enum CommandPaletteSwitcherSearchSettings {
 enum ClaudeCodeIntegrationSettings {
     static let hooksEnabledKey = "claudeCodeHooksEnabled"
     static let defaultHooksEnabled = true
+    static let customClaudePathKey = "claudeCodeCustomClaudePath"
 
     static func hooksEnabled(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: hooksEnabledKey) == nil {
             return defaultHooksEnabled
         }
         return defaults.bool(forKey: hooksEnabledKey)
+    }
+
+    static func customClaudePath(defaults: UserDefaults = .standard) -> String? {
+        let value = defaults.string(forKey: customClaudePathKey) ?? ""
+        return value.isEmpty ? nil : value
     }
 }
 
@@ -4006,6 +4012,8 @@ struct SettingsView: View {
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+    @AppStorage(ClaudeCodeIntegrationSettings.customClaudePathKey)
+    private var customClaudePath = ""
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
@@ -5380,6 +5388,20 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardRow(
+                            String(localized: "settings.automation.claudeCode.customPath", defaultValue: "Claude Binary Path"),
+                            subtitle: String(localized: "settings.automation.claudeCode.customPath.subtitle", defaultValue: "Custom path to the claude binary. Leave empty to use PATH.")
+                        ) {
+                            TextField(
+                                String(localized: "settings.automation.claudeCode.customPath.placeholder", defaultValue: "e.g. /usr/local/bin/claude"),
+                                text: $customClaudePath
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 200)
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsCardNote(String(localized: "settings.automation.claudeCode.note", defaultValue: "When enabled, cmux wraps the claude command to inject session tracking and notification hooks. Disable if you prefer to manage Claude Code hooks yourself."))
                     }
 
@@ -5945,6 +5967,7 @@ struct SettingsView: View {
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+        customClaudePath = ""
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         preferredEditorCommand = ""
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue


### PR DESCRIPTION
## Summary

- Adds a "Claude Binary Path" text field in Settings > Automation > Claude Code Integration
- When set, the custom path takes priority over PATH lookup in the bundled `claude` wrapper, `cmux claude-teams` CLI, and UserDefaults
- Solves the case where users have `claude` installed outside PATH or aliased in their shell profile

## Test plan

- [ ] Open Settings > Automation, verify new "Claude Binary Path" field appears below the hooks toggle
- [ ] Leave empty, verify `claude` and `cmux claude-teams` resolve via PATH as before
- [ ] Set to a valid claude binary path, verify it's used instead of PATH
- [ ] Set to an invalid path, verify fallback to PATH resolution
- [ ] Reset all settings, verify the field clears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Claude Binary Path” setting so users can point to a specific `claude` binary when PATH or aliases don’t apply. It’s in its own settings card and is respected by the `claude` wrapper, `cmux claude-teams`, and terminal sessions via `CMUX_CUSTOM_CLAUDE_PATH`, with safe fallbacks.

- **New Features**
  - Respects `CMUX_CUSTOM_CLAUDE_PATH` and `UserDefaults` key `claudeCodeCustomClaudePath`; resolution: custom → PATH lookup → bundled binary.
  - App injects `CMUX_CUSTOM_CLAUDE_PATH` per session so shells use the chosen binary.
  - Localized UI (EN/JA); Reset All clears the field.

- **Bug Fixes**
  - Trim whitespace, ignore empty values, and require real executables; reject directories.
  - Use a symlink-safe self-reference guard (`-ef`) to skip the wrapper itself.

<sup>Written for commit 66d286eec1755dc41c2b3ac0ad60e78942bb6025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Claude Binary Path” setting so users can specify a custom Claude executable; the app now prefers this custom path (from settings or a launcher-provided env) when launching Claude Code and Reset Settings clears it.
  * The per-surface runtime environment now includes the configured custom path so launched sessions use the specified binary when applicable.

* **Localization**
  * Added English and Japanese labels, placeholder, and subtitle for the custom Claude path setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->