### PR TITLE
Fix degraded colors in claude-teams

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9550,7 +9550,7 @@ struct CMUXCLI {
         let fakeTmuxPane = focusedContext.map { "%\($0.paneHandle)" }
             ?? processEnvironment["TMUX_PANE"]
             ?? "%1"
-        let fakeTerm = processEnvironment[termOverrideEnvVar] ?? "xterm-256color"
+        let fakeTerm = processEnvironment[termOverrideEnvVar] ?? "xterm-ghostty"
 
         setenv(cmuxBinEnvVar, executablePath, 1)
         setenv("PATH", updatedPath, 1)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9550,13 +9550,14 @@ struct CMUXCLI {
         let fakeTmuxPane = focusedContext.map { "%\($0.paneHandle)" }
             ?? processEnvironment["TMUX_PANE"]
             ?? "%1"
-        let fakeTerm = processEnvironment[termOverrideEnvVar] ?? "screen-256color"
+        let fakeTerm = processEnvironment[termOverrideEnvVar] ?? "xterm-256color"
 
         setenv(cmuxBinEnvVar, executablePath, 1)
         setenv("PATH", updatedPath, 1)
         setenv("TMUX", fakeTmuxValue, 1)
         setenv("TMUX_PANE", fakeTmuxPane, 1)
         setenv("TERM", fakeTerm, 1)
+        setenv("COLORTERM", "truecolor", 1)
         setenv("CMUX_SOCKET_PATH", socketPath, 1)
         setenv("CMUX_SOCKET", socketPath, 1)
         if let explicitPassword,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9564,7 +9564,6 @@ struct CMUXCLI {
            !explicitPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             setenv("CMUX_SOCKET_PASSWORD", explicitPassword, 1)
         }
-        unsetenv("TERM_PROGRAM")
         for envVar in extraEnvVars {
             setenv(envVar.key, envVar.value, 1)
         }
@@ -10185,6 +10184,9 @@ struct CMUXCLI {
             termOverrideEnvVar: "CMUX_OMO_TERM",
             extraEnvVars: [(key: "OPENCODE_PORT", value: openCodePort)]
         )
+        // Unset TERM_PROGRAM for opencode specifically: it switches to
+        // light theme when it sees TERM_PROGRAM=ghostty.
+        unsetenv("TERM_PROGRAM")
     }
 
     private func runOMO(

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -375,9 +375,10 @@ func configureAgentEnvironment(cfg agentConfig) {
 	// Terminal settings
 	fakeTerm := os.Getenv(cfg.termEnvVar)
 	if fakeTerm == "" {
-		fakeTerm = "screen-256color"
+		fakeTerm = "xterm-256color"
 	}
 	os.Setenv("TERM", fakeTerm)
+	os.Setenv("COLORTERM", "truecolor")
 
 	// Socket path
 	os.Setenv("CMUX_SOCKET_PATH", cfg.socketPath)

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -375,7 +375,7 @@ func configureAgentEnvironment(cfg agentConfig) {
 	// Terminal settings
 	fakeTerm := os.Getenv(cfg.termEnvVar)
 	if fakeTerm == "" {
-		fakeTerm = "xterm-256color"
+		fakeTerm = "xterm-ghostty"
 	}
 	os.Setenv("TERM", fakeTerm)
 	os.Setenv("COLORTERM", "truecolor")

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -384,11 +384,6 @@ func configureAgentEnvironment(cfg agentConfig) {
 	os.Setenv("CMUX_SOCKET_PATH", cfg.socketPath)
 	os.Setenv("CMUX_SOCKET", cfg.socketPath)
 
-	// Unset TERM_PROGRAM so apps don't detect the host terminal and
-	// override tmux-compatible behavior (e.g. opencode switches to
-	// light theme when it sees TERM_PROGRAM=ghostty).
-	os.Unsetenv("TERM_PROGRAM")
-
 	// Preserve COLORTERM for truecolor support in subagent panes.
 	if os.Getenv("COLORTERM") == "" {
 		os.Setenv("COLORTERM", "truecolor")

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -203,8 +203,8 @@ fs.writeFileSync(
             raise SystemExit(1)
 
         term_value = read_text(term_log)
-        if term_value != "screen-256color":
-            print(f"FAIL: expected TERM=screen-256color, got {term_value!r}")
+        if term_value != "xterm-256color":
+            print(f"FAIL: expected TERM=xterm-256color, got {term_value!r}")
             raise SystemExit(1)
 
         term_program_value = read_text(term_program_log)

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -203,8 +203,8 @@ fs.writeFileSync(
             raise SystemExit(1)
 
         term_value = read_text(term_log)
-        if term_value != "xterm-256color":
-            print(f"FAIL: expected TERM=xterm-256color, got {term_value!r}")
+        if term_value != "xterm-ghostty":
+            print(f"FAIL: expected TERM=xterm-ghostty, got {term_value!r}")
             raise SystemExit(1)
 
         term_program_value = read_text(term_program_log)

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -208,8 +208,8 @@ fs.writeFileSync(
             raise SystemExit(1)
 
         term_program_value = read_text(term_program_log)
-        if term_program_value != "__UNSET__":
-            print(f"FAIL: expected TERM_PROGRAM to be unset, got {term_program_value!r}")
+        if term_program_value == "__UNSET__":
+            print(f"FAIL: expected TERM_PROGRAM to be preserved, got unset")
             raise SystemExit(1)
 
         socket_path_value = read_text(socket_path_log)


### PR DESCRIPTION
## Summary

- Changed `TERM` from `screen-256color` to `xterm-256color` in claude-teams environment
- Explicitly set `COLORTERM=truecolor` so CLI tools detect truecolor support
- Updated both Swift CLI and Go remote daemon
- `TERM_PROGRAM` stays unset (needed for tmux compat)

`screen-256color` causes tools like Claude Code to fall back to a limited color palette. `xterm-256color` + `COLORTERM=truecolor` gives proper color rendering while still working with the fake tmux environment.

## Test plan

- [ ] Run `cmux claude-teams` and verify colors match regular terminal panes
- [ ] Run `env | grep TERM` in a claude-teams pane, confirm `TERM=xterm-256color` and `COLORTERM=truecolor`
- [ ] Verify teammate mode still works (tmux compat not broken)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes degraded colors in claude-teams by using `TERM=xterm-ghostty` and `COLORTERM=truecolor`, restoring truecolor output while keeping tmux compatibility. `TERM_PROGRAM` is preserved for claude-teams and unset only for opencode; updates cover both the Swift CLI and Go remote daemon.

- **Bug Fixes**
  - Default `TERM`: `screen-256color` -> `xterm-ghostty`.
  - Set `COLORTERM=truecolor` so tools detect 24-bit color.
  - Preserve `TERM_PROGRAM` in claude-teams; unset only in opencode.
  - Update tests for new `TERM` and `TERM_PROGRAM` behavior.

<sup>Written for commit c5dd1461c0aa6a4b896ecbec9a7de8338fe2b426. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default terminal type changed to xterm-ghostty for improved compatibility, COLORTERM=truecolor is now set for richer colors, and clearing of TERM_PROGRAM is limited to a specific launcher path (no longer removed globally).

* **Tests**
  * Updated environment tests and assertions to reflect the new terminal defaults and TERM_PROGRAM behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->