### PR TITLE
fix: new-split falls back to focused surface when target is stale

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4619,13 +4619,11 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            let targetSurfaceId: UUID? = v2UUID(params, "surface_id") ?? ws.focusedPanelId
-            guard let targetSurfaceId else {
+            let requestedSurfaceId: UUID? = v2UUID(params, "surface_id")
+            // Fall back to focused surface if the requested surface no longer exists (e.g. closed teammate pane)
+            let targetSurfaceId: UUID? = requestedSurfaceId.flatMap({ ws.panels[$0] != nil ? $0 : nil }) ?? ws.focusedPanelId
+            guard let targetSurfaceId, ws.panels[targetSurfaceId] != nil else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
-                return
-            }
-            guard ws.panels[targetSurfaceId] != nil else {
-                result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": targetSurfaceId.uuidString])
                 return
             }
 


### PR DESCRIPTION
## Summary

- `cmux new-split --surface <UUID>` returns `"not_found: Surface not found"` when the UUID references a closed surface (e.g. a terminated teammate pane)
- This fix falls back to the workspace's focused surface instead of erroring, matching `new-pane`'s existing behavior

## Problem

When Claude Code spawns agent teams, it uses `new-split` to create panes for each teammate. After a team is shut down and deleted, Claude Code may still reference the old pane surface UUIDs on subsequent team spawns. Since those surfaces no longer exist, `new-split` returns a hard error and all agent spawning fails permanently for the session.

`new-pane` does not have this problem because it always uses `ws.focusedPanelId` directly and never validates an externally provided surface UUID.

## Fix

In `v2SurfaceSplit`, if the requested `surface_id` doesn't exist in `ws.panels`, fall back to `ws.focusedPanelId` instead of returning an error. This is a 4-line change in `TerminalController.swift`.

**Before:** provided UUID not found → error
**After:** provided UUID not found → use focused surface → split succeeds

## Test plan

- [ ] `cmux new-split right --surface <valid-UUID>` still splits next to the specified surface
- [ ] `cmux new-split right --surface <stale-UUID>` falls back to focused surface and succeeds
- [ ] `cmux new-split right` (no surface flag) continues to use focused surface
- [ ] Claude Code agent team: create → shutdown → delete → create again → agents spawn successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `cmux new-split` to fall back to the workspace’s focused surface when the provided `surface_id` is stale or missing, instead of returning “Surface not found.” This aligns with `new-pane` behavior and prevents agent team spawns from failing when old surfaces are referenced (e.g., Claude Code).

<sup>Written for commit ea7d8fe91429bd582c18544b5d28c47615c018e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal split operation handling when panels are closed—now gracefully falls back to the currently focused panel instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->