### PR TITLE
Reveal terminal file links in Finder

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -85175,6 +85175,23 @@
         }
       }
     },
+    "terminalContextMenu.open": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開く"
+          }
+        }
+      }
+    },
     "terminalContextMenu.resetTerminal": {
       "extractionState": "manual",
       "localizations": {
@@ -85188,6 +85205,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "ターミナルをリセット"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.revealInFinder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで表示"
           }
         }
       }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7049,6 +7049,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         currentDirectory: String?,
         allowCachedHoverTarget: Bool = false
     ) -> ResolvedWordPathHoverTarget? {
+        let position = viewportPosition(at: point)
+
         if let snapshot = quicklookWordSnapshotUnderCursor(),
            let line = readViewportLine(at: snapshot.hoveredRow),
            let resolved = resolveTerminalLocalFileTarget(
@@ -7059,12 +7061,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
            ) {
             return ResolvedWordPathHoverTarget(
                 url: resolved.url,
-                row: snapshot.hoveredRow,
+                // Ghostty's quicklook text offsets can disagree with the
+                // viewport row we use for hover fallback across wrapped output.
+                // Cache the target on the live pointer row so internal-space
+                // hover cells reuse the same resolved file target.
+                row: position?.row ?? snapshot.hoveredRow,
                 columnRange: resolved.columnRange
             )
         }
 
-        guard let position = viewportPosition(at: point) else { return nil }
+        guard let position else { return nil }
 
         if let line = readViewportLine(at: position.row),
            let resolved = resolveTerminalLocalFileTarget(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -665,6 +665,38 @@ private func terminalHoveredTokenIndex(
     }?.offset
 }
 
+private func terminalHoveredColumn(
+    in line: String,
+    hoveredWord: String,
+    preferredColumn: Int?
+) -> Int? {
+    let tokenRanges = terminalWhitespaceTokenRanges(in: line)
+    guard !tokenRanges.isEmpty else { return nil }
+
+    let matches = tokenRanges.filter { range in
+        String(line[range]) == hoveredWord
+    }
+
+    if matches.isEmpty {
+        guard let preferredColumn, !line.isEmpty else { return nil }
+        return max(0, min(preferredColumn, line.count - 1))
+    }
+
+    let chosenRange = matches.min { lhs, rhs in
+        let lhsOffset = line.distance(from: line.startIndex, to: lhs.lowerBound)
+        let rhsOffset = line.distance(from: line.startIndex, to: rhs.lowerBound)
+        let preferredOffset = preferredColumn ?? lhsOffset
+        let lhsDistance = abs(lhsOffset - preferredOffset)
+        let rhsDistance = abs(rhsOffset - preferredOffset)
+        if lhsDistance == rhsDistance {
+            return lhsOffset < rhsOffset
+        }
+        return lhsDistance < rhsDistance
+    } ?? matches[0]
+
+    return line.distance(from: line.startIndex, to: chosenRange.lowerBound)
+}
+
 func resolveTerminalLocalFileURL(
     inLine rawLine: String,
     hoveredColumn: Int,
@@ -703,6 +735,26 @@ func resolveTerminalLocalFileURL(
     }
 
     return bestMatch?.url
+}
+
+func resolveTerminalLocalFileURL(
+    inLine rawLine: String,
+    hoveredWord: String,
+    preferredColumn: Int? = nil,
+    currentDirectory: String? = nil
+) -> URL? {
+    let line = rawLine.trimmingCharacters(in: .newlines)
+    guard let hoveredColumn = terminalHoveredColumn(
+        in: line,
+        hoveredWord: hoveredWord,
+        preferredColumn: preferredColumn
+    ) else { return nil }
+
+    return resolveTerminalLocalFileURL(
+        inLine: line,
+        hoveredColumn: hoveredColumn,
+        currentDirectory: currentDirectory
+    )
 }
 
 @MainActor
@@ -4717,6 +4769,12 @@ extension TerminalSurface {
 // MARK: - Ghostty Surface View
 
 class GhosttyNSView: NSView, NSUserInterfaceValidations {
+    private struct QuicklookWordSnapshot {
+        let text: String
+        let hoveredRow: Int
+        let preferredColumn: Int
+    }
+
     private static let focusDebugEnabled: Bool = {
         if ProcessInfo.processInfo.environment["CMUX_FOCUS_DEBUG"] == "1" {
             return true
@@ -6814,8 +6872,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         revealTerminalFileInFinder(resolvedURL)
     }
 
-    private func quicklookWordUnderCursor() -> String? {
+    private func quicklookWordSnapshotUnderCursor() -> QuicklookWordSnapshot? {
         guard let surface = surface else { return nil }
+        let surfaceSize = ghostty_surface_size(surface)
+        let columns = max(Int(surfaceSize.columns), 1)
+        let rows = max(Int(surfaceSize.rows), 1)
 
         var text = ghostty_text_s()
         guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
@@ -6825,7 +6886,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let wordData = Data(bytes: ptr, count: Int(text.text_len))
         guard let decodedWord = String(bytes: wordData, encoding: .utf8) else { return nil }
         let word = decodedWord.trimmingCharacters(in: .whitespacesAndNewlines)
-        return word.isEmpty ? nil : word
+        guard !word.isEmpty else { return nil }
+
+        let offsetStart = Int(text.offset_start)
+        let hoveredRow = max(0, min(offsetStart / columns, rows - 1))
+        let startColumn = max(0, min(offsetStart % columns, columns - 1))
+        let offsetLength = max(Int(text.offset_len), 1)
+        let preferredColumn = max(
+            0,
+            min(startColumn + ((offsetLength - 1) / 2), columns - 1)
+        )
+
+        return QuicklookWordSnapshot(
+            text: word,
+            hoveredRow: hoveredRow,
+            preferredColumn: preferredColumn
+        )
+    }
+
+    private func quicklookWordUnderCursor() -> String? {
+        quicklookWordSnapshotUnderCursor()?.text
     }
 
     /// Resolve the current terminal surface CWD for local relative-path lookup.
@@ -6853,7 +6933,53 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return !workspace.isRemoteTerminalSurface(termSurface.id)
     }
 
+    private func readViewportLine(at row: Int) -> String? {
+        guard let surface = surface else { return nil }
+
+        let surfaceSize = ghostty_surface_size(surface)
+        let columns = max(Int(surfaceSize.columns), 1)
+
+        let selection = ghostty_selection_s(
+            top_left: ghostty_point_s(
+                tag: GHOSTTY_POINT_VIEWPORT,
+                coord: GHOSTTY_POINT_COORD_EXACT,
+                x: 0,
+                y: UInt32(row)
+            ),
+            bottom_right: ghostty_point_s(
+                tag: GHOSTTY_POINT_VIEWPORT,
+                coord: GHOSTTY_POINT_COORD_EXACT,
+                x: UInt32(columns - 1),
+                y: UInt32(row)
+            ),
+            rectangle: false
+        )
+
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+
+        guard let ptr = text.text, text.text_len > 0 else { return nil }
+        var line = String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
+        while line.last == "\n" || line.last == "\r" {
+            line.removeLast()
+        }
+
+        return line
+    }
+
     private func resolvedLinePathUnderCursor(at point: CGPoint, currentDirectory: String?) -> URL? {
+        if let snapshot = quicklookWordSnapshotUnderCursor(),
+           let line = readViewportLine(at: snapshot.hoveredRow),
+           let resolved = resolveTerminalLocalFileURL(
+               inLine: line,
+               hoveredWord: snapshot.text,
+               preferredColumn: snapshot.preferredColumn,
+               currentDirectory: currentDirectory
+           ) {
+            return resolved
+        }
+
         guard let surface = surface else { return nil }
 
         let surfaceSize = ghostty_surface_size(surface)
@@ -6874,32 +7000,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
         let hoveredColumn = max(0, min(Int(floor(visiblePoint.x / resolvedCellWidth)), columns - 1))
         let hoveredRow = max(0, min(Int(floor(max(visiblePoint.y - 1, 0) / resolvedCellHeight)), rows - 1))
-
-        let selection = ghostty_selection_s(
-            top_left: ghostty_point_s(
-                tag: GHOSTTY_POINT_VIEWPORT,
-                coord: GHOSTTY_POINT_COORD_EXACT,
-                x: 0,
-                y: UInt32(hoveredRow)
-            ),
-            bottom_right: ghostty_point_s(
-                tag: GHOSTTY_POINT_VIEWPORT,
-                coord: GHOSTTY_POINT_COORD_EXACT,
-                x: UInt32(columns - 1),
-                y: UInt32(hoveredRow)
-            ),
-            rectangle: false
-        )
-
-        var text = ghostty_text_s()
-        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
-
-        guard let ptr = text.text, text.text_len > 0 else { return nil }
-        var line = String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
-        while line.last == "\n" || line.last == "\r" {
-            line.removeLast()
-        }
+        guard let line = readViewportLine(at: hoveredRow) else { return nil }
 
         return resolveTerminalLocalFileURL(
             inLine: line,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -783,7 +783,11 @@ final class GhosttyDefaultBackgroundNotificationDispatcher {
     }
 }
 
-func resolveTerminalOpenURLTarget(_ rawValue: String, currentDirectory: String? = nil) -> TerminalOpenURLTarget? {
+func resolveTerminalOpenURLTarget(
+    _ rawValue: String,
+    currentDirectory: String? = nil,
+    allowLocalFileTargets: Bool = true
+) -> TerminalOpenURLTarget? {
     let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
     #if DEBUG
     dlog("link.resolve input=\(trimmed)")
@@ -795,7 +799,8 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, currentDirectory: String? 
         return nil
     }
 
-    if let localFileURL = resolveTerminalLocalFileURL(trimmed, currentDirectory: currentDirectory) {
+    if allowLocalFileTargets,
+       let localFileURL = resolveTerminalLocalFileURL(trimmed, currentDirectory: currentDirectory) {
         #if DEBUG
         dlog("link.resolve result=revealInFinder(localFile) url=\(localFileURL)")
         #endif
@@ -803,6 +808,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, currentDirectory: String? 
     }
 
     if NSString(string: trimmed).isAbsolutePath {
+        guard allowLocalFileTargets else {
+            #if DEBUG
+            dlog("link.resolve result=nil (absolutePath-disallowed)")
+            #endif
+            return nil
+        }
         #if DEBUG
         dlog("link.resolve result=external(absolutePath) url=\(trimmed)")
         #endif
@@ -811,6 +822,14 @@ func resolveTerminalOpenURLTarget(_ rawValue: String, currentDirectory: String? 
 
     if let parsed = URL(string: trimmed),
        let scheme = parsed.scheme?.lowercased() {
+        if scheme == "file",
+           !allowLocalFileTargets,
+           terminalFileURLUsesLocalHost(parsed) {
+            #if DEBUG
+            dlog("link.resolve result=nil (localFileURL-disallowed) url=\(parsed)")
+            #endif
+            return nil
+        }
         if scheme == "http" || scheme == "https" {
             guard BrowserInsecureHTTPSettings.normalizeHost(parsed.host ?? "") != nil else {
                 #if DEBUG
@@ -3011,7 +3030,8 @@ class GhosttyApp {
             #endif
             guard let target = resolveTerminalOpenURLTarget(
                 urlString,
-                currentDirectory: surfaceView.currentDirectoryForWordPathResolution()
+                currentDirectory: surfaceView.currentDirectoryForWordPathResolution(),
+                allowLocalFileTargets: surfaceView.allowsLocalFileTargetsForOpenURLAction()
             ) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")
@@ -6825,6 +6845,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
             return dir.isEmpty ? nil : dir
         }()
+    }
+
+    fileprivate func allowsLocalFileTargetsForOpenURLAction() -> Bool {
+        guard let termSurface = terminalSurface,
+              let workspace = termSurface.owningWorkspace() else { return true }
+        return !workspace.isRemoteTerminalSurface(termSurface.id)
     }
 
     private func resolvedLinePathUnderCursor(at point: CGPoint, currentDirectory: String?) -> URL? {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -83,6 +83,7 @@ private func cmuxScalarHex(_ value: String?) -> String {
         .map { String(format: "%04X", $0.value) }
         .joined(separator: ",")
 }
+
 #endif
 
 enum GhosttyPasteboardHelper {
@@ -697,11 +698,16 @@ private func terminalHoveredColumn(
     return line.distance(from: line.startIndex, to: chosenRange.lowerBound)
 }
 
-func resolveTerminalLocalFileURL(
+struct TerminalResolvedLocalFileTarget {
+    let url: URL
+    let columnRange: ClosedRange<Int>
+}
+
+func resolveTerminalLocalFileTarget(
     inLine rawLine: String,
     hoveredColumn: Int,
     currentDirectory: String? = nil
-) -> URL? {
+) -> TerminalResolvedLocalFileTarget? {
     let line = rawLine.trimmingCharacters(in: .newlines)
     let tokenRanges = terminalWhitespaceTokenRanges(in: line)
     guard let hoveredTokenIndex = terminalHoveredTokenIndex(
@@ -711,7 +717,7 @@ func resolveTerminalLocalFileURL(
     ) else { return nil }
 
     let maxTokenSpan = 8
-    var bestMatch: (url: URL, tokenCount: Int, characterCount: Int)?
+    var bestMatch: (target: TerminalResolvedLocalFileTarget, tokenCount: Int, characterCount: Int)?
 
     for startIndex in 0...hoveredTokenIndex {
         for endIndex in hoveredTokenIndex..<tokenRanges.count {
@@ -724,17 +730,56 @@ func resolveTerminalLocalFileURL(
                 continue
             }
 
+            let startColumn = line.distance(from: line.startIndex, to: candidateRange.lowerBound)
+            let endColumn = line.distance(from: line.startIndex, to: candidateRange.upperBound) - 1
+            let target = TerminalResolvedLocalFileTarget(
+                url: resolved,
+                columnRange: startColumn...max(startColumn, endColumn)
+            )
             let characterCount = candidate.count
+
             if let bestMatch {
                 if tokenCount < bestMatch.tokenCount { continue }
                 if tokenCount == bestMatch.tokenCount, characterCount <= bestMatch.characterCount { continue }
             }
 
-            bestMatch = (resolved, tokenCount, characterCount)
+            bestMatch = (target, tokenCount, characterCount)
         }
     }
 
-    return bestMatch?.url
+    return bestMatch?.target
+}
+
+func resolveTerminalLocalFileURL(
+    inLine rawLine: String,
+    hoveredColumn: Int,
+    currentDirectory: String? = nil
+) -> URL? {
+    resolveTerminalLocalFileTarget(
+        inLine: rawLine,
+        hoveredColumn: hoveredColumn,
+        currentDirectory: currentDirectory
+    )?.url
+}
+
+func resolveTerminalLocalFileTarget(
+    inLine rawLine: String,
+    hoveredWord: String,
+    preferredColumn: Int? = nil,
+    currentDirectory: String? = nil
+) -> TerminalResolvedLocalFileTarget? {
+    let line = rawLine.trimmingCharacters(in: .newlines)
+    guard let hoveredColumn = terminalHoveredColumn(
+        in: line,
+        hoveredWord: hoveredWord,
+        preferredColumn: preferredColumn
+    ) else { return nil }
+
+    return resolveTerminalLocalFileTarget(
+        inLine: line,
+        hoveredColumn: hoveredColumn,
+        currentDirectory: currentDirectory
+    )
 }
 
 func resolveTerminalLocalFileURL(
@@ -743,18 +788,12 @@ func resolveTerminalLocalFileURL(
     preferredColumn: Int? = nil,
     currentDirectory: String? = nil
 ) -> URL? {
-    let line = rawLine.trimmingCharacters(in: .newlines)
-    guard let hoveredColumn = terminalHoveredColumn(
-        in: line,
+    resolveTerminalLocalFileTarget(
+        inLine: rawLine,
         hoveredWord: hoveredWord,
-        preferredColumn: preferredColumn
-    ) else { return nil }
-
-    return resolveTerminalLocalFileURL(
-        inLine: line,
-        hoveredColumn: hoveredColumn,
+        preferredColumn: preferredColumn,
         currentDirectory: currentDirectory
-    )
+    )?.url
 }
 
 @MainActor
@@ -4775,6 +4814,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let preferredColumn: Int
     }
 
+    private struct ResolvedWordPathHoverTarget {
+        let url: URL
+        let row: Int
+        let columnRange: ClosedRange<Int>
+    }
+
     private static let focusDebugEnabled: Bool = {
         if ProcessInfo.processInfo.environment["CMUX_FOCUS_DEBUG"] == "1" {
             return true
@@ -4854,6 +4899,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
+    private func clearWordPathHover(clearTarget: Bool = true) {
+        if clearTarget {
+            resolvedWordPathHoverTarget = nil
+        }
+        guard wordPathHoverActive else { return }
+        wordPathHoverActive = false
+        NSCursor.pop()
+    }
+
     var desiredFocus: Bool = false
     var suppressingReparentFocus: Bool = false
     var tabId: UUID?
@@ -4867,6 +4921,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyTables: [String] = []
     fileprivate private(set) var keyboardCopyModeActive = false
     private var wordPathHoverActive = false
+    private var resolvedWordPathHoverTarget: ResolvedWordPathHoverTarget?
     private var keyboardCopyModeConsumedKeyUps: Set<UInt16> = []
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
     private var keyboardCopyModeViewportRow: Int?
@@ -5117,10 +5172,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             self.windowObserver = nil
         }
         // Balance the cursor stack if the view is removed while hover is active
-        if wordPathHoverActive {
-            wordPathHoverActive = false
-            NSCursor.pop()
-        }
+        clearWordPathHover()
 #if DEBUG
         dlog(
             "surface.view.windowMove surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
@@ -6968,18 +7020,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return line
     }
 
-    private func resolvedLinePathUnderCursor(at point: CGPoint, currentDirectory: String?) -> URL? {
-        if let snapshot = quicklookWordSnapshotUnderCursor(),
-           let line = readViewportLine(at: snapshot.hoveredRow),
-           let resolved = resolveTerminalLocalFileURL(
-               inLine: line,
-               hoveredWord: snapshot.text,
-               preferredColumn: snapshot.preferredColumn,
-               currentDirectory: currentDirectory
-           ) {
-            return resolved
-        }
-
+    private func viewportPosition(at point: CGPoint) -> (column: Int, row: Int)? {
         guard let surface = surface else { return nil }
 
         let surfaceSize = ghostty_surface_size(surface)
@@ -7000,13 +7041,80 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
         let hoveredColumn = max(0, min(Int(floor(visiblePoint.x / resolvedCellWidth)), columns - 1))
         let hoveredRow = max(0, min(Int(floor(max(visiblePoint.y - 1, 0) / resolvedCellHeight)), rows - 1))
-        guard let line = readViewportLine(at: hoveredRow) else { return nil }
+        return (hoveredColumn, hoveredRow)
+    }
 
-        return resolveTerminalLocalFileURL(
-            inLine: line,
-            hoveredColumn: hoveredColumn,
-            currentDirectory: currentDirectory
+    private func resolvedLineTargetUnderCursor(
+        at point: CGPoint,
+        currentDirectory: String?,
+        allowCachedHoverTarget: Bool = false
+    ) -> ResolvedWordPathHoverTarget? {
+        if let snapshot = quicklookWordSnapshotUnderCursor(),
+           let line = readViewportLine(at: snapshot.hoveredRow),
+           let resolved = resolveTerminalLocalFileTarget(
+               inLine: line,
+               hoveredWord: snapshot.text,
+               preferredColumn: snapshot.preferredColumn,
+               currentDirectory: currentDirectory
+           ) {
+            return ResolvedWordPathHoverTarget(
+                url: resolved.url,
+                row: snapshot.hoveredRow,
+                columnRange: resolved.columnRange
+            )
+        }
+
+        guard let position = viewportPosition(at: point) else { return nil }
+
+        if let line = readViewportLine(at: position.row),
+           let resolved = resolveTerminalLocalFileTarget(
+               inLine: line,
+               hoveredColumn: position.column,
+               currentDirectory: currentDirectory
+           ) {
+            return ResolvedWordPathHoverTarget(
+                url: resolved.url,
+                row: position.row,
+                columnRange: resolved.columnRange
+            )
+        }
+
+        if allowCachedHoverTarget,
+           let cachedTarget = resolvedWordPathHoverTarget,
+           cachedTarget.row == position.row,
+           cachedTarget.columnRange.contains(position.column) {
+            return cachedTarget
+        }
+
+        return nil
+    }
+
+    private func refreshResolvedWordPathTarget(
+        at point: CGPoint,
+        allowCachedHoverTarget: Bool
+    ) -> ResolvedWordPathHoverTarget? {
+        guard let termSurface = terminalSurface,
+              let workspace = termSurface.owningWorkspace(),
+              !workspace.isRemoteTerminalSurface(termSurface.id) else {
+            resolvedWordPathHoverTarget = nil
+            return nil
+        }
+
+        let target = resolvedLineTargetUnderCursor(
+            at: point,
+            currentDirectory: currentDirectoryForWordPathResolution(),
+            allowCachedHoverTarget: allowCachedHoverTarget
         )
+        resolvedWordPathHoverTarget = target
+        return target
+    }
+
+    private func resolvedLinePathUnderCursor(at point: CGPoint, currentDirectory: String?) -> URL? {
+        resolvedLineTargetUnderCursor(
+            at: point,
+            currentDirectory: currentDirectory,
+            allowCachedHoverTarget: true
+        )?.url
     }
 
     /// Check if the word under the mouse cursor resolves to an existing local
@@ -7029,22 +7137,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// Update the pointing-hand cursor when Cmd-hovering over a local file path
     /// or file URL, including bare relative names from commands like `ls`.
     private func updateWordPathHover(cmdHeld: Bool, point: CGPoint) {
+        let resolvedTarget = refreshResolvedWordPathTarget(
+            at: point,
+            allowCachedHoverTarget: true
+        )
         guard cmdHeld else {
-            if wordPathHoverActive {
-                wordPathHoverActive = false
-                NSCursor.pop()
-            }
+            clearWordPathHover(clearTarget: false)
             return
         }
 
-        if resolveWordUnderCursorAsLocalFileURL(at: point) != nil {
+        if resolvedTarget != nil {
             if !wordPathHoverActive {
                 wordPathHoverActive = true
                 NSCursor.pointingHand.push()
             }
-        } else if wordPathHoverActive {
-            wordPathHoverActive = false
-            NSCursor.pop()
+        } else {
+            clearWordPathHover()
         }
     }
 
@@ -7277,10 +7385,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func mouseExited(with event: NSEvent) {
-        if wordPathHoverActive {
-            wordPathHoverActive = false
-            NSCursor.pop()
-        }
+        clearWordPathHover()
         guard let surface = surface else { return }
         if NSEvent.pressedMouseButtons != 0 {
             return

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7035,12 +7035,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             : CGFloat(surfaceSize.cell_height_px) / scale
         guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
 
-        let visiblePoint = CGPoint(
-            x: point.x - visibleRect.minX,
-            y: visibleRect.maxY - point.y
+        // Match the same top-origin point transform we pass into
+        // `ghostty_surface_mouse_pos` so geometry fallback aligns with
+        // Ghostty quicklook when Cmd is pressed while the pointer is stationary.
+        let viewportPoint = CGPoint(
+            x: point.x,
+            y: bounds.height - point.y
         )
-        let hoveredColumn = max(0, min(Int(floor(visiblePoint.x / resolvedCellWidth)), columns - 1))
-        let hoveredRow = max(0, min(Int(floor(max(visiblePoint.y - 1, 0) / resolvedCellHeight)), rows - 1))
+        let hoveredColumn = max(0, min(Int(floor(viewportPoint.x / resolvedCellWidth)), columns - 1))
+        let hoveredRow = max(0, min(Int(floor(max(viewportPoint.y - 1, 0) / resolvedCellHeight)), rows - 1))
         return (hoveredColumn, hoveredRow)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -459,13 +459,139 @@ func cmuxPasteboardImagePathForTesting(_ pasteboard: NSPasteboard) -> String? {
 enum TerminalOpenURLTarget: Equatable {
     case embeddedBrowser(URL)
     case external(URL)
+    case revealInFinder(URL)
 
     var url: URL {
         switch self {
-        case let .embeddedBrowser(url), let .external(url):
+        case let .embeddedBrowser(url), let .external(url), let .revealInFinder(url):
             return url
         }
     }
+}
+
+private let terminalFileLinkWrappingPairs: [(Character, Character)] = [
+    ("\"", "\""),
+    ("'", "'"),
+    ("(", ")"),
+    ("[", "]"),
+    ("{", "}"),
+    ("<", ">")
+]
+
+private let terminalFileLinkTrailingPunctuation = CharacterSet(charactersIn: ",.;:!?")
+
+private func trimTrailingTerminalFileLinkPunctuation(_ value: String) -> String {
+    var result = value
+    while let lastScalar = result.unicodeScalars.last,
+          terminalFileLinkTrailingPunctuation.contains(lastScalar) {
+        result.unicodeScalars.removeLast()
+    }
+    return result
+}
+
+private func unwrapTerminalFileLinkCandidate(_ value: String) -> String {
+    var result = value
+    while let first = result.first,
+          let last = result.last,
+          terminalFileLinkWrappingPairs.contains(where: { $0.0 == first && $0.1 == last }) {
+        result.removeFirst()
+        result.removeLast()
+    }
+    return result
+}
+
+private func stripTerminalPathLineAndColumnSuffix(_ value: String) -> String {
+    var result = value
+    var strippedComponentCount = 0
+    while strippedComponentCount < 2,
+          let colonIndex = result.lastIndex(of: ":") {
+        let suffix = result[result.index(after: colonIndex)...]
+        guard !suffix.isEmpty, suffix.allSatisfy(\.isNumber) else { break }
+        result = String(result[..<colonIndex])
+        strippedComponentCount += 1
+    }
+    return result
+}
+
+private func terminalFileLinkCandidates(_ rawValue: String) -> [String] {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+
+    var candidates: [String] = []
+    func append(_ candidate: String) {
+        guard !candidate.isEmpty, !candidates.contains(candidate) else { return }
+        candidates.append(candidate)
+    }
+
+    append(trimmed)
+    append(unwrapTerminalFileLinkCandidate(trimmed))
+
+    for candidate in Array(candidates) {
+        append(trimTrailingTerminalFileLinkPunctuation(candidate))
+    }
+
+    for candidate in Array(candidates) {
+        append(unwrapTerminalFileLinkCandidate(candidate))
+    }
+
+    for candidate in Array(candidates) {
+        append(stripTerminalPathLineAndColumnSuffix(candidate))
+    }
+
+    for candidate in Array(candidates) {
+        append(trimTrailingTerminalFileLinkPunctuation(candidate))
+    }
+
+    return candidates
+}
+
+private func resolvedExistingTerminalFileURL(fromPath rawPath: String, currentDirectory: String?) -> URL? {
+    let expandedPath = (rawPath as NSString).expandingTildeInPath
+    var pathCandidates: [String] = []
+    func appendPath(_ candidate: String) {
+        guard !candidate.isEmpty, !pathCandidates.contains(candidate) else { return }
+        pathCandidates.append(candidate)
+    }
+
+    if NSString(string: expandedPath).isAbsolutePath {
+        appendPath(expandedPath)
+        appendPath(stripTerminalPathLineAndColumnSuffix(expandedPath))
+    } else if let currentDirectory,
+              !currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        let cwdURL = URL(fileURLWithPath: currentDirectory)
+        appendPath(cwdURL.appendingPathComponent(expandedPath).path)
+        let strippedPath = stripTerminalPathLineAndColumnSuffix(expandedPath)
+        if strippedPath != expandedPath {
+            appendPath(cwdURL.appendingPathComponent(strippedPath).path)
+        }
+    }
+
+    for candidate in pathCandidates {
+        guard FileManager.default.fileExists(atPath: candidate) else { continue }
+        return URL(fileURLWithPath: candidate).standardizedFileURL
+    }
+
+    return nil
+}
+
+func resolveTerminalLocalFileURL(_ rawValue: String, currentDirectory: String? = nil) -> URL? {
+    for candidate in terminalFileLinkCandidates(rawValue) {
+        if let resolved = resolvedExistingTerminalFileURL(fromPath: candidate, currentDirectory: currentDirectory) {
+            return resolved
+        }
+
+        if let url = URL(string: candidate), url.isFileURL,
+           let resolved = resolvedExistingTerminalFileURL(fromPath: url.path, currentDirectory: nil) {
+            return resolved
+        }
+    }
+
+    return nil
+}
+
+@MainActor
+private func revealTerminalFileInFinder(_ url: URL) {
+    NSWorkspace.shared.activateFileViewerSelecting([url.standardizedFileURL])
 }
 
 enum GhosttyDefaultBackgroundUpdateScope: Int {
@@ -553,6 +679,13 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
         return nil
     }
 
+    if let localFileURL = resolveTerminalLocalFileURL(trimmed) {
+        #if DEBUG
+        dlog("link.resolve result=revealInFinder(localFile) url=\(localFileURL)")
+        #endif
+        return .revealInFinder(localFileURL)
+    }
+
     if NSString(string: trimmed).isAbsolutePath {
         #if DEBUG
         dlog("link.resolve result=external(absolutePath) url=\(trimmed)")
@@ -573,6 +706,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
             dlog("link.resolve result=embeddedBrowser url=\(parsed)")
             #endif
             return .embeddedBrowser(parsed)
+        }
+        if scheme == "file" {
+            #if DEBUG
+            dlog("link.resolve result=external(fileURL-missing) url=\(parsed)")
+            #endif
+            return .external(parsed)
         }
         #if DEBUG
         dlog("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
@@ -2766,6 +2905,15 @@ class GhosttyApp {
                 #endif
                 return false
             }
+            if case let .revealInFinder(url) = target {
+                #if DEBUG
+                dlog("link.openURL target=revealInFinder, revealing in Finder url=\(url)")
+                #endif
+                return performOnMain {
+                    revealTerminalFileInFinder(url)
+                    return true
+                }
+            }
             if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
                 #if DEBUG
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
@@ -2859,6 +3007,8 @@ class GhosttyApp {
                         return workspace.newBrowserSplit(from: sourcePanelId, orientation: .horizontal, url: url) != nil
                     }
                 }
+            case .revealInFinder:
+                return false
             }
         default:
             return false
@@ -6509,32 +6659,29 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
 
         // Fallback: if Cmd was held and ghostty didn't handle the click as a link,
-        // check if the word under cursor is a valid file/directory in the terminal's CWD.
-        // This enables cmd-click on bare filenames from commands like `ls`.
+        // reveal the word under cursor when it resolves to a local file path or file URL.
         if !consumed && event.modifierFlags.contains(.command) {
             // Refresh ghostty's cached mouse position so quicklook_word reads
             // up-to-date coordinates (mouseDown skips pos update on double-click).
             let point = convert(event.locationInWindow, from: nil)
             ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-            tryOpenWordAsPath()
+            tryRevealWordInFinder()
         }
     }
 
-    /// Attempt to open the word under the mouse cursor as a file path, resolved
-    /// against the terminal panel's current working directory.
-    private func tryOpenWordAsPath() {
-        guard let resolvedPath = resolveWordUnderCursorAsPath() else { return }
+    /// Attempt to reveal the word under the mouse cursor in Finder when it
+    /// resolves to a local file path or file URL.
+    private func tryRevealWordInFinder() {
+        guard let resolvedURL = resolveWordUnderCursorAsLocalFileURL() else { return }
 
         #if DEBUG
-        dlog("link.wordFallback resolved=\(resolvedPath)")
+        dlog("link.wordFallback reveal=\(resolvedURL.path)")
         #endif
 
-        PreferredEditorSettings.open(URL(fileURLWithPath: resolvedPath))
+        revealTerminalFileInFinder(resolvedURL)
     }
 
-    /// Check if the word under the mouse cursor resolves to an existing file/directory
-    /// in the terminal panel's CWD. Returns the resolved absolute path, or nil.
-    private func resolveWordUnderCursorAsPath() -> String? {
+    private func quicklookWordUnderCursor() -> String? {
         guard let surface = surface else { return nil }
 
         var text = ghostty_text_s()
@@ -6545,15 +6692,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let wordData = Data(bytes: ptr, count: Int(text.text_len))
         guard let decodedWord = String(bytes: wordData, encoding: .utf8) else { return nil }
         let word = decodedWord.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !word.isEmpty, !word.hasPrefix("/") else { return nil }
+        return word.isEmpty ? nil : word
+    }
 
+    /// Resolve the current terminal surface CWD for local relative-path lookup.
+    private func currentDirectoryForWordPathResolution() -> String? {
         guard let termSurface = terminalSurface,
               let workspace = termSurface.owningWorkspace(),
               !workspace.isRemoteTerminalSurface(termSurface.id) else { return nil }
 
         // Use the same CWD fallback chain as Workspace split creation:
         // panelDirectories (live OSC 7) → requestedWorkingDirectory → workspace currentDirectory
-        let cwd: String? = {
+        return {
             if let dir = workspace.panelDirectories[termSurface.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !dir.isEmpty { return dir }
             if let dir = workspace.terminalPanel(for: termSurface.id)?
@@ -6562,15 +6712,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
             return dir.isEmpty ? nil : dir
         }()
-        guard let cwd else { return nil }
-
-        let resolvedPath = (cwd as NSString).appendingPathComponent(word)
-        guard FileManager.default.fileExists(atPath: resolvedPath) else { return nil }
-        return resolvedPath
     }
 
-    /// Update the pointing-hand cursor when Cmd-hovering over a bare filename
-    /// that exists in the terminal's CWD.
+    /// Check if the word under the mouse cursor resolves to an existing local
+    /// file/directory, using the panel CWD for relative paths.
+    private func resolveWordUnderCursorAsLocalFileURL() -> URL? {
+        guard let word = quicklookWordUnderCursor() else { return nil }
+        return resolveTerminalLocalFileURL(word, currentDirectory: currentDirectoryForWordPathResolution())
+    }
+
+    /// Update the pointing-hand cursor when Cmd-hovering over a local file path
+    /// or file URL, including bare relative names from commands like `ls`.
     private func updateWordPathHover(cmdHeld: Bool) {
         guard cmdHeld else {
             if wordPathHoverActive {
@@ -6580,7 +6732,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
-        if resolveWordUnderCursorAsPath() != nil {
+        if resolveWordUnderCursorAsLocalFileURL() != nil {
             if !wordPathHoverActive {
                 wordPathHoverActive = true
                 NSCursor.pointingHand.push()
@@ -6673,6 +6825,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEquivalent: ""
         )
         pasteItem.target = self
+        if let localFileURL = resolveWordUnderCursorAsLocalFileURL() {
+            menu.addItem(.separator())
+
+            let revealItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.revealInFinder", defaultValue: "Reveal in Finder"),
+                action: #selector(revealResolvedWordPathInFinder(_:)),
+                keyEquivalent: ""
+            )
+            revealItem.target = self
+            revealItem.representedObject = localFileURL
+            revealItem.image = NSImage(
+                systemSymbolName: "folder",
+                accessibilityDescription: nil
+            )
+
+            let openItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.open", defaultValue: "Open"),
+                action: #selector(openResolvedWordPath(_:)),
+                keyEquivalent: ""
+            )
+            openItem.target = self
+            openItem.representedObject = localFileURL
+            openItem.image = NSImage(
+                systemSymbolName: "arrow.up.forward.app",
+                accessibilityDescription: nil
+            )
+        }
         menu.addItem(.separator())
         let splitHorizontallyItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally"),
@@ -6747,6 +6926,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @objc private func resetTerminal(_ sender: Any?) {
         _ = performBindingAction("reset")
+    }
+
+    @objc private func revealResolvedWordPathInFinder(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        revealTerminalFileInFinder(url)
+    }
+
+    @objc private func openResolvedWordPath(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        NSWorkspace.shared.open(url)
     }
 
     override func mouseMoved(with event: NSEvent) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -580,13 +580,106 @@ func resolveTerminalLocalFileURL(_ rawValue: String, currentDirectory: String? =
             return resolved
         }
 
-        if let url = URL(string: candidate), url.isFileURL,
-           let resolved = resolvedExistingTerminalFileURL(fromPath: url.path, currentDirectory: nil) {
+        if let url = URL(string: candidate),
+           terminalFileURLUsesLocalHost(url),
+           let resolved = resolvedExistingTerminalFileURL(fromPath: url.path, currentDirectory: currentDirectory) {
             return resolved
         }
     }
 
     return nil
+}
+
+private func terminalFileURLUsesLocalHost(_ url: URL) -> Bool {
+    guard url.isFileURL else { return false }
+    guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !host.isEmpty else { return true }
+    return host.caseInsensitiveCompare("localhost") == .orderedSame
+}
+
+private func terminalWhitespaceTokenRanges(in line: String) -> [Range<String.Index>] {
+    var ranges: [Range<String.Index>] = []
+    var index = line.startIndex
+
+    while index < line.endIndex {
+        while index < line.endIndex, line[index].isWhitespace {
+            index = line.index(after: index)
+        }
+        guard index < line.endIndex else { break }
+
+        let start = index
+        while index < line.endIndex, !line[index].isWhitespace {
+            index = line.index(after: index)
+        }
+        ranges.append(start..<index)
+    }
+
+    return ranges
+}
+
+private func terminalHoveredTokenIndex(
+    in line: String,
+    hoveredColumn: Int,
+    tokenRanges: [Range<String.Index>]
+) -> Int? {
+    guard !line.isEmpty, !tokenRanges.isEmpty else { return nil }
+
+    let clampedColumn = max(0, min(hoveredColumn, line.count - 1))
+    let hoveredIndex = line.index(line.startIndex, offsetBy: clampedColumn)
+
+    if let directMatch = tokenRanges.firstIndex(where: { $0.contains(hoveredIndex) }) {
+        return directMatch
+    }
+
+    let hoveredOffset = line.distance(from: line.startIndex, to: hoveredIndex)
+    return tokenRanges.enumerated().min { lhs, rhs in
+        let lhsDistance = abs(line.distance(from: line.startIndex, to: lhs.element.lowerBound) - hoveredOffset)
+        let rhsDistance = abs(line.distance(from: line.startIndex, to: rhs.element.lowerBound) - hoveredOffset)
+        if lhsDistance == rhsDistance {
+            return lhs.offset < rhs.offset
+        }
+        return lhsDistance < rhsDistance
+    }?.offset
+}
+
+func resolveTerminalLocalFileURL(
+    inLine rawLine: String,
+    hoveredColumn: Int,
+    currentDirectory: String? = nil
+) -> URL? {
+    let line = rawLine.trimmingCharacters(in: .newlines)
+    let tokenRanges = terminalWhitespaceTokenRanges(in: line)
+    guard let hoveredTokenIndex = terminalHoveredTokenIndex(
+        in: line,
+        hoveredColumn: hoveredColumn,
+        tokenRanges: tokenRanges
+    ) else { return nil }
+
+    let maxTokenSpan = 8
+    var bestMatch: (url: URL, tokenCount: Int, characterCount: Int)?
+
+    for startIndex in 0...hoveredTokenIndex {
+        for endIndex in hoveredTokenIndex..<tokenRanges.count {
+            let tokenCount = endIndex - startIndex + 1
+            guard tokenCount <= maxTokenSpan else { continue }
+
+            let candidateRange = tokenRanges[startIndex].lowerBound..<tokenRanges[endIndex].upperBound
+            let candidate = String(line[candidateRange])
+            guard let resolved = resolveTerminalLocalFileURL(candidate, currentDirectory: currentDirectory) else {
+                continue
+            }
+
+            let characterCount = candidate.count
+            if let bestMatch {
+                if tokenCount < bestMatch.tokenCount { continue }
+                if tokenCount == bestMatch.tokenCount, characterCount <= bestMatch.characterCount { continue }
+            }
+
+            bestMatch = (resolved, tokenCount, characterCount)
+        }
+    }
+
+    return bestMatch?.url
 }
 
 @MainActor
@@ -667,7 +760,7 @@ final class GhosttyDefaultBackgroundNotificationDispatcher {
     }
 }
 
-func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? {
+func resolveTerminalOpenURLTarget(_ rawValue: String, currentDirectory: String? = nil) -> TerminalOpenURLTarget? {
     let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
     #if DEBUG
     dlog("link.resolve input=\(trimmed)")
@@ -679,7 +772,7 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
         return nil
     }
 
-    if let localFileURL = resolveTerminalLocalFileURL(trimmed) {
+    if let localFileURL = resolveTerminalLocalFileURL(trimmed, currentDirectory: currentDirectory) {
         #if DEBUG
         dlog("link.resolve result=revealInFinder(localFile) url=\(localFileURL)")
         #endif
@@ -706,12 +799,6 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
             dlog("link.resolve result=embeddedBrowser url=\(parsed)")
             #endif
             return .embeddedBrowser(parsed)
-        }
-        if scheme == "file" {
-            #if DEBUG
-            dlog("link.resolve result=external(fileURL-missing) url=\(parsed)")
-            #endif
-            return .external(parsed)
         }
         #if DEBUG
         dlog("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
@@ -2899,7 +2986,10 @@ class GhosttyApp {
             #if DEBUG
             dlog("link.openURL raw=\(urlString)")
             #endif
-            guard let target = resolveTerminalOpenURLTarget(urlString) else {
+            guard let target = resolveTerminalOpenURLTarget(
+                urlString,
+                currentDirectory: surfaceView.currentDirectoryForWordPathResolution()
+            ) else {
                 #if DEBUG
                 dlog("link.openURL resolve failed, returning false")
                 #endif
@@ -6416,7 +6506,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // when Cmd is pressed while the pointer is stationary.
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command))
+        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command), point: point)
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
@@ -6665,14 +6755,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // up-to-date coordinates (mouseDown skips pos update on double-click).
             let point = convert(event.locationInWindow, from: nil)
             ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-            tryRevealWordInFinder()
+            tryRevealWordInFinder(at: point)
         }
     }
 
     /// Attempt to reveal the word under the mouse cursor in Finder when it
     /// resolves to a local file path or file URL.
-    private func tryRevealWordInFinder() {
-        guard let resolvedURL = resolveWordUnderCursorAsLocalFileURL() else { return }
+    private func tryRevealWordInFinder(at point: CGPoint? = nil) {
+        guard let resolvedURL = resolveWordUnderCursorAsLocalFileURL(at: point) else { return }
 
         #if DEBUG
         dlog("link.wordFallback reveal=\(resolvedURL.path)")
@@ -6696,7 +6786,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     /// Resolve the current terminal surface CWD for local relative-path lookup.
-    private func currentDirectoryForWordPathResolution() -> String? {
+    fileprivate func currentDirectoryForWordPathResolution() -> String? {
         guard let termSurface = terminalSurface,
               let workspace = termSurface.owningWorkspace(),
               !workspace.isRemoteTerminalSurface(termSurface.id) else { return nil }
@@ -6714,16 +6804,81 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }()
     }
 
+    private func resolvedLinePathUnderCursor(at point: CGPoint, currentDirectory: String?) -> URL? {
+        guard let surface = surface else { return nil }
+
+        let surfaceSize = ghostty_surface_size(surface)
+        let columns = max(Int(surfaceSize.columns), 1)
+        let rows = max(Int(surfaceSize.rows), 1)
+        let scale = max(window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1, 1)
+        let resolvedCellWidth = cellSize.width > 0
+            ? cellSize.width
+            : CGFloat(surfaceSize.cell_width_px) / scale
+        let resolvedCellHeight = cellSize.height > 0
+            ? cellSize.height
+            : CGFloat(surfaceSize.cell_height_px) / scale
+        guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
+
+        let visiblePoint = CGPoint(
+            x: point.x - visibleRect.minX,
+            y: visibleRect.maxY - point.y
+        )
+        let hoveredColumn = max(0, min(Int(floor(visiblePoint.x / resolvedCellWidth)), columns - 1))
+        let hoveredRow = max(0, min(Int(floor(max(visiblePoint.y - 1, 0) / resolvedCellHeight)), rows - 1))
+
+        let selection = ghostty_selection_s(
+            top_left: ghostty_point_s(
+                tag: GHOSTTY_POINT_VIEWPORT,
+                coord: GHOSTTY_POINT_COORD_EXACT,
+                x: 0,
+                y: UInt32(hoveredRow)
+            ),
+            bottom_right: ghostty_point_s(
+                tag: GHOSTTY_POINT_VIEWPORT,
+                coord: GHOSTTY_POINT_COORD_EXACT,
+                x: UInt32(columns - 1),
+                y: UInt32(hoveredRow)
+            ),
+            rectangle: false
+        )
+
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+
+        guard let ptr = text.text, text.text_len > 0 else { return nil }
+        var line = String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
+        while line.last == "\n" || line.last == "\r" {
+            line.removeLast()
+        }
+
+        return resolveTerminalLocalFileURL(
+            inLine: line,
+            hoveredColumn: hoveredColumn,
+            currentDirectory: currentDirectory
+        )
+    }
+
     /// Check if the word under the mouse cursor resolves to an existing local
     /// file/directory, using the panel CWD for relative paths.
-    private func resolveWordUnderCursorAsLocalFileURL() -> URL? {
+    private func resolveWordUnderCursorAsLocalFileURL(at point: CGPoint? = nil) -> URL? {
+        guard let termSurface = terminalSurface,
+              let workspace = termSurface.owningWorkspace(),
+              !workspace.isRemoteTerminalSurface(termSurface.id) else { return nil }
+
+        let currentDirectory = currentDirectoryForWordPathResolution()
+        if let point,
+           let lineResolved = resolvedLinePathUnderCursor(at: point, currentDirectory: currentDirectory) {
+            return lineResolved
+        }
+
         guard let word = quicklookWordUnderCursor() else { return nil }
-        return resolveTerminalLocalFileURL(word, currentDirectory: currentDirectoryForWordPathResolution())
+        return resolveTerminalLocalFileURL(word, currentDirectory: currentDirectory)
     }
 
     /// Update the pointing-hand cursor when Cmd-hovering over a local file path
     /// or file URL, including bare relative names from commands like `ls`.
-    private func updateWordPathHover(cmdHeld: Bool) {
+    private func updateWordPathHover(cmdHeld: Bool, point: CGPoint) {
         guard cmdHeld else {
             if wordPathHoverActive {
                 wordPathHoverActive = false
@@ -6732,7 +6887,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
-        if resolveWordUnderCursorAsLocalFileURL() != nil {
+        if resolveWordUnderCursorAsLocalFileURL(at: point) != nil {
             if !wordPathHoverActive {
                 wordPathHoverActive = true
                 NSCursor.pointingHand.push()
@@ -6825,7 +6980,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEquivalent: ""
         )
         pasteItem.target = self
-        if let localFileURL = resolveWordUnderCursorAsLocalFileURL() {
+        if let localFileURL = resolveWordUnderCursorAsLocalFileURL(at: point) {
             menu.addItem(.separator())
 
             let revealItem = menu.addItem(
@@ -6943,7 +7098,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command))
+        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command), point: point)
     }
 
     override func mouseEntered(with event: NSEvent) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -479,12 +479,35 @@ private let terminalFileLinkWrappingPairs: [(Character, Character)] = [
 ]
 
 private let terminalFileLinkTrailingPunctuation = CharacterSet(charactersIn: ",.;:!?")
+private let terminalFileLinkTrailingClosingDelimiters: [Character: Character] = [
+    ")": "(",
+    "]": "[",
+    "}": "{",
+    ">": "<"
+]
 
 private func trimTrailingTerminalFileLinkPunctuation(_ value: String) -> String {
     var result = value
-    while let lastScalar = result.unicodeScalars.last,
-          terminalFileLinkTrailingPunctuation.contains(lastScalar) {
-        result.unicodeScalars.removeLast()
+    while let lastCharacter = result.last {
+        if let lastScalar = lastCharacter.unicodeScalars.first,
+           terminalFileLinkTrailingPunctuation.contains(lastScalar) {
+            result.removeLast()
+            continue
+        }
+
+        guard let openingDelimiter = terminalFileLinkTrailingClosingDelimiters[lastCharacter] else {
+            break
+        }
+
+        let openingCount = result.reduce(into: 0) { count, character in
+            if character == openingDelimiter { count += 1 }
+        }
+        let closingCount = result.reduce(into: 0) { count, character in
+            if character == lastCharacter { count += 1 }
+        }
+
+        guard closingCount > openingCount else { break }
+        result.removeLast()
     }
     return result
 }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3880,6 +3880,33 @@ final class TerminalLocalFileURLResolutionTests: XCTestCase {
         }
     }
 
+    func testResolvesHoveredWordWithinFilenameWithSpaces() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("Group 8.png")
+            try Data().write(to: imageURL)
+
+            XCTAssertEqual(
+                resolveTerminalLocalFileURL(
+                    inLine: "- Group 8.png",
+                    hoveredWord: "Group",
+                    preferredColumn: 2,
+                    currentDirectory: root.path
+                )?.path,
+                imageURL.path
+            )
+
+            XCTAssertEqual(
+                resolveTerminalLocalFileURL(
+                    inLine: "- Group 8.png",
+                    hoveredWord: "8.png",
+                    preferredColumn: 8,
+                    currentDirectory: root.path
+                )?.path,
+                imageURL.path
+            )
+        }
+    }
+
     func testRejectsFileURLWithNonLocalHost() {
         XCTAssertNil(resolveTerminalLocalFileURL("file://example.com/etc/hosts"))
     }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3645,6 +3645,16 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
 
 
 final class TerminalOpenURLTargetResolutionTests: XCTestCase {
+    private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-open-url-target-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        return try body(root)
+    }
+
     func testResolvesHTTPSAsEmbeddedBrowser() throws {
         let target = try XCTUnwrap(resolveTerminalOpenURLTarget("https://example.com/path?q=1"))
         switch target {
@@ -3724,6 +3734,35 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
             XCTFail("Expected hostless HTTPS URL to open externally")
         }
     }
+
+    func testResolvesRelativePathAgainstCurrentDirectoryAsFinderReveal() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("preview.png")
+            try Data().write(to: imageURL)
+
+            let target = try XCTUnwrap(
+                resolveTerminalOpenURLTarget("preview.png", currentDirectory: root.path)
+            )
+            switch target {
+            case let .revealInFinder(url):
+                XCTAssertEqual(url.path, imageURL.path)
+            default:
+                XCTFail("Expected relative path to reveal in Finder when current directory is local")
+            }
+        }
+    }
+
+    func testLeavesNonLocalFileURLAsExternal() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("file://example.com/etc/hosts"))
+        switch target {
+        case let .external(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.host, "example.com")
+            XCTAssertEqual(url.path, "/etc/hosts")
+        default:
+            XCTFail("Expected non-local file URL to stay external")
+        }
+    }
 }
 
 
@@ -3772,6 +3811,34 @@ final class TerminalLocalFileURLResolutionTests: XCTestCase {
             )
             XCTAssertEqual(resolved.path, imageURL.path)
         }
+    }
+
+    func testResolvesHoveredLineFilenameWithSpaces() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("Group 8.png")
+            try Data().write(to: imageURL)
+
+            XCTAssertEqual(
+                resolveTerminalLocalFileURL(
+                    inLine: "- Group 8.png",
+                    hoveredColumn: 2,
+                    currentDirectory: root.path
+                )?.path,
+                imageURL.path
+            )
+            XCTAssertEqual(
+                resolveTerminalLocalFileURL(
+                    inLine: "- Group 8.png",
+                    hoveredColumn: 9,
+                    currentDirectory: root.path
+                )?.path,
+                imageURL.path
+            )
+        }
+    }
+
+    func testRejectsFileURLWithNonLocalHost() {
+        XCTAssertNil(resolveTerminalLocalFileURL("file://example.com/etc/hosts"))
     }
 
     func testReturnsNilForMissingRelativePath() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3872,11 +3872,40 @@ final class TerminalLocalFileURLResolutionTests: XCTestCase {
             XCTAssertEqual(
                 resolveTerminalLocalFileURL(
                     inLine: "- Group 8.png",
+                    hoveredColumn: 7,
+                    currentDirectory: root.path
+                )?.path,
+                imageURL.path
+            )
+            XCTAssertEqual(
+                resolveTerminalLocalFileURL(
+                    inLine: "- Group 8.png",
                     hoveredColumn: 9,
                     currentDirectory: root.path
                 )?.path,
                 imageURL.path
             )
+        }
+    }
+
+    func testResolvedLineTargetWithSpacesTracksFullColumnRange() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("Group 8.png")
+            try Data().write(to: imageURL)
+
+            let target = try XCTUnwrap(
+                resolveTerminalLocalFileTarget(
+                    inLine: "  - Group 8.png",
+                    hoveredWord: "Group",
+                    preferredColumn: 4,
+                    currentDirectory: root.path
+                )
+            )
+
+            XCTAssertEqual(target.url.path, imageURL.path)
+            XCTAssertTrue(target.columnRange.contains(4))
+            XCTAssertTrue(target.columnRange.contains(9))
+            XCTAssertTrue(target.columnRange.contains(14))
         }
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3752,8 +3752,41 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
+    func testBlocksAbsolutePathWhenLocalFileTargetsDisallowed() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("preview.png")
+            try Data().write(to: imageURL)
+
+            XCTAssertNil(
+                resolveTerminalOpenURLTarget(
+                    imageURL.path,
+                    allowLocalFileTargets: false
+                )
+            )
+        }
+    }
+
+    func testBlocksLocalFileURLWhenLocalFileTargetsDisallowed() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("preview.png")
+            try Data().write(to: imageURL)
+
+            XCTAssertNil(
+                resolveTerminalOpenURLTarget(
+                    imageURL.absoluteString,
+                    allowLocalFileTargets: false
+                )
+            )
+        }
+    }
+
     func testLeavesNonLocalFileURLAsExternal() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("file://example.com/etc/hosts"))
+        let target = try XCTUnwrap(
+            resolveTerminalOpenURLTarget(
+                "file://example.com/etc/hosts",
+                allowLocalFileTargets: false
+            )
+        )
         switch target {
         case let .external(url):
             XCTAssertTrue(url.isFileURL)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3813,6 +3813,16 @@ final class TerminalLocalFileURLResolutionTests: XCTestCase {
         }
     }
 
+    func testResolvesPathWithUnmatchedClosingDelimiter() throws {
+        try withTemporaryDirectory { root in
+            let sourceURL = root.appendingPathComponent("report.swift")
+            try Data("print(1)\n".utf8).write(to: sourceURL)
+
+            let resolved = try XCTUnwrap(resolveTerminalLocalFileURL("\(sourceURL.path))"))
+            XCTAssertEqual(resolved.path, sourceURL.path)
+        }
+    }
+
     func testResolvesHoveredLineFilenameWithSpaces() throws {
         try withTemporaryDirectory { root in
             let imageURL = root.appendingPathComponent("Group 8.png")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3670,24 +3670,36 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
     }
 
     func testResolvesFileSchemeAsExternal() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("file:///tmp/cmux.txt"))
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-open-url-\(UUID().uuidString).txt"
+        )
+        try Data("hi".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget(fileURL.absoluteString))
         switch target {
-        case let .external(url):
+        case let .revealInFinder(url):
             XCTAssertTrue(url.isFileURL)
-            XCTAssertEqual(url.path, "/tmp/cmux.txt")
+            XCTAssertEqual(url.path, fileURL.path)
         default:
-            XCTFail("Expected file URL to open externally")
+            XCTFail("Expected file URL to reveal in Finder")
         }
     }
 
     func testResolvesAbsolutePathAsExternalFileURL() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("/tmp/cmux-path.txt"))
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-absolute-path-\(UUID().uuidString).txt"
+        )
+        try Data("hi".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget(fileURL.path))
         switch target {
-        case let .external(url):
+        case let .revealInFinder(url):
             XCTAssertTrue(url.isFileURL)
-            XCTAssertEqual(url.path, "/tmp/cmux-path.txt")
+            XCTAssertEqual(url.path, fileURL.path)
         default:
-            XCTFail("Expected absolute file path to open externally")
+            XCTFail("Expected absolute file path to reveal in Finder")
         }
     }
 
@@ -3711,6 +3723,64 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         default:
             XCTFail("Expected hostless HTTPS URL to open externally")
         }
+    }
+}
+
+
+final class TerminalLocalFileURLResolutionTests: XCTestCase {
+    private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-terminal-file-url-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        return try body(root)
+    }
+
+    func testResolvesRelativePathAgainstCurrentDirectory() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("preview.png")
+            try Data().write(to: imageURL)
+
+            let resolved = try XCTUnwrap(
+                resolveTerminalLocalFileURL("preview.png", currentDirectory: root.path)
+            )
+            XCTAssertEqual(resolved.path, imageURL.path)
+        }
+    }
+
+    func testResolvesAbsolutePathWithLineAndColumnSuffix() throws {
+        try withTemporaryDirectory { root in
+            let sourceURL = root.appendingPathComponent("Sample.swift")
+            try Data("print(1)\n".utf8).write(to: sourceURL)
+
+            let resolved = try XCTUnwrap(
+                resolveTerminalLocalFileURL("\(sourceURL.path):12:34")
+            )
+            XCTAssertEqual(resolved.path, sourceURL.path)
+        }
+    }
+
+    func testResolvesWrappedFileURLWithTrailingPunctuation() throws {
+        try withTemporaryDirectory { root in
+            let imageURL = root.appendingPathComponent("graph.png")
+            try Data().write(to: imageURL)
+
+            let resolved = try XCTUnwrap(
+                resolveTerminalLocalFileURL("(\(imageURL.absoluteString)),")
+            )
+            XCTAssertEqual(resolved.path, imageURL.path)
+        }
+    }
+
+    func testReturnsNilForMissingRelativePath() {
+        XCTAssertNil(
+            resolveTerminalLocalFileURL(
+                "missing.png",
+                currentDirectory: FileManager.default.temporaryDirectory.path
+            )
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- reveal local file paths and file:// URLs in Finder from terminal link handling and Cmd-click fallback
- add terminal context menu actions for Reveal in Finder and Open
- cover local file-link parsing and file-link target routing with unit tests

## Testing
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/TerminalOpenURLTargetResolutionTests -only-testing:cmuxTests/TerminalLocalFileURLResolutionTests -derivedDataPath /tmp/cmux-task-reveal-file-paths-in-finder-test`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag task-reveal-file-paths-in-finder`

## Issues
- Task: let terminal file paths and file:// URLs support Cmd-click and right-click Reveal in Finder

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reveals terminal file paths and `file://` links in Finder via link handling, Cmd‑click, and a new context menu. Keeps hover active across full filenames (even with spaces), aligns hover geometry with Ghostty mouse coordinates, anchors to the visible row, and blocks local file handling on remote terminals to satisfy the Linear task for Cmd‑click and right‑click reveal.

- **New Features**
  - Detects local paths and `file://` URLs (hostless/`localhost`) and routes them to “Reveal in Finder”; rejects non‑local hosts and disables local file handling on remote terminals.
  - Cmd‑click fallback reveals local files, including relative paths resolved against the panel CWD; hover uses Ghostty’s mouse coordinates for reliable Cmd‑hover and stays active across spaces for the whole filename.
  - Adds “Reveal in Finder” and “Open” to the terminal context menu when a local file is under the cursor; localized in `Resources/Localizable.xcstrings` (en, ja).
  - Unit tests cover CWD‑relative paths, spaced‑filename span and column‑range tracking, visible‑row anchoring, delimiter and trailing‑punctuation trimming, `:line:col` suffix stripping, rejecting non‑local hosts, and blocking local file targets when disallowed.

<sup>Written for commit 551a9bb8a646fd0c5db13ab75598373f9707129e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-menu plus Cmd‑hover/Cmd‑click support for detected local file paths: "Open" and "Reveal in Finder".
  * Geometry-aware detection resolving relative and absolute file paths from terminal output; reveals local files in Finder when available.

* **Localization**
  * Added English and Japanese strings for the new context-menu options.

* **Tests**
  * Expanded unit tests for local file resolution, relative paths, token parsing, hovered-token resolution, and disallowed-local-target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->