### PR TITLE
Reduce sidebar CPU by splitting summary and detail invalidation

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11477,43 +11477,6 @@ private struct TabItemView: View, Equatable {
         let latestNotificationSubtitle = latestNotificationText
         let effectiveSubtitle = latestNotificationSubtitle
         let detailVisibility = visibleAuxiliaryDetails
-        let orderedPanelIds: [UUID]? = (detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests)
-            ? tab.sidebarOrderedPanelIds()
-            : nil
-        let compactGitBranchSummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  sidebarShowGitBranch,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return gitBranchSummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactDirectorySummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return directorySummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactBranchDirectoryRow = branchDirectoryRow(
-            gitSummary: compactGitBranchSummaryText,
-            directorySummary: compactDirectorySummaryText
-        )
-        let branchDirectoryLines: [VerticalBranchDirectoryLine] = {
-            guard detailVisibility.showsBranchDirectory,
-                  sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return []
-            }
-            return verticalBranchDirectoryLines(orderedPanelIds: orderedPanelIds)
-        }()
-        let branchLinesContainBranch = sidebarShowGitBranch && branchDirectoryLines.contains { $0.branch != nil }
-        let pullRequestRows: [PullRequestDisplay] = {
-            guard detailVisibility.showsPullRequests, let orderedPanelIds else { return [] }
-            return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
-        }()
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
@@ -11653,88 +11616,22 @@ private struct TabItemView: View, Equatable {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            // Branch + directory row
-            if detailVisibility.showsBranchDirectory {
-                if sidebarBranchVerticalLayout {
-                    if !branchDirectoryLines.isEmpty {
-                        HStack(alignment: .top, spacing: 3) {
-                            if sidebarShowGitBranchIcon, branchLinesContainBranch {
-                                Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: 9))
-                                    .foregroundColor(activeSecondaryColor(0.6))
-                            }
-                            VStack(alignment: .leading, spacing: 1) {
-                                ForEach(Array(branchDirectoryLines.enumerated()), id: \.offset) { _, line in
-                                    HStack(spacing: 3) {
-                                        if let branch = line.branch {
-                                            Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
-                                                .foregroundColor(activeSecondaryColor(0.75))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                        }
-                                        if line.branch != nil, line.directory != nil {
-                                            Image(systemName: "circle.fill")
-                                                .font(.system(size: 3))
-                                                .foregroundColor(activeSecondaryColor(0.6))
-                                                .padding(.horizontal, 1)
-                                        }
-                                        if let directory = line.directory {
-                                            Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
-                                                .foregroundColor(activeSecondaryColor(0.75))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else if let dirRow = compactBranchDirectoryRow {
-                    HStack(spacing: 3) {
-                        if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
-                                .foregroundColor(activeSecondaryColor(0.6))
-                        }
-                        Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
-                            .foregroundColor(activeSecondaryColor(0.75))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-            }
-
-            // Pull request rows
-            if detailVisibility.showsPullRequests, !pullRequestRows.isEmpty {
-                VStack(alignment: .leading, spacing: 1) {
-                    ForEach(pullRequestRows) { pullRequest in
-                        Button(action: {
-                            openPullRequestLink(pullRequest.url)
-                        }) {
-                            HStack(spacing: 4) {
-                                PullRequestStatusIcon(
-                                    status: pullRequest.status,
-                                    color: pullRequestForegroundColor
-                                )
-                                Text("\(pullRequest.label) #\(pullRequest.number)")
-                                    .underline()
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                                Text(pullRequestStatusLabel(pullRequest.status, checks: pullRequest.checks))
-                                    .lineLimit(1)
-                                Spacer(minLength: 0)
-                            }
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundColor(pullRequestForegroundColor)
-                        }
-                        .buttonStyle(.plain)
-                        .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"))
-                    }
-                }
-            }
+            SidebarWorkspaceStructuredDetailsSection(
+                tab: tab,
+                detailVisibility: detailVisibility,
+                sidebarBranchVerticalLayout: sidebarBranchVerticalLayout,
+                sidebarShowGitBranch: sidebarShowGitBranch,
+                sidebarShowGitBranchIcon: sidebarShowGitBranchIcon,
+                isActive: usesInvertedActiveForeground,
+                branchDirectoryRow: branchDirectoryRow,
+                gitBranchSummaryText: gitBranchSummaryText,
+                directorySummaryText: directorySummaryText,
+                verticalBranchDirectoryLines: verticalBranchDirectoryLines,
+                pullRequestDisplays: pullRequestDisplays,
+                pullRequestStatusLabel: pullRequestStatusLabel,
+                onOpenPullRequest: openPullRequestLink
+            )
+            .equatable()
 
             // Ports row
             if detailVisibility.showsPorts, !tab.listeningPorts.isEmpty {
@@ -11811,11 +11708,11 @@ private struct TabItemView: View, Equatable {
             }
         }
         .onReceive(
-            tab.sidebarObservationPublisher
+            tab.sidebarSummaryObservationPublisher
                 .receive(on: RunLoop.main)
                 // Prompt-time sidebar telemetry can arrive as a short burst
-                // (pwd, branch, PR, shell state). Coalesce that burst so the
-                // row redraws once with the settled state instead of blinking.
+                // (status, metadata, log, progress, ports). Coalesce that
+                // burst so the row summary redraws once with the settled state.
                 .debounce(for: Self.workspaceObservationCoalesceInterval, scheduler: RunLoop.main)
         ) { _ in
             workspaceObservationGeneration &+= 1
@@ -12352,6 +12249,191 @@ private struct TabItemView: View, Equatable {
 
         selectedTabIds.subtract(orderedWorkspaceIds)
         syncSelectionAfterMutation()
+    }
+
+    private struct SidebarWorkspaceStructuredDetailsSection: View, Equatable {
+        nonisolated static func == (
+            lhs: SidebarWorkspaceStructuredDetailsSection,
+            rhs: SidebarWorkspaceStructuredDetailsSection
+        ) -> Bool {
+            lhs.tab === rhs.tab &&
+            lhs.detailVisibility == rhs.detailVisibility &&
+            lhs.sidebarBranchVerticalLayout == rhs.sidebarBranchVerticalLayout &&
+            lhs.sidebarShowGitBranch == rhs.sidebarShowGitBranch &&
+            lhs.sidebarShowGitBranchIcon == rhs.sidebarShowGitBranchIcon &&
+            lhs.isActive == rhs.isActive
+        }
+
+        let tab: Tab
+        let detailVisibility: SidebarWorkspaceAuxiliaryDetailVisibility
+        let sidebarBranchVerticalLayout: Bool
+        let sidebarShowGitBranch: Bool
+        let sidebarShowGitBranchIcon: Bool
+        let isActive: Bool
+        let branchDirectoryRow: (_ gitSummary: String?, _ directorySummary: String?) -> String?
+        let gitBranchSummaryText: ([UUID]) -> String?
+        let directorySummaryText: ([UUID]) -> String?
+        let verticalBranchDirectoryLines: ([UUID]) -> [VerticalBranchDirectoryLine]
+        let pullRequestDisplays: ([UUID]) -> [PullRequestDisplay]
+        let pullRequestStatusLabel: (SidebarPullRequestStatus, SidebarPullRequestChecksStatus?) -> String
+        let onOpenPullRequest: (URL) -> Void
+
+        @State private var detailObservationGeneration: UInt64 = 0
+
+        private var showsAnyDetails: Bool {
+            detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests
+        }
+
+        private var pullRequestForegroundColor: Color {
+            isActive ? .white.opacity(0.75) : .secondary
+        }
+
+        private func secondaryColor(_ opacity: Double = 0.75) -> Color {
+            isActive
+                ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity)))
+                : .secondary
+        }
+
+        private var detailObservationPublisher: AnyPublisher<Void, Never> {
+            guard showsAnyDetails else {
+                return Empty(completeImmediately: false).eraseToAnyPublisher()
+            }
+
+            return tab.sidebarDetailObservationPublisher
+                .receive(on: RunLoop.main)
+                // Prompt-time sidebar telemetry can arrive as a short burst
+                // (pwd, branch, PR, shell state). Coalesce that burst so the
+                // details subtree redraws once with the settled state.
+                .debounce(for: TabItemView.workspaceObservationCoalesceInterval, scheduler: RunLoop.main)
+                .eraseToAnyPublisher()
+        }
+
+        var body: some View {
+            let _ = detailObservationGeneration
+
+            Group {
+                if showsAnyDetails {
+                    let orderedPanelIds = tab.sidebarOrderedPanelIds()
+                    let compactGitBranchSummaryText: String? = {
+                        guard detailVisibility.showsBranchDirectory,
+                              !sidebarBranchVerticalLayout,
+                              sidebarShowGitBranch else {
+                            return nil
+                        }
+                        return gitBranchSummaryText(orderedPanelIds)
+                    }()
+                    let compactDirectorySummaryText: String? = {
+                        guard detailVisibility.showsBranchDirectory,
+                              !sidebarBranchVerticalLayout else {
+                            return nil
+                        }
+                        return directorySummaryText(orderedPanelIds)
+                    }()
+                    let compactBranchDirectoryRow = branchDirectoryRow(
+                        compactGitBranchSummaryText,
+                        compactDirectorySummaryText
+                    )
+                    let branchDirectoryLines: [VerticalBranchDirectoryLine] = {
+                        guard detailVisibility.showsBranchDirectory,
+                              sidebarBranchVerticalLayout else {
+                            return []
+                        }
+                        return verticalBranchDirectoryLines(orderedPanelIds)
+                    }()
+                    let branchLinesContainBranch = sidebarShowGitBranch && branchDirectoryLines.contains { $0.branch != nil }
+                    let pullRequestRows: [PullRequestDisplay] = {
+                        guard detailVisibility.showsPullRequests else { return [] }
+                        return pullRequestDisplays(orderedPanelIds)
+                    }()
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        if detailVisibility.showsBranchDirectory {
+                            if sidebarBranchVerticalLayout {
+                                if !branchDirectoryLines.isEmpty {
+                                    HStack(alignment: .top, spacing: 3) {
+                                        if sidebarShowGitBranchIcon, branchLinesContainBranch {
+                                            Image(systemName: "arrow.triangle.branch")
+                                                .font(.system(size: 9))
+                                                .foregroundColor(secondaryColor(0.6))
+                                        }
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            ForEach(Array(branchDirectoryLines.enumerated()), id: \.offset) { _, line in
+                                                HStack(spacing: 3) {
+                                                    if let branch = line.branch {
+                                                        Text(branch)
+                                                            .font(.system(size: 10, design: .monospaced))
+                                                            .foregroundColor(secondaryColor(0.75))
+                                                            .lineLimit(1)
+                                                            .truncationMode(.tail)
+                                                    }
+                                                    if line.branch != nil, line.directory != nil {
+                                                        Image(systemName: "circle.fill")
+                                                            .font(.system(size: 3))
+                                                            .foregroundColor(secondaryColor(0.6))
+                                                            .padding(.horizontal, 1)
+                                                    }
+                                                    if let directory = line.directory {
+                                                        Text(directory)
+                                                            .font(.system(size: 10, design: .monospaced))
+                                                            .foregroundColor(secondaryColor(0.75))
+                                                            .lineLimit(1)
+                                                            .truncationMode(.tail)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if let dirRow = compactBranchDirectoryRow {
+                                HStack(spacing: 3) {
+                                    if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
+                                        Image(systemName: "arrow.triangle.branch")
+                                            .font(.system(size: 9))
+                                            .foregroundColor(secondaryColor(0.6))
+                                    }
+                                    Text(dirRow)
+                                        .font(.system(size: 10, design: .monospaced))
+                                        .foregroundColor(secondaryColor(0.75))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                }
+                            }
+                        }
+
+                        if detailVisibility.showsPullRequests, !pullRequestRows.isEmpty {
+                            VStack(alignment: .leading, spacing: 1) {
+                                ForEach(pullRequestRows) { pullRequest in
+                                    Button(action: {
+                                        onOpenPullRequest(pullRequest.url)
+                                    }) {
+                                        HStack(spacing: 4) {
+                                            PullRequestStatusIcon(
+                                                status: pullRequest.status,
+                                                color: pullRequestForegroundColor
+                                            )
+                                            Text("\(pullRequest.label) #\(pullRequest.number)")
+                                                .underline()
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                            Text(pullRequestStatusLabel(pullRequest.status, pullRequest.checks))
+                                                .lineLimit(1)
+                                            Spacer(minLength: 0)
+                                        }
+                                        .font(.system(size: 10, weight: .semibold))
+                                        .foregroundColor(pullRequestForegroundColor)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .onReceive(detailObservationPublisher) { _ in
+                detailObservationGeneration &+= 1
+            }
+        }
     }
 
     // latestNotificationText is now passed as a parameter from the parent view

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5632,6 +5632,14 @@ final class Workspace: Identifiable, ObservableObject {
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()
     }()
 
+    lazy var sidebarSummaryObservationPublisher: AnyPublisher<Void, Never> = {
+        sidebarObservationPublisher
+    }()
+
+    lazy var sidebarDetailObservationPublisher: AnyPublisher<Void, Never> = {
+        sidebarObservationPublisher
+    }()
+
     private static func isProxyOnlyRemoteError(_ detail: String) -> Bool {
         let lowered = detail.lowercased()
         return lowered.contains("remote proxy")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5601,27 +5601,24 @@ final class Workspace: Identifiable, ObservableObject {
             .eraseToAnyPublisher()
     }
 
-    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
+    private func sidebarPanelsObservationSignal() -> AnyPublisher<Void, Never> {
+        $panels
+            .map(SidebarPanelObservationState.init)
+            .dropFirst()
+            .removeDuplicates()
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    lazy var sidebarSummaryObservationPublisher: AnyPublisher<Void, Never> = {
         let publishers: [AnyPublisher<Void, Never>] = [
             sidebarObservationSignal($title),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
-            sidebarObservationSignal($currentDirectory),
-            $panels
-                .map(SidebarPanelObservationState.init)
-                .dropFirst()
-                .removeDuplicates()
-                .map { _ in () }
-                .eraseToAnyPublisher(),
-            sidebarObservationSignal($panelDirectories),
             sidebarObservationSignal($statusEntries),
             sidebarObservationSignal($metadataBlocks),
             sidebarObservationSignal($logEntries),
             sidebarObservationSignal($progress),
-            sidebarObservationSignal($gitBranch),
-            sidebarObservationSignal($panelGitBranches),
-            sidebarObservationSignal($pullRequest),
-            sidebarObservationSignal($panelPullRequests),
             sidebarObservationSignal($remoteConfiguration),
             sidebarObservationSignal($remoteConnectionState),
             sidebarObservationSignal($remoteConnectionDetail),
@@ -5632,12 +5629,24 @@ final class Workspace: Identifiable, ObservableObject {
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()
     }()
 
-    lazy var sidebarSummaryObservationPublisher: AnyPublisher<Void, Never> = {
-        sidebarObservationPublisher
+    lazy var sidebarDetailObservationPublisher: AnyPublisher<Void, Never> = {
+        let publishers: [AnyPublisher<Void, Never>] = [
+            sidebarObservationSignal($currentDirectory),
+            sidebarPanelsObservationSignal(),
+            sidebarObservationSignal($panelDirectories),
+            sidebarObservationSignal($gitBranch),
+            sidebarObservationSignal($panelGitBranches),
+            sidebarObservationSignal($pullRequest),
+            sidebarObservationSignal($panelPullRequests),
+            sidebarObservationSignal($remoteConfiguration),
+        ]
+
+        return Publishers.MergeMany(publishers).eraseToAnyPublisher()
     }()
 
-    lazy var sidebarDetailObservationPublisher: AnyPublisher<Void, Never> = {
-        sidebarObservationPublisher
+    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
+        Publishers.Merge(sidebarSummaryObservationPublisher, sidebarDetailObservationPublisher)
+            .eraseToAnyPublisher()
     }()
 
     private static func isProxyOnlyRemoteError(_ detail: String) -> Bool {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2239,6 +2239,86 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testSidebarSummaryObservationPublisherIgnoresDetailOnlyGitUpdates() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial focused panel")
+            return
+        }
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarSummaryObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        workspace.updatePanelGitBranch(panelId: panelId, branch: "main", isDirty: false)
+
+        XCTAssertEqual(
+            publishCount,
+            0,
+            "Expected detail-only git updates to avoid invalidating the lightweight sidebar row summary"
+        )
+    }
+
+    func testSidebarDetailObservationPublisherIgnoresSummaryOnlyStatusUpdates() {
+        let workspace = Workspace()
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarDetailObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        workspace.statusEntries["agent"] = SidebarStatusEntry(
+            key: "agent",
+            value: "Claude Code",
+            priority: 1
+        )
+
+        XCTAssertEqual(
+            publishCount,
+            0,
+            "Expected status-only sidebar metadata updates to avoid invalidating the expensive branch and PR subtree"
+        )
+    }
+
+    func testSidebarDetailObservationPublisherEmitsWhenFocusedPullRequestChanges() {
+        let workspace = Workspace()
+        guard let firstPanelId = workspace.focusedPanelId,
+              let paneId = workspace.paneId(forPanelId: firstPanelId),
+              let secondPanel = workspace.newTerminalSurface(inPane: paneId, focus: false) else {
+            XCTFail("Expected focused panel and a second panel")
+            return
+        }
+
+        workspace.updatePanelDirectory(panelId: firstPanelId, directory: "/repo")
+        workspace.updatePanelDirectory(panelId: secondPanel.id, directory: "/repo")
+        workspace.updatePanelGitBranch(panelId: firstPanelId, branch: "main", isDirty: false)
+        workspace.updatePanelGitBranch(panelId: secondPanel.id, branch: "main", isDirty: false)
+        workspace.updatePanelPullRequest(
+            panelId: secondPanel.id,
+            number: 1629,
+            label: "PR",
+            url: URL(string: "https://github.com/manaflow-ai/cmux/pull/1629")!,
+            status: .open
+        )
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarDetailObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        workspace.focusPanel(secondPanel.id)
+
+        XCTAssertGreaterThan(
+            publishCount,
+            0,
+            "Expected focused pull request changes to invalidate the sidebar detail subtree even when branch and directory stay the same"
+        )
+    }
+
     @MainActor
     func testSidebarPullRequestsTrackFocusedPanelOnly() {
         let workspace = Workspace()


### PR DESCRIPTION
## Summary
- split workspace sidebar invalidation into lightweight summary updates and detail-only branch/PR updates
- move branch, directory, and pull request rendering into a detail subtree so status, metadata, log, and port changes stop recomputing the expensive rows
- add regression coverage for the summary/detail publisher split and focused pull request detail invalidation

## Testing
- `ssh cmux-macmini 'set -e; cd /Users/cmux/fun/cmux-worktrees/issue-2487-sidebar-high-cpu-test; rm -rf /tmp/cmux-issue-2487-sidebar-high-cpu-test; CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination "platform=macOS" -derivedDataPath /tmp/cmux-issue-2487-sidebar-high-cpu-test test -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testUpdatingFocusedPanelGitBranchWithSameStateDoesNotRepublishWorkspace -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testUpdatingFocusedPanelPullRequestWithSameStateDoesNotRepublishWorkspace -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testSidebarObservationPublisherEmitsForFocusedGitBranchChangesOnlyOncePerState -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testSidebarObservationPublisherIgnoresRemoteHeartbeatOnlyChanges -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testSidebarSummaryObservationPublisherIgnoresDetailOnlyGitUpdates -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testSidebarDetailObservationPublisherIgnoresSummaryOnlyStatusUpdates -only-testing:cmuxTests/WorkspacePanelGitBranchTests/testSidebarDetailObservationPublisherEmitsWhenFocusedPullRequestChanges'`

Closes https://github.com/manaflow-ai/cmux/issues/2487

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split sidebar invalidation into a lightweight summary stream and a detail-only stream to reduce redraws and CPU. Branch, directory, and PR UI now update separately from status/metadata/log/ports.

- **Refactors**
  - Added `sidebarSummaryObservationPublisher` (status, metadata, log, progress, ports) and `sidebarDetailObservationPublisher` (directory, branch, PR); `sidebarObservationPublisher` now merges both.
  - Introduced `SidebarWorkspaceStructuredDetailsSection` and moved branch/directory/PR rendering into this detail subtree; `TabItemView` now listens to summary updates, details section to detail updates, both debounced.
  - Extracted `sidebarPanelsObservationSignal()` to consolidate panel change observation and reduce duplicate work.
  - Added regression tests to ensure summary ignores detail-only git updates, details ignore summary-only status updates, and focused PR changes invalidate details.

<sup>Written for commit d4b99165151341e8e4ae0d8f7ee296a64ae2c235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized workspace sidebar updates by separating summary and detail observation pipelines, reducing unnecessary redraws when branch, directory, or pull request information changes.

* **Tests**
  * Added tests verifying correct sidebar observation publisher behavior for summary and detail updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->