### PR TITLE
Fix Korean IME jamo leak during composition

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6130,8 +6130,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     event: translationEvent,
                     markedTextBefore: markedTextBefore
                 )
+            let suppressComposingFallbackText = keyEvent.composing
             if let text = textForKeyEvent(translationEvent) {
-                if shouldSendText(text), !suppressShiftSpaceFallbackText {
+                if shouldSendText(text),
+                   !suppressShiftSpaceFallbackText,
+                   !suppressComposingFallbackText {
                     shouldRefreshAfterTextInput = true
 #if DEBUG
                     let sendTimingStart = CmuxTypingTiming.start()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6063,12 +6063,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
                     text.withCString { ptr in
                         keyEvent.text = ptr
-                        _ = ghostty_surface_key(surface, keyEvent)
+                        #if DEBUG
+                        _ = sendTimedGhosttyKey(
+                            surface,
+                            keyEvent,
+                            path: "terminal.keyDown.accumulatedGhosttySend",
+                            event: event,
+                            extra: "textBytes=\(text.utf8.count)"
+                        )
+                        #else
+                        _ = sendGhosttyKey(surface, keyEvent)
+                        #endif
                     }
 #if DEBUG
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     CmuxTypingTiming.logDuration(
-                        path: "terminal.keyDown.accumulatedGhosttySend",
+                        path: "terminal.keyDown.accumulatedGhosttySend.total",
                         startedAt: sendTimingStart,
                         event: event,
                         extra: "textBytes=\(text.utf8.count)"
@@ -6129,12 +6139,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
                     text.withCString { ptr in
                         keyEvent.text = ptr
-                        _ = ghostty_surface_key(surface, keyEvent)
+                        #if DEBUG
+                        _ = sendTimedGhosttyKey(
+                            surface,
+                            keyEvent,
+                            path: "terminal.keyDown.ghosttySend",
+                            event: event,
+                            extra: "textBytes=\(text.utf8.count)"
+                        )
+                        #else
+                        _ = sendGhosttyKey(surface, keyEvent)
+                        #endif
                     }
 #if DEBUG
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     CmuxTypingTiming.logDuration(
-                        path: "terminal.keyDown.ghosttySend",
+                        path: "terminal.keyDown.ghosttySend.total",
                         startedAt: sendTimingStart,
                         event: event,
                         extra: "textBytes=\(text.utf8.count)"

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1185,10 +1185,10 @@ final class KoreanIMEMarkedTextLeakRegressionTests: XCTestCase {
             return true
         }
 
-        var leakedEvent: ghostty_input_key_s?
+        var capturedEvent: ghostty_input_key_s?
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
             guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 45 else { return }
-            leakedEvent = keyEvent
+            capturedEvent = keyEvent
         }
 
         guard let event = NSEvent.keyEvent(
@@ -1210,13 +1210,15 @@ final class KoreanIMEMarkedTextLeakRegressionTests: XCTestCase {
         window.makeFirstResponder(view)
         view.keyDown(with: event)
 
-        guard let leakedEvent else {
-            XCTFail("Expected terminal key event for composing Hangul input")
+        guard let capturedEvent else {
+            XCTFail(
+                "Expected a composing key event to be forwarded to Ghostty with text=nil; no event was received"
+            )
             return
         }
 
-        XCTAssertTrue(leakedEvent.composing, "Hangul composition keyDown should stay in composing mode")
-        XCTAssertNil(leakedEvent.text, "Uncommitted Hangul jamo must not be encoded into the terminal surface")
+        XCTAssertTrue(capturedEvent.composing, "Hangul composition keyDown should stay in composing mode")
+        XCTAssertNil(capturedEvent.text, "Uncommitted Hangul jamo must not be encoded into the terminal surface")
         XCTAssertTrue(view.hasMarkedText(), "Composition should remain active until the IME commits or cancels")
     }
 }

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -65,7 +65,6 @@ private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
 
     return nil
 }
-
 // MARK: - NSTextInputClient protocol: marked text (preedit) lifecycle
 
 /// Tests that the GhosttyNSView NSTextInputClient implementation correctly
@@ -1123,6 +1122,102 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
 
         XCTAssertFalse(view.hasMarkedText(), "Return should commit the active Hangul composition")
         XCTAssertTrue(sawReturnPress, "Return should still be forwarded after IME commit so the command executes once")
+    }
+}
+
+@MainActor
+final class KoreanIMEMarkedTextLeakRegressionTests: XCTestCase {
+    func testKeyDownDoesNotLeakJamoWhileMarkedTextIsActive() {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            KeyboardLayout.debugInputSourceIdOverride = nil
+            cjkIMEInterpretKeyEventsHook = nil
+            window.orderOut(nil)
+        }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let view = findGhosttyNSView(in: hostedView) else {
+            XCTFail("Expected hosted GhosttyNSView")
+            return
+        }
+
+        view.setMarkedText(
+            "하",
+            selectedRange: NSRange(location: 0, length: 1),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Korean.2SetKorean"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            return true
+        }
+
+        var leakedEvent: ghostty_input_key_s?
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 45 else { return }
+            leakedEvent = keyEvent
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "ㄴ",
+            charactersIgnoringModifiers: "ㄴ",
+            isARepeat: false,
+            keyCode: 45
+        ) else {
+            XCTFail("Failed to create Hangul jamo event")
+            return
+        }
+
+        window.makeFirstResponder(view)
+        view.keyDown(with: event)
+
+        guard let leakedEvent else {
+            XCTFail("Expected terminal key event for composing Hangul input")
+            return
+        }
+
+        XCTAssertTrue(leakedEvent.composing, "Hangul composition keyDown should stay in composing mode")
+        XCTAssertNil(leakedEvent.text, "Uncommitted Hangul jamo must not be encoded into the terminal surface")
+        XCTAssertTrue(view.hasMarkedText(), "Composition should remain active until the IME commits or cancels")
     }
 }
 


### PR DESCRIPTION
## Summary
- add a regression that catches composing Korean key events leaking text into Ghostty
- keep composing keydowns on the nil-text path until the IME commits or cancels
- preserve the existing Korean Return commit behavior

## Testing
- CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-2519-korean-ime-tests test -only-testing:cmuxTests/KoreanIMEMarkedTextLeakRegressionTests -only-testing:cmuxTests/KoreanIMEReturnCommitRegressionTests

Fixes https://github.com/manaflow-ai/cmux/issues/2519

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Korean IME jamo from leaking into the terminal during composition by suppressing fallback text until the IME commits or cancels. Fixes #2519.

- **Bug Fixes**
  - Suppress fallback text while marked text is active; composing keydowns stay on the nil-text path until commit or cancel.
  - Preserve Korean Return-to-commit behavior and add regression tests for jamo leak and Return commit.

- **Refactors**
  - In DEBUG, send keys via `sendTimedGhosttyKey` (release uses `sendGhosttyKey`) and rename timing metric paths to "*.total".

<sup>Written for commit 1968d40c2d7d03e7f577b597f68ab76495ddd14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Korean IME text composition to prevent unintended character leaks while actively composing marked text, improving reliability during multi-stage input.

* **Tests**
  * Added a regression test to verify correct Korean IME input handling while marked text is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->