### PR TITLE
fix: pass locale to VS Code serve-web to resolve NLS MISSING errors

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -966,13 +966,17 @@ final class VSCodeServeWebController {
 
         let process = Process()
         process.executableURL = launchConfiguration.executableURL
-        process.arguments = launchConfiguration.argumentsPrefix + [
+        var arguments = launchConfiguration.argumentsPrefix + [
             "serve-web",
             "--accept-server-license-terms",
             "--host", "127.0.0.1",
             "--port", "0",
             "--connection-token-file", connectionTokenFileURL.path,
         ]
+        if let locale = LanguageSettings.languageAtLaunch.vscodeLocale {
+            arguments.append(contentsOf: ["--locale", locale])
+        }
+        process.arguments = arguments
         process.environment = launchConfiguration.environment
 
         let stdoutPipe = Pipe()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3714,6 +3714,32 @@ enum AppLanguage: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Returns the VS Code compatible locale identifier for use with `serve-web --locale`.
+    /// Returns `nil` for `.system` to let VS Code auto-detect.
+    var vscodeLocale: String? {
+        switch self {
+        case .system: return nil
+        case .en: return "en"
+        case .ar: return "ar"
+        case .bs: return "bs"
+        case .zhHans: return "zh-cn"
+        case .zhHant: return "zh-tw"
+        case .da: return "da"
+        case .de: return "de"
+        case .es: return "es"
+        case .fr: return "fr"
+        case .it: return "it"
+        case .ja: return "ja"
+        case .ko: return "ko"
+        case .nb: return "nb"
+        case .pl: return "pl"
+        case .ptBR: return "pt-br"
+        case .ru: return "ru"
+        case .th: return "th"
+        case .tr: return "tr"
+        }
+    }
+
     var displayName: String {
         switch self {
         case .system: return String(localized: "language.system", defaultValue: "System")


### PR DESCRIPTION
## Summary

- Maps cmux's `AppLanguage` setting to VS Code compatible locale identifiers (e.g. `zh-Hans` → `zh-cn`)
- Passes `--locale` flag to `code-tunnel serve-web` when a non-system language is configured in cmux

## Problem

When opening VS Code Web via cmux, the browser console shows:
```
Error: !!! NLS MISSING: 17086 !!!
```
This happens because `serve-web` is launched without an explicit locale, causing VS Code Web to fail when loading localization strings.

## Changes

- **`cmuxApp.swift`**: Added `vscodeLocale` computed property to `AppLanguage` that returns VS Code compatible locale codes
- **`AppDelegate.swift`**: Pass `--locale` argument to `serve-web` when a specific language is configured

Closes #2532

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "NLS MISSING" errors in VS Code Web by passing the correct locale to `serve-web` based on the app’s language setting.

- **Bug Fixes**
  - Map `AppLanguage` to VS Code locale codes (e.g., `zh-Hans` → `zh-cn`).
  - Add `--locale` to `serve-web` when a non-system language is selected.

<sup>Written for commit 2481514cd679e3aac656c35e297b7d224e76c7b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed language and locale settings propagation to the VS Code integration for consistent localization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->