### PR TITLE
fix: Ctrl+key shortcuts not working with non-Latin input sources (Korean, CJK)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5589,7 +5589,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.composing = false
             keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
 
-            let text = (event.charactersIgnoringModifiers ?? event.characters ?? "")
+            // When a non-Latin input source is active (e.g. Korean 두벌식),
+            // charactersIgnoringModifiers returns non-ASCII (e.g. "ㅏ" for physical K).
+            // Normalize via KeyboardLayout so Ghostty receives the correct ASCII character
+            // for control-character encoding (Ctrl+K → 0x0B, not Ctrl+ㅏ).
+            let text = KeyboardLayout.normalizedCharacters(for: event)
             let handled: Bool
             if text.isEmpty {
                 keyEvent.text = nil


### PR DESCRIPTION
## Summary

When a non-Latin input source (e.g. Korean 두벌식) is active, all Ctrl+letter terminal shortcuts (Ctrl+C, Ctrl+K, Ctrl+L, etc.) stop working. This is because macOS does **not** remap `charactersIgnoringModifiers` for Control-modified keys the way it does for Command-modified keys.

For example, pressing Ctrl+K with Korean IME produces `Ctrl+ㅏ` instead of `Ctrl+K`, because physical key K maps to `ㅏ` in the Korean layout. The Ctrl fast path in `keyDown` was passing this non-ASCII character directly to Ghostty, preventing correct control-character encoding.

### Root cause

| Modifier | macOS behavior with non-Latin IME | Result |
|----------|----------------------------------|--------|
| **Cmd** | Auto-remaps to Latin layout | `event.characters` = `"k"` ✅ |
| **Ctrl** | No remapping | `event.charactersIgnoringModifiers` = `"ㅏ"` ❌ |

### Fix

Use `KeyboardLayout.normalizedCharacters(for:)` — which already exists and is used in `AppDelegate.handleCustomShortcut` — to translate the physical key code back to its ASCII equivalent via `UCKeyTranslate` with ASCII-capable input source fallback. This is the same approach used by iTerm2, WezTerm, and Zed for non-Latin input sources.

### Affected shortcuts

All Ctrl+letter terminal sequences when a non-Latin input source is active:
- Ctrl+C (SIGINT), Ctrl+D (EOF), Ctrl+Z (SIGTSTP)
- Ctrl+K (kill line), Ctrl+L (clear), Ctrl+R (reverse search)
- Ctrl+A / Ctrl+E (line navigation)
- Any other Ctrl+letter combination

### Change

**`Sources/GhosttyTerminalView.swift`** — Ctrl fast path text generation (1 line change):
```swift
// Before:
let text = (event.charactersIgnoringModifiers ?? event.characters ?? "")

// After:
let text = KeyboardLayout.normalizedCharacters(for: event)
```

### How it was tested

1. Built debug app with the fix
2. Switched to Korean 두벌식 input source
3. Verified Ctrl+C, Ctrl+K, Ctrl+L, Ctrl+A, Ctrl+E all work correctly
4. Verified normal Korean text input is unaffected

## Test plan

- [ ] Korean 두벌식: Ctrl+C/D/K/L/R/A/E all produce correct terminal control characters
- [ ] Japanese (Hiragana): Ctrl shortcuts still work
- [ ] English (QWERTY): No regression — shortcuts work as before
- [ ] Normal text input with all IMEs is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ctrl+letter shortcuts not working with non‑Latin input sources on macOS (e.g., Korean). Restores expected terminal controls like Ctrl+C/K/L while leaving normal IME text input untouched.

- **Bug Fixes**
  - In the Ctrl fast path, use `KeyboardLayout.normalizedCharacters(for:)` instead of `event.charactersIgnoringModifiers` so Control-modified keys map to their ASCII equivalents before control-character encoding.
  - Manually tested: Korean 두벌식 and Japanese Hiragana now produce correct Ctrl sequences; English layout unchanged.

<sup>Written for commit 17dd45defe7919794d3a15e48c4a2ded18a54820. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected keyboard input processing for control key combinations with non-Latin keyboard layouts. Control characters are now properly recognized regardless of the active input source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->