### PR TITLE
feat: add float on top (always on top) window support

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5476,6 +5476,14 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.toggleFloatOnTop",
+                title: constant(String(localized: "command.toggleFloatOnTop.title", defaultValue: "Toggle Float on Top")),
+                subtitle: constant(String(localized: "command.toggleFloatOnTop.subtitle", defaultValue: "Window")),
+                keywords: ["float", "top", "pin", "always", "window", "toggle"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.reopenClosedBrowserTab",
                 title: constant(String(localized: "command.reopenClosedBrowserTab.title", defaultValue: "Reopen Closed Browser Tab")),
                 subtitle: constant(String(localized: "command.reopenClosedBrowserTab.subtitle", defaultValue: "Browser")),
@@ -6163,6 +6171,13 @@ struct ContentView: View {
                 return
             }
             window.toggleFullScreen(nil)
+        }
+        registry.register(commandId: "palette.toggleFloatOnTop") {
+            guard let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else {
+                NSSound.beep()
+                return
+            }
+            window.level = window.level == .floating ? .normal : .floating
         }
         registry.register(commandId: "palette.reopenClosedBrowserTab") {
             _ = tabManager.reopenMostRecentlyClosedBrowserPanel()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2750,6 +2750,22 @@ class GhosttyApp {
                 surfaceView.updateKeyTable(action.action.key_table)
                 return true
             }
+        case GHOSTTY_ACTION_FLOAT_WINDOW:
+            let mode = action.action.float_window
+            return performOnMain {
+                guard let window = self.activeMainWindow() else { return false }
+                switch mode {
+                case GHOSTTY_FLOAT_WINDOW_ON:
+                    window.level = .floating
+                case GHOSTTY_FLOAT_WINDOW_OFF:
+                    window.level = .normal
+                case GHOSTTY_FLOAT_WINDOW_TOGGLE:
+                    window.level = window.level == .floating ? .normal : .floating
+                default:
+                    return false
+                }
+                return true
+            }
         case GHOSTTY_ACTION_OPEN_URL:
             let openUrl = action.action.open_url
             guard let cstr = openUrl.url else { return false }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1666,6 +1666,9 @@ class TerminalController {
         case "close_window":
             return closeWindow(args)
 
+        case "float_on_top":
+            return floatOnTop(args)
+
         case "move_workspace_to_window":
             return moveWorkspaceToWindow(args)
 
@@ -2045,6 +2048,8 @@ class TerminalController {
             return v2Result(id: id, self.v2WindowCreate(params: params))
         case "window.close":
             return v2Result(id: id, self.v2WindowClose(params: params))
+        case "window.float_on_top":
+            return v2Result(id: id, self.v2WindowFloatOnTop(params: params))
 
         // Workspaces
         case "workspace.list":
@@ -3276,6 +3281,27 @@ class TerminalController {
                 "window_id": windowId.uuidString,
                 "window_ref": v2Ref(kind: .window, uuid: windowId)
             ])
+    }
+
+    private func v2WindowFloatOnTop(params: [String: Any]) -> V2CallResult {
+        let mode = (params["mode"] as? String ?? "toggle").lowercased()
+        let result: V2CallResult = v2MainSync {
+            guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
+                return .err(code: "not_found", message: "No window found", data: nil)
+            }
+            switch mode {
+            case "on":
+                window.level = .floating
+            case "off":
+                window.level = .normal
+            case "toggle":
+                window.level = window.level == .floating ? .normal : .floating
+            default:
+                return .err(code: "invalid_params", message: "Invalid mode. Use on, off, or toggle", data: nil)
+            }
+            return .ok(["floating": window.level == .floating])
+        }
+        return result
     }
 
     // MARK: - V2 Workspace Methods
@@ -12136,6 +12162,27 @@ class TerminalController {
         guard let windowId = UUID(uuidString: trimmed) else { return "ERROR: Invalid window id" }
         let ok = v2MainSync { AppDelegate.shared?.closeMainWindow(windowId: windowId) ?? false }
         return ok ? "OK" : "ERROR: Window not found"
+    }
+
+    private func floatOnTop(_ arg: String) -> String {
+        let mode = arg.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let result: String = v2MainSync {
+            guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
+                return "ERROR: No window found"
+            }
+            switch mode {
+            case "on":
+                window.level = .floating
+            case "off":
+                window.level = .normal
+            case "toggle", "":
+                window.level = window.level == .floating ? .normal : .floating
+            default:
+                return "ERROR: Invalid mode. Use on, off, or toggle"
+            }
+            return "OK \(window.level == .floating ? "floating" : "normal")"
+        }
+        return result
     }
 
     private func moveWorkspaceToWindow(_ args: String) -> String {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -820,6 +820,14 @@ struct cmuxApp: App {
                     showNotificationsPopover()
                 }
             }
+
+            CommandGroup(before: .windowArrangement) {
+                Button(String(localized: "menu.window.floatOnTop", defaultValue: "Float on Top")) {
+                    guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+                    window.level = window.level == .floating ? .normal : .floating
+                }
+                .keyboardShortcut("t", modifiers: [.control, .shift])
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Wire up libghostty's existing `GHOSTTY_ACTION_FLOAT_WINDOW` action that was previously unhandled in cmux. This allows users to pin the cmux window on top of other windows.

- Handle `GHOSTTY_ACTION_FLOAT_WINDOW` in GhosttyTerminalView action handler (supports on/off/toggle via ghostty keybind config)
- Add **"Float on Top"** to Window menu with `Ctrl+Shift+T` shortcut
- Add **"Toggle Float on Top"** to command palette
- Add v1 socket command: `float_on_top [on|off|toggle]`
- Add v2 socket method: `window.float_on_top {mode: "on"|"off"|"toggle"}`

## How it works

The implementation follows the same pattern Ghostty uses in its macOS app (`Ghostty.App.swift`):
- Sets `window.level = .floating` for on, `.normal` for off
- Uses the `GHOSTTY_FLOAT_WINDOW_ON/OFF/TOGGLE` enum from `ghostty.h`
- The ghostty config keybind `toggle_window_float_on_top` now works in cmux

## Usage

| Method | Command |
|--------|---------|
| Menu | Window > Float on Top |
| Shortcut | Ctrl+Shift+T |
| Command Palette | "Float on Top" |
| CLI v1 | `cmux float_on_top toggle` |
| CLI v2 | `{"method":"window.float_on_top","params":{"mode":"toggle"},"id":1}` |
| Ghostty config | `keybind = ctrl+shift+t=toggle_window_float_on_top` |

## Test plan

- [ ] Toggle float on top via Window menu — window stays above all others
- [ ] Toggle off — window returns to normal z-order
- [ ] Command palette "Float" finds and executes the command
- [ ] `cmux float_on_top on/off/toggle` works from terminal inside cmux
- [ ] Ghostty keybind `toggle_window_float_on_top` triggers correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add always-on-top support so you can keep the cmux window above others. Matches Ghostty’s macOS behavior by toggling the window level between floating and normal.

- New Features
  - Handle `GHOSTTY_ACTION_FLOAT_WINDOW` in `GhosttyTerminalView` (on/off/toggle); enables Ghostty keybind `toggle_window_float_on_top`.
  - Window menu item “Float on Top” with `Ctrl+Shift+T`.
  - Command palette command “Toggle Float on Top”.
  - v1 socket command: `float_on_top [on|off|toggle]`.
  - v2 socket method: `window.float_on_top {mode:"on"|"off"|"toggle"}`.

<sup>Written for commit 0603802255d5b3cc4a1afabd801942469edc3315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Float on Top" window toggle feature, allowing windows to float above other applications.
  * Accessible via Command Palette, menu button, and keyboard shortcut (Control+Shift+T).
  * Supported through multiple interfaces for seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->