### PR TITLE
fix: text selection and copy behavior bugs

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6821,6 +6821,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+        // Kick an immediate render so the selection highlight follows the cursor
+        // without waiting for the next async wakeup tick.
+        ghostty_surface_refresh(surface)
     }
 
     override func scrollWheel(with event: NSEvent) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1139,7 +1139,10 @@ class GhosttyApp {
         // Create runtime config with callbacks
         var runtimeConfig = ghostty_runtime_config_s()
         runtimeConfig.userdata = Unmanaged.passUnretained(self).toOpaque()
-        runtimeConfig.supports_selection_clipboard = true
+        // macOS has no native selection clipboard (unlike X11). Setting this
+        // to false makes ghostty's copy-on-select write directly to the system
+        // clipboard so Cmd+V / paste works as expected.
+        runtimeConfig.supports_selection_clipboard = false
         runtimeConfig.wakeup_cb = { userdata in
             GhosttyApp.shared.scheduleTick()
         }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -141,7 +141,7 @@ enum KeyboardShortcutSettings {
             case .sendFeedback:
                 return StoredShortcut(key: "f", command: true, shift: false, option: true, control: false)
             case .showNotifications:
-                return StoredShortcut(key: "i", command: true, shift: false, option: false, control: false)
+                return StoredShortcut(key: "i", command: true, shift: true, option: false, control: false)
             case .jumpToUnread:
                 return StoredShortcut(key: "u", command: true, shift: true, option: false, control: false)
             case .triggerFlash:

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1661,7 +1661,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(workspace.panels.count, panelCountBefore)
     }
 
-    func testCmdIStillTriggersShowNotificationsShortcut() {
+    func testCmdShiftITriggersShowNotificationsShortcut() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -1679,16 +1679,16 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             guard let event = NSEvent.keyEvent(
                 with: .keyDown,
                 location: .zero,
-                modifierFlags: [.command],
+                modifierFlags: [.command, .shift],
                 timestamp: ProcessInfo.processInfo.systemUptime,
                 windowNumber: window.windowNumber,
                 context: nil,
-                characters: "i",
+                characters: "I",
                 charactersIgnoringModifiers: "i",
                 isARepeat: false,
                 keyCode: 34 // kVK_ANSI_I
             ) else {
-                XCTFail("Failed to construct Cmd+I event")
+                XCTFail("Failed to construct Cmd+Shift+I event")
                 return
             }
 

--- a/cmuxUITests/MultiWindowNotificationsUITests.swift
+++ b/cmuxUITests/MultiWindowNotificationsUITests.swift
@@ -86,9 +86,9 @@ final class MultiWindowNotificationsUITests: XCTestCase {
         XCTAssertEqual(afterJump["focusedWindowId"], expectedLatestWindowId)
         XCTAssertEqual(afterJump["focusedTabId"], expectedLatestTabId)
 
-        // Open the notifications popover (Cmd+I) and click the notification belonging to window 2.
+        // Open the notifications popover (Cmd+Shift+I) and click the notification belonging to window 2.
         let beforeClickToken = afterJump["focusToken"]
-        app.typeKey("i", modifierFlags: [.command])
+        app.typeKey("i", modifierFlags: [.command, .shift])
 
         let targetButton = app.buttons["NotificationPopoverRow.\(notifId2)"]
         XCTAssertTrue(targetButton.waitForExistence(timeout: 6.0), "Expected notification row button to exist")


### PR DESCRIPTION
## Summary

Fixes the three sub-issues under the text selection and copy umbrella (#2203):

- **Cmd+C opens Notifications instead of copying (#1091):** The default shortcut for Show Notifications was `Cmd+I`, which conflicted with standard terminal input and was inconsistent with the docs (which specified `Cmd+Shift+I`). Changed the default to `Cmd+Shift+I` so `Cmd+C` correctly copies selected text via the standard Edit menu.

- **Text selection highlighting lags behind cursor (#1748):** The `mouseDragged` handler updated ghostty's internal mouse position but did not trigger an immediate render, relying on the async wakeup tick. Added a `ghostty_surface_refresh` call after the position update so the selection highlight follows the cursor in real-time.

- **copy-on-select from ghostty config not working (#1322):** cmux told ghostty it supports a selection clipboard (`supports_selection_clipboard = true`), so ghostty's `copy-on-select` wrote to a private NSPasteboard instead of the system clipboard. Since macOS has no native selection clipboard (unlike X11), set this to `false` so copy-on-select writes directly to the system clipboard.

## Test plan

- [ ] Verify `Cmd+C` copies selected terminal text to clipboard
- [ ] Verify `Cmd+Shift+I` opens Notifications panel
- [ ] Verify `Cmd+I` no longer opens Notifications (passes through to terminal)
- [ ] Verify drag-to-select highlights text in real-time without visible lag
- [ ] Verify `copy-on-select = clipboard` in ghostty config copies selected text to system clipboard on mouse-up
- [ ] Verify existing unit tests pass (`testCmdShiftITriggersShowNotificationsShortcut`, `testCmdPhysicalIWithDvorakCharactersDoesNotTriggerShowNotifications`)

Closes #2203
Closes #1091
Closes #1748
Closes #1322

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text selection and copy behavior on macOS. Removes selection lag, makes copy-on-select use the system clipboard, and updates the Notifications shortcut to avoid conflicts.

- **Bug Fixes**
  - Changed default Show Notifications shortcut to Cmd+Shift+I (Cmd+I now passes through), resolving cases where Cmd+C didn’t copy and matching the docs.
  - Refresh the surface on mouse drag so selection highlighting follows the cursor in real time.
  - Disabled the “selection clipboard” on macOS so copy-on-select writes to the system clipboard and pastes with Cmd+V.

<sup>Written for commit 6166d295aa21809bd9a986e213c7f84dfd612349. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

