### PR TITLE
Add sidebar.* V2 JSON-RPC methods for SSH relay compatibility

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2171,7 +2171,7 @@ class TerminalController {
         case "sidebar.clear_status":
             return v2Result(id: id, self.v2SidebarClearStatus(params: params))
         case "sidebar.list_status":
-            return v2Ok(id: id, result: self.v2SidebarListStatus(params: params))
+            return v2Result(id: id, self.v2SidebarListStatus(params: params))
         case "sidebar.set_progress":
             return v2Result(id: id, self.v2SidebarSetProgress(params: params))
         case "sidebar.clear_progress":
@@ -2181,13 +2181,13 @@ class TerminalController {
         case "sidebar.clear_log":
             return v2Result(id: id, self.v2SidebarClearLog(params: params))
         case "sidebar.list_log":
-            return v2Ok(id: id, result: self.v2SidebarListLog(params: params))
+            return v2Result(id: id, self.v2SidebarListLog(params: params))
         case "sidebar.set_meta":
             return v2Result(id: id, self.v2SidebarSetMeta(params: params))
         case "sidebar.clear_meta":
             return v2Result(id: id, self.v2SidebarClearMeta(params: params))
         case "sidebar.list_meta":
-            return v2Ok(id: id, result: self.v2SidebarListMeta(params: params))
+            return v2Result(id: id, self.v2SidebarListMeta(params: params))
         case "sidebar.set_agent_pid":
             return v2Result(id: id, self.v2SidebarSetAgentPid(params: params))
         case "sidebar.clear_agent_pid":
@@ -2197,7 +2197,7 @@ class TerminalController {
         case "sidebar.clear_git_branch":
             return v2Result(id: id, self.v2SidebarClearGitBranch(params: params))
         case "sidebar.state":
-            return v2Ok(id: id, result: self.v2SidebarState(params: params))
+            return v2Result(id: id, self.v2SidebarState(params: params))
         case "sidebar.reset":
             return v2Result(id: id, self.v2SidebarReset(params: params))
 
@@ -6688,6 +6688,12 @@ class TerminalController {
 
     // MARK: - V2 Sidebar Methods
 
+    // NOTE: These methods use v2MainSync to mutate workspace state on the main thread,
+    // matching the existing V1 handler behavior. For high-frequency paths (set_status,
+    // set_progress, log), this serializes socket I/O with UI updates. This is acceptable
+    // for current usage patterns but could be optimized with async dispatch if telemetry
+    // shows main-thread contention from sidebar updates.
+
     private func v2SidebarSetStatus(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -6713,11 +6719,15 @@ class TerminalController {
         }
         let priority = max(-9999, min(9999, v2Int(params, "priority") ?? 0))
         let formatRaw = v2String(params, "format") ?? SidebarMetadataFormat.plain.rawValue
-        guard let format = SidebarMetadataFormat(rawValue: formatRaw) else {
+        let normalizedFormat: String = {
+            let lower = formatRaw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return lower == "md" ? SidebarMetadataFormat.markdown.rawValue : lower
+        }()
+        guard let format = SidebarMetadataFormat(rawValue: normalizedFormat) else {
             return .err(code: "invalid_params", message: "Invalid format '\(formatRaw)' — use: plain, markdown", data: nil)
         }
         let pidValue: pid_t? = {
-            if let p = v2Int(params, "pid"), p > 0 { return pid_t(p) }
+            if let p = v2Int(params, "pid"), p > 0, p <= Int(Int32.max) { return pid_t(p) }
             return nil
         }()
 
@@ -6782,15 +6792,18 @@ class TerminalController {
         return result
     }
 
-    private func v2SidebarListStatus(params: [String: Any]) -> [String: Any] {
+    private func v2SidebarListStatus(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return ["entries": []]
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let isoFormatter = ISO8601DateFormatter()
-        var entries: [[String: Any]] = []
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to list status", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
-            entries = ws.sidebarStatusEntriesInDisplayOrder().map { entry in
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            let entries: [[String: Any]] = ws.sidebarStatusEntriesInDisplayOrder().map { entry in
                 [
                     "key": entry.key,
                     "value": entry.value,
@@ -6802,8 +6815,9 @@ class TerminalController {
                     "timestamp": isoFormatter.string(from: entry.timestamp)
                 ]
             }
+            result = .ok(["entries": entries])
         }
-        return ["entries": entries]
+        return result
     }
 
     private func v2SidebarSetProgress(params: [String: Any]) -> V2CallResult {
@@ -6905,22 +6919,25 @@ class TerminalController {
         return result
     }
 
-    private func v2SidebarListLog(params: [String: Any]) -> [String: Any] {
+    private func v2SidebarListLog(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return ["entries": []]
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let limit = v2Int(params, "limit")
         let isoFormatter = ISO8601DateFormatter()
-        var entries: [[String: Any]] = []
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to list log", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
             let logSlice: [SidebarLogEntry]
             if let limit {
-                logSlice = Array(ws.logEntries.suffix(limit))
+                logSlice = Array(ws.logEntries.suffix(max(0, limit)))
             } else {
                 logSlice = ws.logEntries
             }
-            entries = logSlice.map { entry in
+            let entries: [[String: Any]] = logSlice.map { entry in
                 [
                     "message": entry.message,
                     "level": entry.level.rawValue,
@@ -6928,8 +6945,9 @@ class TerminalController {
                     "timestamp": isoFormatter.string(from: entry.timestamp)
                 ]
             }
+            result = .ok(["entries": entries])
         }
-        return ["entries": entries]
+        return result
     }
 
     private func v2SidebarSetMeta(params: [String: Any]) -> V2CallResult {
@@ -6939,8 +6957,18 @@ class TerminalController {
         guard let key = v2String(params, "key") else {
             return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
         }
-        guard let markdown = v2String(params, "markdown") else {
-            return .err(code: "invalid_params", message: "Missing or empty 'markdown'", data: nil)
+        // Use raw extraction — v2String trims whitespace which breaks markdown formatting.
+        // Normalize escape sequences (\\n → newline, \\t → tab) and CRLF → LF, matching V1 behavior.
+        guard let rawMarkdown = params["markdown"] as? String else {
+            return .err(code: "invalid_params", message: "Missing 'markdown'", data: nil)
+        }
+        let markdown = rawMarkdown
+            .replacingOccurrences(of: "\\n", with: "\n")
+            .replacingOccurrences(of: "\\t", with: "\t")
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        guard !markdown.isEmpty else {
+            return .err(code: "invalid_params", message: "Empty 'markdown'", data: nil)
         }
         let priority = max(-9999, min(9999, v2Int(params, "priority") ?? 0))
 
@@ -6990,15 +7018,18 @@ class TerminalController {
         return result
     }
 
-    private func v2SidebarListMeta(params: [String: Any]) -> [String: Any] {
+    private func v2SidebarListMeta(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return ["blocks": []]
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let isoFormatter = ISO8601DateFormatter()
-        var blocks: [[String: Any]] = []
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to list metadata", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
-            blocks = ws.sidebarMetadataBlocksInDisplayOrder().map { block in
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            let blocks: [[String: Any]] = ws.sidebarMetadataBlocksInDisplayOrder().map { block in
                 [
                     "key": block.key,
                     "markdown": block.markdown,
@@ -7006,8 +7037,9 @@ class TerminalController {
                     "timestamp": isoFormatter.string(from: block.timestamp)
                 ]
             }
+            result = .ok(["blocks": blocks])
         }
-        return ["blocks": blocks]
+        return result
     }
 
     private func v2SidebarSetAgentPid(params: [String: Any]) -> V2CallResult {
@@ -7017,7 +7049,7 @@ class TerminalController {
         guard let key = v2String(params, "key") else {
             return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
         }
-        guard let pid = v2Int(params, "pid"), pid > 0 else {
+        guard let pid = v2Int(params, "pid"), pid > 0, pid <= Int(Int32.max) else {
             return .err(code: "invalid_params", message: "Missing or invalid 'pid' — must be > 0", data: nil)
         }
 
@@ -7109,15 +7141,15 @@ class TerminalController {
         return result
     }
 
-    private func v2SidebarState(params: [String: Any]) -> [String: Any] {
+    private func v2SidebarState(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return ["error": "TabManager not available"]
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let isoFormatter = ISO8601DateFormatter()
-        var state: [String: Any] = [:]
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to get sidebar state", data: nil)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                state = ["error": "Workspace not found"]
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
             // Status entries
@@ -7181,7 +7213,7 @@ class TerminalController {
             for (key, pid) in ws.agentPIDs {
                 agentPids[key] = Int(pid)
             }
-            state = [
+            let state: [String: Any] = [
                 "workspace_id": ws.id.uuidString,
                 "status_entries": statusEntries,
                 "progress": progressDict,
@@ -7191,8 +7223,9 @@ class TerminalController {
                 "metadata_blocks": metadataBlocks,
                 "agent_pids": agentPids
             ]
+            result = .ok(state)
         }
-        return state
+        return result
     }
 
     private func v2SidebarReset(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6870,6 +6870,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Unknown log level '\(levelStr)' — use: info, progress, success, warning, error", data: nil)
         }
         let source = v2String(params, "source")
+        let configuredLimit = UserDefaults.standard.object(forKey: "sidebarMaxLogEntries") as? Int ?? 50
+        let limit = max(1, min(500, configuredLimit))
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to log", data: nil)
         v2MainSync {
@@ -6878,8 +6880,6 @@ class TerminalController {
                 return
             }
             ws.logEntries.append(SidebarLogEntry(message: message, level: level, source: source, timestamp: Date()))
-            let configuredLimit = UserDefaults.standard.object(forKey: "sidebarMaxLogEntries") as? Int ?? 50
-            let limit = max(1, min(500, configuredLimit))
             if ws.logEntries.count > limit {
                 ws.logEntries.removeFirst(ws.logEntries.count - limit)
             }
@@ -7070,8 +7070,16 @@ class TerminalController {
                 return
             }
             if let surfaceId {
+                guard Self.shouldReplaceGitBranch(current: ws.panelGitBranches[surfaceId], branch: branch, isDirty: isDirty) else {
+                    result = .ok(["workspace_id": ws.id.uuidString])
+                    return
+                }
                 ws.panelGitBranches[surfaceId] = SidebarGitBranchState(branch: branch, isDirty: isDirty)
             } else {
+                guard Self.shouldReplaceGitBranch(current: ws.gitBranch, branch: branch, isDirty: isDirty) else {
+                    result = .ok(["workspace_id": ws.id.uuidString])
+                    return
+                }
                 ws.gitBranch = SidebarGitBranchState(branch: branch, isDirty: isDirty)
             }
             result = .ok(["workspace_id": ws.id.uuidString])
@@ -7163,6 +7171,11 @@ class TerminalController {
                     "timestamp": isoFormatter.string(from: block.timestamp)
                 ]
             }
+            // Panel git branches
+            var panelGitBranchesJSON: [String: Any] = [:]
+            for (surfaceId, git) in ws.panelGitBranches {
+                panelGitBranchesJSON[surfaceId.uuidString] = ["branch": git.branch, "dirty": git.isDirty]
+            }
             // Agent PIDs
             var agentPids: [String: Any] = [:]
             for (key, pid) in ws.agentPIDs {
@@ -7173,6 +7186,7 @@ class TerminalController {
                 "status_entries": statusEntries,
                 "progress": progressDict,
                 "git_branch": gitBranchDict,
+                "panel_git_branches": panelGitBranchesJSON,
                 "log_entries": logEntries,
                 "metadata_blocks": metadataBlocks,
                 "agent_pids": agentPids

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2165,6 +2165,42 @@ class TerminalController {
         case "notification.clear":
             return v2Result(id: id, self.v2NotificationClear())
 
+        // Sidebar
+        case "sidebar.set_status":
+            return v2Result(id: id, self.v2SidebarSetStatus(params: params))
+        case "sidebar.clear_status":
+            return v2Result(id: id, self.v2SidebarClearStatus(params: params))
+        case "sidebar.list_status":
+            return v2Ok(id: id, result: self.v2SidebarListStatus(params: params))
+        case "sidebar.set_progress":
+            return v2Result(id: id, self.v2SidebarSetProgress(params: params))
+        case "sidebar.clear_progress":
+            return v2Result(id: id, self.v2SidebarClearProgress(params: params))
+        case "sidebar.log":
+            return v2Result(id: id, self.v2SidebarLog(params: params))
+        case "sidebar.clear_log":
+            return v2Result(id: id, self.v2SidebarClearLog(params: params))
+        case "sidebar.list_log":
+            return v2Ok(id: id, result: self.v2SidebarListLog(params: params))
+        case "sidebar.set_meta":
+            return v2Result(id: id, self.v2SidebarSetMeta(params: params))
+        case "sidebar.clear_meta":
+            return v2Result(id: id, self.v2SidebarClearMeta(params: params))
+        case "sidebar.list_meta":
+            return v2Ok(id: id, result: self.v2SidebarListMeta(params: params))
+        case "sidebar.set_agent_pid":
+            return v2Result(id: id, self.v2SidebarSetAgentPid(params: params))
+        case "sidebar.clear_agent_pid":
+            return v2Result(id: id, self.v2SidebarClearAgentPid(params: params))
+        case "sidebar.report_git_branch":
+            return v2Result(id: id, self.v2SidebarReportGitBranch(params: params))
+        case "sidebar.clear_git_branch":
+            return v2Result(id: id, self.v2SidebarClearGitBranch(params: params))
+        case "sidebar.state":
+            return v2Ok(id: id, result: self.v2SidebarState(params: params))
+        case "sidebar.reset":
+            return v2Result(id: id, self.v2SidebarReset(params: params))
+
         // App focus
         case "app.focus_override.set":
             return v2Result(id: id, self.v2AppFocusOverride(params: params))
@@ -2487,6 +2523,23 @@ class TerminalController {
             "notification.create_for_target",
             "notification.list",
             "notification.clear",
+            "sidebar.set_status",
+            "sidebar.clear_status",
+            "sidebar.list_status",
+            "sidebar.set_progress",
+            "sidebar.clear_progress",
+            "sidebar.log",
+            "sidebar.clear_log",
+            "sidebar.list_log",
+            "sidebar.set_meta",
+            "sidebar.clear_meta",
+            "sidebar.list_meta",
+            "sidebar.set_agent_pid",
+            "sidebar.clear_agent_pid",
+            "sidebar.report_git_branch",
+            "sidebar.clear_git_branch",
+            "sidebar.state",
+            "sidebar.reset",
             "app.focus_override.set",
             "app.simulate_active",
             "markdown.open",
@@ -6631,6 +6684,518 @@ class TerminalController {
             TerminalNotificationStore.shared.clearAll()
         }
         return .ok([:])
+    }
+
+    // MARK: - V2 Sidebar Methods
+
+    private func v2SidebarSetStatus(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+        guard let value = v2String(params, "value") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'value'", data: nil)
+        }
+        let icon = v2String(params, "icon")
+        let color = v2String(params, "color")
+        let parsedURL: URL?
+        if let rawURL = v2String(params, "url") {
+            guard let candidate = URL(string: rawURL),
+                  let scheme = candidate.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https" else {
+                return .err(code: "invalid_params", message: "Invalid URL '\(rawURL)' — expected http(s) URL", data: nil)
+            }
+            parsedURL = candidate
+        } else {
+            parsedURL = nil
+        }
+        let priority = max(-9999, min(9999, v2Int(params, "priority") ?? 0))
+        let formatRaw = v2String(params, "format") ?? SidebarMetadataFormat.plain.rawValue
+        guard let format = SidebarMetadataFormat(rawValue: formatRaw) else {
+            return .err(code: "invalid_params", message: "Invalid format '\(formatRaw)' — use: plain, markdown", data: nil)
+        }
+        let pidValue: pid_t? = {
+            if let p = v2Int(params, "pid"), p > 0 { return pid_t(p) }
+            return nil
+        }()
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to set status", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            guard Self.shouldReplaceStatusEntry(
+                current: ws.statusEntries[key],
+                key: key,
+                value: value,
+                icon: icon,
+                color: color,
+                url: parsedURL,
+                priority: priority,
+                format: format
+            ) else {
+                if let pidValue {
+                    ws.agentPIDs[key] = pidValue
+                }
+                result = .ok(["workspace_id": ws.id.uuidString])
+                return
+            }
+            ws.statusEntries[key] = SidebarStatusEntry(
+                key: key,
+                value: value,
+                icon: icon,
+                color: color,
+                url: parsedURL,
+                priority: priority,
+                format: format,
+                timestamp: Date()
+            )
+            if let pidValue {
+                ws.agentPIDs[key] = pidValue
+            }
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearStatus(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear status", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.statusEntries.removeValue(forKey: key)
+            ws.agentPIDs.removeValue(forKey: key)
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarListStatus(params: [String: Any]) -> [String: Any] {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return ["entries": []]
+        }
+        let isoFormatter = ISO8601DateFormatter()
+        var entries: [[String: Any]] = []
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
+            entries = ws.sidebarStatusEntriesInDisplayOrder().map { entry in
+                [
+                    "key": entry.key,
+                    "value": entry.value,
+                    "icon": v2OrNull(entry.icon),
+                    "color": v2OrNull(entry.color),
+                    "url": v2OrNull(entry.url?.absoluteString),
+                    "priority": entry.priority,
+                    "format": entry.format.rawValue,
+                    "timestamp": isoFormatter.string(from: entry.timestamp)
+                ]
+            }
+        }
+        return ["entries": entries]
+    }
+
+    private func v2SidebarSetProgress(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        let rawValue: Double? = {
+            if let d = params["value"] as? Double { return d }
+            if let n = params["value"] as? NSNumber { return n.doubleValue }
+            if let s = params["value"] as? String { return Double(s) }
+            return nil
+        }()
+        guard let rawValue else {
+            return .err(code: "invalid_params", message: "Missing or invalid 'value' — must be a number 0.0 to 1.0", data: nil)
+        }
+        guard rawValue.isFinite else {
+            return .err(code: "invalid_params", message: "Invalid 'value' — must be a finite number 0.0 to 1.0", data: nil)
+        }
+        let clamped = min(1.0, max(0.0, rawValue))
+        let label = v2String(params, "label")
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to set progress", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            guard Self.shouldReplaceProgress(current: ws.progress, value: clamped, label: label) else {
+                result = .ok(["workspace_id": ws.id.uuidString])
+                return
+            }
+            ws.progress = SidebarProgressState(value: clamped, label: label)
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearProgress(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear progress", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.progress = nil
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarLog(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let message = v2String(params, "message") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'message'", data: nil)
+        }
+        let levelStr = v2String(params, "level") ?? "info"
+        guard let level = SidebarLogLevel(rawValue: levelStr) else {
+            return .err(code: "invalid_params", message: "Unknown log level '\(levelStr)' — use: info, progress, success, warning, error", data: nil)
+        }
+        let source = v2String(params, "source")
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to log", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.logEntries.append(SidebarLogEntry(message: message, level: level, source: source, timestamp: Date()))
+            let configuredLimit = UserDefaults.standard.object(forKey: "sidebarMaxLogEntries") as? Int ?? 50
+            let limit = max(1, min(500, configuredLimit))
+            if ws.logEntries.count > limit {
+                ws.logEntries.removeFirst(ws.logEntries.count - limit)
+            }
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearLog(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear log", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.logEntries.removeAll()
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarListLog(params: [String: Any]) -> [String: Any] {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return ["entries": []]
+        }
+        let limit = v2Int(params, "limit")
+        let isoFormatter = ISO8601DateFormatter()
+        var entries: [[String: Any]] = []
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
+            let logSlice: [SidebarLogEntry]
+            if let limit {
+                logSlice = Array(ws.logEntries.suffix(limit))
+            } else {
+                logSlice = ws.logEntries
+            }
+            entries = logSlice.map { entry in
+                [
+                    "message": entry.message,
+                    "level": entry.level.rawValue,
+                    "source": v2OrNull(entry.source),
+                    "timestamp": isoFormatter.string(from: entry.timestamp)
+                ]
+            }
+        }
+        return ["entries": entries]
+    }
+
+    private func v2SidebarSetMeta(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+        guard let markdown = v2String(params, "markdown") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'markdown'", data: nil)
+        }
+        let priority = max(-9999, min(9999, v2Int(params, "priority") ?? 0))
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to set metadata block", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            guard Self.shouldReplaceMetadataBlock(
+                current: ws.metadataBlocks[key],
+                key: key,
+                markdown: markdown,
+                priority: priority
+            ) else {
+                result = .ok(["workspace_id": ws.id.uuidString])
+                return
+            }
+            ws.metadataBlocks[key] = SidebarMetadataBlock(
+                key: key,
+                markdown: markdown,
+                priority: priority,
+                timestamp: Date()
+            )
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearMeta(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear metadata block", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.metadataBlocks.removeValue(forKey: key)
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarListMeta(params: [String: Any]) -> [String: Any] {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return ["blocks": []]
+        }
+        let isoFormatter = ISO8601DateFormatter()
+        var blocks: [[String: Any]] = []
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
+            blocks = ws.sidebarMetadataBlocksInDisplayOrder().map { block in
+                [
+                    "key": block.key,
+                    "markdown": block.markdown,
+                    "priority": block.priority,
+                    "timestamp": isoFormatter.string(from: block.timestamp)
+                ]
+            }
+        }
+        return ["blocks": blocks]
+    }
+
+    private func v2SidebarSetAgentPid(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+        guard let pid = v2Int(params, "pid"), pid > 0 else {
+            return .err(code: "invalid_params", message: "Missing or invalid 'pid' — must be > 0", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to set agent PID", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.agentPIDs[key] = pid_t(pid)
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearAgentPid(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let key = v2String(params, "key") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'key'", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear agent PID", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.agentPIDs.removeValue(forKey: key)
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarReportGitBranch(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let branch = v2String(params, "branch") else {
+            return .err(code: "invalid_params", message: "Missing or empty 'branch'", data: nil)
+        }
+        let isDirty = v2Bool(params, "dirty") ?? false
+        let surfaceId = v2UUID(params, "surface_id")
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to report git branch", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            if let surfaceId {
+                ws.panelGitBranches[surfaceId] = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+            } else {
+                ws.gitBranch = SidebarGitBranchState(branch: branch, isDirty: isDirty)
+            }
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarClearGitBranch(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        let surfaceId = v2UUID(params, "surface_id")
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to clear git branch", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            if let surfaceId {
+                ws.panelGitBranches.removeValue(forKey: surfaceId)
+            } else {
+                ws.gitBranch = nil
+            }
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
+    }
+
+    private func v2SidebarState(params: [String: Any]) -> [String: Any] {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return ["error": "TabManager not available"]
+        }
+        let isoFormatter = ISO8601DateFormatter()
+        var state: [String: Any] = [:]
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                state = ["error": "Workspace not found"]
+                return
+            }
+            // Status entries
+            let statusEntries: [[String: Any]] = ws.sidebarStatusEntriesInDisplayOrder().map { entry in
+                [
+                    "key": entry.key,
+                    "value": entry.value,
+                    "icon": v2OrNull(entry.icon),
+                    "color": v2OrNull(entry.color),
+                    "url": v2OrNull(entry.url?.absoluteString),
+                    "priority": entry.priority,
+                    "format": entry.format.rawValue,
+                    "timestamp": isoFormatter.string(from: entry.timestamp)
+                ]
+            }
+            // Progress
+            let progressDict: Any
+            if let progress = ws.progress {
+                progressDict = [
+                    "value": progress.value,
+                    "label": v2OrNull(progress.label)
+                ] as [String: Any]
+            } else {
+                progressDict = NSNull()
+            }
+            // Git branch
+            let gitBranchDict: Any
+            if let git = ws.gitBranch {
+                gitBranchDict = [
+                    "branch": git.branch,
+                    "dirty": git.isDirty
+                ] as [String: Any]
+            } else {
+                gitBranchDict = NSNull()
+            }
+            // Log entries
+            let logEntries: [[String: Any]] = ws.logEntries.map { entry in
+                [
+                    "message": entry.message,
+                    "level": entry.level.rawValue,
+                    "source": v2OrNull(entry.source),
+                    "timestamp": isoFormatter.string(from: entry.timestamp)
+                ]
+            }
+            // Metadata blocks
+            let metadataBlocks: [[String: Any]] = ws.sidebarMetadataBlocksInDisplayOrder().map { block in
+                [
+                    "key": block.key,
+                    "markdown": block.markdown,
+                    "priority": block.priority,
+                    "timestamp": isoFormatter.string(from: block.timestamp)
+                ]
+            }
+            // Agent PIDs
+            var agentPids: [String: Any] = [:]
+            for (key, pid) in ws.agentPIDs {
+                agentPids[key] = Int(pid)
+            }
+            state = [
+                "workspace_id": ws.id.uuidString,
+                "status_entries": statusEntries,
+                "progress": progressDict,
+                "git_branch": gitBranchDict,
+                "log_entries": logEntries,
+                "metadata_blocks": metadataBlocks,
+                "agent_pids": agentPids
+            ]
+        }
+        return state
+    }
+
+    private func v2SidebarReset(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to reset sidebar", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            ws.resetSidebarContext(reason: "v2_sidebar_reset")
+            result = .ok(["workspace_id": ws.id.uuidString])
+        }
+        return result
     }
 
     private func v2FeedbackOpen(params: [String: Any]) -> V2CallResult {

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -75,6 +75,25 @@ var commands = []commandSpec{
 	{name: "send-key", proto: protoV2, v2Method: "surface.send_key", flagKeys: []string{"surface", "key"}},
 	{name: "notify", proto: protoV2, v2Method: "notification.create", flagKeys: []string{"title", "body", "workspace"}},
 	{name: "refresh-surfaces", proto: protoV2, v2Method: "surface.refresh", noParams: true},
+
+	// Sidebar commands
+	{name: "set-status", proto: protoV2, v2Method: "sidebar.set_status", flagKeys: []string{"key", "value", "icon", "color", "url", "priority", "format", "pid", "workspace"}},
+	{name: "clear-status", proto: protoV2, v2Method: "sidebar.clear_status", flagKeys: []string{"key", "workspace"}},
+	{name: "list-status", proto: protoV2, v2Method: "sidebar.list_status", flagKeys: []string{"workspace"}},
+	{name: "set-progress", proto: protoV2, v2Method: "sidebar.set_progress", flagKeys: []string{"value", "label", "workspace"}},
+	{name: "clear-progress", proto: protoV2, v2Method: "sidebar.clear_progress", flagKeys: []string{"workspace"}},
+	{name: "log", proto: protoV2, v2Method: "sidebar.log", flagKeys: []string{"message", "level", "source", "workspace"}},
+	{name: "clear-log", proto: protoV2, v2Method: "sidebar.clear_log", flagKeys: []string{"workspace"}},
+	{name: "list-log", proto: protoV2, v2Method: "sidebar.list_log", flagKeys: []string{"limit", "workspace"}},
+	{name: "set-meta", proto: protoV2, v2Method: "sidebar.set_meta", flagKeys: []string{"key", "markdown", "priority", "workspace"}},
+	{name: "clear-meta", proto: protoV2, v2Method: "sidebar.clear_meta", flagKeys: []string{"key", "workspace"}},
+	{name: "list-meta", proto: protoV2, v2Method: "sidebar.list_meta", flagKeys: []string{"workspace"}},
+	{name: "set-agent-pid", proto: protoV2, v2Method: "sidebar.set_agent_pid", flagKeys: []string{"key", "pid", "workspace"}},
+	{name: "clear-agent-pid", proto: protoV2, v2Method: "sidebar.clear_agent_pid", flagKeys: []string{"key", "workspace"}},
+	{name: "report-git-branch", proto: protoV2, v2Method: "sidebar.report_git_branch", flagKeys: []string{"branch", "dirty", "surface", "workspace"}},
+	{name: "clear-git-branch", proto: protoV2, v2Method: "sidebar.clear_git_branch", flagKeys: []string{"surface", "workspace"}},
+	{name: "sidebar-state", proto: protoV2, v2Method: "sidebar.state", flagKeys: []string{"workspace"}},
+	{name: "reset-sidebar", proto: protoV2, v2Method: "sidebar.reset", flagKeys: []string{"workspace"}},
 }
 
 var commandIndex map[string]*commandSpec
@@ -771,4 +790,23 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  claude-teams [args...]     Launch Claude Code in teammate mode")
 	fmt.Fprintln(os.Stderr, "  omo [args...]              Launch OpenCode with cmux integration")
 	fmt.Fprintln(os.Stderr, "  rpc <method> [json-params] Send arbitrary JSON-RPC")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Sidebar commands:")
+	fmt.Fprintln(os.Stderr, "  set-status                Set a sidebar status pill")
+	fmt.Fprintln(os.Stderr, "  clear-status              Clear a sidebar status pill")
+	fmt.Fprintln(os.Stderr, "  list-status               List all sidebar status pills")
+	fmt.Fprintln(os.Stderr, "  set-progress              Set the sidebar progress bar")
+	fmt.Fprintln(os.Stderr, "  clear-progress            Clear the sidebar progress bar")
+	fmt.Fprintln(os.Stderr, "  log                       Add a sidebar activity log entry")
+	fmt.Fprintln(os.Stderr, "  clear-log                 Clear the sidebar activity log")
+	fmt.Fprintln(os.Stderr, "  list-log                  List sidebar activity log entries")
+	fmt.Fprintln(os.Stderr, "  set-meta                  Set a sidebar metadata block")
+	fmt.Fprintln(os.Stderr, "  clear-meta                Clear a sidebar metadata block")
+	fmt.Fprintln(os.Stderr, "  list-meta                 List sidebar metadata blocks")
+	fmt.Fprintln(os.Stderr, "  set-agent-pid             Associate a PID with a status key")
+	fmt.Fprintln(os.Stderr, "  clear-agent-pid           Remove PID association from a status key")
+	fmt.Fprintln(os.Stderr, "  report-git-branch         Report git branch info for a surface")
+	fmt.Fprintln(os.Stderr, "  clear-git-branch          Clear git branch info for a surface")
+	fmt.Fprintln(os.Stderr, "  sidebar-state             Get full sidebar state")
+	fmt.Fprintln(os.Stderr, "  reset-sidebar             Reset all sidebar state")
 }

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -45,6 +45,10 @@ type commandSpec struct {
 	paramKeyOverrides map[string]string
 	// defaultParams are applied before flags/env fallbacks.
 	defaultParams map[string]any
+	// positionalKeys maps positional arguments to param keys by index.
+	// The last key in the slice consumes ALL remaining positional args
+	// (joined with spaces). Earlier keys consume exactly one arg each.
+	positionalKeys []string
 }
 
 var commands = []commandSpec{
@@ -77,20 +81,20 @@ var commands = []commandSpec{
 	{name: "refresh-surfaces", proto: protoV2, v2Method: "surface.refresh", noParams: true},
 
 	// Sidebar commands
-	{name: "set-status", proto: protoV2, v2Method: "sidebar.set_status", flagKeys: []string{"key", "value", "icon", "color", "url", "priority", "format", "pid", "workspace"}},
-	{name: "clear-status", proto: protoV2, v2Method: "sidebar.clear_status", flagKeys: []string{"key", "workspace"}},
+	{name: "set-status", proto: protoV2, v2Method: "sidebar.set_status", flagKeys: []string{"key", "value", "icon", "color", "url", "priority", "format", "pid", "workspace"}, positionalKeys: []string{"key", "value"}},
+	{name: "clear-status", proto: protoV2, v2Method: "sidebar.clear_status", flagKeys: []string{"key", "workspace"}, positionalKeys: []string{"key"}},
 	{name: "list-status", proto: protoV2, v2Method: "sidebar.list_status", flagKeys: []string{"workspace"}},
-	{name: "set-progress", proto: protoV2, v2Method: "sidebar.set_progress", flagKeys: []string{"value", "label", "workspace"}},
+	{name: "set-progress", proto: protoV2, v2Method: "sidebar.set_progress", flagKeys: []string{"value", "label", "workspace"}, positionalKeys: []string{"value"}},
 	{name: "clear-progress", proto: protoV2, v2Method: "sidebar.clear_progress", flagKeys: []string{"workspace"}},
-	{name: "log", proto: protoV2, v2Method: "sidebar.log", flagKeys: []string{"message", "level", "source", "workspace"}},
+	{name: "log", proto: protoV2, v2Method: "sidebar.log", flagKeys: []string{"message", "level", "source", "workspace"}, positionalKeys: []string{"message"}},
 	{name: "clear-log", proto: protoV2, v2Method: "sidebar.clear_log", flagKeys: []string{"workspace"}},
 	{name: "list-log", proto: protoV2, v2Method: "sidebar.list_log", flagKeys: []string{"limit", "workspace"}},
-	{name: "set-meta", proto: protoV2, v2Method: "sidebar.set_meta", flagKeys: []string{"key", "markdown", "priority", "workspace"}},
-	{name: "clear-meta", proto: protoV2, v2Method: "sidebar.clear_meta", flagKeys: []string{"key", "workspace"}},
+	{name: "set-meta", proto: protoV2, v2Method: "sidebar.set_meta", flagKeys: []string{"key", "markdown", "priority", "workspace"}, positionalKeys: []string{"key", "markdown"}},
+	{name: "clear-meta", proto: protoV2, v2Method: "sidebar.clear_meta", flagKeys: []string{"key", "workspace"}, positionalKeys: []string{"key"}},
 	{name: "list-meta", proto: protoV2, v2Method: "sidebar.list_meta", flagKeys: []string{"workspace"}},
-	{name: "set-agent-pid", proto: protoV2, v2Method: "sidebar.set_agent_pid", flagKeys: []string{"key", "pid", "workspace"}},
-	{name: "clear-agent-pid", proto: protoV2, v2Method: "sidebar.clear_agent_pid", flagKeys: []string{"key", "workspace"}},
-	{name: "report-git-branch", proto: protoV2, v2Method: "sidebar.report_git_branch", flagKeys: []string{"branch", "dirty", "surface", "workspace"}},
+	{name: "set-agent-pid", proto: protoV2, v2Method: "sidebar.set_agent_pid", flagKeys: []string{"key", "pid", "workspace"}, positionalKeys: []string{"key", "pid"}},
+	{name: "clear-agent-pid", proto: protoV2, v2Method: "sidebar.clear_agent_pid", flagKeys: []string{"key", "workspace"}, positionalKeys: []string{"key"}},
+	{name: "report-git-branch", proto: protoV2, v2Method: "sidebar.report_git_branch", flagKeys: []string{"branch", "dirty", "surface", "workspace"}, positionalKeys: []string{"branch"}},
 	{name: "clear-git-branch", proto: protoV2, v2Method: "sidebar.clear_git_branch", flagKeys: []string{"surface", "workspace"}},
 	{name: "sidebar-state", proto: protoV2, v2Method: "sidebar.state", flagKeys: []string{"workspace"}},
 	{name: "reset-sidebar", proto: protoV2, v2Method: "sidebar.reset", flagKeys: []string{"workspace"}},
@@ -249,8 +253,26 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 			}
 		}
 
-		// First positional arg is used as initial_command if --command wasn't given
-		if _, ok := params["initial_command"]; !ok && len(parsed.positional) > 0 {
+		// Map positional args to named params via spec.positionalKeys.
+		// Each key gets one positional arg; the last key gets all remaining args joined.
+		if len(spec.positionalKeys) > 0 && len(parsed.positional) > 0 {
+			for i, pkey := range spec.positionalKeys {
+				paramKey := flagToParamKey(pkey)
+				if _, exists := params[paramKey]; exists {
+					continue // explicit flag takes precedence
+				}
+				if i >= len(parsed.positional) {
+					break
+				}
+				if i == len(spec.positionalKeys)-1 {
+					// Last key: join all remaining positional args
+					params[paramKey] = strings.Join(parsed.positional[i:], " ")
+				} else {
+					params[paramKey] = parsed.positional[i]
+				}
+			}
+		} else if _, ok := params["initial_command"]; !ok && len(parsed.positional) > 0 {
+			// Fallback: first positional arg is used as initial_command if --command wasn't given
 			params["initial_command"] = parsed.positional[0]
 		}
 

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -827,8 +827,8 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  list-meta                 List sidebar metadata blocks")
 	fmt.Fprintln(os.Stderr, "  set-agent-pid             Associate a PID with a status key")
 	fmt.Fprintln(os.Stderr, "  clear-agent-pid           Remove PID association from a status key")
-	fmt.Fprintln(os.Stderr, "  report-git-branch         Report git branch info for a surface")
-	fmt.Fprintln(os.Stderr, "  clear-git-branch          Clear git branch info for a surface")
+	fmt.Fprintln(os.Stderr, "  report-git-branch         Report git branch info (surface optional)")
+	fmt.Fprintln(os.Stderr, "  clear-git-branch          Clear git branch info (surface optional)")
 	fmt.Fprintln(os.Stderr, "  sidebar-state             Get full sidebar state")
 	fmt.Fprintln(os.Stderr, "  reset-sidebar             Reset all sidebar state")
 }

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -46,9 +46,16 @@ type commandSpec struct {
 	// defaultParams are applied before flags/env fallbacks.
 	defaultParams map[string]any
 	// positionalKeys maps positional arguments to param keys by index.
-	// The last key in the slice consumes ALL remaining positional args
-	// (joined with spaces). Earlier keys consume exactly one arg each.
+	// Each key consumes exactly one positional arg. If greedyLast is true,
+	// the final key joins all remaining positional args (for free-form text
+	// like status values or markdown). A separate posIdx cursor tracks which
+	// positional to consume next, so flags that satisfy earlier keys don't
+	// misalign the cursor.
 	positionalKeys []string
+	// greedyLast makes the last positionalKey consume all remaining positional
+	// args (joined with spaces). Only set this for commands whose last param
+	// is free-form text (value, markdown, message).
+	greedyLast bool
 }
 
 var commands = []commandSpec{
@@ -81,15 +88,15 @@ var commands = []commandSpec{
 	{name: "refresh-surfaces", proto: protoV2, v2Method: "surface.refresh", noParams: true},
 
 	// Sidebar commands
-	{name: "set-status", proto: protoV2, v2Method: "sidebar.set_status", flagKeys: []string{"key", "value", "icon", "color", "url", "priority", "format", "pid", "workspace"}, positionalKeys: []string{"key", "value"}},
+	{name: "set-status", proto: protoV2, v2Method: "sidebar.set_status", flagKeys: []string{"key", "value", "icon", "color", "url", "priority", "format", "pid", "workspace"}, positionalKeys: []string{"key", "value"}, greedyLast: true},
 	{name: "clear-status", proto: protoV2, v2Method: "sidebar.clear_status", flagKeys: []string{"key", "workspace"}, positionalKeys: []string{"key"}},
 	{name: "list-status", proto: protoV2, v2Method: "sidebar.list_status", flagKeys: []string{"workspace"}},
 	{name: "set-progress", proto: protoV2, v2Method: "sidebar.set_progress", flagKeys: []string{"value", "label", "workspace"}, positionalKeys: []string{"value"}},
 	{name: "clear-progress", proto: protoV2, v2Method: "sidebar.clear_progress", flagKeys: []string{"workspace"}},
-	{name: "log", proto: protoV2, v2Method: "sidebar.log", flagKeys: []string{"message", "level", "source", "workspace"}, positionalKeys: []string{"message"}},
+	{name: "log", proto: protoV2, v2Method: "sidebar.log", flagKeys: []string{"message", "level", "source", "workspace"}, positionalKeys: []string{"message"}, greedyLast: true},
 	{name: "clear-log", proto: protoV2, v2Method: "sidebar.clear_log", flagKeys: []string{"workspace"}},
 	{name: "list-log", proto: protoV2, v2Method: "sidebar.list_log", flagKeys: []string{"limit", "workspace"}},
-	{name: "set-meta", proto: protoV2, v2Method: "sidebar.set_meta", flagKeys: []string{"key", "markdown", "priority", "workspace"}, positionalKeys: []string{"key", "markdown"}},
+	{name: "set-meta", proto: protoV2, v2Method: "sidebar.set_meta", flagKeys: []string{"key", "markdown", "priority", "workspace"}, positionalKeys: []string{"key", "markdown"}, greedyLast: true},
 	{name: "clear-meta", proto: protoV2, v2Method: "sidebar.clear_meta", flagKeys: []string{"key", "workspace"}, positionalKeys: []string{"key"}},
 	{name: "list-meta", proto: protoV2, v2Method: "sidebar.list_meta", flagKeys: []string{"workspace"}},
 	{name: "set-agent-pid", proto: protoV2, v2Method: "sidebar.set_agent_pid", flagKeys: []string{"key", "pid", "workspace"}, positionalKeys: []string{"key", "pid"}},
@@ -254,21 +261,26 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 		}
 
 		// Map positional args to named params via spec.positionalKeys.
-		// Each key gets one positional arg; the last key gets all remaining args joined.
+		// Uses a separate posIdx cursor so flags that satisfy earlier keys
+		// don't misalign the positional consumption.
 		if len(spec.positionalKeys) > 0 && len(parsed.positional) > 0 {
+			posIdx := 0
 			for i, pkey := range spec.positionalKeys {
 				paramKey := flagToParamKey(pkey)
 				if _, exists := params[paramKey]; exists {
-					continue // explicit flag takes precedence
+					continue // explicit flag takes precedence — don't advance posIdx
 				}
-				if i >= len(parsed.positional) {
+				if posIdx >= len(parsed.positional) {
 					break
 				}
-				if i == len(spec.positionalKeys)-1 {
-					// Last key: join all remaining positional args
-					params[paramKey] = strings.Join(parsed.positional[i:], " ")
+				isLast := i == len(spec.positionalKeys)-1
+				if isLast && spec.greedyLast {
+					// Greedy: join all remaining positional args
+					params[paramKey] = strings.Join(parsed.positional[posIdx:], " ")
+					posIdx = len(parsed.positional)
 				} else {
-					params[paramKey] = parsed.positional[i]
+					params[paramKey] = parsed.positional[posIdx]
+					posIdx++
 				}
 			}
 		} else if _, ok := params["initial_command"]; !ok && len(parsed.positional) > 0 {


### PR DESCRIPTION
## Summary

Fixes #2558 — sidebar V1 primitives (status pills, progress bars, activity logs, git branch, metadata) are unavailable over SSH because the TCP relay only speaks V2 JSON-RPC and there were zero V2 methods for sidebar operations.

This PR adds:
- **17 `sidebar.*` V2 JSON-RPC methods** in `TerminalController.swift` that map 1:1 to existing V1 sidebar primitives, following the exact `notification.*` pattern that already works over SSH
- **17 CLI commands** in `cmuxd-remote/cli.go` (the remote daemon) so SSH users can call `cmux set-status`, `cmux set-progress`, `cmux log`, etc.
- **Positional arg mapping** in the remote CLI via a new `positionalKeys` field on `commandSpec`, enabling natural syntax like `cmux set-status build "Working"` instead of requiring `--key build --value Working`

## New V2 Methods

| Method | Description |
|--------|-------------|
| `sidebar.set_status` | Set/update a status pill |
| `sidebar.clear_status` | Remove a status pill |
| `sidebar.list_status` | List all status entries |
| `sidebar.set_progress` | Set progress bar (0.0–1.0) |
| `sidebar.clear_progress` | Clear progress bar |
| `sidebar.log` | Append a log entry |
| `sidebar.clear_log` | Clear all log entries |
| `sidebar.list_log` | List log entries |
| `sidebar.set_meta` | Set a metadata block |
| `sidebar.clear_meta` | Clear a metadata block |
| `sidebar.list_meta` | List metadata blocks |
| `sidebar.set_agent_pid` | Register agent PID |
| `sidebar.clear_agent_pid` | Unregister agent PID |
| `sidebar.report_git_branch` | Report git branch + dirty status |
| `sidebar.clear_git_branch` | Clear git branch |
| `sidebar.state` | Get full sidebar state snapshot |
| `sidebar.reset` | Reset all sidebar state |

## Design Decisions

- **Same store mutations as V1:** Each V2 method directly mutates the same `Workspace` published properties (`statusEntries`, `logEntries`, `progress`, `gitBranch`, etc.) that V1 handlers use. No new data paths.
- **Dedup checks applied:** `shouldReplaceStatusEntry`, `shouldReplaceMetadataBlock`, `shouldReplaceProgress`, `shouldReplaceGitBranch` — matches V1 behavior to avoid unnecessary SwiftUI observer firings.
- **No focus theft:** `sidebar.*` methods are NOT added to `focusIntentV2Methods`.
- **Capabilities registered:** All 17 methods appear in `system.capabilities` response.
- **`rpc` passthrough works too:** `cmux rpc sidebar.set_status '{"key":"build","value":"Working"}'` works immediately since the relay is transparent.

## Remote CLI Usage (SSH sessions)

```bash
# Status pills
cmux set-status agent_name "Working" --icon hammer.fill --color "#4C8DFF"
cmux clear-status agent_name

# Progress bar
cmux set-progress 0.5 --label "5 tools"
cmux clear-progress

# Activity log
cmux log --level info --source claude -- "Bash: npm test → exit 0"
cmux clear-log

# Git branch
cmux report-git-branch main --dirty true

# Metadata blocks
cmux set-meta model "## Current Model\nopus-4.6" --priority 10

# Full state dump
cmux sidebar-state

# Reset everything
cmux reset-sidebar
```

## Files Changed

- `Sources/TerminalController.swift` — V2 method dispatch, capabilities registration, 17 handler implementations
- `daemon/remote/cmd/cmuxd-remote/cli.go` — 17 CLI command specs, positionalKeys mechanism, help text

## Test Plan

- [ ] `cmux rpc sidebar.set_status '{"key":"test","value":"Working"}'` shows status pill in sidebar
- [ ] `cmux rpc sidebar.clear_status '{"key":"test"}'` removes it
- [ ] `cmux rpc sidebar.set_progress '{"value":0.5,"label":"building"}'` shows progress bar
- [ ] `cmux rpc sidebar.clear_progress '{}'` clears it
- [ ] `cmux rpc sidebar.log '{"message":"test log","level":"info"}'` appends log entry
- [ ] `cmux rpc sidebar.state '{}'` returns complete sidebar JSON
- [ ] `cmux rpc sidebar.reset '{}'` clears all sidebar state
- [ ] `cmux rpc system.capabilities '{}'` lists all `sidebar.*` methods
- [ ] SSH session: `cmux set-status test "hello"` updates sidebar on local machine
- [ ] SSH session: `cmux set-progress 0.75 --label "Running tests"` shows progress
- [ ] SSH session: `cmux log -- "Build complete"` appends to sidebar log
- [ ] SSH session: `cmux sidebar-state` returns JSON state dump
- [ ] `go vet ./...` passes in `daemon/remote/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 17 `sidebar.*` V2 JSON-RPC methods and matching `cmux` CLI commands so sidebar status, progress, logs, metadata, and git branch work over SSH via the TCP relay. Fixes #2558.

- **New Features**
  - Implemented 17 V2 methods in `TerminalController.swift`, registered in `system.capabilities`, with dedup (incl. git branch), priority clamping, ISO‑8601 timestamps, and `sidebar.state`/`sidebar.reset`; `sidebar.state` includes `panel_git_branches`.

- **Bug Fixes**
  - Updated `cmuxd-remote` to map positional args to named params via `positionalKeys`, fixed cursor misalignment, and added `greedyLast` for free‑form text commands only (e.g., `set-status`, `set-meta`, `log`).
  - Applied V2 error model and crash guards with input validation (HTTP(S) URLs, PID bounds, `format` alias `md` → `markdown`), added `shouldReplaceGitBranch` to skip redundant writes, and moved log limit reads off the main thread.

<sup>Written for commit 173f075bbba2d5e21c13968a1e308301c0619578. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive sidebar commands for status entries, progress, logs, metadata, git-branch reporting, and agent PID tracking
  * Commands to list, inspect, serialize (with ISO‑8601 timestamps), and reset sidebar state
  * Input validation and normalization for sidebar operations (clamping, URL/scheme checks, PID and progress bounds)
  * CLI support for all sidebar commands, including positional-argument mapping for free-form text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->