### PR TITLE
Fix workspace color picker context menu blinking

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9889,21 +9889,9 @@ private final class SidebarTabItemSettingsStore: ObservableObject {
 
 private struct SidebarTabItemPresentationSnapshot: Equatable {
     let tabId: UUID
-    let index: Int
-    let isActive: Bool
-    let workspaceShortcutDigit: Int?
-    let workspaceShortcutModifierSymbol: String
-    let canCloseWorkspace: Bool
-    let accessibilityWorkspaceCount: Int
     let unreadCount: Int
     let latestNotificationText: String?
-    let rowSpacing: CGFloat
     let showsModifierShortcutHints: Bool
-    let contextMenuWorkspaceIds: [UUID]
-    let remoteContextMenuWorkspaceIds: [UUID]
-    let allRemoteContextMenuTargetsConnecting: Bool
-    let allRemoteContextMenuTargetsDisconnected: Bool
-    let settings: SidebarTabItemSettingsSnapshot
 }
 
 struct VerticalTabsSidebar: View {
@@ -9987,8 +9975,30 @@ struct VerticalTabsSidebar: View {
                                 let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
                                     ? allSelectedRemoteContextMenuTargetsDisconnected
                                     : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
+                                let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
+                                let liveLatestNotificationText: String? = {
+                                    guard showsSidebarNotificationMessage,
+                                          let notification = notificationStore.latestNotification(forTabId: tab.id) else {
+                                        return nil
+                                    }
+                                    let text = notification.body.isEmpty ? notification.title : notification.body
+                                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                    return trimmed.isEmpty ? nil : trimmed
+                                }()
+                                let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
                                 let livePresentation = SidebarTabItemPresentationSnapshot(
                                     tabId: tab.id,
+                                    unreadCount: liveUnreadCount,
+                                    latestNotificationText: liveLatestNotificationText,
+                                    showsModifierShortcutHints: liveShowsModifierShortcutHints
+                                )
+                                let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
+                                    ? frozenTabItemPresentation
+                                    : nil
+                                TabItemView(
+                                    tabManager: tabManager,
+                                    notificationStore: notificationStore,
+                                    tab: tab,
                                     index: index,
                                     isActive: tabManager.selectedTabId == tab.id,
                                     workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
@@ -9998,52 +10008,21 @@ struct VerticalTabsSidebar: View {
                                     workspaceShortcutModifierSymbol: workspaceNumberShortcut.numberedDigitHintPrefix,
                                     canCloseWorkspace: canCloseWorkspace,
                                     accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: notificationStore.unreadCount(forTabId: tab.id),
-                                    latestNotificationText: {
-                                        guard showsSidebarNotificationMessage,
-                                              let notification = notificationStore.latestNotification(forTabId: tab.id) else {
-                                            return nil
-                                        }
-                                        let text = notification.body.isEmpty ? notification.title : notification.body
-                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        return trimmed.isEmpty ? nil : trimmed
-                                    }(),
+                                    unreadCount: frozenPresentation?.unreadCount ?? liveUnreadCount,
+                                    latestNotificationText: frozenPresentation?.latestNotificationText ?? liveLatestNotificationText,
                                     rowSpacing: tabRowSpacing,
-                                    showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
+                                    setSelectionToTabs: { selection = .tabs },
+                                    selectedTabIds: $selectedTabIds,
+                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                    showsModifierShortcutHints: frozenPresentation?.showsModifierShortcutHints ?? liveShowsModifierShortcutHints,
+                                    dragAutoScrollController: dragAutoScrollController,
+                                    draggedTabId: $draggedTabId,
+                                    dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
-                                    settings: tabItemSettings
-                                )
-                                let presentation = frozenTabItemPresentation?.tabId == tab.id
-                                    ? frozenTabItemPresentation ?? livePresentation
-                                    : livePresentation
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
-                                    index: presentation.index,
-                                    isActive: presentation.isActive,
-                                    workspaceShortcutDigit: presentation.workspaceShortcutDigit,
-                                    workspaceShortcutModifierSymbol: presentation.workspaceShortcutModifierSymbol,
-                                    canCloseWorkspace: presentation.canCloseWorkspace,
-                                    accessibilityWorkspaceCount: presentation.accessibilityWorkspaceCount,
-                                    unreadCount: presentation.unreadCount,
-                                    latestNotificationText: presentation.latestNotificationText,
-                                    rowSpacing: presentation.rowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                                    showsModifierShortcutHints: presentation.showsModifierShortcutHints,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
-                                    contextMenuWorkspaceIds: presentation.contextMenuWorkspaceIds,
-                                    remoteContextMenuWorkspaceIds: presentation.remoteContextMenuWorkspaceIds,
-                                    allRemoteContextMenuTargetsConnecting: presentation.allRemoteContextMenuTargetsConnecting,
-                                    allRemoteContextMenuTargetsDisconnected: presentation.allRemoteContextMenuTargetsDisconnected,
-                                    settings: presentation.settings,
+                                    settings: tabItemSettings,
                                     livePresentation: livePresentation,
                                     frozenPresentation: $frozenTabItemPresentation
                                 )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12430,6 +12430,8 @@ private struct TabItemView: View, Equatable {
     let allRemoteContextMenuTargetsDisconnected: Bool
     let settings: SidebarTabItemSettingsSnapshot
     @State private var workspaceObservationGeneration: UInt64 = 0
+    @State private var contextMenuVisible = false
+    @State private var hasDeferredWorkspaceObservationInvalidation = false
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
 
@@ -13027,7 +13029,7 @@ private struct TabItemView: View, Equatable {
                 "desc=\"\(debugCommandPaletteTextPreview(description))\""
             )
 #endif
-            workspaceObservationGeneration &+= 1
+            scheduleWorkspaceObservationInvalidation()
         }
         .onReceive(
             tab.sidebarObservationPublisher
@@ -13047,7 +13049,7 @@ private struct TabItemView: View, Equatable {
                 "desc=\"\(debugCommandPaletteTextPreview(description))\""
             )
 #endif
-            workspaceObservationGeneration &+= 1
+            scheduleWorkspaceObservationInvalidation()
         }
         .onDrag {
             #if DEBUG
@@ -13089,7 +13091,31 @@ private struct TabItemView: View, Equatable {
         .accessibilityAction(named: Text(moveDownActionText)) {
             moveBy(1)
         }
-        .contextMenu { workspaceContextMenu }
+        .contextMenu {
+            workspaceContextMenu
+                .onAppear {
+                    contextMenuVisible = true
+                }
+                .onDisappear {
+                    contextMenuVisible = false
+                    flushDeferredWorkspaceObservationInvalidation()
+                }
+        }
+    }
+
+    private func scheduleWorkspaceObservationInvalidation() {
+        // Keep the context menu stable while background workspace telemetry keeps arriving.
+        if contextMenuVisible {
+            hasDeferredWorkspaceObservationInvalidation = true
+            return
+        }
+        workspaceObservationGeneration &+= 1
+    }
+
+    private func flushDeferredWorkspaceObservationInvalidation() {
+        guard hasDeferredWorkspaceObservationInvalidation else { return }
+        hasDeferredWorkspaceObservationInvalidation = false
+        workspaceObservationGeneration &+= 1
     }
 
     private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9887,6 +9887,25 @@ private final class SidebarTabItemSettingsStore: ObservableObject {
     }
 }
 
+private struct SidebarTabItemPresentationSnapshot: Equatable {
+    let tabId: UUID
+    let index: Int
+    let isActive: Bool
+    let workspaceShortcutDigit: Int?
+    let workspaceShortcutModifierSymbol: String
+    let canCloseWorkspace: Bool
+    let accessibilityWorkspaceCount: Int
+    let unreadCount: Int
+    let latestNotificationText: String?
+    let rowSpacing: CGFloat
+    let showsModifierShortcutHints: Bool
+    let contextMenuWorkspaceIds: [UUID]
+    let remoteContextMenuWorkspaceIds: [UUID]
+    let allRemoteContextMenuTargetsConnecting: Bool
+    let allRemoteContextMenuTargetsDisconnected: Bool
+    let settings: SidebarTabItemSettingsSnapshot
+}
+
 struct VerticalTabsSidebar: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let onSendFeedback: () -> Void
@@ -9902,6 +9921,7 @@ struct VerticalTabsSidebar: View {
     @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @State private var draggedTabId: UUID?
     @State private var dropIndicator: SidebarDropIndicator?
+    @State private var frozenTabItemPresentation: SidebarTabItemPresentationSnapshot?
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
 
@@ -9967,10 +9987,8 @@ struct VerticalTabsSidebar: View {
                                 let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
                                     ? allSelectedRemoteContextMenuTargetsDisconnected
                                     : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
+                                let livePresentation = SidebarTabItemPresentationSnapshot(
+                                    tabId: tab.id,
                                     index: index,
                                     isActive: tabManager.selectedTabId == tab.id,
                                     workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
@@ -9991,18 +10009,43 @@ struct VerticalTabsSidebar: View {
                                         return trimmed.isEmpty ? nil : trimmed
                                     }(),
                                     rowSpacing: tabRowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                                     showsModifierShortcutHints: modifierKeyMonitor.isModifierPressed,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
                                     settings: tabItemSettings
+                                )
+                                let presentation = frozenTabItemPresentation?.tabId == tab.id
+                                    ? frozenTabItemPresentation ?? livePresentation
+                                    : livePresentation
+                                TabItemView(
+                                    tabManager: tabManager,
+                                    notificationStore: notificationStore,
+                                    tab: tab,
+                                    index: presentation.index,
+                                    isActive: presentation.isActive,
+                                    workspaceShortcutDigit: presentation.workspaceShortcutDigit,
+                                    workspaceShortcutModifierSymbol: presentation.workspaceShortcutModifierSymbol,
+                                    canCloseWorkspace: presentation.canCloseWorkspace,
+                                    accessibilityWorkspaceCount: presentation.accessibilityWorkspaceCount,
+                                    unreadCount: presentation.unreadCount,
+                                    latestNotificationText: presentation.latestNotificationText,
+                                    rowSpacing: presentation.rowSpacing,
+                                    setSelectionToTabs: { selection = .tabs },
+                                    selectedTabIds: $selectedTabIds,
+                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                    showsModifierShortcutHints: presentation.showsModifierShortcutHints,
+                                    dragAutoScrollController: dragAutoScrollController,
+                                    draggedTabId: $draggedTabId,
+                                    dropIndicator: $dropIndicator,
+                                    contextMenuWorkspaceIds: presentation.contextMenuWorkspaceIds,
+                                    remoteContextMenuWorkspaceIds: presentation.remoteContextMenuWorkspaceIds,
+                                    allRemoteContextMenuTargetsConnecting: presentation.allRemoteContextMenuTargetsConnecting,
+                                    allRemoteContextMenuTargetsDisconnected: presentation.allRemoteContextMenuTargetsDisconnected,
+                                    settings: presentation.settings,
+                                    livePresentation: livePresentation,
+                                    frozenPresentation: $frozenTabItemPresentation
                                 )
                                 .equatable()
                             }
@@ -10102,6 +10145,11 @@ struct VerticalTabsSidebar: View {
             dragFailsafeMonitor.stop()
             dragAutoScrollController.stop()
             dropIndicator = nil
+        }
+        .onChange(of: tabs.map(\.id)) { tabIds in
+            guard let frozenTabItemPresentation,
+                  !tabIds.contains(frozenTabItemPresentation.tabId) else { return }
+            self.frozenTabItemPresentation = nil
         }
         .onReceive(NotificationCenter.default.publisher(for: SidebarDragLifecycleNotification.requestClear)) { notification in
             guard draggedTabId != nil else { return }
@@ -12377,6 +12425,11 @@ enum SidebarTrailingAccessoryWidthPolicy {
 // and bridge only sidebar-visible workspace changes into local state.
 // Do NOT add @EnvironmentObject or new @Binding without updating ==.
 // Do NOT remove .equatable() from the ForEach call site in VerticalTabsSidebar.
+private final class SidebarTabItemContextMenuState: ObservableObject {
+    var isVisible = false
+    var hasDeferredWorkspaceObservationInvalidation = false
+}
+
 private struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
 
@@ -12429,9 +12482,10 @@ private struct TabItemView: View, Equatable {
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
     let settings: SidebarTabItemSettingsSnapshot
+    let livePresentation: SidebarTabItemPresentationSnapshot
+    @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
     @State private var workspaceObservationGeneration: UInt64 = 0
-    @State private var contextMenuVisible = false
-    @State private var hasDeferredWorkspaceObservationInvalidation = false
+    @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
 
@@ -13080,6 +13134,7 @@ private struct TabItemView: View, Equatable {
             updateSelection()
         }
         .onHover { hovering in
+            guard !contextMenuState.isVisible else { return }
             isHovering = hovering
         }
         .accessibilityElement(children: .combine)
@@ -13094,10 +13149,16 @@ private struct TabItemView: View, Equatable {
         .contextMenu {
             workspaceContextMenu
                 .onAppear {
-                    contextMenuVisible = true
+                    contextMenuState.isVisible = true
+                    contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
+                    frozenPresentation = livePresentation
                 }
                 .onDisappear {
-                    contextMenuVisible = false
+                    contextMenuState.isVisible = false
+                    frozenPresentation = nil
+                    if isHovering {
+                        isHovering = false
+                    }
                     flushDeferredWorkspaceObservationInvalidation()
                 }
         }
@@ -13105,16 +13166,16 @@ private struct TabItemView: View, Equatable {
 
     private func scheduleWorkspaceObservationInvalidation() {
         // Keep the context menu stable while background workspace telemetry keeps arriving.
-        if contextMenuVisible {
-            hasDeferredWorkspaceObservationInvalidation = true
+        if contextMenuState.isVisible {
+            contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
             return
         }
         workspaceObservationGeneration &+= 1
     }
 
     private func flushDeferredWorkspaceObservationInvalidation() {
-        guard hasDeferredWorkspaceObservationInvalidation else { return }
-        hasDeferredWorkspaceObservationInvalidation = false
+        guard contextMenuState.hasDeferredWorkspaceObservationInvalidation else { return }
+        contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
         workspaceObservationGeneration &+= 1
     }
 


### PR DESCRIPTION
Closes #2560.

## Summary
- defer `TabItemView` workspace observation invalidations while its context menu is on screen so the workspace color submenu stays stable
- flush one coalesced row redraw after the menu closes so sidebar metadata still catches up immediately after dismissal
- update `read_clipboard_cb` in `GhosttyTerminalView` to match the current imported `GhosttyKit` callback signature so the branch builds cleanly in the current repo state

## Root Cause
`TabItemView` was subscribing to debounced workspace updates and incrementing `workspaceObservationGeneration` even while the context menu was open. Those updates caused SwiftUI to re-evaluate the row body and rebuild `.contextMenu`, which dismissed and re-presented the workspace color submenu repeatedly.

## Verification
- `./scripts/reload.sh --tag color-picker-blink --launch`
- `./scripts/reload.sh --tag color-picker-blink`

## Notes
- No local tests were run; repo policy says tests run in CI/VM only.
- The `GhosttyTerminalView` callback adjustment is not part of the color-picker behavior change itself; it is included here because it was required to keep the tagged debug build green in the current branch state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blinking in the workspace color picker by freezing only background row fields (unread count, latest notification text, modifier-hint state) and deferring updates while the context menu is open. Also updates the `read_clipboard_cb` to the latest `GhosttyKit` API.

- **Bug Fixes**
  - Limit the freeze to background row fields and defer workspace observation invalidations during the menu; flush once on close and clear the snapshot if the tab disappears.
  - Keep hover visuals stable while the menu is open and reset on dismiss to avoid redraws.

<sup>Written for commit 0837d1a4c52a1a3a4a434f5e1f8fba22a29bfef8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab presentation now “freezes” while a tab's context menu is open, preserving unread counts, notification text, and shortcut hints.

* **Bug Fixes**
  * Improved stability of tab hover states while context menus are visible.
  * More reliable context menu appearance and dismissal with preserved tab visuals.

* **Refactor**
  * Optimized tab state handling and deferred update processing to reduce visual glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SwiftUI invalidation and state handling for sidebar tab rows while a context menu is open; incorrect state coordination could leave sidebar badges/hover state stale or miss an update until the menu closes.
> 
> **Overview**
> Prevents the workspace/tab context menu (including the color picker submenu) from blinking by **freezing each tab row’s presentation** (unread badge, latest notification text, shortcut hint visibility) while the menu is visible.
> 
> Adds context-menu-aware invalidation in `TabItemView`: workspace observation updates are deferred during menu display and a single coalesced redraw is flushed on dismissal, with hover updates suppressed while the menu is open. Also clears any frozen presentation if the underlying tab disappears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0837d1a4c52a1a3a4a434f5e1f8fba22a29bfef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->