### PR TITLE
Suppress cmd-hover path highlighting while terminal selection is active

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 			B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
+			C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 			C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
 			E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 					B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */; };
@@ -297,6 +298,7 @@
 						FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportProfilesUITests.swift; sourceTree = "<group>"; };
 						E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 						AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
+						C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 							818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */,
 							B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */,
 							B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
+							C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
 							E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
 							D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
 							D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
@@ -864,6 +867,7 @@
 							B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */,
 							B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */,
 							B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
+							C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */,
 							E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 							D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,
 							D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2281,8 +2281,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didSetupJumpUnreadUITest = false
     private var jumpUnreadFocusExpectation: (tabId: UUID, surfaceId: UUID)?
     private var jumpUnreadFocusObserver: NSObjectProtocol?
+    private var didSetupTerminalCmdClickUITest = false
     private var didSetupGotoSplitUITest = false
     private var didSetupBonsplitTabDragUITest = false
+    private var terminalCmdClickUITestPoller: DispatchSourceTimer?
     private var bonsplitTabDragUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestRecorder: DispatchSourceTimer?
     private var gotoSplitUITestObservers: [NSObjectProtocol] = []
@@ -2945,6 +2947,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         startSessionAutosaveTimerIfNeeded()
 #if DEBUG
         setupJumpUnreadUITestIfNeeded()
+        setupTerminalCmdClickUITestIfNeeded()
         setupGotoSplitUITestIfNeeded()
         setupBonsplitTabDragUITestIfNeeded()
         setupMultiWindowNotificationsUITestIfNeeded()
@@ -2972,6 +2975,492 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
 #if DEBUG
+    private func setupTerminalCmdClickUITestIfNeeded() {
+        guard !didSetupTerminalCmdClickUITest else { return }
+        didSetupTerminalCmdClickUITest = true
+
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_SETUP"] == "1" else { return }
+        guard let currentTabManager = self.tabManager else { return }
+        guard let manifestPath = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !manifestPath.isEmpty else {
+            return
+        }
+        guard let fixtureDirectory = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FIXTURE_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !fixtureDirectory.isEmpty else {
+            writeTerminalCmdClickUITestData(at: manifestPath, updates: [
+                "setupError": "Missing fixture directory"
+            ])
+            return
+        }
+        let commandPath = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_COMMAND_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let fileName = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedFileName = (fileName?.isEmpty == false) ? fileName! : "Cmd Click Fixture.txt"
+        let fixtureDirectoryURL = URL(fileURLWithPath: fixtureDirectory, isDirectory: true)
+        let expectedFileURL = fixtureDirectoryURL.appendingPathComponent(resolvedFileName)
+        let escapedToken = resolvedFileName.replacingOccurrences(of: " ", with: "\\ ")
+        let blockLine = Array(repeating: escapedToken, count: 3).joined(separator: " ")
+        let shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+        let deadline = Date().addingTimeInterval((commandPath?.isEmpty == false) ? 60.0 : 20.0)
+        var seeded = false
+        var resolved = false
+        var tokenPointPayload: [String: Any]?
+        var observers: [NSObjectProtocol] = []
+        var panelsCancellable: AnyCancellable?
+        var lastHandledCommandID: String?
+
+        func rectPayload(_ rect: CGRect) -> [String: Double] {
+            [
+                "x": rect.origin.x,
+                "y": rect.origin.y,
+                "width": rect.size.width,
+                "height": rect.size.height
+            ]
+        }
+
+        func pointPayload(x: CGFloat, yFromTop: CGFloat) -> [String: Double] {
+            [
+                "x": x,
+                "y": yFromTop
+            ]
+        }
+
+        func pointFromPayload(_ key: String, in terminalPanel: TerminalPanel) -> NSPoint? {
+            guard let payload = tokenPointPayload?[key] as? [String: Any],
+                  let x = payload["x"] as? Double,
+                  let yFromTop = payload["y"] as? Double else {
+                return nil
+            }
+
+            let clampedX = min(max(CGFloat(x), 1), max(terminalPanel.hostedView.bounds.width - 1, 1))
+            let clampedYFromTop = min(
+                max(CGFloat(yFromTop), 1),
+                max(terminalPanel.hostedView.bounds.height - 1, 1)
+            )
+            return NSPoint(
+                x: clampedX,
+                y: terminalPanel.hostedView.bounds.height - clampedYFromTop
+            )
+        }
+
+        func loadCommand(at path: String) -> [String: Any]? {
+            let url = URL(fileURLWithPath: path)
+            guard let data = try? Data(contentsOf: url),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return object
+        }
+
+        func tokenPoints(in terminalPanel: TerminalPanel, visibleText: String) -> [String: Any]? {
+            guard let surface = terminalPanel.surface.surface else { return nil }
+            let bounds = terminalPanel.hostedView.bounds
+            guard bounds.width > 0, bounds.height > 0 else { return nil }
+
+            let size = ghostty_surface_size(surface)
+            let rows = max(Int(size.rows), 1)
+            let cols = max(Int(size.columns), 1)
+            let debugCellSize = terminalPanel.hostedView.debugCellSize
+            let cellWidth = debugCellSize.width > 0 ? debugCellSize.width : CGFloat(size.cell_width_px)
+            let cellHeight = debugCellSize.height > 0 ? debugCellSize.height : CGFloat(size.cell_height_px)
+            guard cellWidth > 0, cellHeight > 0 else { return nil }
+
+            let xInset = max(0, (bounds.width - (CGFloat(cols) * cellWidth)) / 2)
+            let yInset = max(0, (bounds.height - (CGFloat(rows) * cellHeight)) / 2)
+            let pointClampX: (CGFloat) -> CGFloat = { x in
+                min(bounds.width - 4, max(4, x))
+            }
+            let pointClampY: (CGFloat) -> CGFloat = { y in
+                min(bounds.height - 4, max(4, y))
+            }
+
+            let rawVisibleLines = visibleText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let visibleLines = rawVisibleLines.count > rows ? Array(rawVisibleLines.suffix(rows)) : rawVisibleLines
+            let rowOffset = max(0, rows - visibleLines.count)
+
+            var matchedRowFromTop: Int?
+            var matchedColumnStart: Int?
+            var matchedColumnEnd: Int?
+            var matchedLine = ""
+            var matchingLines: [(lineIndex: Int, line: String, ranges: [Range<String.Index>])] = []
+
+            for (lineIndex, line) in visibleLines.enumerated() {
+                var searchStart = line.startIndex
+                var ranges: [Range<String.Index>] = []
+                while searchStart < line.endIndex,
+                      let range = line.range(of: escapedToken, range: searchStart..<line.endIndex) {
+                    ranges.append(range)
+                    searchStart = range.upperBound
+                }
+                if !ranges.isEmpty {
+                    matchingLines.append((lineIndex, line, ranges))
+                }
+            }
+
+            if !matchingLines.isEmpty {
+                let selectedLine = matchingLines[matchingLines.count / 2]
+                let selectedRange = selectedLine.ranges[selectedLine.ranges.count / 2]
+                let startColumn = selectedLine.line.distance(from: selectedLine.line.startIndex, to: selectedRange.lowerBound)
+                let endColumnExclusive = selectedLine.line.distance(from: selectedLine.line.startIndex, to: selectedRange.upperBound)
+                if startColumn < cols {
+                    matchedRowFromTop = rowOffset + selectedLine.lineIndex
+                    matchedColumnStart = startColumn
+                    matchedColumnEnd = max(startColumn, endColumnExclusive - 1)
+                    matchedLine = selectedLine.line
+                }
+            }
+
+            guard let matchedRowFromTop,
+                  let matchedColumnStart,
+                  let matchedColumnEnd else {
+                return [
+                    "tokenLayoutMatch": "0",
+                    "tokenCellMetrics": [
+                        "cellWidth": cellWidth,
+                        "cellHeight": cellHeight,
+                        "columns": cols,
+                        "rows": rows,
+                        "xInset": xInset,
+                        "yInset": yInset,
+                        "visibleLineCount": visibleLines.count
+                    ]
+                ]
+            }
+
+            let yFromTop = pointClampY(yInset + (CGFloat(matchedRowFromTop) * cellHeight) + (cellHeight / 2))
+            let startX = pointClampX(xInset + (CGFloat(matchedColumnStart) * cellWidth) + (cellWidth / 2))
+            let endX = pointClampX(xInset + (CGFloat(matchedColumnEnd) * cellWidth) + (cellWidth / 2))
+            let hitX = pointClampX(startX + min(cellWidth * 2, max(0, endX - startX)))
+            return [
+                "tokenHitPointInTerminal": pointPayload(x: hitX, yFromTop: yFromTop),
+                "tokenSelectionStartInTerminal": pointPayload(x: startX, yFromTop: yFromTop),
+                "tokenSelectionEndInTerminal": pointPayload(x: endX, yFromTop: yFromTop),
+                "tokenQuicklookWord": escapedToken,
+                "tokenLayoutMatch": "1",
+                "tokenCellMetrics": [
+                    "cellWidth": cellWidth,
+                    "cellHeight": cellHeight,
+                    "columns": cols,
+                    "rows": rows,
+                    "xInset": xInset,
+                    "yInset": yInset,
+                    "visibleLineCount": visibleLines.count,
+                    "matchedRowFromTop": matchedRowFromTop,
+                    "matchedColumnStart": matchedColumnStart,
+                    "matchedColumnEnd": matchedColumnEnd,
+                    "matchedLine": matchedLine
+                ]
+            ]
+        }
+
+        func cleanup() {
+            observers.forEach { NotificationCenter.default.removeObserver($0) }
+            observers.removeAll()
+            panelsCancellable?.cancel()
+            panelsCancellable = nil
+            terminalCmdClickUITestPoller?.cancel()
+            terminalCmdClickUITestPoller = nil
+        }
+
+        func writeState(
+            terminalPanel: TerminalPanel?,
+            window: NSWindow?,
+            ready: Bool,
+            setupError: String? = nil,
+            additionalPayload: [String: Any] = [:]
+        ) {
+            var payload: [String: Any] = [
+                "ready": ready ? "1" : "0",
+                "escapedToken": escapedToken,
+                "fileName": resolvedFileName,
+                "expectedPath": expectedFileURL.path,
+                "fixtureDirectory": fixtureDirectoryURL.path
+            ]
+            if let terminalPanel {
+                let terminalFrame = terminalPanel.hostedView.debugPortalFrameInWindow
+                payload["surfaceId"] = terminalPanel.id.uuidString
+                payload["terminalVisibleInUI"] = terminalPanel.hostedView.debugPortalVisibleInUI ? "1" : "0"
+                payload["terminalFrameInWindow"] = rectPayload(terminalFrame)
+            }
+            if let window {
+                payload["windowFrame"] = rectPayload(window.frame)
+                payload["windowVisible"] = window.isVisible ? "1" : "0"
+            }
+            if let setupError {
+                payload["setupError"] = setupError
+            }
+            if let tokenPointPayload {
+                for (key, value) in tokenPointPayload {
+                    payload[key] = value
+                }
+            }
+            for (key, value) in additionalPayload {
+                payload[key] = value
+            }
+            writeTerminalCmdClickUITestData(at: manifestPath, updates: payload)
+        }
+
+        func resizeWindowIfNeeded(_ window: NSWindow) {
+            let screenFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame
+            guard let screenFrame else { return }
+            let targetSize = NSSize(
+                width: min(960, screenFrame.width - 80),
+                height: min(720, screenFrame.height - 80)
+            )
+            let targetOrigin = NSPoint(
+                x: screenFrame.minX + 40,
+                y: screenFrame.maxY - 40 - targetSize.height
+            )
+            let targetFrame = NSRect(origin: targetOrigin, size: targetSize)
+            if !window.frame.equalTo(targetFrame) {
+                window.setFrame(targetFrame, display: true)
+            }
+        }
+
+        @MainActor
+        func executePendingCommandIfNeeded(
+            terminalPanel: TerminalPanel,
+            window: NSWindow
+        ) {
+            guard let commandPath,
+                  !commandPath.isEmpty,
+                  let command = loadCommand(at: commandPath),
+                  let commandID = command["id"] as? String,
+                  commandID != lastHandledCommandID else {
+                return
+            }
+
+            let action = (command["action"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            var payload: [String: Any] = [
+                "lastCommandId": commandID,
+                "lastCommandAction": action,
+                "lastCommandSucceeded": "0"
+            ]
+
+            switch action {
+            case "cmd_click_token":
+                guard let hitPoint = pointFromPayload("tokenHitPointInTerminal", in: terminalPanel) else {
+                    payload["lastCommandError"] = "Missing token hit point"
+                    break
+                }
+
+                let result = terminalPanel.hostedView.debugSimulateCommandClick(at: hitPoint)
+                payload["lastCommandResult"] = result
+                if let openedPath = result["openedPath"] as? String {
+                    payload["lastCommandOpenedPath"] = openedPath
+                    payload["lastCommandSucceeded"] = "1"
+                } else if let error = result["error"] as? String {
+                    payload["lastCommandError"] = error
+                } else {
+                    payload["lastCommandError"] = "Command click did not open a path"
+                }
+
+            case "select_token_and_hold_command":
+                guard let selectionStart = pointFromPayload("tokenSelectionStartInTerminal", in: terminalPanel),
+                      let selectionEnd = pointFromPayload("tokenSelectionEndInTerminal", in: terminalPanel) else {
+                    payload["lastCommandError"] = "Missing token selection points"
+                    break
+                }
+
+                let selectionActive = terminalPanel.hostedView.debugSimulateSelection(
+                    from: selectionStart,
+                    to: selectionEnd
+                )
+                let hoverSuppressed = terminalPanel.hostedView.debugSimulateCommandHover(at: selectionEnd)
+                payload["lastCommandSelectionActive"] = selectionActive ? "1" : "0"
+                payload["lastCommandHoverSuppressed"] = hoverSuppressed ? "1" : "0"
+                if selectionActive && hoverSuppressed {
+                    payload["lastCommandSucceeded"] = "1"
+                } else {
+                    payload["lastCommandError"] = "Selection or hover suppression failed"
+                }
+
+            default:
+                payload["lastCommandError"] = "Unknown command action: \(action)"
+            }
+
+            writeState(
+                terminalPanel: terminalPanel,
+                window: window,
+                ready: true,
+                additionalPayload: payload
+            )
+            lastHandledCommandID = commandID
+            resolved = true
+            cleanup()
+        }
+
+        @MainActor
+        func evaluate() {
+            guard !resolved else { return }
+            if Date() >= deadline {
+                let textSnapshot = tabManager?.selectedWorkspace?.focusedTerminalPanel
+                    .flatMap { TerminalController.shared.readTerminalTextForSnapshot(terminalPanel: $0, lineLimit: 200) } ?? ""
+                writeState(
+                    terminalPanel: tabManager?.selectedWorkspace?.focusedTerminalPanel,
+                    window: NSApp.windows.first(where: { window in
+                        guard let raw = window.identifier?.rawValue else { return false }
+                        return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
+                    }),
+                    ready: false,
+                    setupError: "Timed out waiting for terminal cmd-click setup. text=\(textSnapshot)"
+                )
+                resolved = true
+                cleanup()
+                return
+            }
+
+            guard let tabManager = self.tabManager,
+                  let workspace = tabManager.selectedWorkspace ?? tabManager.tabs.first,
+                  let terminalPanel = workspace.focusedTerminalPanel,
+                  let mainWindow = NSApp.windows.first(where: { window in
+                      guard let raw = window.identifier?.rawValue else { return false }
+                      return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
+                  }) else {
+                return
+            }
+
+            resizeWindowIfNeeded(mainWindow)
+            mainWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            terminalPanel.focus()
+
+            do {
+                try FileManager.default.createDirectory(
+                    at: fixtureDirectoryURL,
+                    withIntermediateDirectories: true
+                )
+                if !FileManager.default.fileExists(atPath: expectedFileURL.path) {
+                    try "fixture\n".write(to: expectedFileURL, atomically: true, encoding: .utf8)
+                }
+            } catch {
+                writeState(
+                    terminalPanel: terminalPanel,
+                    window: mainWindow,
+                    ready: false,
+                    setupError: "Failed to create fixture: \(error.localizedDescription)"
+                )
+                resolved = true
+                cleanup()
+                return
+            }
+
+            workspace.updatePanelDirectory(panelId: terminalPanel.id, directory: fixtureDirectoryURL.path)
+
+            let terminalFrame = terminalPanel.hostedView.debugPortalFrameInWindow
+            let terminalReady = terminalPanel.surface.surface != nil
+            let terminalVisible = terminalPanel.hostedView.window != nil &&
+                terminalPanel.hostedView.debugPortalVisibleInUI &&
+                !terminalFrame.isEmpty &&
+                terminalFrame.width > 0 &&
+                terminalFrame.height > 0
+
+            if terminalReady && terminalVisible && !seeded {
+                seeded = true
+                sendTextWhenReady(shellCommand, to: workspace) {
+                    workspace.updatePanelDirectory(panelId: terminalPanel.id, directory: fixtureDirectoryURL.path)
+                }
+            }
+
+            let visibleText = TerminalController.shared.readTerminalTextForSnapshot(
+                terminalPanel: terminalPanel,
+                lineLimit: 200
+            ) ?? ""
+            let renderedTokenCount = max(0, visibleText.components(separatedBy: escapedToken).count - 1)
+            let hasRenderedToken = renderedTokenCount >= 6
+            if hasRenderedToken, tokenPointPayload == nil {
+                tokenPointPayload = tokenPoints(in: terminalPanel, visibleText: visibleText)
+            }
+            let tokenLayoutReady = (tokenPointPayload?["tokenLayoutMatch"] as? String) == "1"
+
+            writeState(
+                terminalPanel: terminalPanel,
+                window: mainWindow,
+                ready: terminalReady && terminalVisible && hasRenderedToken && tokenLayoutReady,
+                additionalPayload: [
+                    "seeded": seeded ? "1" : "0",
+                    "hasRenderedToken": hasRenderedToken ? "1" : "0",
+                    "renderedTokenCount": renderedTokenCount,
+                    "visibleTextTail": String(visibleText.suffix(1200))
+                ]
+            )
+
+            guard terminalReady, terminalVisible, hasRenderedToken, tokenLayoutReady else { return }
+            if commandPath?.isEmpty == false {
+                executePendingCommandIfNeeded(
+                    terminalPanel: terminalPanel,
+                    window: mainWindow
+                )
+                return
+            }
+            resolved = true
+            cleanup()
+        }
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: NSWindow.didUpdateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in evaluate() }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceHostedViewDidMoveToWindow,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in evaluate() }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in evaluate() }
+        })
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .ghosttyDidFocusSurface,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in evaluate() }
+        })
+        panelsCancellable = currentTabManager.$tabs
+            .map { _ in () }
+            .sink { _ in
+                Task { @MainActor in evaluate() }
+            }
+
+        let poller = DispatchSource.makeTimerSource(queue: .main)
+        poller.schedule(deadline: .now(), repeating: .milliseconds(100))
+        poller.setEventHandler {
+            Task { @MainActor in evaluate() }
+        }
+        terminalCmdClickUITestPoller = poller
+        poller.resume()
+    }
+
+    private func writeTerminalCmdClickUITestData(at path: String, updates: [String: Any]) {
+        let url = URL(fileURLWithPath: path)
+        var payload: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            payload = object
+        }
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return
+        }
+        try? data.write(to: url, options: .atomic)
+    }
+
     private func scheduleUITestSocketSanityCheckIfNeeded() {
         let env = ProcessInfo.processInfo.environment
         guard env["CMUX_UI_TEST_SOCKET_SANITY"] == "1" else { return }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2977,19 +2977,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
     private func setupTerminalCmdClickUITestIfNeeded() {
         guard !didSetupTerminalCmdClickUITest else { return }
-        didSetupTerminalCmdClickUITest = true
 
         let env = ProcessInfo.processInfo.environment
-        guard env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_SETUP"] == "1" else { return }
-        guard let currentTabManager = self.tabManager else { return }
+        guard env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_SETUP"] == "1" else {
+            dlog("cmdclick.ui.setup skip reason=env_missing tag=\(env["CMUX_TAG"] ?? "nil")")
+            return
+        }
         guard let manifestPath = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_PATH"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !manifestPath.isEmpty else {
+            dlog("cmdclick.ui.setup skip reason=missing_manifest_path")
             return
         }
+        didSetupTerminalCmdClickUITest = true
         guard let fixtureDirectory = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FIXTURE_DIR"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !fixtureDirectory.isEmpty else {
+            dlog("cmdclick.ui.setup error reason=missing_fixture_dir manifest=\(manifestPath)")
             writeTerminalCmdClickUITestData(at: manifestPath, updates: [
                 "setupError": "Missing fixture directory"
             ])
@@ -2999,6 +3003,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let displayMode = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_DISPLAY_MODE"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let lineFormat = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_LINE_FORMAT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let linePrefix = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_LINE_PREFIX"] ?? ""
+        let extraFileNamesJSON = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_EXTRA_FILE_NAMES_JSON"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let fileName = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -3006,26 +3015,66 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let fixtureDirectoryURL = URL(fileURLWithPath: fixtureDirectory, isDirectory: true)
         let expectedFileURL = fixtureDirectoryURL.appendingPathComponent(resolvedFileName)
         let siblingFileURL = fixtureDirectoryURL.appendingPathComponent("OtherFile")
+        let extraFileNames: [String]
+        if let extraFileNamesJSON,
+           let data = extraFileNamesJSON.data(using: .utf8),
+           let values = try? JSONSerialization.jsonObject(with: data) as? [String] {
+            extraFileNames = values
+        } else {
+            extraFileNames = []
+        }
         let escapedToken = resolvedFileName.replacingOccurrences(of: " ", with: "\\ ")
         let resolvedDisplayMode = (displayMode == "raw") ? "raw" : "escaped"
+        let resolvedLineFormat: String
+        switch lineFormat {
+        case "log":
+            resolvedLineFormat = "log"
+        case "alt_screen_log":
+            resolvedLineFormat = "alt_screen_log"
+        default:
+            resolvedLineFormat = "grid"
+        }
+        dlog(
+            "cmdclick.ui.setup start manifest=\(manifestPath) fixture=\(fixtureDirectory) " +
+                "command=\(commandPath ?? "nil") display=\(resolvedDisplayMode) " +
+                "lineFormat=\(resolvedLineFormat) " +
+                "file=\(resolvedFileName)"
+        )
+        func singleQuotedShellLiteral(_ text: String) -> String {
+            text.replacingOccurrences(of: "'", with: "'\"'\"'")
+        }
         let displayToken: String
         let shellCommand: String
-        switch resolvedDisplayMode {
-        case "raw":
+        switch resolvedLineFormat {
+        case "log":
             displayToken = resolvedFileName
-            let blockLine = "\(resolvedFileName)    OtherFile"
-            shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+            let blockLine = "\(linePrefix)\(resolvedFileName)"
+            let shellBlockLine = singleQuotedShellLiteral(blockLine)
+            shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(shellBlockLine)'; done\r"
+        case "alt_screen_log":
+            displayToken = resolvedFileName
+            let blockLine = "\(linePrefix)\(resolvedFileName)"
+            let shellBlockLine = singleQuotedShellLiteral(blockLine)
+            shellCommand = "clear\rprintf '\\033[?1049h\\033[H\\033[2J'; for i in $(seq 1 48); do printf '%s\\n' '\(shellBlockLine)'; done\r"
         default:
-            displayToken = escapedToken
-            let blockLine = Array(repeating: escapedToken, count: 3).joined(separator: " ")
-            shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+            switch resolvedDisplayMode {
+            case "raw":
+                displayToken = resolvedFileName
+                let blockLine = "\(resolvedFileName)    OtherFile"
+                let shellBlockLine = singleQuotedShellLiteral(blockLine)
+                shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(shellBlockLine)'; done\r"
+            default:
+                displayToken = escapedToken
+                let blockLine = Array(repeating: escapedToken, count: 3).joined(separator: " ")
+                let shellBlockLine = singleQuotedShellLiteral(blockLine)
+                shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(shellBlockLine)'; done\r"
+            }
         }
         let deadline = Date().addingTimeInterval((commandPath?.isEmpty == false) ? 60.0 : 20.0)
         var seeded = false
         var resolved = false
         var tokenPointPayload: [String: Any]?
         var observers: [NSObjectProtocol] = []
-        var panelsCancellable: AnyCancellable?
         var lastHandledCommandID: String?
 
         func rectPayload(_ rect: CGRect) -> [String: Double] {
@@ -3175,8 +3224,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         func cleanup() {
             observers.forEach { NotificationCenter.default.removeObserver($0) }
             observers.removeAll()
-            panelsCancellable?.cancel()
-            panelsCancellable = nil
             terminalCmdClickUITestPoller?.cancel()
             terminalCmdClickUITestPoller = nil
         }
@@ -3192,6 +3239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "ready": ready ? "1" : "0",
                 "escapedToken": escapedToken,
                 "displayMode": resolvedDisplayMode,
+                "lineFormat": resolvedLineFormat,
                 "displayToken": displayToken,
                 "fileName": resolvedFileName,
                 "expectedPath": expectedFileURL.path,
@@ -3259,6 +3307,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ]
 
             switch action {
+            case "hover_token":
+                guard let hitPoint = pointFromPayload("tokenHitPointInTerminal", in: terminalPanel) else {
+                    payload["lastCommandError"] = "Missing token hit point"
+                    break
+                }
+
+                let result = terminalPanel.hostedView.debugSimulateCommandHoverDetails(at: hitPoint)
+                payload["lastCommandResult"] = result
+                payload["lastCommandHoverActive"] = result["hoverActive"]
+                if let resolvedPath = result["resolvedPath"] as? String {
+                    payload["lastCommandResolvedPath"] = resolvedPath
+                    payload["lastCommandSucceeded"] = "1"
+                } else if let error = result["error"] as? String {
+                    payload["lastCommandError"] = error
+                } else {
+                    payload["lastCommandError"] = "Command hover did not resolve a path"
+                }
+
             case "cmd_click_token":
                 guard let hitPoint = pointFromPayload("tokenHitPointInTerminal", in: terminalPanel) else {
                     payload["lastCommandError"] = "Missing token hit point"
@@ -3314,27 +3380,71 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         @MainActor
         func evaluate() {
             guard !resolved else { return }
-            let workspace = currentTabManager.selectedWorkspace ?? currentTabManager.tabs.first
+            let currentTabManager = self.tabManager
+            let workspace = currentTabManager?.selectedWorkspace ?? currentTabManager?.tabs.first
             let terminalPanel = workspace?.focusedTerminalPanel
             let mainWindow = terminalPanel?.hostedView.window
-                ?? self.windowId(for: currentTabManager).flatMap { self.mainWindow(for: $0) }
+                ?? currentTabManager.flatMap { self.windowId(for: $0).flatMap { self.mainWindow(for: $0) } }
             if Date() >= deadline {
                 let textSnapshot = terminalPanel
                     .flatMap { TerminalController.shared.readTerminalTextForSnapshot(terminalPanel: $0, lineLimit: 200) } ?? ""
+                var timeoutPayload: [String: Any] = [:]
+                if let currentTabManager {
+                    timeoutPayload["tabManager"] = debugManagerToken(currentTabManager)
+                    timeoutPayload["workspaceCount"] = currentTabManager.tabs.count
+                }
+                let waitingFor = [
+                    workspace == nil ? "workspace" : nil,
+                    terminalPanel == nil ? "terminalPanel" : nil,
+                    mainWindow == nil ? "mainWindow" : nil
+                ]
+                    .compactMap { $0 }
+                    .joined(separator: ",")
+                if !waitingFor.isEmpty {
+                    timeoutPayload["waitingFor"] = waitingFor
+                }
                 writeState(
                     terminalPanel: terminalPanel,
                     window: mainWindow,
                     ready: false,
-                    setupError: "Timed out waiting for terminal cmd-click setup. text=\(textSnapshot)"
+                    setupError: "Timed out waiting for terminal cmd-click setup. text=\(textSnapshot)",
+                    additionalPayload: timeoutPayload
                 )
                 resolved = true
                 cleanup()
                 return
             }
 
+            if currentTabManager == nil {
+                writeTerminalCmdClickUITestData(at: manifestPath, updates: [
+                    "ready": "0",
+                    "setupError": "Waiting for tab manager"
+                ])
+                return
+            }
+
             guard let workspace,
                   let terminalPanel,
                   let mainWindow else {
+                var waitingPayload: [String: Any] = [
+                    "ready": "0",
+                    "setupError": "Waiting for terminal workspace"
+                ]
+                if let currentTabManager {
+                    waitingPayload["tabManager"] = debugManagerToken(currentTabManager)
+                    waitingPayload["workspaceCount"] = currentTabManager.tabs.count
+                }
+                let waitingFor = [
+                    workspace == nil ? "workspace" : nil,
+                    terminalPanel == nil ? "terminalPanel" : nil,
+                    mainWindow == nil ? "mainWindow" : nil
+                ]
+                    .compactMap { $0 }
+                    .joined(separator: ",")
+                if !waitingFor.isEmpty {
+                    waitingPayload["waitingFor"] = waitingFor
+                }
+                writeTerminalCmdClickUITestData(at: manifestPath, updates: waitingPayload)
                 return
             }
 
@@ -3353,6 +3463,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 }
                 if !FileManager.default.fileExists(atPath: siblingFileURL.path) {
                     try "fixture\n".write(to: siblingFileURL, atomically: true, encoding: .utf8)
+                }
+                for extraFileName in extraFileNames where !extraFileName.isEmpty {
+                    let extraFileURL = fixtureDirectoryURL.appendingPathComponent(extraFileName)
+                    if !FileManager.default.fileExists(atPath: extraFileURL.path) {
+                        try "fixture\n".write(to: extraFileURL, atomically: true, encoding: .utf8)
+                    }
                 }
             } catch {
                 writeState(
@@ -3447,18 +3563,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ) { _ in
             Task { @MainActor in evaluate() }
         })
-        panelsCancellable = currentTabManager.$tabs
-            .map { _ in () }
-            .sink { _ in
-                Task { @MainActor in evaluate() }
-            }
-
         let poller = DispatchSource.makeTimerSource(queue: .main)
         poller.schedule(deadline: .now(), repeating: .milliseconds(100))
         poller.setEventHandler {
             Task { @MainActor in evaluate() }
         }
         terminalCmdClickUITestPoller = poller
+        dlog("cmdclick.ui.setup poller_started manifest=\(manifestPath)")
         poller.resume()
     }
 
@@ -3473,9 +3584,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             payload[key] = value
         }
         guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            dlog("cmdclick.ui.write skip reason=json path=\(path)")
             return
         }
-        try? data.write(to: url, options: .atomic)
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            dlog("cmdclick.ui.write error path=\(path) error=\(error.localizedDescription)")
+        }
     }
 
     private func scheduleUITestSocketSanityCheckIfNeeded() {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2997,15 +2997,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         let commandPath = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_COMMAND_PATH"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayMode = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_DISPLAY_MODE"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let fileName = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedFileName = (fileName?.isEmpty == false) ? fileName! : "Cmd Click Fixture.txt"
         let fixtureDirectoryURL = URL(fileURLWithPath: fixtureDirectory, isDirectory: true)
         let expectedFileURL = fixtureDirectoryURL.appendingPathComponent(resolvedFileName)
+        let siblingFileURL = fixtureDirectoryURL.appendingPathComponent("OtherFile")
         let escapedToken = resolvedFileName.replacingOccurrences(of: " ", with: "\\ ")
-        let blockLine = Array(repeating: escapedToken, count: 3).joined(separator: " ")
-        let shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+        let resolvedDisplayMode = (displayMode == "raw") ? "raw" : "escaped"
+        let displayToken: String
+        let shellCommand: String
+        switch resolvedDisplayMode {
+        case "raw":
+            displayToken = resolvedFileName
+            let blockLine = "\(resolvedFileName)    OtherFile"
+            shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+        default:
+            displayToken = escapedToken
+            let blockLine = Array(repeating: escapedToken, count: 3).joined(separator: " ")
+            shellCommand = "clear\rfor i in $(seq 1 48); do printf '%s\\n' '\(blockLine)'; done\r"
+        }
         let deadline = Date().addingTimeInterval((commandPath?.isEmpty == false) ? 60.0 : 20.0)
         var seeded = false
         var resolved = false
@@ -3093,7 +3107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 var searchStart = line.startIndex
                 var ranges: [Range<String.Index>] = []
                 while searchStart < line.endIndex,
-                      let range = line.range(of: escapedToken, range: searchStart..<line.endIndex) {
+                      let range = line.range(of: displayToken, range: searchStart..<line.endIndex) {
                     ranges.append(range)
                     searchStart = range.upperBound
                 }
@@ -3140,7 +3154,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "tokenHitPointInTerminal": pointPayload(x: hitX, yFromTop: yFromTop),
                 "tokenSelectionStartInTerminal": pointPayload(x: startX, yFromTop: yFromTop),
                 "tokenSelectionEndInTerminal": pointPayload(x: endX, yFromTop: yFromTop),
-                "tokenQuicklookWord": escapedToken,
+                "tokenQuicklookWord": displayToken,
                 "tokenLayoutMatch": "1",
                 "tokenCellMetrics": [
                     "cellWidth": cellWidth,
@@ -3177,6 +3191,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             var payload: [String: Any] = [
                 "ready": ready ? "1" : "0",
                 "escapedToken": escapedToken,
+                "displayMode": resolvedDisplayMode,
+                "displayToken": displayToken,
                 "fileName": resolvedFileName,
                 "expectedPath": expectedFileURL.path,
                 "fixtureDirectory": fixtureDirectoryURL.path
@@ -3298,15 +3314,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         @MainActor
         func evaluate() {
             guard !resolved else { return }
+            let workspace = currentTabManager.selectedWorkspace ?? currentTabManager.tabs.first
+            let terminalPanel = workspace?.focusedTerminalPanel
+            let mainWindow = terminalPanel?.hostedView.window
+                ?? self.windowId(for: currentTabManager).flatMap { self.mainWindow(for: $0) }
             if Date() >= deadline {
-                let textSnapshot = tabManager?.selectedWorkspace?.focusedTerminalPanel
+                let textSnapshot = terminalPanel
                     .flatMap { TerminalController.shared.readTerminalTextForSnapshot(terminalPanel: $0, lineLimit: 200) } ?? ""
                 writeState(
-                    terminalPanel: tabManager?.selectedWorkspace?.focusedTerminalPanel,
-                    window: NSApp.windows.first(where: { window in
-                        guard let raw = window.identifier?.rawValue else { return false }
-                        return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
-                    }),
+                    terminalPanel: terminalPanel,
+                    window: mainWindow,
                     ready: false,
                     setupError: "Timed out waiting for terminal cmd-click setup. text=\(textSnapshot)"
                 )
@@ -3315,13 +3332,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return
             }
 
-            guard let tabManager = self.tabManager,
-                  let workspace = tabManager.selectedWorkspace ?? tabManager.tabs.first,
-                  let terminalPanel = workspace.focusedTerminalPanel,
-                  let mainWindow = NSApp.windows.first(where: { window in
-                      guard let raw = window.identifier?.rawValue else { return false }
-                      return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
-                  }) else {
+            guard let workspace,
+                  let terminalPanel,
+                  let mainWindow else {
                 return
             }
 
@@ -3337,6 +3350,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
                 if !FileManager.default.fileExists(atPath: expectedFileURL.path) {
                     try "fixture\n".write(to: expectedFileURL, atomically: true, encoding: .utf8)
+                }
+                if !FileManager.default.fileExists(atPath: siblingFileURL.path) {
+                    try "fixture\n".write(to: siblingFileURL, atomically: true, encoding: .utf8)
                 }
             } catch {
                 writeState(
@@ -3371,7 +3387,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 terminalPanel: terminalPanel,
                 lineLimit: 200
             ) ?? ""
-            let renderedTokenCount = max(0, visibleText.components(separatedBy: escapedToken).count - 1)
+            let renderedTokenCount = max(0, visibleText.components(separatedBy: displayToken).count - 1)
             let hasRenderedToken = renderedTokenCount >= 6
             if hasRenderedToken, tokenPointPayload == nil {
                 tokenPointPayload = tokenPoints(in: terminalPanel, visibleText: visibleText)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3389,7 +3389,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ) ?? ""
             let renderedTokenCount = max(0, visibleText.components(separatedBy: displayToken).count - 1)
             let hasRenderedToken = renderedTokenCount >= 6
-            if hasRenderedToken, tokenPointPayload == nil {
+            if hasRenderedToken,
+               (tokenPointPayload?["tokenLayoutMatch"] as? String) != "1" {
                 tokenPointPayload = tokenPoints(in: terminalPanel, visibleText: visibleText)
             }
             let tokenLayoutReady = (tokenPointPayload?["tokenLayoutMatch"] as? String) == "1"

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3111,6 +3111,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
 
+        func pointForTokenColumnOffset(_ offset: Int, in terminalPanel: TerminalPanel) -> NSPoint? {
+            guard let selectionStart = pointFromPayload("tokenSelectionStartInTerminal", in: terminalPanel),
+                  let tokenCellMetrics = tokenPointPayload?["tokenCellMetrics"] as? [String: Any],
+                  let cellWidth = tokenCellMetrics["cellWidth"] as? Double else {
+                return nil
+            }
+
+            let unclampedX = selectionStart.x + (CGFloat(offset) * CGFloat(cellWidth))
+            let clampedX = min(max(unclampedX, 1), max(terminalPanel.hostedView.bounds.width - 1, 1))
+            return NSPoint(x: clampedX, y: selectionStart.y)
+        }
+
+        func commandPoint(
+            from command: [String: Any],
+            defaultPayloadKey: String,
+            in terminalPanel: TerminalPanel
+        ) -> NSPoint? {
+            if let tokenColumnOffset = command["tokenColumnOffset"] as? Int {
+                return pointForTokenColumnOffset(tokenColumnOffset, in: terminalPanel)
+            }
+            if let tokenColumnOffset = command["tokenColumnOffset"] as? NSNumber {
+                return pointForTokenColumnOffset(tokenColumnOffset.intValue, in: terminalPanel)
+            }
+            return pointFromPayload(defaultPayloadKey, in: terminalPanel)
+        }
+
         func loadCommand(at path: String) -> [String: Any]? {
             let url = URL(fileURLWithPath: path)
             guard let data = try? Data(contentsOf: url),
@@ -3308,8 +3334,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             switch action {
             case "hover_token":
-                guard let hitPoint = pointFromPayload("tokenHitPointInTerminal", in: terminalPanel) else {
-                    payload["lastCommandError"] = "Missing token hit point"
+                guard let hitPoint = commandPoint(
+                    from: command,
+                    defaultPayloadKey: "tokenHitPointInTerminal",
+                    in: terminalPanel
+                ) else {
+                    payload["lastCommandError"] = "Missing command point"
                     break
                 }
 
@@ -3326,8 +3356,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 }
 
             case "cmd_click_token":
-                guard let hitPoint = pointFromPayload("tokenHitPointInTerminal", in: terminalPanel) else {
-                    payload["lastCommandError"] = "Missing token hit point"
+                guard let hitPoint = commandPoint(
+                    from: command,
+                    defaultPayloadKey: "tokenHitPointInTerminal",
+                    in: terminalPanel
+                ) else {
+                    payload["lastCommandError"] = "Missing command point"
                     break
                 }
 
@@ -3373,8 +3407,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 additionalPayload: payload
             )
             lastHandledCommandID = commandID
-            resolved = true
-            cleanup()
         }
 
         @MainActor

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -469,6 +469,7 @@ func cmuxPasteboardImageFileURLForTesting(_ pasteboard: NSPasteboard) -> URL? {
 func cmuxPasteboardImagePathForTesting(_ pasteboard: NSPasteboard) -> String? {
     GhosttyPasteboardHelper.saveClipboardImageIfNeeded(from: pasteboard)
 }
+
 #endif
 
 enum TerminalOpenURLTarget: Equatable {
@@ -6545,6 +6546,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         suppressCommandPathHover: Bool
     ) -> ghostty_input_mods_e {
         let effectiveFlags = suppressCommandPathHover ? flags.subtracting(.command) : flags
+#if DEBUG
+        if suppressCommandPathHover, flags.contains(.command) {
+            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+                envKey: "CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"
+            ) { payload in
+                payload["suppressed_command_hover_count"] = (payload["suppressed_command_hover_count"] as? Int ?? 0) + 1
+                if effectiveFlags.contains(.command) {
+                    payload["forwarded_command_hover_count"] = (payload["forwarded_command_hover_count"] as? Int ?? 0) + 1
+                }
+            }
+        }
+#endif
         return modsFromFlags(effectiveFlags)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7150,6 +7150,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return nil
         }
 
+        let snapshotPoint = preferredPointerPoint(from: point)
+        let pointSnapshotResolution = snapshotPoint.flatMap {
+            resolveVisibleWordPath(
+                at: $0,
+                cwd: cwd,
+                workspace: workspace,
+                terminalSurface: termSurface
+            )
+        }
+
         var text = ghostty_text_s()
         if ghostty_surface_quicklook_word(surface, &text) {
             defer { ghostty_surface_free_text(surface, &text) }
@@ -7172,29 +7182,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 }
             }
 
-            if text.offset_len > 0,
+            var viewportResolution: WordPathResolution?
+            if text.offset_len > 0 {
 #if DEBUG
-               let expandedResolution = resolveVisibleWordPathFromViewportOffset(
-                   cmuxTerminalCmdClickViewportOffsetDelta(Int(text.offset_start)),
-                   cwd: cwd,
-                   workspace: workspace,
-                   terminalSurface: termSurface
-               ) {
+                let viewportOffsetStart = cmuxTerminalCmdClickViewportOffsetDelta(Int(text.offset_start))
 #else
-               let expandedResolution = resolveVisibleWordPathFromViewportOffset(
-                   Int(text.offset_start),
-                   cwd: cwd,
-                   workspace: workspace,
-                   terminalSurface: termSurface
+                let viewportOffsetStart = Int(text.offset_start)
 #endif
-               ) {
-                // Ghostty quicklook can return a resolvable but incomplete token for
-                // multi-word `ls` entries. Prefer the viewport-expanded path when it
-                // disagrees, and fall back to quicklook when expansion fails.
-                if let quicklookResolution, quicklookResolution.path == expandedResolution.path {
-                    return quicklookResolution
+                viewportResolution = resolveVisibleWordPathFromViewportOffset(
+                    viewportOffsetStart,
+                    cwd: cwd,
+                    workspace: workspace,
+                    terminalSurface: termSurface
+                )
+            }
+
+            if let viewportResolution {
+                // The pointer-anchored snapshot is the only source tied directly to the
+                // actual click location. Prefer it over quicklook and viewport offsets,
+                // which can lag or target a sibling entry in multi-column `ls` output.
+                if let pointSnapshotResolution {
+                    return pointSnapshotResolution
                 }
-                return expandedResolution
+                return viewportResolution
+            }
+
+            if let pointSnapshotResolution {
+                return pointSnapshotResolution
             }
 
             if let quicklookResolution {
@@ -7202,8 +7216,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
         }
 
-        guard let snapshotPoint = preferredPointerPoint(from: point) else { return nil }
-        return resolveVisibleWordPath(at: snapshotPoint, cwd: cwd, workspace: workspace, terminalSurface: termSurface)
+        return pointSnapshotResolution
     }
 
     #if DEBUG

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -583,6 +583,58 @@ private func cmuxUnescapeShellToken(_ token: String) -> String {
     return String(output)
 }
 
+private func cmuxVisibleTerminalLines(from text: String, rows: Int) -> [String] {
+    let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    if lines.count > rows {
+        return Array(lines.suffix(rows))
+    }
+    return lines
+}
+
+private func cmuxShellEscapedTokenContainingColumn(
+    in line: String,
+    column: Int
+) -> String? {
+    let characters = Array(line)
+    guard !characters.isEmpty, column >= 0, column < characters.count else { return nil }
+
+    var index = 0
+    while index < characters.count {
+        while index < characters.count, characters[index].isWhitespace {
+            index += 1
+        }
+        let start = index
+
+        while index < characters.count {
+            let character = characters[index]
+            guard character.isWhitespace else {
+                index += 1
+                continue
+            }
+
+            var backslashCount = 0
+            var lookbehind = index - 1
+            while lookbehind >= start, characters[lookbehind] == "\\" {
+                backslashCount += 1
+                lookbehind -= 1
+            }
+
+            if backslashCount % 2 == 1 {
+                index += 1
+                continue
+            }
+
+            break
+        }
+
+        if start < index, column >= start, column < index {
+            return String(characters[start..<index])
+        }
+    }
+
+    return nil
+}
+
 enum TerminalOpenURLTarget: Equatable {
     case embeddedBrowser(URL)
     case external(URL)
@@ -4802,6 +4854,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private static let tabTransferPasteboardType = NSPasteboard.PasteboardType("com.splittabbar.tabtransfer")
     private static let sidebarTabReorderPasteboardType = NSPasteboard.PasteboardType("com.cmux.sidebar-tab-reorder")
 
+    private enum WordPathResolutionSource: String {
+        case quicklook
+        case snapshot
+    }
+
+    private struct WordPathResolution {
+        let path: String
+        let source: WordPathResolutionSource
+        let rawToken: String
+    }
+
     fileprivate static func focusLog(_ message: String) {
         guard focusDebugEnabled else { return }
         FocusLogStore.shared.append(message)
@@ -6642,6 +6705,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
         )
         updateWordPathHover(
+            at: point,
             cmdHeld: event.modifierFlags.contains(.command),
             suppressPathHover: suppressCommandPathHover
         )
@@ -6913,70 +6977,67 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         dlog("terminal.mouseUp surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))]")
         #endif
         guard let surface = surface else { return }
+        let point = convert(event.locationInWindow, from: nil)
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
-
-        // Fallback: if Cmd was held and ghostty didn't handle the click as a link,
-        // check if the word under cursor is a valid file/directory in the terminal's CWD.
-        // This enables cmd-click on bare filenames from commands like `ls`.
-        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
-        if !consumed,
-           event.modifierFlags.contains(.command),
-           !suppressCommandPathHover {
-            // Refresh ghostty's cached mouse position so quicklook_word reads
-            // up-to-date coordinates (mouseDown skips pos update on double-click).
-            let point = convert(event.locationInWindow, from: nil)
-            ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-            tryOpenWordAsPath()
-        }
+        _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
     }
 
     /// Attempt to open the word under the mouse cursor as a file path, resolved
     /// against the terminal panel's current working directory.
-    private func tryOpenWordAsPath() {
-        guard let resolvedPath = resolveWordUnderCursorAsPath() else { return }
+    private func tryOpenWordAsPath(at point: NSPoint? = nil) {
+        guard let resolution = resolveWordUnderCursorPath(at: point) else { return }
 
         #if DEBUG
-        dlog("link.wordFallback resolved=\(resolvedPath)")
+        dlog("link.wordFallback resolved=\(resolution.path) source=\(resolution.source.rawValue)")
         #endif
 
-        PreferredEditorSettings.open(URL(fileURLWithPath: resolvedPath))
+        PreferredEditorSettings.open(URL(fileURLWithPath: resolution.path))
     }
 
     /// Check if the word under the mouse cursor resolves to an existing file/directory
     /// in the terminal panel's CWD. Returns the resolved absolute path, or nil.
-    private func resolveWordUnderCursorAsPath() -> String? {
+    private func resolveWordUnderCursorAsPath(at point: NSPoint? = nil) -> String? {
+        resolveWordUnderCursorPath(at: point)?.path
+    }
+
+    private func resolveWordUnderCursorPath(at point: NSPoint? = nil) -> WordPathResolution? {
         guard let surface = surface else { return nil }
-
-        var text = ghostty_text_s()
-        guard ghostty_surface_quicklook_word(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
-
-        guard text.text_len > 0, let ptr = text.text else { return nil }
-        let wordData = Data(bytes: ptr, count: Int(text.text_len))
-        guard let decodedWord = String(bytes: wordData, encoding: .utf8) else { return nil }
 
         guard let termSurface = terminalSurface,
               let workspace = termSurface.owningWorkspace(),
               !workspace.isRemoteTerminalSurface(termSurface.id) else { return nil }
 
-        // Use the same CWD fallback chain as Workspace split creation:
-        // panelDirectories (live OSC 7) → requestedWorkingDirectory → workspace currentDirectory
-        let cwd: String? = {
-            if let dir = workspace.panelDirectories[termSurface.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !dir.isEmpty { return dir }
-            if let dir = workspace.terminalPanel(for: termSurface.id)?
-                .requestedWorkingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !dir.isEmpty { return dir }
-            let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-            return dir.isEmpty ? nil : dir
-        }()
+        guard let cwd = resolvedWordPathWorkingDirectory(workspace: workspace, terminalSurface: termSurface) else {
+            return nil
+        }
 
-        return cmuxResolveQuicklookPath(decodedWord, cwd: cwd)
+        var text = ghostty_text_s()
+        if ghostty_surface_quicklook_word(surface, &text) {
+            defer { ghostty_surface_free_text(surface, &text) }
+            if text.text_len > 0, let ptr = text.text {
+                let wordData = Data(bytes: ptr, count: Int(text.text_len))
+                if let decodedWord = String(bytes: wordData, encoding: .utf8),
+                   let resolvedPath = cmuxResolveQuicklookPath(decodedWord, cwd: cwd) {
+                    return WordPathResolution(
+                        path: resolvedPath,
+                        source: .quicklook,
+                        rawToken: decodedWord
+                    )
+                }
+            }
+        }
+
+        guard let snapshotPoint = point ?? currentMousePointInView() else { return nil }
+        return resolveVisibleWordPath(at: snapshotPoint, cwd: cwd, workspace: workspace, terminalSurface: termSurface)
     }
 
     /// Update the pointing-hand cursor when Cmd-hovering over a bare filename
     /// that exists in the terminal's CWD.
-    private func updateWordPathHover(cmdHeld: Bool, suppressPathHover: Bool = false) {
+    private func updateWordPathHover(
+        at point: NSPoint? = nil,
+        cmdHeld: Bool,
+        suppressPathHover: Bool = false
+    ) {
         guard cmdHeld, !suppressPathHover else {
             if wordPathHoverActive {
                 wordPathHoverActive = false
@@ -6985,7 +7046,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
-        if resolveWordUnderCursorAsPath() != nil {
+        if resolveWordUnderCursorAsPath(at: point) != nil {
             if !wordPathHoverActive {
                 wordPathHoverActive = true
                 NSCursor.pointingHand.push()
@@ -6995,6 +7056,199 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             NSCursor.pop()
         }
     }
+
+    private func resolvedWordPathWorkingDirectory(
+        workspace: Workspace,
+        terminalSurface: TerminalSurface
+    ) -> String? {
+        if let dir = workspace.panelDirectories[terminalSurface.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !dir.isEmpty {
+            return dir
+        }
+        if let dir = workspace.terminalPanel(for: terminalSurface.id)?
+            .requestedWorkingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !dir.isEmpty {
+            return dir
+        }
+        let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        return dir.isEmpty ? nil : dir
+    }
+
+    private func currentMousePointInView() -> NSPoint? {
+        guard let window else { return nil }
+        return convert(window.mouseLocationOutsideOfEventStream, from: nil)
+    }
+
+    private func resolveVisibleWordPath(
+        at point: NSPoint,
+        cwd: String,
+        workspace: Workspace,
+        terminalSurface: TerminalSurface
+    ) -> WordPathResolution? {
+        guard let panel = workspace.terminalPanel(for: terminalSurface.id),
+              let surface else {
+            return nil
+        }
+
+        let size = ghostty_surface_size(surface)
+        let rows = max(Int(size.rows), 1)
+        let cols = max(Int(size.columns), 1)
+        let resolvedCellWidth = cellSize.width > 0 ? cellSize.width : CGFloat(size.cell_width_px)
+        let resolvedCellHeight = cellSize.height > 0 ? cellSize.height : CGFloat(size.cell_height_px)
+        guard resolvedCellWidth > 0, resolvedCellHeight > 0 else { return nil }
+
+        let visibleText = TerminalController.shared.readTerminalTextForSnapshot(
+            terminalPanel: panel,
+            lineLimit: max(200, rows * 4)
+        ) ?? ""
+        let visibleLines = cmuxVisibleTerminalLines(from: visibleText, rows: rows)
+        let rowOffset = max(0, rows - visibleLines.count)
+        let xInset = max(0, (bounds.width - (CGFloat(cols) * resolvedCellWidth)) / 2)
+        let yInset = max(0, (bounds.height - (CGFloat(rows) * resolvedCellHeight)) / 2)
+
+        let yFromTop = bounds.height - point.y
+        let rowFromTop = max(0, min(rows - 1, Int((yFromTop - yInset) / resolvedCellHeight)))
+        let visibleRow = rowFromTop - rowOffset
+        guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
+
+        let column = max(0, min(cols - 1, Int((point.x - xInset) / resolvedCellWidth)))
+        guard let rawToken = cmuxShellEscapedTokenContainingColumn(
+            in: visibleLines[visibleRow],
+            column: column
+        ) else {
+            return nil
+        }
+
+        guard let resolvedPath = cmuxResolveQuicklookPath(rawToken, cwd: cwd) else {
+            return nil
+        }
+
+        return WordPathResolution(
+            path: resolvedPath,
+            source: .snapshot,
+            rawToken: rawToken
+        )
+    }
+
+    @discardableResult
+    private func handleCommandClickRelease(
+        at point: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags,
+        ghosttyConsumed: Bool
+    ) -> WordPathResolution? {
+        guard let surface else { return nil }
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: modifierFlags)
+        guard modifierFlags.contains(.command), !suppressCommandPathHover else { return nil }
+
+        // Refresh ghostty's cached mouse position so quicklook_word reads
+        // up-to-date coordinates (mouseDown skips pos update on double-click).
+        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromFlags(modifierFlags))
+
+        guard let resolution = resolveWordUnderCursorPath(at: point) else { return nil }
+        guard !ghosttyConsumed || resolution.source == .snapshot else { return nil }
+
+        #if DEBUG
+        dlog(
+            "link.wordFallback resolved=\(resolution.path) source=\(resolution.source.rawValue) consumed=\(ghosttyConsumed ? 1 : 0)"
+        )
+        #endif
+
+        PreferredEditorSettings.open(URL(fileURLWithPath: resolution.path))
+        return resolution
+    }
+
+    private func clampedDebugPoint(_ point: NSPoint) -> NSPoint {
+        NSPoint(
+            x: min(max(point.x, 1), max(bounds.width - 1, 1)),
+            y: min(max(point.y, 1), max(bounds.height - 1, 1))
+        )
+    }
+
+#if DEBUG
+    func debugSimulateSelection(from startPoint: NSPoint, to endPoint: NSPoint) -> Bool {
+        guard let surface else { return false }
+        let start = clampedDebugPoint(startPoint)
+        let end = clampedDebugPoint(endPoint)
+        let mods = GHOSTTY_MODS_NONE
+
+        window?.makeFirstResponder(self)
+        ghostty_surface_mouse_pos(surface, start.x, bounds.height - start.y, mods)
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods)
+
+        let steps = max(4, Int(max(abs(end.x - start.x), abs(end.y - start.y)) / max(cellSize.width, 1)))
+        for step in 1...steps {
+            let progress = CGFloat(step) / CGFloat(steps)
+            let intermediatePoint = NSPoint(
+                x: start.x + ((end.x - start.x) * progress),
+                y: start.y + ((end.y - start.y) * progress)
+            )
+            let clampedIntermediatePoint = clampedDebugPoint(intermediatePoint)
+            ghostty_surface_mouse_pos(
+                surface,
+                clampedIntermediatePoint.x,
+                bounds.height - clampedIntermediatePoint.y,
+                mods
+            )
+        }
+
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+        return ghostty_surface_has_selection(surface)
+    }
+
+    func debugSimulateCommandHover(at point: NSPoint) -> Bool {
+        guard let surface else { return false }
+        let clampedPoint = clampedDebugPoint(point)
+        let flags: NSEvent.ModifierFlags = [.command]
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: flags)
+
+        ghostty_surface_mouse_pos(
+            surface,
+            clampedPoint.x,
+            bounds.height - clampedPoint.y,
+            hoverModsFromFlags(
+                flags,
+                suppressCommandPathHover: suppressCommandPathHover
+            )
+        )
+        updateWordPathHover(
+            at: clampedPoint,
+            cmdHeld: true,
+            suppressPathHover: suppressCommandPathHover
+        )
+        return suppressCommandPathHover
+    }
+
+    func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {
+        guard let surface else {
+            return ["error": "Missing surface"]
+        }
+
+        let clampedPoint = clampedDebugPoint(point)
+        let flags: NSEvent.ModifierFlags = [.command]
+        let mods = modsFromFlags(flags)
+
+        window?.makeFirstResponder(self)
+        ghostty_surface_mouse_pos(surface, clampedPoint.x, bounds.height - clampedPoint.y, mods)
+        let pressHandled = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods)
+        let releaseConsumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
+        let resolution = handleCommandClickRelease(
+            at: clampedPoint,
+            modifierFlags: flags,
+            ghosttyConsumed: releaseConsumed
+        )
+
+        var payload: [String: Any] = [
+            "pressHandled": pressHandled ? "1" : "0",
+            "releaseConsumed": releaseConsumed ? "1" : "0",
+        ]
+        if let resolution {
+            payload["openedPath"] = resolution.path
+            payload["resolutionSource"] = resolution.source.rawValue
+            payload["rawToken"] = resolution.rawToken
+        }
+        return payload
+    }
+#endif
 
     override func rightMouseDown(with event: NSEvent) {
         guard let surface = surface else { return }
@@ -7169,6 +7423,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
         )
         updateWordPathHover(
+            at: point,
             cmdHeld: event.modifierFlags.contains(.command),
             suppressPathHover: suppressCommandPathHover
         )
@@ -7190,6 +7445,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
         )
         updateWordPathHover(
+            at: point,
             cmdHeld: event.modifierFlags.contains(.command),
             suppressPathHover: suppressCommandPathHover
         )
@@ -7898,6 +8154,29 @@ final class GhosttySurfaceScrollView: NSView {
 
     var debugSurfaceId: UUID? {
         surfaceView.terminalSurface?.id
+    }
+
+    var debugCellSize: CGSize {
+        surfaceView.cellSize
+    }
+
+    private func debugPointInSurface(_ point: NSPoint) -> NSPoint {
+        surfaceView.convert(point, from: self)
+    }
+
+    func debugSimulateSelection(from startPoint: NSPoint, to endPoint: NSPoint) -> Bool {
+        surfaceView.debugSimulateSelection(
+            from: debugPointInSurface(startPoint),
+            to: debugPointInSurface(endPoint)
+        )
+    }
+
+    func debugSimulateCommandHover(at point: NSPoint) -> Bool {
+        surfaceView.debugSimulateCommandHover(at: debugPointInSurface(point))
+    }
+
+    func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {
+        surfaceView.debugSimulateCommandClick(at: debugPointInSurface(point))
     }
 #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7619,6 +7619,44 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return suppressCommandPathHover
     }
 
+    func debugSimulateCommandHoverDetails(at point: NSPoint) -> [String: Any] {
+        guard let surface else {
+            return ["error": "Missing surface"]
+        }
+
+        let clampedPoint = clampedDebugPoint(point)
+        let flags: NSEvent.ModifierFlags = [.command]
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: flags)
+
+        ghostty_surface_mouse_pos(
+            surface,
+            clampedPoint.x,
+            bounds.height - clampedPoint.y,
+            hoverModsFromFlags(
+                flags,
+                suppressCommandPathHover: suppressCommandPathHover
+            )
+        )
+
+        let resolution = suppressCommandPathHover ? nil : resolveWordUnderCursorPath(at: clampedPoint)
+        updateWordPathHover(
+            at: clampedPoint,
+            cmdHeld: true,
+            suppressPathHover: suppressCommandPathHover
+        )
+
+        var payload: [String: Any] = [
+            "hoverActive": wordPathHoverActive ? "1" : "0",
+            "suppressed": suppressCommandPathHover ? "1" : "0"
+        ]
+        if let resolution {
+            payload["resolvedPath"] = resolution.path
+            payload["resolutionSource"] = resolution.source.rawValue
+            payload["rawToken"] = resolution.rawToken
+        }
+        return payload
+    }
+
     func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {
         guard let surface else {
             return ["error": "Missing surface"]
@@ -8580,6 +8618,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     func debugSimulateCommandHover(at point: NSPoint) -> Bool {
         surfaceView.debugSimulateCommandHover(at: debugPointInSurface(point))
+    }
+
+    func debugSimulateCommandHoverDetails(at point: NSPoint) -> [String: Any] {
+        surfaceView.debugSimulateCommandHoverDetails(at: debugPointInSurface(point))
     }
 
     func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6524,7 +6524,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+            modsFromEvent(event)
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),
@@ -6535,16 +6535,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func shouldSuppressCommandPathHover(for flags: NSEvent.ModifierFlags) -> Bool {
         guard flags.contains(.command), let surface else { return false }
         return ghostty_surface_has_selection(surface)
-    }
-
-    private func hoverModsFromFlags(
-        _ flags: NSEvent.ModifierFlags,
-        suppressCommandPathHover: Bool
-    ) -> ghostty_input_mods_e {
-        if suppressCommandPathHover {
-            return modsFromFlags(flags.subtracting(.command))
-        }
-        return modsFromFlags(flags)
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
@@ -7040,7 +7030,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+            modsFromEvent(event)
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),
@@ -7058,7 +7048,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+            modsFromEvent(event)
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -470,7 +470,118 @@ func cmuxPasteboardImagePathForTesting(_ pasteboard: NSPasteboard) -> String? {
     GhosttyPasteboardHelper.saveClipboardImageIfNeeded(from: pasteboard)
 }
 
+func cmuxResolveQuicklookPathForTesting(
+    _ rawText: String,
+    cwd: String,
+    existingPaths: Set<String>
+) -> String? {
+    cmuxResolveQuicklookPath(
+        rawText,
+        cwd: cwd,
+        fileExists: { path in
+            existingPaths.contains((path as NSString).standardizingPath)
+        }
+    )
+}
 #endif
+
+private func cmuxResolveQuicklookPath(
+    _ rawText: String,
+    cwd: String?,
+    fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+) -> String? {
+    let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    var seenPaths: Set<String> = []
+    for token in cmuxQuicklookPathCandidates(from: trimmed) {
+        let normalizedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedToken.isEmpty else { continue }
+
+        let expandedToken = (normalizedToken as NSString).expandingTildeInPath
+        let candidatePath: String
+        if expandedToken.hasPrefix("/") {
+            candidatePath = expandedToken
+        } else {
+            guard let cwd, !cwd.isEmpty else { continue }
+            candidatePath = (cwd as NSString).appendingPathComponent(expandedToken)
+        }
+
+        let standardizedPath = (candidatePath as NSString).standardizingPath
+        guard seenPaths.insert(standardizedPath).inserted else { continue }
+        if fileExists(standardizedPath) {
+            return standardizedPath
+        }
+    }
+
+    return nil
+}
+
+private func cmuxQuicklookPathCandidates(from rawText: String) -> [String] {
+    var candidates: [String] = []
+
+    func append(_ candidate: String?) {
+        guard let candidate else { return }
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !candidates.contains(trimmed) else { return }
+        candidates.append(trimmed)
+    }
+
+    append(rawText)
+
+    let unescaped = cmuxUnescapeShellToken(rawText)
+    if unescaped != rawText {
+        append(unescaped)
+    }
+
+    if let unquoted = cmuxUnquoteShellToken(rawText) {
+        append(unquoted)
+        let unescapedUnquoted = cmuxUnescapeShellToken(unquoted)
+        if unescapedUnquoted != unquoted {
+            append(unescapedUnquoted)
+        }
+    }
+
+    return candidates
+}
+
+private func cmuxUnquoteShellToken(_ token: String) -> String? {
+    guard token.count >= 2,
+          let first = token.first,
+          let last = token.last,
+          first == last,
+          first == "'" || first == "\"" else {
+        return nil
+    }
+    return String(token.dropFirst().dropLast())
+}
+
+private func cmuxUnescapeShellToken(_ token: String) -> String {
+    var output = String.UnicodeScalarView()
+    output.reserveCapacity(token.unicodeScalars.count)
+    var escaping = false
+
+    for scalar in token.unicodeScalars {
+        if escaping {
+            output.append(scalar)
+            escaping = false
+            continue
+        }
+
+        if scalar == "\\" {
+            escaping = true
+            continue
+        }
+
+        output.append(scalar)
+    }
+
+    if escaping {
+        output.append(UnicodeScalar(0x5C)!)
+    }
+
+    return String(output)
+}
 
 enum TerminalOpenURLTarget: Equatable {
     case embeddedBrowser(URL)
@@ -6843,8 +6954,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard text.text_len > 0, let ptr = text.text else { return nil }
         let wordData = Data(bytes: ptr, count: Int(text.text_len))
         guard let decodedWord = String(bytes: wordData, encoding: .utf8) else { return nil }
-        let word = decodedWord.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !word.isEmpty, !word.hasPrefix("/") else { return nil }
 
         guard let termSurface = terminalSurface,
               let workspace = termSurface.owningWorkspace(),
@@ -6861,11 +6970,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
             return dir.isEmpty ? nil : dir
         }()
-        guard let cwd else { return nil }
 
-        let resolvedPath = (cwd as NSString).appendingPathComponent(word)
-        guard FileManager.default.fileExists(atPath: resolvedPath) else { return nil }
-        return resolvedPath
+        return cmuxResolveQuicklookPath(decodedWord, cwd: cwd)
     }
 
     /// Update the pointing-hand cursor when Cmd-hovering over a bare filename

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6524,7 +6524,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            modsFromEvent(event)
+            hoverModsFromFlags(
+                event.modifierFlags,
+                suppressCommandPathHover: suppressCommandPathHover
+            )
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),
@@ -6535,6 +6538,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func shouldSuppressCommandPathHover(for flags: NSEvent.ModifierFlags) -> Bool {
         guard flags.contains(.command), let surface else { return false }
         return ghostty_surface_has_selection(surface)
+    }
+
+    private func hoverModsFromFlags(
+        _ flags: NSEvent.ModifierFlags,
+        suppressCommandPathHover: Bool
+    ) -> ghostty_input_mods_e {
+        let effectiveFlags = suppressCommandPathHover ? flags.subtracting(.command) : flags
+        return modsFromFlags(effectiveFlags)
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
@@ -6783,7 +6794,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Fallback: if Cmd was held and ghostty didn't handle the click as a link,
         // check if the word under cursor is a valid file/directory in the terminal's CWD.
         // This enables cmd-click on bare filenames from commands like `ls`.
-        if !consumed && event.modifierFlags.contains(.command) {
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
+        if !consumed,
+           event.modifierFlags.contains(.command),
+           !suppressCommandPathHover {
             // Refresh ghostty's cached mouse position so quicklook_word reads
             // up-to-date coordinates (mouseDown skips pos update on double-click).
             let point = convert(event.locationInWindow, from: nil)
@@ -7030,7 +7044,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            modsFromEvent(event)
+            hoverModsFromFlags(
+                event.modifierFlags,
+                suppressCommandPathHover: suppressCommandPathHover
+            )
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),
@@ -7048,7 +7065,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface,
             point.x,
             bounds.height - point.y,
-            modsFromEvent(event)
+            hoverModsFromFlags(
+                event.modifierFlags,
+                suppressCommandPathHover: suppressCommandPathHover
+            )
         )
         updateWordPathHover(
             cmdHeld: event.modifierFlags.contains(.command),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -635,6 +635,76 @@ private func cmuxShellEscapedTokenContainingColumn(
     return nil
 }
 
+private func cmuxIsHardPathDelimiter(
+    in characters: [Character],
+    at index: Int
+) -> Bool {
+    let character = characters[index]
+    if character == "\t" || character == "\n" || character == "\r" {
+        return true
+    }
+
+    guard character.isWhitespace else { return false }
+    let previousIsWhitespace = index > 0 && characters[index - 1].isWhitespace
+    let nextIsWhitespace = (index + 1) < characters.count && characters[index + 1].isWhitespace
+    return previousIsWhitespace || nextIsWhitespace
+}
+
+private func cmuxRawPathSegmentContainingColumn(
+    in line: String,
+    column: Int
+) -> String? {
+    let characters = Array(line)
+    guard !characters.isEmpty, column >= 0, column < characters.count else { return nil }
+    guard !cmuxIsHardPathDelimiter(in: characters, at: column) else { return nil }
+
+    var start = column
+    while start > 0, !cmuxIsHardPathDelimiter(in: characters, at: start - 1) {
+        start -= 1
+    }
+
+    var end = column
+    while (end + 1) < characters.count, !cmuxIsHardPathDelimiter(in: characters, at: end + 1) {
+        end += 1
+    }
+
+    let candidate = String(characters[start...end]).trimmingCharacters(in: .whitespacesAndNewlines)
+    return candidate.isEmpty ? nil : candidate
+}
+
+private func cmuxPathCandidatesContainingColumn(
+    in line: String,
+    column: Int
+) -> [String] {
+    var candidates: [String] = []
+
+    func append(_ candidate: String?) {
+        guard let candidate else { return }
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !candidates.contains(trimmed) else { return }
+        candidates.append(trimmed)
+    }
+
+    append(cmuxRawPathSegmentContainingColumn(in: line, column: column))
+    append(cmuxShellEscapedTokenContainingColumn(in: line, column: column))
+
+    return candidates
+}
+
+private func cmuxResolveVisibleLinePath(
+    _ line: String,
+    column: Int,
+    cwd: String,
+    fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+) -> (rawToken: String, path: String)? {
+    for rawToken in cmuxPathCandidatesContainingColumn(in: line, column: column) {
+        if let resolvedPath = cmuxResolveQuicklookPath(rawToken, cwd: cwd, fileExists: fileExists) {
+            return (rawToken, resolvedPath)
+        }
+    }
+    return nil
+}
+
 enum TerminalOpenURLTarget: Equatable {
     case embeddedBrowser(URL)
     case external(URL)
@@ -4881,6 +4951,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var _scrollbarFlushScheduled = false
     private let _scrollbarLock = NSLock()
     var cellSize: CGSize = .zero
+    private var lastKnownMousePointInView: NSPoint?
 
     /// Coalesce high-frequency scrollbar updates into a single main-thread
     /// dispatch.  The action callback (which may fire thousands of times per
@@ -6691,10 +6762,31 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.composing = false
         _ = ghostty_surface_key(surface, keyEvent)
 
-        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
+        let selectionActive = ghostty_surface_has_selection(surface)
+        let suppressCommandPathHover = event.modifierFlags.contains(.command) && selectionActive
         // Refresh ghostty's mouse position so quicklook_word uses current coordinates
         // when Cmd is pressed while the pointer is stationary.
-        let point = convert(event.locationInWindow, from: nil)
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
+#if DEBUG
+        if event.modifierFlags.contains(.command) || selectionActive {
+            runtimeDebugLog(
+                hypothesisID: "h1",
+                name: "flags_changed",
+                expected: "selection active should suppress cmd-hover",
+                actual: suppressCommandPathHover ? "suppressed" : "forwarded",
+                data: [
+                    "flags": debugModifierString(event.modifierFlags),
+                    "selection_active": selectionActive,
+                    "point_x": eventPoint.x,
+                    "point_y": eventPoint.y,
+                    "resolved_point_x": point.x,
+                    "resolved_point_y": point.y
+                ]
+            )
+        }
+#endif
         ghostty_surface_mouse_pos(
             surface,
             point.x,
@@ -6727,9 +6819,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 envKey: "CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"
             ) { payload in
                 payload["suppressed_command_hover_count"] = (payload["suppressed_command_hover_count"] as? Int ?? 0) + 1
-                if effectiveFlags.contains(.command) {
-                    payload["forwarded_command_hover_count"] = (payload["forwarded_command_hover_count"] as? Int ?? 0) + 1
-                }
             }
         }
 #endif
@@ -6937,6 +7026,42 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             flags.contains(.option) ? "opt" : nil,
         ].compactMap { $0 }.joined(separator: "+")
     }
+
+    private func runtimeDebugLog(
+        hypothesisID: String,
+        name: String,
+        expected: String? = nil,
+        actual: String? = nil,
+        data: [String: Any] = [:]
+    ) {
+        var payload = data
+        payload["surface_id"] = terminalSurface?.id.uuidString ?? "nil"
+        payload["word_path_hover_active"] = wordPathHoverActive
+        CmuxRuntimeDebugCapture.logIfConfigured(
+            hypothesisID: hypothesisID,
+            source: "GhosttyNSView.\(name)",
+            name: name,
+            expected: expected,
+            actual: actual,
+            data: payload
+        )
+    }
+
+    private func runtimeDebugResolutionPayload(_ resolution: WordPathResolution?) -> [String: Any] {
+        guard let resolution else {
+            return [
+                "resolution_source": "none",
+                "resolved_path_basename": "",
+                "raw_token": ""
+            ]
+        }
+
+        return [
+            "resolution_source": resolution.source.rawValue,
+            "resolved_path_basename": URL(fileURLWithPath: resolution.path).lastPathComponent,
+            "raw_token": resolution.rawToken
+        ]
+    }
     #endif
 
     private func requestPointerFocusRecovery() {
@@ -6963,7 +7088,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             )
         }
         guard let surface = surface else { return }
-        let point = convert(event.locationInWindow, from: nil)
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         // Only update mouse position on the first click to prevent unwanted cursor
         // movement during double-click selection (issue #1698)
         if event.clickCount == 1 {
@@ -7025,9 +7152,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     )
                 }
             }
+
+            if text.offset_len > 0,
+               let expandedResolution = resolveVisibleWordPathFromViewportOffset(
+                   Int(text.offset_start),
+                   cwd: cwd,
+                   workspace: workspace,
+                   terminalSurface: termSurface
+               ) {
+                return expandedResolution
+            }
         }
 
-        guard let snapshotPoint = point ?? currentMousePointInView() else { return nil }
+        guard let snapshotPoint = preferredPointerPoint(from: point) else { return nil }
         return resolveVisibleWordPath(at: snapshotPoint, cwd: cwd, workspace: workspace, terminalSurface: termSurface)
     }
 
@@ -7038,15 +7175,33 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         cmdHeld: Bool,
         suppressPathHover: Bool = false
     ) {
+        let hoverWasActive = wordPathHoverActive
         guard cmdHeld, !suppressPathHover else {
             if wordPathHoverActive {
                 wordPathHoverActive = false
                 NSCursor.pop()
             }
+#if DEBUG
+            if cmdHeld || suppressPathHover || hoverWasActive {
+                runtimeDebugLog(
+                    hypothesisID: "h1",
+                    name: "hover_update",
+                    expected: "cmd-hover off while selection is active",
+                    actual: suppressPathHover ? "suppressed" : "inactive",
+                    data: [
+                        "cmd_held": cmdHeld,
+                        "suppress_path_hover": suppressPathHover,
+                        "hover_active_before": hoverWasActive,
+                        "hover_active_after": wordPathHoverActive
+                    ]
+                )
+            }
+#endif
             return
         }
 
-        if resolveWordUnderCursorAsPath(at: point) != nil {
+        let resolution = resolveWordUnderCursorPath(at: point)
+        if resolution != nil {
             if !wordPathHoverActive {
                 wordPathHoverActive = true
                 NSCursor.pointingHand.push()
@@ -7055,6 +7210,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             wordPathHoverActive = false
             NSCursor.pop()
         }
+#if DEBUG
+        if cmdHeld || hoverWasActive || wordPathHoverActive || resolution != nil {
+            var payload: [String: Any] = [
+                "cmd_held": cmdHeld,
+                "suppress_path_hover": suppressPathHover,
+                "hover_active_before": hoverWasActive,
+                "hover_active_after": wordPathHoverActive
+            ]
+            for (key, value) in runtimeDebugResolutionPayload(resolution) {
+                payload[key] = value
+            }
+            runtimeDebugLog(
+                hypothesisID: resolution == nil ? "h1" : "h2",
+                name: "hover_update",
+                expected: "resolved path only when hover should activate",
+                actual: wordPathHoverActive ? "hover_active" : "hover_inactive",
+                data: payload
+            )
+        }
+#endif
     }
 
     private func resolvedWordPathWorkingDirectory(
@@ -7074,9 +7249,75 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return dir.isEmpty ? nil : dir
     }
 
+    private func pointIsUsableForWordResolution(_ point: NSPoint) -> Bool {
+        bounds.width > 0 &&
+        bounds.height > 0 &&
+        point.x >= 0 &&
+        point.y >= 0 &&
+        point.x <= bounds.width &&
+        point.y <= bounds.height
+    }
+
+    private func trackMousePointIfUsable(_ point: NSPoint) {
+        guard pointIsUsableForWordResolution(point) else { return }
+        lastKnownMousePointInView = point
+    }
+
+    private func preferredPointerPoint(from eventPoint: NSPoint? = nil) -> NSPoint? {
+        if let eventPoint, pointIsUsableForWordResolution(eventPoint) {
+            lastKnownMousePointInView = eventPoint
+            return eventPoint
+        }
+        if let currentPoint = currentMousePointInView(), pointIsUsableForWordResolution(currentPoint) {
+            lastKnownMousePointInView = currentPoint
+            return currentPoint
+        }
+        return lastKnownMousePointInView ?? eventPoint
+    }
+
     private func currentMousePointInView() -> NSPoint? {
         guard let window else { return nil }
         return convert(window.mouseLocationOutsideOfEventStream, from: nil)
+    }
+
+    private func resolveVisibleWordPathFromViewportOffset(
+        _ viewportOffsetStart: Int,
+        cwd: String,
+        workspace: Workspace,
+        terminalSurface: TerminalSurface
+    ) -> WordPathResolution? {
+        guard let panel = workspace.terminalPanel(for: terminalSurface.id),
+              let surface else {
+            return nil
+        }
+
+        let size = ghostty_surface_size(surface)
+        let rows = max(Int(size.rows), 1)
+        let cols = max(Int(size.columns), 1)
+        let visibleText = TerminalController.shared.readTerminalTextForSnapshot(
+            terminalPanel: panel,
+            lineLimit: max(200, rows * 4)
+        ) ?? ""
+        let visibleLines = cmuxVisibleTerminalLines(from: visibleText, rows: rows)
+        let rowOffset = max(0, rows - visibleLines.count)
+        let rowFromTop = max(0, min(rows - 1, viewportOffsetStart / cols))
+        let visibleRow = rowFromTop - rowOffset
+        guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
+
+        let column = max(0, min(cols - 1, viewportOffsetStart % cols))
+        guard let resolution = cmuxResolveVisibleLinePath(
+            visibleLines[visibleRow],
+            column: column,
+            cwd: cwd
+        ) else {
+            return nil
+        }
+
+        return WordPathResolution(
+            path: resolution.path,
+            source: .snapshot,
+            rawToken: resolution.rawToken
+        )
     }
 
     private func resolveVisibleWordPath(
@@ -7112,21 +7353,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
 
         let column = max(0, min(cols - 1, Int((point.x - xInset) / resolvedCellWidth)))
-        guard let rawToken = cmuxShellEscapedTokenContainingColumn(
-            in: visibleLines[visibleRow],
-            column: column
+        guard let resolution = cmuxResolveVisibleLinePath(
+            visibleLines[visibleRow],
+            column: column,
+            cwd: cwd
         ) else {
             return nil
         }
 
-        guard let resolvedPath = cmuxResolveQuicklookPath(rawToken, cwd: cwd) else {
-            return nil
-        }
-
         return WordPathResolution(
-            path: resolvedPath,
+            path: resolution.path,
             source: .snapshot,
-            rawToken: rawToken
+            rawToken: resolution.rawToken
         )
     }
 
@@ -7138,18 +7376,108 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     ) -> WordPathResolution? {
         guard let surface else { return nil }
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: modifierFlags)
-        guard modifierFlags.contains(.command), !suppressCommandPathHover else { return nil }
+        let cmdHeld = modifierFlags.contains(.command)
+        let resolvedPoint = preferredPointerPoint(from: point)
+        guard cmdHeld, !suppressCommandPathHover else {
+#if DEBUG
+            if cmdHeld || suppressCommandPathHover {
+                runtimeDebugLog(
+                    hypothesisID: "h1",
+                    name: "command_click_release",
+                    expected: "cmd-click fallback only when selection is inactive",
+                    actual: suppressCommandPathHover ? "suppressed" : "not_cmd_click",
+                    data: [
+                        "flags": debugModifierString(modifierFlags),
+                        "ghostty_consumed": ghosttyConsumed,
+                        "point_x": point.x,
+                        "point_y": point.y,
+                        "resolved_point_x": resolvedPoint?.x ?? -1,
+                        "resolved_point_y": resolvedPoint?.y ?? -1,
+                        "suppress_path_hover": suppressCommandPathHover
+                    ]
+                )
+            }
+#endif
+            return nil
+        }
 
         // Refresh ghostty's cached mouse position so quicklook_word reads
         // up-to-date coordinates (mouseDown skips pos update on double-click).
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromFlags(modifierFlags))
+        if let resolvedPoint {
+            ghostty_surface_mouse_pos(
+                surface,
+                resolvedPoint.x,
+                bounds.height - resolvedPoint.y,
+                modsFromFlags(modifierFlags)
+            )
+        }
 
-        guard let resolution = resolveWordUnderCursorPath(at: point) else { return nil }
-        guard !ghosttyConsumed || resolution.source == .snapshot else { return nil }
+        guard let resolution = resolveWordUnderCursorPath(at: resolvedPoint) else {
+#if DEBUG
+            runtimeDebugLog(
+                hypothesisID: "h2",
+                name: "command_click_release",
+                expected: "cmd-click should resolve the token under the pointer",
+                actual: "no_resolution",
+                data: [
+                    "flags": debugModifierString(modifierFlags),
+                    "ghostty_consumed": ghosttyConsumed,
+                    "point_x": point.x,
+                    "point_y": point.y,
+                    "resolved_point_x": resolvedPoint?.x ?? -1,
+                    "resolved_point_y": resolvedPoint?.y ?? -1
+                ]
+            )
+#endif
+            return nil
+        }
+        guard !ghosttyConsumed || resolution.source == .snapshot else {
+#if DEBUG
+            var payload: [String: Any] = [
+                "flags": debugModifierString(modifierFlags),
+                "ghostty_consumed": ghosttyConsumed,
+                "point_x": point.x,
+                "point_y": point.y,
+                "resolved_point_x": resolvedPoint?.x ?? -1,
+                "resolved_point_y": resolvedPoint?.y ?? -1,
+                "suppress_path_hover": suppressCommandPathHover
+            ]
+            for (key, value) in runtimeDebugResolutionPayload(resolution) {
+                payload[key] = value
+            }
+            runtimeDebugLog(
+                hypothesisID: "h3",
+                name: "command_click_release",
+                expected: "ghostty-consumed clicks should only skip fallback for real ghostty targets",
+                actual: "consumed_quicklook_resolution_skipped",
+                data: payload
+            )
+#endif
+            return nil
+        }
 
         #if DEBUG
         dlog(
             "link.wordFallback resolved=\(resolution.path) source=\(resolution.source.rawValue) consumed=\(ghosttyConsumed ? 1 : 0)"
+        )
+        var payload: [String: Any] = [
+            "flags": debugModifierString(modifierFlags),
+            "ghostty_consumed": ghosttyConsumed,
+            "point_x": point.x,
+            "point_y": point.y,
+            "resolved_point_x": resolvedPoint?.x ?? -1,
+            "resolved_point_y": resolvedPoint?.y ?? -1,
+            "suppress_path_hover": suppressCommandPathHover
+        ]
+        for (key, value) in runtimeDebugResolutionPayload(resolution) {
+            payload[key] = value
+        }
+        runtimeDebugLog(
+            hypothesisID: resolution.source == .snapshot ? "h3" : "h2",
+            name: "command_click_release",
+            expected: "cmd-click should open the resolved path",
+            actual: "opening_resolved_path",
+            data: payload
         )
         #endif
 
@@ -7412,7 +7740,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
-        let point = convert(event.locationInWindow, from: nil)
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         ghostty_surface_mouse_pos(
             surface,
             point.x,
@@ -7434,7 +7764,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
-        let point = convert(event.locationInWindow, from: nil)
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         ghostty_surface_mouse_pos(
             surface,
             point.x,
@@ -7482,7 +7814,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func mouseDragged(with event: NSEvent) {
         guard let surface = surface else { return }
-        let point = convert(event.locationInWindow, from: nil)
+        let eventPoint = convert(event.locationInWindow, from: nil)
+        trackMousePointIfUsable(eventPoint)
+        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4935,6 +4935,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let rawToken: String
     }
 
+    private func makeWordPathResolution(
+        path: String,
+        source: WordPathResolutionSource,
+        rawToken: String
+    ) -> WordPathResolution {
+        WordPathResolution(
+            path: path,
+            source: source,
+            rawToken: rawToken
+        )
+    }
+
     fileprivate static func focusLog(_ message: String) {
         guard focusDebugEnabled else { return }
         FocusLogStore.shared.append(message)
@@ -7141,15 +7153,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var text = ghostty_text_s()
         if ghostty_surface_quicklook_word(surface, &text) {
             defer { ghostty_surface_free_text(surface, &text) }
+            var quicklookResolution: WordPathResolution?
             if text.text_len > 0, let ptr = text.text {
                 let wordData = Data(bytes: ptr, count: Int(text.text_len))
-                if let decodedWord = String(bytes: wordData, encoding: .utf8),
-                   let resolvedPath = cmuxResolveQuicklookPath(decodedWord, cwd: cwd) {
-                    return WordPathResolution(
-                        path: resolvedPath,
-                        source: .quicklook,
-                        rawToken: decodedWord
-                    )
+                if let decodedWord = String(bytes: wordData, encoding: .utf8) {
+#if DEBUG
+                    let resolvedQuicklookWord = cmuxTerminalCmdClickQuicklookOverride(decodedWord)
+#else
+                    let resolvedQuicklookWord = decodedWord
+#endif
+                    if let resolvedPath = cmuxResolveQuicklookPath(resolvedQuicklookWord, cwd: cwd) {
+                        quicklookResolution = makeWordPathResolution(
+                            path: resolvedPath,
+                            source: .quicklook,
+                            rawToken: resolvedQuicklookWord
+                        )
+                    }
                 }
             }
 
@@ -7160,13 +7179,35 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                    workspace: workspace,
                    terminalSurface: termSurface
                ) {
+                // Ghostty quicklook can return a resolvable but incomplete token for
+                // multi-word `ls` entries. Prefer the viewport-expanded path when it
+                // disagrees, and fall back to quicklook when expansion fails.
+                if let quicklookResolution, quicklookResolution.path == expandedResolution.path {
+                    return quicklookResolution
+                }
                 return expandedResolution
+            }
+
+            if let quicklookResolution {
+                return quicklookResolution
             }
         }
 
         guard let snapshotPoint = preferredPointerPoint(from: point) else { return nil }
         return resolveVisibleWordPath(at: snapshotPoint, cwd: cwd, workspace: workspace, terminalSurface: termSurface)
     }
+
+    #if DEBUG
+    private func cmuxTerminalCmdClickQuicklookOverride(_ decodedWord: String) -> String {
+        let env = ProcessInfo.processInfo.environment
+        guard let override = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_QUICKLOOK_OVERRIDE"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !override.isEmpty else {
+            return decodedWord
+        }
+        return override
+    }
+    #endif
 
     /// Update the pointing-hand cursor when Cmd-hovering over a bare filename
     /// that exists in the terminal's CWD.
@@ -7313,7 +7354,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return nil
         }
 
-        return WordPathResolution(
+        return makeWordPathResolution(
             path: resolution.path,
             source: .snapshot,
             rawToken: resolution.rawToken
@@ -7361,7 +7402,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return nil
         }
 
-        return WordPathResolution(
+        return makeWordPathResolution(
             path: resolution.path,
             source: .snapshot,
             rawToken: resolution.rawToken

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7173,11 +7173,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
 
             if text.offset_len > 0,
+#if DEBUG
+               let expandedResolution = resolveVisibleWordPathFromViewportOffset(
+                   cmuxTerminalCmdClickViewportOffsetDelta(Int(text.offset_start)),
+                   cwd: cwd,
+                   workspace: workspace,
+                   terminalSurface: termSurface
+               ) {
+#else
                let expandedResolution = resolveVisibleWordPathFromViewportOffset(
                    Int(text.offset_start),
                    cwd: cwd,
                    workspace: workspace,
                    terminalSurface: termSurface
+#endif
                ) {
                 // Ghostty quicklook can return a resolvable but incomplete token for
                 // multi-word `ls` entries. Prefer the viewport-expanded path when it
@@ -7206,6 +7215,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return decodedWord
         }
         return override
+    }
+
+    private func cmuxTerminalCmdClickViewportOffsetDelta(_ viewportOffsetStart: Int) -> Int {
+        let env = ProcessInfo.processInfo.environment
+        guard let delta = env["CMUX_UI_TEST_TERMINAL_CMD_CLICK_VIEWPORT_OFFSET_DELTA"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let parsedDelta = Int(delta) else {
+            return viewportOffsetStart
+        }
+        return max(0, viewportOffsetStart + parsedDelta)
     }
     #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6515,19 +6515,48 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.text = nil
         keyEvent.composing = false
         _ = ghostty_surface_key(surface, keyEvent)
+
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         // Refresh ghostty's mouse position so quicklook_word uses current coordinates
         // when Cmd is pressed while the pointer is stationary.
         let point = convert(event.locationInWindow, from: nil)
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command))
+        ghostty_surface_mouse_pos(
+            surface,
+            point.x,
+            bounds.height - point.y,
+            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+        )
+        updateWordPathHover(
+            cmdHeld: event.modifierFlags.contains(.command),
+            suppressPathHover: suppressCommandPathHover
+        )
+    }
+
+    private func shouldSuppressCommandPathHover(for flags: NSEvent.ModifierFlags) -> Bool {
+        guard flags.contains(.command), let surface else { return false }
+        return ghostty_surface_has_selection(surface)
+    }
+
+    private func hoverModsFromFlags(
+        _ flags: NSEvent.ModifierFlags,
+        suppressCommandPathHover: Bool
+    ) -> ghostty_input_mods_e {
+        if suppressCommandPathHover {
+            return modsFromFlags(flags.subtracting(.command))
+        }
+        return modsFromFlags(flags)
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
+        modsFromFlags(event.modifierFlags)
+    }
+
+    private func modsFromFlags(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
         var mods = GHOSTTY_MODS_NONE.rawValue
-        if event.modifierFlags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
-        if event.modifierFlags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
-        if event.modifierFlags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
-        if event.modifierFlags.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
+        if flags.contains(.shift) { mods |= GHOSTTY_MODS_SHIFT.rawValue }
+        if flags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }
+        if flags.contains(.option) { mods |= GHOSTTY_MODS_ALT.rawValue }
+        if flags.contains(.command) { mods |= GHOSTTY_MODS_SUPER.rawValue }
         return ghostty_input_mods_e(rawValue: mods)
     }
 
@@ -6824,8 +6853,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     /// Update the pointing-hand cursor when Cmd-hovering over a bare filename
     /// that exists in the terminal's CWD.
-    private func updateWordPathHover(cmdHeld: Bool) {
-        guard cmdHeld else {
+    private func updateWordPathHover(cmdHeld: Bool, suppressPathHover: Bool = false) {
+        guard cmdHeld, !suppressPathHover else {
             if wordPathHoverActive {
                 wordPathHoverActive = false
                 NSCursor.pop()
@@ -7005,17 +7034,36 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override func mouseMoved(with event: NSEvent) {
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let point = convert(event.locationInWindow, from: nil)
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
-        updateWordPathHover(cmdHeld: event.modifierFlags.contains(.command))
+        ghostty_surface_mouse_pos(
+            surface,
+            point.x,
+            bounds.height - point.y,
+            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+        )
+        updateWordPathHover(
+            cmdHeld: event.modifierFlags.contains(.command),
+            suppressPathHover: suppressCommandPathHover
+        )
     }
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
+        let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let point = convert(event.locationInWindow, from: nil)
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+        ghostty_surface_mouse_pos(
+            surface,
+            point.x,
+            bounds.height - point.y,
+            hoverModsFromFlags(event.modifierFlags, suppressCommandPathHover: suppressCommandPathHover)
+        )
+        updateWordPathHover(
+            cmdHeld: event.modifierFlags.contains(.command),
+            suppressPathHover: suppressCommandPathHover
+        )
     }
 
     private func maybeRequestFirstResponderForMouseFocus() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3844,6 +3844,13 @@ enum PreferredEditorSettings {
 
     /// Open a file path with the user's preferred editor, falling back to system default.
     static func open(_ url: URL) {
+        if CmuxUITestCapture.appendLineIfConfigured(
+            envKey: "CMUX_UI_TEST_CAPTURE_OPEN_PATH",
+            line: url.path
+        ) {
+            return
+        }
+
         guard let command = resolvedCommand() else {
             NSWorkspace.shared.open(url)
             return
@@ -3871,6 +3878,74 @@ enum PreferredEditorSettings {
 
     private static func shellQuote(_ s: String) -> String {
         "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+enum CmuxUITestCapture {
+    static func appendLineIfConfigured(envKey: String, line: String) -> Bool {
+        guard let url = configuredURL(for: envKey) else { return false }
+        appendLine(line, to: url)
+        return true
+    }
+
+    static func mutateJSONObjectIfConfigured(
+        envKey: String,
+        _ update: (inout [String: Any]) -> Void
+    ) -> Bool {
+        guard let url = configuredURL(for: envKey) else { return false }
+        mutateJSONObject(at: url, update)
+        return true
+    }
+
+    private static func configuredURL(for envKey: String) -> URL? {
+        let env = ProcessInfo.processInfo.environment
+        guard let rawPath = env[envKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawPath.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: rawPath)
+    }
+
+    private static func appendLine(_ line: String, to url: URL) {
+        ensureParentDirectory(for: url)
+        let payload = (line + "\n").data(using: .utf8) ?? Data()
+
+        if FileManager.default.fileExists(atPath: url.path) {
+            do {
+                let handle = try FileHandle(forWritingTo: url)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: payload)
+            } catch {
+                try? payload.write(to: url, options: .atomic)
+            }
+            return
+        }
+
+        try? payload.write(to: url, options: .atomic)
+    }
+
+    private static func mutateJSONObject(
+        at url: URL,
+        _ update: (inout [String: Any]) -> Void
+    ) {
+        ensureParentDirectory(for: url)
+        var payload: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            payload = object
+        }
+        update(&payload)
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return
+        }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private static func ensureParentDirectory(for url: URL) {
+        let directory = url.deletingLastPathComponent()
+        guard !directory.path.isEmpty else { return }
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3917,7 +3917,13 @@ enum CmuxUITestCapture {
                 try handle.seekToEnd()
                 try handle.write(contentsOf: payload)
             } catch {
-                try? payload.write(to: url, options: .atomic)
+                if let existing = try? Data(contentsOf: url) {
+                    var combined = existing
+                    combined.append(payload)
+                    try? combined.write(to: url, options: .atomic)
+                } else {
+                    try? payload.write(to: url, options: .atomic)
+                }
             }
             return
         }
@@ -3946,6 +3952,79 @@ enum CmuxUITestCapture {
         let directory = url.deletingLastPathComponent()
         guard !directory.path.isEmpty else { return }
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+}
+
+enum CmuxRuntimeDebugCapture {
+    private struct Configuration {
+        let baseURL: URL
+        let token: String
+        let sessionID: String
+    }
+
+    private static let configuration: Configuration? = {
+        let env = ProcessInfo.processInfo.environment
+        guard let baseURLString = env["CMUX_RUNTIME_DEBUG_BASE_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let baseURL = URL(string: baseURLString),
+              let token = env["CMUX_RUNTIME_DEBUG_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty,
+              let sessionID = env["CMUX_RUNTIME_DEBUG_SESSION_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty else {
+            return nil
+        }
+        return Configuration(baseURL: baseURL, token: token, sessionID: sessionID)
+    }()
+
+    private static let lock = NSLock()
+    private static var sequence: Int = 0
+
+    static func logIfConfigured(
+        hypothesisID: String,
+        source: String,
+        name: String,
+        expected: String? = nil,
+        actual: String? = nil,
+        data: [String: Any] = [:]
+    ) {
+        guard let configuration else { return }
+
+        var payload: [String: Any] = [
+            "session_id": configuration.sessionID,
+            "hypothesis_id": hypothesisID,
+            "service": "cmux-macos",
+            "source": source,
+            "name": name,
+            "ts": ISO8601DateFormatter().string(from: Date()),
+            "mono_ms": ProcessInfo.processInfo.systemUptime * 1000,
+            "seq": nextSequence(),
+            "data": data
+        ]
+        if let expected {
+            payload["expected"] = expected
+        }
+        if let actual {
+            payload["actual"] = actual
+        }
+
+        guard JSONSerialization.isValidJSONObject(payload),
+              let requestBody = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+            return
+        }
+
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("api/logs"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(configuration.token, forHTTPHeaderField: "X-Debug-Token")
+        request.httpBody = requestBody
+
+        URLSession.shared.dataTask(with: request).resume()
+    }
+
+    private static func nextSequence() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        sequence += 1
+        return sequence
     }
 }
 

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -1,71 +1,69 @@
 import XCTest
 import Foundation
-import AppKit
-import CoreGraphics
-import Carbon.HIToolbox
 
 final class TerminalCmdClickUITests: XCTestCase {
-    private struct TerminalGeometry {
-        let surfaceId: String
-        let windowFrame: CGRect
-        let terminalFrameInWindow: CGRect
+    private struct SetupData {
+        let expectedPath: String
     }
 
-    private var socketPath = ""
     private var hoverDiagnosticsPath = ""
     private var openCapturePath = ""
+    private var setupDataPath = ""
+    private var commandPath = ""
     private var fixtureDirectoryURL: URL!
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
 
-        socketPath = "/tmp/cmux-ui-test-terminal-cmd-click-\(UUID().uuidString).sock"
-        hoverDiagnosticsPath = "/tmp/cmux-ui-test-terminal-cmd-hover-\(UUID().uuidString).json"
-        openCapturePath = "/tmp/cmux-ui-test-terminal-open-\(UUID().uuidString).log"
         fixtureDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ui-test-terminal-cmd-click-\(UUID().uuidString)", isDirectory: true)
+        hoverDiagnosticsPath = fixtureDirectoryURL.appendingPathComponent("hover.json").path
+        openCapturePath = fixtureDirectoryURL.appendingPathComponent("open.log").path
+        setupDataPath = fixtureDirectoryURL.appendingPathComponent("setup.json").path
+        commandPath = fixtureDirectoryURL.appendingPathComponent("command.json").path
 
-        try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: hoverDiagnosticsPath)
         try? FileManager.default.removeItem(atPath: openCapturePath)
+        try? FileManager.default.removeItem(atPath: setupDataPath)
+        try? FileManager.default.removeItem(atPath: commandPath)
         try? FileManager.default.createDirectory(at: fixtureDirectoryURL, withIntermediateDirectories: true)
     }
 
     override func tearDown() {
-        try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: hoverDiagnosticsPath)
         try? FileManager.default.removeItem(atPath: openCapturePath)
+        try? FileManager.default.removeItem(atPath: setupDataPath)
+        try? FileManager.default.removeItem(atPath: commandPath)
         try? FileManager.default.removeItem(at: fixtureDirectoryURL)
         super.tearDown()
     }
 
     func testHoldingCommandAfterSelectionSuppresssCommandHoverDispatch() throws {
         let app = launchApp(captureOpenPaths: false, captureHoverDiagnostics: true)
-        let geometry = try waitForFocusedTerminalGeometry()
-        let token = try seedTerminalFixture(
-            surfaceId: geometry.surfaceId,
-            fileName: "Cmd Click Fixture.txt"
+        defer { app.terminate() }
+
+        _ = try waitForReadySetup()
+        let result = try runCommand(action: "select_token_and_hold_command")
+
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected setup harness to create a selection and suppress cmd-hover. result=\(result)"
         )
-
-        XCTAssertTrue(
-            waitForTerminalText(surfaceId: geometry.surfaceId, contains: token, timeout: 8.0),
-            "Expected terminal to render the escaped path fixture before selecting it"
+        XCTAssertEqual(
+            result["lastCommandSelectionActive"] as? String,
+            "1",
+            "Expected a real Ghostty selection before holding Command. result=\(result)"
         )
-
-        let dragStart = accessibilityPoint(in: geometry, xFromLeft: 48, yFromTop: 54)
-        let dragEnd = accessibilityPoint(in: geometry, xFromLeft: 240, yFromTop: 54)
-        guard let dragSession = beginMouseDrag(fromAccessibilityPoint: dragStart) else {
-            XCTFail("Expected raw drag session for terminal selection")
-            return
-        }
-        continueMouseDrag(dragSession, toAccessibilityPoint: dragEnd)
-        endMouseDrag(dragSession, atAccessibilityPoint: dragEnd)
-
-        holdCommandKey()
+        XCTAssertEqual(
+            result["lastCommandHoverSuppressed"] as? String,
+            "1",
+            "Expected cmd-hover suppression to trigger while selection stayed active. result=\(result)"
+        )
 
         guard let diagnostics = waitForHoverDiagnostics(timeout: 5.0) else {
-            XCTFail("Expected hover diagnostics after holding Command with an active selection")
+            XCTFail("Expected hover diagnostics after holding Command with an active selection. result=\(result)")
             return
         }
 
@@ -81,27 +79,32 @@ final class TerminalCmdClickUITests: XCTestCase {
             0,
             "Expected no command-modified hover dispatch to reach Ghostty while selection is active. diagnostics=\(diagnostics)"
         )
-
-        app.terminate()
     }
 
     func testCmdClickEscapedPathWithSpacesOpensResolvedFile() throws {
         let app = launchApp(captureOpenPaths: true, captureHoverDiagnostics: false)
-        let geometry = try waitForFocusedTerminalGeometry()
+        defer { app.terminate() }
+
         let fileName = "Cmd Click Fixture.txt"
-        let token = try seedTerminalFixture(surfaceId: geometry.surfaceId, fileName: fileName)
+        let setup = try waitForReadySetup()
         let expectedPath = fixtureDirectoryURL.appendingPathComponent(fileName).path
 
-        XCTAssertTrue(
-            waitForTerminalText(surfaceId: geometry.surfaceId, contains: token, timeout: 8.0),
-            "Expected terminal to render the escaped path fixture before cmd-clicking it"
+        XCTAssertEqual(setup.expectedPath, expectedPath)
+
+        let result = try runCommand(action: "cmd_click_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-click harness to open the escaped-space path. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandOpenedPath"] as? String,
+            expectedPath,
+            "Expected cmd-click to resolve the escaped-space path to the real file. result=\(result)"
         )
 
-        let clickPoint = accessibilityPoint(in: geometry, xFromLeft: 140, yFromTop: 54)
-        commandClick(atAccessibilityPoint: clickPoint)
-
         guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
-            XCTFail("Expected cmd-click capture log after clicking escaped path")
+            XCTFail("Expected cmd-click capture log after running the command harness. result=\(result)")
             return
         }
 
@@ -109,15 +112,17 @@ final class TerminalCmdClickUITests: XCTestCase {
             openedPaths.contains(expectedPath),
             "Expected cmd-click to resolve the escaped-space path to the real file. opened=\(openedPaths) expected=\(expectedPath)"
         )
-
-        app.terminate()
     }
 
     private func launchApp(captureOpenPaths: Bool, captureHoverDiagnostics: Bool) -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments += ["-socketControlMode", "allowAll"]
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_PATH"] = setupDataPath
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_COMMAND_PATH"] = commandPath
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FIXTURE_DIR"] = fixtureDirectoryURL.path
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"] = "Cmd Click Fixture.txt"
         if captureOpenPaths {
             app.launchEnvironment["CMUX_UI_TEST_CAPTURE_OPEN_PATH"] = openCapturePath
         }
@@ -125,97 +130,8 @@ final class TerminalCmdClickUITests: XCTestCase {
             app.launchEnvironment["CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"] = hoverDiagnosticsPath
         }
         launchAndEnsureForeground(app)
-
-        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
-        _ = socketCommand("activate_app")
         app.activate()
         return app
-    }
-
-    @discardableResult
-    private func seedTerminalFixture(surfaceId: String, fileName: String) throws -> String {
-        let fileURL = fixtureDirectoryURL.appendingPathComponent(fileName)
-        try "fixture\n".write(to: fileURL, atomically: true, encoding: .utf8)
-
-        XCTAssertEqual(
-            socketCommand("focus_surface \(surfaceId)"),
-            "OK",
-            "Expected focused terminal before seeding fixture text"
-        )
-        XCTAssertEqual(
-            socketCommand("report_pwd \(fixtureDirectoryURL.path) --panel=\(surfaceId)"),
-            "OK",
-            "Expected report_pwd to update the terminal cwd for fallback path resolution"
-        )
-        XCTAssertTrue(
-            waitForCondition(timeout: 5.0) { self.socketCommand("is_terminal_focused \(surfaceId)") == "true" },
-            "Expected terminal surface to remain focused before UI input"
-        )
-
-        let escapedToken = fileName.replacingOccurrences(of: " ", with: "\\ ")
-        let blockLine = "\(escapedToken) \(escapedToken) \(escapedToken)"
-        let shellCommand = "clear\rfor i in 1 2 3 4 5 6 7 8; do printf '%s\\n' '\(blockLine)'; done\r"
-
-        guard let envelope = socketJSON(
-            method: "surface.send_text",
-            params: ["surface_id": surfaceId, "text": shellCommand]
-        ),
-        let ok = envelope["ok"] as? Bool,
-        ok else {
-            XCTFail("Expected surface.send_text to seed terminal content. response=\(String(describing: socketJSON(method: "surface.send_text", params: ["surface_id": surfaceId, "text": shellCommand])))")
-            return escapedToken
-        }
-
-        return escapedToken
-    }
-
-    private func waitForFocusedTerminalGeometry(timeout: TimeInterval = 12.0) throws -> TerminalGeometry {
-        var geometry: TerminalGeometry?
-        let matched = waitForCondition(timeout: timeout) {
-            guard let envelope = self.socketJSON(method: "debug.terminals", params: [:]),
-                  let ok = envelope["ok"] as? Bool,
-                  ok,
-                  let result = envelope["result"] as? [String: Any],
-                  let terminals = result["terminals"] as? [[String: Any]],
-                  let terminal = terminals.first(where: { ($0["surface_focused"] as? Bool) == true }) ?? terminals.first,
-                  let surfaceId = terminal["surface_id"] as? String,
-                  let windowFrame = Self.rect(from: terminal["window_frame"]),
-                  let terminalFrame = Self.rect(from: terminal["hosted_view_frame_in_window"]),
-                  (terminal["hosted_view_in_window"] as? Bool) == true else {
-                return false
-            }
-
-            geometry = TerminalGeometry(
-                surfaceId: surfaceId,
-                windowFrame: windowFrame,
-                terminalFrameInWindow: terminalFrame
-            )
-            return true
-        }
-
-        guard matched, let geometry else {
-            throw NSError(domain: "TerminalCmdClickUITests", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Expected focused terminal geometry from debug.terminals"
-            ])
-        }
-        return geometry
-    }
-
-    private func waitForTerminalText(surfaceId: String, contains token: String, timeout: TimeInterval) -> Bool {
-        waitForCondition(timeout: timeout) {
-            guard let text = self.readTerminalText(surfaceId: surfaceId) else { return false }
-            return text.contains(token)
-        }
-    }
-
-    private func readTerminalText(surfaceId: String) -> String? {
-        guard let response = socketCommand("read_terminal_text \(surfaceId)"),
-              response.hasPrefix("OK ") else {
-            return nil
-        }
-        let encoded = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let data = Data(base64Encoded: encoded) else { return nil }
-        return String(data: data, encoding: .utf8)
     }
 
     private func waitForCapturedOpenPaths(timeout: TimeInterval) -> [String]? {
@@ -249,148 +165,62 @@ final class TerminalCmdClickUITests: XCTestCase {
         return matched ? diagnostics : nil
     }
 
-    private func accessibilityPoint(
-        in geometry: TerminalGeometry,
-        xFromLeft: CGFloat,
-        yFromTop: CGFloat
-    ) -> CGPoint {
-        CGPoint(
-            x: geometry.windowFrame.minX + geometry.terminalFrameInWindow.minX + xFromLeft,
-            y: geometry.windowFrame.minY + geometry.terminalFrameInWindow.maxY - yFromTop
-        )
-    }
-
-    private func commandClick(atAccessibilityPoint point: CGPoint) {
-        guard let source = CGEventSource(stateID: .hidSystemState) else {
-            XCTFail("Expected CGEventSource for cmd-click")
-            return
+    private func waitForReadySetup(timeout: TimeInterval = 15.0) throws -> SetupData {
+        var setup: SetupData?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let payload = self.loadSetupData(),
+                  payload["ready"] as? String == "1",
+                  let expectedPath = payload["expectedPath"] as? String else {
+                return false
+            }
+            setup = SetupData(expectedPath: expectedPath)
+            return true
         }
 
-        let quartzPoint = quartzPoint(fromAccessibilityPoint: point)
-        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: true, flags: .maskCommand, source: source)
-        postMouseEvent(type: .mouseMoved, at: quartzPoint, flags: .maskCommand, source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        postMouseEvent(type: .leftMouseDown, at: quartzPoint, flags: .maskCommand, source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        postMouseEvent(type: .leftMouseUp, at: quartzPoint, flags: .maskCommand, source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.15))
-        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: false, flags: [], source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.10))
+        guard matched, let setup else {
+            throw NSError(domain: "TerminalCmdClickUITests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Expected terminal cmd-click setup data. payload=\(loadSetupData() ?? [:])"
+            ])
+        }
+        return setup
     }
 
-    private func holdCommandKey(duration: TimeInterval = 0.25) {
-        guard let source = CGEventSource(stateID: .hidSystemState) else {
-            XCTFail("Expected CGEventSource for Command-key hold")
-            return
+    private func runCommand(
+        action: String,
+        timeout: TimeInterval = 10.0
+    ) throws -> [String: Any] {
+        let commandID = UUID().uuidString
+        let request: [String: Any] = [
+            "id": commandID,
+            "action": action,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: request, options: [.sortedKeys])
+        try data.write(to: URL(fileURLWithPath: commandPath), options: .atomic)
+
+        var result: [String: Any]?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let payload = self.loadSetupData(),
+                  payload["lastCommandId"] as? String == commandID else {
+                return false
+            }
+            result = payload
+            return true
         }
 
-        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: true, flags: .maskCommand, source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(duration))
-        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: false, flags: [], source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.10))
+        guard matched, let result else {
+            throw NSError(domain: "TerminalCmdClickUITests", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Expected command result for \(action). payload=\(loadSetupData() ?? [:])"
+            ])
+        }
+        return result
     }
 
-    private struct RawMouseDragSession {
-        let source: CGEventSource
-    }
-
-    private func beginMouseDrag(
-        fromAccessibilityPoint start: CGPoint,
-        holdDuration: TimeInterval = 0.15
-    ) -> RawMouseDragSession? {
-        guard let source = CGEventSource(stateID: .hidSystemState) else {
-            XCTFail("Expected CGEventSource for raw mouse drag")
+    private func loadSetupData() -> [String: Any]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: setupDataPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }
-
-        let quartzStart = quartzPoint(fromAccessibilityPoint: start)
-        postMouseEvent(type: .mouseMoved, at: quartzStart, flags: [], source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        postMouseEvent(type: .leftMouseDown, at: quartzStart, flags: [], source: source)
-        RunLoop.current.run(until: Date().addingTimeInterval(holdDuration))
-        return RawMouseDragSession(source: source)
-    }
-
-    private func continueMouseDrag(
-        _ session: RawMouseDragSession,
-        toAccessibilityPoint end: CGPoint,
-        steps: Int = 20,
-        dragDuration: TimeInterval = 0.30
-    ) {
-        let currentLocation = NSEvent.mouseLocation
-        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
-        let clampedSteps = max(2, steps)
-
-        for step in 1...clampedSteps {
-            let progress = CGFloat(step) / CGFloat(clampedSteps)
-            let point = CGPoint(
-                x: currentLocation.x + ((quartzEnd.x - currentLocation.x) * progress),
-                y: currentLocation.y + ((quartzEnd.y - currentLocation.y) * progress)
-            )
-            postMouseEvent(type: .leftMouseDragged, at: point, flags: [], source: session.source)
-            RunLoop.current.run(until: Date().addingTimeInterval(dragDuration / Double(clampedSteps)))
-        }
-    }
-
-    private func endMouseDrag(_ session: RawMouseDragSession, atAccessibilityPoint end: CGPoint) {
-        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
-        postMouseEvent(type: .leftMouseUp, at: quartzEnd, flags: [], source: session.source)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.20))
-    }
-
-    private func postMouseEvent(
-        type: CGEventType,
-        at point: CGPoint,
-        flags: CGEventFlags,
-        source: CGEventSource
-    ) {
-        guard let event = CGEvent(
-            mouseEventSource: source,
-            mouseType: type,
-            mouseCursorPosition: point,
-            mouseButton: .left
-        ) else {
-            XCTFail("Expected CGEvent for mouse type \(type.rawValue) at \(point)")
-            return
-        }
-
-        event.flags = flags
-        event.setIntegerValueField(.mouseEventClickState, value: 1)
-        event.post(tap: .cghidEventTap)
-    }
-
-    private func postKeyEvent(
-        keyCode: CGKeyCode,
-        keyDown: Bool,
-        flags: CGEventFlags,
-        source: CGEventSource
-    ) {
-        guard let event = CGEvent(
-            keyboardEventSource: source,
-            virtualKey: keyCode,
-            keyDown: keyDown
-        ) else {
-            XCTFail("Expected keyboard CGEvent for keyCode \(keyCode)")
-            return
-        }
-
-        event.flags = flags
-        event.post(tap: .cghidEventTap)
-    }
-
-    private func quartzPoint(fromAccessibilityPoint point: CGPoint) -> CGPoint {
-        let desktopBounds = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
-            partialResult.union(screen.frame)
-        }
-        XCTAssertFalse(desktopBounds.isNull, "Expected at least one screen when converting raw mouse coordinates")
-        guard !desktopBounds.isNull else { return point }
-        return CGPoint(x: point.x, y: desktopBounds.maxY - point.y)
-    }
-
-    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
-        waitForCondition(timeout: timeout) {
-            self.socketCommand("ping") == "PONG"
-        }
+        return object
     }
 
     private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
@@ -405,140 +235,18 @@ final class TerminalCmdClickUITests: XCTestCase {
         XCTFail("App failed to start. state=\(app.state.rawValue)")
     }
 
-    private func waitForCondition(timeout: TimeInterval, predicate: @escaping () -> Bool) -> Bool {
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in predicate() },
-            object: nil
-        )
-        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
-    }
-
-    private func socketCommand(_ command: String) -> String? {
-        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
-    }
-
-    private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
-        let request: [String: Any] = [
-            "id": UUID().uuidString,
-            "method": method,
-            "params": params,
-        ]
-        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
-    }
-
-    private static func rect(from value: Any?) -> CGRect? {
-        guard let payload = value as? [String: Any],
-              let x = payload["x"] as? Double,
-              let y = payload["y"] as? Double,
-              let width = payload["width"] as? Double,
-              let height = payload["height"] as? Double else {
-            return nil
+    private func waitForCondition(
+        timeout: TimeInterval,
+        pollInterval: TimeInterval = 0.05,
+        predicate: @escaping () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
         }
-        return CGRect(x: x, y: y, width: width, height: height)
-    }
-
-    private final class ControlSocketClient {
-        private let path: String
-        private let responseTimeout: TimeInterval
-
-        init(path: String, responseTimeout: TimeInterval) {
-            self.path = path
-            self.responseTimeout = responseTimeout
-        }
-
-        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
-            guard JSONSerialization.isValidJSONObject(object),
-                  let data = try? JSONSerialization.data(withJSONObject: object),
-                  let line = String(data: data, encoding: .utf8),
-                  let response = sendLine(line),
-                  let responseData = response.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
-                return nil
-            }
-            return parsed
-        }
-
-        func sendLine(_ line: String) -> String? {
-            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-            guard fd >= 0 else { return nil }
-            defer { close(fd) }
-
-#if os(macOS)
-            var noSigPipe: Int32 = 1
-            _ = withUnsafePointer(to: &noSigPipe) { ptr in
-                setsockopt(
-                    fd,
-                    SOL_SOCKET,
-                    SO_NOSIGPIPE,
-                    ptr,
-                    socklen_t(MemoryLayout<Int32>.size)
-                )
-            }
-#endif
-
-            var addr = sockaddr_un()
-            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
-            addr.sun_family = sa_family_t(AF_UNIX)
-
-            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
-            let bytes = Array(path.utf8CString)
-            guard bytes.count <= maxLen else { return nil }
-            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-                memset(raw, 0, maxLen)
-                for index in 0..<bytes.count {
-                    raw[index] = bytes[index]
-                }
-            }
-
-            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
-            let addrLen = socklen_t(pathOffset + bytes.count)
-#if os(macOS)
-            addr.sun_len = UInt8(min(Int(addrLen), 255))
-#endif
-
-            let connectResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    connect(fd, $0, addrLen)
-                }
-            }
-            guard connectResult == 0 else { return nil }
-
-            Self.configureSocketTimeouts(fd, timeout: responseTimeout)
-
-            guard let outbound = (line + "\n").data(using: .utf8) else { return nil }
-            let writeResult = outbound.withUnsafeBytes { bytes in
-                send(fd, bytes.baseAddress, bytes.count, 0)
-            }
-            guard writeResult >= 0 else { return nil }
-
-            var accumulator = ""
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let readCount = recv(fd, &buffer, buffer.count, 0)
-                if readCount <= 0 { break }
-                if let chunk = String(bytes: buffer[0..<readCount], encoding: .utf8) {
-                    accumulator.append(chunk)
-                    if let newlineIndex = accumulator.firstIndex(of: "\n") {
-                        return String(accumulator[..<newlineIndex])
-                    }
-                }
-            }
-
-            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        private static func configureSocketTimeouts(_ fd: Int32, timeout: TimeInterval) {
-            var socketTimeout = timeval(
-                tv_sec: Int(timeout.rounded(.down)),
-                tv_usec: Int32(((timeout - floor(timeout)) * 1_000_000).rounded())
-            )
-            _ = withUnsafePointer(to: &socketTimeout) { ptr in
-                setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
-            }
-            _ = withUnsafePointer(to: &socketTimeout) { ptr in
-                setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
-            }
-        }
+        return predicate()
     }
 }

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -7,6 +7,12 @@ final class TerminalCmdClickUITests: XCTestCase {
         case raw
     }
 
+    private enum LineFormat: String {
+        case grid
+        case log
+        case altScreenLog = "alt_screen_log"
+    }
+
     private struct SetupData {
         let expectedPath: String
     }
@@ -33,6 +39,13 @@ final class TerminalCmdClickUITests: XCTestCase {
         try? FileManager.default.removeItem(atPath: setupDataPath)
         try? FileManager.default.removeItem(atPath: commandPath)
         try? FileManager.default.createDirectory(at: fixtureDirectoryURL, withIntermediateDirectories: true)
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: commandPath,
+                contents: Data("{}".utf8)
+            ),
+            "Expected shared command file to be writable at \(commandPath)"
+        )
     }
 
     override func tearDown() {
@@ -265,8 +278,225 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
+    func testCmdHoverLsStylePathResolvesFullConsultantAgreementDocx() throws {
+        try assertCommandHoverResolves(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .grid,
+            linePrefix: "",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdClickLsStylePathOpensFullConsultantAgreementDocx() throws {
+        try assertCommandClickOpens(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .grid,
+            linePrefix: "",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdHoverLsStylePathResolvesFullNintendoMkv() throws {
+        try assertCommandHoverResolves(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .grid,
+            linePrefix: ""
+        )
+    }
+
+    func testCmdClickLsStylePathOpensFullNintendoMkv() throws {
+        try assertCommandClickOpens(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .grid,
+            linePrefix: ""
+        )
+    }
+
+    func testCmdHoverDashPrefixedLogPathResolvesFullConsultantAgreementDocx() throws {
+        try assertCommandHoverResolves(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .log,
+            linePrefix: "- ",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdClickDashPrefixedLogPathOpensFullConsultantAgreementDocx() throws {
+        try assertCommandClickOpens(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .log,
+            linePrefix: "- ",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdHoverDashPrefixedLogPathResolvesFullNintendoMkv() throws {
+        try assertCommandHoverResolves(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .log,
+            linePrefix: "- "
+        )
+    }
+
+    func testCmdClickDashPrefixedLogPathOpensFullNintendoMkv() throws {
+        try assertCommandClickOpens(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .log,
+            linePrefix: "- "
+        )
+    }
+
+    func testCmdHoverAltScreenDashPrefixedLogPathResolvesFullConsultantAgreementDocx() throws {
+        try assertCommandHoverResolves(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .altScreenLog,
+            linePrefix: "- ",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdClickAltScreenDashPrefixedLogPathOpensFullConsultantAgreementDocx() throws {
+        try assertCommandClickOpens(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .altScreenLog,
+            linePrefix: "- ",
+            extraFileNames: ["Agreement.docx"],
+            disallowedFileName: "Agreement.docx"
+        )
+    }
+
+    func testCmdHoverAltScreenDashPrefixedLogPathResolvesFullNintendoMkv() throws {
+        try assertCommandHoverResolves(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .altScreenLog,
+            linePrefix: "- "
+        )
+    }
+
+    func testCmdClickAltScreenDashPrefixedLogPathOpensFullNintendoMkv() throws {
+        try assertCommandClickOpens(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .altScreenLog,
+            linePrefix: "- "
+        )
+    }
+
+    private func assertCommandHoverResolves(
+        fileName: String,
+        lineFormat: LineFormat,
+        linePrefix: String,
+        extraFileNames: [String] = [],
+        disallowedFileName: String? = nil
+    ) throws {
+        let app = launchApp(
+            displayMode: .raw,
+            lineFormat: lineFormat,
+            fileName: fileName,
+            linePrefix: linePrefix,
+            extraFileNames: extraFileNames,
+            captureOpenPaths: false,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let setup = try waitForReadySetup()
+        let expectedResolvedPath = expectedPath(for: fileName)
+        XCTAssertEqual(setup.expectedPath, expectedResolvedPath)
+
+        let result = try runCommand(action: "hover_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-hover to resolve the full spaced path. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandHoverActive"] as? String,
+            "1",
+            "Expected cmd-hover to activate the pointing cursor for the full spaced path. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandResolvedPath"] as? String,
+            expectedResolvedPath,
+            "Expected cmd-hover to resolve the full spaced path, not a suffix token. result=\(result)"
+        )
+
+        if let disallowedFileName {
+            XCTAssertNotEqual(
+                result["lastCommandResolvedPath"] as? String,
+                expectedPath(for: disallowedFileName),
+                "Expected cmd-hover to reject suffix-token decoys. result=\(result)"
+            )
+        }
+    }
+
+    private func assertCommandClickOpens(
+        fileName: String,
+        lineFormat: LineFormat,
+        linePrefix: String,
+        extraFileNames: [String] = [],
+        disallowedFileName: String? = nil
+    ) throws {
+        let app = launchApp(
+            displayMode: .raw,
+            lineFormat: lineFormat,
+            fileName: fileName,
+            linePrefix: linePrefix,
+            extraFileNames: extraFileNames,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let setup = try waitForReadySetup()
+        let expectedResolvedPath = expectedPath(for: fileName)
+        XCTAssertEqual(setup.expectedPath, expectedResolvedPath)
+
+        let result = try runCommand(action: "cmd_click_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-click to open the full spaced path. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandOpenedPath"] as? String,
+            expectedResolvedPath,
+            "Expected cmd-click to open the full spaced path, not a suffix token. result=\(result)"
+        )
+
+        guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
+            XCTFail("Expected open capture after cmd-clicking the spaced path. result=\(result)")
+            return
+        }
+
+        XCTAssertTrue(
+            openedPaths.contains(expectedResolvedPath),
+            "Expected cmd-click to open the intended spaced path. opened=\(openedPaths) expected=\(expectedResolvedPath)"
+        )
+
+        if let disallowedFileName {
+            let disallowedPath = expectedPath(for: disallowedFileName)
+            XCTAssertFalse(
+                openedPaths.contains(disallowedPath),
+                "Expected cmd-click to reject suffix-token decoys. opened=\(openedPaths) wrong=\(disallowedPath)"
+            )
+        }
+    }
+
+    private func expectedPath(for fileName: String) -> String {
+        fixtureDirectoryURL.appendingPathComponent(fileName).path
+    }
+
     private func launchApp(
         displayMode: DisplayMode = .escaped,
+        lineFormat: LineFormat = .grid,
+        fileName: String = "Cmd Click Fixture.txt",
+        linePrefix: String = "",
+        extraFileNames: [String] = [],
         captureOpenPaths: Bool,
         captureHoverDiagnostics: Bool,
         quicklookOverride: String? = nil,
@@ -279,8 +509,17 @@ final class TerminalCmdClickUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_PATH"] = setupDataPath
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_COMMAND_PATH"] = commandPath
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FIXTURE_DIR"] = fixtureDirectoryURL.path
-        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"] = "Cmd Click Fixture.txt"
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"] = fileName
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_DISPLAY_MODE"] = displayMode.rawValue
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_LINE_FORMAT"] = lineFormat.rawValue
+        if !linePrefix.isEmpty {
+            app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_LINE_PREFIX"] = linePrefix
+        }
+        if !extraFileNames.isEmpty,
+           let data = try? JSONSerialization.data(withJSONObject: extraFileNames, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_EXTRA_FILE_NAMES_JSON"] = json
+        }
         if captureOpenPaths {
             app.launchEnvironment["CMUX_UI_TEST_CAPTURE_OPEN_PATH"] = openCapturePath
         }
@@ -358,7 +597,7 @@ final class TerminalCmdClickUITests: XCTestCase {
             "action": action,
         ]
         let data = try JSONSerialization.data(withJSONObject: request, options: [.sortedKeys])
-        try data.write(to: URL(fileURLWithPath: commandPath), options: .atomic)
+        try data.write(to: URL(fileURLWithPath: commandPath))
 
         var result: [String: Any]?
         let matched = waitForCondition(timeout: timeout) {

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -1,0 +1,544 @@
+import XCTest
+import Foundation
+import AppKit
+import CoreGraphics
+import Carbon.HIToolbox
+
+final class TerminalCmdClickUITests: XCTestCase {
+    private struct TerminalGeometry {
+        let surfaceId: String
+        let windowFrame: CGRect
+        let terminalFrameInWindow: CGRect
+    }
+
+    private var socketPath = ""
+    private var hoverDiagnosticsPath = ""
+    private var openCapturePath = ""
+    private var fixtureDirectoryURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        socketPath = "/tmp/cmux-ui-test-terminal-cmd-click-\(UUID().uuidString).sock"
+        hoverDiagnosticsPath = "/tmp/cmux-ui-test-terminal-cmd-hover-\(UUID().uuidString).json"
+        openCapturePath = "/tmp/cmux-ui-test-terminal-open-\(UUID().uuidString).log"
+        fixtureDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-terminal-cmd-click-\(UUID().uuidString)", isDirectory: true)
+
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: hoverDiagnosticsPath)
+        try? FileManager.default.removeItem(atPath: openCapturePath)
+        try? FileManager.default.createDirectory(at: fixtureDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: hoverDiagnosticsPath)
+        try? FileManager.default.removeItem(atPath: openCapturePath)
+        try? FileManager.default.removeItem(at: fixtureDirectoryURL)
+        super.tearDown()
+    }
+
+    func testHoldingCommandAfterSelectionSuppresssCommandHoverDispatch() throws {
+        let app = launchApp(captureOpenPaths: false, captureHoverDiagnostics: true)
+        let geometry = try waitForFocusedTerminalGeometry()
+        let token = try seedTerminalFixture(
+            surfaceId: geometry.surfaceId,
+            fileName: "Cmd Click Fixture.txt"
+        )
+
+        XCTAssertTrue(
+            waitForTerminalText(surfaceId: geometry.surfaceId, contains: token, timeout: 8.0),
+            "Expected terminal to render the escaped path fixture before selecting it"
+        )
+
+        let dragStart = accessibilityPoint(in: geometry, xFromLeft: 48, yFromTop: 54)
+        let dragEnd = accessibilityPoint(in: geometry, xFromLeft: 240, yFromTop: 54)
+        guard let dragSession = beginMouseDrag(fromAccessibilityPoint: dragStart) else {
+            XCTFail("Expected raw drag session for terminal selection")
+            return
+        }
+        continueMouseDrag(dragSession, toAccessibilityPoint: dragEnd)
+        endMouseDrag(dragSession, atAccessibilityPoint: dragEnd)
+
+        holdCommandKey()
+
+        guard let diagnostics = waitForHoverDiagnostics(timeout: 5.0) else {
+            XCTFail("Expected hover diagnostics after holding Command with an active selection")
+            return
+        }
+
+        let suppressedCount = diagnostics["suppressed_command_hover_count"] as? Int ?? 0
+        let forwardedCount = diagnostics["forwarded_command_hover_count"] as? Int ?? 0
+        XCTAssertGreaterThanOrEqual(
+            suppressedCount,
+            1,
+            "Expected holding Command after selecting text to suppress command hover dispatch. diagnostics=\(diagnostics)"
+        )
+        XCTAssertEqual(
+            forwardedCount,
+            0,
+            "Expected no command-modified hover dispatch to reach Ghostty while selection is active. diagnostics=\(diagnostics)"
+        )
+
+        app.terminate()
+    }
+
+    func testCmdClickEscapedPathWithSpacesOpensResolvedFile() throws {
+        let app = launchApp(captureOpenPaths: true, captureHoverDiagnostics: false)
+        let geometry = try waitForFocusedTerminalGeometry()
+        let fileName = "Cmd Click Fixture.txt"
+        let token = try seedTerminalFixture(surfaceId: geometry.surfaceId, fileName: fileName)
+        let expectedPath = fixtureDirectoryURL.appendingPathComponent(fileName).path
+
+        XCTAssertTrue(
+            waitForTerminalText(surfaceId: geometry.surfaceId, contains: token, timeout: 8.0),
+            "Expected terminal to render the escaped path fixture before cmd-clicking it"
+        )
+
+        let clickPoint = accessibilityPoint(in: geometry, xFromLeft: 140, yFromTop: 54)
+        commandClick(atAccessibilityPoint: clickPoint)
+
+        guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
+            XCTFail("Expected cmd-click capture log after clicking escaped path")
+            return
+        }
+
+        XCTAssertTrue(
+            openedPaths.contains(expectedPath),
+            "Expected cmd-click to resolve the escaped-space path to the real file. opened=\(openedPaths) expected=\(expectedPath)"
+        )
+
+        app.terminate()
+    }
+
+    private func launchApp(captureOpenPaths: Bool, captureHoverDiagnostics: Bool) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += ["-socketControlMode", "allowAll"]
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
+        if captureOpenPaths {
+            app.launchEnvironment["CMUX_UI_TEST_CAPTURE_OPEN_PATH"] = openCapturePath
+        }
+        if captureHoverDiagnostics {
+            app.launchEnvironment["CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"] = hoverDiagnosticsPath
+        }
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
+        _ = socketCommand("activate_app")
+        app.activate()
+        return app
+    }
+
+    @discardableResult
+    private func seedTerminalFixture(surfaceId: String, fileName: String) throws -> String {
+        let fileURL = fixtureDirectoryURL.appendingPathComponent(fileName)
+        try "fixture\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            socketCommand("focus_surface \(surfaceId)"),
+            "OK",
+            "Expected focused terminal before seeding fixture text"
+        )
+        XCTAssertEqual(
+            socketCommand("report_pwd \(fixtureDirectoryURL.path) --panel=\(surfaceId)"),
+            "OK",
+            "Expected report_pwd to update the terminal cwd for fallback path resolution"
+        )
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { self.socketCommand("is_terminal_focused \(surfaceId)") == "true" },
+            "Expected terminal surface to remain focused before UI input"
+        )
+
+        let escapedToken = fileName.replacingOccurrences(of: " ", with: "\\ ")
+        let blockLine = "\(escapedToken) \(escapedToken) \(escapedToken)"
+        let shellCommand = "clear\rfor i in 1 2 3 4 5 6 7 8; do printf '%s\\n' '\(blockLine)'; done\r"
+
+        guard let envelope = socketJSON(
+            method: "surface.send_text",
+            params: ["surface_id": surfaceId, "text": shellCommand]
+        ),
+        let ok = envelope["ok"] as? Bool,
+        ok else {
+            XCTFail("Expected surface.send_text to seed terminal content. response=\(String(describing: socketJSON(method: "surface.send_text", params: ["surface_id": surfaceId, "text": shellCommand])))")
+            return escapedToken
+        }
+
+        return escapedToken
+    }
+
+    private func waitForFocusedTerminalGeometry(timeout: TimeInterval = 12.0) throws -> TerminalGeometry {
+        var geometry: TerminalGeometry?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let envelope = self.socketJSON(method: "debug.terminals", params: [:]),
+                  let ok = envelope["ok"] as? Bool,
+                  ok,
+                  let result = envelope["result"] as? [String: Any],
+                  let terminals = result["terminals"] as? [[String: Any]],
+                  let terminal = terminals.first(where: { ($0["surface_focused"] as? Bool) == true }) ?? terminals.first,
+                  let surfaceId = terminal["surface_id"] as? String,
+                  let windowFrame = Self.rect(from: terminal["window_frame"]),
+                  let terminalFrame = Self.rect(from: terminal["hosted_view_frame_in_window"]),
+                  (terminal["hosted_view_in_window"] as? Bool) == true else {
+                return false
+            }
+
+            geometry = TerminalGeometry(
+                surfaceId: surfaceId,
+                windowFrame: windowFrame,
+                terminalFrameInWindow: terminalFrame
+            )
+            return true
+        }
+
+        guard matched, let geometry else {
+            throw NSError(domain: "TerminalCmdClickUITests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Expected focused terminal geometry from debug.terminals"
+            ])
+        }
+        return geometry
+    }
+
+    private func waitForTerminalText(surfaceId: String, contains token: String, timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            guard let text = self.readTerminalText(surfaceId: surfaceId) else { return false }
+            return text.contains(token)
+        }
+    }
+
+    private func readTerminalText(surfaceId: String) -> String? {
+        guard let response = socketCommand("read_terminal_text \(surfaceId)"),
+              response.hasPrefix("OK ") else {
+            return nil
+        }
+        let encoded = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = Data(base64Encoded: encoded) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func waitForCapturedOpenPaths(timeout: TimeInterval) -> [String]? {
+        var openedPaths: [String]?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let contents = try? String(contentsOfFile: self.openCapturePath, encoding: .utf8) else {
+                return false
+            }
+            let lines = contents
+                .split(separator: "\n")
+                .map(String.init)
+                .filter { !$0.isEmpty }
+            guard !lines.isEmpty else { return false }
+            openedPaths = lines
+            return true
+        }
+        return matched ? openedPaths : nil
+    }
+
+    private func waitForHoverDiagnostics(timeout: TimeInterval) -> [String: Any]? {
+        var diagnostics: [String: Any]?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: self.hoverDiagnosticsPath)),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  (object["suppressed_command_hover_count"] as? Int ?? 0) > 0 else {
+                return false
+            }
+            diagnostics = object
+            return true
+        }
+        return matched ? diagnostics : nil
+    }
+
+    private func accessibilityPoint(
+        in geometry: TerminalGeometry,
+        xFromLeft: CGFloat,
+        yFromTop: CGFloat
+    ) -> CGPoint {
+        CGPoint(
+            x: geometry.windowFrame.minX + geometry.terminalFrameInWindow.minX + xFromLeft,
+            y: geometry.windowFrame.minY + geometry.terminalFrameInWindow.maxY - yFromTop
+        )
+    }
+
+    private func commandClick(atAccessibilityPoint point: CGPoint) {
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            XCTFail("Expected CGEventSource for cmd-click")
+            return
+        }
+
+        let quartzPoint = quartzPoint(fromAccessibilityPoint: point)
+        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: true, flags: .maskCommand, source: source)
+        postMouseEvent(type: .mouseMoved, at: quartzPoint, flags: .maskCommand, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        postMouseEvent(type: .leftMouseDown, at: quartzPoint, flags: .maskCommand, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        postMouseEvent(type: .leftMouseUp, at: quartzPoint, flags: .maskCommand, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.15))
+        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: false, flags: [], source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.10))
+    }
+
+    private func holdCommandKey(duration: TimeInterval = 0.25) {
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            XCTFail("Expected CGEventSource for Command-key hold")
+            return
+        }
+
+        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: true, flags: .maskCommand, source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(duration))
+        postKeyEvent(keyCode: CGKeyCode(kVK_Command), keyDown: false, flags: [], source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.10))
+    }
+
+    private struct RawMouseDragSession {
+        let source: CGEventSource
+    }
+
+    private func beginMouseDrag(
+        fromAccessibilityPoint start: CGPoint,
+        holdDuration: TimeInterval = 0.15
+    ) -> RawMouseDragSession? {
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            XCTFail("Expected CGEventSource for raw mouse drag")
+            return nil
+        }
+
+        let quartzStart = quartzPoint(fromAccessibilityPoint: start)
+        postMouseEvent(type: .mouseMoved, at: quartzStart, flags: [], source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        postMouseEvent(type: .leftMouseDown, at: quartzStart, flags: [], source: source)
+        RunLoop.current.run(until: Date().addingTimeInterval(holdDuration))
+        return RawMouseDragSession(source: source)
+    }
+
+    private func continueMouseDrag(
+        _ session: RawMouseDragSession,
+        toAccessibilityPoint end: CGPoint,
+        steps: Int = 20,
+        dragDuration: TimeInterval = 0.30
+    ) {
+        let currentLocation = NSEvent.mouseLocation
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+        let clampedSteps = max(2, steps)
+
+        for step in 1...clampedSteps {
+            let progress = CGFloat(step) / CGFloat(clampedSteps)
+            let point = CGPoint(
+                x: currentLocation.x + ((quartzEnd.x - currentLocation.x) * progress),
+                y: currentLocation.y + ((quartzEnd.y - currentLocation.y) * progress)
+            )
+            postMouseEvent(type: .leftMouseDragged, at: point, flags: [], source: session.source)
+            RunLoop.current.run(until: Date().addingTimeInterval(dragDuration / Double(clampedSteps)))
+        }
+    }
+
+    private func endMouseDrag(_ session: RawMouseDragSession, atAccessibilityPoint end: CGPoint) {
+        let quartzEnd = quartzPoint(fromAccessibilityPoint: end)
+        postMouseEvent(type: .leftMouseUp, at: quartzEnd, flags: [], source: session.source)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.20))
+    }
+
+    private func postMouseEvent(
+        type: CGEventType,
+        at point: CGPoint,
+        flags: CGEventFlags,
+        source: CGEventSource
+    ) {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else {
+            XCTFail("Expected CGEvent for mouse type \(type.rawValue) at \(point)")
+            return
+        }
+
+        event.flags = flags
+        event.setIntegerValueField(.mouseEventClickState, value: 1)
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func postKeyEvent(
+        keyCode: CGKeyCode,
+        keyDown: Bool,
+        flags: CGEventFlags,
+        source: CGEventSource
+    ) {
+        guard let event = CGEvent(
+            keyboardEventSource: source,
+            virtualKey: keyCode,
+            keyDown: keyDown
+        ) else {
+            XCTFail("Expected keyboard CGEvent for keyCode \(keyCode)")
+            return
+        }
+
+        event.flags = flags
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func quartzPoint(fromAccessibilityPoint point: CGPoint) -> CGPoint {
+        let desktopBounds = NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+            partialResult.union(screen.frame)
+        }
+        XCTAssertFalse(desktopBounds.isNull, "Expected at least one screen when converting raw mouse coordinates")
+        guard !desktopBounds.isNull else { return point }
+        return CGPoint(x: point.x, y: desktopBounds.maxY - point.y)
+    }
+
+    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            self.socketCommand("ping") == "PONG"
+        }
+    }
+
+    private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless GUI runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground { return }
+        if app.state == .runningBackground { return }
+        XCTFail("App failed to start. state=\(app.state.rawValue)")
+    }
+
+    private func waitForCondition(timeout: TimeInterval, predicate: @escaping () -> Bool) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in predicate() },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func socketCommand(_ command: String) -> String? {
+        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
+    }
+
+    private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
+    }
+
+    private static func rect(from value: Any?) -> CGRect? {
+        guard let payload = value as? [String: Any],
+              let x = payload["x"] as? Double,
+              let y = payload["y"] as? Double,
+              let width = payload["width"] as? Double,
+              let height = payload["height"] as? Double else {
+            return nil
+        }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
+            guard JSONSerialization.isValidJSONObject(object),
+                  let data = try? JSONSerialization.data(withJSONObject: object),
+                  let line = String(data: data, encoding: .utf8),
+                  let response = sendLine(line),
+                  let responseData = response.data(using: .utf8),
+                  let parsed = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+                return nil
+            }
+            return parsed
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+#if os(macOS)
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
+            }
+#endif
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let bytes = Array(path.utf8CString)
+            guard bytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
+                for index in 0..<bytes.count {
+                    raw[index] = bytes[index]
+                }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + bytes.count)
+#if os(macOS)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+#endif
+
+            let connectResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    connect(fd, $0, addrLen)
+                }
+            }
+            guard connectResult == 0 else { return nil }
+
+            Self.configureSocketTimeouts(fd, timeout: responseTimeout)
+
+            guard let outbound = (line + "\n").data(using: .utf8) else { return nil }
+            let writeResult = outbound.withUnsafeBytes { bytes in
+                send(fd, bytes.baseAddress, bytes.count, 0)
+            }
+            guard writeResult >= 0 else { return nil }
+
+            var accumulator = ""
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let readCount = recv(fd, &buffer, buffer.count, 0)
+                if readCount <= 0 { break }
+                if let chunk = String(bytes: buffer[0..<readCount], encoding: .utf8) {
+                    accumulator.append(chunk)
+                    if let newlineIndex = accumulator.firstIndex(of: "\n") {
+                        return String(accumulator[..<newlineIndex])
+                    }
+                }
+            }
+
+            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        private static func configureSocketTimeouts(_ fd: Int32, timeout: TimeInterval) {
+            var socketTimeout = timeval(
+                tv_sec: Int(timeout.rounded(.down)),
+                tv_usec: Int32(((timeout - floor(timeout)) * 1_000_000).rounded())
+            )
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+            }
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+            }
+        }
+    }
+}

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -15,6 +15,7 @@ final class TerminalCmdClickUITests: XCTestCase {
 
     private struct SetupData {
         let expectedPath: String
+        let payload: [String: Any]
     }
 
     private var hoverDiagnosticsPath = ""
@@ -289,7 +290,7 @@ final class TerminalCmdClickUITests: XCTestCase {
     }
 
     func testCmdClickLsStylePathOpensFullConsultantAgreementDocx() throws {
-        try assertCommandClickOpens(
+        try assertCommandClickOpensAcrossEveryCharacter(
             fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
             lineFormat: .grid,
             linePrefix: "",
@@ -307,7 +308,24 @@ final class TerminalCmdClickUITests: XCTestCase {
     }
 
     func testCmdClickLsStylePathOpensFullNintendoMkv() throws {
-        try assertCommandClickOpens(
+        try assertCommandClickOpensAcrossEveryCharacter(
+            fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
+            lineFormat: .grid,
+            linePrefix: ""
+        )
+    }
+
+    func testCmdClickLsStyleInvalidCellsDoNothingForConsultantAgreementDocx() throws {
+        try assertCommandClickDoesNothingAtInvalidOffsets(
+            fileName: "Standard - Consultant Agreement - Form of Consulting Agreement.docx",
+            lineFormat: .grid,
+            linePrefix: "",
+            extraFileNames: ["Agreement.docx"]
+        )
+    }
+
+    func testCmdClickLsStyleInvalidCellsDoNothingForNintendoMkv() throws {
+        try assertCommandClickDoesNothingAtInvalidOffsets(
             fileName: "(NINTENDO) BOTW Guardian Sound Effect.mkv",
             lineFormat: .grid,
             linePrefix: ""
@@ -487,8 +505,117 @@ final class TerminalCmdClickUITests: XCTestCase {
         }
     }
 
+    private func assertCommandClickOpensAcrossEveryCharacter(
+        fileName: String,
+        lineFormat: LineFormat,
+        linePrefix: String,
+        extraFileNames: [String] = [],
+        disallowedFileName: String? = nil
+    ) throws {
+        let app = launchApp(
+            displayMode: .raw,
+            lineFormat: lineFormat,
+            fileName: fileName,
+            linePrefix: linePrefix,
+            extraFileNames: extraFileNames,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let setup = try waitForReadySetup()
+        let expectedResolvedPath = expectedPath(for: fileName)
+        XCTAssertEqual(setup.expectedPath, expectedResolvedPath)
+
+        var previousOpenCount = loadCapturedOpenPaths().count
+        for tokenColumnOffset in 0..<fileName.count {
+            let result = try runCommand(
+                action: "cmd_click_token",
+                additionalPayload: ["tokenColumnOffset": tokenColumnOffset]
+            )
+            XCTAssertEqual(
+                result["lastCommandSucceeded"] as? String,
+                "1",
+                "Expected cmd-click to open the full spaced path from token column \(tokenColumnOffset). result=\(result)"
+            )
+            XCTAssertEqual(
+                result["lastCommandOpenedPath"] as? String,
+                expectedResolvedPath,
+                "Expected cmd-click at token column \(tokenColumnOffset) to open the full spaced path. result=\(result)"
+            )
+
+            let openedPaths = try waitForOpenCount(previousOpenCount + 1, timeout: 5.0)
+            XCTAssertEqual(
+                openedPaths.last,
+                expectedResolvedPath,
+                "Expected cmd-click at token column \(tokenColumnOffset) to open the intended spaced path. opened=\(openedPaths)"
+            )
+
+            if let disallowedFileName {
+                XCTAssertNotEqual(
+                    openedPaths.last,
+                    expectedPath(for: disallowedFileName),
+                    "Expected cmd-click at token column \(tokenColumnOffset) to reject suffix-token decoys. opened=\(openedPaths)"
+                )
+            }
+
+            previousOpenCount = openedPaths.count
+        }
+    }
+
+    private func assertCommandClickDoesNothingAtInvalidOffsets(
+        fileName: String,
+        lineFormat: LineFormat,
+        linePrefix: String,
+        extraFileNames: [String] = []
+    ) throws {
+        let app = launchApp(
+            displayMode: .raw,
+            lineFormat: lineFormat,
+            fileName: fileName,
+            linePrefix: linePrefix,
+            extraFileNames: extraFileNames,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let setup = try waitForReadySetup()
+        let expectedResolvedPath = expectedPath(for: fileName)
+        XCTAssertEqual(setup.expectedPath, expectedResolvedPath)
+
+        let invalidOffsets = invalidTokenColumnOffsets(for: fileName)
+        let previousOpenCount = loadCapturedOpenPaths().count
+        for tokenColumnOffset in invalidOffsets {
+            let result = try runCommand(
+                action: "cmd_click_token",
+                additionalPayload: ["tokenColumnOffset": tokenColumnOffset]
+            )
+            XCTAssertNil(
+                result["lastCommandOpenedPath"] as? String,
+                "Expected cmd-click on invalid token column \(tokenColumnOffset) to open nothing. result=\(result)"
+            )
+            XCTAssertEqual(
+                result["lastCommandSucceeded"] as? String,
+                "0",
+                "Expected cmd-click on invalid token column \(tokenColumnOffset) to stay unresolved. result=\(result)"
+            )
+            XCTAssertTrue(
+                waitForOpenCountToStay(previousOpenCount, timeout: 0.75),
+                "Expected cmd-click on invalid token column \(tokenColumnOffset) to leave open count unchanged. opened=\(loadCapturedOpenPaths())"
+            )
+        }
+    }
+
     private func expectedPath(for fileName: String) -> String {
         fixtureDirectoryURL.appendingPathComponent(fileName).path
+    }
+
+    private func invalidTokenColumnOffsets(for fileName: String) -> [Int] {
+        let separatorStart = fileName.count
+        let separatorOffsets = Array(separatorStart..<(separatorStart + 4))
+        let trailingBlankOffset = separatorStart + 4 + "OtherFile".count + 2
+        return separatorOffsets + [trailingBlankOffset]
     }
 
     private func launchApp(
@@ -539,18 +666,52 @@ final class TerminalCmdClickUITests: XCTestCase {
     private func waitForCapturedOpenPaths(timeout: TimeInterval) -> [String]? {
         var openedPaths: [String]?
         let matched = waitForCondition(timeout: timeout) {
-            guard let contents = try? String(contentsOfFile: self.openCapturePath, encoding: .utf8) else {
-                return false
-            }
-            let lines = contents
-                .split(separator: "\n")
-                .map(String.init)
-                .filter { !$0.isEmpty }
+            let lines = self.loadCapturedOpenPaths()
             guard !lines.isEmpty else { return false }
             openedPaths = lines
             return true
         }
         return matched ? openedPaths : nil
+    }
+
+    private func loadCapturedOpenPaths() -> [String] {
+        guard let contents = try? String(contentsOfFile: openCapturePath, encoding: .utf8) else {
+            return []
+        }
+
+        return contents
+            .split(separator: "\n")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+    }
+
+    private func waitForOpenCount(_ expectedCount: Int, timeout: TimeInterval) throws -> [String] {
+        var openedPaths: [String] = []
+        let matched = waitForCondition(timeout: timeout) {
+            let lines = self.loadCapturedOpenPaths()
+            guard lines.count >= expectedCount else { return false }
+            openedPaths = lines
+            return true
+        }
+
+        guard matched else {
+            throw NSError(domain: "TerminalCmdClickUITests", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "Expected at least \(expectedCount) opened paths. opened=\(loadCapturedOpenPaths())"
+            ])
+        }
+
+        return openedPaths
+    }
+
+    private func waitForOpenCountToStay(_ expectedCount: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if loadCapturedOpenPaths().count != expectedCount {
+                return false
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return loadCapturedOpenPaths().count == expectedCount
     }
 
     private func waitForHoverDiagnostics(timeout: TimeInterval) -> [String: Any]? {
@@ -575,7 +736,7 @@ final class TerminalCmdClickUITests: XCTestCase {
                   let expectedPath = payload["expectedPath"] as? String else {
                 return false
             }
-            setup = SetupData(expectedPath: expectedPath)
+            setup = SetupData(expectedPath: expectedPath, payload: payload)
             return true
         }
 
@@ -589,13 +750,17 @@ final class TerminalCmdClickUITests: XCTestCase {
 
     private func runCommand(
         action: String,
+        additionalPayload: [String: Any] = [:],
         timeout: TimeInterval = 10.0
     ) throws -> [String: Any] {
-        let commandID = UUID().uuidString
-        let request: [String: Any] = [
-            "id": commandID,
+        var request: [String: Any] = [
+            "id": UUID().uuidString,
             "action": action,
         ]
+        for (key, value) in additionalPayload {
+            request[key] = value
+        }
+        let commandID = request["id"] as! String
         let data = try JSONSerialization.data(withJSONObject: request, options: [.sortedKeys])
         try data.write(to: URL(fileURLWithPath: commandPath))
 

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -2,6 +2,11 @@ import XCTest
 import Foundation
 
 final class TerminalCmdClickUITests: XCTestCase {
+    private enum DisplayMode: String {
+        case escaped
+        case raw
+    }
+
     private struct SetupData {
         let expectedPath: String
     }
@@ -82,7 +87,11 @@ final class TerminalCmdClickUITests: XCTestCase {
     }
 
     func testCmdClickEscapedPathWithSpacesOpensResolvedFile() throws {
-        let app = launchApp(captureOpenPaths: true, captureHoverDiagnostics: false)
+        let app = launchApp(
+            displayMode: .escaped,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
         defer { app.terminate() }
 
         let fileName = "Cmd Click Fixture.txt"
@@ -114,7 +123,48 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
-    private func launchApp(captureOpenPaths: Bool, captureHoverDiagnostics: Bool) -> XCUIApplication {
+    func testCmdClickRawLsStylePathWithSpacesOpensResolvedFile() throws {
+        let app = launchApp(
+            displayMode: .raw,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false
+        )
+        defer { app.terminate() }
+
+        let fileName = "Cmd Click Fixture.txt"
+        let setup = try waitForReadySetup()
+        let expectedPath = fixtureDirectoryURL.appendingPathComponent(fileName).path
+
+        XCTAssertEqual(setup.expectedPath, expectedPath)
+
+        let result = try runCommand(action: "cmd_click_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-click harness to open the raw-space path. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandOpenedPath"] as? String,
+            expectedPath,
+            "Expected cmd-click to resolve the raw-space path to the real file. result=\(result)"
+        )
+
+        guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
+            XCTFail("Expected cmd-click capture log after running the raw-space command harness. result=\(result)")
+            return
+        }
+
+        XCTAssertTrue(
+            openedPaths.contains(expectedPath),
+            "Expected cmd-click to resolve the raw-space path to the real file. opened=\(openedPaths) expected=\(expectedPath)"
+        )
+    }
+
+    private func launchApp(
+        displayMode: DisplayMode = .escaped,
+        captureOpenPaths: Bool,
+        captureHoverDiagnostics: Bool
+    ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
@@ -123,6 +173,7 @@ final class TerminalCmdClickUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_COMMAND_PATH"] = commandPath
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FIXTURE_DIR"] = fixtureDirectoryURL.path
         app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_FILE_NAME"] = "Cmd Click Fixture.txt"
+        app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_DISPLAY_MODE"] = displayMode.rawValue
         if captureOpenPaths {
             app.launchEnvironment["CMUX_UI_TEST_CAPTURE_OPEN_PATH"] = openCapturePath
         }
@@ -130,7 +181,6 @@ final class TerminalCmdClickUITests: XCTestCase {
             app.launchEnvironment["CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"] = hoverDiagnosticsPath
         }
         launchAndEnsureForeground(app)
-        app.activate()
         return app
     }
 
@@ -230,9 +280,19 @@ final class TerminalCmdClickUITests: XCTestCase {
             app.launch()
         }
 
-        if app.state == .runningForeground { return }
-        if app.state == .runningBackground { return }
-        XCTFail("App failed to start. state=\(app.state.rawValue)")
+        guard app.state == .runningForeground || app.state == .runningBackground else {
+            XCTFail("App failed to start. state=\(app.state.rawValue)")
+            return
+        }
+
+        app.activate()
+        let foregrounded = waitForCondition(timeout: timeout) {
+            app.state == .runningForeground || app.windows.firstMatch.exists
+        }
+        XCTAssertTrue(
+            foregrounded,
+            "Expected app activation before driving cmd-key harness. state=\(app.state.rawValue)"
+        )
     }
 
     private func waitForCondition(

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -160,10 +160,61 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
+    func testCmdClickRawLsStylePathPrefersSnapshotWhenQuicklookDisagrees() throws {
+        let app = launchApp(
+            displayMode: .raw,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false,
+            quicklookOverride: "OtherFile"
+        )
+        defer { app.terminate() }
+
+        let fileName = "Cmd Click Fixture.txt"
+        let setup = try waitForReadySetup()
+        let expectedPath = fixtureDirectoryURL.appendingPathComponent(fileName).path
+        let wrongQuicklookPath = fixtureDirectoryURL.appendingPathComponent("OtherFile").path
+
+        XCTAssertEqual(setup.expectedPath, expectedPath)
+
+        let result = try runCommand(action: "cmd_click_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-click to prefer the snapshot-expanded raw-space path when quicklook disagrees. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandOpenedPath"] as? String,
+            expectedPath,
+            "Expected cmd-click to prefer the snapshot-expanded raw-space path when quicklook disagrees. result=\(result)"
+        )
+        if let lastCommandResult = result["lastCommandResult"] as? [String: Any] {
+            XCTAssertEqual(
+                lastCommandResult["resolutionSource"] as? String,
+                "snapshot",
+                "Expected disagreement cases to resolve through the snapshot path expander. result=\(result)"
+            )
+        }
+
+        guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
+            XCTFail("Expected cmd-click capture log after forcing a quicklook mismatch. result=\(result)")
+            return
+        }
+
+        XCTAssertTrue(
+            openedPaths.contains(expectedPath),
+            "Expected cmd-click to open the intended raw-space path. opened=\(openedPaths) expected=\(expectedPath)"
+        )
+        XCTAssertFalse(
+            openedPaths.contains(wrongQuicklookPath),
+            "Expected cmd-click to reject the mismatched quicklook path. opened=\(openedPaths) wrong=\(wrongQuicklookPath)"
+        )
+    }
+
     private func launchApp(
         displayMode: DisplayMode = .escaped,
         captureOpenPaths: Bool,
-        captureHoverDiagnostics: Bool
+        captureHoverDiagnostics: Bool,
+        quicklookOverride: String? = nil
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
@@ -179,6 +230,9 @@ final class TerminalCmdClickUITests: XCTestCase {
         }
         if captureHoverDiagnostics {
             app.launchEnvironment["CMUX_UI_TEST_CMD_HOVER_DIAGNOSTICS_PATH"] = hoverDiagnosticsPath
+        }
+        if let quicklookOverride {
+            app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_QUICKLOOK_OVERRIDE"] = quicklookOverride
         }
         launchAndEnsureForeground(app)
         return app

--- a/cmuxUITests/TerminalCmdClickUITests.swift
+++ b/cmuxUITests/TerminalCmdClickUITests.swift
@@ -210,11 +210,67 @@ final class TerminalCmdClickUITests: XCTestCase {
         )
     }
 
+    func testCmdClickRawLsStylePathPrefersPointSnapshotWhenViewportOffsetDisagrees() throws {
+        let app = launchApp(
+            displayMode: .raw,
+            captureOpenPaths: true,
+            captureHoverDiagnostics: false,
+            viewportOffsetDelta: 24
+        )
+        defer { app.terminate() }
+
+        let fileName = "Cmd Click Fixture.txt"
+        let setup = try waitForReadySetup()
+        let expectedPath = fixtureDirectoryURL.appendingPathComponent(fileName).path
+        let wrongViewportPath = fixtureDirectoryURL.appendingPathComponent("OtherFile").path
+
+        XCTAssertEqual(setup.expectedPath, expectedPath)
+
+        let result = try runCommand(action: "cmd_click_token")
+        XCTAssertEqual(
+            result["lastCommandSucceeded"] as? String,
+            "1",
+            "Expected cmd-click to prefer the click-point snapshot when viewport offsets disagree. result=\(result)"
+        )
+        XCTAssertEqual(
+            result["lastCommandOpenedPath"] as? String,
+            expectedPath,
+            "Expected cmd-click to keep the clicked raw-space path when viewport offsets disagree. result=\(result)"
+        )
+        if let lastCommandResult = result["lastCommandResult"] as? [String: Any] {
+            XCTAssertEqual(
+                lastCommandResult["resolutionSource"] as? String,
+                "snapshot",
+                "Expected disagreement cases to resolve through the click-point snapshot. result=\(result)"
+            )
+            XCTAssertEqual(
+                lastCommandResult["rawToken"] as? String,
+                fileName,
+                "Expected disagreement cases to keep the clicked raw token. result=\(result)"
+            )
+        }
+
+        guard let openedPaths = waitForCapturedOpenPaths(timeout: 5.0) else {
+            XCTFail("Expected cmd-click capture log after forcing a viewport mismatch. result=\(result)")
+            return
+        }
+
+        XCTAssertTrue(
+            openedPaths.contains(expectedPath),
+            "Expected cmd-click to open the clicked raw-space path. opened=\(openedPaths) expected=\(expectedPath)"
+        )
+        XCTAssertFalse(
+            openedPaths.contains(wrongViewportPath),
+            "Expected cmd-click to reject the mismatched viewport path. opened=\(openedPaths) wrong=\(wrongViewportPath)"
+        )
+    }
+
     private func launchApp(
         displayMode: DisplayMode = .escaped,
         captureOpenPaths: Bool,
         captureHoverDiagnostics: Bool,
-        quicklookOverride: String? = nil
+        quicklookOverride: String? = nil,
+        viewportOffsetDelta: Int? = nil
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_TAG"] = "ui-test-terminal-cmd-click"
@@ -233,6 +289,9 @@ final class TerminalCmdClickUITests: XCTestCase {
         }
         if let quicklookOverride {
             app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_QUICKLOOK_OVERRIDE"] = quicklookOverride
+        }
+        if let viewportOffsetDelta {
+            app.launchEnvironment["CMUX_UI_TEST_TERMINAL_CMD_CLICK_VIEWPORT_OFFSET_DELTA"] = String(viewportOffsetDelta)
         }
         launchAndEnsureForeground(app)
         return app


### PR DESCRIPTION
## Summary
- suppress command-modified hover refresh when the terminal already has an active text selection
- disable cmux's extra bare-path hover cursor in that selected state so holding Cmd does not add visual interference
- keep normal Cmd key handling and Cmd+click behavior unchanged when there is no selection

## Testing
- Not run locally per repo policy
- Built tagged dev app via `./scripts/reload.sh --tag cmd-hold-highlight --launch`
- Rebuilt tagged dev app via `./scripts/reload.sh --tag cmd-hold-highlight`

Fixes #2577

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Cmd-hover link/path highlighting and the hand cursor while a text selection is active; behavior without a selection is unchanged (fixes #2577). Improves Cmd-click path opening by resolving escaped/quoted/raw-space filenames with unquoting/unescaping, tilde/CWD expansion, and preferring the click-point snapshot path when quicklook or viewport offsets disagree.

- **Tests**
  - Added `TerminalCmdClickUITests` and a harness to simulate selection and cmd-hover/click, and to capture opened paths and hover diagnostics.
  - Verifies hover suppression during selection; cmd-click opening for escaped/raw-space paths in the CWD; and mismatch cases that prefer the snapshot path (quicklook and viewport-offset).
  - Adds a logged-path cmd-click regression matrix across grid, log, and alt-screen output; strengthens ls cell coverage.

<sup>Written for commit 641f1159e932a00645847736cf500b0bb45f602d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI-test harness and capture mechanisms to record open-paths and hover diagnostics and simulate cmd-hover/click interactions.

* **Bug Fixes**
  * Cmd-hover and pointing-hand cursor are suppressed correctly during active text selection.
  * Cmd-click now resolves escaped/quoted paths (including spaces) before opening.

* **Refactor**
  * Improved modifier-handling and a two-stage path-resolution flow for hover/click interactions.

* **Tests**
  * New UI tests validating hover-suppression and cmd-click path-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->