### PR TITLE
Fix sidebar PR status polling rate limits

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -190,6 +190,8 @@ _CMUX_PR_POLL_INTERVAL="${_CMUX_PR_POLL_INTERVAL:-45}"
 _CMUX_PR_FORCE="${_CMUX_PR_FORCE:-0}"
 _CMUX_PR_DEBUG="${_CMUX_PR_DEBUG:-0}"
 _CMUX_ASYNC_JOB_TIMEOUT="${_CMUX_ASYNC_JOB_TIMEOUT:-20}"
+_CMUX_LAST_PR_ACTION="${_CMUX_LAST_PR_ACTION:-}"
+_CMUX_LAST_PR_TARGET="${_CMUX_LAST_PR_TARGET:-}"
 
 _CMUX_PORTS_LAST_RUN="${_CMUX_PORTS_LAST_RUN:-0}"
 _CMUX_SHELL_ACTIVITY_LAST="${_CMUX_SHELL_ACTIVITY_LAST:-}"
@@ -428,6 +430,95 @@ _cmux_clear_pr_for_panel() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     # Synchronous: must arrive before the next report_pr from the poll loop.
     _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+}
+
+_cmux_record_pr_command_hint() {
+    local cmd="$1"
+    _CMUX_LAST_PR_ACTION=""
+    _CMUX_LAST_PR_TARGET=""
+
+    local -a words=()
+    read -r -a words <<< "$cmd"
+
+    local index=0
+    local word base
+    while (( index < ${#words[@]} )); do
+        word="${words[index]}"
+
+        case "$word" in
+            *=*)
+                index=$(( index + 1 ))
+                continue ;;
+            exec|command|builtin|noglob|time)
+                index=$(( index + 1 ))
+                continue ;;
+            env)
+                index=$(( index + 1 ))
+                while (( index < ${#words[@]} )); do
+                    word="${words[index]}"
+                    case "$word" in
+                        -*|*=*)
+                            index=$(( index + 1 ))
+                            continue ;;
+                    esac
+                    break
+                done
+                continue ;;
+        esac
+
+        base="${word##*/}"
+        [[ "$base" == "gh" ]] || return 0
+        index=$(( index + 1 ))
+        break
+    done
+
+    (( index + 1 < ${#words[@]} )) || return 0
+    [[ "${words[index]}" == "pr" ]] || return 0
+    local action="${words[index + 1]}"
+    action="$(printf '%s' "$action" | tr '[:upper:]' '[:lower:]')"
+    case "$action" in
+        merge|close|reopen|create|checkout|ready|edit|view)
+            _CMUX_LAST_PR_ACTION="$action" ;;
+        *)
+            return 0 ;;
+    esac
+
+    index=$(( index + 2 ))
+    while (( index < ${#words[@]} )); do
+        word="${words[index]}"
+        case "$word" in
+            --*=*)
+                index=$(( index + 1 ))
+                continue ;;
+            --*)
+                index=$(( index + 2 ))
+                continue ;;
+            -*)
+                index=$(( index + 1 ))
+                continue ;;
+            *)
+                _CMUX_LAST_PR_TARGET="$word"
+                break ;;
+        esac
+    done
+}
+
+_cmux_emit_pr_command_hint() {
+    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+    [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    [[ -n "$_CMUX_LAST_PR_ACTION" ]] || return 0
+
+    local payload="report_pr_action $_CMUX_LAST_PR_ACTION --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    if [[ -n "$_CMUX_LAST_PR_TARGET" ]]; then
+        local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
+        payload+=" --target=\"$quoted_target\""
+    fi
+    {
+        _cmux_send "$payload"
+    } >/dev/null 2>&1 & disown
+    _CMUX_LAST_PR_ACTION=""
+    _CMUX_LAST_PR_TARGET=""
 }
 
 _cmux_pr_output_indicates_no_pull_request() {
@@ -833,6 +924,7 @@ _cmux_preexec_command() {
     _cmux_socket_is_unix && cmux_has_unix_socket=1
     (( cmux_has_unix_socket )) || _cmux_has_port_scan_transport || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
+    _cmux_record_pr_command_hint "$cmd"
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t
@@ -855,6 +947,7 @@ _cmux_bash_preexec_hook() {
 }
 
 _cmux_prompt_command() {
+    local last_status=$?
     _cmux_tmux_sync_cmux_environment
 
     local cmux_has_unix_socket=0
@@ -977,41 +1070,15 @@ _cmux_prompt_command() {
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 
-    # Pull request metadata is remote state. Keep polling while the shell sits
-    # at a prompt so newly created or merged PRs appear without another command.
-    local should_restart_pr_poll=0
-    local should_signal_pr_probe=0
-    local pr_context_changed=0
-    if [[ -n "$_CMUX_PR_POLL_PWD" && "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
-        pr_context_changed=1
-    elif [[ "$git_head_changed" == "1" ]]; then
-        pr_context_changed=1
-    fi
-    if [[ "$pwd" != "$_CMUX_PR_POLL_PWD" || "$git_head_changed" == "1" ]]; then
-        should_restart_pr_poll=1
-    elif (( _CMUX_PR_FORCE )); then
-        if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-            should_signal_pr_probe=1
-        else
-            should_restart_pr_poll=1
-        fi
-    elif [[ -z "$_CMUX_PR_POLL_PID" ]] || ! kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        should_restart_pr_poll=1
-    fi
-
-    if (( pr_context_changed )); then
+    if [[ "$git_head_changed" == "1" ]]; then
         _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
     fi
-
-    if (( should_signal_pr_probe )); then
-        _CMUX_PR_FORCE=0
-        _cmux_pr_request_probe
-    fi
-
-    if (( should_restart_pr_poll )); then
-        _CMUX_PR_FORCE=0
-        _cmux_start_pr_poll_loop "$pwd" 1
+    if (( last_status == 0 )); then
+        _cmux_emit_pr_command_hint
+    else
+        _CMUX_LAST_PR_ACTION=""
+        _CMUX_LAST_PR_TARGET=""
     fi
 
     # Ports: lightweight kick to the app's batched scanner every ~10s.

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -193,6 +193,8 @@ typeset -g _CMUX_PR_POLL_INTERVAL=45
 typeset -g _CMUX_PR_FORCE=0
 typeset -g _CMUX_PR_DEBUG=${_CMUX_PR_DEBUG:-0}
 typeset -g _CMUX_ASYNC_JOB_TIMEOUT=20
+typeset -g _CMUX_LAST_PR_ACTION=""
+typeset -g _CMUX_LAST_PR_TARGET=""
 
 typeset -g _CMUX_PORTS_LAST_RUN=0
 typeset -g _CMUX_CMD_START=0
@@ -535,6 +537,92 @@ _cmux_report_git_branch_for_path() {
     else
         _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
     fi
+}
+
+_cmux_record_pr_command_hint() {
+    local cmd="$1"
+    _CMUX_LAST_PR_ACTION=""
+    _CMUX_LAST_PR_TARGET=""
+
+    local -a words
+    words=("${(z)cmd}")
+
+    local index=1
+    local word base
+    while (( index <= ${#words} )); do
+        word="${words[index]}"
+
+        case "$word" in
+            *=*)
+                index=$(( index + 1 ))
+                continue ;;
+            exec|command|builtin|noglob|time)
+                index=$(( index + 1 ))
+                continue ;;
+            env)
+                index=$(( index + 1 ))
+                while (( index <= ${#words} )); do
+                    word="${words[index]}"
+                    case "$word" in
+                        -*|*=*)
+                            index=$(( index + 1 ))
+                            continue ;;
+                    esac
+                    break
+                done
+                continue ;;
+        esac
+
+        base="${word:t}"
+        [[ "$base" == "gh" ]] || return 0
+        index=$(( index + 1 ))
+        break
+    done
+
+    (( index + 1 <= ${#words} )) || return 0
+    [[ "${words[index]}" == "pr" ]] || return 0
+    local action="${words[index + 1]:l}"
+    case "$action" in
+        merge|close|reopen|create|checkout|ready|edit|view)
+            _CMUX_LAST_PR_ACTION="$action" ;;
+        *)
+            return 0 ;;
+    esac
+
+    index=$(( index + 2 ))
+    while (( index <= ${#words} )); do
+        word="${words[index]}"
+        case "$word" in
+            --*=*)
+                index=$(( index + 1 ))
+                continue ;;
+            --*)
+                index=$(( index + 2 ))
+                continue ;;
+            -*)
+                index=$(( index + 1 ))
+                continue ;;
+            *)
+                _CMUX_LAST_PR_TARGET="$word"
+                break ;;
+        esac
+    done
+}
+
+_cmux_emit_pr_command_hint() {
+    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+    [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    [[ -n "$_CMUX_LAST_PR_ACTION" ]] || return 0
+
+    local payload="report_pr_action $_CMUX_LAST_PR_ACTION --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    if [[ -n "$_CMUX_LAST_PR_TARGET" ]]; then
+        local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
+        payload+=" --target=\"$quoted_target\""
+    fi
+    _cmux_send_bg "$payload"
+    _CMUX_LAST_PR_ACTION=""
+    _CMUX_LAST_PR_TARGET=""
 }
 
 _cmux_clear_pr_for_panel() {
@@ -919,11 +1007,6 @@ _cmux_start_git_head_watch() {
                 _cmux_pr_cache_clear
                 _cmux_report_git_branch_for_path "$watch_pwd"
                 _cmux_clear_pr_for_panel
-                if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-                    _cmux_pr_request_probe
-                else
-                    _cmux_run_pr_probe_with_timeout "$watch_pwd" 1 || true
-                fi
             fi
         done
     } >/dev/null 2>&1 &!
@@ -982,6 +1065,7 @@ _cmux_command_starts_nested_shell() {
 
 _cmux_preexec() {
     _cmux_tmux_sync_cmux_environment
+    local cmd="${1## }"
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t
@@ -992,9 +1076,9 @@ _cmux_preexec() {
 
     _CMUX_CMD_START="$(_cmux_now)"
     _cmux_report_shell_activity_state running
+    _cmux_record_pr_command_hint "$cmd"
 
     # Heuristic: commands that may change git branch/dirty state without changing $PWD.
-    local cmd="${1## }"
     case "$cmd" in
         git\ *|git|gh\ *|lazygit|lazygit\ *|tig|tig\ *|gitui|gitui\ *|stg\ *|jj\ *)
             _CMUX_GIT_FORCE=1
@@ -1013,6 +1097,7 @@ _cmux_preexec() {
 }
 
 _cmux_precmd() {
+    local last_status=$?
     _cmux_stop_git_head_watch
     _cmux_tmux_sync_cmux_environment
 
@@ -1148,43 +1233,15 @@ _cmux_precmd() {
             _CMUX_GIT_JOB_STARTED_AT=$now
         fi
     fi
-
-    # Pull request metadata is remote state. Keep a lightweight background poll
-    # alive while the shell is idle so gh-created PRs and merge status changes
-    # appear even without another prompt.
-    local should_restart_pr_poll=0
-    local should_signal_pr_probe=0
-    local pr_context_changed=0
-    if [[ -n "$_CMUX_PR_POLL_PWD" && "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
-        pr_context_changed=1
-    elif (( git_head_changed )); then
-        pr_context_changed=1
-    fi
-    if [[ "$pwd" != "$_CMUX_PR_POLL_PWD" ]]; then
-        should_restart_pr_poll=1
-    elif (( _CMUX_PR_FORCE )); then
-        if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-            should_signal_pr_probe=1
-        else
-            should_restart_pr_poll=1
-        fi
-    elif [[ -z "$_CMUX_PR_POLL_PID" ]] || ! kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        should_restart_pr_poll=1
-    fi
-
-    if (( pr_context_changed )); then
+    if (( git_head_changed )); then
         _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
     fi
-
-    if (( should_signal_pr_probe )); then
-        _CMUX_PR_FORCE=0
-        _cmux_pr_request_probe
-    fi
-
-    if (( should_restart_pr_poll )); then
-        _CMUX_PR_FORCE=0
-        _cmux_start_pr_poll_loop "$pwd" 1
+    if (( last_status == 0 )); then
+        _cmux_emit_pr_command_hint
+    else
+        _CMUX_LAST_PR_ACTION=""
+        _CMUX_LAST_PR_TARGET=""
     fi
 
     # Ports: lightweight kick to the app's batched scanner.

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -9,6 +9,570 @@ import Combine
 // The old Tab class is replaced by Workspace
 typealias Tab = Workspace
 
+private actor GitHubPullRequestRESTPoller {
+    struct Candidate: Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+        let branch: String
+        let repoSlugs: [String]
+        let currentPullRequest: CurrentPullRequest?
+    }
+
+    struct CurrentPullRequest: Sendable {
+        let number: Int
+        let urlString: String
+        let repoSlug: String?
+        let statusRawValue: String
+        let branch: String?
+        let checksRawValue: String?
+    }
+
+    struct RefreshResult: Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+        let resolution: Resolution
+    }
+
+    enum Resolution: Sendable {
+        case unsupportedRepository
+        case notFound
+        case resolved(ResolvedPullRequest)
+        case transientFailure
+    }
+
+    struct ResolvedPullRequest: Sendable {
+        let number: Int
+        let urlString: String
+        let statusRawValue: String
+        let branch: String?
+        let checksRawValue: String?
+    }
+
+    private struct WorkspacePanelKey: Hashable, Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+    }
+
+    private struct PullRequestKey: Hashable, Sendable {
+        let repoSlug: String
+        let number: Int
+    }
+
+    private struct CachedValue<Payload: Sendable>: Sendable {
+        let etag: String?
+        let payload: Payload
+    }
+
+    private struct HTTPResponse: Sendable {
+        let statusCode: Int
+        let data: Data
+        let etag: String?
+        let rateLimitResetAt: Date?
+    }
+
+    private enum RepoLookupResult: Sendable {
+        case success([OpenPullRequest])
+        case transientFailure
+    }
+
+    private struct OpenPullRequest: Decodable, Sendable {
+        struct PullHead: Decodable, Sendable {
+            let ref: String
+        }
+
+        let number: Int
+        let state: String
+        let htmlURL: String
+        let updatedAt: String?
+        let head: PullHead
+
+        enum CodingKeys: String, CodingKey {
+            case number
+            case state
+            case htmlURL = "html_url"
+            case updatedAt = "updated_at"
+            case head
+        }
+    }
+
+    private struct PullRequestDetail: Decodable, Sendable {
+        let number: Int
+        let state: String
+        let htmlURL: String
+        let mergedAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case number
+            case state
+            case htmlURL = "html_url"
+            case mergedAt = "merged_at"
+        }
+    }
+
+    private let session: URLSession
+    private var authToken: String?
+    private var attemptedAuthTokenLookup = false
+    private var openPullRequestCacheByRepo: [String: CachedValue<[OpenPullRequest]>] = [:]
+    private var pullRequestDetailCacheByKey: [PullRequestKey: CachedValue<PullRequestDetail>] = [:]
+    private var resourceBackoffUntil: [String: Date] = [:]
+
+    init() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 8
+        configuration.timeoutIntervalForResource = 8
+        session = URLSession(configuration: configuration)
+    }
+
+    func refresh(candidates: [Candidate]) async -> [RefreshResult] {
+        guard !candidates.isEmpty else { return [] }
+
+        let repoSlugs = Set(candidates.flatMap(\.repoSlugs))
+        let repoResults = await fetchOpenPullRequests(repoSlugs: repoSlugs)
+
+        var resultsByKey: [WorkspacePanelKey: Resolution] = [:]
+        var pendingDetailLookups: [WorkspacePanelKey: PullRequestKey] = [:]
+        var detailTargets: Set<PullRequestKey> = []
+        var detailNeedsByKey: [WorkspacePanelKey: Bool] = [:]
+
+        for candidate in candidates {
+            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
+            guard !candidate.repoSlugs.isEmpty else {
+                resultsByKey[key] = .unsupportedRepository
+                continue
+            }
+
+            var sawTransientFailure = false
+            var resolvedOpenPullRequest: OpenPullRequest?
+
+            for repoSlug in candidate.repoSlugs {
+                guard let repoResult = repoResults[repoSlug] else { continue }
+                switch repoResult {
+                case .success(let pullRequests):
+                    let matchingPullRequests = pullRequests.filter {
+                        $0.head.ref.trimmingCharacters(in: .whitespacesAndNewlines) == candidate.branch
+                    }
+                    if let preferred = Self.preferredOpenPullRequest(from: matchingPullRequests) {
+                        resolvedOpenPullRequest = preferred
+                        break
+                    }
+                case .transientFailure:
+                    sawTransientFailure = true
+                }
+            }
+
+            if let resolvedOpenPullRequest,
+               let resolved = Self.resolvedPullRequest(from: resolvedOpenPullRequest, branch: candidate.branch) {
+                resultsByKey[key] = .resolved(resolved)
+                continue
+            }
+
+            if let currentPullRequest = candidate.currentPullRequest {
+                switch currentPullRequest.statusRawValue {
+                case SidebarPullRequestStatus.open.rawValue:
+                    if let repoSlug = currentPullRequest.repoSlug {
+                        let detailKey = PullRequestKey(repoSlug: repoSlug, number: currentPullRequest.number)
+                        pendingDetailLookups[key] = detailKey
+                        detailTargets.insert(detailKey)
+                        detailNeedsByKey[key] = sawTransientFailure
+                        continue
+                    }
+                    resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
+                case SidebarPullRequestStatus.merged.rawValue,
+                     SidebarPullRequestStatus.closed.rawValue:
+                    resultsByKey[key] = .resolved(
+                        ResolvedPullRequest(
+                            number: currentPullRequest.number,
+                            urlString: currentPullRequest.urlString,
+                            statusRawValue: currentPullRequest.statusRawValue,
+                            branch: currentPullRequest.branch ?? candidate.branch,
+                            checksRawValue: currentPullRequest.checksRawValue
+                        )
+                    )
+                default:
+                    resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
+                }
+                continue
+            }
+
+            resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
+        }
+
+        let detailResults = await fetchPullRequestDetails(keys: detailTargets)
+
+        for candidate in candidates {
+            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
+            guard let detailKey = pendingDetailLookups[key] else { continue }
+            guard let detail = detailResults[detailKey] ?? nil else {
+                let needsTransientFailure = detailNeedsByKey[key] ?? false
+                resultsByKey[key] = needsTransientFailure ? .transientFailure : .notFound
+                continue
+            }
+
+            guard let statusRawValue = Self.pullRequestStatusRawValue(
+                from: detail.state,
+                mergedAt: detail.mergedAt
+            ) else {
+                let needsTransientFailure = detailNeedsByKey[key] ?? false
+                resultsByKey[key] = needsTransientFailure ? .transientFailure : .notFound
+                continue
+            }
+
+            resultsByKey[key] = .resolved(
+                ResolvedPullRequest(
+                    number: detail.number,
+                    urlString: detail.htmlURL,
+                    statusRawValue: statusRawValue,
+                    branch: candidate.branch,
+                    checksRawValue: nil
+                )
+            )
+        }
+
+        return candidates.map { candidate in
+            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
+            return RefreshResult(
+                workspaceId: candidate.workspaceId,
+                panelId: candidate.panelId,
+                resolution: resultsByKey[key] ?? .notFound
+            )
+        }
+    }
+
+    private struct OpenPullRequestFetchPlan: Sendable {
+        let repoSlug: String
+        let resourceKey: String
+        let cached: CachedValue<[OpenPullRequest]>?
+    }
+
+    private struct PullRequestDetailFetchPlan: Sendable {
+        let key: PullRequestKey
+        let resourceKey: String
+        let cached: CachedValue<PullRequestDetail>?
+    }
+
+    private func fetchOpenPullRequests(
+        repoSlugs: Set<String>
+    ) async -> [String: RepoLookupResult] {
+        let now = Date()
+        var results: [String: RepoLookupResult] = [:]
+        var plansByRepo: [String: OpenPullRequestFetchPlan] = [:]
+
+        for repoSlug in repoSlugs {
+            let resourceKey = "open:\(repoSlug)"
+            if let backoffUntil = resourceBackoffUntil[resourceKey],
+               backoffUntil > now {
+                if let cached = openPullRequestCacheByRepo[repoSlug] {
+                    results[repoSlug] = .success(cached.payload)
+                } else {
+                    results[repoSlug] = .transientFailure
+                }
+                continue
+            }
+
+            plansByRepo[repoSlug] = OpenPullRequestFetchPlan(
+                repoSlug: repoSlug,
+                resourceKey: resourceKey,
+                cached: openPullRequestCacheByRepo[repoSlug]
+            )
+        }
+
+        guard !plansByRepo.isEmpty else { return results }
+
+        let authHeader = authHeaderValue()
+        let session = self.session
+        let responses = await withTaskGroup(
+            of: (String, RequestResult).self,
+            returning: [(String, RequestResult)].self
+        ) { group in
+            for plan in plansByRepo.values {
+                let endpoint = "repos/\(plan.repoSlug)/pulls?state=open&sort=updated&direction=desc&per_page=100"
+                group.addTask {
+                    let response = await Self.performRequest(
+                        session: session,
+                        endpoint: endpoint,
+                        ifNoneMatch: plan.cached?.etag,
+                        authHeader: authHeader
+                    )
+                    return (plan.repoSlug, response)
+                }
+            }
+
+            var collected: [(String, RequestResult)] = []
+            for await response in group {
+                collected.append(response)
+            }
+            return collected
+        }
+
+        for (repoSlug, response) in responses {
+            guard let plan = plansByRepo[repoSlug] else { continue }
+            switch response {
+            case .success(let httpResponse):
+                switch httpResponse.statusCode {
+                case 200:
+                    guard let pullRequests = Self.decodeJSON([OpenPullRequest].self, from: httpResponse.data) else {
+                        results[repoSlug] = .transientFailure
+                        continue
+                    }
+                    openPullRequestCacheByRepo[repoSlug] = CachedValue(
+                        etag: httpResponse.etag,
+                        payload: pullRequests
+                    )
+                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
+                    results[repoSlug] = .success(pullRequests)
+                case 304:
+                    if let cached = plan.cached {
+                        resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
+                        results[repoSlug] = .success(cached.payload)
+                    } else {
+                        results[repoSlug] = .transientFailure
+                    }
+                default:
+                    if let resetAt = httpResponse.rateLimitResetAt {
+                        resourceBackoffUntil[plan.resourceKey] = resetAt
+                    }
+                    if let cached = plan.cached {
+                        results[repoSlug] = .success(cached.payload)
+                    } else {
+                        results[repoSlug] = .transientFailure
+                    }
+                }
+            case .failure:
+                if let cached = plan.cached {
+                    results[repoSlug] = .success(cached.payload)
+                } else {
+                    results[repoSlug] = .transientFailure
+                }
+            }
+        }
+
+        return results
+    }
+
+    private func fetchPullRequestDetails(
+        keys: Set<PullRequestKey>
+    ) async -> [PullRequestKey: PullRequestDetail?] {
+        let now = Date()
+        var results: [PullRequestKey: PullRequestDetail?] = [:]
+        var plansByKey: [PullRequestKey: PullRequestDetailFetchPlan] = [:]
+
+        for key in keys {
+            let resourceKey = "detail:\(key.repoSlug)#\(key.number)"
+            if let backoffUntil = resourceBackoffUntil[resourceKey],
+               backoffUntil > now {
+                results[key] = pullRequestDetailCacheByKey[key]?.payload
+                continue
+            }
+
+            plansByKey[key] = PullRequestDetailFetchPlan(
+                key: key,
+                resourceKey: resourceKey,
+                cached: pullRequestDetailCacheByKey[key]
+            )
+        }
+
+        guard !plansByKey.isEmpty else { return results }
+
+        let authHeader = authHeaderValue()
+        let session = self.session
+        let responses = await withTaskGroup(
+            of: (PullRequestKey, RequestResult).self,
+            returning: [(PullRequestKey, RequestResult)].self
+        ) { group in
+            for plan in plansByKey.values {
+                let endpoint = "repos/\(plan.key.repoSlug)/pulls/\(plan.key.number)"
+                group.addTask {
+                    let response = await Self.performRequest(
+                        session: session,
+                        endpoint: endpoint,
+                        ifNoneMatch: plan.cached?.etag,
+                        authHeader: authHeader
+                    )
+                    return (plan.key, response)
+                }
+            }
+
+            var collected: [(PullRequestKey, RequestResult)] = []
+            for await response in group {
+                collected.append(response)
+            }
+            return collected
+        }
+
+        for (key, response) in responses {
+            guard let plan = plansByKey[key] else { continue }
+            switch response {
+            case .success(let httpResponse):
+                switch httpResponse.statusCode {
+                case 200:
+                    guard let detail = Self.decodeJSON(PullRequestDetail.self, from: httpResponse.data) else {
+                        results[key] = nil
+                        continue
+                    }
+                    pullRequestDetailCacheByKey[key] = CachedValue(
+                        etag: httpResponse.etag,
+                        payload: detail
+                    )
+                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
+                    results[key] = detail
+                case 304:
+                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
+                    results[key] = plan.cached?.payload
+                default:
+                    if let resetAt = httpResponse.rateLimitResetAt {
+                        resourceBackoffUntil[plan.resourceKey] = resetAt
+                    }
+                    results[key] = plan.cached?.payload
+                }
+            case .failure:
+                results[key] = plan.cached?.payload
+            }
+        }
+
+        return results
+    }
+
+    private enum RequestResult: Sendable {
+        case success(HTTPResponse)
+        case failure
+    }
+
+    private nonisolated static func performRequest(
+        session: URLSession,
+        endpoint: String,
+        ifNoneMatch: String?,
+        authHeader: String?
+    ) async -> RequestResult {
+        guard let url = URL(string: "https://api.github.com/\(endpoint)") else {
+            return .failure
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("cmux-sidebar-pr-poller", forHTTPHeaderField: "User-Agent")
+        if let ifNoneMatch, !ifNoneMatch.isEmpty {
+            request.setValue(ifNoneMatch, forHTTPHeaderField: "If-None-Match")
+        }
+        if let authHeader {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .failure
+            }
+            return .success(
+                HTTPResponse(
+                    statusCode: httpResponse.statusCode,
+                    data: data,
+                    etag: httpResponse.value(forHTTPHeaderField: "ETag"),
+                    rateLimitResetAt: Self.rateLimitResetDate(from: httpResponse)
+                )
+            )
+        } catch {
+            return .failure
+        }
+    }
+
+    private func authHeaderValue() -> String? {
+        if let token = authToken, !token.isEmpty {
+            return "Bearer \(token)"
+        }
+        guard !attemptedAuthTokenLookup else { return nil }
+        attemptedAuthTokenLookup = true
+
+        let environment = ProcessInfo.processInfo.environment
+        if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
+            let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                authToken = trimmed
+                return "Bearer \(trimmed)"
+            }
+        }
+
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["gh", "auth", "token"]
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let tokenData = stdout.fileHandleForReading.readDataToEndOfFile()
+            let token = String(data: tokenData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !token.isEmpty else { return nil }
+            authToken = token
+            return "Bearer \(token)"
+        } catch {
+            return nil
+        }
+    }
+
+    private static func decodeJSON<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
+        try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func rateLimitResetDate(from response: HTTPURLResponse) -> Date? {
+        guard response.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0",
+              let resetValue = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
+              let resetInterval = TimeInterval(resetValue) else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: resetInterval)
+    }
+
+    private static func preferredOpenPullRequest(
+        from pullRequests: [OpenPullRequest]
+    ) -> OpenPullRequest? {
+        pullRequests.max { lhs, rhs in
+            let lhsUpdatedAt = lhs.updatedAt ?? ""
+            let rhsUpdatedAt = rhs.updatedAt ?? ""
+            if lhsUpdatedAt != rhsUpdatedAt {
+                return lhsUpdatedAt < rhsUpdatedAt
+            }
+            return lhs.number < rhs.number
+        }
+    }
+
+    private static func resolvedPullRequest(
+        from pullRequest: OpenPullRequest,
+        branch: String
+    ) -> ResolvedPullRequest? {
+        guard let statusRawValue = pullRequestStatusRawValue(from: pullRequest.state, mergedAt: nil) else {
+            return nil
+        }
+        return ResolvedPullRequest(
+            number: pullRequest.number,
+            urlString: pullRequest.htmlURL,
+            statusRawValue: statusRawValue,
+            branch: branch,
+            checksRawValue: nil
+        )
+    }
+
+    private static func pullRequestStatusRawValue(
+        from rawState: String,
+        mergedAt: String?
+    ) -> String? {
+        switch rawState.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "OPEN":
+            return SidebarPullRequestStatus.open.rawValue
+        case "CLOSED":
+            return (mergedAt?.isEmpty == false)
+                ? SidebarPullRequestStatus.merged.rawValue
+                : SidebarPullRequestStatus.closed.rawValue
+        default:
+            return nil
+        }
+    }
+}
+
 enum NewWorkspacePlacement: String, CaseIterable, Identifiable {
     case top
     case afterCurrent
@@ -716,6 +1280,7 @@ fileprivate func cmuxVsyncIOSurfaceTimelineCallback(
 @MainActor
 class TabManager: ObservableObject {
     private enum WorkspacePullRequestSnapshot: Equatable {
+        case deferred
         case unsupportedRepository
         case notFound
         case resolved(SidebarPullRequestState)
@@ -768,6 +1333,11 @@ class TabManager: ObservableObject {
     private static let initialWorkspaceGitProbeDelays: [TimeInterval] = [0, 0.5, 1.5, 3.0, 6.0, 10.0]
     private static let workspaceGitMetadataPollInterval: TimeInterval = 30
     private static let selectedWorkspaceGitMetadataPollInterval: TimeInterval = 5
+    private static let workspacePullRequestPollTickInterval: TimeInterval = 5
+    private static let workspacePullRequestIdlePollInterval: TimeInterval = 60
+    private static let selectedWorkspacePullRequestIdlePollInterval: TimeInterval = 15
+    private static let workspacePullRequestBurstPollInterval: TimeInterval = 5
+    private static let workspacePullRequestBurstDuration: TimeInterval = 30
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
     @Published var selectedTabId: UUID? {
         willSet {
@@ -855,9 +1425,14 @@ class TabManager: ObservableObject {
         label: "com.cmux.initial-workspace-git-probe",
         qos: .utility
     )
+    private let workspacePullRequestRESTPoller = GitHubPullRequestRESTPoller()
     private var workspaceGitProbeGenerationByKey: [WorkspaceGitProbeKey: UUID] = [:]
     private var workspaceGitProbeTimersByKey: [WorkspaceGitProbeKey: [DispatchSourceTimer]] = [:]
     private var workspaceGitTrackedDirectoryByKey: [WorkspaceGitProbeKey: String] = [:]
+    private var workspacePullRequestNextPollAtByKey: [WorkspaceGitProbeKey: Date] = [:]
+    private var workspacePullRequestBurstUntilByKey: [WorkspaceGitProbeKey: Date] = [:]
+    private var workspacePullRequestPollTimer: DispatchSourceTimer?
+    private var workspacePullRequestRefreshTask: Task<Void, Never>?
 
     // Recent tab history for back/forward navigation (like browser history)
     private var tabHistory: [UUID] = []
@@ -939,6 +1514,7 @@ class TabManager: ObservableObject {
         startAgentPIDSweepTimer()
         startWorkspaceGitMetadataPollTimer()
         startSelectedWorkspaceGitMetadataPollTimer()
+        startWorkspacePullRequestPollTimer()
 #if DEBUG
         setupUITestFocusShortcutsIfNeeded()
         setupSplitCloseRightUITestIfNeeded()
@@ -952,6 +1528,8 @@ class TabManager: ObservableObject {
         agentPIDSweepTimer?.cancel()
         workspaceGitMetadataPollTimer?.cancel()
         selectedWorkspaceGitMetadataPollTimer?.cancel()
+        workspacePullRequestPollTimer?.cancel()
+        workspacePullRequestRefreshTask?.cancel()
     }
 
     // MARK: - Agent PID Sweep
@@ -1009,6 +1587,20 @@ class TabManager: ObservableObject {
         selectedWorkspaceGitMetadataPollTimer = timer
     }
 
+    private func startWorkspacePullRequestPollTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        let interval = Self.workspacePullRequestPollTickInterval
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            DispatchQueue.main.async { [weak self] in
+                self?.refreshTrackedWorkspacePullRequestsIfNeeded(reason: "timer")
+            }
+        }
+        timer.resume()
+        workspacePullRequestPollTimer = timer
+    }
+
     private func refreshTrackedWorkspaceGitMetadata() {
         let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
 
@@ -1044,6 +1636,233 @@ class TabManager: ObservableObject {
             panelId: focusedPanelId,
             reason: "selectedPeriodicPoll"
         )
+
+        scheduleWorkspacePullRequestRefresh(
+            workspaceId: workspace.id,
+            panelId: focusedPanelId,
+            reason: "selectedPeriodicPoll",
+            burst: false
+        )
+    }
+
+    private func refreshTrackedWorkspacePullRequestsIfNeeded(reason: String) {
+        guard workspacePullRequestRefreshTask == nil else { return }
+
+        let now = Date()
+        var candidates: [GitHubPullRequestRESTPoller.Candidate] = []
+        var requestedKeys: [WorkspaceGitProbeKey] = []
+        var validKeys: Set<WorkspaceGitProbeKey> = []
+
+        for workspace in tabs {
+            for panelId in Set(workspace.panelGitBranches.keys).union(workspace.panelPullRequests.keys) {
+                let key = WorkspaceGitProbeKey(workspaceId: workspace.id, panelId: panelId)
+                validKeys.insert(key)
+                guard shouldRefreshWorkspacePullRequest(key: key, now: now) else { continue }
+                guard let candidate = workspacePullRequestCandidate(
+                    workspace: workspace,
+                    panelId: panelId
+                ) else {
+                    continue
+                }
+                candidates.append(candidate)
+                requestedKeys.append(key)
+            }
+        }
+
+        pruneWorkspacePullRequestTracking(validKeys: validKeys)
+        guard !candidates.isEmpty else { return }
+
+        let poller = workspacePullRequestRESTPoller
+        workspacePullRequestRefreshTask = Task { [weak self] in
+            let results = await poller.refresh(candidates: candidates)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.workspacePullRequestRefreshTask = nil
+                self.applyWorkspacePullRequestRefreshResults(
+                    results,
+                    requestedKeys: requestedKeys,
+                    now: Date(),
+                    reason: reason
+                )
+            }
+        }
+    }
+
+    private func shouldRefreshWorkspacePullRequest(
+        key: WorkspaceGitProbeKey,
+        now: Date
+    ) -> Bool {
+        let nextPollAt = workspacePullRequestNextPollAtByKey[key] ?? .distantPast
+        return nextPollAt <= now
+    }
+
+    private func workspacePullRequestCandidate(
+        workspace: Workspace,
+        panelId: UUID
+    ) -> GitHubPullRequestRESTPoller.Candidate? {
+        let branch = Self.normalizedBranchName(
+            workspace.panelGitBranches[panelId]?.branch
+                ?? workspace.panelPullRequests[panelId]?.branch
+        )
+        guard let branch, !Self.shouldSkipWorkspacePullRequestLookup(branch: branch) else {
+            return nil
+        }
+
+        let directory = gitProbeDirectory(for: workspace, panelId: panelId)
+        let repoSlugs = directory.map(Self.githubRepositorySlugs(directory:)) ?? []
+        let currentPullRequest = workspace.panelPullRequests[panelId].map {
+            GitHubPullRequestRESTPoller.CurrentPullRequest(
+                number: $0.number,
+                urlString: $0.url.absoluteString,
+                repoSlug: Self.githubRepositorySlug(fromPullRequestURL: $0.url),
+                statusRawValue: $0.status.rawValue,
+                branch: $0.branch,
+                checksRawValue: $0.checks?.rawValue
+            )
+        }
+
+        return GitHubPullRequestRESTPoller.Candidate(
+            workspaceId: workspace.id,
+            panelId: panelId,
+            branch: branch,
+            repoSlugs: repoSlugs,
+            currentPullRequest: currentPullRequest
+        )
+    }
+
+    private func scheduleWorkspacePullRequestRefresh(
+        workspaceId: UUID,
+        panelId: UUID,
+        reason: String,
+        burst: Bool
+    ) {
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        workspacePullRequestNextPollAtByKey[key] = .distantPast
+        if burst {
+            let burstUntil = Date().addingTimeInterval(Self.workspacePullRequestBurstDuration)
+            let existingBurstUntil = workspacePullRequestBurstUntilByKey[key] ?? .distantPast
+            if burstUntil > existingBurstUntil {
+                workspacePullRequestBurstUntilByKey[key] = burstUntil
+            }
+        }
+#if DEBUG
+        dlog(
+            "workspace.prRefresh.schedule workspace=\(workspaceId.uuidString.prefix(5)) " +
+            "panel=\(panelId.uuidString.prefix(5)) reason=\(reason) burst=\(burst ? 1 : 0)"
+        )
+#endif
+        refreshTrackedWorkspacePullRequestsIfNeeded(reason: reason)
+    }
+
+    private func applyWorkspacePullRequestRefreshResults(
+        _ results: [GitHubPullRequestRESTPoller.RefreshResult],
+        requestedKeys: [WorkspaceGitProbeKey],
+        now: Date,
+        reason: String
+    ) {
+        let requestedKeySet = Set(requestedKeys)
+        for result in results {
+            let key = WorkspaceGitProbeKey(workspaceId: result.workspaceId, panelId: result.panelId)
+            guard requestedKeySet.contains(key),
+                  let workspace = tabs.first(where: { $0.id == result.workspaceId }),
+                  workspace.panels[result.panelId] != nil else {
+                continue
+            }
+
+            switch result.resolution {
+            case .resolved(let resolvedPullRequest):
+                guard let status = SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
+                      let url = URL(string: resolvedPullRequest.urlString) else {
+                    continue
+                }
+                workspace.updatePanelPullRequest(
+                    panelId: result.panelId,
+                    number: resolvedPullRequest.number,
+                    label: "PR",
+                    url: url,
+                    status: status,
+                    branch: resolvedPullRequest.branch,
+                    checks: resolvedPullRequest.checksRawValue.flatMap(SidebarPullRequestChecksStatus.init(rawValue:))
+                )
+            case .notFound:
+                if workspace.panelPullRequests[result.panelId] != nil {
+                    workspace.clearPanelPullRequest(panelId: result.panelId)
+                }
+            case .unsupportedRepository, .transientFailure:
+                break
+            }
+
+            scheduleNextWorkspacePullRequestPoll(
+                key: key,
+                workspace: workspace,
+                panelId: result.panelId,
+                now: now,
+                resolution: result.resolution
+            )
+
+#if DEBUG
+            let label: String = {
+                switch result.resolution {
+                case .unsupportedRepository:
+                    return "unsupported"
+                case .notFound:
+                    return "none"
+                case .transientFailure:
+                    return "transientFailure"
+                case .resolved(let resolvedPullRequest):
+                    return "#\(resolvedPullRequest.number):\(resolvedPullRequest.statusRawValue)"
+                }
+            }()
+            dlog(
+                "workspace.prRefresh.apply workspace=\(result.workspaceId.uuidString.prefix(5)) " +
+                "panel=\(result.panelId.uuidString.prefix(5)) result=\(label) reason=\(reason)"
+            )
+#endif
+        }
+    }
+
+    private func scheduleNextWorkspacePullRequestPoll(
+        key: WorkspaceGitProbeKey,
+        workspace: Workspace,
+        panelId: UUID,
+        now: Date,
+        resolution: GitHubPullRequestRESTPoller.Resolution
+    ) {
+        let isSelectedFocusedPanel = selectedWorkspace?.id == workspace.id
+            && selectedWorkspace?.focusedPanelId == panelId
+        let burstUntil = workspacePullRequestBurstUntilByKey[key]
+        let isBursting = (burstUntil ?? .distantPast) > now
+        let interval: TimeInterval
+
+        if isBursting {
+            interval = Self.workspacePullRequestBurstPollInterval
+        } else if case .transientFailure = resolution {
+            interval = Self.workspacePullRequestBurstPollInterval
+        } else if isSelectedFocusedPanel {
+            interval = Self.selectedWorkspacePullRequestIdlePollInterval
+        } else {
+            interval = Self.workspacePullRequestIdlePollInterval
+        }
+
+        workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(interval)
+        if !isBursting {
+            workspacePullRequestBurstUntilByKey.removeValue(forKey: key)
+        }
+    }
+
+    private func pruneWorkspacePullRequestTracking(validKeys: Set<WorkspaceGitProbeKey>) {
+        workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.filter { validKeys.contains($0.key) }
+        workspacePullRequestBurstUntilByKey = workspacePullRequestBurstUntilByKey.filter { validKeys.contains($0.key) }
+    }
+
+    private func clearWorkspacePullRequestTracking(for key: WorkspaceGitProbeKey) {
+        workspacePullRequestNextPollAtByKey.removeValue(forKey: key)
+        workspacePullRequestBurstUntilByKey.removeValue(forKey: key)
+    }
+
+    private func clearWorkspacePullRequestTracking(workspaceId: UUID) {
+        workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestBurstUntilByKey = workspacePullRequestBurstUntilByKey.filter { $0.key.workspaceId != workspaceId }
     }
 
     func refreshTrackedWorkspaceGitMetadataForTesting() {
@@ -1572,6 +2391,7 @@ class TabManager: ObservableObject {
         workspaceGitTrackedDirectoryByKey = workspaceGitTrackedDirectoryByKey.filter { key, _ in
             key.workspaceId != workspaceId
         }
+        clearWorkspacePullRequestTracking(workspaceId: workspaceId)
     }
 
     private func applyWorkspaceGitMetadataSnapshot(
@@ -1652,14 +2472,25 @@ class TabManager: ObservableObject {
             if workspace.panelPullRequests[probeKey.panelId] != nil {
                 workspace.clearPanelPullRequest(panelId: probeKey.panelId)
             }
-        case .unsupportedRepository, .transientFailure:
+        case .deferred, .unsupportedRepository, .transientFailure:
             break
+        }
+
+        if snapshot.branch != nil {
+            scheduleWorkspacePullRequestRefresh(
+                workspaceId: probeKey.workspaceId,
+                panelId: probeKey.panelId,
+                reason: "localGitProbe",
+                burst: false
+            )
         }
 
 #if DEBUG
         let branchLabel = snapshot.branch ?? "none"
         let prLabel: String = {
             switch snapshot.pullRequest {
+            case .deferred:
+                return "deferred"
             case .unsupportedRepository:
                 return "unsupported"
             case .notFound:
@@ -1683,7 +2514,7 @@ class TabManager: ObservableObject {
         _ snapshot: InitialWorkspaceGitMetadataSnapshot
     ) -> Bool {
         switch snapshot.pullRequest {
-        case .transientFailure:
+        case .deferred, .transientFailure:
             return false
         case .unsupportedRepository, .notFound, .resolved:
             return true
@@ -1704,8 +2535,11 @@ class TabManager: ObservableObject {
 
         let statusOutput = runGitCommand(directory: directory, arguments: ["status", "--porcelain", "-uno"])
         let isDirty = !(statusOutput?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-        let pullRequest = workspacePullRequestSnapshot(directory: directory, branch: branch)
-        return InitialWorkspaceGitMetadataSnapshot(branch: branch, isDirty: isDirty, pullRequest: pullRequest)
+        return InitialWorkspaceGitMetadataSnapshot(
+            branch: branch,
+            isDirty: isDirty,
+            pullRequest: .deferred
+        )
     }
 
     private nonisolated static func runGitCommand(directory: String, arguments: [String]) -> String? {
@@ -1732,6 +2566,8 @@ class TabManager: ObservableObject {
         var sawTransientFailure = false
         for repoSlug in repoSlugs {
             switch workspacePullRequestSnapshot(directory: directory, branch: branch, repoSlug: repoSlug) {
+            case .deferred:
+                continue
             case .resolved(let pullRequest):
                 return .resolved(pullRequest)
             case .transientFailure:
@@ -2247,6 +3083,14 @@ class TabManager: ObservableObject {
         return normalizedGitHubRepositorySlug(url.path)
     }
 
+    private nonisolated static func githubRepositorySlug(fromPullRequestURL url: URL) -> String? {
+        guard let host = url.host?.lowercased(),
+              host == "github.com" else {
+            return nil
+        }
+        return normalizedGitHubRepositorySlug(url.path)
+    }
+
     private nonisolated static func normalizedGitHubRepositorySlug(_ rawPath: String) -> String? {
         let trimmedPath = rawPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !trimmedPath.isEmpty else { return nil }
@@ -2669,6 +3513,12 @@ class TabManager: ObservableObject {
         tab.updatePanelDirectory(panelId: surfaceId, directory: normalized)
         let nextDirectory = normalizedWorkingDirectory(normalized)
         if previousDirectory != nextDirectory {
+            scheduleWorkspacePullRequestRefresh(
+                workspaceId: tabId,
+                panelId: surfaceId,
+                reason: "directoryChange",
+                burst: true
+            )
             scheduleWorkspaceGitMetadataRefreshIfPossible(
                 workspaceId: tabId,
                 panelId: surfaceId,
@@ -2692,6 +3542,12 @@ class TabManager: ObservableObject {
             let probeKey = WorkspaceGitProbeKey(workspaceId: tabId, panelId: surfaceId)
             workspaceGitTrackedDirectoryByKey[probeKey] = directory
         }
+        scheduleWorkspacePullRequestRefresh(
+            workspaceId: tabId,
+            panelId: surfaceId,
+            reason: "branchChange",
+            burst: true
+        )
         scheduleWorkspaceGitMetadataRefreshIfPossible(
             workspaceId: tabId,
             panelId: surfaceId,
@@ -2704,6 +3560,9 @@ class TabManager: ObservableObject {
         let hadBranch = tab.panelGitBranches[surfaceId] != nil
         let hadPullRequest = tab.panelPullRequests[surfaceId] != nil
         guard hadBranch || hadPullRequest else { return }
+        clearWorkspacePullRequestTracking(
+            for: WorkspaceGitProbeKey(workspaceId: tabId, panelId: surfaceId)
+        )
         tab.clearPanelGitBranch(panelId: surfaceId)
         tab.clearPanelPullRequest(panelId: surfaceId)
         scheduleWorkspaceGitMetadataRefreshIfPossible(
@@ -2720,6 +3579,105 @@ class TabManager: ObservableObject {
     ) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         tab.updatePanelShellActivityState(panelId: surfaceId, state: state)
+        if state == .promptIdle {
+            scheduleWorkspacePullRequestRefresh(
+                workspaceId: tabId,
+                panelId: surfaceId,
+                reason: "shellPrompt",
+                burst: false
+            )
+        }
+    }
+
+    func handleWorkspacePullRequestCommandHint(
+        tabId: UUID,
+        surfaceId: UUID,
+        action: String,
+        target: String?
+    ) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        reconcileLocalPullRequestActionIfPossible(
+            workspace: tab,
+            panelId: surfaceId,
+            action: action,
+            target: target
+        )
+        scheduleWorkspacePullRequestRefresh(
+            workspaceId: tabId,
+            panelId: surfaceId,
+            reason: "commandHint:\(action)",
+            burst: true
+        )
+    }
+
+    private func reconcileLocalPullRequestActionIfPossible(
+        workspace: Workspace,
+        panelId: UUID,
+        action: String,
+        target: String?
+    ) {
+        guard let currentPullRequest = workspace.panelPullRequests[panelId],
+              pullRequestCommandTargetMatchesCurrentPullRequest(
+                target,
+                currentPullRequest: currentPullRequest
+              ) else {
+            return
+        }
+
+        let nextStatus: SidebarPullRequestStatus
+        switch action {
+        case "merge":
+            guard currentPullRequest.status == .open else { return }
+            nextStatus = .merged
+        case "close":
+            guard currentPullRequest.status == .open else { return }
+            nextStatus = .closed
+        case "reopen":
+            guard currentPullRequest.status != .open else { return }
+            nextStatus = .open
+        default:
+            return
+        }
+
+        workspace.updatePanelPullRequest(
+            panelId: panelId,
+            number: currentPullRequest.number,
+            label: currentPullRequest.label,
+            url: currentPullRequest.url,
+            status: nextStatus,
+            branch: currentPullRequest.branch,
+            checks: nil
+        )
+    }
+
+    private func pullRequestCommandTargetMatchesCurrentPullRequest(
+        _ rawTarget: String?,
+        currentPullRequest: SidebarPullRequestState
+    ) -> Bool {
+        let trimmedTarget = rawTarget?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedTarget.isEmpty else { return true }
+
+        let numberToken = trimmedTarget.hasPrefix("#") ? String(trimmedTarget.dropFirst()) : trimmedTarget
+        if let number = Int(numberToken), number == currentPullRequest.number {
+            return true
+        }
+
+        if let targetURL = URL(string: trimmedTarget) {
+            if targetURL == currentPullRequest.url {
+                return true
+            }
+            if let lastComponent = targetURL.pathComponents.last,
+               let number = Int(lastComponent),
+               number == currentPullRequest.number {
+                return true
+            }
+        }
+
+        if Self.normalizedBranchName(trimmedTarget) == Self.normalizedBranchName(currentPullRequest.branch) {
+            return true
+        }
+
+        return false
     }
 
     private func normalizeDirectory(_ directory: String) -> String {
@@ -2737,6 +3695,7 @@ class TabManager: ObservableObject {
         guard tabs.count > 1 else { return }
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         clearWorkspaceGitProbes(workspaceId: workspace.id)
+        clearWorkspacePullRequestTracking(workspaceId: workspace.id)
         sidebarSelectedWorkspaceIds.remove(workspace.id)
 
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1837,6 +1837,9 @@ class TerminalController {
         case "report_shell_state":
             return reportShellState(args)
 
+        case "report_pr_action":
+            return reportPullRequestAction(args)
+
         case "report_pwd":
             return reportPwd(args)
 
@@ -11390,6 +11393,7 @@ class TerminalController {
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
           ports_kick [--tab=X] [--panel=Y] [--reason=command|refresh] - Request batched port scan for panel
           report_shell_state <prompt|running> [--tab=X] [--panel=Y] - Report whether the shell is idle at a prompt or running a command
+          report_pr_action <merge|close|reopen|create|checkout|ready|edit|view> [--target=X] [--tab=X] [--panel=Y] - Hint that a PR-affecting command completed in the panel
           report_pwd <path> [--tab=X] [--panel=Y] - Report current working directory
           clear_ports [--tab=X] [--panel=Y] - Clear listening ports
           sidebar_state [--tab=X] - Dump sidebar metadata
@@ -15289,6 +15293,34 @@ class TerminalController {
             tabManager.updateSurfaceShellActivity(tabId: tab.id, surfaceId: surfaceId, state: state)
         }
         return result
+    }
+
+    private func reportPullRequestAction(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        guard let rawAction = parsed.positional.first, !rawAction.isEmpty else {
+            return "ERROR: Missing PR action — usage: report_pr_action <merge|close|reopen|create|checkout|ready|edit|view> [--target=X] [--tab=X] [--panel=Y]"
+        }
+
+        let action = rawAction.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let validActions = Set(["merge", "close", "reopen", "create", "checkout", "ready", "edit", "view"])
+        guard validActions.contains(action) else {
+            return "ERROR: Invalid PR action '\(rawAction)'"
+        }
+
+        let target = normalizedOptionValue(parsed.options["target"])
+        return schedulePanelMetadataMutation(
+            args: args,
+            options: parsed.options,
+            missingPanelUsage: "report_pr_action <merge|close|reopen|create|checkout|ready|edit|view> [--target=X] [--tab=X] [--panel=Y]"
+        ) { tab, surfaceId in
+            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: tab.id) else { return }
+            tabManager.handleWorkspacePullRequestCommandHint(
+                tabId: tab.id,
+                surfaceId: surfaceId,
+                action: action,
+                target: target
+            )
+        }
     }
 
     private func clearPorts(_ args: String) -> String {

--- a/tests/test_issue_1138_sidebar_pr_polling.py
+++ b/tests/test_issue_1138_sidebar_pr_polling.py
@@ -1,21 +1,12 @@
 #!/usr/bin/env python3
 """
-Regression coverage for issue #1138.
+Regression coverage for shell-side sidebar PR refresh hints.
 
 Validates that shell integration:
-1) keeps polling PR state while idle and recovers after a transient gh failure
-2) resolves the current branch PR via `gh pr view` instead of repository-wide
-   branch-name matching
-3) clears stale PR state when the branch changes and the new probe fails
-4) recovers when a gh probe wedges longer than the async timeout
-5) keeps polling in bash after prompt-render helper commands run
-6) tears down the timed-out gh probe instead of leaking it in the background
-7) falls back to explicit branch lookup when implicit gh branch resolution fails
-8) does not clear an existing PR badge on the first prompt while establishing
-   the HEAD baseline
-9) stops parent-shell PR tracking before nested shells start in the same panel
-10) preserves ports polling throttling after an explicit ports kick
-11) preserves cached PR results across ordinary preexec cycles
+1) no longer polls GitHub directly while idle at a prompt
+2) emits PR action hints after successful `gh pr ...` commands
+3) does not emit PR action hints after failed commands or non-PR `gh` commands
+4) clears stale PR badges when the checked-out branch changes
 """
 
 from __future__ import annotations
@@ -76,6 +67,11 @@ def _git_stub() -> str:
           esac
         fi
 
+        if [ "$1" = "rev-parse" ] && [ "$2" = "--git-dir" ]; then
+          printf '%s/.git\\n' "$repo_path"
+          exit 0
+        fi
+
         if [ "$1" = "branch" ] && [ "$2" = "--show-current" ]; then
           if [ -n "$branch" ]; then
             printf '%s\\n' "$branch"
@@ -103,188 +99,56 @@ def _gh_stub() -> str:
         """\
         #!/bin/sh
         args_log="${CMUX_TEST_GH_ARGS_LOG:?}"
-        count_file="${CMUX_TEST_GH_COUNT_FILE:?}"
-        pid_file="${CMUX_TEST_GH_PID_FILE:-}"
-        scenario="${CMUX_TEST_SCENARIO:?}"
-        head_file="${CMUX_TEST_HEAD_FILE:?}"
-
         printf '%s\\n' "$*" >> "$args_log"
-
-        count=0
-        if [ -f "$count_file" ]; then
-          count="$(cat "$count_file")"
-        fi
-        count=$((count + 1))
-        printf '%s\\n' "$count" > "$count_file"
-
-        if [ "$1" != "pr" ] || [ "$2" != "view" ]; then
-          printf 'unexpected gh args: %s\\n' "$*" >&2
-          exit 9
-        fi
-
-        requested_branch=""
-        if [ $# -ge 3 ]; then
-          case "$3" in
-            --*)
-              ;;
-            *)
-              requested_branch="$3"
-              ;;
-          esac
-        fi
-
-        branch=""
-        if [ -f "$head_file" ]; then
-          head_line="$(cat "$head_file")"
-          case "$head_line" in
-            ref:\ refs/heads/*)
-              branch="${head_line#ref: refs/heads/}"
-              ;;
-          esac
-        fi
-
-        case "$scenario" in
-          prompt_helper_idle)
-            printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
-            ;;
-          initial_prompt_preserves_pr_badge)
-            printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
-            ;;
-          transient_same_context)
-            if [ "$count" -eq 1 ]; then
-              printf 'rate limit exceeded\\n' >&2
-              exit 1
-            fi
-            printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
-            ;;
-          branch_switch_clear)
-            if [ "$branch" = "feature/old" ]; then
-              printf '111\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/111\\n'
-              exit 0
-            fi
-            if [ "$branch" = "feature/new" ]; then
-              printf 'network unavailable\\n' >&2
-              exit 1
-            fi
-            printf 'no pull requests found for branch "%s"\\n' "$branch" >&2
-            exit 1
-            ;;
-          timeout_recovery)
-            if [ "$count" -eq 1 ]; then
-              if [ -n "$pid_file" ]; then
-                printf '%s\\n' "$$" > "$pid_file"
-              fi
-              sleep "${CMUX_TEST_HANG_SECONDS:-4}"
-              exit 0
-            fi
-            printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
-            ;;
-          explicit_branch_fallback)
-            if [ -z "$requested_branch" ]; then
-              printf 'no pull requests found for branch "%s"\\n' "$branch" >&2
-              exit 1
-            fi
-            if [ "$requested_branch" = "$branch" ]; then
-              printf '1138\\tOPEN\\thttps://github.com/manaflow-ai/cmux/pull/1138\\n'
-              exit 0
-            fi
-            printf 'unexpected branch lookup: %s\\n' "$requested_branch" >&2
-            exit 8
-            ;;
-          *)
-            printf 'unknown scenario: %s\\n' "$scenario" >&2
-            exit 2
-            ;;
-        esac
+        exit 0
         """
     )
 
 
 def _shell_command(kind: str, scenario: str) -> str:
     shared = {
-        "prompt_helper_idle": (
+        "prompt_does_not_call_gh": (
             'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=1\n'
             '_cmux_prompt_entry\n'
-            ': "$(/bin/printf helper)"\n'
-            'sleep 3\n'
+            'sleep 1\n'
             '_cmux_cleanup\n'
         ),
-        "transient_same_context": (
+        "merge_action": (
             'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=1\n'
+            '_cmux_pr_command_entry "gh pr merge"\n'
             '_cmux_prompt_entry\n'
-            'sleep 3\n'
+            'sleep 1\n'
             '_cmux_cleanup\n'
         ),
-        "branch_switch_clear": (
+        "close_action_target": (
             'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
+            '_cmux_pr_command_entry "gh pr close 2580"\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_cleanup\n'
+        ),
+        "failed_merge_no_action": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_cmux_pr_command_entry "gh pr merge"\n'
+            'false\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_cleanup\n'
+        ),
+        "non_pr_gh_no_action": (
+            'cd "$CMUX_TEST_REPO"\n'
+            '_cmux_pr_command_entry "gh issue view 1"\n'
+            '_cmux_prompt_entry\n'
+            'sleep 1\n'
+            '_cmux_cleanup\n'
+        ),
+        "head_change_clears_pr": (
+            'cd "$CMUX_TEST_REPO"\n'
             '_cmux_prompt_entry\n'
             'sleep 1\n'
             'printf \'ref: refs/heads/feature/new\\n\' > "$CMUX_TEST_HEAD_FILE"\n'
             '_cmux_prompt_entry\n'
             'sleep 2\n'
-            '_cmux_cleanup\n'
-        ),
-        "timeout_recovery": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=1\n'
-            '_CMUX_ASYNC_JOB_TIMEOUT=1\n'
-            '_cmux_prompt_entry\n'
-            'sleep 4\n'
-            '_cmux_cleanup\n'
-        ),
-        "explicit_branch_fallback": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
-            '_cmux_prompt_entry\n'
-            'sleep 2\n'
-            '_cmux_cleanup\n'
-        ),
-        "initial_prompt_preserves_pr_badge": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
-            '_cmux_prompt_entry\n'
-            'sleep 2\n'
-            '_cmux_cleanup\n'
-        ),
-        "nested_shell_stops_parent_poll": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
-            '_cmux_prompt_entry\n'
-            'parent_pid="$_CMUX_PR_POLL_PID"\n'
-            '[ -n "$parent_pid" ] || { echo "missing parent poll pid" >&2; exit 41; }\n'
-            '_cmux_nested_shell_entry\n'
-            'sleep 1\n'
-            'if kill -0 "$parent_pid" 2>/dev/null; then\n'
-            '  echo "parent poller still running" >&2\n'
-            '  exit 42\n'
-            'fi\n'
-            'parent_watch_pid="${_CMUX_GIT_HEAD_WATCH_PID:-}"\n'
-            'if [ -n "$parent_watch_pid" ] && kill -0 "$parent_watch_pid" 2>/dev/null; then\n'
-            '  echo "parent HEAD watcher still running" >&2\n'
-            '  exit 43\n'
-            'fi\n'
-            '_cmux_cleanup\n'
-        ),
-        "ports_kick_throttle": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
-            '_cmux_ports_kick\n'
-            '_cmux_prompt_entry\n'
-            'sleep 1\n'
-            '_cmux_prompt_entry\n'
-            '_cmux_cleanup\n'
-        ),
-        "preexec_preserves_pr_cache": (
-            'cd "$CMUX_TEST_REPO"\n'
-            '_CMUX_PR_POLL_INTERVAL=10\n'
-            '_cmux_prompt_entry\n'
-            'sleep 1\n'
-            '_cmux_regular_command_entry\n'
-            '_cmux_prompt_entry\n'
-            'sleep 1\n'
             '_cmux_cleanup\n'
         ),
     }[scenario]
@@ -295,8 +159,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             source "$CMUX_TEST_SCRIPT"
             _cmux_send() {{ print -r -- "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_precmd; }}
-            _cmux_nested_shell_entry() {{ _cmux_preexec zsh; }}
-            _cmux_regular_command_entry() {{ _cmux_preexec "echo hi"; }}
+            _cmux_pr_command_entry() {{ _cmux_preexec "$1"; }}
             _cmux_cleanup() {{ _cmux_zshexit; }}
             {shared}"""
         )
@@ -307,8 +170,7 @@ def _shell_command(kind: str, scenario: str) -> str:
             source "$CMUX_TEST_SCRIPT"
             _cmux_send() {{ printf '%s\\n' "$1" >> "$CMUX_TEST_SEND_LOG"; }}
             _cmux_prompt_entry() {{ _cmux_prompt_command; }}
-            _cmux_nested_shell_entry() {{ _cmux_bash_preexec_hook bash; }}
-            _cmux_regular_command_entry() {{ _cmux_bash_preexec_hook "echo hi"; }}
+            _cmux_pr_command_entry() {{ _cmux_bash_preexec_hook "$1"; }}
             _cmux_cleanup() {{ type _cmux_bash_cleanup >/dev/null 2>&1 && _cmux_bash_cleanup; }}
             {shared}"""
         )
@@ -322,38 +184,18 @@ def _read_lines(path: Path) -> list[str]:
     return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def _report_line(number: int) -> str:
-    return (
-        f"report_pr {number} https://github.com/manaflow-ai/cmux/pull/{number} "
-        "--state=open --tab=00000000-0000-0000-0000-000000000001 "
-        "--panel=00000000-0000-0000-0000-000000000002"
-    )
-
-
-def _pid_exists(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
-
-
 def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, scenario: str) -> tuple[int, str]:
     bindir = base / "bin"
     repo = base / "repo"
     repo_git = repo / ".git"
     socket_path = base / "cmux.sock"
     send_log = base / f"{shell}-{scenario}-send.log"
-    gh_count_file = base / f"{shell}-{scenario}-gh-count.txt"
     gh_args_log = base / f"{shell}-{scenario}-gh-args.log"
-    gh_pid_file = base / f"{shell}-{scenario}-gh-pid.txt"
     head_file = repo_git / "HEAD"
 
     bindir.mkdir(parents=True, exist_ok=True)
     repo_git.mkdir(parents=True, exist_ok=True)
-    initial_branch = "feature/old" if scenario == "branch_switch_clear" else "feature/issue-1138"
+    initial_branch = "feature/old" if scenario == "head_change_clears_pr" else "feature/issue-1138"
     head_file.write_text(f"ref: refs/heads/{initial_branch}\n", encoding="utf-8")
     _write_executable(bindir / "git", _git_stub())
     _write_executable(bindir / "gh", _gh_stub())
@@ -366,12 +208,8 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
     env["CMUX_TEST_SCRIPT"] = str(script)
     env["CMUX_TEST_REPO"] = str(repo)
     env["CMUX_TEST_SEND_LOG"] = str(send_log)
-    env["CMUX_TEST_GH_COUNT_FILE"] = str(gh_count_file)
     env["CMUX_TEST_GH_ARGS_LOG"] = str(gh_args_log)
-    env["CMUX_TEST_GH_PID_FILE"] = str(gh_pid_file)
-    env["CMUX_TEST_SCENARIO"] = scenario
     env["CMUX_TEST_HEAD_FILE"] = str(head_file)
-    env["CMUX_TEST_HANG_SECONDS"] = "4"
 
     with BoundUnixSocket(socket_path):
         result = subprocess.run(
@@ -388,109 +226,43 @@ def _run_case(base: Path, *, shell: str, shell_args: list[str], script: Path, sc
 
     send_lines = _read_lines(send_log)
     gh_args_lines = _read_lines(gh_args_log)
-    gh_count = int((gh_count_file.read_text(encoding="utf-8").strip() or "0")) if gh_count_file.exists() else 0
+    pr_action_lines = [line for line in send_lines if line.startswith("report_pr_action ")]
 
-    scenarios_requiring_gh = {
-        "prompt_helper_idle",
-        "transient_same_context",
-        "branch_switch_clear",
-        "timeout_recovery",
-        "explicit_branch_fallback",
-        "initial_prompt_preserves_pr_badge",
-        "ports_kick_throttle",
-        "preexec_preserves_pr_cache",
-    }
-    if scenario in scenarios_requiring_gh:
-        if not gh_args_lines:
-            return (1, f"{shell}/{scenario}: expected at least one gh invocation")
-        if any(not line.startswith("pr view ") for line in gh_args_lines):
-            return (1, f"{shell}/{scenario}: expected gh pr view only\n" + "\n".join(gh_args_lines))
-
-    if scenario == "prompt_helper_idle":
-        if gh_count < 2:
-            return (1, f"{shell}/{scenario}: expected idle polling to survive prompt helpers, saw {gh_count}")
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
+    if scenario == "prompt_does_not_call_gh":
+        if gh_args_lines:
+            return (1, f"{shell}/{scenario}: expected no gh invocations\n" + "\n".join(gh_args_lines))
         return (0, f"{shell}/{scenario}: ok")
 
-    if scenario == "transient_same_context":
-        if gh_count < 2:
-            return (1, f"{shell}/{scenario}: expected at least 2 gh probes while idle, saw {gh_count}")
-        if any(line.startswith("clear_pr ") for line in send_lines):
-            return (1, f"{shell}/{scenario}: transient failure should not clear PR state\n" + "\n".join(send_lines))
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: expected recovered report_pr payload\n" + "\n".join(send_lines))
+    if scenario == "merge_action":
+        expected = "report_pr_action merge --tab=00000000-0000-0000-0000-000000000001 --panel=00000000-0000-0000-0000-000000000002"
+        if expected not in pr_action_lines:
+            return (1, f"{shell}/{scenario}: missing merge action hint\n" + "\n".join(send_lines))
+        if gh_args_lines:
+            return (1, f"{shell}/{scenario}: expected no gh invocations\n" + "\n".join(gh_args_lines))
         return (0, f"{shell}/{scenario}: ok")
 
-    if scenario == "branch_switch_clear":
-        old_report = _report_line(111)
-        if old_report not in send_lines:
-            return (1, f"{shell}/{scenario}: missing old-branch report\n" + "\n".join(send_lines))
-        try:
-            old_index = send_lines.index(old_report)
-        except ValueError:
-            return (1, f"{shell}/{scenario}: missing old-branch report\n" + "\n".join(send_lines))
-        clear_indices = [idx for idx, line in enumerate(send_lines) if line.startswith("clear_pr ")]
-        if not clear_indices:
-            return (1, f"{shell}/{scenario}: expected clear_pr after branch change\n" + "\n".join(send_lines))
-        if clear_indices[0] <= old_index:
-            return (1, f"{shell}/{scenario}: clear_pr happened before old report\n" + "\n".join(send_lines))
+    if scenario == "close_action_target":
+        expected = "report_pr_action close --tab=00000000-0000-0000-0000-000000000001 --panel=00000000-0000-0000-0000-000000000002 --target=\"2580\""
+        if expected not in pr_action_lines:
+            return (1, f"{shell}/{scenario}: missing close action hint\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
 
-    if scenario == "timeout_recovery":
-        if gh_count < 2:
-            return (1, f"{shell}/{scenario}: expected timed-out probe to be retried, saw {gh_count}")
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: missing report_pr after timeout recovery\n" + "\n".join(send_lines))
-        if gh_pid_file.exists():
-            gh_pid = int(gh_pid_file.read_text(encoding="utf-8").strip() or "0")
-            if gh_pid > 0 and _pid_exists(gh_pid):
-                return (1, f"{shell}/{scenario}: timed-out gh probe still running as pid {gh_pid}")
+    if scenario == "failed_merge_no_action":
+        if pr_action_lines:
+            return (1, f"{shell}/{scenario}: failed command should not emit PR action hint\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
 
-    if scenario == "explicit_branch_fallback":
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
-        if not any(line.startswith("pr view feature/issue-1138 ") for line in gh_args_lines):
-            return (
-                1,
-                f"{shell}/{scenario}: expected explicit branch fallback\n" + "\n".join(gh_args_lines),
-            )
+    if scenario == "non_pr_gh_no_action":
+        if pr_action_lines:
+            return (1, f"{shell}/{scenario}: non-PR gh command should not emit PR action hint\n" + "\n".join(send_lines))
         return (0, f"{shell}/{scenario}: ok")
 
-    if scenario == "initial_prompt_preserves_pr_badge":
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
-        if any(line.startswith("clear_pr ") for line in send_lines):
-            return (
-                1,
-                f"{shell}/{scenario}: initial prompt should not clear an existing PR badge\n"
-                + "\n".join(send_lines),
-            )
-        return (0, f"{shell}/{scenario}: ok")
-
-    if scenario == "ports_kick_throttle":
-        ports_kicks = [line for line in send_lines if line.startswith("ports_kick ")]
-        if len(ports_kicks) != 1:
-            return (
-                1,
-                f"{shell}/{scenario}: expected exactly one ports_kick across explicit kick + throttled prompts\n"
-                + "\n".join(send_lines),
-            )
-        return (0, f"{shell}/{scenario}: ok")
-
-    if scenario == "nested_shell_stops_parent_poll":
-        return (0, f"{shell}/{scenario}: ok")
-
-    if scenario == "preexec_preserves_pr_cache":
-        if gh_count != 1:
-            return (
-                1,
-                f"{shell}/{scenario}: expected cached PR result to survive ordinary preexec, saw {gh_count} gh calls\n"
-                + "\n".join(gh_args_lines),
-            )
-        if _report_line(1138) not in send_lines:
-            return (1, f"{shell}/{scenario}: missing report_pr payload\n" + "\n".join(send_lines))
+    if scenario == "head_change_clears_pr":
+        expected = "clear_pr --tab=00000000-0000-0000-0000-000000000001 --panel=00000000-0000-0000-0000-000000000002"
+        if expected not in send_lines:
+            return (1, f"{shell}/{scenario}: missing clear_pr after HEAD change\n" + "\n".join(send_lines))
+        if gh_args_lines:
+            return (1, f"{shell}/{scenario}: expected no gh invocations\n" + "\n".join(gh_args_lines))
         return (0, f"{shell}/{scenario}: ok")
 
     return (1, f"{shell}/{scenario}: unhandled scenario")
@@ -503,15 +275,12 @@ def main() -> int:
         ("bash", ["--noprofile", "--norc", "-c"], root / "Resources" / "shell-integration" / "cmux-bash-integration.bash"),
     ]
     scenarios = [
-        "prompt_helper_idle",
-        "transient_same_context",
-        "branch_switch_clear",
-        "timeout_recovery",
-        "explicit_branch_fallback",
-        "initial_prompt_preserves_pr_badge",
-        "nested_shell_stops_parent_poll",
-        "ports_kick_throttle",
-        "preexec_preserves_pr_cache",
+        "prompt_does_not_call_gh",
+        "merge_action",
+        "close_action_target",
+        "failed_merge_no_action",
+        "non_pr_gh_no_action",
+        "head_change_clears_pr",
     ]
 
     base = Path("/tmp") / f"cmux_issue_1138_pr_poll_{os.getpid()}"
@@ -541,7 +310,7 @@ def main() -> int:
                 print(failure)
             return 1
 
-        print("PASS: shell integrations poll PR state robustly across transient failures, branch changes, and timeouts")
+        print("PASS: shell integrations emit PR action hints locally and no longer poll GitHub directly")
         return 0
     finally:
         shutil.rmtree(base, ignore_errors=True)


### PR DESCRIPTION
Closes #2580

## Summary
- move sidebar PR refreshes to a shared GitHub REST poller instead of per-workspace `gh` PR lookups
- batch repository PR lookups, reuse ETags with conditional requests, and back off on rate-limit or transient failures
- refresh more aggressively after local branch/directory/shell activity and reconcile `gh pr merge`/`close`/`reopen` actions immediately in the sidebar
- update shell integration regression coverage to verify local PR action hints and removal of direct GitHub polling from the prompt path

## Testing
- Not run locally (per repo policy)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces per-panel `gh` polling with a shared GitHub REST poller that batches requests, uses ETags, and backs off on rate limits. Shell integrations now emit PR action hints and stop direct GitHub polling, fixing sidebar rate-limit errors and making updates faster.

- **New Features**
  - Shared REST poller: batched repo lookups, conditional requests via ETags, per-resource backoff, and parallel fetches.
  - Smarter scheduling: idle vs. burst intervals, faster refresh after branch/dir changes and when the shell returns to a prompt.
  - Local reconciliation of `gh pr merge/close/reopen` so the sidebar updates immediately.
  - New `report_pr_action` IPC; bash/zsh record `gh pr` actions and send hints to the app; TabManager applies them.

- **Bug Fixes**
  - Removed direct GitHub polling from shell prompt path to prevent rate-limit hits and prompt latency.
  - Clear stale PR badges on HEAD changes.
  - Updated regression tests to assert no shell-side GitHub calls while idle and to cover PR action hints.

<sup>Written for commit a3db3af4579ef6209d56e304d1e23586b3ee99c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture and report GitHub PR actions (merge, close, reopen, create, checkout, ready, edit, view) directly from shell commands
  * Immediate sidebar status updates when PR commands complete successfully

* **Improvements**
  * More responsive and efficient PR status refresh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->