### PR TITLE
Fix terminal scroll geometry during resize

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4707,6 +4707,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private let _scrollbarLock = NSLock()
     var cellSize: CGSize = .zero
 
+    @MainActor
+    func isAlternateScreenActiveForScrollGeometry() -> Bool? {
+        nil
+    }
+
     /// Coalesce high-frequency scrollbar updates into a single main-thread
     /// dispatch.  The action callback (which may fire thousands of times per
     /// second during bulk output like `seq 1 100000`) stores the latest value

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4709,7 +4709,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @MainActor
     func isAlternateScreenActiveForScrollGeometry() -> Bool? {
-        nil
+        guard let terminalSurface,
+              let surface = terminalSurface.liveSurfaceForGhosttyAccess(
+                  reason: "surface.scrollGeometryAlternateScreen"
+              ) else {
+            return nil
+        }
+        return ghostty_surface_is_alternate_screen(surface)
     }
 
     /// Coalesce high-frequency scrollbar updates into a single main-thread
@@ -10104,35 +10110,47 @@ final class GhosttySurfaceScrollView: NSView {
             didChangeGeometry = true
         }
 
+        let alternateScreenActive = surfaceView.isAlternateScreenActiveForScrollGeometry() == true
         if !isLiveScrolling {
-            let cellHeight = scrollGeometryCellHeight()
-            if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
-                let offsetY =
-                    CGFloat(scrollbar.total - scrollbar.offset - scrollbar.len) * cellHeight
-                let targetOrigin = CGPoint(x: 0, y: offsetY)
-
-                // Check if we're currently at the bottom (with threshold for float drift)
+            if alternateScreenActive {
+                userScrolledAwayFromBottom = false
+                lastSentRow = nil
+                let targetOrigin = CGPoint.zero
                 let currentOrigin = scrollView.contentView.bounds.origin
-                let documentHeight = documentView.frame.height
-                let viewportHeight = scrollView.contentView.bounds.height
-                let distanceFromBottom = documentHeight - currentOrigin.y - viewportHeight
-                let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
-
-                // Update userScrolledAwayFromBottom based on current position
-                if isAtBottom {
-                    userScrolledAwayFromBottom = false
-                }
-
-                // Passive bottom packets should not override an explicit scrollback review,
-                // but the first scrollbar packet caused by the user's own wheel input should
-                // still move the viewport to the requested scrollback position.
-                let shouldAutoScroll = !userScrolledAwayFromBottom || allowExplicitScrollbarSync
-
-                if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                if !pointApproximatelyEqual(currentOrigin, targetOrigin) {
                     scrollView.contentView.scroll(to: targetOrigin)
                     didChangeGeometry = true
                 }
-                lastSentRow = Int(scrollbar.offset)
+            } else {
+                let cellHeight = scrollGeometryCellHeight()
+                if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
+                    let offsetY =
+                        CGFloat(scrollbar.total - scrollbar.offset - scrollbar.len) * cellHeight
+                    let targetOrigin = CGPoint(x: 0, y: offsetY)
+
+                    // Check if we're currently at the bottom (with threshold for float drift)
+                    let currentOrigin = scrollView.contentView.bounds.origin
+                    let documentHeight = documentView.frame.height
+                    let viewportHeight = scrollView.contentView.bounds.height
+                    let distanceFromBottom = documentHeight - currentOrigin.y - viewportHeight
+                    let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
+
+                    // Update userScrolledAwayFromBottom based on current position
+                    if isAtBottom {
+                        userScrolledAwayFromBottom = false
+                    }
+
+                    // Passive bottom packets should not override an explicit scrollback review,
+                    // but the first scrollbar packet caused by the user's own wheel input should
+                    // still move the viewport to the requested scrollback position.
+                    let shouldAutoScroll = !userScrolledAwayFromBottom || allowExplicitScrollbarSync
+
+                    if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                        scrollView.contentView.scroll(to: targetOrigin)
+                        didChangeGeometry = true
+                    }
+                    lastSentRow = Int(scrollbar.offset)
+                }
             }
         }
 
@@ -10148,6 +10166,12 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func handleLiveScroll() {
+        if surfaceView.isAlternateScreenActiveForScrollGeometry() == true {
+            userScrolledAwayFromBottom = false
+            lastSentRow = nil
+            return
+        }
+
         let cellHeight = scrollGeometryCellHeight()
         guard cellHeight > 0 else { return }
 
@@ -10216,6 +10240,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func documentHeight() -> CGFloat {
         let contentHeight = scrollView.contentSize.height
+        if surfaceView.isAlternateScreenActiveForScrollGeometry() == true {
+            return contentHeight
+        }
         let cellHeight = scrollGeometryCellHeight()
         if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
             let documentGridHeight = CGFloat(scrollbar.total) * cellHeight

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10100,7 +10100,7 @@ final class GhosttySurfaceScrollView: NSView {
         }
 
         if !isLiveScrolling {
-            let cellHeight = surfaceView.cellSize.height
+            let cellHeight = scrollGeometryCellHeight()
             if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
                 let offsetY =
                     CGFloat(scrollbar.total - scrollbar.offset - scrollbar.len) * cellHeight
@@ -10143,7 +10143,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func handleLiveScroll() {
-        let cellHeight = surfaceView.cellSize.height
+        let cellHeight = scrollGeometryCellHeight()
         guard cellHeight > 0 else { return }
 
         let visibleRect = scrollView.contentView.documentVisibleRect
@@ -10192,9 +10192,26 @@ final class GhosttySurfaceScrollView: NSView {
         _ = synchronizeCoreSurface()
     }
 
+    private func scrollGeometryCellHeight() -> CGFloat {
+        let cellHeight = surfaceView.cellSize.height
+        guard cellHeight > 0 else { return 0 }
+
+        // Ghostty reports cell metrics in backing pixels, while scroll view
+        // geometry is maintained in AppKit points.
+        let scale = max(
+            1.0,
+            window?.backingScaleFactor
+                ?? surfaceView.layer?.contentsScale
+                ?? layer?.contentsScale
+                ?? NSScreen.main?.backingScaleFactor
+                ?? 1.0
+        )
+        return cellHeight / scale
+    }
+
     private func documentHeight() -> CGFloat {
         let contentHeight = scrollView.contentSize.height
-        let cellHeight = surfaceView.cellSize.height
+        let cellHeight = scrollGeometryCellHeight()
         if cellHeight > 0, let scrollbar = surfaceView.scrollbar {
             let documentGridHeight = CGFloat(scrollbar.total) * cellHeight
             let padding = contentHeight - (CGFloat(scrollbar.len) * cellHeight)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2032,6 +2032,14 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         }
     }
 
+    private final class AlternateScreenSurfaceView: GhosttyNSView {
+        var alternateScreenActive = false
+
+        override func isAlternateScreenActiveForScrollGeometry() -> Bool? {
+            alternateScreenActive
+        }
+    }
+
     private func makeScrollbar(total: UInt64, offset: UInt64, len: UInt64) -> GhosttyScrollbar {
         GhosttyScrollbar(
             c: ghostty_action_scrollbar_s(
@@ -2296,6 +2304,43 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             expectedScrollbackHeight,
             accuracy: 0.01,
             "Scrollbar-driven viewport origin should be derived from point-sized rows"
+        )
+    }
+
+    func testAlternateScreenIgnoresScrollbarDocumentGrowth() throws {
+        let surfaceView = AlternateScreenSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 100))
+        surfaceView.cellSize = CGSize(width: 20, height: 20)
+        surfaceView.alternateScreenActive = true
+
+        let (window, scrollView) = try makeHostedScrollView(surfaceView: surfaceView)
+        defer { window.orderOut(nil) }
+
+        let expectedDocumentHeight = scrollView.contentSize.height
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: surfaceView,
+            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 12, offset: 0, len: 10)]
+        )
+
+        XCTAssertTrue(
+            waitUntil(description: "alternate-screen ignores scrollbar growth") {
+                let documentHeight = scrollView.documentView?.frame.height ?? 0
+                let originY = scrollView.contentView.bounds.origin.y
+                return abs(documentHeight - expectedDocumentHeight) < 0.01
+                    && abs(originY) < 0.01
+            }
+        )
+        XCTAssertEqual(
+            scrollView.documentView?.frame.height ?? 0,
+            expectedDocumentHeight,
+            accuracy: 0.01,
+            "Alternate-screen scrollbar packets should not grow the document height"
+        )
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.y,
+            0,
+            accuracy: 0.01,
+            "Alternate-screen scrollbar packets should not offset the viewport"
         )
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1979,6 +1979,24 @@ final class WindowTerminalHostViewTests: XCTestCase {
 
 @MainActor
 final class GhosttySurfaceOverlayTests: XCTestCase {
+    private final class FixedBackingScaleWindow: NSWindow {
+        let forcedBackingScaleFactor: CGFloat
+
+        init(contentRect: NSRect, forcedBackingScaleFactor: CGFloat) {
+            self.forcedBackingScaleFactor = forcedBackingScaleFactor
+            super.init(
+                contentRect: contentRect,
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+        }
+
+        override var backingScaleFactor: CGFloat {
+            forcedBackingScaleFactor
+        }
+    }
+
     private final class ScrollProbeSurfaceView: GhosttyNSView {
         private(set) var scrollWheelCallCount = 0
 
@@ -2001,6 +2019,19 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         }
     }
 
+    private final class BindingCaptureSurfaceView: GhosttyNSView {
+        private(set) var bindingActions: [String] = []
+
+        override func performBindingAction(_ action: String) -> Bool {
+            bindingActions.append(action)
+            return true
+        }
+
+        func clearBindingActions() {
+            bindingActions.removeAll()
+        }
+    }
+
     private func makeScrollbar(total: UInt64, offset: UInt64, len: UInt64) -> GhosttyScrollbar {
         GhosttyScrollbar(
             c: ghostty_action_scrollbar_s(
@@ -2009,6 +2040,39 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
                 len: len
             )
         )
+    }
+
+    private func makeHostedScrollView(
+        surfaceView: GhosttyNSView,
+        contentRect: NSRect = NSRect(x: 0, y: 0, width: 160, height: 100),
+        backingScaleFactor: CGFloat = 2
+    ) throws -> (window: NSWindow, scrollView: NSScrollView) {
+        let window = FixedBackingScaleWindow(
+            contentRect: contentRect,
+            forcedBackingScaleFactor: backingScaleFactor
+        )
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            throw NSError(domain: "GhosttySurfaceOverlayTests", code: 1)
+        }
+
+        let hostedView = GhosttySurfaceScrollView(surfaceView: surfaceView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let scrollView = hostedView.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView else {
+            XCTFail("Expected hosted terminal scroll view")
+            throw NSError(domain: "GhosttySurfaceOverlayTests", code: 2)
+        }
+
+        return (window, scrollView)
     }
 
     private func findEditableTextField(in view: NSView) -> NSTextField? {
@@ -2191,6 +2255,83 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             500,
             accuracy: 0.01,
             "A passive bottom packet should not yank the viewport after an explicit wheel scroll into scrollback"
+        )
+    }
+
+    func testScrollbarGeometryUsesPointSizedCells() throws {
+        let surfaceView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 100))
+        surfaceView.cellSize = CGSize(width: 20, height: 20)
+
+        let (window, scrollView) = try makeHostedScrollView(surfaceView: surfaceView)
+        defer { window.orderOut(nil) }
+
+        let scrollbar = makeScrollbar(total: 12, offset: 0, len: 10)
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: surfaceView,
+            userInfo: [GhosttyNotificationKey.scrollbar: scrollbar]
+        )
+
+        let pointCellHeight = surfaceView.cellSize.height / window.backingScaleFactor
+        let expectedScrollbackHeight = CGFloat(scrollbar.total - scrollbar.len) * pointCellHeight
+        let expectedDocumentHeight = scrollView.contentSize.height + expectedScrollbackHeight
+
+        XCTAssertTrue(
+            waitUntil(description: "point-space scrollbar geometry") {
+                let documentHeight = scrollView.documentView?.frame.height ?? 0
+                let originY = scrollView.contentView.bounds.origin.y
+                return abs(documentHeight - expectedDocumentHeight) < 0.01
+                    && abs(originY - expectedScrollbackHeight) < 0.01
+            }
+        )
+
+        XCTAssertEqual(
+            scrollView.documentView?.frame.height ?? 0,
+            expectedDocumentHeight,
+            accuracy: 0.01,
+            "Scrollbar-driven document height should use AppKit points, not backing pixels"
+        )
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.y,
+            expectedScrollbackHeight,
+            accuracy: 0.01,
+            "Scrollbar-driven viewport origin should be derived from point-sized rows"
+        )
+    }
+
+    func testLiveScrollUsesPointSizedCellsForScrollToRow() throws {
+        let surfaceView = BindingCaptureSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 100))
+        surfaceView.cellSize = CGSize(width: 20, height: 20)
+
+        let (window, scrollView) = try makeHostedScrollView(surfaceView: surfaceView)
+        defer { window.orderOut(nil) }
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: surfaceView,
+            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 12, offset: 0, len: 10)]
+        )
+
+        let pointCellHeight = surfaceView.cellSize.height / window.backingScaleFactor
+        XCTAssertTrue(
+            waitUntil(description: "initial point-space scrollbar sync") {
+                abs(scrollView.contentView.bounds.origin.y - (pointCellHeight * 2)) < 0.01
+            }
+        )
+
+        surfaceView.clearBindingActions()
+        scrollView.contentView.scroll(to: CGPoint(x: 0, y: pointCellHeight))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        XCTAssertTrue(
+            waitUntil(description: "point-space live scroll binding") {
+                surfaceView.bindingActions.contains("scroll_to_row:1")
+            }
+        )
+        XCTAssertEqual(
+            surfaceView.bindingActions.last,
+            "scroll_to_row:1",
+            "Live scroll row bindings should use point-sized rows"
         )
     }
 


### PR DESCRIPTION
## Summary
- add regression coverage for scroll geometry when Ghostty reports backing-pixel cell sizes on HiDPI windows
- convert hosted terminal scroll math from backing-pixel cell heights to AppKit point heights for document size, viewport sync, and live scroll row binding

## Testing
- ./scripts/setup.sh
- ./scripts/reload.sh --tag task-terminal-resize-extra-space
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-terminal-resize-extra-space-unit build (hits an existing Ghostty helper script panic outside reload: `tagged releases must be in vX.Y.Z format matching build.zig`)

## Task
- Terminal Resize Extra Space

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes extra scroll space and incorrect scroll position on HiDPI macOS by using AppKit point-sized cell heights and by ignoring scrollback geometry while the alternate screen is active. Addresses Linear task “Terminal Resize Extra Space” by keeping document height, viewport origin, and live scroll bindings consistent with point-sized rows.

- **Bug Fixes**
  - Switched scroll math (document height, viewport sync, live scroll) to point-sized rows via `scrollGeometryCellHeight()`; when the alternate screen is active, ignore scrollbar-driven growth and keep the viewport at origin.
  - Added regression tests for point-space geometry, `scroll_to_row`, and alternate-screen resize behavior.

<sup>Written for commit ffb04f4af0d84905425696a80a34fccc2656b61e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected scroll/viewport behavior: display scaling is now handled consistently and alternate-screen mode no longer causes incorrect viewport or document-height adjustments during scrolling.

* **Tests**
  * Added tests covering point-vs-pixel sizing, scroll-to-row behavior, and alternate-screen scroll handling.

* **Chores**
  * Updated vendored terminal submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->