### PR TITLE
Fix sidebar layout loop and CLI socket deadlocks

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -861,10 +861,12 @@ final class SocketClient {
     private var socketFD: Int32 = -1
     private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
     private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
+    private static let maxSocketTimeoutSeconds: TimeInterval = 9_007_199_254_740_991
     private static let responseTimeoutSeconds: TimeInterval = {
         let env = ProcessInfo.processInfo.environment
         if let raw = env["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"],
            let seconds = Double(raw),
+           seconds.isFinite,
            seconds > 0 {
             return seconds
         }
@@ -892,10 +894,16 @@ final class SocketClient {
     }
 
     private static func socketTimeval(for timeout: TimeInterval) -> timeval {
-        let clampedTimeout = max(timeout, 0.01)
+        let sanitizedTimeout = timeout.isFinite ? timeout : defaultResponseTimeoutSeconds
+        let clampedTimeout = min(max(sanitizedTimeout, 0.01), maxSocketTimeoutSeconds)
+        let seconds = floor(clampedTimeout)
+        let microseconds = min(
+            max(Int((clampedTimeout - seconds) * 1_000_000), 0),
+            999_999
+        )
         return timeval(
-            tv_sec: Int(clampedTimeout.rounded(.down)),
-            tv_usec: __darwin_suseconds_t((clampedTimeout - floor(clampedTimeout)) * 1_000_000)
+            tv_sec: Int(seconds),
+            tv_usec: __darwin_suseconds_t(microseconds)
         )
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -891,6 +891,14 @@ final class SocketClient {
         return trimmed
     }
 
+    private static func socketTimeval(for timeout: TimeInterval) -> timeval {
+        let clampedTimeout = max(timeout, 0.01)
+        return timeval(
+            tv_sec: Int(clampedTimeout.rounded(.down)),
+            tv_usec: __darwin_suseconds_t((clampedTimeout - floor(clampedTimeout)) * 1_000_000)
+        )
+    }
+
     func connect() throws {
         if socketFD >= 0 { return }
         try connectOnce()
@@ -916,12 +924,11 @@ final class SocketClient {
         }
 
         let payload = command + "\n"
-        try payload.withCString { ptr in
-            let sent = Darwin.write(socketFD, ptr, strlen(ptr))
-            if sent < 0 {
-                throw CLIError(message: "Failed to write to socket")
-            }
-        }
+        try writeAll(
+            Data(payload.utf8),
+            timeoutMessage: "Command timed out",
+            failureMessage: "Failed to write to socket"
+        )
 
         var data = Data()
         var sawNewline = false
@@ -984,6 +991,12 @@ final class SocketClient {
         socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
         if socketFD < 0 {
             throw CLIError(message: "Failed to create socket")
+        }
+        do {
+            try configureSocketWriteSafety(Self.responseTimeoutSeconds)
+        } catch {
+            close()
+            throw error
         }
 
         var addr = sockaddr_un()
@@ -1084,14 +1097,12 @@ final class SocketClient {
         guard socketFD >= 0 else {
             throw CLIError(message: "Failed to create relay socket")
         }
-
-        var timeout = timeval(
-            tv_sec: Int(Self.responseTimeoutSeconds.rounded(.down)),
-            tv_usec: __darwin_suseconds_t((Self.responseTimeoutSeconds - floor(Self.responseTimeoutSeconds)) * 1_000_000)
-        )
-        withUnsafePointer(to: &timeout) { pointer in
-            _ = setsockopt(socketFD, SOL_SOCKET, SO_RCVTIMEO, pointer, socklen_t(MemoryLayout<timeval>.size))
-            _ = setsockopt(socketFD, SOL_SOCKET, SO_SNDTIMEO, pointer, socklen_t(MemoryLayout<timeval>.size))
+        do {
+            try configureSocketWriteSafety(Self.responseTimeoutSeconds)
+            try configureReceiveTimeout(Self.responseTimeoutSeconds)
+        } catch {
+            close()
+            throw error
         }
 
         var address = sockaddr_in()
@@ -1149,7 +1160,11 @@ final class SocketClient {
             "relay_id": relayID,
             "mac": Self.hexString(from: mac),
         ])
-        try writeAll(authPayload + Data([0x0A]))
+        try writeAll(
+            authPayload + Data([0x0A]),
+            timeoutMessage: "Relay command timed out",
+            failureMessage: "Failed to write to relay socket"
+        )
 
         let authResponseLine = try readLine()
         guard let authResponseData = authResponseLine.data(using: .utf8),
@@ -1159,7 +1174,11 @@ final class SocketClient {
         }
     }
 
-    private func writeAll(_ data: Data) throws {
+    private func writeAll(
+        _ data: Data,
+        timeoutMessage: String,
+        failureMessage: String
+    ) throws {
         try data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
                 return
@@ -1168,14 +1187,58 @@ final class SocketClient {
             while offset < data.count {
                 let written = Darwin.write(socketFD, baseAddress.advanced(by: offset), data.count - offset)
                 if written < 0 {
-                    if errno == EINTR {
+                    let errorCode = errno
+                    if errorCode == EINTR {
                         continue
                     }
-                    throw CLIError(message: "Failed to write to relay socket")
+                    close()
+                    if errorCode == EAGAIN || errorCode == EWOULDBLOCK || errorCode == ETIMEDOUT {
+                        throw CLIError(message: timeoutMessage)
+                    }
+                    let reason = String(cString: strerror(errorCode))
+                    throw CLIError(
+                        message: "\(failureMessage) (\(reason), errno \(errorCode))"
+                    )
+                }
+                if written == 0 {
+                    close()
+                    throw CLIError(message: failureMessage)
                 }
                 offset += written
             }
         }
+    }
+
+    private func configureSocketWriteSafety(_ timeout: TimeInterval) throws {
+        var interval = Self.socketTimeval(for: timeout)
+        let sendTimeoutResult = withUnsafePointer(to: &interval) { ptr in
+            setsockopt(
+                socketFD,
+                SOL_SOCKET,
+                SO_SNDTIMEO,
+                ptr,
+                socklen_t(MemoryLayout<timeval>.size)
+            )
+        }
+        guard sendTimeoutResult == 0 else {
+            throw CLIError(message: "Failed to configure socket write timeout")
+        }
+
+#if os(macOS)
+        var noSigPipe: Int32 = 1
+        let noSigPipeResult = withUnsafePointer(to: &noSigPipe) { ptr in
+            setsockopt(
+                socketFD,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                ptr,
+                socklen_t(MemoryLayout<Int32>.size)
+            )
+        }
+        guard noSigPipeResult == 0 else {
+            throw CLIError(message: "Failed to disable SIGPIPE on socket")
+        }
+#endif
     }
 
     private func readLine(maxBytes: Int = 16 * 1024) throws -> String {
@@ -1214,10 +1277,7 @@ final class SocketClient {
     }
 
     private func configureReceiveTimeout(_ timeout: TimeInterval) throws {
-        var interval = timeval(
-            tv_sec: Int(timeout.rounded(.down)),
-            tv_usec: __darwin_suseconds_t((timeout - floor(timeout)) * 1_000_000)
-        )
+        var interval = Self.socketTimeval(for: timeout)
         let result = withUnsafePointer(to: &interval) { ptr in
             setsockopt(
                 socketFD,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9929,7 +9929,9 @@ struct VerticalTabsSidebar: View {
                         Spacer()
                             .frame(height: trafficLightPadding)
 
-                        LazyVStack(spacing: tabRowSpacing) {
+                        // Workspaces are bounded, so prefer a non-lazy stack here.
+                        // LazyVStack + drag-state invalidations can recurse through layout.
+                        VStack(spacing: tabRowSpacing) {
                             ForEach(tabs, id: \.id) { tab in
                                 let index = tabIndexById[tab.id] ?? 0
                                 let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
@@ -9986,6 +9988,7 @@ struct VerticalTabsSidebar: View {
                             }
                         }
                         .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
                         SidebarEmptyArea(
                             rowSpacing: tabRowSpacing,
@@ -14246,12 +14249,12 @@ private struct SidebarMetadataMarkdownBlockRow: View {
     }
 }
 
-enum SidebarDropEdge {
+enum SidebarDropEdge: Equatable {
     case top
     case bottom
 }
 
-struct SidebarDropIndicator {
+struct SidebarDropIndicator: Equatable {
     let tabId: UUID?
     let edge: SidebarDropEdge
 }
@@ -14790,7 +14793,7 @@ private struct SidebarTabDropDelegate: DropDelegate {
     private func updateDropIndicator(for info: DropInfo) {
         let tabIds = tabManager.tabs.map(\.id)
         let pinnedTabIds = Set(tabManager.tabs.filter(\.isPinned).map(\.id))
-        dropIndicator = SidebarDropPlanner.indicator(
+        let nextIndicator = SidebarDropPlanner.indicator(
             draggedTabId: draggedTabId,
             targetTabId: targetTabId,
             tabIds: tabIds,
@@ -14798,6 +14801,8 @@ private struct SidebarTabDropDelegate: DropDelegate {
             pointerY: targetTabId == nil ? nil : info.location.y,
             targetHeight: targetRowHeight
         )
+        guard dropIndicator != nextIndicator else { return }
+        dropIndicator = nextIndicator
     }
 
     private func syncSidebarSelection(preferredSelectedTabId: UUID? = nil) {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12676,10 +12676,14 @@ class TerminalController {
 
         if let workspaceId = UUID(uuidString: tabArg),
            let panelId = UUID(uuidString: panelArg) {
-            DispatchQueue.main.async { [weak self] in
-                guard let self,
-                      let tab = self.tabForSidebarMutation(id: workspaceId),
-                      tab.panels[panelId] != nil else {
+            var result = "OK"
+            DispatchQueue.main.sync {
+                guard let tab = self.tabForSidebarMutation(id: workspaceId) else {
+                    result = "ERROR: Tab not found"
+                    return
+                }
+                guard tab.panels[panelId] != nil else {
+                    result = "ERROR: Panel not found"
                     return
                 }
                 TerminalNotificationStore.shared.addNotification(
@@ -12690,7 +12694,7 @@ class TerminalController {
                     body: body
                 )
             }
-            return "OK"
+            return result
         }
 
         var result = "OK"
@@ -14480,7 +14484,7 @@ class TerminalController {
     }
 
     private func resolveTabIdForSidebarMutation(
-        reportArgs: String,
+        reportArgs _: String,
         options: [String: String]
     ) -> (tabId: UUID?, error: String?) {
         if let rawTabArg = options["tab"] {
@@ -14489,24 +14493,25 @@ class TerminalController {
                 return (nil, "ERROR: Tab not found")
             }
             if let tabId = UUID(uuidString: tabArg) {
-                // Telemetry/socket mutations commonly pass an explicit workspace UUID.
-                // Accept it directly so the socket handler doesn't block on main-thread
-                // layout stalls before it can enqueue the mutation.
+                guard tabForSidebarMutation(id: tabId) != nil else {
+                    return (nil, "ERROR: Tab not found")
+                }
                 return (tabId, nil)
             }
+
+            guard let tabManager = self.tabManager,
+                  let tab = resolveTab(from: tabArg, tabManager: tabManager) else {
+                return (nil, "ERROR: Tab not found")
+            }
+            return (tab.id, nil)
         }
 
-        var tabId: UUID?
-        DispatchQueue.main.sync {
-            if let tab = resolveTabForReport(reportArgs) {
-                tabId = tab.id
-            }
+        guard let tabManager = self.tabManager,
+              let selectedId = tabManager.selectedTabId,
+              tabManager.tabs.contains(where: { $0.id == selectedId }) else {
+            return (nil, "ERROR: No tab selected")
         }
-        if let tabId {
-            return (tabId, nil)
-        }
-        let error = options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
-        return (nil, error)
+        return (selectedId, nil)
     }
 
     private func tabForSidebarMutation(id: UUID) -> Tab? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6913,7 +6913,7 @@ class TerminalController {
     }
 
     private func v2NotificationClear() -> V2CallResult {
-        DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             TerminalNotificationStore.shared.clearAll()
         }
         return .ok([:])
@@ -12672,6 +12672,26 @@ class TerminalController {
         let tabArg = parts[0]
         let panelArg = parts[1]
         let payload = parts.count > 2 ? parts[2] : ""
+        let (title, subtitle, body) = parseNotificationPayload(payload)
+
+        if let workspaceId = UUID(uuidString: tabArg),
+           let panelId = UUID(uuidString: panelArg) {
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let tab = self.tabForSidebarMutation(id: workspaceId),
+                      tab.panels[panelId] != nil else {
+                    return
+                }
+                TerminalNotificationStore.shared.addNotification(
+                    tabId: workspaceId,
+                    surfaceId: panelId,
+                    title: title,
+                    subtitle: subtitle,
+                    body: body
+                )
+            }
+            return "OK"
+        }
 
         var result = "OK"
         DispatchQueue.main.sync {
@@ -12690,7 +12710,6 @@ class TerminalController {
                 result = "ERROR: Panel not found"
                 return
             }
-            let (title, subtitle, body) = parseNotificationPayload(payload)
             TerminalNotificationStore.shared.addNotification(
                 tabId: tab.id,
                 surfaceId: panelId,
@@ -12718,7 +12737,7 @@ class TerminalController {
     private func clearNotifications(_ args: String) -> String {
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            DispatchQueue.main.sync {
+            DispatchQueue.main.async {
                 TerminalNotificationStore.shared.clearAll()
             }
             return "OK"
@@ -12728,16 +12747,12 @@ class TerminalController {
               !tabOption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return "ERROR: Usage: clear_notifications [--tab=X]"
         }
-        var tabId: UUID?
-        DispatchQueue.main.sync {
-            if let tab = resolveTabForReport(trimmed) {
-                tabId = tab.id
-            }
-        }
+        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: trimmed, options: parsed.options)
+        let tabId = tabResolution.tabId
         guard let tabId else {
-            return "ERROR: Tab not found"
+            return tabResolution.error ?? "ERROR: Tab not found"
         }
-        DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             TerminalNotificationStore.shared.clearNotifications(forTabId: tabId)
         }
         return "OK"
@@ -14468,6 +14483,19 @@ class TerminalController {
         reportArgs: String,
         options: [String: String]
     ) -> (tabId: UUID?, error: String?) {
+        if let rawTabArg = options["tab"] {
+            let tabArg = rawTabArg.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !tabArg.isEmpty else {
+                return (nil, "ERROR: Tab not found")
+            }
+            if let tabId = UUID(uuidString: tabArg) {
+                // Telemetry/socket mutations commonly pass an explicit workspace UUID.
+                // Accept it directly so the socket handler doesn't block on main-thread
+                // layout stalls before it can enqueue the mutation.
+                return (tabId, nil)
+            }
+        }
+
         var tabId: UUID?
         DispatchQueue.main.sync {
             if let tab = resolveTabForReport(reportArgs) {
@@ -14655,20 +14683,19 @@ class TerminalController {
             return "ERROR: Missing metadata key — usage: \(usage)"
         }
 
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
-                return
-            }
-            if tab.statusEntries.removeValue(forKey: key) == nil {
-                result = "OK (key not found)"
-            }
+        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
+        guard let targetTabId = tabResolution.tabId else {
+            return tabResolution.error ?? "ERROR: No tab selected"
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+            _ = tab.statusEntries.removeValue(forKey: key)
             if tab.agentPIDs.removeValue(forKey: key) != nil {
                 self.refreshTrackedAgentPorts(for: tab)
             }
         }
-        return result
+        return "OK"
     }
 
     /// Register an agent PID for stale-session detection without setting a visible status entry.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -14667,7 +14667,7 @@ class TerminalController {
             return nil
         }()
 
-        scheduleSidebarMutation(target: target) { self, tab in
+        scheduleSidebarMutation(target: target) { controller, tab in
             guard Self.shouldReplaceStatusEntry(
                 current: tab.statusEntries[key],
                 key: key,
@@ -14681,7 +14681,7 @@ class TerminalController {
                 // Still update PID tracking even if the status display hasn't changed.
                 if let pidValue {
                     tab.agentPIDs[key] = pidValue
-                    self.refreshTrackedAgentPorts(for: tab)
+                    controller.refreshTrackedAgentPorts(for: tab)
                 }
                 return
             }
@@ -14697,7 +14697,7 @@ class TerminalController {
             )
             if let pidValue {
                 tab.agentPIDs[key] = pidValue
-                self.refreshTrackedAgentPorts(for: tab)
+                controller.refreshTrackedAgentPorts(for: tab)
             }
         }
         return "OK"
@@ -14714,10 +14714,10 @@ class TerminalController {
             return targetResolution.error ?? "ERROR: No tab selected"
         }
 
-        scheduleSidebarMutation(target: target) { self, tab in
+        scheduleSidebarMutation(target: target) { controller, tab in
             _ = tab.statusEntries.removeValue(forKey: key)
             if tab.agentPIDs.removeValue(forKey: key) != nil {
-                self.refreshTrackedAgentPorts(for: tab)
+                controller.refreshTrackedAgentPorts(for: tab)
             }
         }
         return "OK"
@@ -14736,9 +14736,9 @@ class TerminalController {
         guard let target = targetResolution.target else {
             return targetResolution.error ?? "ERROR: No tab selected"
         }
-        scheduleSidebarMutation(target: target) { self, tab in
+        scheduleSidebarMutation(target: target) { controller, tab in
             tab.agentPIDs[key] = pid
-            self.refreshTrackedAgentPorts(for: tab)
+            controller.refreshTrackedAgentPorts(for: tab)
         }
         return "OK"
     }
@@ -14753,9 +14753,9 @@ class TerminalController {
         guard let target = targetResolution.target else {
             return targetResolution.error ?? "ERROR: No tab selected"
         }
-        scheduleSidebarMutation(target: target) { self, tab in
+        scheduleSidebarMutation(target: target) { controller, tab in
             tab.agentPIDs.removeValue(forKey: key)
-            self.refreshTrackedAgentPorts(for: tab)
+            controller.refreshTrackedAgentPorts(for: tab)
         }
         return "OK"
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12751,13 +12751,12 @@ class TerminalController {
               !tabOption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return "ERROR: Usage: clear_notifications [--tab=X]"
         }
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: trimmed, options: parsed.options)
-        let tabId = tabResolution.tabId
-        guard let tabId else {
-            return tabResolution.error ?? "ERROR: Tab not found"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: Tab not found"
         }
-        DispatchQueue.main.async {
-            TerminalNotificationStore.shared.clearNotifications(forTabId: tabId)
+        scheduleSidebarMutation(target: target) { _, tab in
+            TerminalNotificationStore.shared.clearNotifications(forTabId: tab.id)
         }
         return "OK"
     }
@@ -14483,35 +14482,48 @@ class TerminalController {
         return tabManager.tabs.first(where: { $0.id == selectedId })
     }
 
-    private func resolveTabIdForSidebarMutation(
-        reportArgs _: String,
+    private enum SidebarMutationTabTarget {
+        case selected
+        case workspace(UUID)
+        case index(Int)
+    }
+
+    private func parseSidebarMutationTabTarget(
         options: [String: String]
-    ) -> (tabId: UUID?, error: String?) {
+    ) -> (target: SidebarMutationTabTarget?, error: String?) {
         if let rawTabArg = options["tab"] {
             let tabArg = rawTabArg.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !tabArg.isEmpty else {
                 return (nil, "ERROR: Tab not found")
             }
             if let tabId = UUID(uuidString: tabArg) {
-                guard tabForSidebarMutation(id: tabId) != nil else {
-                    return (nil, "ERROR: Tab not found")
-                }
-                return (tabId, nil)
+                return (.workspace(tabId), nil)
             }
+            if let index = Int(tabArg), index >= 0 {
+                return (.index(index), nil)
+            }
+            return (nil, "ERROR: Tab not found")
+        }
+        return (.selected, nil)
+    }
 
+    private func resolveSidebarMutationTab(_ target: SidebarMutationTabTarget) -> Tab? {
+        switch target {
+        case .selected:
             guard let tabManager = self.tabManager,
-                  let tab = resolveTab(from: tabArg, tabManager: tabManager) else {
-                return (nil, "ERROR: Tab not found")
+                  let selectedId = tabManager.selectedTabId else {
+                return nil
             }
-            return (tab.id, nil)
+            return tabManager.tabs.first(where: { $0.id == selectedId })
+        case .workspace(let tabId):
+            return tabForSidebarMutation(id: tabId)
+        case .index(let index):
+            guard let tabManager = self.tabManager,
+                  index < tabManager.tabs.count else {
+                return nil
+            }
+            return tabManager.tabs[index]
         }
-
-        guard let tabManager = self.tabManager,
-              let selectedId = tabManager.selectedTabId,
-              tabManager.tabs.contains(where: { $0.id == selectedId }) else {
-            return (nil, "ERROR: No tab selected")
-        }
-        return (selectedId, nil)
     }
 
     private func tabForSidebarMutation(id: UUID) -> Tab? {
@@ -14539,6 +14551,16 @@ class TerminalController {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func scheduleSidebarMutation(
+        target: SidebarMutationTabTarget,
+        mutation: @escaping (TerminalController, Tab) -> Void
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let tab = self.resolveSidebarMutationTab(target) else { return }
+            mutation(self, tab)
+        }
     }
 
     private func schedulePanelMetadataMutation(
@@ -14632,9 +14654,9 @@ class TerminalController {
             parsedURL = nil
         }
 
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
-        guard let targetTabId = tabResolution.tabId else {
-            return tabResolution.error ?? "ERROR: No tab selected"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
         }
 
         let pidValue: pid_t? = {
@@ -14645,8 +14667,7 @@ class TerminalController {
             return nil
         }()
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+        scheduleSidebarMutation(target: target) { self, tab in
             guard Self.shouldReplaceStatusEntry(
                 current: tab.statusEntries[key],
                 key: key,
@@ -14688,13 +14709,12 @@ class TerminalController {
             return "ERROR: Missing metadata key — usage: \(usage)"
         }
 
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
-        guard let targetTabId = tabResolution.tabId else {
-            return tabResolution.error ?? "ERROR: No tab selected"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
         }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+        scheduleSidebarMutation(target: target) { self, tab in
             _ = tab.statusEntries.removeValue(forKey: key)
             if tab.agentPIDs.removeValue(forKey: key) != nil {
                 self.refreshTrackedAgentPorts(for: tab)
@@ -14712,12 +14732,11 @@ class TerminalController {
             return "ERROR: Usage: set_agent_pid <key> <pid> [--tab=<id>]"
         }
         let key = parsed.positional[0]
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
-        guard let targetTabId = tabResolution.tabId else {
-            return tabResolution.error ?? "ERROR: No tab selected"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
         }
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+        scheduleSidebarMutation(target: target) { self, tab in
             tab.agentPIDs[key] = pid
             self.refreshTrackedAgentPorts(for: tab)
         }
@@ -14730,14 +14749,11 @@ class TerminalController {
         guard let key = parsed.positional.first else {
             return "ERROR: Usage: clear_agent_pid <key> [--tab=<id>]"
         }
-        // Resolve tab ID synchronously before dispatching to avoid
-        // racing against selection changes on the main queue.
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: args, options: parsed.options)
-        guard let targetTabId = tabResolution.tabId else {
-            return tabResolution.error ?? "ERROR: No tab selected"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
         }
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+        scheduleSidebarMutation(target: target) { self, tab in
             tab.agentPIDs.removeValue(forKey: key)
             self.refreshTrackedAgentPorts(for: tab)
         }
@@ -14859,13 +14875,12 @@ class TerminalController {
             priority = 0
         }
 
-        let tabResolution = resolveTabIdForSidebarMutation(reportArgs: parts.optionsPart, options: parsed.options)
-        guard let targetTabId = tabResolution.tabId else {
-            return tabResolution.error ?? "ERROR: No tab selected"
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
         }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let tab = self.tabForSidebarMutation(id: targetTabId) else { return }
+        scheduleSidebarMutation(target: target) { _, tab in
             guard Self.shouldReplaceMetadataBlock(
                 current: tab.metadataBlocks[key],
                 key: key,


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a sidebar layout recursion loop during drag updates and prevents CLI socket deadlocks with safer socket config, main-queue tab resolution, and non-blocking UI mutations. Addresses Linear issue 2586.

- **Bug Fixes**
  - Sidebar: replaced LazyVStack with VStack and set leading max width to stop layout loops.
  - Drag/drop: made drop indicator and edge Equatable; guarded state updates to avoid extra re-layouts.
  - CLI sockets: clamped/sanitized timeouts, set send/receive timeouts, disabled SIGPIPE on macOS, hardened writes (retry on EINTR, close on error), and clearer timeout vs failure errors (treat EAGAIN/EWOULDBLOCK/ETIMEDOUT as timeouts).
  - Sidebar socket commands: validate tab/panel UUIDs, accept `--tab` as UUID or index and allow direct tab/panel UUID pairs, resolve targets and mutate on the main queue, use non-blocking clears, and fix mutation helper closure parameters.

<sup>Written for commit 8c0203dc977c9ef18e45922ee035c21fd3c7d373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable socket/relay communication with sanitized timeouts, retries for interrupted writes, safer socket shutdowns, and clearer error reporting.
  * Prevented unnecessary sidebar redraws during drag-and-drop by avoiding redundant state updates.
  * Made notification clearing and status updates non-blocking to avoid UI stalls.

* **Improvements**
  * Updated sidebar workspace layout for consistent left alignment.

* **Refactor**
  * Sidebar mutation handling now resolves and schedules updates asynchronously to reduce main-thread work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->