### PR TITLE
Fix window tiling and Swish gestures broken by isMovable=false

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6295,7 +6295,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.isMovable = false
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)
@@ -13203,8 +13202,13 @@ private extension NSWindow {
             cmuxFirstResponderGuardContextWindowNumber = previousContextWindowNumber
         }
 
-        guard shouldSuppressWindowMoveForFolderDrag(window: self, event: event),
-              let contentView = self.contentView else {
+        // Temporarily suppress window movability for all left-mouse-down events.
+        // This prevents AppKit's native titlebar drag from intercepting clicks on
+        // interactive views in the titlebar area (folder icon, sidebar buttons in
+        // minimal mode) while keeping isMovable=true globally for Swish / macOS
+        // tiling / Accessibility API compatibility. WindowDragHandleView.performDrag
+        // re-enables isMovable=true inside its modal event loop for explicit drags.
+        guard event.type == .leftMouseDown, isMovable else {
 #if DEBUG
             if event.type == .keyDown {
                 folderGuardMs = (ProcessInfo.processInfo.systemUptime - folderGuardStart) * 1000.0
@@ -13224,16 +13228,10 @@ private extension NSWindow {
         let originalDispatchStart = event.type == .keyDown ? ProcessInfo.processInfo.systemUptime : 0
 #endif
 
-        let contentPoint = contentView.convert(event.locationInWindow, from: nil)
-        let hitView = contentView.hitTest(contentPoint)
-        let previousMovableState = isMovable
-        if previousMovableState {
-            isMovable = false
-        }
+        isMovable = false
 
         #if DEBUG
-        let hitDesc = hitView.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog("window.sendEvent.folderDown suppress=1 hit=\(hitDesc) wasMovable=\(previousMovableState)")
+        dlog("window.sendEvent.leftMouseDown suppress isMovable=false")
         #endif
 
         cmux_sendEvent(event)
@@ -13243,12 +13241,10 @@ private extension NSWindow {
         }
 #endif
 
-        if previousMovableState {
-            isMovable = previousMovableState
-        }
+        isMovable = true
 
         #if DEBUG
-        dlog("window.sendEvent.folderDown restore nowMovable=\(isMovable)")
+        dlog("window.sendEvent.leftMouseDown restore isMovable=true")
         #endif
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3420,12 +3420,13 @@ struct ContentView: View {
         view = AnyView(view.background(WindowAccessor { [sidebarBlendMode, bgGlassEnabled, bgGlassTintHex, bgGlassTintOpacity] window in
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.titlebarAppearsTransparent = true
-            // Keep window immovable; the sidebar's WindowDragHandleView handles
-            // drag-to-move via performDrag with temporary movable override.
-            // isMovableByWindowBackground=true breaks tab reordering, and
-            // isMovable=true blocks clicks on sidebar buttons in minimal mode.
+            // isMovableByWindowBackground=true breaks tab reordering.
+            // Window dragging is handled explicitly by WindowDragHandleView via
+            // performDrag. The sendEvent swizzle temporarily suppresses isMovable
+            // during leftMouseDown so AppKit's native titlebar drag doesn't
+            // intercept clicks on interactive titlebar views (folder icon,
+            // sidebar buttons in minimal mode).
             window.isMovableByWindowBackground = false
-            window.isMovable = false
             window.styleMask.insert(.fullSizeContentView)
 
             // Track this window for fullscreen notifications
@@ -14918,10 +14919,7 @@ private struct DraggableFolderIcon: View {
     var body: some View {
         DraggableFolderIconRepresentable(directory: directory)
             .frame(width: 16, height: 16)
-            .safeHelp(String(localized: "sidebar.folderIcon.dragHint", defaultValue: "Drag to open in Finder or another app"))
-            .onTapGesture(count: 2) {
-                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: directory)
-            }
+            .safeHelp(String(localized: "sidebar.folderIcon.hint", defaultValue: "Click to copy path \u{2022} Double-click to reveal in Finder \u{2022} Right-click for path menu"))
     }
 }
 
@@ -14938,21 +14936,13 @@ private struct DraggableFolderIconRepresentable: NSViewRepresentable {
     }
 }
 
-final class DraggableFolderNSView: NSView, NSDraggingSource {
+final class DraggableFolderNSView: NSView {
     private final class FolderIconImageView: NSImageView {
         override var mouseDownCanMoveWindow: Bool { false }
     }
 
     var directory: String
     private var imageView: FolderIconImageView!
-    private var previousWindowMovableState: Bool?
-    private weak var suppressedWindow: NSWindow?
-    private var hasActiveDragSession = false
-    private var didArmWindowDragSuppression = false
-
-    private func formatPoint(_ point: NSPoint) -> String {
-        String(format: "(%.1f,%.1f)", point.x, point.y)
-    }
 
     init(directory: String) {
         self.directory = directory
@@ -14992,69 +14982,27 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         imageView.image = icon
     }
 
-    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
-        return context == .outsideApplication ? [.copy, .link] : .copy
-    }
-
-    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
-        hasActiveDragSession = false
-        restoreWindowMovableStateIfNeeded()
-        #if DEBUG
-        let nowMovable = window.map { String($0.isMovable) } ?? "nil"
-        let windowOrigin = window.map { formatPoint($0.frame.origin) } ?? "nil"
-        dlog("folder.dragEnd dir=\(directory) operation=\(operation.rawValue) screen=\(formatPoint(screenPoint)) nowMovable=\(nowMovable) windowOrigin=\(windowOrigin)")
-        #endif
-    }
-
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard bounds.contains(point) else { return nil }
-        let hit = super.hitTest(point)
-        #if DEBUG
-        let hitDesc = hit.map { String(describing: type(of: $0)) } ?? "nil"
-        let imageHit = (hit === imageView)
-        let wasMovable = previousWindowMovableState.map(String.init) ?? "nil"
-        let nowMovable = window.map { String($0.isMovable) } ?? "nil"
-        dlog("folder.hitTest point=\(formatPoint(point)) hit=\(hitDesc) imageViewHit=\(imageHit) returning=DraggableFolderNSView wasMovable=\(wasMovable) nowMovable=\(nowMovable)")
-        #endif
         return self
     }
 
     override func mouseDown(with event: NSEvent) {
-        maybeDisableWindowDraggingEarly(trigger: "mouseDown")
-        hasActiveDragSession = false
+        if event.clickCount >= 2 {
+            // Double-click: reveal in Finder
+            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: directory)
+        } else {
+            // Single click: copy path to clipboard
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(directory, forType: .string)
+        }
         #if DEBUG
-        let localPoint = convert(event.locationInWindow, from: nil)
-        let responderDesc = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        let wasMovable = previousWindowMovableState.map(String.init) ?? "nil"
-        let nowMovable = window.map { String($0.isMovable) } ?? "nil"
-        let windowOrigin = window.map { formatPoint($0.frame.origin) } ?? "nil"
-        dlog("folder.mouseDown dir=\(directory) point=\(formatPoint(localPoint)) firstResponder=\(responderDesc) wasMovable=\(wasMovable) nowMovable=\(nowMovable) windowOrigin=\(windowOrigin)")
+        dlog("folder.mouseDown dir=\(directory) clickCount=\(event.clickCount)")
         #endif
-        let fileURL = URL(fileURLWithPath: directory)
-        let draggingItem = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
-
-        let iconImage = NSWorkspace.shared.icon(forFile: directory)
-        iconImage.size = NSSize(width: 32, height: 32)
-        draggingItem.setDraggingFrame(bounds, contents: iconImage)
-
-        let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
-        hasActiveDragSession = true
-        #if DEBUG
-        let itemCount = session.draggingPasteboard.pasteboardItems?.count ?? 0
-        dlog("folder.dragStart dir=\(directory) pasteboardItems=\(itemCount)")
-        #endif
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        super.mouseUp(with: event)
-        // Always restore suppression on mouse-up; drag-session callbacks can be
-        // skipped for non-started drags, which would otherwise leave suppression stuck.
-        restoreWindowMovableStateIfNeeded()
     }
 
     override func rightMouseDown(with event: NSEvent) {
         let menu = buildPathMenu()
-        // Pop up menu at bottom-left of icon (like native proxy icon)
         let menuLocation = NSPoint(x: 0, y: bounds.height)
         menu.popUp(positioning: nil, at: menuLocation, in: self)
     }
@@ -15064,7 +15012,6 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         let url = URL(fileURLWithPath: directory).standardized
         var pathComponents: [URL] = []
 
-        // Build path from current directory up to root
         var current = url
         while current.path != "/" {
             pathComponents.append(current)
@@ -15072,14 +15019,12 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         }
         pathComponents.append(URL(fileURLWithPath: "/"))
 
-        // Add path components (current dir at top, root at bottom - matches native macOS)
         for pathURL in pathComponents {
             let icon = NSWorkspace.shared.icon(forFile: pathURL.path)
             icon.size = NSSize(width: 16, height: 16)
 
             let displayName: String
             if pathURL.path == "/" {
-                // Use the volume name for root
                 if let volumeName = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeNameKey]).volumeName {
                     displayName = volumeName
                 } else {
@@ -15096,7 +15041,6 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
             menu.addItem(item)
         }
 
-        // Add computer name at the bottom (like native proxy icon)
         let computerName = Host.current().localizedName ?? ProcessInfo.processInfo.hostName
         let computerIcon = NSImage(named: NSImage.computerName) ?? NSImage()
         computerIcon.size = NSSize(width: 16, height: 16)
@@ -15115,47 +15059,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     }
 
     @objc private func openComputer(_ sender: NSMenuItem) {
-        // Open "Computer" view in Finder (shows all volumes)
         NSWorkspace.shared.open(URL(fileURLWithPath: "/", isDirectory: true))
-    }
-
-    private func restoreWindowMovableStateIfNeeded() {
-        guard didArmWindowDragSuppression || previousWindowMovableState != nil else { return }
-        let targetWindow = suppressedWindow ?? window
-        let depthAfter = endWindowDragSuppression(window: targetWindow)
-        restoreWindowDragging(window: targetWindow, previousMovableState: previousWindowMovableState)
-        self.previousWindowMovableState = nil
-        self.suppressedWindow = nil
-        self.didArmWindowDragSuppression = false
-        #if DEBUG
-        let nowMovable = targetWindow.map { String($0.isMovable) } ?? "nil"
-        dlog("folder.dragSuppression restore depth=\(depthAfter) nowMovable=\(nowMovable)")
-        #endif
-    }
-
-    private func maybeDisableWindowDraggingEarly(trigger: String) {
-        guard !didArmWindowDragSuppression else { return }
-        guard let eventType = NSApp.currentEvent?.type,
-              eventType == .leftMouseDown || eventType == .leftMouseDragged else {
-            return
-        }
-        guard let currentWindow = window else { return }
-
-        didArmWindowDragSuppression = true
-        suppressedWindow = currentWindow
-        let suppressionDepth = beginWindowDragSuppression(window: currentWindow) ?? 0
-        if currentWindow.isMovable {
-            previousWindowMovableState = temporarilyDisableWindowDragging(window: currentWindow)
-        } else {
-            previousWindowMovableState = nil
-        }
-        #if DEBUG
-        let wasMovable = previousWindowMovableState.map(String.init) ?? "nil"
-        let nowMovable = String(currentWindow.isMovable)
-        dlog(
-            "folder.dragSuppression trigger=\(trigger) event=\(eventType) depth=\(suppressionDepth) wasMovable=\(wasMovable) nowMovable=\(nowMovable)"
-        )
-        #endif
     }
 }
 

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -431,6 +431,26 @@ struct WindowDragHandleView: NSViewRepresentable {
             )
             #endif
 
+            // The sibling walk in hitTest can miss views nested inside SwiftUI
+            // hosting containers. Before starting a window drag (or handling a
+            // titlebar double-click), do a full window-level hit test to check
+            // if an interactive view (e.g. the folder icon) is the real target.
+            // If so, forward the event — including double-clicks.
+            if let window, let contentView = window.contentView {
+                let pointInContent = contentView.convert(event.locationInWindow, from: nil)
+                Self.isResolvingForwardTarget = true
+                let realTarget = contentView.hitTest(pointInContent)
+                Self.isResolvingForwardTarget = false
+                if let realTarget,
+                   !windowDragHandleShouldTreatTopHitAsPassiveHost(realTarget) {
+                    #if DEBUG
+                    dlog("titlebar.dragHandle.mouseDown forwarding to \(type(of: realTarget))")
+                    #endif
+                    realTarget.mouseDown(with: event)
+                    return
+                }
+            }
+
             if event.clickCount >= 2 {
                 let action = performStandardTitlebarDoubleClick(window: window)
                 #if DEBUG
@@ -446,25 +466,6 @@ struct WindowDragHandleView: NSViewRepresentable {
                 dlog("titlebar.dragHandle.mouseDownIgnored reason=suppressed")
                 #endif
                 return
-            }
-
-            // The sibling walk in hitTest can miss views nested inside SwiftUI
-            // hosting containers. Before starting a window drag, do a full
-            // window-level hit test to check if an interactive view (e.g. the
-            // folder icon) is the real target. If so, forward the event.
-            if let window, let contentView = window.contentView {
-                let pointInContent = contentView.convert(event.locationInWindow, from: nil)
-                Self.isResolvingForwardTarget = true
-                let realTarget = contentView.hitTest(pointInContent)
-                Self.isResolvingForwardTarget = false
-                if let realTarget,
-                   !windowDragHandleShouldTreatTopHitAsPassiveHost(realTarget) {
-                    #if DEBUG
-                    dlog("titlebar.dragHandle.mouseDown forwarding to \(type(of: realTarget))")
-                    #endif
-                    realTarget.mouseDown(with: event)
-                    return
-                }
             }
 
             if let window {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -394,7 +394,12 @@ struct WindowDragHandleView: NSViewRepresentable {
     private final class DraggableView: NSView {
         override var mouseDownCanMoveWindow: Bool { false }
 
+        /// Set during the mouseDown forwarding check so the nested
+        /// contentView.hitTest skips this view and finds the real target.
+        private static var isResolvingForwardTarget = false
+
         override func hitTest(_ point: NSPoint) -> NSView? {
+            if Self.isResolvingForwardTarget { return nil }
             let currentEvent = NSApp.currentEvent
             // Fast bail-out: only claim hits for left-mouse-down events.
             // For mouseMoved / mouseEntered / etc., return nil immediately
@@ -441,6 +446,25 @@ struct WindowDragHandleView: NSViewRepresentable {
                 dlog("titlebar.dragHandle.mouseDownIgnored reason=suppressed")
                 #endif
                 return
+            }
+
+            // The sibling walk in hitTest can miss views nested inside SwiftUI
+            // hosting containers. Before starting a window drag, do a full
+            // window-level hit test to check if an interactive view (e.g. the
+            // folder icon) is the real target. If so, forward the event.
+            if let window, let contentView = window.contentView {
+                let pointInContent = contentView.convert(event.locationInWindow, from: nil)
+                Self.isResolvingForwardTarget = true
+                let realTarget = contentView.hitTest(pointInContent)
+                Self.isResolvingForwardTarget = false
+                if let realTarget,
+                   !windowDragHandleShouldTreatTopHitAsPassiveHost(realTarget) {
+                    #if DEBUG
+                    dlog("titlebar.dragHandle.mouseDown forwarding to \(type(of: realTarget))")
+                    #endif
+                    realTarget.mouseDown(with: event)
+                    return
+                }
             }
 
             if let window {


### PR DESCRIPTION
## Problem

Since `0d98db72`, `window.isMovable = false` is set globally on all main windows to prevent the folder icon drag from moving the window. This makes macOS mark the Accessibility `kAXPositionAttribute` as non-settable, which silently breaks:

- **Swish** trackpad gestures (tile/resize via two-finger swipe)
- **Green button** missing "Move and Resize" / "Fill and Arrange" options
- **macOS system tiling** (Stage Manager, window snapping)
- **Rectangle / Magnet / BetterSnapTool** and any AX-based window manager

All external window managers use `AXUIElementSetAttributeValue` on the position attribute to move windows. When `isMovable = false`, AppKit marks that attribute as non-settable and the writes fail silently.

## Fix

**Remove global `isMovable = false`** and instead suppress it temporarily during `leftMouseDown` event processing only (via the existing `cmux_sendEvent` swizzle). Outside of event dispatch, `isMovable` remains `true` so the AX API reports the window as movable. `WindowDragHandleView.performDrag` re-enables `isMovable` inside its modal event loop for explicit titlebar drags.

**Replace folder icon drag with click-to-copy-path.** The `beginDraggingSession` call was the original source of the conflict — it fought AppKit's titlebar event routing. Now: single click copies path to clipboard, double-click reveals in Finder, right-click shows the path component menu.

**Forward events past the drag handle.** `WindowDragHandleView`'s sibling walk can miss views nested inside SwiftUI hosting containers (`siblingCount=1` in practice). Added a window-level hit test in `mouseDown` (with a re-entrancy guard) that finds the real target and forwards the event instead of calling `performDrag`.

## Changes

| File | What |
|------|------|
| `AppDelegate.swift` | Remove `window.isMovable = false` from window creation; broaden `cmux_sendEvent` to suppress `isMovable` for all `leftMouseDown` events |
| `ContentView.swift` | Remove `window.isMovable = false` from WindowAccessor; strip drag machinery from `DraggableFolderNSView`; replace with copy-path on click |
| `WindowDragHandleView.swift` | Add forwarding check in `DraggableView.mouseDown` with `isResolvingForwardTarget` re-entrancy guard |

## Testing

- Swish gestures tile/resize correctly
- Green button shows full "Move and Resize" / "Fill and Arrange" menu
- Clicking folder icon copies path to clipboard, does not move window
- Double-click folder icon opens Finder
- Right-click folder icon shows path menu
- Dragging empty titlebar space moves window normally
- Double-click titlebar zooms/minimizes per system preference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores macOS window tiling and external window manager support by keeping windows movable, and updates the folder icon to avoid titlebar drag conflicts. Swish, Stage Manager, the green button menu, and AX-based apps work again.

- **Bug Fixes**
  - Removed global `window.isMovable = false`; now temporarily suppressed only during `leftMouseDown` dispatch.
  - AX position is settable again; Swish, Rectangle, Magnet, and macOS tiling/green-button options are restored.
  - Drag handle now does a window-level hit test and forwards events to the real target (including double-clicks). Fixes missed hits in SwiftUI containers and prevents folder-icon double-click from triggering titlebar zoom/minimize.

- **New Features**
  - Folder icon behavior: single click copies path, double-click reveals in Finder, right-click shows the path menu.

<sup>Written for commit 17ab18c0c86ea1c29afcd92db615787456ab1a13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of interactive titlebar elements to prevent unintended window movement.

* **Changes**
  * Folder icon interaction updated: single-click copies the folder path; double-click opens the folder in Finder.
  * Added contextual hint text for folder icons describing available actions.
  * Refined window-drag handling to consistently suppress titlebar dragging during targeted pointer interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->