### PR TITLE
Fix: bound socket thread pool

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -49,6 +49,16 @@ class TerminalController {
     private nonisolated(unsafe) var listenerStartInProgress = false
     private nonisolated let listenerStateLock = NSLock()
     private var clientHandlers: [Int32: Thread] = [:]
+    /// Bounded queue for socket client handlers. Limits concurrent handler threads
+    /// to prevent unbounded thread accumulation when the main thread is stalled.
+    private nonisolated let clientQueue = DispatchQueue(
+        label: "com.cmuxterm.socket-clients",
+        qos: .utility,
+        attributes: .concurrent
+    )
+    /// Maximum concurrent socket handler operations. Limits memory growth from
+    /// blocked handlers when the main queue is temporarily unresponsive.
+    private nonisolated let clientConcurrencyLimit = DispatchSemaphore(value: 64)
     private var tabManager: TabManager?
     private var accessMode: SocketControlMode = .cmuxOnly
     private let myPid = getpid()
@@ -1512,9 +1522,22 @@ class TerminalController {
             // the time a new thread starts the peer may already be gone.
             let peerPid = getPeerPid(clientSocket)
 
-            // Handle client in new thread
-            Thread.detachNewThread { [weak self] in
-                self?.handleClient(clientSocket, peerPid: peerPid)
+            // Handle client on bounded queue to prevent unbounded thread growth
+            // when the main thread is temporarily unresponsive.
+            clientQueue.async { [weak self] in
+                guard let self else {
+                    close(clientSocket)
+                    return
+                }
+                guard self.clientConcurrencyLimit.wait(timeout: .now() + 30) == .success else {
+                    // All handler slots full — reject this connection to apply backpressure.
+                    let msg = "ERROR: Server busy\n"
+                    msg.withCString { ptr in _ = write(clientSocket, ptr, strlen(ptr)) }
+                    close(clientSocket)
+                    return
+                }
+                defer { self.clientConcurrencyLimit.signal() }
+                self.handleClient(clientSocket, peerPid: peerPid)
             }
         }
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -49,16 +49,20 @@ class TerminalController {
     private nonisolated(unsafe) var listenerStartInProgress = false
     private nonisolated let listenerStateLock = NSLock()
     private var clientHandlers: [Int32: Thread] = [:]
-    /// Bounded queue for socket client handlers. Limits concurrent handler threads
-    /// to prevent unbounded thread accumulation when the main thread is stalled.
+    /// Dispatches accepted socket connections onto GCD instead of one `NSThread` per client.
+    /// This queue is **concurrent**: many `async` blocks may be waiting; the semaphore below caps
+    /// how many run `handleClient` at once (so a connection flood still queues work, but avoids
+    /// unbounded thread creation when handlers stall on the main actor).
     private nonisolated let clientQueue = DispatchQueue(
         label: "com.cmuxterm.socket-clients",
         qos: .utility,
         attributes: .concurrent
     )
-    /// Maximum concurrent socket handler operations. Limits memory growth from
-    /// blocked handlers when the main queue is temporarily unresponsive.
+    /// Max concurrent `handleClient` executions (tunable). Chosen as a generous ceiling for normal
+    /// CLI/automation parallelism while bounding worst-case thread/memory growth.
     private nonisolated let clientConcurrencyLimit = DispatchSemaphore(value: 64)
+    /// How long a connection waits for a handler slot before we reject with "Server busy".
+    private nonisolated let clientHandlerSlotWait: DispatchTimeInterval = .seconds(30)
     private var tabManager: TabManager?
     private var accessMode: SocketControlMode = .cmuxOnly
     private let myPid = getpid()
@@ -1529,7 +1533,7 @@ class TerminalController {
                     close(clientSocket)
                     return
                 }
-                guard self.clientConcurrencyLimit.wait(timeout: .now() + 30) == .success else {
+                guard self.clientConcurrencyLimit.wait(timeout: .now() + self.clientHandlerSlotWait) == .success else {
                     // All handler slots full — reject this connection to apply backpressure.
                     let msg = "ERROR: Server busy\n"
                     msg.withCString { ptr in _ = write(clientSocket, ptr, strlen(ptr)) }

--- a/docs/pr-bound-socket-thread-pool.md
+++ b/docs/pr-bound-socket-thread-pool.md
@@ -1,0 +1,37 @@
+## Summary
+
+Replace unbounded `Thread.detachNewThread` for socket client handlers with a
+bounded concurrent `DispatchQueue` and semaphore, preventing runaway thread
+accumulation when the main thread is temporarily unresponsive.
+
+## Problem
+
+Each incoming socket connection (e.g. `cmux claude-hook` calls from Claude Code
+hooks) spawns a new `NSThread` via `Thread.detachNewThread`. When the main
+thread stalls — for example during a heavy SwiftUI render pass — handler threads
+that call `@MainActor`-isolated methods block on `DispatchQueue.main.sync`.
+Because thread creation is unbounded, these blocked threads pile up indefinitely.
+
+In a real incident this produced **150+ blocked threads** and a **10.93 GB**
+memory footprint, making the app permanently unresponsive and unrecoverable
+without a force kill.
+
+## Fix
+
+- Add a private concurrent `DispatchQueue` (`com.cmuxterm.socket-clients`) for
+  client handler dispatch.
+- Gate handler execution behind a `DispatchSemaphore(value: 64)` to cap
+  concurrent handlers.
+- Handlers that cannot acquire a slot within 30 seconds return `ERROR: Server busy`
+  and close the connection, applying backpressure to callers instead of
+  accumulating memory.
+- The accept loop's own `Thread.detachNewThread` (single long-lived thread) is
+  unchanged.
+
+## Test plan
+
+- [ ] Verify normal `cmux` CLI commands still work (ping, report_*, etc.)
+- [ ] Simulate main thread stall with a debug sleep and confirm thread count
+      stays bounded
+- [ ] Confirm "Server busy" response when all slots are exhausted
+- [ ] Run existing socket tests (`tests_v2/`) against a tagged debug build


### PR DESCRIPTION
## Summary

**What changed?**

- Replaced unbounded `Thread.detachNewThread` for **per-connection** socket client handlers with a **bounded** concurrent `DispatchQueue` (`com.cmuxterm.socket-clients`) and a **`DispatchSemaphore(value: 64)`** so at most 64 handlers run `handleClient` at once.
- Connections that cannot acquire a slot within **30 seconds** get **`ERROR: Server busy`**, the socket is closed, and backpressure is applied to callers.
- The accept loop still uses a **single** long-lived `Thread.detachNewThread`; only per-client dispatch is bounded.
- Follow-up doc tweak on the branch: comments clarify that the **queue can still backlog** `async` work while the semaphore caps **concurrent** execution; the 30s wait is a named constant (`clientHandlerSlotWait`).

**Why?**

Each incoming connection (e.g. `cmux` / Claude Code hooks) used to spawn a new `NSThread`. When the main thread stalls (e.g. heavy SwiftUI), handler threads that hit `@MainActor` / `DispatchQueue.main.sync` can block. With **unbounded** thread creation, blocked threads pile up. In a real incident that led to **150+ blocked threads** and **~10.93 GB** memory, leaving the app unrecoverable without a force kill. Bounding concurrency limits worst-case thread/memory growth and surfaces overload explicitly via “Server busy”.

---

## Testing

⚠️  I did not yet.  The bug happened over a very long runtime, that will be hard to reproduce.   This PR is being opened for solicitation for feedback, to evaluate if the long test cycle - with a test compilation of the app - may be worth it.

I can follow any suggestions you offer. 🤝  

**How did you test this change?**

- [ ] Normal `cmux` CLI over the socket (e.g. `ping`, `report_*`, etc.).
- [ ] Optional: simulate a main-thread stall (e.g. debug sleep) and confirm **thread count stays bounded** (vs unbounded growth before).
- [ ] Optional: drive enough concurrent socket clients to exhaust 64 slots and confirm **`ERROR: Server busy`** and connection close.
- [ ] Run **`tests_v2/`** against a **tagged** debug build and socket (`CMUX_SOCKET=...` as per project docs).


## Test plan

- [ ] Verify normal `cmux` CLI commands still work (ping, report_*, etc.)
- [ ] Simulate main thread stall with a debug sleep and confirm thread count
      stays bounded
- [ ] Confirm "Server busy" response when all slots are exhausted
- [ ] Run existing socket tests (`tests_v2/`) against a tagged debug build

**What did you verify manually?**

- [ ] (Describe: e.g. “Tagged `reload.sh --tag …`, ran CLI ping + a few report commands; optional Instruments/thread count check.”)

---

## Demo Video

the app hangs, with a spinning color wheel.   Memory is consumed until crash of the machine. 

---

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

---

## Checklist

- [ ] I tested the change locally  
- [ ] I added or updated tests for behavior changes *(optional: note if you rely on manual/socket tests only; consider a follow-up test for “Server busy” if you want CI coverage)*  
- [ ] I updated docs/changelog if needed *(PR doc under `docs/` is fine; `CHANGELOG.md` only if your repo requires it for this kind of fix)*  
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)  
- [ ] All code review bot comments are resolved  
- [ ] All human review comments are resolved  

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound socket client handler concurrency to prevent runaway threads and memory spikes during main-thread stalls. Per-connection work now runs on a concurrent queue with a 64-handler cap; saturated connections get "ERROR: Server busy" after 30s.

- **Bug Fixes**
  - Replaced per-connection `Thread.detachNewThread` with a concurrent `DispatchQueue` (`com.cmuxterm.socket-clients`) gated by a `DispatchSemaphore(64)`.
  - If a slot isn’t available within 30s, respond with `ERROR: Server busy` and close the socket to apply backpressure.
  - Accept loop remains a single long-lived thread; only client handling is bounded.
  - Added docs clarifying queue backlog vs concurrency cap and the named wait constant.

<sup>Written for commit 857fd9e80941fe39ed6ce0fb104ef4deb965f991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

