### PR TITLE
fix: break BrowserPanelView render loop by deferring @AppStorage writ…

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -590,10 +590,15 @@ struct BrowserPanelView: View {
         }
         .onChange(of: browserThemeModeRaw) { _ in
             let normalizedMode = BrowserThemeSettings.mode(for: browserThemeModeRaw)
-            if browserThemeModeRaw != normalizedMode.rawValue {
-                browserThemeModeRaw = normalizedMode.rawValue
-            }
             panel.setBrowserThemeMode(normalizedMode)
+            // Defer the normalization write to the next run loop turn so we do not write to the
+            // observed @AppStorage key during the same attribute-graph update that triggered
+            // onChange (can re-enter SwiftUI updates and spin the main thread).
+            if browserThemeModeRaw != normalizedMode.rawValue {
+                DispatchQueue.main.async {
+                    browserThemeModeRaw = normalizedMode.rawValue
+                }
+            }
         }
         .onChange(of: colorScheme) { _ in
             refreshBrowserChromeStyle()

--- a/docs/pr-browser-panel-render-loop.md
+++ b/docs/pr-browser-panel-render-loop.md
@@ -1,0 +1,39 @@
+## Summary
+
+Fix an infinite SwiftUI render loop in `BrowserPanelView` caused by writing to
+an `@AppStorage` property inside its own `onChange` handler.
+
+## Problem
+
+The `onChange(of: browserThemeModeRaw)` handler normalizes the raw value and
+writes the result back to `browserThemeModeRaw`. Because `@AppStorage` mutations
+immediately invalidate the SwiftUI attribute graph, this write can trigger body
+re-evaluation during the current render pass. When combined with
+`panel.setBrowserThemeMode()` firing `objectWillChange` on the observed panel,
+the attribute graph enters an infinite update cycle:
+
+```
+GraphHost.flushTransactions()
+  → AG::Subgraph::update()
+    → AG::Graph::UpdateStack::update()
+      → BrowserPanelView.body.getter
+        → addressBar / addressBarButtonBar
+```
+
+In a real incident, this consumed 100% CPU on the main thread for 26+ minutes,
+completely blocking the event loop and preventing all UI interaction.
+
+## Fix
+
+Move the `@AppStorage` normalization write to `DispatchQueue.main.async` so it
+executes on the next runloop iteration rather than during the current attribute
+graph update. The `panel.setBrowserThemeMode()` call remains synchronous so the
+panel state is updated immediately.
+
+## Test plan
+
+- [ ] Toggle browser theme mode in settings — verify the mode applies correctly
+- [ ] Verify no render loop by monitoring CPU usage during theme changes
+- [ ] Test with mismatched `browserThemeModeRaw` values in UserDefaults to
+      confirm normalization still converges
+- [ ] Run UI tests against a tagged debug build


### PR DESCRIPTION
## Summary

**What changed?**

- In `BrowserPanelView`, the `onChange(of: browserThemeModeRaw)` handler still computes `normalizedMode` and calls `panel.setBrowserThemeMode(normalizedMode)` synchronously.
- Writing the **normalized** value back into **`browserThemeModeRaw`** (`@AppStorage`) is deferred with **`DispatchQueue.main.async`**, so it runs on the **next** main run loop turn instead of during the same attribute-graph update that triggered `onChange`.

**Why?**

- Writing to `@AppStorage` inside its own `onChange` can invalidate the SwiftUI attribute graph **during** the current update. Together with `panel.setBrowserThemeMode()` (and related observable updates), that can create a **tight re-entrancy / update cycle** (e.g. through `GraphHost.flushTransactions` → `BrowserPanelView.body` → chrome subviews).
- In a real incident this pinned **100% main-thread CPU** for **26+ minutes**, blocking the event loop and UI. Deferring only the persistence write breaks that synchronous feedback loop while keeping panel theme state updated immediately.

---

## Testing


⚠️  I did not yet.  The bug happened over a very long runtime, that will be hard to reproduce.   This PR is being opened for solicitation for feedback, to evaluate if the long test cycle - with a test compilation of the app - may be worth it.

I can follow any suggestions you offer. 🤝  



**How did you test this change?**

- [ ] Toggle **browser theme mode** in Settings and confirm the browser chrome/theme matches the selected mode.
- [ ] While changing theme, watch **CPU** (Activity Monitor or Instruments) and confirm there is **no sustained 100% main-thread spin**.
- [ ] Seed **UserDefaults** with a mismatched `browserThemeModeRaw` vs. the enum you normalize to; open the browser panel and confirm values **converge** after one deferred write.
- [ ] Run **UI / E2E tests** on a **tagged** debug build per project workflow.


## Test plan

- [ ] Toggle browser theme mode in settings — verify the mode applies correctly
- [ ] Verify no render loop by monitoring CPU usage during theme changes
- [ ] Test with mismatched `browserThemeModeRaw` values in UserDefaults to
      confirm normalization still converges
- [ ] Run UI tests against a tagged debug build

---

## Demo Video

the app hangs, with a spinning color wheel.   Memory is consumed until crash of the machine. 

---

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

---

## Checklist

- [ ] I tested the change locally  
- [ ] I added or updated tests for behavior changes *(optional: automated test for this loop is hard; note if relying on manual + existing UI suite)*  
- [ ] I updated docs/changelog if needed *(PR doc under `docs/` if present; `CHANGELOG.md` only if your release process requires it for user-visible fixes)*  
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)  
- [ ] All code review bot comments are resolved  
- [ ] All human review comments are resolved  



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SwiftUI render loop in `BrowserPanelView` by deferring the `@AppStorage` normalization write to the next run loop. This breaks the main-thread re-entrancy while keeping the panel theme update immediate.

- **Bug Fixes**
  - In `onChange(of: browserThemeModeRaw)`, keep `panel.setBrowserThemeMode(normalizedMode)` synchronous, but write back to `browserThemeModeRaw` via `DispatchQueue.main.async` only when values differ.
  - Prevents attribute-graph re-entry from writing to `@AppStorage` during its own change, avoiding 100% CPU spins and UI lockups.

<sup>Written for commit ae05fa4850e03c510238fbfba68a1a68ae77da1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

