### PR TITLE
fix: report_ports async mutation with synchronous ERROR contract

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -15168,45 +15168,70 @@ class TerminalController {
             ports.append(port)
         }
 
-        var result = "OK"
-        DispatchQueue.main.sync {
-            guard let tab = resolveTabForReport(args) else {
-                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+        // Resolve and validate on the main queue synchronously so the socket client still receives
+        // concrete ERROR lines for bad targets. Apply the mutation asynchronously so handler threads
+        // are not stuck in `main.sync` for the full update when the main queue is slow (CLAUDE.md).
+        var validationError: String?
+        var workspaceId: UUID?
+        var surfaceId: UUID?
+
+        DispatchQueue.main.sync { [weak self] in
+            guard let self else {
+                validationError = "ERROR: TabManager not available"
+                return
+            }
+            guard let tab = self.resolveTabForReport(args) else {
+                validationError = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
             }
 
             let validSurfaceIds = Set(tab.panels.keys)
-            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
 
             let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
-            let surfaceId: UUID
+            let resolvedSurfaceId: UUID
             if let panelArg {
                 if panelArg.isEmpty {
-                    result = "ERROR: Missing panel id — usage: report_ports <port1> [port2...] [--tab=X] [--panel=Y]"
+                    validationError = "ERROR: Missing panel id — usage: report_ports <port1> [port2...] [--tab=X] [--panel=Y]"
                     return
                 }
                 guard let parsedId = UUID(uuidString: panelArg) else {
-                    result = "ERROR: Invalid panel id '\(panelArg)'"
+                    validationError = "ERROR: Invalid panel id '\(panelArg)'"
                     return
                 }
-                surfaceId = parsedId
+                resolvedSurfaceId = parsedId
             } else {
                 guard let focused = tab.focusedPanelId else {
-                    result = "ERROR: Missing panel id (no focused surface)"
+                    validationError = "ERROR: Missing panel id (no focused surface)"
                     return
                 }
-                surfaceId = focused
+                resolvedSurfaceId = focused
             }
 
-            guard validSurfaceIds.contains(surfaceId) else {
-                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+            guard validSurfaceIds.contains(resolvedSurfaceId) else {
+                validationError = "ERROR: Panel not found '\(resolvedSurfaceId.uuidString)'"
                 return
             }
 
-            tab.surfaceListeningPorts[surfaceId] = ports
+            workspaceId = tab.id
+            surfaceId = resolvedSurfaceId
+        }
+
+        if let validationError { return validationError }
+        guard let workspaceId, let surfaceId else {
+            return parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+        }
+
+        let portsCopy = ports
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard let tab = self.tabForSidebarMutation(id: workspaceId) else { return }
+            let validSurfaceIds = Set(tab.panels.keys)
+            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+            guard validSurfaceIds.contains(surfaceId) else { return }
+            tab.surfaceListeningPorts[surfaceId] = portsCopy
             tab.recomputeListeningPorts()
         }
-        return result
+        return "OK"
     }
 
     private func reportPwd(_ args: String) -> String {

--- a/docs/pr-socket-handler-async-dispatch.md
+++ b/docs/pr-socket-handler-async-dispatch.md
@@ -1,0 +1,50 @@
+## Summary
+
+Reduce `reportPorts` handler blocking by applying the port mutation on
+`DispatchQueue.main.async` instead of holding `main.sync` through the full update.
+Tab/panel resolution and validation still run in a **short** `main.sync` so
+invalid targets return synchronous `ERROR:` lines on the socket (same contract as
+before `schedulePanelMetadataMutation`, which would have returned `OK` on
+silent async failures).
+
+## Problem
+
+`reportPorts` (the `report_ports` socket command) used `DispatchQueue.main.sync`
+to resolve the target tab/panel and apply the port mutation in one block. When
+the main thread is stalled — for example during a heavy SwiftUI render pass —
+the handler thread blocks at `dispatch_sync_f_slow`, consuming memory and
+contributing to thread pile-up.
+
+In a real incident, many socket handler threads accumulated via this pattern,
+making the app unresponsive.
+
+The project's CLAUDE.md documents a "Socket command threading policy" that
+discourages `DispatchQueue.main.sync` on high-frequency telemetry paths. The
+narrower fix is to avoid a **long** sync that includes the mutation, not to
+drop correct `ERROR:` responses for bad `--tab` / `--panel`.
+
+## Fix
+
+1. Parse ports off-main (unchanged).
+2. **`DispatchQueue.main.sync`:** resolve tab, resolve surface id, membership
+   checks — return the same `ERROR: ...` strings as the original implementation.
+3. **`DispatchQueue.main.async`:** `tabForSidebarMutation`, `pruneSurfaceMetadata`,
+   then `surfaceListeningPorts` + `recomputeListeningPorts`.
+4. Return `"OK"` only after validation succeeds (errors never become `OK`).
+
+Added `tests_v2/test_report_ports_v1_error_contract.py` to assert invalid
+`--tab` / `--panel` still produce `ERROR:` on the wire.
+
+## Scope and follow-up
+
+There are additional `DispatchQueue.main.sync` call sites in
+`TerminalController.swift` that could use similar split patterns where clients
+rely on synchronous error strings.
+
+## Test plan
+
+- [ ] Verify `report_ports` still updates sidebar port indicators correctly
+- [ ] Verify `report_ports` with explicit `--tab` and `--panel` arguments
+- [ ] Verify `report_ports` with invalid arguments still returns errors
+- [ ] Run `tests_v2/test_report_ports_v1_error_contract.py` and full `tests_v2/` against a tagged debug build
+- [ ] Simulate main thread stall and confirm `report_ports` callers do not hang for the full mutation duration

--- a/tests_v2/test_report_ports_v1_error_contract.py
+++ b/tests_v2/test_report_ports_v1_error_contract.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Regression: report_ports returns synchronous ERROR for invalid targets (v1 socket contract)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_REPO_TESTS = Path(__file__).resolve().parent.parent / "tests"
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(_REPO_TESTS))
+
+from cmux import cmux, cmuxError  # noqa: E402
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    fake_tab = "00000000-0000-0000-0000-000000000042"
+    with cmux(SOCKET_PATH) as client:
+        response = client._send_command(f"report_ports 8080 --tab={fake_tab}")
+        _must(
+            response.startswith("ERROR:"),
+            f"report_ports with non-existent tab must return ERROR synchronously, got {response!r}",
+        )
+        lowered = response.lower()
+        _must(
+            "tab" in lowered or "not found" in lowered or "no tab" in lowered,
+            f"report_ports error should mention tab/not found: {response!r}",
+        )
+
+        workspace_id = client.new_workspace()
+        try:
+            bad_panel = "00000000-0000-0000-0000-000000000099"
+            response2 = client._send_command(
+                f"report_ports 9090 --tab={workspace_id} --panel={bad_panel}"
+            )
+            _must(
+                response2.startswith("ERROR:"),
+                f"report_ports with missing panel must return ERROR synchronously, got {response2!r}",
+            )
+            _must(
+                "panel" in response2.lower(),
+                f"report_ports panel error should mention panel: {response2!r}",
+            )
+        finally:
+            client.close_workspace(workspace_id)
+
+    print("PASS: report_ports invalid targets return ERROR on the wire")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION

## Summary

**What changed?**

- `report_ports` (`reportPorts` in [`TerminalController.swift`](Sources/TerminalController.swift)) no longer performs the **full** tab/panel resolve + port write inside one long `DispatchQueue.main.sync` block.
- **Port list parsing** stays off the main queue (unchanged).
- **Target resolution and validation** (tab via `resolveTabForReport`, panel id / focused surface, membership in `tab.panels`) run in a **short** `DispatchQueue.main.sync` and return the same **`ERROR: ...`** strings as before on failure.
- **Mutation** (`tabForSidebarMutation`, `pruneSurfaceMetadata`, `surfaceListeningPorts`, `recomputeListeningPorts`) runs on **`DispatchQueue.main.async`**.
- **`"OK"`** is returned only after validation succeeds (invalid `--tab` / `--panel` / focus never turn into `OK`).
- Added **`tests_v2/test_report_ports_v1_error_contract.py`** to assert invalid `--tab` / `--panel` still yield **`ERROR:`** on the wire (guards against the `schedulePanelMetadataMutation`-style silent async failure + `OK` regression).

**Why?**

- A single `main.sync` that includes the mutation lets the **socket handler thread** block at `dispatch_sync_f_slow` when the **main queue** is slow (e.g. heavy SwiftUI). That stacks with other blocked handlers and can make the app feel wedged.
- Project policy (CLAUDE.md) discourages **`main.sync`** on hot telemetry paths; the goal is to shorten blocking, **not** to break the v1 socket contract where callers expect **synchronous error text** for bad arguments. Splitting **validate (sync)** vs **apply (async)** preserves that contract while reducing how long the handler pins the main queue for the write path.

---

## Testing

⚠️  I did not yet.  The bug happened over a very long runtime, that will be hard to reproduce.   This PR is being opened for solicitation for feedback, to evaluate if the long test cycle - with a test compilation of the app - may be worth it.

I can follow any suggestions you offer. 🤝  

**How did you test this change?**

- [ ] **`report_ports`** still updates **sidebar listening-port** UI for the intended surface.
- [ ] **`report_ports`** with explicit **`--tab`** and **`--panel`** (or `--surface`) still targets the right panel.
- [ ] Invalid **`--tab`**, missing focus, bad **`--panel`**, etc. still return **`ERROR:`** (not `OK`).
- [ ] Run **`tests_v2/test_report_ports_v1_error_contract.py`** and, as appropriate, the full **`tests_v2/`** suite against a **tagged** debug build and **`CMUX_SOCKET`** pointing at that instance’s socket.
- [ ] Optional: simulate a **main-thread stall** and confirm **`report_ports`** callers are not blocked for the **full** mutation duration (they may still wait for the **validation** `sync`).

**What did you verify manually?**

- [ ] (e.g. “Tagged build, ran CLI / hook that calls `report_ports`, checked sidebar ports; forced bad UUIDs and confirmed `ERROR:` in the response line.”)

## Test plan

- [ ] Verify `report_ports` still updates sidebar port indicators correctly
- [ ] Verify `report_ports` with explicit `--tab` and `--panel` arguments
- [ ] Verify `report_ports` with invalid arguments still returns errors
- [ ] Run `tests_v2/test_report_ports_v1_error_contract.py` and full `tests_v2/` against a tagged debug build
- [ ] Simulate main thread stall and confirm `report_ports` callers do not hang for the full mutation duration

---

## Demo Video

the app hangs, with a spinning color wheel.   Memory is consumed until crash of the machine. 

---

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

---

## Checklist

- [ ] I tested the change locally  
- [ ] I added or updated tests for behavior changes  
- [ ] I updated docs/changelog if needed *(PR doc / `docs/pr-socket-handler-async-dispatch.md` if present; changelog only if your process requires it)*  
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)  
- [ ] All code review bot comments are resolved  
- [ ] All human review comments are resolved  

---

**Scope / follow-up (from your notes):** Other `DispatchQueue.main.sync` sites in `TerminalController.swift` may deserve the same **sync validate / async mutate** split where the protocol promises **synchronous `ERROR:`** lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `report_ports` so validation runs in a short `DispatchQueue.main.sync` (keeps synchronous `ERROR:` responses) and the port mutation runs on `DispatchQueue.main.async` to reduce main-thread blocking. This prevents handler pile-ups during slow UI while preserving the v1 socket contract.

- **Bug Fixes**
  - Validate tab/panel on a short `DispatchQueue.main.sync` and keep the exact `ERROR: ...` responses for invalid args.
  - Apply port updates on `DispatchQueue.main.async` to avoid blocking the socket handler during slow SwiftUI frames.
  - Return `"OK"` only after validation passes; invalid targets never return `OK`.
  - Add `tests_v2/test_report_ports_v1_error_contract.py` to enforce the synchronous `ERROR` contract and `docs/pr-socket-handler-async-dispatch.md` for context.

<sup>Written for commit 996092bb6d20ded7a4b1e82ef34faa80e1fb13aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

