### PR TITLE
Add configurable close confirmation settings

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5064,6 +5064,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func confirmCloseMainWindow(_ window: NSWindow) -> Bool {
+        guard CloseWindowSettings.isEnabled() else { return true }
+
 #if DEBUG
         if let debugCloseMainWindowConfirmationHandler {
             return debugCloseMainWindowConfirmationHandler(window)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2901,17 +2901,21 @@ class TabManager: ObservableObject {
         }
 
         let plan = closeWorkspacesPlan(for: workspaces)
+        let batchConfirmed: Bool
         if BatchCloseSettings.isEnabled() {
             guard confirmClose(
                 title: plan.title,
                 message: plan.message,
                 acceptCmdD: plan.acceptCmdD
             ) else { return }
+            batchConfirmed = true
+        } else {
+            batchConfirmed = false
         }
 
         for workspace in plan.workspaces {
             guard tabs.contains(where: { $0.id == workspace.id }) else { continue }
-            closeWorkspaceIfRunningProcess(workspace, requiresConfirmation: false)
+            closeWorkspaceIfRunningProcess(workspace, requiresConfirmation: !batchConfirmed)
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2915,7 +2915,11 @@ class TabManager: ObservableObject {
 
         for workspace in plan.workspaces {
             guard tabs.contains(where: { $0.id == workspace.id }) else { continue }
-            closeWorkspaceIfRunningProcess(workspace, requiresConfirmation: !batchConfirmed)
+            if batchConfirmed {
+                closeWorkspaceIfRunningProcess(workspace, requiresConfirmation: false)
+            } else {
+                _ = closeWorkspaceWithConfirmation(workspace)
+            }
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2827,14 +2827,16 @@ class TabManager: ObservableObject {
     func closeOtherTabsInFocusedPaneWithConfirmation() {
         guard let plan = closeOtherTabsInFocusedPanePlan() else { return }
 
-        let count = plan.panelIds.count
-        let titleLines = plan.titles.map { "• \($0)" }.joined(separator: "\n")
-        let message = "This is about to close \(count) tab\(count == 1 ? "" : "s") in this pane:\n\(titleLines)"
-        guard confirmClose(
-            title: "Close other tabs?",
-            message: message,
-            acceptCmdD: false
-        ) else { return }
+        if BatchCloseSettings.isEnabled() {
+            let count = plan.panelIds.count
+            let titleLines = plan.titles.map { "• \($0)" }.joined(separator: "\n")
+            let message = "This is about to close \(count) tab\(count == 1 ? "" : "s") in this pane:\n\(titleLines)"
+            guard confirmClose(
+                title: "Close other tabs?",
+                message: message,
+                acceptCmdD: false
+            ) else { return }
+        }
 
         for panelId in plan.panelIds {
             _ = plan.workspace.closePanel(panelId, force: true)
@@ -2861,7 +2863,7 @@ class TabManager: ObservableObject {
 
     @discardableResult
     func closeWorkspaceWithConfirmation(_ workspace: Workspace) -> Bool {
-        if workspace.isPinned {
+        if workspace.isPinned && ClosePinnedWorkspaceSettings.isEnabled() {
             guard confirmClose(
                 title: String(localized: "dialog.closePinnedWorkspace.title", defaultValue: "Close pinned workspace?"),
                 message: String(
@@ -2899,11 +2901,13 @@ class TabManager: ObservableObject {
         }
 
         let plan = closeWorkspacesPlan(for: workspaces)
-        guard confirmClose(
-            title: plan.title,
-            message: plan.message,
-            acceptCmdD: plan.acceptCmdD
-        ) else { return }
+        if BatchCloseSettings.isEnabled() {
+            guard confirmClose(
+                title: plan.title,
+                message: plan.message,
+                acceptCmdD: plan.acceptCmdD
+            ) else { return }
+        }
 
         for workspace in plan.workspaces {
             guard tabs.contains(where: { $0.id == workspace.id }) else { continue }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6735,7 +6735,7 @@ final class Workspace: Identifiable, ObservableObject {
         case .promptIdle:
             return false
         case .commandRunning:
-            return true
+            return CloseRunningProcessSettings.isEnabled()
         case .unknown:
             return fallbackNeedsConfirmClose
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3768,6 +3768,70 @@ enum QuitWarningSettings {
     }
 }
 
+enum CloseRunningProcessSettings {
+    static let enabledKey = "confirmCloseRunningProcess"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ isEnabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(isEnabled, forKey: enabledKey)
+    }
+}
+
+enum ClosePinnedWorkspaceSettings {
+    static let enabledKey = "confirmClosePinnedWorkspace"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ isEnabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(isEnabled, forKey: enabledKey)
+    }
+}
+
+enum CloseWindowSettings {
+    static let enabledKey = "confirmCloseWindow"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ isEnabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(isEnabled, forKey: enabledKey)
+    }
+}
+
+enum BatchCloseSettings {
+    static let enabledKey = "confirmBatchClose"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ isEnabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(isEnabled, forKey: enabledKey)
+    }
+}
+
 enum CommandPaletteRenameSelectionSettings {
     static let selectAllOnFocusKey = "commandPalette.renameSelectAllOnFocus"
     static let defaultSelectAllOnFocus = true
@@ -3932,6 +3996,10 @@ struct SettingsView: View {
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
     @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
+    @AppStorage(CloseRunningProcessSettings.enabledKey) private var confirmCloseRunningProcess = CloseRunningProcessSettings.defaultEnabled
+    @AppStorage(ClosePinnedWorkspaceSettings.enabledKey) private var confirmClosePinnedWorkspace = ClosePinnedWorkspaceSettings.defaultEnabled
+    @AppStorage(CloseWindowSettings.enabledKey) private var confirmCloseWindow = CloseWindowSettings.defaultEnabled
+    @AppStorage(BatchCloseSettings.enabledKey) private var confirmBatchClose = BatchCloseSettings.defaultEnabled
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
     @AppStorage(CommandPaletteSwitcherSearchSettings.searchAllSurfacesKey)
@@ -4778,6 +4846,58 @@ struct SettingsView: View {
                                 : String(localized: "settings.app.warnBeforeQuit.subtitleOff", defaultValue: "Cmd+Q quits immediately without confirmation.")
                         ) {
                             Toggle("", isOn: $warnBeforeQuitShortcut)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.confirmCloseRunningProcess", defaultValue: "Confirm Close Running Process"),
+                            subtitle: confirmCloseRunningProcess
+                                ? String(localized: "settings.app.confirmCloseRunningProcess.subtitleOn", defaultValue: "Show a confirmation before closing a workspace with a running command.")
+                                : String(localized: "settings.app.confirmCloseRunningProcess.subtitleOff", defaultValue: "Close workspaces without confirmation, even with running commands.")
+                        ) {
+                            Toggle("", isOn: $confirmCloseRunningProcess)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.confirmClosePinnedWorkspace", defaultValue: "Confirm Close Pinned Workspace"),
+                            subtitle: confirmClosePinnedWorkspace
+                                ? String(localized: "settings.app.confirmClosePinnedWorkspace.subtitleOn", defaultValue: "Show a confirmation before closing a pinned workspace.")
+                                : String(localized: "settings.app.confirmClosePinnedWorkspace.subtitleOff", defaultValue: "Close pinned workspaces without extra confirmation.")
+                        ) {
+                            Toggle("", isOn: $confirmClosePinnedWorkspace)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.confirmCloseWindow", defaultValue: "Confirm Close Window"),
+                            subtitle: confirmCloseWindow
+                                ? String(localized: "settings.app.confirmCloseWindow.subtitleOn", defaultValue: "Show a confirmation before closing a window with workspaces.")
+                                : String(localized: "settings.app.confirmCloseWindow.subtitleOff", defaultValue: "Close windows without confirmation.")
+                        ) {
+                            Toggle("", isOn: $confirmCloseWindow)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            String(localized: "settings.app.confirmBatchClose", defaultValue: "Confirm Batch Close"),
+                            subtitle: confirmBatchClose
+                                ? String(localized: "settings.app.confirmBatchClose.subtitleOn", defaultValue: "Show a confirmation before closing multiple tabs or workspaces at once.")
+                                : String(localized: "settings.app.confirmBatchClose.subtitleOff", defaultValue: "Close multiple tabs or workspaces without confirmation.")
+                        ) {
+                            Toggle("", isOn: $confirmBatchClose)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -5910,6 +6030,10 @@ struct SettingsView: View {
         notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
         showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
         warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
+        confirmCloseRunningProcess = CloseRunningProcessSettings.defaultEnabled
+        confirmClosePinnedWorkspace = ClosePinnedWorkspaceSettings.defaultEnabled
+        confirmCloseWindow = CloseWindowSettings.defaultEnabled
+        confirmBatchClose = BatchCloseSettings.defaultEnabled
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
         commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces
         ShortcutHintDebugSettings.resetVisibilityDefaults()


### PR DESCRIPTION
## Summary

- Add 4 new independently togglable close confirmation settings in Settings > App
- Each confirmation type can be turned on/off without affecting the others
- All default to enabled, preserving existing behavior

### New settings

| Setting | UserDefaults Key | Controls |
|---------|-----------------|----------|
| Confirm Close Running Process | `confirmCloseRunningProcess` | Workspace close when a command is running |
| Confirm Close Pinned Workspace | `confirmClosePinnedWorkspace` | Pinned workspace close confirmation |
| Confirm Close Window | `confirmCloseWindow` | Window close with workspaces |
| Confirm Batch Close | `confirmBatchClose` | "Close other tabs" and multi-workspace close |

Settings are also configurable via `defaults write`:
```bash
defaults write com.cmuxterm.app confirmCloseRunningProcess -bool false
```

### Files changed

- `Sources/cmuxApp.swift` — Settings enums, `@AppStorage` properties, UI toggles, reset defaults
- `Sources/Workspace.swift` — Gate `resolveCloseConfirmation` running-process case
- `Sources/TabManager.swift` — Gate pinned workspace and batch close confirmations
- `Sources/AppDelegate.swift` — Gate close window confirmation

## Test plan

- [ ] Build and verify no compilation errors
- [ ] Open Settings > App and verify 4 new toggles appear below "Warn Before Quit"
- [ ] Toggle each off and verify the corresponding confirmation dialog is skipped
- [ ] Toggle each back on and verify confirmations return
- [ ] Reset all settings and verify toggles return to enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added four per-action toggles in Settings > App to control close confirmations. Users can turn off prompts for running processes, pinned workspaces, window close, and batch closes; defaults stay on.

- **New Features**
  - Toggles: Confirm Close Running Process (`confirmCloseRunningProcess`), Confirm Close Pinned Workspace (`confirmClosePinnedWorkspace`), Confirm Close Window (`confirmCloseWindow`), Confirm Batch Close (`confirmBatchClose`).
  - Configure in-app or via `defaults write com.cmuxterm.app <key> -bool <true|false>`.

- **Bug Fixes**
  - Batch close no longer skips per-workspace running-process confirmation when batch confirmation is off.
  - Batch close no longer bypasses pinned-workspace confirmation when batch confirmation is off.

<sup>Written for commit d11667e96537dd676b5bc7252f47a406babc5ce1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four Settings toggles to control confirmations for closing running processes, pinned workspaces, windows, and batch closes (enabled by default).

* **Behavior Changes**
  * Disabling a toggle skips the corresponding confirmation dialog.
  * Batch-close now honors the batch setting and changes per-workspace confirmation behavior.
  * Pinned-workspace prompt shown only when its confirmation setting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->