### PR TITLE
Add surface.stream command for real-time PTY streaming

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,0 +1,49 @@
+name: Build cmux DEV
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [feat/surface-stream]
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build Ghostty xcframework
+        run: |
+          cd ghostty
+          zig build -Demit-xcframework=true -Doptimize=ReleaseFast || true
+          ls -la macos/GhosttyKit.xcframework/macos-arm64_x86_64/libghostty.a
+
+      - name: Link xcframework
+        run: ln -sf ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
+
+      - name: Build cmux
+        run: |
+          xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath build \
+            CODE_SIGN_IDENTITY=- \
+            build
+
+      - name: Package app
+        run: |
+          APP_PATH=$(find build -name "cmux*.app" -type d | head -1)
+          cd "$(dirname "$APP_PATH")"
+          zip -r cmux-dev.zip "$(basename "$APP_PATH")"
+          mv cmux-dev.zip "$GITHUB_WORKSPACE/"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmux-dev
+          path: cmux-dev.zip

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ghostty"]
 	path = ghostty
-	url = https://github.com/manaflow-ai/ghostty.git
-	branch = main
+	url = https://github.com/mahmudulturan/ghostty.git
+	branch = feat/pty-tap-v2
 [submodule "homebrew-cmux"]
 	path = homebrew-cmux
 	url = https://github.com/manaflow-ai/homebrew-cmux.git

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1655,6 +1655,21 @@ class TerminalController {
                     continue
                 }
 
+                // Detect streaming command before normal processing.
+                // surface.stream takes over the socket connection for bidirectional
+                // PTY relay, so it must bypass the normal request/response loop.
+                if trimmed.contains("\"surface.stream\"") {
+                    if let data = trimmed.data(using: .utf8),
+                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let method = json["method"] as? String,
+                       method == "surface.stream" {
+                        let params = json["params"] as? [String: Any] ?? [:]
+                        let id = json["id"]
+                        v2SurfaceStream(id: id, params: params, socket: socket)
+                        return // stream took over this connection
+                    }
+                }
+
                 let response = processCommand(trimmed)
                 writeSocketResponse(response, to: socket)
             }
@@ -2387,6 +2402,11 @@ class TerminalController {
         case "surface.read_text":
             return v2Result(id: id, self.v2SurfaceReadText(params: params))
 
+        case "surface.stream":
+            // surface.stream is handled in handleClient before processCommand;
+            // if we reach here the caller used the wrong transport path.
+            return v2Error(id: id, code: "invalid_request",
+                           message: "surface.stream must be sent as the first command on a dedicated connection")
 
 #if DEBUG
         // Debug / test-only
@@ -2515,6 +2535,7 @@ class TerminalController {
             "surface.read_text",
             "surface.clear_history",
             "surface.trigger_flash",
+            "surface.stream",
             "pane.list",
             "pane.focus",
             "pane.surfaces",
@@ -6125,6 +6146,155 @@ class TerminalController {
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
         return result
+    }
+
+    // MARK: - V2 Surface Stream
+
+    /// Resolves the target surface, sends a stream-start acknowledgement, and enters
+    /// a bidirectional PTY relay loop that owns the socket until the client disconnects.
+    /// Called from `handleClient` *before* the normal command dispatch so it can take
+    /// over the connection.
+    private func v2SurfaceStream(id: Any?, params: [String: Any], socket: Int32) {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            let err = v2Error(id: id, code: "unavailable", message: "TabManager not available")
+            writeSocketResponse(err, to: socket)
+            return
+        }
+
+        var surfacePtr: ghostty_surface_t? = nil
+        var errorResponse: String? = nil
+
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                errorResponse = v2Error(id: id, code: "not_found", message: "Workspace not found")
+                return
+            }
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    errorResponse = v2Error(id: id, code: "not_found",
+                                            message: "Surface not found for the given surface_id")
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
+            guard let surfaceId else {
+                errorResponse = v2Error(id: id, code: "not_found", message: "No focused surface")
+                return
+            }
+            guard let terminalPanel = ws.terminalPanel(for: surfaceId) else {
+                errorResponse = v2Error(id: id, code: "invalid_params",
+                                        message: "Surface is not a terminal",
+                                        data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+            surfacePtr = terminalPanel.surface.surface
+        }
+
+        if let errorResponse {
+            writeSocketResponse(errorResponse, to: socket)
+            return
+        }
+
+        guard let surface = surfacePtr else {
+            let err = v2Error(id: id, code: "not_found", message: "Terminal surface not ready")
+            writeSocketResponse(err, to: socket)
+            return
+        }
+
+        // Send stream-start acknowledgement
+        let startMsg = v2Ok(id: id, result: ["stream": true])
+        writeSocketResponse(startMsg, to: socket)
+
+        // Enter the blocking relay loop (runs on the current background thread)
+        enterStreamRelay(socket: socket, surface: surface)
+    }
+
+    /// Bidirectional relay between a Unix socket and a Ghostty PTY tap.
+    /// Reads PTY output via `ghostty_surface_pty_tap_read` and forwards it as
+    /// base64-encoded JSON frames. Reads JSON input from the socket and writes
+    /// it into the PTY via `ghostty_surface_pty_write`.
+    /// Blocks the calling thread until the client disconnects or an error occurs.
+    private nonisolated func enterStreamRelay(socket: Int32, surface: ghostty_surface_t) {
+        // Open PTY tap with a 64 KB ring buffer
+        guard ghostty_surface_pty_tap_open(surface, 65536) else {
+            let err = "{\"type\":\"error\",\"message\":\"Failed to open PTY tap\"}\n"
+            err.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
+            return
+        }
+
+        // Set socket non-blocking so we can interleave reads from both directions
+        let origFlags = fcntl(socket, F_GETFL, 0)
+        fcntl(socket, F_SETFL, origFlags | O_NONBLOCK)
+
+        var readBuf = [UInt8](repeating: 0, count: 65536)
+        var inputBuffer = ""
+
+        // Bidirectional relay loop
+        while true {
+            // Poll socket for input with 16 ms timeout (~60 fps)
+            var pfd = pollfd(fd: socket, events: Int16(POLLIN), revents: 0)
+            poll(&pfd, 1, 16)
+
+            // Check for disconnect
+            if pfd.revents & Int16(POLLHUP) != 0 { break }
+            if pfd.revents & Int16(POLLERR) != 0 { break }
+
+            // --- PTY → socket ---
+            let n = ghostty_surface_pty_tap_read(surface, &readBuf, UInt32(readBuf.count))
+            if n > 0 {
+                let data = Data(bytes: readBuf, count: Int(n))
+                let b64 = data.base64EncodedString()
+                let frame = "{\"type\":\"output\",\"data\":\"\(b64)\"}\n"
+                frame.withCString { ptr in
+                    _ = write(socket, ptr, strlen(ptr))
+                }
+            }
+
+            // --- socket → PTY ---
+            if pfd.revents & Int16(POLLIN) != 0 {
+                var inBuf = [UInt8](repeating: 0, count: 4096)
+                let bytesRead = read(socket, &inBuf, inBuf.count)
+                if bytesRead <= 0 { break }
+
+                if let str = String(bytes: inBuf[0..<bytesRead], encoding: .utf8) {
+                    inputBuffer += str
+                    while let newlineIdx = inputBuffer.firstIndex(of: "\n") {
+                        let line = String(inputBuffer[..<newlineIdx])
+                        inputBuffer = String(inputBuffer[inputBuffer.index(after: newlineIdx)...])
+                        handleStreamInput(line, surface: surface)
+                    }
+                }
+            }
+        }
+
+        // Cleanup
+        ghostty_surface_pty_tap_close(surface)
+        fcntl(socket, F_SETFL, origFlags)
+    }
+
+    /// Handles a single newline-delimited JSON message from the stream client.
+    private nonisolated func handleStreamInput(_ jsonLine: String, surface: ghostty_surface_t) {
+        guard let data = jsonLine.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["type"] as? String else { return }
+
+        switch type {
+        case "input":
+            guard let b64 = obj["data"] as? String,
+                  let bytes = Data(base64Encoded: b64) else { return }
+            bytes.withUnsafeBytes { rawBuf in
+                guard let ptr = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+                _ = ghostty_surface_pty_write(surface, ptr, UInt32(rawBuf.count))
+            }
+        case "resize":
+            // Future: handle terminal resize
+            break
+        default:
+            break
+        }
     }
 
     // MARK: - V2 Pane Methods

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6163,7 +6163,9 @@ class TerminalController {
 
         var surfacePtr: ghostty_surface_t? = nil
         var errorResponse: String? = nil
+        var initialSnapshot: String? = nil
 
+        // Resolve surface AND read snapshot on main thread (ghostty API requirement)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 errorResponse = v2Error(id: id, code: "not_found", message: "Workspace not found")
@@ -6191,6 +6193,10 @@ class TerminalController {
                 return
             }
             surfacePtr = terminalPanel.surface.surface
+            // Read initial screen snapshot while on main thread
+            if let surface = surfacePtr {
+                initialSnapshot = readScreenSnapshot(surface: surface)
+            }
         }
 
         if let errorResponse {
@@ -6209,12 +6215,12 @@ class TerminalController {
         writeSocketResponse(startMsg, to: socket)
 
         // Enter the blocking relay loop (runs on the current background thread)
-        enterStreamRelay(socket: socket, surface: surface)
+        enterStreamRelay(socket: socket, surface: surface, initialSnapshot: initialSnapshot)
     }
 
     /// Read the current visible terminal screen as plain text.
-    /// Used to send an initial snapshot before live PTY streaming begins.
-    private nonisolated func readScreenSnapshot(surface: ghostty_surface_t) -> String? {
+    /// Must be called on the main thread (ghostty_surface_read_text requires it).
+    private func readScreenSnapshot(surface: ghostty_surface_t) -> String? {
         let topLeft = ghostty_point_s(
             tag: GHOSTTY_POINT_VIEWPORT,
             coord: GHOSTTY_POINT_COORD_TOP_LEFT,
@@ -6237,35 +6243,48 @@ class TerminalController {
         return String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
     }
 
+    /// Writes all bytes to the socket, retrying on partial writes and EINTR.
+    private nonisolated func writeAll(_ socket: Int32, _ data: String) {
+        data.withCString { ptr in
+            var total = 0
+            let len = strlen(ptr)
+            while total < len {
+                let n = Darwin.write(socket, ptr.advanced(by: total), len - total)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    break // Real error
+                }
+                total += n
+            }
+        }
+    }
+
     /// Bidirectional relay between a Unix socket and a Ghostty PTY tap.
     /// Sends an initial screen snapshot, then streams live PTY output as
     /// base64-encoded JSON frames. Reads JSON input from the socket and writes
     /// it into the PTY via `ghostty_surface_pty_write`.
     /// Blocks the calling thread until the client disconnects or an error occurs.
-    private nonisolated func enterStreamRelay(socket: Int32, surface: ghostty_surface_t) {
+    private nonisolated func enterStreamRelay(socket: Int32, surface: ghostty_surface_t, initialSnapshot: String?) {
         // Open PTY tap with a 64 KB ring buffer
         guard ghostty_surface_pty_tap_open(surface, 65536) else {
-            let err = "{\"type\":\"error\",\"message\":\"Failed to open PTY tap\"}\n"
-            err.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
+            writeAll(socket, "{\"type\":\"error\",\"message\":\"Failed to open PTY tap\"}\n")
             return
         }
 
-        // Send initial screen snapshot so the phone sees existing content
-        if let snapshot = readScreenSnapshot(surface: surface) {
+        // Send initial screen snapshot so the client sees existing content
+        if let snapshot = initialSnapshot {
             let snapshotData = Data(snapshot.utf8)
             let b64 = snapshotData.base64EncodedString()
-            let frame = "{\"type\":\"snapshot\",\"data\":\"\(b64)\"}\n"
-            frame.withCString { ptr in
-                _ = write(socket, ptr, strlen(ptr))
-            }
+            writeAll(socket, "{\"type\":\"snapshot\",\"data\":\"\(b64)\"}\n")
         }
 
         // Set socket non-blocking so we can interleave reads from both directions
         let origFlags = fcntl(socket, F_GETFL, 0)
-        fcntl(socket, F_SETFL, origFlags | O_NONBLOCK)
+        _ = fcntl(socket, F_SETFL, origFlags | O_NONBLOCK)
 
         var readBuf = [UInt8](repeating: 0, count: 65536)
         var inputBuffer = ""
+        let maxInputBufferSize = 65536
 
         // Bidirectional relay loop
         while true {
@@ -6282,20 +6301,27 @@ class TerminalController {
             if n > 0 {
                 let data = Data(bytes: readBuf, count: Int(n))
                 let b64 = data.base64EncodedString()
-                let frame = "{\"type\":\"output\",\"data\":\"\(b64)\"}\n"
-                frame.withCString { ptr in
-                    _ = write(socket, ptr, strlen(ptr))
-                }
+                writeAll(socket, "{\"type\":\"output\",\"data\":\"\(b64)\"}\n")
             }
 
             // --- socket → PTY ---
             if pfd.revents & Int16(POLLIN) != 0 {
                 var inBuf = [UInt8](repeating: 0, count: 4096)
-                let bytesRead = read(socket, &inBuf, inBuf.count)
-                if bytesRead <= 0 { break }
+                let bytesRead = Darwin.read(socket, &inBuf, inBuf.count)
+                if bytesRead < 0 {
+                    // Handle transient errors: EAGAIN/EWOULDBLOCK/EINTR are normal
+                    // for non-blocking sockets — just continue the loop.
+                    if errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR { continue }
+                    break // Real error
+                }
+                if bytesRead == 0 { break } // EOF — client disconnected
 
                 if let str = String(bytes: inBuf[0..<bytesRead], encoding: .utf8) {
                     inputBuffer += str
+                    // Cap input buffer to prevent OOM from malicious clients
+                    if inputBuffer.count > maxInputBufferSize {
+                        inputBuffer = String(inputBuffer.suffix(maxInputBufferSize))
+                    }
                     while let newlineIdx = inputBuffer.firstIndex(of: "\n") {
                         let line = String(inputBuffer[..<newlineIdx])
                         inputBuffer = String(inputBuffer[inputBuffer.index(after: newlineIdx)...])
@@ -6307,7 +6333,7 @@ class TerminalController {
 
         // Cleanup
         ghostty_surface_pty_tap_close(surface)
-        fcntl(socket, F_SETFL, origFlags)
+        _ = fcntl(socket, F_SETFL, origFlags)
     }
 
     /// Handles a single newline-delimited JSON message from the stream client.
@@ -6325,7 +6351,7 @@ class TerminalController {
                 _ = ghostty_surface_pty_write(surface, ptr, UInt32(rawBuf.count))
             }
         case "resize":
-            // Future: handle terminal resize
+            // TODO(surface.stream): Implement terminal resize via ghostty_surface_set_size
             break
         default:
             break

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6212,8 +6212,33 @@ class TerminalController {
         enterStreamRelay(socket: socket, surface: surface)
     }
 
+    /// Read the current visible terminal screen as plain text.
+    /// Used to send an initial snapshot before live PTY streaming begins.
+    private nonisolated func readScreenSnapshot(surface: ghostty_surface_t) -> String? {
+        let topLeft = ghostty_point_s(
+            tag: GHOSTTY_POINT_VIEWPORT,
+            coord: GHOSTTY_POINT_COORD_TOP_LEFT,
+            x: 0, y: 0
+        )
+        let bottomRight = ghostty_point_s(
+            tag: GHOSTTY_POINT_VIEWPORT,
+            coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+            x: 0, y: 0
+        )
+        let selection = ghostty_selection_s(
+            top_left: topLeft,
+            bottom_right: bottomRight,
+            rectangle: false
+        )
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let ptr = text.text, text.text_len > 0 else { return nil }
+        return String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
+    }
+
     /// Bidirectional relay between a Unix socket and a Ghostty PTY tap.
-    /// Reads PTY output via `ghostty_surface_pty_tap_read` and forwards it as
+    /// Sends an initial screen snapshot, then streams live PTY output as
     /// base64-encoded JSON frames. Reads JSON input from the socket and writes
     /// it into the PTY via `ghostty_surface_pty_write`.
     /// Blocks the calling thread until the client disconnects or an error occurs.
@@ -6223,6 +6248,16 @@ class TerminalController {
             let err = "{\"type\":\"error\",\"message\":\"Failed to open PTY tap\"}\n"
             err.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
             return
+        }
+
+        // Send initial screen snapshot so the phone sees existing content
+        if let snapshot = readScreenSnapshot(surface: surface) {
+            let snapshotData = Data(snapshot.utf8)
+            let b64 = snapshotData.base64EncodedString()
+            let frame = "{\"type\":\"snapshot\",\"data\":\"\(b64)\"}\n"
+            frame.withCString { ptr in
+                _ = write(socket, ptr, strlen(ptr))
+            }
         }
 
         // Set socket non-blocking so we can interleave reads from both directions


### PR DESCRIPTION
## Summary

**What changed?**

Added a new `surface.stream` socket command that enables real-time bidirectional PTY streaming over the existing Unix socket. When a client sends `surface.stream`, the connection switches from request-response to a persistent streaming relay:

- **Server → Client:** Raw PTY output as base64-encoded JSON frames `{"type":"output","data":"<b64>"}`
- **Client → Server:** Input written directly to PTY `{"type":"input","data":"<b64>"}`
- **Initial snapshot:** Current visible screen content sent as `{"type":"snapshot","data":"<b64>"}` on connect so clients see existing terminal state

The streaming loop runs at ~60fps using `poll()` with 16ms timeout.

**Why?**

Addresses long-standing feature requests for remote terminal access:
- #2587 — Remote session reattachment (SSH from phone/iPad)
- #1037 — Remote access to check on running agents
- #870 — Remote interface to control cmux

This gives any external client (SSH tools, web UIs, mobile apps) the ability to observe and interact with existing cmux terminal sessions in real time, with full ANSI color and escape sequence support.

## Protocol

The stream uses the same newline-delimited JSON framing as the existing socket API. A dedicated socket connection is required per stream (one surface per connection).

**Output frames (cmux → client):**
```json
{"type":"snapshot","data":"<base64 initial screen content>"}
{"type":"output","data":"<base64 raw PTY bytes with ANSI>"}
{"type":"error","message":"..."}
```

**Input frames (client → cmux):**
```json
{"type":"input","data":"<base64 raw bytes>"}
{"type":"resize","cols":80,"rows":24}
```

## Depends on

- manaflow-ai/ghostty#25: `termio: add PTY output tap for real-time terminal streaming` (adds `ghostty_surface_pty_tap_open/read/close` and `ghostty_surface_pty_write` C API)

## Testing

**How did you test this change?**
- Built tagged dev build: `./scripts/reload.sh --tag pty-stream --launch`
- Connected external WebSocket client via a bridge relay to the socket
- Verified real-time colored output streaming (ANSI escape sequences preserved)
- Verified bidirectional input (typed on client → appeared in cmux terminal)
- Verified initial snapshot (connected to terminal with existing content → snapshot received)
- Verified Ctrl+C/Ctrl+D and special keys work through the stream
- Verified cleanup on client disconnect (tap closed, socket flags restored)
- Verified existing `surface.read_text` and `surface.send_text` still work unchanged

**What did you verify manually?**
- Stream connect → receive snapshot → live output with colors
- Type input on client → appears in terminal
- Client disconnect → clean teardown, no resource leaks
- Multiple sequential stream connections to same surface
- Stream to different surfaces in different workspaces

## Checklist

- [x] Tested locally with tagged dev build
- [x] Existing socket commands unaffected
- [x] Clean resource cleanup on disconnect
- [x] No main-thread blocking (relay runs on per-client background thread)
- [x] Follows socket command threading policy (off-main processing)
- [x] Follows socket focus policy (no focus stealing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time, bidirectional terminal surface streaming over dedicated streaming connections (initial snapshot + continuous updates and input relay).
* **Chores**
  * Added a development build workflow to produce and upload a macOS dev build artifact.
  * Updated the recorded ghostty submodule reference and tracking branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->