### PR TITLE
Fix sidebar bg: add missing locale entries and portal resync

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -83709,6 +83709,108 @@
             "state": "translated",
             "value": "ターミナルの背景に合わせる"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Match Terminal Background"
+          }
         }
       }
     },
@@ -83725,6 +83827,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "ターミナルと同じ背景色と透明度を使用します。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Use the same background color and transparency as the terminal."
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3387,6 +3387,16 @@ struct ContentView: View {
             syncTrafficLightInset()
         })
 
+        view = AnyView(view.onChange(of: sidebarMatchTerminalBackground) { _ in
+            guard sidebarState.isVisible,
+                  sidebarBlendMode == SidebarBlendModeOption.withinWindow.rawValue else { return }
+            if let observedWindow {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: observedWindow)
+            } else {
+                TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+            }
+        })
+
         view = AnyView(view.onChange(of: isMinimalMode) { _, _ in
             syncTrafficLightInset()
         })


### PR DESCRIPTION
## Summary
- Add English fallback locale entries for all 17 supported languages on the two `matchTerminalBackground` localization keys (previously only en+ja were present)
- Schedule portal geometry resync when toggling "Match Terminal Background" with withinWindow blend mode, preventing misaligned terminal/browser portals

Follow-up to https://github.com/manaflow-ai/cmux/pull/2293, addressing review feedback from Greptile and CodeRabbit.

## Test plan
- Toggle "Match Terminal Background" in Settings > Sidebar Appearance with withinWindow blend mode active, verify portals stay aligned
- Verify no missing-translation warnings in non-English locales for the new sidebar setting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents portal misalignment when toggling “Match Terminal Background” by resyncing geometry for the within-window blend mode. Adds English fallback strings for the setting and its tooltip across all locales to remove missing-translation warnings.

- **Bug Fixes**
  - Resync portal geometry on toggle when the sidebar is visible and within-window blend mode is active to keep portals aligned.
  - Add English fallback entries for “Match Terminal Background” and its description in 17 locales to eliminate missing-translation warnings.

<sup>Written for commit 65cd8d8706ac7706ec3d8c66b05ec3884aeb1f6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Match Terminal Background" setting to synchronize sidebar appearance with terminal colors and transparency.

* **Improvements**
  * Sidebar synchronization now occurs more selectively when relevant visibility and blend conditions are met.

* **Localization**
  * Added translations for 16 languages (Arabic, Bosnian, Danish, German, Spanish, French, Italian, Korean, Norwegian, Polish, Brazilian Portuguese, Russian, Thai, Turkish, Ukrainian, Simplified & Traditional Chinese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->