### PR TITLE
feat: add rename window support with keyboard shortcut, CLI, and command palette

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1863,7 +1863,8 @@ struct CMUXCLI {
         let idFormat = try resolvedIDFormat(jsonOutput: jsonOutput, raw: idFormatArg)
 
         // If the user explicitly targets a window, focus it first so commands route correctly.
-        if let windowId {
+        // Exclude non-focus-intent commands that route by explicit window_id.
+        if let windowId, command != "rename-window" {
             let normalizedWindow = try normalizeWindowHandle(windowId, client: client) ?? windowId
             _ = try client.sendV2(method: "window.focus", params: ["window_id": normalizedWindow])
         }
@@ -2355,18 +2356,41 @@ struct CMUXCLI {
             let payload = try client.sendV2(method: "workspace.select", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
 
-        case "rename-workspace", "rename-window":
+        case "rename-workspace":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let titleArgs = rem0.dropFirst(rem0.first == "--" ? 1 : 0)
             let title = titleArgs.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             guard !title.isEmpty else {
-                throw CLIError(message: "\(command) requires a title")
+                throw CLIError(message: "rename-workspace requires a title")
             }
             let wsId = try resolveWorkspaceId(workspaceArg, client: client)
             let params: [String: Any] = ["title": title, "workspace_id": wsId]
             let payload = try client.sendV2(method: "workspace.rename", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
+
+        case "rename-window":
+            let (winArg, rem0) = parseOption(commandArgs, name: "--window")
+            let titleArgs = rem0.dropFirst(rem0.first == "--" ? 1 : 0)
+            let title = titleArgs.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else {
+                throw CLIError(message: "rename-window requires a title")
+            }
+            let winId: String
+            if let winArg {
+                winId = try normalizeWindowHandle(winArg, client: client) ?? winArg
+            } else if let windowId {
+                winId = try normalizeWindowHandle(windowId, client: client) ?? windowId
+            } else {
+                let current = try client.sendV2(method: "window.current")
+                guard let id = (current["window_id"] as? String) else {
+                    throw CLIError(message: "Could not determine current window")
+                }
+                winId = id
+            }
+            let params: [String: Any] = ["title": title, "window_id": winId]
+            let payload = try client.sendV2(method: "window.rename", params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["window"]))
 
         case "current-workspace":
             let response = try client.sendV2(method: "workspace.current")
@@ -7400,19 +7424,31 @@ struct CMUXCLI {
               cmux select-workspace --workspace workspace:2
               cmux select-workspace --workspace 0
             """
-        case "rename-workspace", "rename-window":
+        case "rename-workspace":
             return """
             Usage: cmux rename-workspace [--workspace <id|ref|index>] [--] <title>
 
             Rename a workspace. Defaults to the current workspace.
-            tmux-compatible alias: rename-window
 
             Flags:
               --workspace <id|ref|index>   Workspace to rename (default: current/$CMUX_WORKSPACE_ID)
 
             Example:
               cmux rename-workspace "backend logs"
-              cmux rename-window --workspace workspace:2 "agent run"
+              cmux rename-workspace --workspace workspace:2 "agent run"
+            """
+        case "rename-window":
+            return """
+            Usage: cmux rename-window [--window <id|ref|index>] [--] <title>
+
+            Rename a window. Defaults to the current window.
+
+            Flags:
+              --window <id|ref|index>   Window to rename (default: current window)
+
+            Example:
+              cmux rename-window "Gymatch"
+              cmux rename-window --window window:2 "staging"
             """
         case "current-workspace":
             return """
@@ -11532,6 +11568,7 @@ struct CMUXCLI {
             guard !title.isEmpty else {
                 throw CLIError(message: "rename-window requires a title")
             }
+            // In tmux mode, rename-window maps to workspace rename for compatibility
             let workspaceId = try tmuxResolveWorkspaceTarget(parsed.value("-t"), client: client)
             _ = try client.sendV2(method: "workspace.rename", params: [
                 "workspace_id": workspaceId,
@@ -14367,7 +14404,7 @@ struct CMUXCLI {
           close-workspace --workspace <id|ref>
           select-workspace --workspace <id|ref>
           rename-workspace [--workspace <id|ref>] <title>
-          rename-window [--workspace <id|ref>] <title>
+          rename-window [--window <id|ref|index>] <title>
           current-workspace
           read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
           send [--workspace <id|ref>] [--surface <id|ref>] <text>

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -67814,6 +67814,125 @@
         }
       }
     },
+    "shortcut.renameWindow.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ名を変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名視窗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름 변경"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster umbenennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb vindue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę okna"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать окно"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preimenuj prozor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gi vinduet nytt navn"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปลี่ยนชื่อหน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencereyi Yeniden Adlandır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати вікно"
+          }
+        }
+      }
+    },
     "shortcut.renameWorkspace.label": {
       "extractionState": "manual",
       "localizations": {
@@ -74374,6 +74493,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Системна"
+          }
+        }
+      }
+    },
+    "titlebar.windowWithWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ – %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — %@"
           }
         }
       }
@@ -87286,6 +87524,1077 @@
           "stringUnit": {
             "state": "translated",
             "value": "ワークスペースの説明を消去"
+          }
+        }
+      }
+    },
+    "command.clearWindowName.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Window Name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ名をクリア"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除窗口名称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除視窗名稱"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름 지우기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenstername löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar nombre de ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer le nom de la fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancella nome finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ryd vinduenavn"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyczyść nazwę okna"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить имя окна"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obriši naziv prozora"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسح اسم النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern vindusnavn"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpar Nome da Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ล้างชื่อหน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencere Adını Temizle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути назву вікна"
+          }
+        }
+      }
+    },
+    "command.clearWindowName.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視窗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vindue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Okno"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Окно"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vindu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "หน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencere"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вікно"
+          }
+        }
+      }
+    },
+    "command.renameWindow.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Window…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウの名称変更…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名窗口..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名視窗..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름 변경…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster umbenennen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar ventana…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la fenêtre..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina finestra…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb vindue…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę okna…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать окно..."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preimenuj prozor…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية النافذة…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gi vinduet nytt navn …"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear Janela…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปลี่ยนชื่อหน้าต่าง..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencereyi Yeniden Adlandır…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати вікно…"
+          }
+        }
+      }
+    },
+    "command.renameWindow.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視窗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vindue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Okno"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Окно"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vindu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "หน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencere"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вікно"
+          }
+        }
+      }
+    },
+    "commandPalette.rename.windowConfirmHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to apply this window name, or Escape to cancel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enterキーでウィンドウ名を適用、Escapeキーでキャンセルします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按 Enter 应用此窗口名称，或按 Escape 取消。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按 Enter 套用此視窗名稱，或按 Escape 取消。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter를 눌러 윈도우 이름을 적용하거나, Escape를 눌러 취소하세요."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drücken Sie die Eingabetaste, um den Fensternamen zu übernehmen, oder Escape zum Abbrechen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulsa Intro para aplicar este nombre de ventana, o Escape para cancelar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appuyez sur Entrée pour appliquer ce nom de fenêtre, ou sur Échap pour annuler."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premi Invio per applicare il nome della finestra, oppure Esc per annullare."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryk Enter for at anvende dette vinduenavn, eller Escape for at annullere."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naciśnij Enter, aby zastosować nazwę okna, lub Escape, aby anulować."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите Enter, чтобы применить имя окна, или Escape для отмены."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pritisnite Enter za primjenu naziva prozora, ili Escape za otkazivanje."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط Enter لتطبيق اسم النافذة، أو Escape للإلغاء."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trykk Enter for å bruke dette vindusnavnet, eller Escape for å avbryte."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pressione Enter para aplicar este nome de janela ou Escape para cancelar."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กด Enter เพื่อใช้ชื่อหน้าต่างนี้ หรือ Escape เพื่อยกเลิก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu pencere adını uygulamak için Enter tuşuna basın veya iptal etmek için Escape tuşuna basın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Натисніть Enter, щоб застосувати назву вікна, або Escape для скасування."
+          }
+        }
+      }
+    },
+    "commandPalette.rename.windowDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a custom window name."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウのカスタム名を選択してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择自定义窗口名称。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇自訂視窗名稱。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 윈도우 이름을 선택하세요."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie einen benutzerdefinierten Fensternamen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un nombre personalizado para la ventana."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez un nom personnalisé pour la fenêtre."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli un nome personalizzato per la finestra."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vælg et brugerdefineret vinduenavn."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz własną nazwę okna."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите пользовательское имя окна."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odaberite prilagođeni naziv prozora."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختر اسمًا مخصصًا للنافذة."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velg et egendefinert vindusnavn."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha um nome personalizado para a janela."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลือกชื่อหน้าต่างที่กำหนดเอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel bir pencere adı seçin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть власну назву вікна."
+          }
+        }
+      }
+    },
+    "commandPalette.rename.windowInputHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a window name. Press Enter to rename, Escape to cancel."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ名を入力してください。Enterで名称変更、Escapeでキャンセルします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入窗口名称。按 Enter 重命名，按 Escape 取消。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入視窗名稱。按 Enter 重新命名，按 Escape 取消。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름을 입력하세요. Enter로 이름 변경, Escape로 취소."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geben Sie einen Fensternamen ein. Eingabetaste zum Umbenennen, Escape zum Abbrechen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introduce un nombre de ventana. Pulsa Intro para renombrar, Escape para cancelar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisissez un nom de fenêtre. Appuyez sur Entrée pour renommer, Échap pour annuler."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserisci un nome per la finestra. Premi Invio per rinominare, Esc per annullare."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indtast et vinduenavn. Tryk Enter for at omdøbe, Escape for at annullere."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wprowadź nazwę okna. Naciśnij Enter, aby zmienić nazwę, Escape, aby anulować."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите имя окна. Нажмите Enter для переименования, Escape для отмены."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unesite naziv prozora. Pritisnite Enter za preimenovanje, Escape za otkazivanje."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدخل اسم النافذة. اضغط Enter لإعادة التسمية، Escape للإلغاء."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skriv inn et vindusnavn. Trykk Enter for å gi nytt navn, Escape for å avbryte."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Insira um nome para a janela. Pressione Enter para renomear, Escape para cancelar."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้อนชื่อหน้าต่าง กด Enter เพื่อเปลี่ยนชื่อ, Escape เพื่อยกเลิก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir pencere adı girin. Yeniden adlandırmak için Enter, iptal etmek için Escape tuşuna basın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть назву вікна. Enter — перейменувати, Escape — скасувати."
+          }
+        }
+      }
+    },
+    "commandPalette.rename.windowPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ名"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口名称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視窗名稱"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenstername"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre de ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom de la fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vinduenavn"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa okna"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Имя окна"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv prozora"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vindusnavn"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome da janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อหน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencere adı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва вікна"
+          }
+        }
+      }
+    },
+    "commandPalette.rename.windowTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウの名称変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新命名視窗"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윈도우 이름 변경"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fenster umbenennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renombrar ventana"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina finestra"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb vindue"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień nazwę okna"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать окно"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preimenuj prozor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية النافذة"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gi vinduet nytt navn"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renomear Janela"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปลี่ยนชื่อหน้าต่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pencereyi Yeniden Adlandır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати вікно"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2173,6 +2173,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let sidebarState: SidebarState
         let sidebarSelectionState: SidebarSelectionState
         weak var window: NSWindow?
+        var customWindowTitle: String?
 
         init(
             windowId: UUID,
@@ -3895,6 +3896,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             SessionPersistencePolicy.sanitizedSidebarWidth(snapshot.sidebar.width)
         )
         context.sidebarSelectionState.selection = snapshot.sidebar.selection.sidebarSelection
+        context.customWindowTitle = snapshot.customWindowTitle
 
         if let restoredFrame = resolvedWindowFrame(from: snapshot), let window {
             window.setFrame(restoredFrame, display: true)
@@ -4385,6 +4387,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 hasher.combine(1)
             }
 
+            hasher.combine(context.customWindowTitle)
+
             if let window = context.window ?? windowForMainWindowId(context.windowId) {
                 Self.hashFrame(window.frame, into: &hasher)
             } else {
@@ -4683,7 +4687,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         isVisible: context.sidebarState.isVisible,
                         selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
                         width: SessionPersistencePolicy.sanitizedSidebarWidth(Double(context.sidebarState.persistedWidth))
-                    )
+                    ),
+                    customWindowTitle: context.customWindowTitle
                 )
             }
 
@@ -4810,6 +4815,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isVisible: Bool
         let workspaceCount: Int
         let selectedWorkspaceId: UUID?
+        let customWindowTitle: String?
     }
 
     struct WindowMoveTarget: Identifiable {
@@ -4844,9 +4850,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 isKeyWindow: window?.isKeyWindow ?? false,
                 isVisible: window?.isVisible ?? false,
                 workspaceCount: ctx.tabManager.tabs.count,
-                selectedWorkspaceId: ctx.tabManager.selectedTabId
+                selectedWorkspaceId: ctx.tabManager.selectedTabId,
+                customWindowTitle: ctx.customWindowTitle
             )
         }
+    }
+
+    func customWindowTitle(for windowId: UUID) -> String? {
+        mainWindowContexts.values.first(where: { $0.windowId == windowId })?.customWindowTitle
+    }
+
+    func setCustomWindowTitle(windowId: UUID, title: String?) {
+        guard let context = mainWindowContexts.values.first(where: { $0.windowId == windowId }) else { return }
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        context.customWindowTitle = (trimmed?.isEmpty ?? true) ? nil : trimmed
+        notifyMainWindowContextsDidChange()
     }
 
     func windowMoveTargets(referenceWindowId: UUID?) -> [WindowMoveTarget] {
@@ -5416,6 +5434,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    func requestCommandPaletteRenameWindow(
+        preferredWindow: NSWindow? = nil,
+        source: String = "api.commandPaletteRenameWindow"
+    ) {
+        postCommandPaletteRequest(
+            name: .commandPaletteRenameWindowRequested,
+            preferredWindow: preferredWindow,
+            source: source,
+            markPending: true
+        )
+    }
+
     func requestCommandPaletteEditWorkspaceDescription(
         preferredWindow: NSWindow? = nil,
         source: String = "api.commandPaletteEditWorkspaceDescription"
@@ -5910,7 +5940,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func windowLabelsById(orderedSummaries: [MainWindowSummary], referenceWindowId: UUID?) -> [UUID: String] {
         var labels: [UUID: String] = [:]
         for (index, summary) in orderedSummaries.enumerated() {
-            if summary.windowId == referenceWindowId {
+            if let customTitle = summary.customWindowTitle {
+                labels[summary.windowId] = customTitle
+            } else if summary.windowId == referenceWindowId {
                 labels[summary.windowId] = String(localized: "menu.currentWindow", defaultValue: "Current Window")
             } else {
                 let number = index + 1
@@ -7124,6 +7156,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             sidebarState: sidebarState,
             sidebarSelectionState: sidebarSelectionState
         )
+        if let customTitle = sessionWindowSnapshot?.customWindowTitle {
+            mainWindowContexts[ObjectIdentifier(window)]?.customWindowTitle = customTitle
+        }
         installFileDropOverlay(on: window, tabManager: tabManager)
         if TerminalController.shouldSuppressSocketCommandActivation() {
             window.orderFront(nil)
@@ -10492,6 +10527,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+
     private func handleCustomShortcut(event: NSEvent) -> Bool {
         // `charactersIgnoringModifiers` can be nil for some synthetic NSEvents and certain special keys.
         // Treat nil as "" and rely on keyCode/layout-aware fallback logic where needed.
@@ -11076,6 +11112,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if matchConfiguredShortcut(event: event, action: .renameWorkspace) {
             return requestRenameWorkspaceViaCommandPalette(
+                preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            )
+        }
+
+        if matchConfiguredShortcut(event: event, action: .renameWindow) {
+            return requestRenameWindowViaCommandPalette(
                 preferredWindow: commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             )
         }
@@ -12082,6 +12124,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         requestCommandPaletteRenameWorkspace(
             preferredWindow: targetWindow,
             source: "shortcut.renameWorkspace"
+        )
+        return true
+    }
+
+    @discardableResult
+    func requestRenameWindowViaCommandPalette(preferredWindow: NSWindow? = nil) -> Bool {
+        let targetWindow = preferredWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
+        requestCommandPaletteRenameWindow(
+            preferredWindow: targetWindow,
+            source: "shortcut.renameWindow"
         )
         return true
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1895,6 +1895,7 @@ struct ContentView: View {
         enum Kind: Equatable {
             case workspace(workspaceId: UUID)
             case tab(workspaceId: UUID, panelId: UUID)
+            case window(windowId: UUID)
         }
 
         let kind: Kind
@@ -1906,6 +1907,8 @@ struct ContentView: View {
                 return String(localized: "commandPalette.rename.workspaceTitle", defaultValue: "Rename Workspace")
             case .tab:
                 return String(localized: "commandPalette.rename.tabTitle", defaultValue: "Rename Tab")
+            case .window:
+                return String(localized: "commandPalette.rename.windowTitle", defaultValue: "Rename Window")
             }
         }
 
@@ -1915,6 +1918,8 @@ struct ContentView: View {
                 return String(localized: "commandPalette.rename.workspaceDescription", defaultValue: "Choose a custom workspace name.")
             case .tab:
                 return String(localized: "commandPalette.rename.tabDescription", defaultValue: "Choose a custom tab name.")
+            case .window:
+                return String(localized: "commandPalette.rename.windowDescription", defaultValue: "Choose a custom window name.")
             }
         }
 
@@ -1924,6 +1929,8 @@ struct ContentView: View {
                 return String(localized: "commandPalette.rename.workspacePlaceholder", defaultValue: "Workspace name")
             case .tab:
                 return String(localized: "commandPalette.rename.tabPlaceholder", defaultValue: "Tab name")
+            case .window:
+                return String(localized: "commandPalette.rename.windowPlaceholder", defaultValue: "Window name")
             }
         }
     }
@@ -2191,6 +2198,8 @@ struct ContentView: View {
         static let panelHasCustomName = "panel.hasCustomName"
         static let panelShouldPin = "panel.shouldPin"
         static let panelHasUnread = "panel.hasUnread"
+
+        static let windowHasCustomTitle = "window.hasCustomTitle"
 
         static let updateHasAvailable = "update.hasAvailable"
         static let cliInstalledInPATH = "cli.installedInPATH"
@@ -2798,7 +2807,19 @@ struct ContentView: View {
             }
             return
         }
-        let title = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let workspaceName = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let windowCustomTitle = AppDelegate.shared?.customWindowTitle(for: windowId)
+        let title: String
+        if let windowCustomTitle, !windowCustomTitle.isEmpty {
+            title = workspaceName.isEmpty
+                ? windowCustomTitle
+                : String(
+                    localized: "titlebar.windowWithWorkspace",
+                    defaultValue: "\(windowCustomTitle) - \(workspaceName)"
+                )
+        } else {
+            title = workspaceName
+        }
         if titlebarText != title {
             titlebarText = title
         }
@@ -3064,6 +3085,13 @@ struct ContentView: View {
             scheduleTitlebarTextRefresh()
         })
 
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .mainWindowContextsDidChange)) { _ in
+            scheduleTitlebarTextRefresh()
+            if isCommandPalettePresented {
+                scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true)
+            }
+        })
+
         view = AnyView(view.onChange(of: titlebarThemeGeneration) { oldValue, newValue in
             guard GhosttyApp.shared.backgroundLogEnabled else { return }
             GhosttyApp.shared.logBackground(
@@ -3243,6 +3271,17 @@ struct ContentView: View {
                 mainWindow: NSApp.mainWindow
             ) else { return }
             openCommandPaletteRenameWorkspaceInput()
+        })
+
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRenameWindowRequested)) { notification in
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ) else { return }
+            openCommandPaletteRenameWindowInput()
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteEditWorkspaceDescriptionRequested)) { notification in
@@ -5097,6 +5136,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.rename.workspaceInputHint", defaultValue: "Enter a workspace name. Press Enter to rename, Escape to cancel.")
         case .tab:
             return String(localized: "commandPalette.rename.tabInputHint", defaultValue: "Enter a tab name. Press Enter to rename, Escape to cancel.")
+        case .window:
+            return String(localized: "commandPalette.rename.windowInputHint", defaultValue: "Enter a window name. Press Enter to rename, Escape to cancel.")
         }
     }
 
@@ -5106,6 +5147,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.rename.workspaceConfirmHint", defaultValue: "Press Enter to apply this workspace name, or Escape to cancel.")
         case .tab:
             return String(localized: "commandPalette.rename.tabConfirmHint", defaultValue: "Press Enter to apply this tab name, or Escape to cancel.")
+        case .window:
+            return String(localized: "commandPalette.rename.windowConfirmHint", defaultValue: "Press Enter to apply this window name, or Escape to cancel.")
         }
     }
 
@@ -5910,7 +5953,11 @@ struct ContentView: View {
         var windowLabelById: [UUID: String] = [:]
         if orderedSummaries.count > 1 {
             for (index, summary) in orderedSummaries.enumerated() where summary.windowId != windowId {
-                windowLabelById[summary.windowId] = String(localized: "commandPalette.switcher.windowLabel", defaultValue: "Window \(index + 1)")
+                if let customTitle = summary.customWindowTitle {
+                    windowLabelById[summary.windowId] = customTitle
+                } else {
+                    windowLabelById[summary.windowId] = String(localized: "commandPalette.switcher.windowLabel", defaultValue: "Window \(index + 1)")
+                }
             }
         }
 
@@ -6155,6 +6202,8 @@ struct ContentView: View {
             return .renameTab
         case "palette.renameWorkspace":
             return .renameWorkspace
+        case "palette.renameWindow":
+            return .renameWindow
         case "palette.editWorkspaceDescription":
             return .editWorkspaceDescription
         case "palette.nextWorkspace":
@@ -6301,6 +6350,11 @@ struct ContentView: View {
                 }
             }
         }
+
+        snapshot.setBool(
+            CommandPaletteContextKeys.windowHasCustomTitle,
+            AppDelegate.shared?.customWindowTitle(for: windowId) != nil
+        )
 
         if case .updateAvailable = updateViewModel.effectiveState {
             snapshot.setBool(CommandPaletteContextKeys.updateHasAvailable, true)
@@ -6559,6 +6613,24 @@ struct ContentView: View {
                 keywords: ["rename", "workspace", "title"],
                 dismissOnRun: false,
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.renameWindow",
+                title: constant(String(localized: "command.renameWindow.title", defaultValue: "Rename Window…")),
+                subtitle: constant(String(localized: "command.renameWindow.subtitle", defaultValue: "Window")),
+                keywords: ["rename", "window", "title", "name"],
+                dismissOnRun: false
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.clearWindowName",
+                title: constant(String(localized: "command.clearWindowName.title", defaultValue: "Clear Window Name")),
+                subtitle: constant(String(localized: "command.clearWindowName.subtitle", defaultValue: "Window")),
+                keywords: ["clear", "window", "name"],
+                when: { $0.bool(CommandPaletteContextKeys.windowHasCustomTitle) }
             )
         )
         contributions.append(
@@ -7210,6 +7282,12 @@ struct ContentView: View {
 
         registry.register(commandId: "palette.renameWorkspace") {
             beginRenameWorkspaceFlow()
+        }
+        registry.register(commandId: "palette.renameWindow") {
+            beginRenameWindowFlow()
+        }
+        registry.register(commandId: "palette.clearWindowName") {
+            AppDelegate.shared?.setCustomWindowTitle(windowId: windowId, title: nil)
         }
         registry.register(commandId: "palette.editWorkspaceDescription") {
             beginWorkspaceDescriptionFlow()
@@ -7881,6 +7959,13 @@ struct ContentView: View {
         beginRenameWorkspaceFlow()
     }
 
+    private func openCommandPaletteRenameWindowInput() {
+        if !isCommandPalettePresented {
+            presentCommandPalette(initialQuery: Self.commandPaletteCommandsPrefix)
+        }
+        beginRenameWindowFlow()
+    }
+
     private func openCommandPaletteWorkspaceDescriptionInput() {
 #if DEBUG
         dlog(
@@ -8524,6 +8609,15 @@ struct ContentView: View {
         startRenameFlow(target)
     }
 
+    private func beginRenameWindowFlow() {
+        let currentTitle = AppDelegate.shared?.customWindowTitle(for: windowId) ?? ""
+        let target = CommandPaletteRenameTarget(
+            kind: .window(windowId: windowId),
+            currentName: currentTitle
+        )
+        startRenameFlow(target)
+    }
+
     private func beginWorkspaceDescriptionFlow() {
         guard let workspace = tabManager.selectedWorkspace else {
             NSSound.beep()
@@ -8604,6 +8698,8 @@ struct ContentView: View {
                 return
             }
             workspace.setPanelCustomTitle(panelId: panelId, title: normalizedName)
+        case .window(let windowId):
+            AppDelegate.shared?.setCustomWindowTitle(windowId: windowId, title: normalizedName)
         }
 
         dismissCommandPalette()

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -41,6 +41,7 @@ enum KeyboardShortcutSettings {
         case selectWorkspaceByNumber
         case renameTab
         case renameWorkspace
+        case renameWindow
         case editWorkspaceDescription
         case closeTab
         case closeOtherTabsInPane
@@ -105,6 +106,7 @@ enum KeyboardShortcutSettings {
             case .selectWorkspaceByNumber: return String(localized: "shortcut.selectWorkspaceByNumber.label", defaultValue: "Select Workspace 1…9")
             case .renameTab: return String(localized: "shortcut.renameTab.label", defaultValue: "Rename Tab")
             case .renameWorkspace: return String(localized: "shortcut.renameWorkspace.label", defaultValue: "Rename Workspace")
+            case .renameWindow: return String(localized: "shortcut.renameWindow.label", defaultValue: "Rename Window")
             case .editWorkspaceDescription: return String(localized: "shortcut.editWorkspaceDescription.label", defaultValue: "Edit Workspace Description")
             case .closeTab: return String(localized: "menu.file.closeTab", defaultValue: "Close Tab")
             case .closeOtherTabsInPane: return String(localized: "menu.file.closeOtherTabs", defaultValue: "Close Other Tabs in Pane")
@@ -182,6 +184,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
             case .renameWorkspace:
                 return StoredShortcut(key: "r", command: true, shift: true, option: false, control: false)
+            case .renameWindow:
+                return StoredShortcut(key: "r", command: true, shift: true, option: true, control: false)
             case .editWorkspaceDescription:
                 return StoredShortcut(key: "e", command: true, shift: true, option: false, control: false)
             case .closeTab:

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -353,6 +353,7 @@ struct SessionWindowSnapshot: Codable, Sendable {
     var display: SessionDisplaySnapshot?
     var tabManager: SessionTabManagerSnapshot
     var sidebar: SessionSidebarSnapshot
+    var customWindowTitle: String?
 }
 
 struct AppSessionSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5909,6 +5909,7 @@ extension Notification.Name {
     static let commandPaletteDismissRequested = Notification.Name("cmux.commandPaletteDismissRequested")
     static let commandPaletteRenameTabRequested = Notification.Name("cmux.commandPaletteRenameTabRequested")
     static let commandPaletteRenameWorkspaceRequested = Notification.Name("cmux.commandPaletteRenameWorkspaceRequested")
+    static let commandPaletteRenameWindowRequested = Notification.Name("cmux.commandPaletteRenameWindowRequested")
     static let commandPaletteEditWorkspaceDescriptionRequested = Notification.Name("cmux.commandPaletteEditWorkspaceDescriptionRequested")
     static let commandPaletteMoveSelection = Notification.Name("cmux.commandPaletteMoveSelection")
     static let commandPaletteRenameInputInteractionRequested = Notification.Name("cmux.commandPaletteRenameInputInteractionRequested")

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2079,6 +2079,8 @@ class TerminalController {
             return v2Result(id: id, self.v2WindowCreate(params: params))
         case "window.close":
             return v2Result(id: id, self.v2WindowClose(params: params))
+        case "window.rename":
+            return v2Result(id: id, self.v2WindowRename(params: params))
 
         // Workspaces
         case "workspace.list":
@@ -2473,6 +2475,7 @@ class TerminalController {
             "window.focus",
             "window.create",
             "window.close",
+            "window.rename",
             "workspace.list",
             "workspace.create",
             "workspace.select",
@@ -3257,7 +3260,8 @@ class TerminalController {
                 "visible": item.isVisible,
                 "workspace_count": item.workspaceCount,
                 "selected_workspace_id": v2OrNull(item.selectedWorkspaceId?.uuidString),
-                "selected_workspace_ref": v2Ref(kind: .workspace, uuid: item.selectedWorkspaceId)
+                "selected_workspace_ref": v2Ref(kind: .workspace, uuid: item.selectedWorkspaceId),
+                "custom_title": v2OrNull(item.customWindowTitle)
             ]
         }
         return .ok(["windows": payload])
@@ -3270,9 +3274,11 @@ class TerminalController {
         guard let windowId = v2ResolveWindowId(tabManager: tabManager) else {
             return .err(code: "not_found", message: "Current window not found", data: nil)
         }
+        let customTitle = v2MainSync { AppDelegate.shared?.customWindowTitle(for: windowId) }
         return .ok([
             "window_id": windowId.uuidString,
-            "window_ref": v2Ref(kind: .window, uuid: windowId)
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "custom_title": v2OrNull(customTitle)
         ])
     }
 
@@ -3320,6 +3326,37 @@ class TerminalController {
                 "window_id": windowId.uuidString,
                 "window_ref": v2Ref(kind: .window, uuid: windowId)
             ])
+    }
+
+    private func v2WindowRename(params: [String: Any]) -> V2CallResult {
+        guard let windowId = v2UUID(params, "window_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid window_id", data: nil)
+        }
+        guard let titleRaw = v2String(params, "title"),
+              !titleRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .err(code: "invalid_params", message: "Missing or invalid title", data: nil)
+        }
+
+        let title = titleRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        var renamed = false
+        v2MainSync {
+            guard AppDelegate.shared?.tabManagerFor(windowId: windowId) != nil else { return }
+            AppDelegate.shared?.setCustomWindowTitle(windowId: windowId, title: title)
+            renamed = true
+        }
+
+        guard renamed else {
+            return .err(code: "not_found", message: "Window not found", data: [
+                "window_id": windowId.uuidString,
+                "window_ref": v2Ref(kind: .window, uuid: windowId)
+            ])
+        }
+
+        return .ok([
+            "window_id": windowId.uuidString,
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "title": title
+        ])
     }
 
     // MARK: - V2 Workspace Methods


### PR DESCRIPTION
## Summary

Adds first-class window renaming to cmux. Windows can now have persistent custom names that appear in the title bar, Move Workspace picker, command palette switcher, and window list API.

- **Keyboard shortcut**: `Cmd+Shift+Option+R` to rename the current window
- **Command palette**: "Rename Window..." and "Clear Window Name" commands
- **CLI**: `cmux rename-window "Gymatch"` renames the current window
- **Socket API**: New `window.rename` method; `window.list` and `window.current` now return `custom_title`
- **Title bar**: Shows `WindowName - WorkspaceName` when a custom title is set
- **Move Workspace picker**: Shows custom window name instead of "Window N"
- **Command palette switcher**: Shows custom window names for other windows
- **Session persistence**: Custom window titles survive app restarts

### Breaking change

`cmux rename-window` now renames the **window**, not the workspace. Use `cmux rename-workspace` for workspaces. The tmux-compat mode (`cmux tmux rename-window`) remains mapped to workspace rename for backward compatibility.

### Files changed (7)

| File | What changed |
|------|-------------|
| `Sources/AppDelegate.swift` | `customWindowTitle` on `MainWindowContext` + `MainWindowSummary`, accessor methods, `promptRenameWindow()` dialog, shortcut handler, session snapshot build/restore, `windowLabelsById()` prefers custom titles |
| `Sources/ContentView.swift` | `.window` case in `CommandPaletteRenameTarget`, notification observer, `beginRenameWindowFlow()`, command registration, `palette.clearWindowName`, `windowHasCustomTitle` context key, titlebar `WindowName - WorkspaceName`, switcher labels |
| `Sources/KeyboardShortcutSettings.swift` | `renameWindow` action with `Cmd+Shift+Option+R` default |
| `Sources/TabManager.swift` | `.commandPaletteRenameWindowRequested` notification name |
| `Sources/SessionPersistence.swift` | `customWindowTitle` on `SessionWindowSnapshot` (optional, backward compatible) |
| `Sources/TerminalController.swift` | `window.rename` socket method, `custom_title` in `window.list`/`window.current` responses |
| `CLI/cmux.swift` | Real `rename-window` command (separate from `rename-workspace`), new help text |

### Design decisions

- **Separator**: Title bar uses ` - ` (space-hyphen-space) between window and workspace names
- **Feature parity**: "Clear Window Name" command mirrors "Clear Workspace Name" and "Clear Tab Name"
- **Session backward compatibility**: `customWindowTitle` is optional in `SessionWindowSnapshot`, so old snapshots decode cleanly (nil)
- **tmux compat preserved**: The tmux-mode `rename-window` still maps to workspace rename, only the native CLI command changes semantics

## Test plan

- [ ] `Cmd+Shift+Option+R` — rename dialog appears, enter name, title bar updates
- [ ] Title bar shows `WindowName - WorkspaceName` format
- [ ] Move Workspace to Window picker shows custom window name
- [ ] Command palette: "Rename Window..." triggers rename flow
- [ ] Command palette: "Clear Window Name" appears only when window has a name, clears it
- [ ] `cmux rename-window "Gymatch"` — renames the current window
- [ ] `cmux rename-workspace "test"` — still renames the workspace
- [ ] Quit and reopen cmux — custom window title persists
- [ ] `cmux window list --json` — returns `custom_title` field
- [ ] tmux compat: `cmux tmux rename-window "test"` still renames workspace
- [ ] Multiple windows: each window's custom name appears correctly in all pickers

Closes #2249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class window renaming to `cmux` with keyboard, command palette, CLI, and socket support; custom names persist and appear in the title bar, pickers, and API. `cmux rename-window` now targets windows (use `cmux rename-workspace` for workspaces); tmux-compat `cmux tmux rename-window` still renames the workspace.

- **New Features**
  - Keyboard: Cmd+Shift+Option+R to rename the current window.
  - Command palette: “Rename Window…” and “Clear Window Name”.
  - CLI: `cmux rename-window [--window <id|ref|index>] [--] <title>`.
  - Socket API: `window.rename`; `window.list`/`window.current` include `custom_title`.
  - UI: Title bar shows `WindowName - WorkspaceName`; Move Workspace picker and the switcher show custom window names.
  - Session: Custom window names persist across restarts.

- **Bug Fixes**
  - CLI: Normalize `--window` before `window.rename`; do not pre-focus for `rename-window`; help now documents `--window`; clearer window vs. workspace errors.
  - Session restore: Restore `customWindowTitle` for all windows; included in autosave fingerprints.
  - UI: Title bar updates immediately on rename via `.mainWindowContextsDidChange`; titlebar format string is localized.
  - Localization: Added `shortcut.renameWindow.label` and command palette strings for rename/clear window in all supported languages.

<sup>Written for commit 88b11805e13e521bacf617c04295328a7fba8769. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename windows via command palette, a new shortcut (Cmd+Shift+Opt+R), CLI or socket; custom window titles persist across sessions and appear in the titlebar and switcher.
  * Command palette adds Rename and Clear Window Name actions with localized strings and a shortcut label.

* **Bug Fixes**
  * CLI rename commands split and clarified with distinct usage/help and clearer validation/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->