### PR TITLE
Add Claude Code plugin for end-user skill installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "cmux",
+  "owner": {
+    "name": "Manaflow AI",
+    "url": "https://github.com/manaflow-ai"
+  },
+  "metadata": {
+    "description": "Official Claude Code skills for cmux terminal multiplexer"
+  },
+  "plugins": [
+    {
+      "name": "cmux",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Jac0bDeal/cmux.git",
+        "ref": "feat/claude-code-plugin"
+      },
+      "description": "Window management, browser automation, and markdown viewing skills for cmux"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,7 @@
       "name": "cmux",
       "source": {
         "source": "url",
-        "url": "https://github.com/Jac0bDeal/cmux.git",
-        "ref": "feat/claude-code-plugin"
+        "url": "https://github.com/manaflow-ai/cmux.git"
       },
       "description": "Window management, browser automation, and markdown viewing skills for cmux"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "cmux",
+  "version": "0.1.0",
+  "description": "Claude Code skills for cmux terminal multiplexer — window management, browser automation, and markdown viewing",
+  "repository": "https://github.com/manaflow-ai/cmux",
+  "homepage": "https://cmux.dev",
+  "license": "MIT",
+  "keywords": ["terminal", "multiplexer", "tmux", "window-management", "browser", "markdown"],
+  "skills": [
+    "./skills/cmux",
+    "./skills/cmux-browser",
+    "./skills/cmux-markdown"
+  ],
+  "author": {
+    "name": "Manaflow AI",
+    "url": "https://github.com/manaflow-ai"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ brew upgrade --cask cmux
 
 On first launch, macOS may ask you to confirm opening an app from an identified developer. Click **Open** to proceed.
 
+### Claude Code Plugin
+
+Install the cmux skills for Claude Code to give your agent control over windows, panes, browser panels, and markdown viewers:
+
+```
+/plugin marketplace add manaflow-ai/cmux
+/plugin install cmux@cmux
+```
+
 ## Why cmux?
 
 I run a lot of Claude Code and Codex sessions in parallel. I was using Ghostty with a bunch of split panes, and relying on native macOS notifications to know when an agent needed me. But Claude Code's notification body is always just "Claude is waiting for your input" with no context, and with enough tabs open I couldn't even read the titles anymore.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ On first launch, macOS may ask you to confirm opening an app from an identified 
 
 Install the cmux skills for Claude Code to give your agent control over windows, panes, browser panels, and markdown viewers:
 
-```
+```bash
 /plugin marketplace add manaflow-ai/cmux
 /plugin install cmux@cmux
 ```


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` manifest with metadata and explicit skill selection
- Adds `.claude-plugin/marketplace.json` for marketplace distribution
- Exposes only end-user skills (`cmux`, `cmux-browser`, `cmux-markdown`), excluding dev-only skills (`cmux-debug-windows`, `release`)

Once merged, users can install with:
```
/plugin marketplace add manaflow-ai/cmux
/plugin install cmux
```

Closes #2542

## Testing

- Verify `/plugin marketplace add manaflow-ai/cmux` discovers the marketplace
- Verify `/plugin install cmux` installs the plugin with only the 3 end-user skills
- Verify dev-only skills (`cmux-debug-windows`, `release`) are not exposed
- Verify skills are invocable as `/cmux:cmux`, `/cmux:cmux-browser`, `/cmux:cmux-markdown`

## Demo Video

N/A — no UI or behavior changes, plugin manifest only.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a Claude Code plugin for `cmux` so users can install only the three end‑user skills from the marketplace. Marketplace source points to upstream `manaflow-ai/cmux`. Addresses #2542.

- **New Features**
  - Added `.claude-plugin/plugin.json` exposing `./skills/cmux`, `./skills/cmux-browser`, `./skills/cmux-markdown`; excludes `cmux-debug-windows` and `release`.
  - Added `.claude-plugin/marketplace.json` with source `https://github.com/manaflow-ai/cmux.git`.
  - README: added install steps with bash code block.

- **Migration**
  - Add the marketplace: /plugin marketplace add `manaflow-ai/cmux`
  - Install the plugin: /plugin install `cmux@cmux`

<sup>Written for commit 48e1b315d82da40086199ad4d221a0fa81787fe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code plugin "cmux" is now available in the marketplace, providing window management, browser automation, and markdown viewing capabilities.

* **Documentation**
  * Added instructions for adding and installing the cmux plugin via the Claude Code plugin marketplace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->