### PR TITLE
ci: only enforce Sparkle monotonic check on release

### DIFF
--- a/.claude/commands/release-local.md
+++ b/.claude/commands/release-local.md
@@ -38,10 +38,12 @@ Full end-to-end release built locally. Bumps version, updates changelog, tags, t
 
 - Run: `./scripts/bump-version.sh` (bumps minor by default)
 
-### 5. Commit, tag, and push
+### 5. Commit, run the pre-tag guard, then tag and push
 
 - Stage: `CHANGELOG.md`, `GhosttyTabs.xcodeproj/project.pbxproj`
 - Commit message: `Bump version to X.Y.Z`
+- Run: `./scripts/release-pretag-guard.sh`
+- If it fails, run `./scripts/bump-version.sh`, commit the build-number bump, and rerun the guard
 - Create tag: `git tag vX.Y.Z`
 - Push: `git push origin main && git push origin vX.Y.Z`
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -56,7 +56,9 @@ Prepare a new release for cmux. This command updates the changelog, bumps the ve
    - Merge: `gh pr merge --squash --delete-branch`
    - Switch back to main: `git checkout main && git pull`
 
-10. **Create and push the tag**
+10. **Run the pre-tag guard, then create and push the tag**
+    - Run: `./scripts/release-pretag-guard.sh`
+    - If it fails, run `./scripts/bump-version.sh`, commit the build-number bump, push/merge that change, and retry the tag
     - Create tag: `git tag vX.Y.Z`
     - Push tag: `git push origin vX.Y.Z`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Validate current GhosttyKit checksum pin
         run: ./tests/test_ci_ghosttykit_checksum_present.sh
 
-      - name: Validate Sparkle build number is monotonic
-        run: ./tests/test_ci_sparkle_build_monotonic.sh
-
   remote-daemon-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Validate Sparkle build number is monotonic
+        run: ./tests/test_ci_sparkle_build_monotonic.sh
+
       - name: Guard immutable release assets
         id: guard_release_assets
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -78,30 +81,6 @@ jobs:
               }
               throw error;
             }
-
-      - name: Guard Sparkle build number is monotonic
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
-        run: |
-          set -euo pipefail
-          LOCAL_BUILD=$(grep -m1 'CURRENT_PROJECT_VERSION = ' GhosttyTabs.xcodeproj/project.pbxproj | sed 's/.*= //;s/;.*//')
-          if ! [[ "$LOCAL_BUILD" =~ ^[0-9]+$ ]]; then
-            echo "Could not parse CURRENT_PROJECT_VERSION (got '$LOCAL_BUILD')" >&2
-            exit 1
-          fi
-          echo "Local CURRENT_PROJECT_VERSION=$LOCAL_BUILD"
-          PUBLISHED_BUILD=$(curl -fsSL --max-time 15 \
-            https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml 2>/dev/null \
-            | sed -n 's#.*<sparkle:version>\([0-9][0-9]*\)</sparkle:version>.*#\1#p' \
-            | head -n1 || true)
-          if [[ "$PUBLISHED_BUILD" =~ ^[0-9]+$ ]]; then
-            echo "Latest published Sparkle build=$PUBLISHED_BUILD"
-            if (( LOCAL_BUILD <= PUBLISHED_BUILD )); then
-              echo "::error::CURRENT_PROJECT_VERSION ($LOCAL_BUILD) must be > latest published Sparkle build ($PUBLISHED_BUILD). Run scripts/bump-version.sh to bump the build number before tagging." >&2
-              exit 1
-            fi
-          else
-            echo "Latest published appcast unavailable; skipping monotonic check"
-          fi
 
       - name: Select Xcode
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Use the `/release` command to prepare a new release. This will:
 2. Gather commits since the last tag and update the changelog
 3. Update `CHANGELOG.md` (the docs changelog page at `web/app/docs/changelog/page.tsx` reads from it)
 4. Run `./scripts/bump-version.sh` to update both versions
-5. Commit, tag, and push
+5. Commit, run `./scripts/release-pretag-guard.sh`, tag, and push
 
 Version bumping:
 
@@ -248,9 +248,18 @@ Version bumping:
 
 This updates both `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` (build number). The build number is auto-incremented and is required for Sparkle auto-update to work.
 
+Before creating a release tag, run:
+
+```bash
+./scripts/release-pretag-guard.sh
+```
+
+If it fails, run `./scripts/bump-version.sh`, commit the build-number bump, then retry tagging.
+
 Manual release steps (if not using the command):
 
 ```bash
+./scripts/release-pretag-guard.sh
 git tag vX.Y.Z
 git push origin vX.Y.Z
 gh run watch --repo manaflow-ai/cmux

--- a/scripts/release-pretag-guard.sh
+++ b/scripts/release-pretag-guard.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Running release pre-tag checks..."
+"$ROOT_DIR/tests/test_ci_sparkle_build_monotonic.sh"
+echo "Release pre-tag checks passed."

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -53,7 +53,9 @@ Run this workflow to prepare and publish a cmux release.
 - `gh pr merge --squash --delete-branch`
 - `git checkout main && git pull --ff-only`
 
-10. Create and push tag:
+10. Run the pre-tag guard, then create and push tag:
+- `./scripts/release-pretag-guard.sh`
+- If it fails, run `./scripts/bump-version.sh`, commit the build-number bump, push/merge that change, and retry the tag.
 - `git tag vX.Y.Z`
 - `git push origin vX.Y.Z`
 


### PR DESCRIPTION
## Summary
- remove the Sparkle monotonic guard from the CI workflow guard job
- run the existing Sparkle monotonic script early in the release workflow right after checkout
- fail releases before expensive build/sign work when the published Sparkle build is newer or equal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only enforce Sparkle build-number monotonicity during releases. Run the check pre-tag via `./scripts/release-pretag-guard.sh` and first in `release.yml` to fail fast before build/sign.

- **Refactors**
  - Remove the check from `ci.yml`; use the shared `./tests/test_ci_sparkle_build_monotonic.sh` in `release.yml` and the new pre-tag guard script.
  - Delete inline Sparkle version parsing in `release.yml` and update release docs/commands to require the pre-tag guard before tagging.

<sup>Written for commit 05eff80c413b13385f42ac2d6636f1012f1d510a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized build validation checks in the release pipeline by consolidating the Sparkle build number validation into the release workflow for improved streamlining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->