### PR TITLE
Write last build tag to /tmp for statusline

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -405,6 +405,10 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       CMUX_DEBUG_LOG="/tmp/cmux-debug-${TAG_SLUG}.log"
       write_last_socket_path "$CMUX_SOCKET"
       echo "$CMUX_DEBUG_LOG" > /tmp/cmux-last-debug-log-path || true
+      echo "$TAG" > /tmp/cmux-last-tag || true
+      if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+        echo "$TAG" > "/tmp/cmux-last-tag-${CLAUDE_SESSION_ID}" || true
+      fi
       /usr/libexec/PlistBuddy -c "Add :LSEnvironment dict" "$INFO_PLIST" 2>/dev/null || true
       /usr/libexec/PlistBuddy -c "Set :LSEnvironment:CMUXD_UNIX_PATH \"${CMUXD_SOCKET}\"" "$INFO_PLIST" 2>/dev/null \
         || /usr/libexec/PlistBuddy -c "Add :LSEnvironment:CMUXD_UNIX_PATH string \"${CMUXD_SOCKET}\"" "$INFO_PLIST"


### PR DESCRIPTION
## Summary
- `reload.sh` writes the tag to `/tmp/cmux-last-tag` (global fallback) and `/tmp/cmux-last-tag-$CLAUDE_SESSION_ID` (per-session) after each build
- Enables Claude Code statusline to show the latest tag each session has built, without sessions clobbering each other

Companion: a SessionStart hook in cmuxterm-hq bridges `session_id` into `CLAUDE_SESSION_ID` env var, and a statusline script reads the per-session tag file.

## Test plan
- Run `CLAUDE_SESSION_ID=test123 ./scripts/reload.sh --tag foo` and verify `/tmp/cmux-last-tag-test123` contains `foo`
- Run without `CLAUDE_SESSION_ID` and verify `/tmp/cmux-last-tag` is written

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
After each build, `scripts/reload.sh` now writes the tag to `/tmp/cmux-last-tag` and, when `CLAUDE_SESSION_ID` is set, to `/tmp/cmux-last-tag-$CLAUDE_SESSION_ID`. This lets the Claude Code statusline show the latest tag per session without clobbering across sessions.

<sup>Written for commit 550571955a00becd413197b1bd7b95df1f6fa9ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

