### PR TITLE
Hide stale startup workspace portals during teardown

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9259,6 +9259,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// Called before the workspace is removed from TabManager to ensure child
     /// processes receive SIGHUP even if ARC deallocation is delayed.
     func teardownAllPanels() {
+        // Hide portal-hosted content up front so a workspace being torn down
+        // cannot keep drawing above the next selected/restored workspace while
+        // panel close work is still unwinding.
+        hideAllTerminalPortalViews()
+        hideAllBrowserPortalViews()
+
         let panelEntries = Array(panels)
         for (panelId, panel) in panelEntries {
             panelSubscriptions.removeValue(forKey: panelId)


### PR DESCRIPTION
## Summary
- investigate issue #2656 and confirm `git log v0.63.2..HEAD` contains no relevant startup fix; the only code change after the release is unrelated sidebar PR polling work
- harden `Workspace.teardownAllPanels()` to hide terminal and browser portal-hosted content before panel close/unwind work begins
- guard the startup session-restore path where a bootstrap workspace can be replaced and torn down while its portal views are still capable of drawing above the restored workspace

## Testing
- `./scripts/reload.sh --tag issue-2656-startup-page-disorganized --launch`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lifecycle change that only adjusts teardown ordering to hide portal views earlier; main risk is unintended visibility side effects during workspace transitions.
> 
> **Overview**
> Pre-hides terminal and browser *portal-hosted* views at the start of `Workspace.teardownAllPanels()` so a retiring/bootstrap workspace can’t keep rendering above the newly selected/restored workspace while panel closure is still unwinding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ae58030cdf3e818778d3522d64742cfd82dbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide terminal and browser portal views at the start of workspace teardown so a retiring startup workspace can’t render above the restored workspace. Addresses #2656 where the startup page looked disorganized due to lingering portal content.

- **Bug Fixes**
  - Pre-hide portal-hosted content in `Workspace.teardownAllPanels()` by calling `hideAllTerminalPortalViews()` and `hideAllBrowserPortalViews()` before panel close.
  - Guard session-restore flow so a bootstrap workspace being replaced can’t draw while teardown unwinds.

<sup>Written for commit a6ae58030cdf3e818778d3522d64742cfd82dbf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel teardown behavior to prevent terminal and browser views from remaining visible during cleanup operations, reducing visual glitches when closing panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->