### PR TITLE
Add passkey, WebAuthn, and FIDO2 support to browser pane

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -393,19 +393,20 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          ENTITLEMENTS="cmux.entitlements"
+          APP_ENTITLEMENTS="cmux.entitlements"
+          EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
             if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
             fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           done
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -400,14 +400,15 @@ jobs:
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
             if [ -f "$CLI_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
             fi
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+            ./scripts/assert-passkey-entitlement.sh "$APP_PATH"
           done
 
       - name: Notarize apps and dmgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,16 +257,17 @@ jobs:
             exit 1
           fi
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          ENTITLEMENTS="cmux.entitlements"
+          APP_ENTITLEMENTS="cmux.entitlements"
+          EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
           if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
           fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 
       - name: Notarize app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,14 +261,15 @@ jobs:
           EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
           if [ -f "$CLI_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
           fi
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          ./scripts/assert-passkey-entitlement.sh "$APP_PATH"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -47,6 +47,8 @@
 	<string>A program running within cmux would like to use your microphone.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>A program running within cmux would like to use your camera.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>cmux uses Bluetooth for cross-device passkey sign-in in embedded browser authentication flows.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -16,6 +16,102 @@
             "state": "translated",
             "value": "cmux は内蔵ブラウザの認証フローでクロスデバイスのパスキーサインインに Bluetooth を使用します。"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 在嵌入式浏览器身份验证流程中使用蓝牙进行跨设备通行密钥登录。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 在內嵌瀏覽器身份驗證流程中使用藍牙進行跨裝置密碼金鑰登入。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux는 내장 브라우저 인증 흐름에서 기기 간 패스키 로그인에 Bluetooth를 사용합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux verwendet Bluetooth für die geräteübergreifende Passkey-Anmeldung in den Authentifizierungsabläufen des integrierten Browsers."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux usa Bluetooth para el inicio de sesión con claves de acceso entre dispositivos en los flujos de autenticación del navegador integrado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux utilise Bluetooth pour la connexion par clé d'accès entre appareils dans les flux d'authentification du navigateur intégré."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux usa il Bluetooth per l'accesso con passkey tra dispositivi nei flussi di autenticazione del browser integrato."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux bruger Bluetooth til adgangsnøgle-login på tværs af enheder i den integrerede browsers godkendelsesforløb."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux używa Bluetooth do logowania za pomocą kluczy dostępu między urządzeniami w procesach uwierzytelniania wbudowanej przeglądarki."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux использует Bluetooth для входа с помощью ключей доступа между устройствами в потоках аутентификации встроенного браузера."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux koristi Bluetooth za prijavu pomoću pristupnog ključa između uređaja u tokovima autentifikacije ugrađenog preglednika."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يستخدم cmux البلوتوث لتسجيل الدخول باستخدام مفاتيح المرور عبر الأجهزة في تدفقات المصادقة بالمتصفح المدمج."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux bruker Bluetooth for tilgangsnøkkel-pålogging på tvers av enheter i den innebygde nettleserens autentiseringsflyter."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O cmux usa Bluetooth para login com chaves de acesso entre dispositivos nos fluxos de autenticação do navegador integrado."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux ใช้บลูทูธสำหรับการลงชื่อเข้าใช้ด้วย passkey ข้ามอุปกรณ์ในขั้นตอนการตรวจสอบสิทธิ์ของเบราว์เซอร์ในตัว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux, gömülü tarayıcının kimlik doğrulama akışlarında cihazlar arası geçiş anahtarı oturum açma için Bluetooth kullanır."
+          }
         }
       }
     },

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -2,6 +2,23 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "NSBluetoothAlwaysUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux uses Bluetooth for cross-device passkey sign-in in embedded browser authentication flows."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux は内蔵ブラウザの認証フローでクロスデバイスのパスキーサインインに Bluetooth を使用します。"
+          }
+        }
+      }
+    },
     "NSCameraUsageDescription": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import AuthenticationServices
 import WebKit
 import AppKit
 import Bonsplit
@@ -1725,6 +1726,145 @@ final class BrowserPortalAnchorView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
+    }
+}
+
+// WKWebView handles WebAuthn itself for browser apps; this support code only
+// determines when cmux should request browser passkey access from macOS.
+enum BrowserPasskeyAuthorizationSupport {
+    static func isPotentiallyTrustworthy(url: URL?) -> Bool {
+        guard let url,
+              let scheme = url.scheme?.lowercased() else {
+            return false
+        }
+        if scheme == "https" {
+            return true
+        }
+        guard scheme == "http",
+              let host = url.host else {
+            return false
+        }
+        return isLoopbackHost(host)
+    }
+
+    static func shouldRequestAuthorization(
+        for url: URL?,
+        authorizationState: ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState,
+        hasPendingRequest: Bool,
+        didPromptThisSession: Bool
+    ) -> Bool {
+        guard isPotentiallyTrustworthy(url: url) else { return false }
+        guard authorizationState == .notDetermined else { return false }
+        guard !hasPendingRequest else { return false }
+        guard !didPromptThisSession else { return false }
+        return true
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = normalizedHost(host)
+        let octets = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        let is127Loopback = octets.count == 4
+            && octets[0] == "127"
+            && octets.allSatisfy { component in
+                guard let value = Int(component) else { return false }
+                return (0...255).contains(value)
+            }
+
+        return normalized == "localhost"
+            || normalized.hasSuffix(".localhost")
+            || normalized == "::1"
+            || is127Loopback
+    }
+
+    private static func normalizedHost(_ host: String) -> String {
+        var normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized.hasPrefix("[") && normalized.hasSuffix("]") {
+            normalized.removeFirst()
+            normalized.removeLast()
+        }
+        if normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
+        return normalized
+    }
+}
+
+private extension ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState {
+    var cmuxDebugName: String {
+        switch self {
+        case .authorized:
+            return "authorized"
+        case .denied:
+            return "denied"
+        case .notDetermined:
+            return "notDetermined"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}
+
+@MainActor
+private final class BrowserPasskeyAuthorizationManager {
+    static let shared = BrowserPasskeyAuthorizationManager()
+
+    private let credentialManager = ASAuthorizationWebBrowserPublicKeyCredentialManager()
+    private var authorizationTask: Task<ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState, Never>?
+    private var didPromptThisSession = false
+
+    private init() {}
+
+    func requestAuthorizationIfNeeded(for url: URL?, source: String) {
+        let state = credentialManager.authorizationStateForPlatformCredentials
+        guard BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+            for: url,
+            authorizationState: state,
+            hasPendingRequest: authorizationTask != nil,
+            didPromptThisSession: didPromptThisSession
+        ) else {
+#if DEBUG
+            let requestURL = url?.absoluteString ?? "nil"
+            dlog(
+                "browser.passkey.authorization.skip " +
+                "source=\(source) url=\(requestURL) state=\(state.cmuxDebugName) " +
+                "pending=\(authorizationTask == nil ? 0 : 1) prompted=\(didPromptThisSession ? 1 : 0)"
+            )
+#endif
+            return
+        }
+
+        didPromptThisSession = true
+#if DEBUG
+        let requestURL = url?.absoluteString ?? "nil"
+        dlog(
+            "browser.passkey.authorization.begin " +
+            "source=\(source) url=\(requestURL) state=\(state.cmuxDebugName)"
+        )
+#endif
+
+        let task = Task<ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState, Never> { [credentialManager] in
+            await withCheckedContinuation { continuation in
+                credentialManager.requestAuthorizationForPublicKeyCredentials { authorizationState in
+                    continuation.resume(returning: authorizationState)
+                }
+            }
+        }
+        authorizationTask = task
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await task.value
+            self.authorizationTask = nil
+            if result == .notDetermined {
+                self.didPromptThisSession = false
+            }
+#if DEBUG
+            dlog(
+                "browser.passkey.authorization.end " +
+                "source=\(source) url=\(requestURL) result=\(result.cmuxDebugName)"
+            )
+#endif
+        }
     }
 }
 
@@ -6187,6 +6327,13 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
             openInNewTab?(url)
             decisionHandler(.cancel)
             return
+        }
+
+        if navigationAction.targetFrame?.isMainFrame != false {
+            BrowserPasskeyAuthorizationManager.shared.requestAuthorizationIfNeeded(
+                for: navigationAction.request.url,
+                source: "browser.navigation.mainFrame"
+            )
         }
 
 #if DEBUG

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1732,6 +1732,8 @@ final class BrowserPortalAnchorView: NSView {
 // WKWebView handles WebAuthn itself for browser apps; this support code only
 // determines when cmux should request browser passkey access from macOS.
 enum BrowserPasskeyAuthorizationSupport {
+    static let remoteLoopbackAliasHost = "cmux-loopback.localtest.me"
+
     static func isPotentiallyTrustworthy(url: URL?) -> Bool {
         guard let url,
               let scheme = url.scheme?.lowercased() else {
@@ -1760,6 +1762,15 @@ enum BrowserPasskeyAuthorizationSupport {
         return true
     }
 
+    /// Returns a host/origin string suitable for debug logs without leaking
+    /// query parameters, paths, OIDC state, or auth codes.
+    static func redactedURLDescription(for url: URL?) -> String {
+        guard let url else { return "nil" }
+        let scheme = url.scheme?.lowercased() ?? "?"
+        let host = url.host ?? "?"
+        return "\(scheme)://\(host)"
+    }
+
     private static func isLoopbackHost(_ host: String) -> Bool {
         let normalized = normalizedHost(host)
         let octets = normalized.split(separator: ".", omittingEmptySubsequences: false)
@@ -1774,6 +1785,8 @@ enum BrowserPasskeyAuthorizationSupport {
             || normalized.hasSuffix(".localhost")
             || normalized == "::1"
             || is127Loopback
+            || normalized == remoteLoopbackAliasHost
+            || normalized.hasSuffix("." + remoteLoopbackAliasHost)
     }
 
     private static func normalizedHost(_ host: String) -> String {
@@ -1815,7 +1828,15 @@ final class BrowserPasskeyAuthorizationManager {
     private init() {}
 
     func requestAuthorizationIfNeeded(for url: URL?, source: String) {
+        // Skip the system passkey authorization prompt when running under
+        // automated UI tests; the dialog blocks the main thread and breaks
+        // unrelated keyboard regressions on CI.
+        if SessionRestorePolicy.isRunningUnderAutomatedTests() {
+            return
+        }
+
         let state = credentialManager.authorizationStateForPlatformCredentials
+        let redactedURL = BrowserPasskeyAuthorizationSupport.redactedURLDescription(for: url)
         guard BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
             for: url,
             authorizationState: state,
@@ -1823,10 +1844,9 @@ final class BrowserPasskeyAuthorizationManager {
             didPromptThisSession: didPromptThisSession
         ) else {
 #if DEBUG
-            let requestURL = url?.absoluteString ?? "nil"
             dlog(
                 "browser.passkey.authorization.skip " +
-                "source=\(source) url=\(requestURL) state=\(state.cmuxDebugName) " +
+                "source=\(source) origin=\(redactedURL) state=\(state.cmuxDebugName) " +
                 "pending=\(authorizationTask == nil ? 0 : 1) prompted=\(didPromptThisSession ? 1 : 0)"
             )
 #endif
@@ -1835,10 +1855,9 @@ final class BrowserPasskeyAuthorizationManager {
 
         didPromptThisSession = true
 #if DEBUG
-        let requestURL = url?.absoluteString ?? "nil"
         dlog(
             "browser.passkey.authorization.begin " +
-            "source=\(source) url=\(requestURL) state=\(state.cmuxDebugName)"
+            "source=\(source) origin=\(redactedURL) state=\(state.cmuxDebugName)"
         )
 #endif
 
@@ -1861,7 +1880,7 @@ final class BrowserPasskeyAuthorizationManager {
 #if DEBUG
             dlog(
                 "browser.passkey.authorization.end " +
-                "source=\(source) url=\(requestURL) result=\(result.cmuxDebugName)"
+                "source=\(source) origin=\(redactedURL) result=\(result.cmuxDebugName)"
             )
 #endif
         }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1805,7 +1805,7 @@ private extension ASAuthorizationWebBrowserPublicKeyCredentialManager.Authorizat
 }
 
 @MainActor
-private final class BrowserPasskeyAuthorizationManager {
+final class BrowserPasskeyAuthorizationManager {
     static let shared = BrowserPasskeyAuthorizationManager()
 
     private let credentialManager = ASAuthorizationWebBrowserPublicKeyCredentialManager()

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -577,6 +577,11 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
+        BrowserPasskeyAuthorizationManager.shared.requestAuthorizationIfNeeded(
+            for: url,
+            source: "browser.popup.navigation.mainFrame"
+        )
+
         decisionHandler(.allow)
     }
 

--- a/cmux.embedded.entitlements
+++ b/cmux.embedded.entitlements
@@ -8,8 +8,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.developer.web-browser.public-key-credential</key>
-	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Combine
 import AppKit
+import AuthenticationServices
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -1221,6 +1222,117 @@ final class BrowserDeveloperToolsShortcutDefaultsTests: XCTestCase {
         XCTAssertFalse(shortcut.option)
         XCTAssertTrue(shortcut.shift)
         XCTAssertFalse(shortcut.control)
+    }
+}
+
+final class BrowserPasskeyAuthorizationSupportTests: XCTestCase {
+    func testPotentiallyTrustworthyWebAuthnURLAllowsHTTPSAndLoopbackHTTP() {
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "https://github.com/login")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://localhost:3000/login")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://auth.localhost/challenge")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://127.0.0.1:8080")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://127.42.99.1/login")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://[::1]:8443")
+            )
+        )
+    }
+
+    func testPotentiallyTrustworthyWebAuthnURLRejectsUnsupportedOrigins() {
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://example.com/login")
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://cmux-loopback.localtest.me")
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://0.0.0.0:3000")
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "file:///tmp/login.html")
+            )
+        )
+        XCTAssertFalse(BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(url: nil))
+    }
+
+    func testShouldRequestAuthorizationRequiresTrustworthyPendingFreeNotDeterminedState() {
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "https://accounts.google.com"),
+                authorizationState: .notDetermined,
+                hasPendingRequest: false,
+                didPromptThisSession: false
+            )
+        )
+
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "https://accounts.google.com"),
+                authorizationState: .authorized,
+                hasPendingRequest: false,
+                didPromptThisSession: false
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "https://accounts.google.com"),
+                authorizationState: .denied,
+                hasPendingRequest: false,
+                didPromptThisSession: false
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "https://accounts.google.com"),
+                authorizationState: .notDetermined,
+                hasPendingRequest: true,
+                didPromptThisSession: false
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "https://accounts.google.com"),
+                authorizationState: .notDetermined,
+                hasPendingRequest: false,
+                didPromptThisSession: true
+            )
+        )
+        XCTAssertFalse(
+            BrowserPasskeyAuthorizationSupport.shouldRequestAuthorization(
+                for: URL(string: "http://example.com"),
+                authorizationState: .notDetermined,
+                hasPendingRequest: false,
+                didPromptThisSession: false
+            )
+        )
     }
 }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1257,17 +1257,24 @@ final class BrowserPasskeyAuthorizationSupportTests: XCTestCase {
                 url: URL(string: "http://[::1]:8443")
             )
         )
+        // BrowserPanel.remoteProxyLoopbackAliasURL rewrites local pages on
+        // remote workspaces to this host, so it must be treated as loopback.
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://cmux-loopback.localtest.me/login")
+            )
+        )
+        XCTAssertTrue(
+            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
+                url: URL(string: "http://app.cmux-loopback.localtest.me/login")
+            )
+        )
     }
 
     func testPotentiallyTrustworthyWebAuthnURLRejectsUnsupportedOrigins() {
         XCTAssertFalse(
             BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
                 url: URL(string: "http://example.com/login")
-            )
-        )
-        XCTAssertFalse(
-            BrowserPasskeyAuthorizationSupport.isPotentiallyTrustworthy(
-                url: URL(string: "http://cmux-loopback.localtest.me")
             )
         )
         XCTAssertFalse(
@@ -1332,6 +1339,25 @@ final class BrowserPasskeyAuthorizationSupportTests: XCTestCase {
                 hasPendingRequest: false,
                 didPromptThisSession: false
             )
+        )
+    }
+
+    func testRedactedURLDescriptionStripsPathAndQuery() {
+        XCTAssertEqual(
+            BrowserPasskeyAuthorizationSupport.redactedURLDescription(
+                for: URL(string: "https://login.example.com/oauth?code=secret&state=token")
+            ),
+            "https://login.example.com"
+        )
+        XCTAssertEqual(
+            BrowserPasskeyAuthorizationSupport.redactedURLDescription(
+                for: URL(string: "http://localhost:3000/path?token=abc")
+            ),
+            "http://localhost"
+        )
+        XCTAssertEqual(
+            BrowserPasskeyAuthorizationSupport.redactedURLDescription(for: nil),
+            "nil"
         )
     }
 }

--- a/scripts/assert-passkey-entitlement.sh
+++ b/scripts/assert-passkey-entitlement.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 /path/to/app.app" >&2
+  exit 64
+fi
+
+APP_PATH="$1"
+EXPECTED_KEY="com.apple.developer.web-browser.public-key-credential"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "App bundle not found: $APP_PATH" >&2
+  exit 66
+fi
+
+RAW_OUTPUT="$(mktemp)"
+PLIST_OUTPUT="$(mktemp)"
+cleanup() {
+  rm -f "$RAW_OUTPUT" "$PLIST_OUTPUT"
+}
+trap cleanup EXIT
+
+/usr/bin/codesign -d --entitlements :- "$APP_PATH" >"$RAW_OUTPUT" 2>&1
+awk 'found { print } /^<\?xml/ { found = 1; print }' "$RAW_OUTPUT" >"$PLIST_OUTPUT"
+
+if [ ! -s "$PLIST_OUTPUT" ]; then
+  echo "Could not extract entitlements from signed app: $APP_PATH" >&2
+  cat "$RAW_OUTPUT" >&2
+  exit 1
+fi
+
+VALUE="$(/usr/libexec/PlistBuddy -c "Print :$EXPECTED_KEY" "$PLIST_OUTPUT" 2>/dev/null || true)"
+if [ "$VALUE" != "true" ]; then
+  echo "Missing expected entitlement '$EXPECTED_KEY' on: $APP_PATH" >&2
+  cat "$PLIST_OUTPUT" >&2
+  exit 1
+fi
+
+echo "Verified entitlement '$EXPECTED_KEY' on: $APP_PATH"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -47,7 +47,8 @@ fi
 
 TAG="$1"
 SIGN_HASH="A050CC7E193C8221BDBA204E731B046CDCCC1B30"
-ENTITLEMENTS="cmux.entitlements"
+APP_ENTITLEMENTS="cmux.entitlements"
+EMBEDDED_ENTITLEMENTS="cmux.embedded.entitlements"
 APP_PATH="build/Build/Products/Release/cmux.app"
 
 # --- Pre-flight ---
@@ -93,13 +94,14 @@ echo "Sparkle keys injected"
 # --- Codesign ---
 echo "Codesigning..."
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
+echo "Applying app entitlements from $APP_ENTITLEMENTS"
+/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
 if [ -f "$CLI_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
 fi
 if [ -f "$HELPER_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
 fi
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
 /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 echo "Codesign verified"
 

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -95,14 +95,15 @@ echo "Sparkle keys injected"
 echo "Codesigning..."
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
 echo "Applying app entitlements from $APP_ENTITLEMENTS"
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$APP_ENTITLEMENTS" --deep "$APP_PATH"
 if [ -f "$CLI_PATH" ]; then
   /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$CLI_PATH"
 fi
 if [ -f "$HELPER_PATH" ]; then
   /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
 fi
+/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
 /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+./scripts/assert-passkey-entitlement.sh "$APP_PATH"
 echo "Codesign verified"
 
 # --- Notarize app ---

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -430,7 +430,7 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
         rm -f "$CMUX_SOCKET"
       fi
     fi
-    /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$TAG_APP_PATH" >/dev/null 2>&1 || true
+    /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der --entitlements "$PWD/cmux.entitlements" "$TAG_APP_PATH" >/dev/null 2>&1 || true
   fi
   APP_PATH="$TAG_APP_PATH"
 fi

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -36,10 +36,18 @@ should_skip_ghostty_cli_helper_zig_build() {
   return 1
 }
 
-find_apple_development_identity() {
+find_codesigning_identity_sha() {
+  local label_prefix="$1"
   security find-identity -v -p codesigning 2>/dev/null \
-    | sed -n 's/.*"\(Apple Development: .*\)"/\1/p' \
-    | head -n 1
+    | awk -v prefix="$label_prefix" 'index($0, "\"" prefix) { print $2; exit }'
+}
+
+find_apple_development_identity_sha() {
+  find_codesigning_identity_sha "Apple Development:"
+}
+
+find_developer_id_application_identity_sha() {
+  find_codesigning_identity_sha "Developer ID Application:"
 }
 
 write_dev_cli_shim() {
@@ -436,13 +444,8 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
         rm -f "$CMUX_SOCKET"
       fi
     fi
-    APPLE_DEVELOPMENT_IDENTITY="$(find_apple_development_identity || true)"
-    if [[ -n "${APPLE_DEVELOPMENT_IDENTITY:-}" ]]; then
-      /usr/bin/codesign --force --sign "$APPLE_DEVELOPMENT_IDENTITY" --timestamp=none --generate-entitlement-der --entitlements "$PWD/cmux.entitlements" "$TAG_APP_PATH" >/dev/null 2>&1 || true
-    else
-      echo "No Apple Development signing identity found; local tagged app will launch without passkey entitlements."
-      /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$TAG_APP_PATH" >/dev/null 2>&1 || true
-    fi
+    APPLE_DEVELOPMENT_IDENTITY_SHA="$(find_apple_development_identity_sha || true)"
+    DEVELOPER_ID_IDENTITY_SHA="$(find_developer_id_application_identity_sha || true)"
   fi
   APP_PATH="$TAG_APP_PATH"
 fi
@@ -486,6 +489,17 @@ if [[ -x "$GHOSTTY_HELPER_SRC" ]]; then
   mkdir -p "$BIN_DIR"
   cp "$GHOSTTY_HELPER_SRC" "$BIN_DIR/ghostty"
   chmod +x "$BIN_DIR/ghostty"
+fi
+if [[ -n "$TAG" && -d "$APP_PATH" ]]; then
+  if [[ -n "${APPLE_DEVELOPMENT_IDENTITY_SHA:-}" ]]; then
+    /usr/bin/codesign --force --sign "$APPLE_DEVELOPMENT_IDENTITY_SHA" --timestamp=none --generate-entitlement-der --entitlements "$PWD/cmux.entitlements" "$APP_PATH"
+  elif [[ -n "${DEVELOPER_ID_IDENTITY_SHA:-}" ]]; then
+    echo "Only Developer ID signing identities were found. Unnotarized Developer ID-tagged builds fail local launch assessment, so this build stays ad-hoc and will not have passkey entitlements. Install an Apple Development identity to test passkeys locally."
+    /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$APP_PATH"
+  else
+    echo "No Apple Development or Developer ID signing identity found; local tagged app will launch without passkey entitlements."
+    /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$APP_PATH"
+  fi
 fi
 CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
 if [[ -x "$CLI_PATH" ]]; then

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -36,6 +36,12 @@ should_skip_ghostty_cli_helper_zig_build() {
   return 1
 }
 
+find_apple_development_identity() {
+  security find-identity -v -p codesigning 2>/dev/null \
+    | sed -n 's/.*"\(Apple Development: .*\)"/\1/p' \
+    | head -n 1
+}
+
 write_dev_cli_shim() {
   local target="$1"
   local fallback_bin="$2"
@@ -430,7 +436,13 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
         rm -f "$CMUX_SOCKET"
       fi
     fi
-    /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der --entitlements "$PWD/cmux.entitlements" "$TAG_APP_PATH" >/dev/null 2>&1 || true
+    APPLE_DEVELOPMENT_IDENTITY="$(find_apple_development_identity || true)"
+    if [[ -n "${APPLE_DEVELOPMENT_IDENTITY:-}" ]]; then
+      /usr/bin/codesign --force --sign "$APPLE_DEVELOPMENT_IDENTITY" --timestamp=none --generate-entitlement-der --entitlements "$PWD/cmux.entitlements" "$TAG_APP_PATH" >/dev/null 2>&1 || true
+    else
+      echo "No Apple Development signing identity found; local tagged app will launch without passkey entitlements."
+      /usr/bin/codesign --force --sign - --timestamp=none --generate-entitlement-der "$TAG_APP_PATH" >/dev/null 2>&1 || true
+    fi
   fi
   APP_PATH="$TAG_APP_PATH"
 fi


### PR DESCRIPTION
Implements full passkey / WebAuthn / FIDO2 support for the cmux browser pane.

Refs umbrella issue: https://github.com/manaflow-ai/cmux/issues/2657
Also covers:
- https://github.com/manaflow-ai/cmux/issues/124
- https://github.com/manaflow-ai/cmux/issues/1056
- https://github.com/manaflow-ai/cmux/issues/1278

What changed:
- Request browser passkey authorization through AuthenticationServices for trustworthy main-frame WKWebView navigations in both browser tabs and auth popups.
- Add the `com.apple.developer.web-browser.public-key-credential` entitlement to the app signing path, while keeping embedded CLI/helper binaries on a narrower entitlement set.
- Add the Bluetooth privacy usage description needed for cross-device / phone passkey handoff.
- Add unit coverage for trustworthy-origin and authorization-gating behavior.

This intentionally keeps WebKit handling native `navigator.credentials` WebAuthn flows instead of reimplementing them in JavaScript/native glue. That aligns cmux with Apple's browser-app passkey model for platform passkeys, cross-device handoff, hardware security keys, and enterprise SSO step-up flows.

Local tests were not run per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new passkey authorization prompting and adds the `com.apple.developer.web-browser.public-key-credential` entitlement, plus updates CI/release signing paths; mistakes could break login flows or macOS code-signing/notarization behavior.
> 
> **Overview**
> Enables passkey/WebAuthn support in the embedded browser by requesting `ASAuthorizationWebBrowserPublicKeyCredentialManager` authorization on *trustworthy main-frame navigations* (HTTPS or loopback HTTP) in both the main browser panel and auth popups, with session-level gating to avoid repeated prompts.
> 
> Updates macOS packaging/signing to include the new `com.apple.developer.web-browser.public-key-credential` app entitlement, splits entitlements so embedded CLI/helper binaries use `cmux.embedded.entitlements`, and adds a CI/script check (`scripts/assert-passkey-entitlement.sh`) to fail builds if the signed app is missing the entitlement.
> 
> Adds the required `NSBluetoothAlwaysUsageDescription` (localized) for cross-device passkey flows, and adds unit tests covering trustworthy-origin detection and authorization-request conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a767c3264d8d3ef1937f5bad65bdb34faedd4b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds passkey/WebAuthn/FIDO2 to the in‑app browser so users can sign in with platform passkeys, cross‑device handoff, and hardware security keys in tabs and auth popups. Prompts for passkey access only on trustworthy main‑frame navigations. Addresses #2657 (also #124, #1056, #1278).

- **New Features**
  - Enable passkeys via `WKWebView` (WebKit handles `navigator.credentials`).
  - Request authorization only on HTTPS and loopback main‑frame navigations, including `cmux-loopback.localtest.me`; single prompt per session.
  - Add `com.apple.developer.web-browser.public-key-credential` to app entitlements; new `cmux.embedded.entitlements` for CLI/helpers.
  - Add `NSBluetoothAlwaysUsageDescription` with expanded localizations.

- **Bug Fixes**
  - Skip the system passkey prompt during automated UI tests to prevent CI timeouts.
  - Share the passkey authorization manager with auth popups; redact debug logs to scheme/host only.
  - Fix signing order and verify the passkey entitlement via `scripts/assert-passkey-entitlement.sh` in `release`/`nightly` and `scripts/build-sign-upload.sh`.
  - Improve `scripts/reload.sh` to prefer an Apple Development identity for tagged builds, falling back to ad‑hoc with a clear note if not.
  - Add/extend tests for origin trust, prompt gating, loopback alias handling, and URL redaction.

<sup>Written for commit 6458077c06a9bd90fc98da1830fd6e28cb0094e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAuthn passkey support added to the embedded browser for secure sign-ins; authorization limited to HTTPS and loopback/localhost origins.

* **Privacy / Permissions**
  * Bluetooth access enabled to support cross-device passkey authentication.

* **Localization**
  * Added localized Bluetooth usage descriptions (multiple locales, including English and Japanese).

* **Tests**
  * Added unit tests validating passkey origin and authorization logic.

* **Chores**
  * Refined app signing flow and added an entitlement verification step to ensure passkey entitlement is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up: CI fix and review responses (commit 6458077c)

- **CI:** `testCmdFFocusesBrowserFindFieldAfterCmdDCmdLNavigation` was timing out because the new passkey authorization request, triggered on the first main-frame navigation, opened a system permission dialog that blocked the main thread. Skip the prompt under automated UI tests via `SessionRestorePolicy.isRunningUnderAutomatedTests()`.
- **CodeRabbit (BrowserPanel):** treat `cmux-loopback.localtest.me` (and subdomains) as a loopback host so WebAuthn works in remote workspaces where local pages are proxied through that alias.
- **CodeRabbit (BrowserPanel):** redact passkey debug logs to log scheme/host only via a new `redactedURLDescription(for:)` helper, avoiding leaks of OIDC state, auth codes, or user identifiers.
- **Greptile / CodeRabbit (InfoPlist.xcstrings):** add the broader privacy-prompt locale set for `NSBluetoothAlwaysUsageDescription` (zh-Hans, zh-Hant, ko, de, es, fr, it, da, pl, ru, bs, ar, nb, pt-BR, th, tr) so non-English builds do not fall back to English in the macOS Bluetooth permission dialog.
- **Cubic / CodeRabbit (workflows):** verified the codesign order in `release.yml`, `nightly.yml`, and `scripts/build-sign-upload.sh` is already correct (CLI → helper → app, no `--deep` on the outer sign). The bot reports were inaccurate.
- **CodeRabbit (reload.sh):** verified the codesign step already runs after the helper-binary copy and no longer suppresses failures (fixed in commit a767c326).
