### PR TITLE
Coalesce sidebar PR polling per-repo, drop checks fetch, state-machine the probe queue

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12926,12 +12926,13 @@ private struct TabItemView: View, Equatable {
                                     .underline()
                                     .lineLimit(1)
                                     .truncationMode(.tail)
-                                Text(pullRequestStatusLabel(pullRequest.status, checks: pullRequest.checks))
+                                Text(pullRequestStatusLabel(pullRequest.status))
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(pullRequestForegroundColor)
+                            .opacity(pullRequest.isStale ? 0.5 : 1)
                         }
                         .buttonStyle(.plain)
                         .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"))
@@ -13703,7 +13704,7 @@ private struct TabItemView: View, Equatable {
         let label: String
         let url: URL
         let status: SidebarPullRequestStatus
-        let checks: SidebarPullRequestChecksStatus?
+        let isStale: Bool
     }
 
     private func pullRequestDisplays(orderedPanelIds: [UUID]) -> [PullRequestDisplay] {
@@ -13714,7 +13715,7 @@ private struct TabItemView: View, Equatable {
                 label: pullRequest.label,
                 url: pullRequest.url,
                 status: pullRequest.status,
-                checks: pullRequest.checks
+                isStale: pullRequest.isStale
             )
         }
     }
@@ -13756,10 +13757,7 @@ private struct TabItemView: View, Equatable {
         NSWorkspace.shared.open(url)
     }
 
-    private func pullRequestStatusLabel(
-        _ status: SidebarPullRequestStatus,
-        checks _: SidebarPullRequestChecksStatus?
-    ) -> String {
+    private func pullRequestStatusLabel(_ status: SidebarPullRequestStatus) -> String {
         switch status {
         case .open: return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
         case .merged: return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -9,570 +9,6 @@ import Combine
 // The old Tab class is replaced by Workspace
 typealias Tab = Workspace
 
-private actor GitHubPullRequestRESTPoller {
-    struct Candidate: Sendable {
-        let workspaceId: UUID
-        let panelId: UUID
-        let branch: String
-        let repoSlugs: [String]
-        let currentPullRequest: CurrentPullRequest?
-    }
-
-    struct CurrentPullRequest: Sendable {
-        let number: Int
-        let urlString: String
-        let repoSlug: String?
-        let statusRawValue: String
-        let branch: String?
-        let checksRawValue: String?
-    }
-
-    struct RefreshResult: Sendable {
-        let workspaceId: UUID
-        let panelId: UUID
-        let resolution: Resolution
-    }
-
-    enum Resolution: Sendable {
-        case unsupportedRepository
-        case notFound
-        case resolved(ResolvedPullRequest)
-        case transientFailure
-    }
-
-    struct ResolvedPullRequest: Sendable {
-        let number: Int
-        let urlString: String
-        let statusRawValue: String
-        let branch: String?
-        let checksRawValue: String?
-    }
-
-    private struct WorkspacePanelKey: Hashable, Sendable {
-        let workspaceId: UUID
-        let panelId: UUID
-    }
-
-    private struct PullRequestKey: Hashable, Sendable {
-        let repoSlug: String
-        let number: Int
-    }
-
-    private struct CachedValue<Payload: Sendable>: Sendable {
-        let etag: String?
-        let payload: Payload
-    }
-
-    private struct HTTPResponse: Sendable {
-        let statusCode: Int
-        let data: Data
-        let etag: String?
-        let rateLimitResetAt: Date?
-    }
-
-    private enum RepoLookupResult: Sendable {
-        case success([OpenPullRequest])
-        case transientFailure
-    }
-
-    private struct OpenPullRequest: Decodable, Sendable {
-        struct PullHead: Decodable, Sendable {
-            let ref: String
-        }
-
-        let number: Int
-        let state: String
-        let htmlURL: String
-        let updatedAt: String?
-        let head: PullHead
-
-        enum CodingKeys: String, CodingKey {
-            case number
-            case state
-            case htmlURL = "html_url"
-            case updatedAt = "updated_at"
-            case head
-        }
-    }
-
-    private struct PullRequestDetail: Decodable, Sendable {
-        let number: Int
-        let state: String
-        let htmlURL: String
-        let mergedAt: String?
-
-        enum CodingKeys: String, CodingKey {
-            case number
-            case state
-            case htmlURL = "html_url"
-            case mergedAt = "merged_at"
-        }
-    }
-
-    private let session: URLSession
-    private var authToken: String?
-    private var attemptedAuthTokenLookup = false
-    private var openPullRequestCacheByRepo: [String: CachedValue<[OpenPullRequest]>] = [:]
-    private var pullRequestDetailCacheByKey: [PullRequestKey: CachedValue<PullRequestDetail>] = [:]
-    private var resourceBackoffUntil: [String: Date] = [:]
-
-    init() {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 8
-        configuration.timeoutIntervalForResource = 8
-        session = URLSession(configuration: configuration)
-    }
-
-    func refresh(candidates: [Candidate]) async -> [RefreshResult] {
-        guard !candidates.isEmpty else { return [] }
-
-        let repoSlugs = Set(candidates.flatMap(\.repoSlugs))
-        let repoResults = await fetchOpenPullRequests(repoSlugs: repoSlugs)
-
-        var resultsByKey: [WorkspacePanelKey: Resolution] = [:]
-        var pendingDetailLookups: [WorkspacePanelKey: PullRequestKey] = [:]
-        var detailTargets: Set<PullRequestKey> = []
-        var detailNeedsByKey: [WorkspacePanelKey: Bool] = [:]
-
-        for candidate in candidates {
-            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
-            guard !candidate.repoSlugs.isEmpty else {
-                resultsByKey[key] = .unsupportedRepository
-                continue
-            }
-
-            var sawTransientFailure = false
-            var resolvedOpenPullRequest: OpenPullRequest?
-
-            for repoSlug in candidate.repoSlugs {
-                guard let repoResult = repoResults[repoSlug] else { continue }
-                switch repoResult {
-                case .success(let pullRequests):
-                    let matchingPullRequests = pullRequests.filter {
-                        $0.head.ref.trimmingCharacters(in: .whitespacesAndNewlines) == candidate.branch
-                    }
-                    if let preferred = Self.preferredOpenPullRequest(from: matchingPullRequests) {
-                        resolvedOpenPullRequest = preferred
-                        break
-                    }
-                case .transientFailure:
-                    sawTransientFailure = true
-                }
-            }
-
-            if let resolvedOpenPullRequest,
-               let resolved = Self.resolvedPullRequest(from: resolvedOpenPullRequest, branch: candidate.branch) {
-                resultsByKey[key] = .resolved(resolved)
-                continue
-            }
-
-            if let currentPullRequest = candidate.currentPullRequest {
-                switch currentPullRequest.statusRawValue {
-                case SidebarPullRequestStatus.open.rawValue:
-                    if let repoSlug = currentPullRequest.repoSlug {
-                        let detailKey = PullRequestKey(repoSlug: repoSlug, number: currentPullRequest.number)
-                        pendingDetailLookups[key] = detailKey
-                        detailTargets.insert(detailKey)
-                        detailNeedsByKey[key] = sawTransientFailure
-                        continue
-                    }
-                    resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
-                case SidebarPullRequestStatus.merged.rawValue,
-                     SidebarPullRequestStatus.closed.rawValue:
-                    resultsByKey[key] = .resolved(
-                        ResolvedPullRequest(
-                            number: currentPullRequest.number,
-                            urlString: currentPullRequest.urlString,
-                            statusRawValue: currentPullRequest.statusRawValue,
-                            branch: currentPullRequest.branch ?? candidate.branch,
-                            checksRawValue: currentPullRequest.checksRawValue
-                        )
-                    )
-                default:
-                    resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
-                }
-                continue
-            }
-
-            resultsByKey[key] = sawTransientFailure ? .transientFailure : .notFound
-        }
-
-        let detailResults = await fetchPullRequestDetails(keys: detailTargets)
-
-        for candidate in candidates {
-            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
-            guard let detailKey = pendingDetailLookups[key] else { continue }
-            guard let detail = detailResults[detailKey] ?? nil else {
-                let needsTransientFailure = detailNeedsByKey[key] ?? false
-                resultsByKey[key] = needsTransientFailure ? .transientFailure : .notFound
-                continue
-            }
-
-            guard let statusRawValue = Self.pullRequestStatusRawValue(
-                from: detail.state,
-                mergedAt: detail.mergedAt
-            ) else {
-                let needsTransientFailure = detailNeedsByKey[key] ?? false
-                resultsByKey[key] = needsTransientFailure ? .transientFailure : .notFound
-                continue
-            }
-
-            resultsByKey[key] = .resolved(
-                ResolvedPullRequest(
-                    number: detail.number,
-                    urlString: detail.htmlURL,
-                    statusRawValue: statusRawValue,
-                    branch: candidate.branch,
-                    checksRawValue: nil
-                )
-            )
-        }
-
-        return candidates.map { candidate in
-            let key = WorkspacePanelKey(workspaceId: candidate.workspaceId, panelId: candidate.panelId)
-            return RefreshResult(
-                workspaceId: candidate.workspaceId,
-                panelId: candidate.panelId,
-                resolution: resultsByKey[key] ?? .notFound
-            )
-        }
-    }
-
-    private struct OpenPullRequestFetchPlan: Sendable {
-        let repoSlug: String
-        let resourceKey: String
-        let cached: CachedValue<[OpenPullRequest]>?
-    }
-
-    private struct PullRequestDetailFetchPlan: Sendable {
-        let key: PullRequestKey
-        let resourceKey: String
-        let cached: CachedValue<PullRequestDetail>?
-    }
-
-    private func fetchOpenPullRequests(
-        repoSlugs: Set<String>
-    ) async -> [String: RepoLookupResult] {
-        let now = Date()
-        var results: [String: RepoLookupResult] = [:]
-        var plansByRepo: [String: OpenPullRequestFetchPlan] = [:]
-
-        for repoSlug in repoSlugs {
-            let resourceKey = "open:\(repoSlug)"
-            if let backoffUntil = resourceBackoffUntil[resourceKey],
-               backoffUntil > now {
-                if let cached = openPullRequestCacheByRepo[repoSlug] {
-                    results[repoSlug] = .success(cached.payload)
-                } else {
-                    results[repoSlug] = .transientFailure
-                }
-                continue
-            }
-
-            plansByRepo[repoSlug] = OpenPullRequestFetchPlan(
-                repoSlug: repoSlug,
-                resourceKey: resourceKey,
-                cached: openPullRequestCacheByRepo[repoSlug]
-            )
-        }
-
-        guard !plansByRepo.isEmpty else { return results }
-
-        let authHeader = authHeaderValue()
-        let session = self.session
-        let responses = await withTaskGroup(
-            of: (String, RequestResult).self,
-            returning: [(String, RequestResult)].self
-        ) { group in
-            for plan in plansByRepo.values {
-                let endpoint = "repos/\(plan.repoSlug)/pulls?state=open&sort=updated&direction=desc&per_page=100"
-                group.addTask {
-                    let response = await Self.performRequest(
-                        session: session,
-                        endpoint: endpoint,
-                        ifNoneMatch: plan.cached?.etag,
-                        authHeader: authHeader
-                    )
-                    return (plan.repoSlug, response)
-                }
-            }
-
-            var collected: [(String, RequestResult)] = []
-            for await response in group {
-                collected.append(response)
-            }
-            return collected
-        }
-
-        for (repoSlug, response) in responses {
-            guard let plan = plansByRepo[repoSlug] else { continue }
-            switch response {
-            case .success(let httpResponse):
-                switch httpResponse.statusCode {
-                case 200:
-                    guard let pullRequests = Self.decodeJSON([OpenPullRequest].self, from: httpResponse.data) else {
-                        results[repoSlug] = .transientFailure
-                        continue
-                    }
-                    openPullRequestCacheByRepo[repoSlug] = CachedValue(
-                        etag: httpResponse.etag,
-                        payload: pullRequests
-                    )
-                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
-                    results[repoSlug] = .success(pullRequests)
-                case 304:
-                    if let cached = plan.cached {
-                        resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
-                        results[repoSlug] = .success(cached.payload)
-                    } else {
-                        results[repoSlug] = .transientFailure
-                    }
-                default:
-                    if let resetAt = httpResponse.rateLimitResetAt {
-                        resourceBackoffUntil[plan.resourceKey] = resetAt
-                    }
-                    if let cached = plan.cached {
-                        results[repoSlug] = .success(cached.payload)
-                    } else {
-                        results[repoSlug] = .transientFailure
-                    }
-                }
-            case .failure:
-                if let cached = plan.cached {
-                    results[repoSlug] = .success(cached.payload)
-                } else {
-                    results[repoSlug] = .transientFailure
-                }
-            }
-        }
-
-        return results
-    }
-
-    private func fetchPullRequestDetails(
-        keys: Set<PullRequestKey>
-    ) async -> [PullRequestKey: PullRequestDetail?] {
-        let now = Date()
-        var results: [PullRequestKey: PullRequestDetail?] = [:]
-        var plansByKey: [PullRequestKey: PullRequestDetailFetchPlan] = [:]
-
-        for key in keys {
-            let resourceKey = "detail:\(key.repoSlug)#\(key.number)"
-            if let backoffUntil = resourceBackoffUntil[resourceKey],
-               backoffUntil > now {
-                results[key] = pullRequestDetailCacheByKey[key]?.payload
-                continue
-            }
-
-            plansByKey[key] = PullRequestDetailFetchPlan(
-                key: key,
-                resourceKey: resourceKey,
-                cached: pullRequestDetailCacheByKey[key]
-            )
-        }
-
-        guard !plansByKey.isEmpty else { return results }
-
-        let authHeader = authHeaderValue()
-        let session = self.session
-        let responses = await withTaskGroup(
-            of: (PullRequestKey, RequestResult).self,
-            returning: [(PullRequestKey, RequestResult)].self
-        ) { group in
-            for plan in plansByKey.values {
-                let endpoint = "repos/\(plan.key.repoSlug)/pulls/\(plan.key.number)"
-                group.addTask {
-                    let response = await Self.performRequest(
-                        session: session,
-                        endpoint: endpoint,
-                        ifNoneMatch: plan.cached?.etag,
-                        authHeader: authHeader
-                    )
-                    return (plan.key, response)
-                }
-            }
-
-            var collected: [(PullRequestKey, RequestResult)] = []
-            for await response in group {
-                collected.append(response)
-            }
-            return collected
-        }
-
-        for (key, response) in responses {
-            guard let plan = plansByKey[key] else { continue }
-            switch response {
-            case .success(let httpResponse):
-                switch httpResponse.statusCode {
-                case 200:
-                    guard let detail = Self.decodeJSON(PullRequestDetail.self, from: httpResponse.data) else {
-                        results[key] = nil
-                        continue
-                    }
-                    pullRequestDetailCacheByKey[key] = CachedValue(
-                        etag: httpResponse.etag,
-                        payload: detail
-                    )
-                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
-                    results[key] = detail
-                case 304:
-                    resourceBackoffUntil.removeValue(forKey: plan.resourceKey)
-                    results[key] = plan.cached?.payload
-                default:
-                    if let resetAt = httpResponse.rateLimitResetAt {
-                        resourceBackoffUntil[plan.resourceKey] = resetAt
-                    }
-                    results[key] = plan.cached?.payload
-                }
-            case .failure:
-                results[key] = plan.cached?.payload
-            }
-        }
-
-        return results
-    }
-
-    private enum RequestResult: Sendable {
-        case success(HTTPResponse)
-        case failure
-    }
-
-    private nonisolated static func performRequest(
-        session: URLSession,
-        endpoint: String,
-        ifNoneMatch: String?,
-        authHeader: String?
-    ) async -> RequestResult {
-        guard let url = URL(string: "https://api.github.com/\(endpoint)") else {
-            return .failure
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("cmux-sidebar-pr-poller", forHTTPHeaderField: "User-Agent")
-        if let ifNoneMatch, !ifNoneMatch.isEmpty {
-            request.setValue(ifNoneMatch, forHTTPHeaderField: "If-None-Match")
-        }
-        if let authHeader {
-            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        }
-
-        do {
-            let (data, response) = try await session.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return .failure
-            }
-            return .success(
-                HTTPResponse(
-                    statusCode: httpResponse.statusCode,
-                    data: data,
-                    etag: httpResponse.value(forHTTPHeaderField: "ETag"),
-                    rateLimitResetAt: Self.rateLimitResetDate(from: httpResponse)
-                )
-            )
-        } catch {
-            return .failure
-        }
-    }
-
-    private func authHeaderValue() -> String? {
-        if let token = authToken, !token.isEmpty {
-            return "Bearer \(token)"
-        }
-        guard !attemptedAuthTokenLookup else { return nil }
-        attemptedAuthTokenLookup = true
-
-        let environment = ProcessInfo.processInfo.environment
-        if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
-            let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                authToken = trimmed
-                return "Bearer \(trimmed)"
-            }
-        }
-
-        let process = Process()
-        let stdout = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["gh", "auth", "token"]
-        process.standardOutput = stdout
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
-            let tokenData = stdout.fileHandleForReading.readDataToEndOfFile()
-            let token = String(data: tokenData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard !token.isEmpty else { return nil }
-            authToken = token
-            return "Bearer \(token)"
-        } catch {
-            return nil
-        }
-    }
-
-    private static func decodeJSON<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
-        try? JSONDecoder().decode(T.self, from: data)
-    }
-
-    private static func rateLimitResetDate(from response: HTTPURLResponse) -> Date? {
-        guard response.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0",
-              let resetValue = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
-              let resetInterval = TimeInterval(resetValue) else {
-            return nil
-        }
-        return Date(timeIntervalSince1970: resetInterval)
-    }
-
-    private static func preferredOpenPullRequest(
-        from pullRequests: [OpenPullRequest]
-    ) -> OpenPullRequest? {
-        pullRequests.max { lhs, rhs in
-            let lhsUpdatedAt = lhs.updatedAt ?? ""
-            let rhsUpdatedAt = rhs.updatedAt ?? ""
-            if lhsUpdatedAt != rhsUpdatedAt {
-                return lhsUpdatedAt < rhsUpdatedAt
-            }
-            return lhs.number < rhs.number
-        }
-    }
-
-    private static func resolvedPullRequest(
-        from pullRequest: OpenPullRequest,
-        branch: String
-    ) -> ResolvedPullRequest? {
-        guard let statusRawValue = pullRequestStatusRawValue(from: pullRequest.state, mergedAt: nil) else {
-            return nil
-        }
-        return ResolvedPullRequest(
-            number: pullRequest.number,
-            urlString: pullRequest.htmlURL,
-            statusRawValue: statusRawValue,
-            branch: branch,
-            checksRawValue: nil
-        )
-    }
-
-    private static func pullRequestStatusRawValue(
-        from rawState: String,
-        mergedAt: String?
-    ) -> String? {
-        switch rawState.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
-        case "OPEN":
-            return SidebarPullRequestStatus.open.rawValue
-        case "CLOSED":
-            return (mergedAt?.isEmpty == false)
-                ? SidebarPullRequestStatus.merged.rawValue
-                : SidebarPullRequestStatus.closed.rawValue
-        default:
-            return nil
-        }
-    }
-}
-
 enum NewWorkspacePlacement: String, CaseIterable, Identifiable {
     case top
     case afterCurrent
@@ -1882,8 +1318,7 @@ class TabManager: ObservableObject {
     private func scheduleWorkspacePullRequestRefresh(
         workspaceId: UUID,
         panelId: UUID,
-        reason: String,
-        burst: Bool
+        reason: String
     ) {
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
         let shouldBypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
@@ -1901,7 +1336,7 @@ class TabManager: ObservableObject {
 #if DEBUG
         dlog(
             "workspace.prRefresh.schedule workspace=\(workspaceId.uuidString.prefix(5)) " +
-            "panel=\(panelId.uuidString.prefix(5)) reason=\(reason) burst=\(burst ? 1 : 0)"
+            "panel=\(panelId.uuidString.prefix(5)) reason=\(reason)"
         )
 #endif
         refreshTrackedWorkspacePullRequestsIfNeeded(reason: reason)
@@ -1931,7 +1366,7 @@ class TabManager: ObservableObject {
         var needsFollowUpPass = false
 
         defer {
-            if needsFollowUpPass || workspacePullRequestRefreshTask == nil {
+            if needsFollowUpPass {
                 let shouldBypassRepoCache = workspacePullRequestFollowUpShouldBypassRepoCache
                 workspacePullRequestFollowUpShouldBypassRepoCache = false
                 refreshTrackedWorkspacePullRequestsIfNeeded(
@@ -2781,10 +2216,14 @@ class TabManager: ObservableObject {
         expectedDirectory: String,
         isLastAttempt: Bool
     ) {
+        let wasInFlight: Bool = {
+            if case .inFlight = workspaceGitProbeStateByKey[probeKey] { return true }
+            return false
+        }()
         let shouldClearProbe = shouldStopWorkspaceGitMetadataRefresh(snapshot) || isLastAttempt
         var didClearProbe = false
         defer {
-            if !didClearProbe {
+            if wasInFlight, !didClearProbe {
                 let rerunPending = workspaceGitProbeRerunPending(for: probeKey)
                 if rerunPending {
                     workspaceGitProbeStateByKey[probeKey] = .idle
@@ -2804,7 +2243,7 @@ class TabManager: ObservableObject {
             }
         }
 
-        guard case .inFlight = workspaceGitProbeStateByKey[probeKey] else { return }
+        guard wasInFlight else { return }
         guard let workspace = tabs.first(where: { $0.id == probeKey.workspaceId }) else {
             clearWorkspaceGitProbe(probeKey)
             didClearProbe = true
@@ -2881,8 +2320,7 @@ class TabManager: ObservableObject {
             scheduleWorkspacePullRequestRefresh(
                 workspaceId: probeKey.workspaceId,
                 panelId: probeKey.panelId,
-                reason: "localGitProbe",
-                burst: false
+                reason: "localGitProbe"
             )
         }
 
@@ -4164,8 +3602,7 @@ class TabManager: ObservableObject {
             scheduleWorkspacePullRequestRefresh(
                 workspaceId: tabId,
                 panelId: surfaceId,
-                reason: "directoryChange",
-                burst: true
+                reason: "directoryChange"
             )
             scheduleWorkspaceGitMetadataRefreshIfPossible(
                 workspaceId: tabId,
@@ -4193,8 +3630,7 @@ class TabManager: ObservableObject {
         scheduleWorkspacePullRequestRefresh(
             workspaceId: tabId,
             panelId: surfaceId,
-            reason: "branchChange",
-            burst: true
+            reason: "branchChange"
         )
         scheduleWorkspaceGitMetadataRefreshIfPossible(
             workspaceId: tabId,
@@ -4231,8 +3667,7 @@ class TabManager: ObservableObject {
             scheduleWorkspacePullRequestRefresh(
                 workspaceId: tabId,
                 panelId: surfaceId,
-                reason: "shellPrompt",
-                burst: false
+                reason: "shellPrompt"
             )
         }
     }
@@ -4253,8 +3688,7 @@ class TabManager: ObservableObject {
         scheduleWorkspacePullRequestRefresh(
             workspaceId: tabId,
             panelId: surfaceId,
-            reason: "commandHint:\(action)",
-            burst: true
+            reason: "commandHint:\(action)"
         )
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1301,21 +1301,59 @@ class TabManager: ObservableObject {
         let executionError: String?
     }
 
-    private struct WorkspaceGitProbeKey: Hashable {
+    private struct WorkspaceGitProbeKey: Hashable, Sendable {
         let workspaceId: UUID
         let panelId: UUID
     }
 
-    struct GitHubPullRequestProbeItem: Decodable, Equatable {
+    private enum WorkspaceGitProbeState: Equatable {
+        case idle
+        case inFlight(rerunPending: Bool)
+    }
+
+    private struct WorkspacePullRequestCandidate: Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+        let branch: String
+        let repoSlugs: [String]
+    }
+
+    private struct WorkspacePullRequestResolvedItem: Sendable {
+        let number: Int
+        let urlString: String
+        let statusRawValue: String
+        let branch: String
+    }
+
+    private struct WorkspacePullRequestRefreshResult: Sendable {
+        enum Resolution: Sendable {
+            case unsupportedRepository
+            case notFound
+            case resolved(WorkspacePullRequestResolvedItem)
+            case transientFailure
+        }
+
+        let workspaceId: UUID
+        let panelId: UUID
+        let resolution: Resolution
+    }
+
+    private struct WorkspacePullRequestRepoCacheEntry: Sendable {
+        let fetchedAt: Date
+        let pullRequestsByBranch: [String: GitHubPullRequestProbeItem]
+    }
+
+    private enum WorkspacePullRequestRepoFetchResult: Sendable {
+        case success(WorkspacePullRequestRepoCacheEntry, usedCache: Bool)
+        case transientFailure
+    }
+
+    struct GitHubPullRequestProbeItem: Decodable, Equatable, Sendable {
         let number: Int
         let state: String
         let url: String
         let updatedAt: String?
-    }
-
-    private struct GitHubPullRequestCheckItem: Decodable {
-        let bucket: String?
-        let state: String?
+        let headRefName: String?
     }
 
     /// The window that owns this TabManager. Set by AppDelegate.registerMainWindow().
@@ -1330,14 +1368,13 @@ class TabManager: ObservableObject {
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
     private static var nextPortOrdinal: Int = 0
-    private static let initialWorkspaceGitProbeDelays: [TimeInterval] = [0, 0.5, 1.5, 3.0, 6.0, 10.0]
-    private static let workspaceGitMetadataPollInterval: TimeInterval = 30
-    private static let selectedWorkspaceGitMetadataPollInterval: TimeInterval = 5
-    private static let workspacePullRequestPollTickInterval: TimeInterval = 5
-    private static let workspacePullRequestIdlePollInterval: TimeInterval = 60
-    private static let selectedWorkspacePullRequestIdlePollInterval: TimeInterval = 15
-    private static let workspacePullRequestBurstPollInterval: TimeInterval = 5
-    private static let workspacePullRequestBurstDuration: TimeInterval = 30
+    private nonisolated static let initialWorkspaceGitProbeDelays: [TimeInterval] = [0, 0.5, 1.5, 3.0, 6.0, 10.0]
+    private nonisolated static let backgroundPollInterval: TimeInterval = 60
+    private nonisolated static let selectedPollInterval: TimeInterval = 10
+    private nonisolated static let workspacePullRequestPollTickInterval: TimeInterval = 1
+    private nonisolated static let workspacePullRequestRepoCacheLifetime: TimeInterval = 15
+    private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
+    private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
     @Published var selectedTabId: UUID? {
         willSet {
@@ -1425,12 +1462,14 @@ class TabManager: ObservableObject {
         label: "com.cmux.initial-workspace-git-probe",
         qos: .utility
     )
-    private let workspacePullRequestRESTPoller = GitHubPullRequestRESTPoller()
-    private var workspaceGitProbeGenerationByKey: [WorkspaceGitProbeKey: UUID] = [:]
+    private var workspaceGitProbeStateByKey: [WorkspaceGitProbeKey: WorkspaceGitProbeState] = [:]
     private var workspaceGitProbeTimersByKey: [WorkspaceGitProbeKey: [DispatchSourceTimer]] = [:]
     private var workspaceGitTrackedDirectoryByKey: [WorkspaceGitProbeKey: String] = [:]
+    private var workspacePullRequestProbeStateByKey: [WorkspaceGitProbeKey: WorkspaceGitProbeState] = [:]
     private var workspacePullRequestNextPollAtByKey: [WorkspaceGitProbeKey: Date] = [:]
-    private var workspacePullRequestBurstUntilByKey: [WorkspaceGitProbeKey: Date] = [:]
+    private var workspacePullRequestLastTerminalStateRefreshAtByKey: [WorkspaceGitProbeKey: Date] = [:]
+    private var workspacePullRequestTransientFailureCountByKey: [WorkspaceGitProbeKey: Int] = [:]
+    private var workspacePullRequestRepoCacheBySlug: [String: WorkspacePullRequestRepoCacheEntry] = [:]
     private var workspacePullRequestPollTimer: DispatchSourceTimer?
     private var workspacePullRequestRefreshTask: Task<Void, Never>?
 
@@ -1556,7 +1595,7 @@ class TabManager: ObservableObject {
     /// even when the local branch/directory does not change.
     private func startWorkspaceGitMetadataPollTimer() {
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        let interval = Self.workspaceGitMetadataPollInterval
+        let interval = Self.backgroundPollInterval
         timer.schedule(deadline: .now() + interval, repeating: interval)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
@@ -1574,7 +1613,7 @@ class TabManager: ObservableObject {
     /// background sweep across every tracked workspace.
     private func startSelectedWorkspaceGitMetadataPollTimer() {
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        let interval = Self.selectedWorkspaceGitMetadataPollInterval
+        let interval = Self.selectedPollInterval
         timer.schedule(deadline: .now() + interval, repeating: interval)
         timer.setEventHandler { [weak self] in
             guard let self else { return }
@@ -1602,7 +1641,7 @@ class TabManager: ObservableObject {
     }
 
     private func refreshTrackedWorkspaceGitMetadata() {
-        let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
+        let activeProbeKeys = activeWorkspaceGitProbeKeys
 
         for workspace in tabs {
             for panelId in trackedWorkspaceGitMetadataPollCandidatePanelIds(
@@ -1624,7 +1663,7 @@ class TabManager: ObservableObject {
             return
         }
 
-        let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
+        let activeProbeKeys = activeWorkspaceGitProbeKeys
         let candidatePanelIds = trackedWorkspaceGitMetadataPollCandidatePanelIds(
             in: workspace,
             activeProbeKeys: activeProbeKeys
@@ -1637,19 +1676,12 @@ class TabManager: ObservableObject {
             reason: "selectedPeriodicPoll"
         )
 
-        scheduleWorkspacePullRequestRefresh(
-            workspaceId: workspace.id,
-            panelId: focusedPanelId,
-            reason: "selectedPeriodicPoll",
-            burst: false
-        )
     }
 
     private func refreshTrackedWorkspacePullRequestsIfNeeded(reason: String) {
-        guard workspacePullRequestRefreshTask == nil else { return }
-
         let now = Date()
-        var candidates: [GitHubPullRequestRESTPoller.Candidate] = []
+        var candidates: [WorkspacePullRequestCandidate] = []
+        var repoDirectoriesBySlug: [String: String] = [:]
         var requestedKeys: [WorkspaceGitProbeKey] = []
         var validKeys: Set<WorkspaceGitProbeKey> = []
 
@@ -1657,29 +1689,74 @@ class TabManager: ObservableObject {
             for panelId in Set(workspace.panelGitBranches.keys).union(workspace.panelPullRequests.keys) {
                 let key = WorkspaceGitProbeKey(workspaceId: workspace.id, panelId: panelId)
                 validKeys.insert(key)
-                guard shouldRefreshWorkspacePullRequest(key: key, now: now) else { continue }
+                let branch = Self.normalizedBranchName(
+                    workspace.panelGitBranches[panelId]?.branch
+                        ?? workspace.panelPullRequests[panelId]?.branch
+                )
+                guard let branch else {
+                    clearWorkspacePullRequestTracking(for: key)
+                    continue
+                }
+
+                if Self.shouldSkipWorkspacePullRequestLookup(branch: branch) {
+                    workspace.clearPanelPullRequest(panelId: panelId)
+                    clearWorkspacePullRequestTracking(for: key)
+                    continue
+                }
+
+                guard shouldRefreshWorkspacePullRequest(
+                    key: key,
+                    now: now,
+                    currentPullRequest: workspace.panelPullRequests[panelId]
+                ) else {
+                    continue
+                }
+
+                if case .inFlight = workspacePullRequestProbeStateByKey[key] {
+                    markWorkspacePullRequestProbeRerunPending(for: key)
+                    continue
+                }
+
                 guard let candidate = workspacePullRequestCandidate(
                     workspace: workspace,
-                    panelId: panelId
+                    panelId: panelId,
+                    branch: branch
                 ) else {
                     continue
                 }
                 candidates.append(candidate)
                 requestedKeys.append(key)
+                if let directory = gitProbeDirectory(for: workspace, panelId: panelId) {
+                    for repoSlug in candidate.repoSlugs where repoDirectoriesBySlug[repoSlug] == nil {
+                        repoDirectoriesBySlug[repoSlug] = directory
+                    }
+                }
             }
         }
 
         pruneWorkspacePullRequestTracking(validKeys: validKeys)
-        guard !candidates.isEmpty else { return }
+        guard !candidates.isEmpty, workspacePullRequestRefreshTask == nil else { return }
+        for key in requestedKeys {
+            workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: false)
+        }
 
-        let poller = workspacePullRequestRESTPoller
+        let cacheBySlug = workspacePullRequestRepoCacheBySlug
         workspacePullRequestRefreshTask = Task { [weak self] in
-            let results = await poller.refresh(candidates: candidates)
+            let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
+                repoDirectoriesBySlug: repoDirectoriesBySlug,
+                cacheBySlug: cacheBySlug,
+                now: now
+            )
+            let results = Self.resolveWorkspacePullRequestRefreshResults(
+                candidates: candidates,
+                repoResults: repoResults
+            )
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.workspacePullRequestRefreshTask = nil
                 self.applyWorkspacePullRequestRefreshResults(
                     results,
+                    repoResults: repoResults,
                     requestedKeys: requestedKeys,
                     now: Date(),
                     reason: reason
@@ -1690,43 +1767,31 @@ class TabManager: ObservableObject {
 
     private func shouldRefreshWorkspacePullRequest(
         key: WorkspaceGitProbeKey,
-        now: Date
+        now: Date,
+        currentPullRequest: SidebarPullRequestState?
     ) -> Bool {
+        if let currentPullRequest,
+           currentPullRequest.status != .open {
+            let lastTerminalRefreshAt = workspacePullRequestLastTerminalStateRefreshAtByKey[key] ?? .distantPast
+            return now.timeIntervalSince(lastTerminalRefreshAt) >= Self.workspacePullRequestTerminalStateSweepInterval
+        }
         let nextPollAt = workspacePullRequestNextPollAtByKey[key] ?? .distantPast
         return nextPollAt <= now
     }
 
     private func workspacePullRequestCandidate(
         workspace: Workspace,
-        panelId: UUID
-    ) -> GitHubPullRequestRESTPoller.Candidate? {
-        let branch = Self.normalizedBranchName(
-            workspace.panelGitBranches[panelId]?.branch
-                ?? workspace.panelPullRequests[panelId]?.branch
-        )
-        guard let branch, !Self.shouldSkipWorkspacePullRequestLookup(branch: branch) else {
-            return nil
-        }
-
+        panelId: UUID,
+        branch: String
+    ) -> WorkspacePullRequestCandidate? {
         let directory = gitProbeDirectory(for: workspace, panelId: panelId)
         let repoSlugs = directory.map(Self.githubRepositorySlugs(directory:)) ?? []
-        let currentPullRequest = workspace.panelPullRequests[panelId].map {
-            GitHubPullRequestRESTPoller.CurrentPullRequest(
-                number: $0.number,
-                urlString: $0.url.absoluteString,
-                repoSlug: Self.githubRepositorySlug(fromPullRequestURL: $0.url),
-                statusRawValue: $0.status.rawValue,
-                branch: $0.branch,
-                checksRawValue: $0.checks?.rawValue
-            )
-        }
-
-        return GitHubPullRequestRESTPoller.Candidate(
+        guard !repoSlugs.isEmpty else { return nil }
+        return WorkspacePullRequestCandidate(
             workspaceId: workspace.id,
             panelId: panelId,
             branch: branch,
-            repoSlugs: repoSlugs,
-            currentPullRequest: currentPullRequest
+            repoSlugs: repoSlugs
         )
     }
 
@@ -1737,13 +1802,10 @@ class TabManager: ObservableObject {
         burst: Bool
     ) {
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
-        workspacePullRequestNextPollAtByKey[key] = .distantPast
-        if burst {
-            let burstUntil = Date().addingTimeInterval(Self.workspacePullRequestBurstDuration)
-            let existingBurstUntil = workspacePullRequestBurstUntilByKey[key] ?? .distantPast
-            if burstUntil > existingBurstUntil {
-                workspacePullRequestBurstUntilByKey[key] = burstUntil
-            }
+        if case .inFlight = workspacePullRequestProbeStateByKey[key] {
+            markWorkspacePullRequestProbeRerunPending(for: key)
+        } else {
+            workspacePullRequestNextPollAtByKey[key] = .distantPast
         }
 #if DEBUG
         dlog(
@@ -1755,22 +1817,59 @@ class TabManager: ObservableObject {
     }
 
     private func applyWorkspacePullRequestRefreshResults(
-        _ results: [GitHubPullRequestRESTPoller.RefreshResult],
+        _ results: [WorkspacePullRequestRefreshResult],
+        repoResults: [String: WorkspacePullRequestRepoFetchResult],
         requestedKeys: [WorkspaceGitProbeKey],
         now: Date,
         reason: String
     ) {
+        for (repoSlug, repoResult) in repoResults {
+            guard case .success(let cacheEntry, let usedCache) = repoResult,
+                  !usedCache else {
+                continue
+            }
+            workspacePullRequestRepoCacheBySlug[repoSlug] = cacheEntry
+        }
+
         let requestedKeySet = Set(requestedKeys)
-        for result in results {
-            let key = WorkspaceGitProbeKey(workspaceId: result.workspaceId, panelId: result.panelId)
+        let resultsByKey = Dictionary(
+            uniqueKeysWithValues: results.map {
+                (WorkspaceGitProbeKey(workspaceId: $0.workspaceId, panelId: $0.panelId), $0)
+            }
+        )
+        var needsFollowUpPass = false
+
+        defer {
+            if needsFollowUpPass || workspacePullRequestRefreshTask == nil {
+                refreshTrackedWorkspacePullRequestsIfNeeded(reason: "\(reason).followUp")
+            }
+        }
+
+        for key in requestedKeys {
+            let rerunPending = workspacePullRequestProbeRerunPending(for: key)
+            workspacePullRequestProbeStateByKey[key] = .idle
+            if rerunPending {
+                workspacePullRequestNextPollAtByKey[key] = .distantPast
+                needsFollowUpPass = true
+            }
+
             guard requestedKeySet.contains(key),
-                  let workspace = tabs.first(where: { $0.id == result.workspaceId }),
-                  workspace.panels[result.panelId] != nil else {
+                  let result = resultsByKey[key] else {
                 continue
             }
 
+            guard let workspace = tabs.first(where: { $0.id == result.workspaceId }),
+                  workspace.panels[result.panelId] != nil else {
+                clearWorkspacePullRequestTracking(for: key)
+                continue
+            }
+
+            let priorPullRequest = workspace.panelPullRequests[result.panelId]
+            let countsAsTerminalSweep = priorPullRequest?.status != .open
+
             switch result.resolution {
             case .resolved(let resolvedPullRequest):
+                workspacePullRequestTransientFailureCountByKey[key] = 0
                 guard let status = SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
                       let url = URL(string: resolvedPullRequest.urlString) else {
                     continue
@@ -1782,14 +1881,31 @@ class TabManager: ObservableObject {
                     url: url,
                     status: status,
                     branch: resolvedPullRequest.branch,
-                    checks: resolvedPullRequest.checksRawValue.flatMap(SidebarPullRequestChecksStatus.init(rawValue:))
+                    isStale: false
                 )
             case .notFound:
+                workspacePullRequestTransientFailureCountByKey[key] = 0
+                workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
                 if workspace.panelPullRequests[result.panelId] != nil {
                     workspace.clearPanelPullRequest(panelId: result.panelId)
                 }
-            case .unsupportedRepository, .transientFailure:
-                break
+            case .unsupportedRepository:
+                workspacePullRequestTransientFailureCountByKey[key] = 0
+            case .transientFailure:
+                let nextFailureCount = (workspacePullRequestTransientFailureCountByKey[key] ?? 0) + 1
+                workspacePullRequestTransientFailureCountByKey[key] = nextFailureCount
+                if nextFailureCount >= 3,
+                   let currentPullRequest = workspace.panelPullRequests[result.panelId] {
+                    workspace.updatePanelPullRequest(
+                        panelId: result.panelId,
+                        number: currentPullRequest.number,
+                        label: currentPullRequest.label,
+                        url: currentPullRequest.url,
+                        status: currentPullRequest.status,
+                        branch: currentPullRequest.branch,
+                        isStale: true
+                    )
+                }
             }
 
             scheduleNextWorkspacePullRequestPoll(
@@ -1797,7 +1913,8 @@ class TabManager: ObservableObject {
                 workspace: workspace,
                 panelId: result.panelId,
                 now: now,
-                resolution: result.resolution
+                resolution: result.resolution,
+                countsAsTerminalSweep: countsAsTerminalSweep
             )
 
 #if DEBUG
@@ -1826,43 +1943,98 @@ class TabManager: ObservableObject {
         workspace: Workspace,
         panelId: UUID,
         now: Date,
-        resolution: GitHubPullRequestRESTPoller.Resolution
+        resolution: WorkspacePullRequestRefreshResult.Resolution,
+        countsAsTerminalSweep: Bool
     ) {
-        let isSelectedFocusedPanel = selectedWorkspace?.id == workspace.id
-            && selectedWorkspace?.focusedPanelId == panelId
-        let burstUntil = workspacePullRequestBurstUntilByKey[key]
-        let isBursting = (burstUntil ?? .distantPast) > now
-        let interval: TimeInterval
-
-        if isBursting {
-            interval = Self.workspacePullRequestBurstPollInterval
-        } else if case .transientFailure = resolution {
-            interval = Self.workspacePullRequestBurstPollInterval
-        } else if isSelectedFocusedPanel {
-            interval = Self.selectedWorkspacePullRequestIdlePollInterval
-        } else {
-            interval = Self.workspacePullRequestIdlePollInterval
+        if countsAsTerminalSweep {
+            workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
         }
 
-        workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(interval)
-        if !isBursting {
-            workspacePullRequestBurstUntilByKey.removeValue(forKey: key)
+        if case .resolved(let resolvedPullRequest) = resolution,
+           let status = SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
+           status != .open {
+            workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
+            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
+            return
         }
+
+        if case .unsupportedRepository = resolution {
+            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
+            return
+        }
+
+        workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
+        let baseInterval = isSelectedFocusedPanel(workspace: workspace, panelId: panelId)
+            ? Self.selectedPollInterval
+            : Self.backgroundPollInterval
+        workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
     }
 
     private func pruneWorkspacePullRequestTracking(validKeys: Set<WorkspaceGitProbeKey>) {
         workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.filter { validKeys.contains($0.key) }
-        workspacePullRequestBurstUntilByKey = workspacePullRequestBurstUntilByKey.filter { validKeys.contains($0.key) }
+        workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { validKeys.contains($0.key) }
+        workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { validKeys.contains($0.key) }
+        workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { validKeys.contains($0.key) }
     }
 
     private func clearWorkspacePullRequestTracking(for key: WorkspaceGitProbeKey) {
         workspacePullRequestNextPollAtByKey.removeValue(forKey: key)
-        workspacePullRequestBurstUntilByKey.removeValue(forKey: key)
+        workspacePullRequestProbeStateByKey.removeValue(forKey: key)
+        workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
+        workspacePullRequestTransientFailureCountByKey.removeValue(forKey: key)
     }
 
     private func clearWorkspacePullRequestTracking(workspaceId: UUID) {
         workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.filter { $0.key.workspaceId != workspaceId }
-        workspacePullRequestBurstUntilByKey = workspacePullRequestBurstUntilByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { $0.key.workspaceId != workspaceId }
+    }
+
+    private var activeWorkspaceGitProbeKeys: Set<WorkspaceGitProbeKey> {
+        Set(workspaceGitProbeStateByKey.compactMap { key, state in
+            guard case .inFlight = state else { return nil }
+            return key
+        })
+    }
+
+    private func markWorkspaceGitProbeRerunPending(for key: WorkspaceGitProbeKey) {
+        guard case .inFlight(let rerunPending) = workspaceGitProbeStateByKey[key],
+              !rerunPending else {
+            return
+        }
+        workspaceGitProbeStateByKey[key] = .inFlight(rerunPending: true)
+    }
+
+    private func workspaceGitProbeRerunPending(for key: WorkspaceGitProbeKey) -> Bool {
+        guard case .inFlight(let rerunPending) = workspaceGitProbeStateByKey[key] else {
+            return false
+        }
+        return rerunPending
+    }
+
+    private func markWorkspacePullRequestProbeRerunPending(for key: WorkspaceGitProbeKey) {
+        guard case .inFlight(let rerunPending) = workspacePullRequestProbeStateByKey[key],
+              !rerunPending else {
+            return
+        }
+        workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: true)
+    }
+
+    private func workspacePullRequestProbeRerunPending(for key: WorkspaceGitProbeKey) -> Bool {
+        guard case .inFlight(let rerunPending) = workspacePullRequestProbeStateByKey[key] else {
+            return false
+        }
+        return rerunPending
+    }
+
+    private func isSelectedFocusedPanel(workspace: Workspace, panelId: UUID) -> Bool {
+        selectedWorkspace?.id == workspace.id && selectedWorkspace?.focusedPanelId == panelId
+    }
+
+    private nonisolated static func jitteredPollInterval(base: TimeInterval) -> TimeInterval {
+        let jitter = base * Self.workspacePullRequestPollJitterFraction
+        return base + Double.random(in: -jitter...jitter)
     }
 
     func refreshTrackedWorkspaceGitMetadataForTesting() {
@@ -1870,7 +2042,7 @@ class TabManager: ObservableObject {
     }
 
     func trackedWorkspaceGitMetadataPollCandidatePanelIdsForTesting(workspaceId: UUID) -> Set<UUID> {
-        let activeProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
+        let activeProbeKeys = activeWorkspaceGitProbeKeys
         guard let workspace = tabs.first(where: { $0.id == workspaceId }) else {
             return []
         }
@@ -1881,7 +2053,7 @@ class TabManager: ObservableObject {
     }
 
     func activeWorkspaceGitProbePanelIdsForTesting(workspaceId: UUID) -> Set<UUID> {
-        let probeKeys = Set(workspaceGitProbeGenerationByKey.keys.filter { $0.workspaceId == workspaceId })
+        let probeKeys = Set(workspaceGitProbeStateByKey.keys.filter { $0.workspaceId == workspaceId })
             .union(workspaceGitProbeTimersByKey.keys.filter { $0.workspaceId == workspaceId })
         return Set(probeKeys.map(\.panelId))
     }
@@ -2347,9 +2519,10 @@ class TabManager: ObservableObject {
     ) {
         let normalizedDirectory = normalizeDirectory(directory)
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
-        let generation = UUID()
         cancelWorkspaceGitProbeTimers(for: key)
-        workspaceGitProbeGenerationByKey[key] = generation
+        if workspaceGitProbeStateByKey[key] == nil {
+            workspaceGitProbeStateByKey[key] = .idle
+        }
 
 #if DEBUG
         dlog(
@@ -2364,11 +2537,8 @@ class TabManager: ObservableObject {
             let timer = DispatchSource.makeTimerSource(queue: initialWorkspaceGitProbeQueue)
             timer.schedule(deadline: .now() + delay, repeating: .never)
             timer.setEventHandler { [weak self] in
-                let snapshot = Self.initialWorkspaceGitMetadataSnapshot(for: normalizedDirectory)
                 Task { @MainActor [weak self] in
-                    self?.applyWorkspaceGitMetadataSnapshot(
-                        snapshot,
-                        generation: generation,
+                    self?.beginWorkspaceGitMetadataProbeAttempt(
                         probeKey: key,
                         expectedDirectory: normalizedDirectory,
                         isLastAttempt: isLastAttempt
@@ -2379,6 +2549,32 @@ class TabManager: ObservableObject {
             timer.resume()
         }
         workspaceGitProbeTimersByKey[key] = timers
+    }
+
+    private func beginWorkspaceGitMetadataProbeAttempt(
+        probeKey: WorkspaceGitProbeKey,
+        expectedDirectory: String,
+        isLastAttempt: Bool
+    ) {
+        switch workspaceGitProbeStateByKey[probeKey] ?? .idle {
+        case .idle:
+            workspaceGitProbeStateByKey[probeKey] = .inFlight(rerunPending: false)
+        case .inFlight:
+            markWorkspaceGitProbeRerunPending(for: probeKey)
+            return
+        }
+
+        initialWorkspaceGitProbeQueue.async { [weak self] in
+            let snapshot = Self.initialWorkspaceGitMetadataSnapshot(for: expectedDirectory)
+            Task { @MainActor [weak self] in
+                self?.applyWorkspaceGitMetadataSnapshot(
+                    snapshot,
+                    probeKey: probeKey,
+                    expectedDirectory: expectedDirectory,
+                    isLastAttempt: isLastAttempt
+                )
+            }
+        }
     }
 
     private func cancelWorkspaceGitProbeTimers(for key: WorkspaceGitProbeKey) {
@@ -2392,12 +2588,12 @@ class TabManager: ObservableObject {
     }
 
     private func clearWorkspaceGitProbe(_ key: WorkspaceGitProbeKey) {
-        workspaceGitProbeGenerationByKey.removeValue(forKey: key)
+        workspaceGitProbeStateByKey.removeValue(forKey: key)
         cancelWorkspaceGitProbeTimers(for: key)
     }
 
     private func clearWorkspaceGitProbes(workspaceId: UUID) {
-        let keys = Set(workspaceGitProbeGenerationByKey.keys.filter { $0.workspaceId == workspaceId })
+        let keys = Set(workspaceGitProbeStateByKey.keys.filter { $0.workspaceId == workspaceId })
             .union(workspaceGitProbeTimersByKey.keys.filter { $0.workspaceId == workspaceId })
         for key in keys {
             clearWorkspaceGitProbe(key)
@@ -2410,34 +2606,53 @@ class TabManager: ObservableObject {
 
     private func applyWorkspaceGitMetadataSnapshot(
         _ snapshot: InitialWorkspaceGitMetadataSnapshot,
-        generation: UUID,
         probeKey: WorkspaceGitProbeKey,
         expectedDirectory: String,
         isLastAttempt: Bool
     ) {
+        let shouldClearProbe = shouldStopWorkspaceGitMetadataRefresh(snapshot) || isLastAttempt
+        var didClearProbe = false
         defer {
-            if shouldStopWorkspaceGitMetadataRefresh(snapshot) || isLastAttempt,
-               workspaceGitProbeGenerationByKey[probeKey] == generation {
-                clearWorkspaceGitProbe(probeKey)
+            if !didClearProbe {
+                let rerunPending = workspaceGitProbeRerunPending(for: probeKey)
+                if rerunPending {
+                    workspaceGitProbeStateByKey[probeKey] = .idle
+                    if shouldClearProbe {
+                        cancelWorkspaceGitProbeTimers(for: probeKey)
+                    }
+                    scheduleWorkspaceGitMetadataRefreshIfPossible(
+                        workspaceId: probeKey.workspaceId,
+                        panelId: probeKey.panelId,
+                        reason: "rerunPending"
+                    )
+                } else if shouldClearProbe {
+                    clearWorkspaceGitProbe(probeKey)
+                } else {
+                    workspaceGitProbeStateByKey[probeKey] = .idle
+                }
             }
         }
 
-        guard workspaceGitProbeGenerationByKey[probeKey] == generation else { return }
+        guard case .inFlight = workspaceGitProbeStateByKey[probeKey] else { return }
         guard let workspace = tabs.first(where: { $0.id == probeKey.workspaceId }) else {
             clearWorkspaceGitProbe(probeKey)
+            didClearProbe = true
             return
         }
         guard workspace.panels[probeKey.panelId] != nil else {
             clearWorkspaceGitProbe(probeKey)
+            didClearProbe = true
             return
         }
 
         guard let currentDirectory = gitProbeDirectory(for: workspace, panelId: probeKey.panelId) else {
             clearWorkspaceGitProbe(probeKey)
+            didClearProbe = true
             return
         }
         if currentDirectory != expectedDirectory {
             clearWorkspaceGitProbe(probeKey)
+            didClearProbe = true
 #if DEBUG
             dlog(
                 "workspace.gitProbe.skip workspace=\(probeKey.workspaceId.uuidString.prefix(5)) " +
@@ -2480,7 +2695,8 @@ class TabManager: ObservableObject {
                 label: pullRequest.label,
                 url: pullRequest.url,
                 status: pullRequest.status,
-                checks: pullRequest.checks
+                branch: pullRequest.branch,
+                isStale: false
             )
         case .notFound:
             if workspace.panelPullRequests[probeKey.panelId] != nil {
@@ -2512,8 +2728,7 @@ class TabManager: ObservableObject {
             case .transientFailure:
                 return "transientFailure"
             case .resolved(let pullRequest):
-                let checks = pullRequest.checks?.rawValue ?? "none"
-                return "#\(pullRequest.number):\(pullRequest.status.rawValue):\(checks)"
+                return "#\(pullRequest.number):\(pullRequest.status.rawValue)"
             }
         }()
         dlog(
@@ -2564,41 +2779,107 @@ class TabManager: ObservableObject {
         )
     }
 
-    private nonisolated static func workspacePullRequestSnapshot(
-        directory: String,
-        branch: String
-    ) -> WorkspacePullRequestSnapshot {
-        guard !shouldSkipWorkspacePullRequestLookup(branch: branch) else {
-            return .notFound
-        }
+    private nonisolated static func fetchWorkspacePullRequestRepoResults(
+        repoDirectoriesBySlug: [String: String],
+        cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
+        now: Date
+    ) async -> [String: WorkspacePullRequestRepoFetchResult] {
+        var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
+        var staleRequests: [(repoSlug: String, directory: String)] = []
 
-        let repoSlugs = githubRepositorySlugs(directory: directory)
-        guard !repoSlugs.isEmpty else {
-            return .unsupportedRepository
-        }
-
-        var sawTransientFailure = false
-        for repoSlug in repoSlugs {
-            switch workspacePullRequestSnapshot(directory: directory, branch: branch, repoSlug: repoSlug) {
-            case .deferred:
-                continue
-            case .resolved(let pullRequest):
-                return .resolved(pullRequest)
-            case .transientFailure:
-                sawTransientFailure = true
-            case .notFound, .unsupportedRepository:
-                continue
+        for (repoSlug, directory) in repoDirectoriesBySlug {
+            if let cacheEntry = cacheBySlug[repoSlug],
+               now.timeIntervalSince(cacheEntry.fetchedAt) < Self.workspacePullRequestRepoCacheLifetime {
+                results[repoSlug] = .success(cacheEntry, usedCache: true)
+            } else {
+                staleRequests.append((repoSlug: repoSlug, directory: directory))
             }
         }
 
-        return sawTransientFailure ? .transientFailure : .notFound
+        guard !staleRequests.isEmpty else { return results }
+
+        let fetchedResults = await withTaskGroup(
+            of: (String, WorkspacePullRequestRepoFetchResult).self,
+            returning: [(String, WorkspacePullRequestRepoFetchResult)].self
+        ) { group in
+            for request in staleRequests {
+                group.addTask {
+                    let result = Self.workspacePullRequestRepoFetchResult(
+                        directory: request.directory,
+                        repoSlug: request.repoSlug
+                    )
+                    return (request.repoSlug, result)
+                }
+            }
+
+            var collected: [(String, WorkspacePullRequestRepoFetchResult)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        for (repoSlug, result) in fetchedResults {
+            results[repoSlug] = result
+        }
+        return results
     }
 
-    private nonisolated static func workspacePullRequestSnapshot(
+    private nonisolated static func resolveWorkspacePullRequestRefreshResults(
+        candidates: [WorkspacePullRequestCandidate],
+        repoResults: [String: WorkspacePullRequestRepoFetchResult]
+    ) -> [WorkspacePullRequestRefreshResult] {
+        candidates.map { candidate in
+            var preferredMatch: GitHubPullRequestProbeItem?
+            var sawTransientFailure = false
+
+            for repoSlug in candidate.repoSlugs {
+                guard let repoResult = repoResults[repoSlug] else { continue }
+                switch repoResult {
+                case .success(let cacheEntry, _):
+                    guard let matchedPullRequest = cacheEntry.pullRequestsByBranch[candidate.branch] else {
+                        continue
+                    }
+                    if let currentBest = preferredMatch {
+                        preferredMatch = preferredPullRequest(from: [currentBest, matchedPullRequest]) ?? currentBest
+                    } else {
+                        preferredMatch = matchedPullRequest
+                    }
+                case .transientFailure:
+                    sawTransientFailure = true
+                }
+            }
+
+            let resolution: WorkspacePullRequestRefreshResult.Resolution
+            if let preferredMatch,
+               let status = pullRequestStatus(from: preferredMatch.state) {
+                resolution = .resolved(
+                    WorkspacePullRequestResolvedItem(
+                        number: preferredMatch.number,
+                        urlString: preferredMatch.url,
+                        statusRawValue: status.rawValue,
+                        branch: candidate.branch
+                    )
+                )
+            } else if sawTransientFailure {
+                resolution = .transientFailure
+            } else {
+                resolution = .notFound
+            }
+
+            return WorkspacePullRequestRefreshResult(
+                workspaceId: candidate.workspaceId,
+                panelId: candidate.panelId,
+                resolution: resolution
+            )
+        }
+    }
+
+    private nonisolated static func workspacePullRequestRepoFetchResult(
         directory: String,
-        branch: String,
         repoSlug: String
-    ) -> WorkspacePullRequestSnapshot {
+    ) -> WorkspacePullRequestRepoFetchResult {
+        let fetchTimestamp = Date()
         let result = runCommandResult(
             directory: directory,
             executable: "gh",
@@ -2606,105 +2887,135 @@ class TabManager: ObservableObject {
                 "pr", "list",
                 "--repo", repoSlug,
                 "--state", "all",
-                "--head", branch,
-                "--json", "number,state,url,updatedAt",
+                "--limit", "200",
+                "--json", "number,state,url,updatedAt,headRefName",
             ],
             timeout: workspacePullRequestProbeTimeout
         )
 
         guard let result else {
-#if DEBUG
-            dlog(
-                "workspace.gitProbe.pr.fail dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug) status=nil"
-            )
-#endif
-            return .transientFailure
+            return workspacePullRequestRepoFetchResultViaREST(
+                directory: directory,
+                repoSlug: repoSlug,
+                fetchTimestamp: fetchTimestamp
+            ) ?? .transientFailure
         }
 
         guard !result.timedOut,
               result.executionError == nil,
-              let exitStatus = result.exitStatus else {
-#if DEBUG
-            let statusText: String
-            if result.timedOut {
-                statusText = "timeout"
-            } else if let executionError = result.executionError {
-                statusText = "error=\(executionError)"
-            } else {
-                statusText = "unknown"
-            }
-            let stderr = debugLogSnippet(result.stderr) ?? "none"
-            dlog(
-                "workspace.gitProbe.pr.fail dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug) status=\(statusText) stderr=\(stderr)"
-            )
-#endif
-            return .transientFailure
-        }
-
-        if exitStatus != 0 {
+              let exitStatus = result.exitStatus,
+              exitStatus == 0,
+              let output = result.stdout,
+              let pullRequests = decodeJSON([GitHubPullRequestProbeItem].self, from: output) else {
 #if DEBUG
             dlog(
-                "workspace.gitProbe.pr.fail dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug) status=exit=\(exitStatus) stderr=\(debugLogSnippet(result.stderr) ?? "none")"
+                "workspace.prRefresh.repo.fail repo=\(repoSlug) " +
+                "status=\(result.exitStatus.map(String.init) ?? "nil") stderr=\(debugLogSnippet(result.stderr) ?? "none")"
             )
 #endif
-            return .transientFailure
+            return workspacePullRequestRepoFetchResultViaREST(
+                directory: directory,
+                repoSlug: repoSlug,
+                fetchTimestamp: fetchTimestamp
+            ) ?? .transientFailure
         }
 
-        let output = result.stdout ?? ""
-        guard let pullRequests = decodeJSON([GitHubPullRequestProbeItem].self, from: output) else {
-#if DEBUG
-            dlog(
-                "workspace.gitProbe.pr.parseFail dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug) output=\(debugLogSnippet(output) ?? "none")"
-            )
-#endif
-            return .transientFailure
-        }
-
-        guard let pullRequest = preferredPullRequest(from: pullRequests) else {
-#if DEBUG
-            dlog(
-                "workspace.gitProbe.pr.none dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug)"
-            )
-#endif
-            return .notFound
-        }
-
-        guard let status = pullRequestStatus(from: pullRequest.state),
-              let url = URL(string: pullRequest.url) else {
-#if DEBUG
-            dlog(
-                "workspace.gitProbe.pr.parseFail dir=\(directory) branch=\(branch) " +
-                "repo=\(repoSlug) output=\(debugLogSnippet(output) ?? "none")"
-            )
-#endif
-            return .transientFailure
-        }
-
-        let checks = status == .open
-            ? pullRequestChecksStatus(number: pullRequest.number, directory: directory, repoSlug: repoSlug)
-            : nil
-
+        let cacheEntry = WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: fetchTimestamp,
+            pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: pullRequests)
+        )
 #if DEBUG
         dlog(
-            "workspace.gitProbe.pr.success dir=\(directory) branch=\(branch) " +
-            "repo=\(repoSlug) number=\(pullRequest.number) state=\(status.rawValue) checks=\(checks?.rawValue ?? "none")"
+            "workspace.prRefresh.repo.success repo=\(repoSlug) branches=\(cacheEntry.pullRequestsByBranch.count)"
         )
 #endif
-        return .resolved(
-            SidebarPullRequestState(
-                number: pullRequest.number,
-                label: "PR",
-                url: url,
-                status: status,
-                branch: branch,
-                checks: checks
-            )
+        return .success(cacheEntry, usedCache: false)
+    }
+
+    private nonisolated static func workspacePullRequestRepoFetchResultViaREST(
+        directory: String,
+        repoSlug: String,
+        fetchTimestamp: Date
+    ) -> WorkspacePullRequestRepoFetchResult? {
+        struct RESTPullRequestItem: Decodable {
+            struct Head: Decodable {
+                let ref: String
+            }
+
+            let number: Int
+            let state: String
+            let htmlURL: String
+            let updatedAt: String?
+            let mergedAt: String?
+            let head: Head
+
+            enum CodingKeys: String, CodingKey {
+                case number
+                case state
+                case htmlURL = "html_url"
+                case updatedAt = "updated_at"
+                case mergedAt = "merged_at"
+                case head
+            }
+        }
+
+        let result = runCommandResult(
+            directory: directory,
+            executable: "gh",
+            arguments: [
+                "api",
+                "repos/\(repoSlug)/pulls?state=all&per_page=100",
+            ],
+            timeout: workspacePullRequestProbeTimeout
         )
+
+        guard let result,
+              !result.timedOut,
+              result.executionError == nil,
+              let exitStatus = result.exitStatus,
+              exitStatus == 0,
+              let output = result.stdout,
+              let pullRequests = decodeJSON([RESTPullRequestItem].self, from: output) else {
+            return nil
+        }
+
+        let normalizedPullRequests = pullRequests.map { pullRequest in
+            let rawState = pullRequest.mergedAt?.isEmpty == false ? "MERGED" : pullRequest.state
+            return GitHubPullRequestProbeItem(
+                number: pullRequest.number,
+                state: rawState,
+                url: pullRequest.htmlURL,
+                updatedAt: pullRequest.updatedAt,
+                headRefName: pullRequest.head.ref
+            )
+        }
+        let cacheEntry = WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: fetchTimestamp,
+            pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: normalizedPullRequests)
+        )
+        return .success(cacheEntry, usedCache: false)
+    }
+
+    private nonisolated static func pullRequestMapByNormalizedBranch(
+        from pullRequests: [GitHubPullRequestProbeItem]
+    ) -> [String: GitHubPullRequestProbeItem] {
+        var pullRequestsByBranch: [String: GitHubPullRequestProbeItem] = [:]
+
+        for pullRequest in pullRequests {
+            guard let branch = normalizedBranchName(pullRequest.headRefName),
+                  pullRequestStatus(from: pullRequest.state) != nil,
+                  URL(string: pullRequest.url) != nil else {
+                continue
+            }
+
+            if let currentBest = pullRequestsByBranch[branch] {
+                pullRequestsByBranch[branch] = preferredPullRequest(from: [currentBest, pullRequest]) ?? currentBest
+            } else {
+                pullRequestsByBranch[branch] = pullRequest
+            }
+        }
+
+        return pullRequestsByBranch
     }
 
     nonisolated static func preferredPullRequest(
@@ -2762,60 +3073,6 @@ class TabManager: ObservableObject {
         return best
     }
 
-    private nonisolated static func pullRequestChecksStatus(
-        number: Int,
-        directory: String,
-        repoSlug: String
-    ) -> SidebarPullRequestChecksStatus? {
-        let result = runCommandResult(
-            directory: directory,
-            executable: "gh",
-            arguments: [
-                "pr", "checks", String(number),
-                "--repo", repoSlug,
-                "--json", "bucket,state"
-            ],
-            timeout: workspacePullRequestProbeTimeout
-        )
-
-        guard let result,
-              !result.timedOut,
-              result.executionError == nil,
-              let output = result.stdout,
-              let exitStatus = result.exitStatus,
-              exitStatus == 0 || exitStatus == 8,
-              let checks = decodeJSON([GitHubPullRequestCheckItem].self, from: output) else {
-            return nil
-        }
-
-        var sawPending = false
-        var sawPass = false
-
-        for check in checks {
-            let bucket = check.bucket?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            let state = check.state?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-
-            if isFailingCheckState(bucket: bucket, state: state) {
-                return .fail
-            }
-            if isPendingCheckState(bucket: bucket, state: state) {
-                sawPending = true
-                continue
-            }
-            if isPassingCheckState(bucket: bucket, state: state) {
-                sawPass = true
-            }
-        }
-
-        if sawPending {
-            return .pending
-        }
-        if sawPass {
-            return .pass
-        }
-        return nil
-    }
-
     private nonisolated static func pullRequestStatus(
         from rawState: String
     ) -> SidebarPullRequestStatus? {
@@ -2834,34 +3091,6 @@ class TabManager: ObservableObject {
     private nonisolated static func decodeJSON<T: Decodable>(_ type: T.Type, from text: String) -> T? {
         guard let data = text.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(T.self, from: data)
-    }
-
-    private nonisolated static func isFailingCheckState(bucket: String?, state: String?) -> Bool {
-        switch bucket ?? state ?? "" {
-        case "fail", "failure", "failed", "error", "timed_out", "timedout",
-             "cancel", "cancelled", "canceled", "action_required", "startup_failure":
-            return true
-        default:
-            return false
-        }
-    }
-
-    private nonisolated static func isPendingCheckState(bucket: String?, state: String?) -> Bool {
-        switch bucket ?? state ?? "" {
-        case "pending", "queued", "in_progress", "requested", "waiting", "expected":
-            return true
-        default:
-            return false
-        }
-    }
-
-    private nonisolated static func isPassingCheckState(bucket: String?, state: String?) -> Bool {
-        switch bucket ?? state ?? "" {
-        case "pass", "success", "successful", "completed", "neutral", "skipping", "skipped":
-            return true
-        default:
-            return false
-        }
     }
 
     private nonisolated static let fallbackCommandSearchDirectories: [String] = [
@@ -3660,7 +3889,7 @@ class TabManager: ObservableObject {
             url: currentPullRequest.url,
             status: nextStatus,
             branch: currentPullRequest.branch,
-            checks: nil
+            isStale: false
         )
     }
 
@@ -6721,7 +6950,7 @@ extension TabManager {
         for tab in previousTabs {
             unwireClosedBrowserTracking(for: tab)
         }
-        let existingProbeKeys = Set(workspaceGitProbeGenerationByKey.keys)
+        let existingProbeKeys = Set(workspaceGitProbeStateByKey.keys)
             .union(workspaceGitProbeTimersByKey.keys)
         for key in existingProbeKeys {
             clearWorkspaceGitProbe(key)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1415,6 +1415,7 @@ class TabManager: ObservableObject {
     private nonisolated static let selectedPollInterval: TimeInterval = 10
     private nonisolated static let workspacePullRequestPollTickInterval: TimeInterval = 1
     private nonisolated static let workspacePullRequestRepoCacheLifetime: TimeInterval = 15
+    private nonisolated static let workspacePullRequestRepoCachePruneLifetime: TimeInterval = 60
     private nonisolated static let workspacePullRequestRepoPageSize = 100
     private nonisolated static let workspacePullRequestRepoPageLimit = 2
     private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
@@ -1803,8 +1804,10 @@ class TabManager: ObservableObject {
                 candidates: candidates,
                 repoResults: repoResults
             )
+            guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
                 guard let self else { return }
+                guard !Task.isCancelled else { return }
                 self.workspacePullRequestRefreshTask = nil
                 self.applyWorkspacePullRequestRefreshResults(
                     results,
@@ -1853,6 +1856,9 @@ class TabManager: ObservableObject {
     ) {
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
         let shouldBypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
+        if shouldBypassRepoCache, workspacePullRequestRefreshTask != nil {
+            workspacePullRequestFollowUpShouldBypassRepoCache = true
+        }
         if case .inFlight = workspacePullRequestProbeStateByKey[key] {
             markWorkspacePullRequestProbeRerunPending(
                 for: key,
@@ -1930,7 +1936,7 @@ class TabManager: ObservableObject {
             }
 
             let priorPullRequest = workspace.panelPullRequests[result.panelId]
-            let countsAsTerminalSweep = priorPullRequest?.status != .open
+            let countsAsTerminalSweep = priorPullRequest.map { $0.status != .open } ?? false
 
             switch result.resolution {
             case .resolved(let resolvedPullRequest):
@@ -1956,6 +1962,10 @@ class TabManager: ObservableObject {
                 }
             case .unsupportedRepository:
                 workspacePullRequestTransientFailureCountByKey[key] = 0
+                workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
+                if workspace.panelPullRequests[result.panelId] != nil {
+                    workspace.clearPanelPullRequest(panelId: result.panelId)
+                }
             case .transientFailure:
                 let nextFailureCount = (workspacePullRequestTransientFailureCountByKey[key] ?? 0) + 1
                 workspacePullRequestTransientFailureCountByKey[key] = nextFailureCount
@@ -1981,6 +1991,9 @@ class TabManager: ObservableObject {
                 resolution: result.resolution,
                 countsAsTerminalSweep: countsAsTerminalSweep
             )
+            if rerunPending {
+                workspacePullRequestNextPollAtByKey[key] = .distantPast
+            }
 
 #if DEBUG
             let label: String = {
@@ -2023,7 +2036,14 @@ class TabManager: ObservableObject {
             return
         }
 
+        if case .transientFailure = resolution,
+           workspacePullRequestLastTerminalStateRefreshAtByKey[key] != nil {
+            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
+            return
+        }
+
         if case .unsupportedRepository = resolution {
+            workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
             workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
             return
         }
@@ -2040,6 +2060,10 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { validKeys.contains($0.key) }
+        let repoCacheCutoff = Date().addingTimeInterval(-Self.workspacePullRequestRepoCachePruneLifetime)
+        workspacePullRequestRepoCacheBySlug = workspacePullRequestRepoCacheBySlug.filter {
+            $0.value.fetchedAt >= repoCacheCutoff
+        }
     }
 
     private func clearWorkspacePullRequestTracking(for key: WorkspaceGitProbeKey) {
@@ -2054,6 +2078,17 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { $0.key.workspaceId != workspaceId }
+    }
+
+    private func resetWorkspacePullRequestRefreshState() {
+        workspacePullRequestRefreshTask?.cancel()
+        workspacePullRequestRefreshTask = nil
+        workspacePullRequestProbeStateByKey.removeAll()
+        workspacePullRequestNextPollAtByKey.removeAll()
+        workspacePullRequestLastTerminalStateRefreshAtByKey.removeAll()
+        workspacePullRequestTransientFailureCountByKey.removeAll()
+        workspacePullRequestRepoCacheBySlug.removeAll()
+        workspacePullRequestFollowUpShouldBypassRepoCache = false
     }
 
     private var activeWorkspaceGitProbeKeys: Set<WorkspaceGitProbeKey> {
@@ -7093,6 +7128,7 @@ extension TabManager {
             clearWorkspaceGitProbe(key)
         }
         workspaceGitTrackedDirectoryByKey.removeAll()
+        resetWorkspacePullRequestRefreshState()
 
         // Clear non-@Published state without touching tabs/selectedTabId yet.
         lastFocusedPanelByTab.removeAll()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1336,6 +1336,7 @@ class TabManager: ObservableObject {
         let workspaceId: UUID
         let panelId: UUID
         let resolution: Resolution
+        let usedCachedRepoData: Bool
     }
 
     private struct WorkspacePullRequestRepoCacheEntry: Sendable {
@@ -1348,12 +1349,53 @@ class TabManager: ObservableObject {
         case transientFailure
     }
 
+    private struct WorkspacePullRequestHTTPResponse: Sendable {
+        let statusCode: Int
+        let data: Data
+    }
+
+    private struct WorkspacePullRequestRESTItem: Decodable, Sendable {
+        struct Head: Decodable, Sendable {
+            let ref: String
+        }
+
+        let number: Int
+        let state: String
+        let htmlURL: String
+        let updatedAt: String?
+        let mergedAt: String?
+        let head: Head
+
+        enum CodingKeys: String, CodingKey {
+            case number
+            case state
+            case htmlURL = "html_url"
+            case updatedAt = "updated_at"
+            case mergedAt = "merged_at"
+            case head
+        }
+    }
+
     struct GitHubPullRequestProbeItem: Decodable, Equatable, Sendable {
         let number: Int
         let state: String
         let url: String
         let updatedAt: String?
         let headRefName: String?
+
+        init(
+            number: Int,
+            state: String,
+            url: String,
+            updatedAt: String?,
+            headRefName: String? = nil
+        ) {
+            self.number = number
+            self.state = state
+            self.url = url
+            self.updatedAt = updatedAt
+            self.headRefName = headRefName
+        }
     }
 
     /// The window that owns this TabManager. Set by AppDelegate.registerMainWindow().
@@ -1472,6 +1514,7 @@ class TabManager: ObservableObject {
     private var workspacePullRequestRepoCacheBySlug: [String: WorkspacePullRequestRepoCacheEntry] = [:]
     private var workspacePullRequestPollTimer: DispatchSourceTimer?
     private var workspacePullRequestRefreshTask: Task<Void, Never>?
+    private var workspacePullRequestFollowUpShouldBypassRepoCache = false
 
     // Recent tab history for back/forward navigation (like browser history)
     private var tabHistory: [UUID] = []
@@ -1678,7 +1721,10 @@ class TabManager: ObservableObject {
 
     }
 
-    private func refreshTrackedWorkspacePullRequestsIfNeeded(reason: String) {
+    private func refreshTrackedWorkspacePullRequestsIfNeeded(
+        reason: String,
+        allowCachedResultsOverride: Bool? = nil
+    ) {
         let now = Date()
         var candidates: [WorkspacePullRequestCandidate] = []
         var repoDirectoriesBySlug: [String: String] = [:]
@@ -1713,7 +1759,10 @@ class TabManager: ObservableObject {
                 }
 
                 if case .inFlight = workspacePullRequestProbeStateByKey[key] {
-                    markWorkspacePullRequestProbeRerunPending(for: key)
+                    markWorkspacePullRequestProbeRerunPending(
+                        for: key,
+                        bypassRepoCache: !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
+                    )
                     continue
                 }
 
@@ -1741,11 +1790,14 @@ class TabManager: ObservableObject {
         }
 
         let cacheBySlug = workspacePullRequestRepoCacheBySlug
+        let allowCachedResults = allowCachedResultsOverride
+            ?? Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
         workspacePullRequestRefreshTask = Task { [weak self] in
             let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
                 repoDirectoriesBySlug: repoDirectoriesBySlug,
                 cacheBySlug: cacheBySlug,
-                now: now
+                now: now,
+                allowCachedResults: allowCachedResults
             )
             let results = Self.resolveWorkspacePullRequestRefreshResults(
                 candidates: candidates,
@@ -1770,13 +1822,12 @@ class TabManager: ObservableObject {
         now: Date,
         currentPullRequest: SidebarPullRequestState?
     ) -> Bool {
-        if let currentPullRequest,
-           currentPullRequest.status != .open {
-            let lastTerminalRefreshAt = workspacePullRequestLastTerminalStateRefreshAtByKey[key] ?? .distantPast
-            return now.timeIntervalSince(lastTerminalRefreshAt) >= Self.workspacePullRequestTerminalStateSweepInterval
-        }
-        let nextPollAt = workspacePullRequestNextPollAtByKey[key] ?? .distantPast
-        return nextPollAt <= now
+        Self.shouldRefreshWorkspacePullRequest(
+            now: now,
+            nextPollAt: workspacePullRequestNextPollAtByKey[key],
+            lastTerminalStateRefreshAt: workspacePullRequestLastTerminalStateRefreshAtByKey[key],
+            currentPullRequestStatus: currentPullRequest?.status
+        )
     }
 
     private func workspacePullRequestCandidate(
@@ -1802,8 +1853,12 @@ class TabManager: ObservableObject {
         burst: Bool
     ) {
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        let shouldBypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
         if case .inFlight = workspacePullRequestProbeStateByKey[key] {
-            markWorkspacePullRequestProbeRerunPending(for: key)
+            markWorkspacePullRequestProbeRerunPending(
+                for: key,
+                bypassRepoCache: shouldBypassRepoCache
+            )
         } else {
             workspacePullRequestNextPollAtByKey[key] = .distantPast
         }
@@ -1841,7 +1896,12 @@ class TabManager: ObservableObject {
 
         defer {
             if needsFollowUpPass || workspacePullRequestRefreshTask == nil {
-                refreshTrackedWorkspacePullRequestsIfNeeded(reason: "\(reason).followUp")
+                let shouldBypassRepoCache = workspacePullRequestFollowUpShouldBypassRepoCache
+                workspacePullRequestFollowUpShouldBypassRepoCache = false
+                refreshTrackedWorkspacePullRequestsIfNeeded(
+                    reason: "\(reason).followUp",
+                    allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
+                )
             }
         }
 
@@ -1855,6 +1915,12 @@ class TabManager: ObservableObject {
 
             guard requestedKeySet.contains(key),
                   let result = resultsByKey[key] else {
+                continue
+            }
+
+            if rerunPending,
+               workspacePullRequestFollowUpShouldBypassRepoCache,
+               result.usedCachedRepoData {
                 continue
             }
 
@@ -2013,12 +2079,21 @@ class TabManager: ObservableObject {
         return rerunPending
     }
 
-    private func markWorkspacePullRequestProbeRerunPending(for key: WorkspaceGitProbeKey) {
+    private func markWorkspacePullRequestProbeRerunPending(
+        for key: WorkspaceGitProbeKey,
+        bypassRepoCache: Bool
+    ) {
         guard case .inFlight(let rerunPending) = workspacePullRequestProbeStateByKey[key],
               !rerunPending else {
+            if bypassRepoCache {
+                workspacePullRequestFollowUpShouldBypassRepoCache = true
+            }
             return
         }
         workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: true)
+        if bypassRepoCache {
+            workspacePullRequestFollowUpShouldBypassRepoCache = true
+        }
     }
 
     private func workspacePullRequestProbeRerunPending(for key: WorkspaceGitProbeKey) -> Bool {
@@ -2035,6 +2110,37 @@ class TabManager: ObservableObject {
     private nonisolated static func jitteredPollInterval(base: TimeInterval) -> TimeInterval {
         let jitter = base * Self.workspacePullRequestPollJitterFraction
         return base + Double.random(in: -jitter...jitter)
+    }
+
+    nonisolated static func workspacePullRequestRefreshAllowsRepoCache(reason: String) -> Bool {
+        let periodicPrefixes = [
+            "periodicPoll",
+            "selectedPeriodicPoll",
+            "timer",
+        ]
+        return periodicPrefixes.contains { prefix in
+            reason == prefix || reason.hasPrefix("\(prefix).")
+        }
+    }
+
+    nonisolated static func shouldRefreshWorkspacePullRequest(
+        now: Date,
+        nextPollAt: Date?,
+        lastTerminalStateRefreshAt: Date?,
+        currentPullRequestStatus: SidebarPullRequestStatus?
+    ) -> Bool {
+        let nextPollAt = nextPollAt ?? .distantPast
+        if nextPollAt <= now {
+            return true
+        }
+
+        guard let currentPullRequestStatus,
+              currentPullRequestStatus != .open else {
+            return false
+        }
+
+        let lastTerminalRefreshAt = lastTerminalStateRefreshAt ?? .distantPast
+        return now.timeIntervalSince(lastTerminalRefreshAt) >= Self.workspacePullRequestTerminalStateSweepInterval
     }
 
     func refreshTrackedWorkspaceGitMetadataForTesting() {
@@ -2782,33 +2888,42 @@ class TabManager: ObservableObject {
     private nonisolated static func fetchWorkspacePullRequestRepoResults(
         repoDirectoriesBySlug: [String: String],
         cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
-        now: Date
+        now: Date,
+        allowCachedResults: Bool
     ) async -> [String: WorkspacePullRequestRepoFetchResult] {
         var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
-        var staleRequests: [(repoSlug: String, directory: String)] = []
+        var staleRepoSlugs: [String] = []
 
-        for (repoSlug, directory) in repoDirectoriesBySlug {
-            if let cacheEntry = cacheBySlug[repoSlug],
+        for repoSlug in repoDirectoriesBySlug.keys {
+            if allowCachedResults,
+               let cacheEntry = cacheBySlug[repoSlug],
                now.timeIntervalSince(cacheEntry.fetchedAt) < Self.workspacePullRequestRepoCacheLifetime {
                 results[repoSlug] = .success(cacheEntry, usedCache: true)
             } else {
-                staleRequests.append((repoSlug: repoSlug, directory: directory))
+                staleRepoSlugs.append(repoSlug)
             }
         }
 
-        guard !staleRequests.isEmpty else { return results }
+        guard !staleRepoSlugs.isEmpty else { return results }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = max(Self.workspacePullRequestProbeTimeout, 8)
+        configuration.timeoutIntervalForResource = max(Self.workspacePullRequestProbeTimeout, 8)
+        let session = URLSession(configuration: configuration)
+        let authHeader = workspacePullRequestAuthHeaderValue()
 
         let fetchedResults = await withTaskGroup(
             of: (String, WorkspacePullRequestRepoFetchResult).self,
             returning: [(String, WorkspacePullRequestRepoFetchResult)].self
         ) { group in
-            for request in staleRequests {
+            for repoSlug in staleRepoSlugs {
                 group.addTask {
-                    let result = Self.workspacePullRequestRepoFetchResult(
-                        directory: request.directory,
-                        repoSlug: request.repoSlug
+                    let result = await Self.workspacePullRequestRepoFetchResult(
+                        repoSlug: repoSlug,
+                        session: session,
+                        authHeader: authHeader
                     )
-                    return (request.repoSlug, result)
+                    return (repoSlug, result)
                 }
             }
 
@@ -2831,19 +2946,29 @@ class TabManager: ObservableObject {
     ) -> [WorkspacePullRequestRefreshResult] {
         candidates.map { candidate in
             var preferredMatch: GitHubPullRequestProbeItem?
+            var preferredMatchUsedCache = false
             var sawTransientFailure = false
+            var sawCachedSuccess = false
 
             for repoSlug in candidate.repoSlugs {
                 guard let repoResult = repoResults[repoSlug] else { continue }
                 switch repoResult {
-                case .success(let cacheEntry, _):
+                case .success(let cacheEntry, let usedCache):
+                    if usedCache {
+                        sawCachedSuccess = true
+                    }
                     guard let matchedPullRequest = cacheEntry.pullRequestsByBranch[candidate.branch] else {
                         continue
                     }
                     if let currentBest = preferredMatch {
-                        preferredMatch = preferredPullRequest(from: [currentBest, matchedPullRequest]) ?? currentBest
+                        let updatedPreferred = preferredPullRequest(from: [currentBest, matchedPullRequest]) ?? currentBest
+                        preferredMatch = updatedPreferred
+                        if updatedPreferred == matchedPullRequest {
+                            preferredMatchUsedCache = usedCache
+                        }
                     } else {
                         preferredMatch = matchedPullRequest
+                        preferredMatchUsedCache = usedCache
                     }
                 case .transientFailure:
                     sawTransientFailure = true
@@ -2851,6 +2976,7 @@ class TabManager: ObservableObject {
             }
 
             let resolution: WorkspacePullRequestRefreshResult.Resolution
+            let usedCachedRepoData: Bool
             if let preferredMatch,
                let status = pullRequestStatus(from: preferredMatch.state) {
                 resolution = .resolved(
@@ -2861,139 +2987,136 @@ class TabManager: ObservableObject {
                         branch: candidate.branch
                     )
                 )
+                usedCachedRepoData = preferredMatchUsedCache
             } else if sawTransientFailure {
                 resolution = .transientFailure
+                usedCachedRepoData = false
             } else {
                 resolution = .notFound
+                usedCachedRepoData = sawCachedSuccess
             }
 
             return WorkspacePullRequestRefreshResult(
                 workspaceId: candidate.workspaceId,
                 panelId: candidate.panelId,
-                resolution: resolution
+                resolution: resolution,
+                usedCachedRepoData: usedCachedRepoData
             )
         }
     }
 
     private nonisolated static func workspacePullRequestRepoFetchResult(
-        directory: String,
-        repoSlug: String
-    ) -> WorkspacePullRequestRepoFetchResult {
+        repoSlug: String,
+        session: URLSession,
+        authHeader: String?
+    ) async -> WorkspacePullRequestRepoFetchResult {
         let fetchTimestamp = Date()
-        let result = runCommandResult(
-            directory: directory,
-            executable: "gh",
-            arguments: [
-                "pr", "list",
-                "--repo", repoSlug,
-                "--state", "all",
-                "--limit", "200",
-                "--json", "number,state,url,updatedAt,headRefName",
-            ],
-            timeout: workspacePullRequestProbeTimeout
-        )
+        var page = 1
+        var allPullRequests: [GitHubPullRequestProbeItem] = []
 
-        guard let result else {
-            return workspacePullRequestRepoFetchResultViaREST(
-                directory: directory,
-                repoSlug: repoSlug,
-                fetchTimestamp: fetchTimestamp
-            ) ?? .transientFailure
-        }
-
-        guard !result.timedOut,
-              result.executionError == nil,
-              let exitStatus = result.exitStatus,
-              exitStatus == 0,
-              let output = result.stdout,
-              let pullRequests = decodeJSON([GitHubPullRequestProbeItem].self, from: output) else {
+        while true {
+            let endpoint = "repos/\(repoSlug)/pulls?state=all&sort=updated&direction=desc&per_page=100&page=\(page)"
+            guard let response = await performWorkspacePullRequestRequest(
+                session: session,
+                endpoint: endpoint,
+                authHeader: authHeader
+            ) else {
 #if DEBUG
-            dlog(
-                "workspace.prRefresh.repo.fail repo=\(repoSlug) " +
-                "status=\(result.exitStatus.map(String.init) ?? "nil") stderr=\(debugLogSnippet(result.stderr) ?? "none")"
-            )
+                dlog("workspace.prRefresh.repo.fail repo=\(repoSlug) page=\(page) status=nil")
 #endif
-            return workspacePullRequestRepoFetchResultViaREST(
-                directory: directory,
-                repoSlug: repoSlug,
-                fetchTimestamp: fetchTimestamp
-            ) ?? .transientFailure
+                return .transientFailure
+            }
+
+            guard response.statusCode == 200,
+                  let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
+#if DEBUG
+                dlog("workspace.prRefresh.repo.fail repo=\(repoSlug) page=\(page) status=\(response.statusCode)")
+#endif
+                return .transientFailure
+            }
+
+            allPullRequests.append(contentsOf: pullRequests.map(Self.workspacePullRequestProbeItem))
+            if pullRequests.count < 100 {
+                break
+            }
+            page += 1
         }
 
         let cacheEntry = WorkspacePullRequestRepoCacheEntry(
             fetchedAt: fetchTimestamp,
-            pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: pullRequests)
+            pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: allPullRequests)
         )
 #if DEBUG
         dlog(
-            "workspace.prRefresh.repo.success repo=\(repoSlug) branches=\(cacheEntry.pullRequestsByBranch.count)"
+            "workspace.prRefresh.repo.success repo=\(repoSlug) pages=\(page) " +
+            "branches=\(cacheEntry.pullRequestsByBranch.count)"
         )
 #endif
         return .success(cacheEntry, usedCache: false)
     }
 
-    private nonisolated static func workspacePullRequestRepoFetchResultViaREST(
-        directory: String,
-        repoSlug: String,
-        fetchTimestamp: Date
-    ) -> WorkspacePullRequestRepoFetchResult? {
-        struct RESTPullRequestItem: Decodable {
-            struct Head: Decodable {
-                let ref: String
-            }
-
-            let number: Int
-            let state: String
-            let htmlURL: String
-            let updatedAt: String?
-            let mergedAt: String?
-            let head: Head
-
-            enum CodingKeys: String, CodingKey {
-                case number
-                case state
-                case htmlURL = "html_url"
-                case updatedAt = "updated_at"
-                case mergedAt = "merged_at"
-                case head
-            }
-        }
-
-        let result = runCommandResult(
-            directory: directory,
-            executable: "gh",
-            arguments: [
-                "api",
-                "repos/\(repoSlug)/pulls?state=all&per_page=100",
-            ],
-            timeout: workspacePullRequestProbeTimeout
+    private nonisolated static func workspacePullRequestProbeItem(
+        from pullRequest: WorkspacePullRequestRESTItem
+    ) -> GitHubPullRequestProbeItem {
+        let rawState = pullRequest.mergedAt?.isEmpty == false ? "MERGED" : pullRequest.state
+        return GitHubPullRequestProbeItem(
+            number: pullRequest.number,
+            state: rawState,
+            url: pullRequest.htmlURL,
+            updatedAt: pullRequest.updatedAt,
+            headRefName: pullRequest.head.ref
         )
+    }
 
-        guard let result,
-              !result.timedOut,
-              result.executionError == nil,
-              let exitStatus = result.exitStatus,
-              exitStatus == 0,
-              let output = result.stdout,
-              let pullRequests = decodeJSON([RESTPullRequestItem].self, from: output) else {
+    private nonisolated static func performWorkspacePullRequestRequest(
+        session: URLSession,
+        endpoint: String,
+        authHeader: String?
+    ) async -> WorkspacePullRequestHTTPResponse? {
+        guard let url = URL(string: "https://api.github.com/\(endpoint)") else {
             return nil
         }
 
-        let normalizedPullRequests = pullRequests.map { pullRequest in
-            let rawState = pullRequest.mergedAt?.isEmpty == false ? "MERGED" : pullRequest.state
-            return GitHubPullRequestProbeItem(
-                number: pullRequest.number,
-                state: rawState,
-                url: pullRequest.htmlURL,
-                updatedAt: pullRequest.updatedAt,
-                headRefName: pullRequest.head.ref
-            )
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+        if let authHeader, !authHeader.isEmpty {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         }
-        let cacheEntry = WorkspacePullRequestRepoCacheEntry(
-            fetchedAt: fetchTimestamp,
-            pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: normalizedPullRequests)
-        )
-        return .success(cacheEntry, usedCache: false)
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return nil
+            }
+            return WorkspacePullRequestHTTPResponse(
+                statusCode: httpResponse.statusCode,
+                data: data
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private nonisolated static func workspacePullRequestAuthHeaderValue() -> String? {
+        let environment = ProcessInfo.processInfo.environment
+        if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
+            let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return "Bearer \(trimmed)"
+            }
+        }
+
+        let directory = FileManager.default.currentDirectoryPath
+        let token = runCommand(
+            directory: directory,
+            executable: "gh",
+            arguments: ["auth", "token"],
+            timeout: workspacePullRequestProbeTimeout
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !token.isEmpty else { return nil }
+        return "Bearer \(token)"
     }
 
     private nonisolated static func pullRequestMapByNormalizedBranch(
@@ -3091,6 +3214,10 @@ class TabManager: ObservableObject {
     private nonisolated static func decodeJSON<T: Decodable>(_ type: T.Type, from text: String) -> T? {
         guard let data = text.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private nonisolated static func decodeJSON<T: Decodable>(_ type: T.Type, from data: Data) -> T? {
+        try? JSONDecoder().decode(T.self, from: data)
     }
 
     private nonisolated static let fallbackCommandSearchDirectories: [String] = [

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1415,6 +1415,8 @@ class TabManager: ObservableObject {
     private nonisolated static let selectedPollInterval: TimeInterval = 10
     private nonisolated static let workspacePullRequestPollTickInterval: TimeInterval = 1
     private nonisolated static let workspacePullRequestRepoCacheLifetime: TimeInterval = 15
+    private nonisolated static let workspacePullRequestRepoPageSize = 100
+    private nonisolated static let workspacePullRequestRepoPageLimit = 2
     private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
     private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
@@ -1766,13 +1768,11 @@ class TabManager: ObservableObject {
                     continue
                 }
 
-                guard let candidate = workspacePullRequestCandidate(
+                let candidate = workspacePullRequestCandidate(
                     workspace: workspace,
                     panelId: panelId,
                     branch: branch
-                ) else {
-                    continue
-                }
+                )
                 candidates.append(candidate)
                 requestedKeys.append(key)
                 if let directory = gitProbeDirectory(for: workspace, panelId: panelId) {
@@ -1834,10 +1834,9 @@ class TabManager: ObservableObject {
         workspace: Workspace,
         panelId: UUID,
         branch: String
-    ) -> WorkspacePullRequestCandidate? {
+    ) -> WorkspacePullRequestCandidate {
         let directory = gitProbeDirectory(for: workspace, panelId: panelId)
         let repoSlugs = directory.map(Self.githubRepositorySlugs(directory:)) ?? []
-        guard !repoSlugs.isEmpty else { return nil }
         return WorkspacePullRequestCandidate(
             workspaceId: workspace.id,
             panelId: panelId,
@@ -2945,6 +2944,15 @@ class TabManager: ObservableObject {
         repoResults: [String: WorkspacePullRequestRepoFetchResult]
     ) -> [WorkspacePullRequestRefreshResult] {
         candidates.map { candidate in
+            if candidate.repoSlugs.isEmpty {
+                return WorkspacePullRequestRefreshResult(
+                    workspaceId: candidate.workspaceId,
+                    panelId: candidate.panelId,
+                    resolution: .unsupportedRepository,
+                    usedCachedRepoData: false
+                )
+            }
+
             var preferredMatch: GitHubPullRequestProbeItem?
             var preferredMatchUsedCache = false
             var sawTransientFailure = false
@@ -3012,10 +3020,11 @@ class TabManager: ObservableObject {
     ) async -> WorkspacePullRequestRepoFetchResult {
         let fetchTimestamp = Date()
         var page = 1
+        var fetchedPageCount = 0
         var allPullRequests: [GitHubPullRequestProbeItem] = []
 
-        while true {
-            let endpoint = "repos/\(repoSlug)/pulls?state=all&sort=updated&direction=desc&per_page=100&page=\(page)"
+        while page <= Self.workspacePullRequestRepoPageLimit {
+            let endpoint = "repos/\(repoSlug)/pulls?state=all&sort=updated&direction=desc&per_page=\(Self.workspacePullRequestRepoPageSize)&page=\(page)"
             guard let response = await performWorkspacePullRequestRequest(
                 session: session,
                 endpoint: endpoint,
@@ -3035,8 +3044,9 @@ class TabManager: ObservableObject {
                 return .transientFailure
             }
 
+            fetchedPageCount += 1
             allPullRequests.append(contentsOf: pullRequests.map(Self.workspacePullRequestProbeItem))
-            if pullRequests.count < 100 {
+            if pullRequests.count < Self.workspacePullRequestRepoPageSize {
                 break
             }
             page += 1
@@ -3048,7 +3058,7 @@ class TabManager: ObservableObject {
         )
 #if DEBUG
         dlog(
-            "workspace.prRefresh.repo.success repo=\(repoSlug) pages=\(page) " +
+            "workspace.prRefresh.repo.success repo=\(repoSlug) pages=\(fetchedPageCount) " +
             "branches=\(cacheEntry.pullRequestsByBranch.count)"
         )
 #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1342,11 +1342,37 @@ class TabManager: ObservableObject {
     private struct WorkspacePullRequestRepoCacheEntry: Sendable {
         let fetchedAt: Date
         let pullRequestsByBranch: [String: GitHubPullRequestProbeItem]
+        let knownAbsentBranches: Set<String>
+
+        init(
+            fetchedAt: Date,
+            pullRequestsByBranch: [String: GitHubPullRequestProbeItem],
+            knownAbsentBranches: Set<String> = []
+        ) {
+            self.fetchedAt = fetchedAt
+            self.pullRequestsByBranch = pullRequestsByBranch
+            self.knownAbsentBranches = knownAbsentBranches
+        }
     }
 
     private enum WorkspacePullRequestRepoFetchResult: Sendable {
-        case success(WorkspacePullRequestRepoCacheEntry, usedCache: Bool)
+        case success(
+            WorkspacePullRequestRepoCacheEntry,
+            usedCache: Bool,
+            transientBranches: Set<String>
+        )
         case transientFailure
+    }
+
+    private enum WorkspacePullRequestBranchFetchResult: Sendable {
+        case found(GitHubPullRequestProbeItem)
+        case notFound
+        case transientFailure
+    }
+
+    private struct WorkspacePullRequestBranchLookupOutcome: Sendable {
+        let cacheEntry: WorkspacePullRequestRepoCacheEntry
+        let transientBranches: Set<String>
     }
 
     private struct WorkspacePullRequestHTTPResponse: Sendable {
@@ -1730,6 +1756,7 @@ class TabManager: ObservableObject {
     ) {
         let now = Date()
         var candidates: [WorkspacePullRequestCandidate] = []
+        var candidateBranchesByRepo: [String: Set<String>] = [:]
         var repoDirectoriesBySlug: [String: String] = [:]
         var requestedKeys: [WorkspaceGitProbeKey] = []
         var validKeys: Set<WorkspaceGitProbeKey> = []
@@ -1776,6 +1803,9 @@ class TabManager: ObservableObject {
                 )
                 candidates.append(candidate)
                 requestedKeys.append(key)
+                for repoSlug in candidate.repoSlugs {
+                    candidateBranchesByRepo[repoSlug, default: []].insert(candidate.branch)
+                }
                 if let directory = gitProbeDirectory(for: workspace, panelId: panelId) {
                     for repoSlug in candidate.repoSlugs where repoDirectoriesBySlug[repoSlug] == nil {
                         repoDirectoriesBySlug[repoSlug] = directory
@@ -1796,6 +1826,7 @@ class TabManager: ObservableObject {
         workspacePullRequestRefreshTask = Task { [weak self] in
             let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
                 repoDirectoriesBySlug: repoDirectoriesBySlug,
+                candidateBranchesByRepo: candidateBranchesByRepo,
                 cacheBySlug: cacheBySlug,
                 now: now,
                 allowCachedResults: allowCachedResults
@@ -1884,7 +1915,7 @@ class TabManager: ObservableObject {
         reason: String
     ) {
         for (repoSlug, repoResult) in repoResults {
-            guard case .success(let cacheEntry, let usedCache) = repoResult,
+            guard case .success(let cacheEntry, let usedCache, _) = repoResult,
                   !usedCache else {
                 continue
             }
@@ -2921,39 +2952,34 @@ class TabManager: ObservableObject {
 
     private nonisolated static func fetchWorkspacePullRequestRepoResults(
         repoDirectoriesBySlug: [String: String],
+        candidateBranchesByRepo: [String: Set<String>],
         cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
         now: Date,
         allowCachedResults: Bool
     ) async -> [String: WorkspacePullRequestRepoFetchResult] {
-        var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
-        var staleRepoSlugs: [String] = []
-
-        for repoSlug in repoDirectoriesBySlug.keys {
-            if allowCachedResults,
-               let cacheEntry = cacheBySlug[repoSlug],
-               now.timeIntervalSince(cacheEntry.fetchedAt) < Self.workspacePullRequestRepoCacheLifetime {
-                results[repoSlug] = .success(cacheEntry, usedCache: true)
-            } else {
-                staleRepoSlugs.append(repoSlug)
-            }
-        }
-
-        guard !staleRepoSlugs.isEmpty else { return results }
+        guard !repoDirectoriesBySlug.isEmpty else { return [:] }
 
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = max(Self.workspacePullRequestProbeTimeout, 8)
         configuration.timeoutIntervalForResource = max(Self.workspacePullRequestProbeTimeout, 8)
         let session = URLSession(configuration: configuration)
         let authHeader = workspacePullRequestAuthHeaderValue()
+        var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
 
         let fetchedResults = await withTaskGroup(
             of: (String, WorkspacePullRequestRepoFetchResult).self,
             returning: [(String, WorkspacePullRequestRepoFetchResult)].self
         ) { group in
-            for repoSlug in staleRepoSlugs {
+            for repoSlug in repoDirectoriesBySlug.keys {
                 group.addTask {
                     let result = await Self.workspacePullRequestRepoFetchResult(
                         repoSlug: repoSlug,
+                        candidateBranches: candidateBranchesByRepo[repoSlug] ?? [],
+                        cachedEntry: cacheBySlug[repoSlug],
+                        useCachedRecentWindow: allowCachedResults
+                            && (cacheBySlug[repoSlug].map {
+                                now.timeIntervalSince($0.fetchedAt) < Self.workspacePullRequestRepoCacheLifetime
+                            } ?? false),
                         session: session,
                         authHeader: authHeader
                     )
@@ -2988,30 +3014,25 @@ class TabManager: ObservableObject {
                 )
             }
 
-            var preferredMatch: GitHubPullRequestProbeItem?
-            var preferredMatchUsedCache = false
+            var matchedPullRequest: GitHubPullRequestProbeItem?
+            var matchedPullRequestUsedCache = false
             var sawTransientFailure = false
             var sawCachedSuccess = false
 
             for repoSlug in candidate.repoSlugs {
                 guard let repoResult = repoResults[repoSlug] else { continue }
                 switch repoResult {
-                case .success(let cacheEntry, let usedCache):
+                case .success(let cacheEntry, let usedCache, let transientBranches):
                     if usedCache {
                         sawCachedSuccess = true
                     }
-                    guard let matchedPullRequest = cacheEntry.pullRequestsByBranch[candidate.branch] else {
-                        continue
+                    if let candidateMatch = cacheEntry.pullRequestsByBranch[candidate.branch] {
+                        matchedPullRequest = candidateMatch
+                        matchedPullRequestUsedCache = usedCache
+                        break
                     }
-                    if let currentBest = preferredMatch {
-                        let updatedPreferred = preferredPullRequest(from: [currentBest, matchedPullRequest]) ?? currentBest
-                        preferredMatch = updatedPreferred
-                        if updatedPreferred == matchedPullRequest {
-                            preferredMatchUsedCache = usedCache
-                        }
-                    } else {
-                        preferredMatch = matchedPullRequest
-                        preferredMatchUsedCache = usedCache
+                    if transientBranches.contains(candidate.branch) {
+                        sawTransientFailure = true
                     }
                 case .transientFailure:
                     sawTransientFailure = true
@@ -3020,17 +3041,17 @@ class TabManager: ObservableObject {
 
             let resolution: WorkspacePullRequestRefreshResult.Resolution
             let usedCachedRepoData: Bool
-            if let preferredMatch,
-               let status = pullRequestStatus(from: preferredMatch.state) {
+            if let matchedPullRequest,
+               let status = pullRequestStatus(from: matchedPullRequest.state) {
                 resolution = .resolved(
                     WorkspacePullRequestResolvedItem(
-                        number: preferredMatch.number,
-                        urlString: preferredMatch.url,
+                        number: matchedPullRequest.number,
+                        urlString: matchedPullRequest.url,
                         statusRawValue: status.rawValue,
                         branch: candidate.branch
                     )
                 )
-                usedCachedRepoData = preferredMatchUsedCache
+                usedCachedRepoData = matchedPullRequestUsedCache
             } else if sawTransientFailure {
                 resolution = .transientFailure
                 usedCachedRepoData = false
@@ -3050,9 +3071,51 @@ class TabManager: ObservableObject {
 
     private nonisolated static func workspacePullRequestRepoFetchResult(
         repoSlug: String,
+        candidateBranches: Set<String>,
+        cachedEntry: WorkspacePullRequestRepoCacheEntry?,
+        useCachedRecentWindow: Bool,
         session: URLSession,
         authHeader: String?
     ) async -> WorkspacePullRequestRepoFetchResult {
+        let normalizedCandidateBranches = Set(candidateBranches.compactMap(normalizedBranchName))
+
+        if useCachedRecentWindow,
+           let cachedEntry {
+            let unresolvedBranches = unresolvedWorkspacePullRequestBranches(
+                normalizedCandidateBranches,
+                in: cachedEntry
+            )
+            if unresolvedBranches.isEmpty {
+#if DEBUG
+                dlog(
+                    "workspace.prRefresh.repo.cache repo=\(repoSlug) " +
+                    "branches=\(cachedEntry.pullRequestsByBranch.count)"
+                )
+#endif
+                return .success(cachedEntry, usedCache: true, transientBranches: [])
+            }
+
+            let lookupOutcome = await workspacePullRequestBranchLookupOutcome(
+                repoSlug: repoSlug,
+                candidateBranches: unresolvedBranches,
+                baseEntry: cachedEntry,
+                refreshedAt: Date(),
+                session: session,
+                authHeader: authHeader
+            )
+#if DEBUG
+            dlog(
+                "workspace.prRefresh.repo.cache.miss repo=\(repoSlug) " +
+                "branchLookups=\(unresolvedBranches.count) transient=\(lookupOutcome.transientBranches.count)"
+            )
+#endif
+            return .success(
+                lookupOutcome.cacheEntry,
+                usedCache: false,
+                transientBranches: lookupOutcome.transientBranches
+            )
+        }
+
         let fetchTimestamp = Date()
         var page = 1
         var fetchedPageCount = 0
@@ -3087,17 +3150,187 @@ class TabManager: ObservableObject {
             page += 1
         }
 
-        let cacheEntry = WorkspacePullRequestRepoCacheEntry(
+        let recentWindowEntry = WorkspacePullRequestRepoCacheEntry(
             fetchedAt: fetchTimestamp,
             pullRequestsByBranch: pullRequestMapByNormalizedBranch(from: allPullRequests)
         )
+        let unresolvedBranches = unresolvedWorkspacePullRequestBranches(
+            normalizedCandidateBranches,
+            in: recentWindowEntry
+        )
+        let lookupOutcome: WorkspacePullRequestBranchLookupOutcome
+        if unresolvedBranches.isEmpty {
+            lookupOutcome = WorkspacePullRequestBranchLookupOutcome(
+                cacheEntry: recentWindowEntry,
+                transientBranches: []
+            )
+        } else {
+            lookupOutcome = await workspacePullRequestBranchLookupOutcome(
+                repoSlug: repoSlug,
+                candidateBranches: unresolvedBranches,
+                baseEntry: recentWindowEntry,
+                refreshedAt: fetchTimestamp,
+                session: session,
+                authHeader: authHeader
+            )
+        }
 #if DEBUG
         dlog(
             "workspace.prRefresh.repo.success repo=\(repoSlug) pages=\(fetchedPageCount) " +
-            "branches=\(cacheEntry.pullRequestsByBranch.count)"
+            "branches=\(lookupOutcome.cacheEntry.pullRequestsByBranch.count) " +
+            "branchLookups=\(unresolvedBranches.count) transient=\(lookupOutcome.transientBranches.count)"
         )
 #endif
-        return .success(cacheEntry, usedCache: false)
+        return .success(
+            lookupOutcome.cacheEntry,
+            usedCache: false,
+            transientBranches: lookupOutcome.transientBranches
+        )
+    }
+
+    private nonisolated static func unresolvedWorkspacePullRequestBranches(
+        _ candidateBranches: Set<String>,
+        in cacheEntry: WorkspacePullRequestRepoCacheEntry
+    ) -> [String] {
+        candidateBranches
+            .filter {
+                cacheEntry.pullRequestsByBranch[$0] == nil
+                    && !cacheEntry.knownAbsentBranches.contains($0)
+            }
+            .sorted()
+    }
+
+    private nonisolated static func workspacePullRequestBranchLookupOutcome(
+        repoSlug: String,
+        candidateBranches: [String],
+        baseEntry: WorkspacePullRequestRepoCacheEntry,
+        refreshedAt: Date,
+        session: URLSession,
+        authHeader: String?
+    ) async -> WorkspacePullRequestBranchLookupOutcome {
+        guard !candidateBranches.isEmpty else {
+            return WorkspacePullRequestBranchLookupOutcome(
+                cacheEntry: baseEntry,
+                transientBranches: []
+            )
+        }
+
+        let branchResults = await withTaskGroup(
+            of: (String, WorkspacePullRequestBranchFetchResult).self,
+            returning: [(String, WorkspacePullRequestBranchFetchResult)].self
+        ) { group in
+            for branch in candidateBranches {
+                group.addTask {
+                    let result = await Self.workspacePullRequestBranchFetchResult(
+                        repoSlug: repoSlug,
+                        branch: branch,
+                        session: session,
+                        authHeader: authHeader
+                    )
+                    return (branch, result)
+                }
+            }
+
+            var collected: [(String, WorkspacePullRequestBranchFetchResult)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        var pullRequestsByBranch = baseEntry.pullRequestsByBranch
+        var knownAbsentBranches = baseEntry.knownAbsentBranches
+        var transientBranches: Set<String> = []
+
+        for (branch, result) in branchResults {
+            switch result {
+            case .found(let pullRequest):
+                pullRequestsByBranch[branch] = pullRequest
+                knownAbsentBranches.remove(branch)
+            case .notFound:
+                knownAbsentBranches.insert(branch)
+            case .transientFailure:
+                transientBranches.insert(branch)
+            }
+        }
+
+        return WorkspacePullRequestBranchLookupOutcome(
+            cacheEntry: WorkspacePullRequestRepoCacheEntry(
+                fetchedAt: refreshedAt,
+                pullRequestsByBranch: pullRequestsByBranch,
+                knownAbsentBranches: knownAbsentBranches
+            ),
+            transientBranches: transientBranches
+        )
+    }
+
+    private nonisolated static func workspacePullRequestBranchFetchResult(
+        repoSlug: String,
+        branch: String,
+        session: URLSession,
+        authHeader: String?
+    ) async -> WorkspacePullRequestBranchFetchResult {
+        guard let endpoint = workspacePullRequestBranchEndpoint(
+            repoSlug: repoSlug,
+            branch: branch
+        ) else {
+            return .transientFailure
+        }
+
+        guard let response = await performWorkspacePullRequestRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: authHeader
+        ) else {
+#if DEBUG
+            dlog("workspace.prRefresh.branch.fail repo=\(repoSlug) branch=\(branch) status=nil")
+#endif
+            return .transientFailure
+        }
+
+        guard response.statusCode == 200,
+              let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
+#if DEBUG
+            dlog(
+                "workspace.prRefresh.branch.fail repo=\(repoSlug) " +
+                "branch=\(branch) status=\(response.statusCode)"
+            )
+#endif
+            return .transientFailure
+        }
+
+        let matchingPullRequests = pullRequests
+            .map(Self.workspacePullRequestProbeItem)
+            .filter { normalizedBranchName($0.headRefName) == branch }
+        if let preferredPullRequest = preferredPullRequest(from: matchingPullRequests) {
+            return .found(preferredPullRequest)
+        }
+        return .notFound
+    }
+
+    private nonisolated static func workspacePullRequestBranchEndpoint(
+        repoSlug: String,
+        branch: String
+    ) -> String? {
+        let components = repoSlug.split(separator: "/", maxSplits: 1).map(String.init)
+        guard components.count == 2,
+              !components[0].isEmpty,
+              !components[1].isEmpty else {
+            return nil
+        }
+
+        var query = URLComponents()
+        query.queryItems = [
+            URLQueryItem(name: "state", value: "all"),
+            URLQueryItem(name: "head", value: "\(components[0]):\(branch)"),
+            URLQueryItem(name: "sort", value: "updated"),
+            URLQueryItem(name: "direction", value: "desc"),
+            URLQueryItem(name: "per_page", value: String(Self.workspacePullRequestRepoPageSize)),
+        ]
+        guard let percentEncodedQuery = query.percentEncodedQuery else {
+            return nil
+        }
+        return "repos/\(repoSlug)/pulls?\(percentEncodedQuery)"
     }
 
     private nonisolated static func workspacePullRequestProbeItem(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -389,8 +389,7 @@ class TerminalController {
         label: String,
         url: URL,
         status: SidebarPullRequestStatus,
-        branch: String?,
-        checks: SidebarPullRequestChecksStatus?
+        branch: String?
     ) -> Bool {
         guard let current else { return true }
         let normalizedBranch = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -406,24 +405,11 @@ class TerminalController {
             }
             return current.branch
         }()
-        let effectiveChecks: SidebarPullRequestChecksStatus? = {
-            if let checks {
-                return checks
-            }
-            guard current.number == number,
-                  current.label == label,
-                  current.url == url,
-                  current.status == status else {
-                return nil
-            }
-            return current.checks
-        }()
         return current.number != number
             || current.label != label
             || current.url != url
             || current.status != status
             || current.branch != effectiveBranch
-            || current.checks != effectiveChecks
     }
 
     nonisolated static func shouldReplacePorts(current: [Int]?, next: [Int]) -> Bool {
@@ -15149,14 +15135,11 @@ class TerminalController {
         }
         let branch = normalizedOptionValue(parsed.options["branch"])
 
-        let checks: SidebarPullRequestChecksStatus?
         if let rawChecks = normalizedOptionValue(parsed.options["checks"]) {
             guard let parsedChecks = SidebarPullRequestChecksStatus(rawValue: rawChecks.lowercased()) else {
                 return "ERROR: Invalid pull request checks '\(rawChecks)' — use: pass, fail, pending"
             }
-            checks = parsedChecks
-        } else {
-            checks = nil
+            _ = parsedChecks
         }
 
         let labelRaw = normalizedOptionValue(parsed.options["label"]) ?? "PR"
@@ -15178,8 +15161,7 @@ class TerminalController {
                 label: label,
                 url: url,
                 status: status,
-                branch: branch,
-                checks: checks
+                branch: branch
             ) else {
                 return
             }
@@ -15190,8 +15172,7 @@ class TerminalController {
                 label: label,
                 url: url,
                 status: status,
-                branch: branch,
-                checks: checks
+                branch: branch
             )
         }
     }
@@ -15618,11 +15599,9 @@ class TerminalController {
             if let pr = tab.sidebarPullRequestsInDisplayOrder().first {
                 lines.append("pr=#\(pr.number) \(pr.status.rawValue) \(pr.url.absoluteString)")
                 lines.append("pr_label=\(pr.label)")
-                lines.append("pr_checks=\(pr.checks?.rawValue ?? "none")")
             } else {
                 lines.append("pr=none")
                 lines.append("pr_label=none")
-                lines.append("pr_checks=none")
             }
 
             if tab.listeningPorts.isEmpty {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -410,6 +410,7 @@ class TerminalController {
             || current.url != url
             || current.status != status
             || current.branch != effectiveBranch
+            || current.isStale
     }
 
     nonisolated static func shouldReplacePorts(current: [Int]?, next: [Int]) -> Bool {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -15135,13 +15135,7 @@ class TerminalController {
             return "ERROR: Invalid pull request state '\(statusRaw)' — use: open, merged, closed"
         }
         let branch = normalizedOptionValue(parsed.options["branch"])
-
-        if let rawChecks = normalizedOptionValue(parsed.options["checks"]) {
-            guard let parsedChecks = SidebarPullRequestChecksStatus(rawValue: rawChecks.lowercased()) else {
-                return "ERROR: Invalid pull request checks '\(rawChecks)' — use: pass, fail, pending"
-            }
-            _ = parsedChecks
-        }
+        _ = normalizedOptionValue(parsed.options["checks"])
 
         let labelRaw = normalizedOptionValue(parsed.options["label"]) ?? "PR"
         guard !labelRaw.isEmpty else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -11419,8 +11419,8 @@ class TerminalController {
           clear_progress [--tab=X] - Clear progress bar
           report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y] - Report git branch
           clear_git_branch [--tab=X] [--panel=Y] - Clear git branch
-          report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--checks=pass|fail|pending] [--tab=X] [--panel=Y] - Report pull request / review item
-          report_review <number> <url> [--label=MR] [--state=open|merged|closed] [--checks=pass|fail|pending] [--tab=X] [--panel=Y] - Alias for provider-specific review item
+          report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y] - Report pull request / review item
+          report_review <number> <url> [--label=MR] [--state=open|merged|closed] [--tab=X] [--panel=Y] - Alias for provider-specific review item
           clear_pr [--tab=X] [--panel=Y] - Clear pull request
           report_ports <port1> [port2...] [--tab=X] [--panel=Y] - Report listening ports
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
@@ -15114,7 +15114,7 @@ class TerminalController {
     private func reportPullRequest(_ args: String) -> String {
         let parsed = parseOptions(args)
         guard parsed.positional.count >= 2 else {
-            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--checks=pass|fail|pending] [--tab=X] [--panel=Y]"
+            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
         }
 
         let rawNumber = parsed.positional[0].trimmingCharacters(in: .whitespacesAndNewlines)
@@ -15135,11 +15135,13 @@ class TerminalController {
             return "ERROR: Invalid pull request state '\(statusRaw)' — use: open, merged, closed"
         }
         let branch = normalizedOptionValue(parsed.options["branch"])
-        _ = normalizedOptionValue(parsed.options["checks"])
+        if normalizedOptionValue(parsed.options["checks"]) != nil {
+            return "ERROR: Unsupported option '--checks' — pull request checks are no longer tracked"
+        }
 
         let labelRaw = normalizedOptionValue(parsed.options["label"]) ?? "PR"
         guard !labelRaw.isEmpty else {
-            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--checks=pass|fail|pending] [--tab=X] [--panel=Y]"
+            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
         }
         let label = String(labelRaw.prefix(16))
 
@@ -15148,7 +15150,7 @@ class TerminalController {
         return schedulePanelMetadataMutation(
             args: args,
             options: parsed.options,
-            missingPanelUsage: "report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--checks=pass|fail|pending] [--tab=X] [--panel=Y]"
+            missingPanelUsage: "report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
         ) { tab, surfaceId in
             guard Self.shouldReplacePullRequest(
                 current: tab.panelPullRequests[surfaceId],

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6057,7 +6057,7 @@ struct SidebarPullRequestState: Equatable {
     let url: URL
     let status: SidebarPullRequestStatus
     let branch: String?
-    let checks: SidebarPullRequestChecksStatus?
+    let isStale: Bool
 
     init(
         number: Int,
@@ -6065,14 +6065,14 @@ struct SidebarPullRequestState: Equatable {
         url: URL,
         status: SidebarPullRequestStatus,
         branch: String? = nil,
-        checks: SidebarPullRequestChecksStatus? = nil
+        isStale: Bool = false
     ) {
         self.number = number
         self.label = label
         self.url = url
         self.status = status
         self.branch = normalizedSidebarBranchName(branch)
-        self.checks = checks
+        self.isStale = isStale
     }
 }
 
@@ -6317,13 +6317,8 @@ enum SidebarBranchOrdering {
             }
         }
 
-        func checksPriority(_ checks: SidebarPullRequestChecksStatus?) -> Int {
-            switch checks {
-            case .fail: return 3
-            case .pending: return 2
-            case .pass: return 1
-            case nil: return 0
-            }
+        func freshnessPriority(_ isStale: Bool) -> Int {
+            isStale ? 0 : 1
         }
 
         func normalizedReviewURLKey(for url: URL) -> String {
@@ -6363,7 +6358,7 @@ enum SidebarBranchOrdering {
             if statusPriority(state.status) > statusPriority(existing.status) {
                 pullRequestsByKey[key] = state
             } else if state.status == existing.status,
-                      checksPriority(state.checks) > checksPriority(existing.checks) {
+                      freshnessPriority(state.isStale) > freshnessPriority(existing.isStale) {
                 pullRequestsByKey[key] = state
             }
         }
@@ -7616,7 +7611,7 @@ final class Workspace: Identifiable, ObservableObject {
         url: URL,
         status: SidebarPullRequestStatus,
         branch: String? = nil,
-        checks: SidebarPullRequestChecksStatus? = nil
+        isStale: Bool = false
     ) {
         let existing = panelPullRequests[panelId]
         let normalizedBranch = normalizedSidebarBranchName(branch)
@@ -7637,26 +7632,13 @@ final class Workspace: Identifiable, ObservableObject {
             }
             return existing.branch
         }()
-        let resolvedChecks: SidebarPullRequestChecksStatus? = {
-            if let checks {
-                return checks
-            }
-            guard let existing,
-                  existing.number == number,
-                  existing.label == label,
-                  existing.url == url,
-                  existing.status == status else {
-                return nil
-            }
-            return existing.checks
-        }()
         let state = SidebarPullRequestState(
             number: number,
             label: label,
             url: url,
             status: status,
             branch: resolvedBranch,
-            checks: resolvedChecks
+            isStale: isStale
         )
         if existing != state {
             panelPullRequests[panelId] = state

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6355,10 +6355,10 @@ enum SidebarBranchOrdering {
                 continue
             }
             guard let existing = pullRequestsByKey[key] else { continue }
-            if statusPriority(state.status) > statusPriority(existing.status) {
+            if freshnessPriority(state.isStale) > freshnessPriority(existing.isStale) {
                 pullRequestsByKey[key] = state
-            } else if state.status == existing.status,
-                      freshnessPriority(state.isStale) > freshnessPriority(existing.isStale) {
+            } else if freshnessPriority(state.isStale) == freshnessPriority(existing.isStale),
+                      statusPriority(state.status) > statusPriority(existing.status) {
                 pullRequestsByKey[key] = state
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6039,12 +6039,6 @@ enum SidebarPullRequestStatus: String {
     case closed
 }
 
-enum SidebarPullRequestChecksStatus: String {
-    case pass
-    case fail
-    case pending
-}
-
 private func normalizedSidebarBranchName(_ branch: String?) -> String? {
     guard let branch else { return nil }
     let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -451,7 +451,8 @@ final class SidebarBranchOrderingTests: XCTestCase {
                     number: 42,
                     label: "PR",
                     url: "https://github.com/manaflow-ai/cmux/pull/42",
-                    status: .open
+                    status: .open,
+                    isStale: true
                 ),
                 second: pullRequestState(
                     number: 42,

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -388,7 +388,8 @@ final class SidebarBranchOrderingTests: XCTestCase {
                     number: 42,
                     label: "PR",
                     url: "https://github.com/manaflow-ai/cmux/pull/42",
-                    status: .open
+                    status: .open,
+                    isStale: true
                 ),
                 second: pullRequestState(
                     number: 42,
@@ -438,7 +439,7 @@ final class SidebarBranchOrderingTests: XCTestCase {
         )
     }
 
-    func testOrderedUniquePullRequestsPrefersEntryWithChecksWhenStatusesMatch() {
+    func testOrderedUniquePullRequestsPrefersFreshEntryWhenStatusesMatch() {
         let first = UUID()
         let second = UUID()
 
@@ -456,18 +457,18 @@ final class SidebarBranchOrderingTests: XCTestCase {
                     label: "PR",
                     url: "https://github.com/manaflow-ai/cmux/pull/42",
                     status: .open,
-                    checks: .pass
+                    isStale: false
                 )
             ],
             fallbackPullRequest: nil
         )
 
         XCTAssertEqual(pullRequests.count, 1)
-        XCTAssertEqual(pullRequests.first?.checks, .pass)
+        XCTAssertEqual(pullRequests.first?.isStale, false)
     }
 
     @MainActor
-    func testUpdatePanelPullRequestPreservesExistingChecksWhenUpdateOmitsThem() {
+    func testUpdatePanelPullRequestClearsStaleFlagOnFreshUpdate() {
         let workspace = Workspace(title: "Tests", workingDirectory: FileManager.default.currentDirectoryPath, portOrdinal: 0)
         guard let panelId = workspace.focusedPanelId else {
             XCTFail("Expected focused panel for new workspace")
@@ -480,7 +481,7 @@ final class SidebarBranchOrderingTests: XCTestCase {
             label: "PR",
             url: URL(string: "https://github.com/manaflow-ai/cmux/pull/42")!,
             status: .open,
-            checks: .pass
+            isStale: true
         )
         workspace.updatePanelPullRequest(
             panelId: panelId,
@@ -490,8 +491,8 @@ final class SidebarBranchOrderingTests: XCTestCase {
             status: .open
         )
 
-        XCTAssertEqual(workspace.panelPullRequests[panelId]?.checks, .pass)
-        XCTAssertEqual(workspace.pullRequest?.checks, .pass)
+        XCTAssertEqual(workspace.panelPullRequests[panelId]?.isStale, false)
+        XCTAssertEqual(workspace.pullRequest?.isStale, false)
     }
 
     func testOrderedUniquePullRequestsUsesFallbackWhenNoPanelPullRequestsExist() {
@@ -561,7 +562,7 @@ final class SidebarBranchOrderingTests: XCTestCase {
         url: String,
         status: SidebarPullRequestStatus,
         branch: String? = nil,
-        checks: SidebarPullRequestChecksStatus? = nil
+        isStale: Bool = false
     ) -> SidebarPullRequestState {
         SidebarPullRequestState(
             number: number,
@@ -569,7 +570,7 @@ final class SidebarBranchOrderingTests: XCTestCase {
             url: URL(string: url)!,
             status: status,
             branch: branch,
-            checks: checks
+            isStale: isStale
         )
     }
 }

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -418,7 +418,8 @@ final class SidebarBranchOrderingTests: XCTestCase {
                     number: 42,
                     label: "PR",
                     url: "https://github.com/manaflow-ai/cmux/pull/42",
-                    status: .open
+                    status: .open,
+                    isStale: true
                 ),
                 second: pullRequestState(
                     number: 42,

--- a/cmuxTests/SidebarOrderingTests.swift
+++ b/cmuxTests/SidebarOrderingTests.swift
@@ -921,6 +921,29 @@ final class TerminalControllerSidebarDedupeTests: XCTestCase {
         )
     }
 
+    func testShouldReplacePullRequestReturnsTrueWhenCurrentStateIsStale() throws {
+        let url = try XCTUnwrap(URL(string: "https://github.com/manaflow-ai/cmux/pull/42"))
+        let current = SidebarPullRequestState(
+            number: 42,
+            label: "PR",
+            url: url,
+            status: .open,
+            branch: "feature/work",
+            isStale: true
+        )
+
+        XCTAssertTrue(
+            TerminalController.shouldReplacePullRequest(
+                current: current,
+                number: 42,
+                label: "PR",
+                url: url,
+                status: .open,
+                branch: "feature/work"
+            )
+        )
+    }
+
     func testExplicitSocketScopeParsesValidUUIDTabAndPanel() {
         let workspaceId = UUID()
         let panelId = UUID()

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -404,6 +404,40 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertFalse(TabManager.shouldSkipWorkspacePullRequestLookup(branch: "release/master-fix"))
     }
 
+    func testWorkspacePullRequestRefreshAllowsRepoCacheForTimerAndPeriodicReasons() {
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "periodicPoll"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "selectedPeriodicPoll.followUp"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer.followUp"))
+
+        XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange"))
+        XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange.followUp"))
+        XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt"))
+        XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "commandHint:merge"))
+    }
+
+    func testWorkspacePullRequestShouldRefreshHonorsForcedRefreshForTerminalStates() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let recentTerminalRefresh = now.addingTimeInterval(-60)
+
+        XCTAssertTrue(
+            TabManager.shouldRefreshWorkspacePullRequest(
+                now: now,
+                nextPollAt: .distantPast,
+                lastTerminalStateRefreshAt: recentTerminalRefresh,
+                currentPullRequestStatus: .merged
+            )
+        )
+        XCTAssertFalse(
+            TabManager.shouldRefreshWorkspacePullRequest(
+                now: now,
+                nextPollAt: now.addingTimeInterval(60),
+                lastTerminalStateRefreshAt: recentTerminalRefresh,
+                currentPullRequestStatus: .closed
+            )
+        )
+    }
+
     func testTrackedWorkspaceGitMetadataPollCandidatesIncludeMainAndMasterPanels() throws {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -406,6 +406,8 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
 
     func testWorkspacePullRequestRefreshAllowsRepoCacheForTimerAndPeriodicReasons() {
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "periodicPoll"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "periodicPoll.followUp"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "selectedPeriodicPoll"))
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "selectedPeriodicPoll.followUp"))
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer"))
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer.followUp"))

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -56,7 +56,7 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
             url: url,
             status: .open,
             branch: "feature/work",
-            checks: .pass
+            isStale: true
         )
         workspace.panelPullRequests[secondPanelId] = SidebarPullRequestState(
             number: 1640,


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/2659

## Summary
- coalesce sidebar PR refreshes into one `gh pr list --repo ... --state all --limit 200 --json number,state,url,updatedAt,headRefName` fetch per repo, with a 15s repo cache and REST fallback
- replace the generation/cancel git probe flow with an idle/inFlight(rerunPending) state machine and update PR polling cadence to 10s selected / 60s background with jitter
- drop PR checks fetching/rendering, skip terminal-state polling except for 15 minute sanity sweeps, and dim stale badges after repeated transient failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors and replaces the sidebar pull-request polling pipeline (timers, caching, retry/state handling) and changes PR state semantics, which could impact sidebar freshness or GitHub API behavior despite being UI-adjacent.
> 
> **Overview**
> **Sidebar pull request tracking is reworked to poll GitHub per-repo with caching and smarter scheduling.** The old per-panel REST poller and `gh pr checks` fetching are removed; PR refresh now coalesces candidates by repo, fetches `/pulls?state=all` (paged/limited) with a short-lived repo cache plus branch-scoped fallbacks, and adds jittered intervals with reduced polling for terminal PR states.
> 
> **PR “checks” are dropped and replaced with a “stale” concept.** `SidebarPullRequestState` removes `checks` and adds `isStale`; after repeated transient failures PRs are marked stale and the sidebar row is dimmed. Ordering/merge rules and the `report_pr` CLI are updated accordingly (rejecting `--checks`), and tests are updated/added to cover caching decisions, stale replacement, and ordering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f457bf9bb0096ff5a44e7bafcd629b4a03228579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces sidebar PR polling per repo with a 15s GitHub REST cache and branch-level fallback. Removes PR checks, adds stale-dimming, and hardens the probe queue; fixes follow-up scheduling and teardown edge cases, addressing #2659.

- **New Features**
  - Repo-wide REST fetch (max 200 PRs) with 15s cache and branch fallback; polling at 10s selected / 60s background with jitter and 15m terminal sweeps.
  - Stale PRs are dimmed; checks removed from models/UI/CLI (`report_pr` rejects `--checks`); ordering prefers fresh over stale.

- **Refactors & Bug Fixes**
  - Replaced probe flow with idle/inFlight(rerunPending) state machines; removed unreferenced GitHubPullRequestRESTPoller actor and dropped the vestigial `burst:` parameter.
  - Fixed always-on follow-up scheduling in applyWorkspacePullRequestRefreshResults; prevented applyWorkspaceGitMetadataSnapshot from resurrecting cleared probe state; tightened tests (freshness ordering, repo-cache allowance).

<sup>Written for commit f457bf9bb0096ff5a44e7bafcd629b4a03228579. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR rows show a visual "stale" state (reduced opacity) and PRs expose an explicit stale flag.

* **Improvements**
  * Status labels simplified to remove checks-based labeling.
  * Refresh flow reworked to per-repo REST fetches with caching, jittered polling, retry/backoff and terminal-state sweeps.
  * Sidebar ordering now prefers fresher (non-stale) PRs.

* **Tests**
  * Tests updated/added to validate stale/fresh behavior, ordering, replacement, and refresh logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->