### PR TITLE
Fix Ctrl-Z killing suspended foreground jobs in bash sessions

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -771,19 +771,28 @@ _cmux_run_pr_probe_with_timeout() {
     local repo_path="$1"
     local force_probe="${2:-0}"
     local probe_pid=""
+    local status_file=""
     local started_at=""
     local now=""
     started_at="$(_cmux_now)"
     now=$started_at
+
+    status_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/cmux-pr-probe-status.XXXXXX" 2>/dev/null || true)"
+    [[ -n "$status_file" ]] || return 1
 
     # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
     probe_pid=$(
         set -m
         (
             _cmux_report_pr_for_path "$repo_path" "$force_probe"
+            echo $? > "$status_file"
         ) &
         echo $!
     )
+    if [[ -z "$probe_pid" ]]; then
+        /bin/rm -f -- "$status_file" >/dev/null 2>&1 || true
+        return 1
+    fi
 
     while kill -0 "$probe_pid" >/dev/null 2>&1; do
         sleep 1
@@ -795,14 +804,22 @@ _cmux_run_pr_probe_with_timeout() {
                 _cmux_kill_process_tree "$probe_pid" KILL
                 sleep 0.2
             fi
-            if ! kill -0 "$probe_pid" >/dev/null 2>&1; then
-                wait "$probe_pid" >/dev/null 2>&1 || true
-            fi
+            /bin/rm -f -- "$status_file" >/dev/null 2>&1 || true
             return 1
         fi
     done
 
-    wait "$probe_pid"
+    # The probe is no longer a direct child (it was launched in a subshell
+    # for the isolated process group), so `wait` would fail. Read its
+    # exit status from the status file written by the probe itself.
+    sleep 0.05
+    local probe_status=1
+    if [[ -s "$status_file" ]]; then
+        probe_status="$(/bin/cat "$status_file" 2>/dev/null || echo 1)"
+    fi
+    [[ "$probe_status" =~ ^[0-9]+$ ]] || probe_status=1
+    /bin/rm -f -- "$status_file" >/dev/null 2>&1 || true
+    return "$probe_status"
 }
 
 _cmux_halt_pr_poll_loop() {

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -72,10 +72,10 @@ _cmux_relay_rpc_bg() {
     local relay_cli=""
     _cmux_socket_uses_remote_relay || return 1
     relay_cli="$(_cmux_relay_cli_path)" || return 1
-    {
+    # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+    ( set -m; {
         "$relay_cli" rpc "$method" "$params" >/dev/null 2>&1 || true
-    } >/dev/null 2>&1 &
-    disown 2>/dev/null || true
+    } >/dev/null 2>&1 & )
 }
 
 _cmux_relay_rpc() {
@@ -380,9 +380,13 @@ _cmux_report_tty_once() {
         payload="$(_cmux_report_tty_payload)"
         [[ -n "$payload" ]] || return 0
         _CMUX_TTY_REPORTED=1
-        {
+        # Run in its own process group so bash's stopped-job cleanup
+        # (triggered by Ctrl-Z on a foreground job) cannot SIGHUP this
+        # background subshell and the suspended job along with it.
+        # See https://github.com/manaflow-ai/cmux/issues/2105
+        ( set -m; {
             _cmux_send "$payload"
-        } >/dev/null 2>&1 & disown
+        } >/dev/null 2>&1 & )
     else
         [[ -n "$_CMUX_TTY_NAME" ]] || return 0
         # Keep the first relay TTY report synchronous so the server can resolve
@@ -400,9 +404,10 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
+    # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+    ( set -m; {
         _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    } >/dev/null 2>&1 & )
 }
 
 _cmux_ports_kick() {
@@ -416,9 +421,10 @@ _cmux_ports_kick() {
     fi
     _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     if _cmux_socket_is_unix; then
-        {
+        # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+        ( set -m; {
             _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
-        } >/dev/null 2>&1 & disown
+        } >/dev/null 2>&1 & )
     else
         _cmux_ports_kick_via_relay "$reason"
     fi
@@ -514,9 +520,10 @@ _cmux_emit_pr_command_hint() {
         local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
         payload+=" --target=\"$quoted_target\""
     fi
-    {
+    # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+    ( set -m; {
         _cmux_send "$payload"
-    } >/dev/null 2>&1 & disown
+    } >/dev/null 2>&1 & )
     _CMUX_LAST_PR_ACTION=""
     _CMUX_LAST_PR_TARGET=""
 }
@@ -769,10 +776,14 @@ _cmux_run_pr_probe_with_timeout() {
     started_at="$(_cmux_now)"
     now=$started_at
 
-    (
-        _cmux_report_pr_for_path "$repo_path" "$force_probe"
-    ) &
-    probe_pid=$!
+    # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+    probe_pid=$(
+        set -m
+        (
+            _cmux_report_pr_for_path "$repo_path" "$force_probe"
+        ) &
+        echo $!
+    )
 
     while kill -0 "$probe_pid" >/dev/null 2>&1; do
         sleep 1
@@ -835,31 +846,36 @@ _cmux_start_pr_poll_loop() {
     fi
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
-    {
-        local signal_path=""
-        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-        while :; do
-            kill -0 "$watch_shell_pid" 2>/dev/null || break
-            local force_probe=0
-            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                force_probe=1
-                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-            fi
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
-
-            local slept=0
-            while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
+    # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+    # `set -m` inside the command substitution gives the inner `&` its own
+    # process group; `echo $!` relays the PID so we can still kill -0 / kill it.
+    _CMUX_PR_POLL_PID=$(
+        set -m
+        {
+            local signal_path=""
+            signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
+            while :; do
+                kill -0 "$watch_shell_pid" 2>/dev/null || break
+                local force_probe=0
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                    break
+                    force_probe=1
+                    /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
                 fi
-                sleep 1
-                slept=$(( slept + 1 ))
+                _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
+
+                local slept=0
+                while (( slept < interval )); do
+                    kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
+                    if [[ -n "$signal_path" && -f "$signal_path" ]]; then
+                        break
+                    fi
+                    sleep 1
+                    slept=$(( slept + 1 ))
+                done
             done
-        done
-    } >/dev/null 2>&1 &
-    _CMUX_PR_POLL_PID=$!
-    disown "$_CMUX_PR_POLL_PID" 2>/dev/null || disown
+        } >/dev/null 2>&1 &
+        echo $!
+    )
 }
 
 _cmux_bash_cleanup() {
@@ -1004,10 +1020,11 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
+        # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+        ( set -m; {
             local qpwd="${pwd//\"/\\\"}"
             _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+        } >/dev/null 2>&1 & )
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -1051,22 +1068,27 @@ _cmux_prompt_command() {
     if [[ -z "$_CMUX_GIT_JOB_PID" ]] || ! kill -0 "$_CMUX_GIT_JOB_PID" 2>/dev/null; then
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
-        {
-            # Skip git operations if not in a git repository to avoid TCC prompts
-            git rev-parse --git-dir >/dev/null 2>&1 || return 0
-            local branch dirty_opt=""
-            branch=$(git branch --show-current 2>/dev/null)
-            if [[ -n "$branch" ]]; then
-                local first
-                first=$(git status --porcelain -uno 2>/dev/null | head -1)
-                [[ -n "$first" ]] && dirty_opt="--status=dirty"
-                _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            else
-                _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-            fi
-        } >/dev/null 2>&1 &
-        _CMUX_GIT_JOB_PID=$!
-        disown
+        # Isolated process group: see issue #2105 (Ctrl-Z stopped-job SIGHUP).
+        # `set -m` inside the command substitution gives the inner `&` its own
+        # process group; `echo $!` relays the PID so kill -0 / kill still work.
+        _CMUX_GIT_JOB_PID=$(
+            set -m
+            {
+                # Skip git operations if not in a git repository to avoid TCC prompts
+                git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+                local branch dirty_opt=""
+                branch=$(git branch --show-current 2>/dev/null)
+                if [[ -n "$branch" ]]; then
+                    local first
+                    first=$(git status --porcelain -uno 2>/dev/null | head -1)
+                    [[ -n "$first" ]] && dirty_opt="--status=dirty"
+                    _cmux_send "report_git_branch $branch $dirty_opt --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                else
+                    _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                fi
+            } >/dev/null 2>&1 &
+            echo $!
+        )
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 


### PR DESCRIPTION
## Summary
- Fixes Ctrl-Z killing suspended foreground jobs (vim, less, nano, etc.) in bash sessions inside cmux.
- Wraps every `{ ... } & disown` site in `cmux-bash-integration.bash` so the background work runs in its **own process group**, isolating it from bash's stopped-job SIGHUP cleanup.
- Closes https://github.com/manaflow-ai/cmux/issues/2105

## Root cause

When a foreground job is suspended with Ctrl-Z, bash sends SIGTSTP to the foreground process, reclaims the terminal, and runs `PROMPT_COMMAND`. cmux's `_cmux_prompt_command` then spawned background subshells with `{ ... } & disown`.

`disown` only removes the job from bash's job table — it does **not** put the child in a separate process group. The disowned child stays in the shell's pgid. When that background subshell exits, bash notices a stopped job in the same pgid and runs its cleanup, which prints `bash: warning: deleting stopped job 1 with process group <pgid>` and SIGHUPs the whole pgid — killing the suspended foreground job.

Diagnosis credit goes to @anthhub in the issue thread; initial fix approach goes to @freshtonic.

## The fix

Replace every `{ ... } >/dev/null 2>&1 & disown` with one of:

- **Fire-and-forget:** `( set -m; { ... } >/dev/null 2>&1 & )` — the outer subshell enables job control via `set -m`, so the inner `&` gets its own pgid, then exits. Bash's stopped-job cleanup can no longer reach it.
- **PID-tracked:** `var=$( set -m; { ... } & echo $! )` — same trick, but the inner PID is relayed via `echo $!` so existing `kill -0` / `kill` cleanup paths still work.

`setsid` was rejected because it is not in macOS's default PATH (per the discussion in the issue thread).

## Call sites updated

All in `Resources/shell-integration/cmux-bash-integration.bash`:

- `_cmux_relay_rpc_bg`
- `_cmux_report_tty_once`
- `_cmux_report_shell_activity_state`
- `_cmux_ports_kick`
- `_cmux_emit_pr_command_hint`
- `_cmux_prompt_command` (report_pwd block)
- `_cmux_run_pr_probe_with_timeout` (PID-tracked)
- `_cmux_start_pr_poll_loop` (PID-tracked)
- `_cmux_prompt_command` git branch probe (PID-tracked)

After this patch, `grep 'disown\| & *$' cmux-bash-integration.bash` shows zero unwrapped `disown`s.

## Test plan

- [x] `bash -n cmux-bash-integration.bash` passes (no syntax regressions).
- [x] `./scripts/reload.sh --tag issue-2105-ctrl-z` builds successfully.
- [ ] Open dev app, launch a bash terminal (`bash -i`), run `vim`, hit Ctrl-Z. Expected: `[1]+ Stopped vim`, prompt returns, no `bash: warning: deleting stopped job` line, `fg` resumes vim cleanly.
- [ ] Repeat with `less`, `nano`, `sleep 30`, `python3 -i`.
- [ ] Verify the sidebar git branch / PR badges still update on `cd` and `git checkout` (regression check for the PID-tracked rewrites).
- [ ] Verify `ports_kick` still fires (open a workspace, run `python3 -m http.server 8765`, see the port appear in the sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bash job-control/process management across multiple async paths; a mistake could break PR polling, git/TTY/ports reporting, or leave orphaned processes, but scope is limited to shell integration.
> 
> **Overview**
> Fixes a bash job-control bug where cmux’s background subshells could trigger bash stopped-job cleanup and SIGHUP suspended foreground apps after Ctrl-Z.
> 
> All `{ ... } & disown` call sites in `cmux-bash-integration.bash` are rewritten to run under an isolated process group via `set -m`, including TTY/shell-state/PWD/ports reporting and relay RPC.
> 
> Async workflows that need PID tracking (PR probe timeout handling, PR poll loop, git branch probe) are updated to launch in an isolated process group while still returning a usable PID; PR probe exit status is now captured via a temp status file instead of `wait`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9039a6a72abd239b49082b2a591b2a4cbfb8d9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ctrl-Z killing suspended foreground jobs in cmux bash sessions by running background tasks in their own process groups. Suspended apps like vim now survive, no warning, and `fg` resumes cleanly. Fixes #2105.

- **Bug Fixes**
  - Replaced `{ ... } & disown` with isolated wrappers:
    - Fire-and-forget: `( set -m; { ... } >/dev/null 2>&1 & )`
    - PID-tracked: `$( set -m; { ... } & echo $! )`
  - Applied across `cmux-bash-integration.bash` for PR probes/polling, git branch probe, ports kick, TTY and shell-state reports, `report_pwd`, and RPC relay.
  - PR probe: fixed waiting on a non-child by writing the exit code to a temp file and reading it instead of `wait`, preserving timeouts and kill checks with isolated pgids.
  - Reason: `set -m` gives the inner `&` its own process group, avoiding bash’s stopped-job SIGHUP after `PROMPT_COMMAND`.
  - Avoided `setsid` to keep macOS default PATH compatibility.

<sup>Written for commit 9039a6a72abd239b49082b2a591b2a4cbfb8d9f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved background process isolation and lifecycle handling in shell integration for more reliable async tasks, reporting, prompts, and port/PR-related operations.
* **Bug Fixes**
  * Prevented background job termination and incorrect status reporting (e.g., stopped-job SIGHUP and probe/poll PID issues), resulting in steadier polling and status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->