### PR TITLE
Fix terminal blank when last pane closes (#2665)

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11811,7 +11811,23 @@ extension Workspace: BonsplitDelegate {
         if bonsplitController.allPaneIds.contains(pane) {
             normalizePinnedTabs(in: pane)
         }
-        scheduleTerminalGeometryReconcile()
+        // When a pane was auto-closed (e.g. N→1 panes), the SwiftUI split view rebuilds
+        // asynchronously, transiently detaching the surviving terminal surface. The synchronous
+        // ensureFocus from applyTabSelection may succeed on the old layout but the first responder
+        // is lost when SwiftUI tears down the split and recreates a single-pane wrapper. Include
+        // the surviving panel in the layout follow-up so the retry loop re-applies focus once the
+        // view is reattached (#2665).
+        if !isDetaching && !bonsplitController.allPaneIds.contains(pane),
+           let survivingPanelId = focusedPanelId,
+           terminalPanel(for: survivingPanelId) != nil {
+            beginEventDrivenLayoutFollowUp(
+                reason: "workspace.paneCollapse",
+                terminalFocusPanelId: survivingPanelId,
+                includeGeometry: true
+            )
+        } else {
+            scheduleTerminalGeometryReconcile()
+        }
         if !isDetaching {
             scheduleFocusReconcile()
         }
@@ -11931,7 +11947,19 @@ extension Workspace: BonsplitDelegate {
             }
         }
 
-        scheduleTerminalGeometryReconcile()
+        // Same pane-collapse focus fix as didCloseTab (#2665): the SwiftUI split view
+        // rebuild can transiently detach the surviving terminal, losing first responder.
+        if shouldScheduleFocusReconcile,
+           let survivingPanelId = focusedPanelId,
+           terminalPanel(for: survivingPanelId) != nil {
+            beginEventDrivenLayoutFollowUp(
+                reason: "workspace.paneCollapse",
+                terminalFocusPanelId: survivingPanelId,
+                includeGeometry: true
+            )
+        } else {
+            scheduleTerminalGeometryReconcile()
+        }
         if shouldScheduleFocusReconcile {
             scheduleFocusReconcile()
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10068,12 +10068,11 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         if let terminalPanel = panels[panelId] as? TerminalPanel {
-            // Always set up a focus follow-up when the terminal is not yet first responder.
-            // The .terminalFirstResponder trigger always needs it (reentrant focus assertion).
-            // The .standard trigger needs it when the surface view isn't ready yet (e.g.
-            // new workspace via Cmd+T where the portal hasn't attached to a window yet).
+            // Always set up a focus follow-up when the terminal's preferred keyboard target
+            // is not yet active. That target can be either the surface view or the terminal
+            // find field, so surface-first-responder alone is too strict here.
             let needsFocusFollowUp = trigger == .terminalFirstResponder
-                || !terminalPanel.hostedView.isSurfaceViewFirstResponder()
+                || terminalPanelKeyboardFocusNeedsFollowUp(panelId: panelId, terminalPanel: terminalPanel)
             if needsFocusFollowUp {
                 beginEventDrivenLayoutFollowUp(
                     reason: "workspace.focusPanel.terminal",
@@ -10596,7 +10595,19 @@ final class Workspace: Identifiable, ObservableObject {
               let terminalPanel = terminalPanel(for: panelId) else {
             return false
         }
-        return focusedPanelId != panelId || !terminalPanel.hostedView.isSurfaceViewFirstResponder()
+        return terminalPanelKeyboardFocusNeedsFollowUp(panelId: panelId, terminalPanel: terminalPanel)
+    }
+
+    private func terminalPanelKeyboardFocusNeedsFollowUp(
+        panelId: UUID,
+        terminalPanel: TerminalPanel
+    ) -> Bool {
+        guard focusedPanelId == panelId else { return true }
+        guard let window = terminalPanel.hostedView.window,
+              let firstResponder = window.firstResponder else {
+            return true
+        }
+        return !terminalPanel.hostedView.responderMatchesPreferredKeyboardFocus(firstResponder)
     }
 
     private func browserPanelNeedsFollowUp() -> Bool {
@@ -10628,8 +10639,16 @@ final class Workspace: Identifiable, ObservableObject {
         if let terminalFocusPanelId = layoutFollowUpTerminalFocusPanelId {
             if let terminalPanel = terminalPanel(for: terminalFocusPanelId),
                focusedPanelId == terminalFocusPanelId {
-                terminalPanel.hostedView.ensureFocus(for: id, surfaceId: terminalFocusPanelId)
-                if terminalPanel.hostedView.isSurfaceViewFirstResponder() {
+                if terminalPanelKeyboardFocusNeedsFollowUp(
+                    panelId: terminalFocusPanelId,
+                    terminalPanel: terminalPanel
+                ) {
+                    terminalPanel.hostedView.ensureFocus(for: id, surfaceId: terminalFocusPanelId)
+                }
+                if !terminalPanelKeyboardFocusNeedsFollowUp(
+                    panelId: terminalFocusPanelId,
+                    terminalPanel: terminalPanel
+                ) {
                     layoutFollowUpTerminalFocusPanelId = nil
                 }
             } else if terminalPanel(for: terminalFocusPanelId) == nil {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10067,12 +10067,19 @@ final class Workspace: Identifiable, ObservableObject {
             maybeAutoFocusBrowserAddressBarOnPanelFocus(browserPanel, trigger: trigger)
         }
 
-        if trigger == .terminalFirstResponder,
-           panels[panelId] is TerminalPanel {
-            beginEventDrivenLayoutFollowUp(
-                reason: "workspace.focusPanel.terminal",
-                terminalFocusPanelId: panelId
-            )
+        if let terminalPanel = panels[panelId] as? TerminalPanel {
+            // Always set up a focus follow-up when the terminal is not yet first responder.
+            // The .terminalFirstResponder trigger always needs it (reentrant focus assertion).
+            // The .standard trigger needs it when the surface view isn't ready yet (e.g.
+            // new workspace via Cmd+T where the portal hasn't attached to a window yet).
+            let needsFocusFollowUp = trigger == .terminalFirstResponder
+                || !terminalPanel.hostedView.isSurfaceViewFirstResponder()
+            if needsFocusFollowUp {
+                beginEventDrivenLayoutFollowUp(
+                    reason: "workspace.focusPanel.terminal",
+                    terminalFocusPanelId: panelId
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- When closing terminal panes in a workspace down to the last remaining pane, the surviving terminal went blank and stopped accepting input
- Root cause: the SwiftUI split-to-single-pane rebuild transiently detaches the terminal surface view, causing the first responder to be lost. The one-shot async focus reconcile fires before the view is reattached, and no further retry occurs
- Fix: include the surviving panel in the layout follow-up as `terminalFocusPanelId`, so the existing retry loop (triggered by `terminalSurfaceHostedViewDidMoveToWindow`) keeps calling `ensureFocus` until the surface view successfully becomes first responder after reattachment

## Test plan
- [ ] Open a workspace with 2+ split panes
- [ ] Close panes one by one until only 1 remains
- [ ] Verify the surviving terminal is not blank and accepts keyboard input
- [ ] Verify closing panes in a 3+ pane split (leaving 2+ remaining) still works correctly
- [ ] Verify detaching a pane (drag to new workspace) still works correctly

Closes #2665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts workspace focus/layout follow-up logic around terminal first-responder handling and split-view rebuilds; regressions could leave focus stuck or cause extra layout retries in terminal panels.
> 
> **Overview**
> Prevents the surviving terminal from going blank after collapsing split panes by starting an event-driven layout follow-up that keeps re-applying `ensureFocus` until the terminal’s *preferred keyboard target* is active.
> 
> This expands terminal focus follow-up beyond the `.terminalFirstResponder` trigger, adds `terminalPanelKeyboardFocusNeedsFollowUp` (checks window first responder vs. terminal preferred focus), and uses it to gate both follow-up scheduling and clearing. Pane close/collapse paths now prefer `beginEventDrivenLayoutFollowUp(... includeGeometry: true)` for the surviving terminal (skipping detach flows), falling back to the existing geometry reconcile otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e480abf93752f5c54d5ff30d2f6c6b1f367e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank terminals and lost input when collapsing to a single pane or creating a new workspace (Cmd+T). Keeps the surviving terminal—or its find field—in focus so input works (fixes #2665).

- **Bug Fixes**
  - On pane collapse, start an event-driven layout follow-up with the surviving panel as `terminalFocusPanelId` so focus is reapplied after the split rebuild; applies to tab-close and pane-collapse; skipped on detach.
  - Trigger the same follow-up whenever the terminal isn’t at its preferred keyboard target (surface or find field), not only on `.terminalFirstResponder`; covers new workspace creation.
  - In the follow-up loop, stop only after the preferred keyboard target is focused to preserve terminal find focus when active.

<sup>Written for commit f8e480abf93752f5c54d5ff30d2f6c6b1f367e02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus recovery after pane closes or collapses so the remaining terminal reliably regains keyboard focus.
  * Reduced layout/geometry glitches after pane collapse by using a targeted, event-driven layout follow-up when possible, with a safe fallback to a full geometry reconcile when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->