### PR TITLE
Add show-options stub to tmux compatibility layer

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12286,6 +12286,11 @@ struct CMUXCLI {
                 print(message)
             }
 
+        case "show-options":
+            // Stub: omx queries `tmux show-options -sv extended-keys` to check
+            // terminal key mode. cmux handles keys natively, so return empty.
+            print("")
+
         default:
             throw CLIError(message: "Unsupported tmux compatibility command: \(command)")
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2698,7 +2698,9 @@ struct CMUXCLI {
              "paste-buffer",
              "list-buffers",
              "respawn-pane",
-             "display-message":
+             "display-message",
+             "show-options",
+             "show-option":
             try runTmuxCompatCommand(
                 command: command,
                 commandArgs: commandArgs,
@@ -11688,6 +11690,11 @@ struct CMUXCLI {
                 // future splits don't incorrectly redirect to the old column.
                 try tmuxPruneCompatWorkspaceState(workspaceId: workspaceId)
             }
+
+        case "show-options", "show-option":
+            // Stub: omx queries `tmux show-options -sv extended-keys` to check
+            // terminal key mode. cmux handles keys natively, so return empty.
+            print("")
 
         case "set-option", "set", "set-window-option", "setw", "source-file", "refresh-client", "attach-session", "detach-client":
             return


### PR DESCRIPTION
## Summary

- Add `show-options` case to `runTmuxCompatCommand` in `CLI/cmux.swift`
- omx queries `tmux show-options -sv extended-keys` on startup, which routes through cmux's tmux shim and hits the unsupported command error. This stub returns an empty string since cmux handles keys natively.

Fixes #2671

## Testing

- Ran `cmux omx` — no longer errors with "Unsupported tmux compatibility command: show-options"
- Verified other tmux compat commands still work

## Demo Video

N/A — CLI-only change, no UI impact.

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `show-options`/`show-option` handling across the `tmux` compatibility layer in `cmux` so the `omx` startup call (`tmux show-options -sv extended-keys`) returns an empty string instead of error. The stub is wired through both the top-level dispatch and the `__tmux-compat` path, fixing #2671.

<sup>Written for commit 808655fc94693a93ff0d86ed971a24275dc50fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the `show-options` and `show-option` tmux-compat subcommands; they now return an empty response instead of triggering an error.
  * No other tmux-compat subcommands’ behavior was changed by this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->