### PR TITLE
Fix nightly codesign: sign CmuxDockTilePlugin and other nested bundles

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -406,6 +406,14 @@ jobs:
             if [ -f "$HELPER_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
             fi
+            # Sign nested bundles (plugins, frameworks, appex, xpc) deepest-first before the outer app
+            for DIR in "$APP_PATH/Contents/PlugIns" "$APP_PATH/Contents/Frameworks"; do
+              if [ -d "$DIR" ]; then
+                while IFS= read -r -d '' bundle; do
+                  /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
+                done < <(find "$DIR" -depth -type d \( -name '*.plugin' -o -name '*.appex' -o -name '*.framework' -o -name '*.xpc' \) -print0)
+              fi
+            done
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
             ./scripts/assert-passkey-entitlement.sh "$APP_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,14 @@ jobs:
           if [ -f "$HELPER_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
           fi
+          # Sign nested bundles (plugins, frameworks, appex, xpc) deepest-first before the outer app
+          for DIR in "$APP_PATH/Contents/PlugIns" "$APP_PATH/Contents/Frameworks"; do
+            if [ -d "$DIR" ]; then
+              while IFS= read -r -d '' bundle; do
+                /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
+              done < <(find "$DIR" -depth -type d \( -name '*.plugin' -o -name '*.appex' -o -name '*.framework' -o -name '*.xpc' \) -print0)
+            fi
+          done
           /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           ./scripts/assert-passkey-entitlement.sh "$APP_PATH"


### PR DESCRIPTION
## Summary

- Fix codesign failure in nightly builds caused by unsigned `CmuxDockTilePlugin.plugin` in `Contents/PlugIns`
- Add deepest-first signing sweep of all nested bundles (`.plugin`, `.appex`, `.framework`, `.xpc`) under `Contents/PlugIns` and `Contents/Frameworks` before signing the outer `.app`
- Applied the same fix to both `nightly.yml` and `release.yml`

## Root cause

The [failing nightly run](https://github.com/manaflow-ai/cmux/actions/runs/24072474849) failed at the "Codesign apps" step with:

```
code object is not signed at all
In subcomponent: .../cmux NIGHTLY.app/Contents/PlugIns/CmuxDockTilePlugin.plugin
```

The manual codesign loop only signed `Contents/Resources/bin/cmux`, `Contents/Resources/bin/ghostty`, and the outer `.app`. The new dock tile plugin (`CmuxDockTilePlugin.plugin`) was never added to the signing list, so `codesign --verify --deep --strict` caught it as unsigned.

## Fix

Before signing the outer `.app`, the workflow now finds and signs all nested bundles (deepest-first via `find -depth`) matching `.plugin`, `.appex`, `.framework`, or `.xpc` under both `Contents/PlugIns` and `Contents/Frameworks`. This is forward-compatible — any future nested bundles will be signed automatically.

## Files changed

- `.github/workflows/nightly.yml`
- `.github/workflows/release.yml`

## Test plan

- [ ] Re-trigger nightly workflow: `gh workflow run nightly.yml -f force=true`
- [ ] Verify "Codesign apps" step passes
- [ ] Verify notarization succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the macOS signing order in both nightly and release workflows; mistakes could break codesign verification/notarization and block publishing, but scope is limited to CI packaging steps.
> 
> **Overview**
> Fixes macOS CI signing failures by **adding a deepest-first codesign sweep of nested bundles** before signing the outer `.app`.
> 
> Both `nightly.yml` and `release.yml` now find and sign any `.plugin`, `.appex`, `.framework`, and `.xpc` under `Contents/PlugIns` and `Contents/Frameworks`, preventing `codesign --verify --deep --strict` from failing on newly introduced embedded components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba65971e6ffec3ceba249f131eaac08968aa93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix codesign in nightly and release by signing all nested bundles before the outer app. This signs `CmuxDockTilePlugin.plugin` and future bundles so verification and notarization pass.

- **Bug Fixes**
  - Add deepest-first sweep under `Contents/PlugIns` and `Contents/Frameworks` to sign nested bundles.
  - Run after helper signing and before app signing using embedded entitlements; keeps `--verify --deep --strict` green.
  - Updated `.github/workflows/nightly.yml` and `.github/workflows/release.yml`.

<sup>Written for commit 8ba65971e6ffec3ceba249f131eaac08968aa93d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS app code signing workflow to comprehensively sign all nested application components including plugins, frameworks, and extensions during both nightly and release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->