### PR TITLE
Fix nightly codesign: sign Sparkle nested executables and dock tile plugin

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -406,12 +406,29 @@ jobs:
             if [ -f "$HELPER_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
             fi
-            # Sign nested bundles (plugins, frameworks, appex, xpc) deepest-first before the outer app
+            # Sign all nested bundles and executables deepest-first before the outer app.
+            # Three passes to guarantee correct ordering:
+            #   1) Nested .app/.xpc bundles inside frameworks (e.g. Sparkle's Updater.app)
+            #   2) Standalone Mach-O executables inside frameworks (e.g. Sparkle's Autoupdate)
+            #   3) Top-level .framework/.plugin/.appex bundles themselves
             for DIR in "$APP_PATH/Contents/PlugIns" "$APP_PATH/Contents/Frameworks"; do
               if [ -d "$DIR" ]; then
+                # Pass 1: nested .app and .xpc bundles (deepest-first)
                 while IFS= read -r -d '' bundle; do
                   /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
-                done < <(find "$DIR" -depth -type d \( -name '*.plugin' -o -name '*.appex' -o -name '*.framework' -o -name '*.xpc' \) -print0)
+                done < <(find "$DIR" -depth -type d \( -name '*.app' -o -name '*.xpc' \) -print0)
+
+                # Pass 2: standalone Mach-O executables & dylibs (skip those inside .app bundles)
+                while IFS= read -r -d '' f; do
+                  if file "$f" | grep -qE 'Mach-O'; then
+                    /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
+                  fi
+                done < <(find "$DIR" -type f \( -perm +111 -o -name '*.dylib' \) -not -path '*.app/*' -print0)
+
+                # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
+                while IFS= read -r -d '' bundle; do
+                  /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
+                done < <(find "$DIR" -depth -type d \( -name '*.framework' -o -name '*.plugin' -o -name '*.appex' \) -print0)
               fi
             done
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,12 +267,29 @@ jobs:
           if [ -f "$HELPER_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$HELPER_PATH"
           fi
-          # Sign nested bundles (plugins, frameworks, appex, xpc) deepest-first before the outer app
+          # Sign all nested bundles and executables deepest-first before the outer app.
+          # Three passes to guarantee correct ordering:
+          #   1) Nested .app/.xpc bundles inside frameworks (e.g. Sparkle's Updater.app)
+          #   2) Standalone Mach-O executables inside frameworks (e.g. Sparkle's Autoupdate)
+          #   3) Top-level .framework/.plugin/.appex bundles themselves
           for DIR in "$APP_PATH/Contents/PlugIns" "$APP_PATH/Contents/Frameworks"; do
             if [ -d "$DIR" ]; then
+              # Pass 1: nested .app and .xpc bundles (deepest-first)
               while IFS= read -r -d '' bundle; do
                 /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
-              done < <(find "$DIR" -depth -type d \( -name '*.plugin' -o -name '*.appex' -o -name '*.framework' -o -name '*.xpc' \) -print0)
+              done < <(find "$DIR" -depth -type d \( -name '*.app' -o -name '*.xpc' \) -print0)
+
+              # Pass 2: standalone Mach-O executables & dylibs (skip those inside .app bundles)
+              while IFS= read -r -d '' f; do
+                if file "$f" | grep -qE 'Mach-O'; then
+                  /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
+                fi
+              done < <(find "$DIR" -type f \( -perm +111 -o -name '*.dylib' \) -not -path '*.app/*' -print0)
+
+              # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
+              while IFS= read -r -d '' bundle; do
+                /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$bundle"
+              done < <(find "$DIR" -depth -type d \( -name '*.framework' -o -name '*.plugin' -o -name '*.appex' \) -print0)
             fi
           done
           /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"


### PR DESCRIPTION
## Summary

- Fix codesign failure in nightly/release builds caused by unsigned nested bundles
- Three-pass deepest-first signing: nested `.app`/`.xpc` bundles, standalone Mach-O executables (Sparkle's `Autoupdate`), then `.framework`/`.plugin`/`.appex` bundles
- Applied to both `nightly.yml` and `release.yml`

## Root cause

The [failing nightly run](https://github.com/manaflow-ai/cmux/actions/runs/24072474849) failed because:
1. `CmuxDockTilePlugin.plugin` was not in the manual sign loop
2. Sparkle.framework's nested `Updater.app` and `Autoupdate` executable were not individually signed with Developer ID + timestamp

Signing a `.framework` bundle only signs its main binary — nested executables and app bundles inside it must be signed individually.

## Fix

Before signing the outer `.app`, the workflow now runs three passes:
1. Sign nested `.app`/`.xpc` bundles inside frameworks (e.g. Sparkle's `Updater.app`)
2. Sign standalone Mach-O executables not inside `.app` bundles (e.g. Sparkle's `Autoupdate`)
3. Sign `.framework`/`.plugin`/`.appex` bundles themselves

## Files changed

- `.github/workflows/nightly.yml`
- `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release/nightly CI signing order and file-selection logic, which can break notarization if the find/sign patterns miss or incorrectly sign embedded binaries.
> 
> **Overview**
> Updates the macOS `nightly.yml` and `release.yml` codesigning steps to **sign nested components explicitly** before signing the outer `.app`.
> 
> Replaces the single “sign nested bundles” sweep with a **three-pass deepest-first** process: (1) nested `.app`/`.xpc` bundles, (2) standalone embedded Mach-O executables and `.dylib`s (excluding those inside `.app` bundles), then (3) `.framework`/`.plugin`/`.appex` bundles, improving `codesign --verify` and notarization reliability (e.g., Sparkle nested helpers / dock tile plugin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d9fca64e3ab7af149a0b6d841a4e756f58380e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes codesign in nightly and release by deep-signing nested apps and executables before the outer app. Adds a deepest-first three-pass sweep to stop verify failures and allow notarized builds.

- **Bug Fixes**
  - Sign `CmuxDockTilePlugin.plugin` in Contents/PlugIns.
  - Individually sign Sparkle’s `Updater.app` and `Autoupdate` before `Sparkle.framework`.
  - Three-pass inside `Contents/Frameworks` and `Contents/PlugIns`: 1) `.app`/`.xpc`, 2) standalone Mach‑O execs and `.dylib` (skip inside `.app`), 3) `.framework`/`.plugin`/`.appex`.
  - Applied to `.github/workflows/nightly.yml` and `.github/workflows/release.yml`.

<sup>Written for commit 18d9fca64e3ab7af149a0b6d841a4e756f58380e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS code signing process in automated build workflows to implement a more structured three-pass signing approach for nested application bundles and executables, enhancing code signing reliability across both nightly and release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->