### PR TITLE
Auto-hide terminal scroll bar fixes 2674

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5809,8 +5809,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func refreshTerminalSurfacesAfterGhosttyConfigReload(source: String) {
         var refreshedCount = 0
         forEachTerminalPanel { terminalPanel in
-            terminalPanel.hostedView.reconcileGeometryNow()
             terminalPanel.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
+            terminalPanel.hostedView.reconcileGeometryNow()
             terminalPanel.surface.forceRefresh(reason: "appDelegate.refreshAfterGhosttyConfigReload")
             refreshedCount += 1
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1181,6 +1181,11 @@ private final class GhosttySurfaceCallbackContext {
 // MARK: - Ghostty App Singleton
 
 class GhosttyApp {
+    enum ScrollbarVisibility: String {
+        case system
+        case never
+    }
+
     static let shared = GhosttyApp()
     private static let releaseBundleIdentifier = "com.cmuxterm.app"
     private static let backgroundLogTimestampFormatter: ISO8601DateFormatter = {
@@ -2466,6 +2471,17 @@ class GhosttyApp {
         let keyLength = UInt(key.lengthOfBytes(using: .utf8))
         let found = ghostty_config_get(config, &enabled, key, keyLength)
         return found && enabled
+    }
+
+    func scrollbarVisibility() -> ScrollbarVisibility {
+        guard let config else { return .system }
+        var value: UnsafePointer<Int8>?
+        let key = "scrollbar"
+        guard ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))),
+              let value else {
+            return .system
+        }
+        return ScrollbarVisibility(rawValue: String(cString: value)) ?? .system
     }
 
     func appleScriptAutomationEnabled() -> Bool {
@@ -8532,6 +8548,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var searchOverlayMutationGeneration: UInt64 = 0
     private var observers: [NSObjectProtocol] = []
     private var windowObservers: [NSObjectProtocol] = []
+    private var scrollbarTrackingArea: NSTrackingArea?
     private var isLiveScrolling = false
     private var lastSentRow: Int?
     /// Tracks whether the user has scrolled away from the bottom to review scrollback.
@@ -8777,6 +8794,7 @@ final class GhosttySurfaceScrollView: NSView {
         backgroundView.layer?.isOpaque = initialTerminalBackground.alphaComponent >= 1.0
         addSubview(backgroundView)
         addSubview(scrollView)
+        synchronizeScrollbarAppearance()
         inactiveOverlayView.wantsLayer = true
         inactiveOverlayView.layer?.backgroundColor = NSColor.clear.cgColor
         inactiveOverlayView.isHidden = true
@@ -9071,6 +9089,37 @@ final class GhosttySurfaceScrollView: NSView {
 
     // Avoid stealing focus on scroll; focus is managed explicitly by the surface view.
     override var acceptsFirstResponder: Bool { false }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        guard scrollView.hasVerticalScroller,
+              NSScroller.preferredScrollerStyle == .legacy else { return }
+        scrollView.flashScrollers()
+    }
+
+    override func updateTrackingAreas() {
+        if let scrollbarTrackingArea {
+            removeTrackingArea(scrollbarTrackingArea)
+            self.scrollbarTrackingArea = nil
+        }
+
+        super.updateTrackingAreas()
+
+        guard scrollView.hasVerticalScroller,
+              let scroller = scrollView.verticalScroller else { return }
+
+        let trackingArea = NSTrackingArea(
+            rect: convert(scroller.bounds, from: scroller),
+            options: [
+                .mouseMoved,
+                .activeInKeyWindow,
+            ],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        scrollbarTrackingArea = trackingArea
+    }
 
     override func layout() {
         super.layout()
@@ -9769,6 +9818,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func refreshHostBackgroundAfterGhosttyConfigReload() {
+        synchronizeScrollbarAppearance()
         surfaceView.applySurfaceBackground()
         surfaceView.applyWindowBackgroundIfActive()
     }
@@ -11225,6 +11275,16 @@ final class GhosttySurfaceScrollView: NSView {
         synchronizeScrollView()
     }
 
+    private func synchronizeScrollbarAppearance() {
+        scrollView.hasVerticalScroller = GhosttyApp.shared.scrollbarVisibility() != .never
+        // Mirror upstream Ghostty: keep overlay scrollers even when the
+        // system preference is legacy so terminal content never sits beneath a
+        // permanently reserved scrollbar gutter.
+        scrollView.autohidesScrollers = false
+        scrollView.scrollerStyle = .overlay
+        updateTrackingAreas()
+    }
+
     private func handlePreferredScrollerStyleChange() {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
@@ -11232,6 +11292,8 @@ final class GhosttySurfaceScrollView: NSView {
             }
             return
         }
+
+        synchronizeScrollbarAppearance()
 
         // Retile just the scroll view so contentSize reflects the current
         // scrollbar mode without perturbing viewport origin or hosted view

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2209,7 +2209,7 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         XCTAssertTrue(state.isHidden)
     }
 
-    func testPreferredScrollerStyleChangeRecalculatesTerminalSurfaceWidth() {
+    func testPreferredScrollerStyleChangeRestoresOverlayScrollbarWidth() {
         let surface = TerminalSurface(
             tabId: UUID(),
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
@@ -2289,32 +2289,17 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         NotificationCenter.default.post(name: NSScroller.preferredScrollerStyleDidChangeNotification, object: nil)
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
-        XCTAssertEqual(scrollView.scrollerStyle, .legacy)
-        assertPendingSurfaceWidth(
-            legacyContentWidth,
-            "Preferred scroller style changes should recalculate the terminal grid width immediately"
-        )
-
-        scrollView.scrollerStyle = .overlay
-        scrollView.layoutSubtreeIfNeeded()
-        let overlayContentWidth = scrollView.contentSize.width
-        XCTAssertGreaterThan(
-            overlayContentWidth,
-            legacyContentWidth,
-            "Overlay scrollbars should restore the full terminal content width"
-        )
-        assertPendingSurfaceWidth(
-            legacyContentWidth,
-            "Changing the scroll view style alone should leave the terminal grid stale until the scroller-style observer runs"
-        )
-
-        NotificationCenter.default.post(name: NSScroller.preferredScrollerStyleDidChangeNotification, object: nil)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-
+        let restoredContentWidth = scrollView.contentSize.width
         XCTAssertEqual(scrollView.scrollerStyle, .overlay)
+        XCTAssertEqual(
+            restoredContentWidth,
+            initialContentWidth,
+            accuracy: 0.5,
+            "Preferred scroller style changes should restore Ghostty's overlay scrollbar behavior so terminal content is not occluded by a persistent gutter"
+        )
         assertPendingSurfaceWidth(
-            overlayContentWidth,
-            "Preferred scroller style changes should also restore the wider terminal grid when overlay scrollbars return"
+            restoredContentWidth,
+            "Preferred scroller style changes should restore the wider terminal grid when overlay scrollbars return"
         )
     }
 


### PR DESCRIPTION
Closes #2674.

## What changed
- read Ghostty's embedded `scrollbar` config in the cmux host wrapper so `scrollbar = never` is respected instead of always showing a vertical scroller
- restore Ghostty's macOS overlay-scrollbar behavior when AppKit reports preferred scroller style changes, so the terminal grid width returns to the full overlay width instead of staying under a persistent legacy gutter
- flash the overlay scroller on hover when the system preference is legacy, matching Ghostty's usability fallback for mouse users
- refresh scrollbar appearance before terminal geometry is reconciled after Ghostty config reloads
- update the existing scrollbar-width regression to assert that preferred style changes restore overlay width rather than pinning the terminal under a visible gutter

## Why
cmux embeds Ghostty but its forked `GhosttySurfaceScrollView` had drifted from Ghostty's macOS scrollbar behavior. That let a persistent right-side scrollbar gutter overlap the terminal's last column. This brings cmux back to Ghostty-style overlay behavior so the scrollbar only surfaces as an overlay instead of permanently occluding content.

## Notes
- no local tests were run per repo policy
- verified the change builds successfully with the required tagged reload flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal scroll view sizing and event handling, which can regress layout (grid width) or scrolling behavior across macOS scroller-style modes. Changes are localized to UI but affect a core interaction path.
> 
> **Overview**
> Restores Ghostty-like macOS scrollbar behavior in the embedded terminal: reads Ghostty’s `scrollbar` config (honoring `scrollbar = never`), forces overlay scrollers (no reserved gutter), and re-syncs scroller appearance when system preferred scroller style changes.
> 
> Adds hover flashing for overlay scrollers when the system preference is legacy via a scroller tracking area, and refreshes scrollbar appearance before geometry reconciliation on config reload. Updates the existing regression test to assert overlay-width restoration after preferred scroller style changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a08fb222625ab347e58890e2aa2dbe441b7d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal scrollbar occlusion by restoring macOS overlay scroller behavior in the embedded Ghostty view and honoring the `scrollbar` config (e.g., hides when `scrollbar = never`). This removes the permanent right gutter and keeps the last column visible.

- **Bug Fixes**
  - Read `scrollbar` from Ghostty config and hide the vertical scroller when set to `never`.
  - Always use overlay scrollers and refresh on AppKit preferred-style changes to avoid reserving a gutter; retile only the scroll view.
  - Flash the overlay scroller on mouse hover in legacy mode; add a tracking area to the vertical scroller.
  - Sync scroller appearance during init and before geometry reconciliation on config reload.
  - Update tests to assert overlay width is restored and rename the scroller-style test accordingly.

<sup>Written for commit c4a08fb222625ab347e58890e2aa2dbe441b7d46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced scrollbar visibility configuration option enabling system-default or always-hidden modes
  * Enhanced scrollbar behavior with improved hover detection and responsive visibility feedback during interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->