### PR TITLE
Fix codesign: drop -perm filter so Sparkle Autoupdate gets signed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -423,7 +423,7 @@ jobs:
                   if file "$f" | grep -qE 'Mach-O'; then
                     /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
                   fi
-                done < <(find "$DIR" -type f \( -perm +111 -o -name '*.dylib' \) -not -path '*.app/*' -print0)
+                done < <(find "$DIR" -type f -not -path '*.app/*' -print0)
 
                 # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
                 while IFS= read -r -d '' bundle; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
                 if file "$f" | grep -qE 'Mach-O'; then
                   /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
                 fi
-              done < <(find "$DIR" -type f \( -perm +111 -o -name '*.dylib' \) -not -path '*.app/*' -print0)
+              done < <(find "$DIR" -type f -not -path '*.app/*' -print0)
 
               # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
               while IFS= read -r -d '' bundle; do


### PR DESCRIPTION
## Summary

- Fix notarization failure: Sparkle's `Autoupdate` binary still unsigned after previous codesign fix
- Root cause: `-perm +111` filter in Pass 2 excluded `Autoupdate` (no execute bits in built artifact)
- Fix: remove permission filter, check ALL regular files with `file` command for Mach-O instead

## Context

Previous fix (#2677) added three-pass signing which fixed `Updater.app` and `CmuxDockTilePlugin.plugin`, but `Autoupdate` was still excluded by the `-perm +111` find filter before the `file` Mach-O check could run on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CI workflow change that only broadens which files are inspected for Mach-O signing; main risk is slightly longer signing time or accidentally signing unexpected Mach-O files in embedded frameworks.
> 
> **Overview**
> Fixes macOS signing in CI by changing the “Pass 2” codesigning scan in both `nightly.yml` and `release.yml` to inspect **all regular files** (excluding those inside nested `.app` bundles) rather than only executables/`*.dylib` matched by `find -perm +111`.
> 
> This ensures Mach-O binaries like Sparkle’s `Autoupdate` are detected via `file` and signed, preventing notarization failures from unsigned embedded executables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2624a7a819d2fd673f003ad599a087f37e50b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notarization by ensuring the `Sparkle` `Autoupdate` binary gets codesigned in Nightly and Release workflows. Drops the execute-permission filter so all Mach-O files are signed.

- **Bug Fixes**
  - Removed the `-perm +111` filter in Pass 2 and scan all regular files outside `.app` bundles, signing those detected as Mach-O.
  - This catches `Autoupdate`, which lacked execute bits and was previously skipped.

<sup>Written for commit 1a2624a7a819d2fd673f003ad599a087f37e50b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app codesigning process to improve file verification during builds, ensuring consistent application signing across release and nightly workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->