### PR TITLE
Fix codesign: path filter excluded all files inside outer .app

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -423,7 +423,7 @@ jobs:
                   if file "$f" | grep -qE 'Mach-O'; then
                     /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
                   fi
-                done < <(find "$DIR" -type f -not -path '*.app/*' -print0)
+                done < <(find "$DIR" \( -type d -name '*.app' -prune \) -o \( -type f -print0 \))
 
                 # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
                 while IFS= read -r -d '' bundle; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
                 if file "$f" | grep -qE 'Mach-O'; then
                   /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$EMBEDDED_ENTITLEMENTS" "$f"
                 fi
-              done < <(find "$DIR" -type f -not -path '*.app/*' -print0)
+              done < <(find "$DIR" \( -type d -name '*.app' -prune \) -o \( -type f -print0 \))
 
               # Pass 3: .framework, .plugin, .appex bundles (deepest-first)
               while IFS= read -r -d '' bundle; do


### PR DESCRIPTION
## Summary

- Fix: `-not -path '*.app/*'` in Pass 2's find matched the **outer** `cmux NIGHTLY.app/` in every path, excluding ALL files — Autoupdate was never reached
- Replace with `find -prune` on nested `.app` dirs, which correctly skips only `Updater.app/` contents while finding standalone executables like `Autoupdate`

## Root cause

`find "$DIR" -type f -not -path '*.app/*'` where `$DIR` is `cmux NIGHTLY.app/Contents/Frameworks` — every file's full path contains `cmux NIGHTLY.app/`, so the glob `*.app/*` matches everything and Pass 2 signs nothing.

## Fix

```diff
-find "$DIR" -type f -not -path '*.app/*' -print0
+find "$DIR" \( -type d -name '*.app' -prune \) -o \( -type f -print0 \)
```

`-prune` on `*.app` directories prevents descending into nested app bundles (like `Updater.app`, already signed in Pass 1) without filtering by full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the macOS release/nightly signing pipeline; a mistake could cause unsigned binaries or failed notarization, but the change is a small, targeted `find` filter correction.
> 
> **Overview**
> Fixes Pass 2 of the macOS codesigning loops in `nightly.yml` and `release.yml` so standalone Mach-O files inside `Contents/Frameworks`/`Contents/PlugIns` are actually discovered and signed.
> 
> Replaces the previous `find ... -not -path '*.app/*'` filter (which could exclude everything under an outer `.app`) with a `find` `-prune` on nested `*.app` directories, skipping only embedded app bundles while still signing executables like Sparkle’s `Autoupdate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d5cff17ed9fa5d528195a711b24d0d1fb07f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix codesign filter in GitHub workflows so Pass 2 signs standalone executables (e.g., Autoupdate) instead of skipping everything inside the outer .app. This restores proper signing for nightly and release builds.

- **Bug Fixes**
  - Replaced `-not -path '*.app/*'` with `find ... -prune` to skip only nested `.app` bundles (e.g., `Updater.app`).
  - Ensures Mach-O files under `Contents/Frameworks` are found and signed in Pass 2.
  - Applied to `.github/workflows/nightly.yml` and `.github/workflows/release.yml`.

<sup>Written for commit e2d5cff17ed9fa5d528195a711b24d0d1fb07f9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated macOS app codesigning process in build workflows to use an improved file enumeration method.

**Note:** These are internal build system improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->