### PR TITLE
fix: update surface config on theme switch to restore ANSI palette

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2005,7 +2005,7 @@ struct ContentView: View {
     }
 
     static func tmuxWorkspacePaneExactRect(
-        for panel: Panel,
+        for panel: any Panel,
         in contentView: NSView
     ) -> CGRect? {
         let targetView: NSView?

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5647,6 +5647,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
             return
         }
+        // Push the current config to this surface before switching the color scheme.
+        // ghostty_surface_set_color_scheme alone only updates the scheme flag but does
+        // not re-apply the ANSI palette (OSC 4, colors 0-15) to the existing surface.
+        // Calling ghostty_surface_update_config first ensures the surface picks up the
+        // full palette for the new scheme (light/dark) from the current config.
+        if let config = GhosttyApp.shared.config {
+            ghostty_surface_update_config(surface, config)
+        }
         ghostty_surface_set_color_scheme(surface, scheme)
         appliedColorScheme = scheme
         if GhosttyApp.shared.backgroundLogEnabled {


### PR DESCRIPTION
## Problem

When switching between light and dark themes in cmux, existing terminal windows retain the ANSI color palette (colors 0–15) from the previous theme. This causes white text on a light background when switching from dark → light.

**Root cause:** `applySurfaceColorScheme` calls `ghostty_surface_set_color_scheme`, which only updates the scheme flag on the surface but does not re-apply the full ANSI palette. The palette (OSC 4, colors 0–15) stays from the previous theme.

New windows are unaffected because ghostty initializes their palette from the current config at surface creation time.

This is the cmux-side equivalent of the fix ghostty made in their standalone app (ghostty-org/ghostty#9360, shipped in ghostty 1.3.0): explicitly pushing the updated config to existing surfaces when the color scheme changes.

## Fix

In `applySurfaceColorScheme` (`GhosttyTerminalView.swift`), call `ghostty_surface_update_config(surface, config)` before `ghostty_surface_set_color_scheme`. This pushes the complete config — including the correct ANSI palette for the new theme — to each existing surface.

```swift
// Push the current config to this surface before switching the color scheme.
// ghostty_surface_set_color_scheme alone only updates the scheme flag but does
// not re-apply the ANSI palette (OSC 4, colors 0-15) to the existing surface.
if let config = GhosttyApp.shared.config {
    ghostty_surface_update_config(surface, config)
}
ghostty_surface_set_color_scheme(surface, scheme)
```

Also fixes a Swift build error in `ContentView.swift`: protocol `Panel` used as an existential type must be written as `any Panel`.

## Testing

1. Open several terminal windows/panes
2. Switch cmux theme from dark → light
3. Verify existing windows now show dark text on light background (previously showed white text)
4. Switch back to dark → verify existing windows show white text on dark background

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme switching so existing terminal surfaces update their ANSI palette, preventing white-on-light text after dark → light (and vice versa). Also resolves a Swift build error in `ContentView.swift`.

- **Bug Fixes**
  - In `GhosttyTerminalView.swift`, call `ghostty_surface_update_config(surface, config)` before `ghostty_surface_set_color_scheme(surface, scheme)` to re-apply the ANSI palette on existing surfaces.
  - In `ContentView.swift`, change `Panel` existential to `any Panel` to fix the build.

<sup>Written for commit 1ba3da7a1f1af3fc354835888e062161a87a4310. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed color palette application when switching between light and dark color schemes to ensure all ANSI colors display correctly.

* **Refactor**
  * Updated method signature to use modern type system conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->