### PR TITLE
fix: route all config-open call sites through PreferredEditorSettings

### DIFF
--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -359,7 +359,7 @@ struct cmuxApp: App {
                     openCmuxSettingsFileInEditor()
                 }
                 Button(String(localized: "menu.app.ghosttySettings", defaultValue: "Ghostty Settings…")) {
-                    GhosttyApp.shared.openConfigurationInTextEdit()
+                    openGhosttyConfigInEditor()
                 }
                 splitCommandButton(title: String(localized: "menu.app.reloadConfiguration", defaultValue: "Reload Configuration"), shortcut: menuShortcut(for: .reloadConfiguration)) {
                     GhosttyApp.shared.reloadConfiguration(source: "menu.reload_configuration")
@@ -4038,6 +4038,28 @@ private func openCmuxSettingsFileInEditor() {
     PreferredEditorSettings.open(url)
 }
 
+private func openGhosttyConfigInEditor() {
+    let configPaths = [
+        "~/.config/ghostty/config",
+        "~/.config/ghostty/config.ghostty",
+        "~/Library/Application Support/com.mitchellh.ghostty/config",
+        "~/Library/Application Support/com.mitchellh.ghostty/config.ghostty",
+    ].map { NSString(string: $0).expandingTildeInPath }
+
+    let resolvedPath: String
+    if let existing = configPaths.first(where: { FileManager.default.fileExists(atPath: $0) }) {
+        resolvedPath = existing
+    } else {
+        let defaultPath = configPaths[0]
+        let dir = (defaultPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: defaultPath, contents: nil)
+        resolvedPath = defaultPath
+    }
+
+    PreferredEditorSettings.open(URL(fileURLWithPath: resolvedPath))
+}
+
 private func openCmuxSettingsFileInTextEdit() {
     #if os(macOS)
     let fileURL = KeyboardShortcutSettings.settingsFileStore.settingsFileURLForEditing()
@@ -5846,7 +5868,7 @@ struct SettingsView: View {
                                     .accessibilityIdentifier("SettingsKeyboardShortcutsChordDocsLink")
 
                                 Button(String(localized: "settings.app.settingsFile.openButton", defaultValue: "Open settings.json")) {
-                                    openCmuxSettingsFileInTextEdit()
+                                    openCmuxSettingsFileInEditor()
                                 }
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
@@ -5969,7 +5991,7 @@ struct SettingsView: View {
                             title: String(localized: "settings.app.settingsFile.openButton", defaultValue: "Open settings.json"),
                             helpText: KeyboardShortcutSettings.settingsFileStore.settingsFileDisplayPath(),
                             accessibilityIdentifier: "SettingsFileOpenButton",
-                            action: openCmuxSettingsFileInTextEdit
+                            action: openCmuxSettingsFileInEditor
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #2694

Three call sites were hardcoding TextEdit or bypassing `PreferredEditorSettings`, making `preferredEditorCommand` only work for the menu bar "Open settings.json" entry.

| Before | After |
|---|---|
| Menu "Ghostty Settings\u2026" \u2192 `GhosttyApp.shared.openConfigurationInTextEdit()` \u2192 TextEdit hardcoded | \u2192 `openGhosttyConfigInEditor()` \u2192 respects `preferredEditorCommand` |
| Settings panel "Open settings.json" (shortcuts section) \u2192 `openCmuxSettingsFileInTextEdit()` \u2192 TextEdit hardcoded | \u2192 `openCmuxSettingsFileInEditor()` \u2192 respects `preferredEditorCommand` |
| Settings panel "Open settings.json" (header button) \u2192 `openCmuxSettingsFileInTextEdit()` \u2192 TextEdit hardcoded | \u2192 `openCmuxSettingsFileInEditor()` \u2192 respects `preferredEditorCommand` |

`openGhosttyConfigInEditor()` resolves the Ghostty config path using the same search order already used in `GhosttyConfig.swift`, creates the default file at `~/.config/ghostty/config` if none exists, then delegates to `PreferredEditorSettings.open()` \u2014 matching the fallback behaviour of `openConfigurationInTextEdit()`.

## Testing

- Set `preferredEditorCommand` to `code` in cmux Settings
- Click menu bar \u2192 "Ghostty Settings\u2026" \u2192 opens in VS Code
- Open Settings panel \u2192 click "Open settings.json" in header \u2192 opens in VS Code
- Open Settings panel \u2192 Keyboard Shortcuts \u2192 click "Open settings.json" \u2192 opens in VS Code
- Clear `preferredEditorCommand` \u2192 all four fall back to system default

## Demo Video

N/A \u2014 editor launch behaviour only, no visual UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all config-open actions through `PreferredEditorSettings` so `preferredEditorCommand` is respected across the app. Fixes #2694; the Ghostty Settings menu and both “Open settings.json” buttons now open in the chosen editor with a system-default fallback.

- **Bug Fixes**
  - Added `openGhosttyConfigInEditor()` to resolve the Ghostty config via the existing search order, create `~/.config/ghostty/config` if missing, then call `PreferredEditorSettings.open()`.
  - Replaced `openConfigurationInTextEdit()` / `openCmuxSettingsFileInTextEdit()` with `openGhosttyConfigInEditor()` / `openCmuxSettingsFileInEditor()` in the menu and settings UI.

<sup>Written for commit 846dc44f3adfe8f5132b2e5cc72c238032ec83d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced configuration file handling for Ghostty settings—the app now automatically creates the configuration file if it doesn't exist when you access the Ghostty Settings option, ensuring a smoother setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->