### PR TITLE
Graceful SSH reconnect + relay cleanup/logging (#2692)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1723,8 +1723,6 @@ struct CMUXCLI {
             return
         }
 
-        _ = try? sweepLocalRelayState()
-
         // If the argument looks like a path (not a known command), open a workspace there.
         if looksLikePath(command) {
             try openPath(command, socketPath: resolvedSocketPath)
@@ -2038,8 +2036,6 @@ struct CMUXCLI {
 
         case "ssh":
             try runSSH(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
-        case "relay":
-            try runRelayCommand(commandArgs: commandArgs, jsonOutput: jsonOutput)
         case "ssh-session-end":
             try runSSHSessionEnd(commandArgs: commandArgs, client: client)
 
@@ -4086,8 +4082,15 @@ struct CMUXCLI {
                    let pid = Int32(pidText),
                    pid > 0,
                    !isProcessAlive(pid: pid) {
-                    try? FileManager.default.removeItem(at: entryURL)
-                    removedSessionDirs += 1
+                    let lockFD = tryLockRelaySession(at: entryURL)
+                    guard let lockFD else { continue }
+                    defer { unlockRelaySession(lockFD) }
+                    do {
+                        try FileManager.default.removeItem(at: entryURL)
+                        removedSessionDirs += 1
+                    } catch {
+                        continue
+                    }
                 }
                 continue
             }
@@ -4099,8 +4102,12 @@ struct CMUXCLI {
 
         for (port, artifactURLs) in portArtifacts where !isLoopbackPortReachable(port: port) {
             for artifactURL in artifactURLs {
-                try? FileManager.default.removeItem(at: artifactURL)
-                removedPortArtifacts += 1
+                do {
+                    try FileManager.default.removeItem(at: artifactURL)
+                    removedPortArtifacts += 1
+                } catch {
+                    continue
+                }
             }
         }
 
@@ -4182,6 +4189,22 @@ struct CMUXCLI {
             getsockopt(socketFD, SOL_SOCKET, SO_ERROR, pointer, &socketErrorLength)
         }
         return optionResult == 0 && socketError == 0
+    }
+
+    private func tryLockRelaySession(at entryURL: URL) -> Int32? {
+        let lockPath = entryURL.appendingPathComponent(".lock", isDirectory: false).path
+        let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else { return nil }
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            Darwin.close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    private func unlockRelaySession(_ fd: Int32) {
+        _ = flock(fd, LOCK_UN)
+        Darwin.close(fd)
     }
 
     private func runSSH(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4057,13 +4057,20 @@ struct CMUXCLI {
         let relayRootURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cmux", isDirectory: true)
             .appendingPathComponent("relay", isDirectory: true)
-
-        guard let entries = try? FileManager.default.contentsOfDirectory(
-            at: relayRootURL,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return RelayCleanupSummary(removedSessionDirs: 0, removedPortArtifacts: 0)
+        let entries: [URL]
+        do {
+            entries = try FileManager.default.contentsOfDirectory(
+                at: relayRootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            if isRelayCleanupFileNotFoundError(error) {
+                return RelayCleanupSummary(removedSessionDirs: 0, removedPortArtifacts: 0)
+            }
+            throw CLIError(
+                message: "Failed to read relay state at \(relayRootURL.path): \(error.localizedDescription)"
+            )
         }
 
         var removedSessionDirs = 0
@@ -4082,14 +4089,19 @@ struct CMUXCLI {
                    let pid = Int32(pidText),
                    pid > 0,
                    !isProcessAlive(pid: pid) {
-                    let lockFD = tryLockRelaySession(at: entryURL)
+                    let lockFD = try tryLockRelaySession(at: entryURL)
                     guard let lockFD else { continue }
                     defer { unlockRelaySession(lockFD) }
                     do {
                         try FileManager.default.removeItem(at: entryURL)
                         removedSessionDirs += 1
                     } catch {
-                        continue
+                        if isRelayCleanupFileNotFoundError(error) {
+                            continue
+                        }
+                        throw CLIError(
+                            message: "Failed to remove stale relay session at \(entryURL.path): \(error.localizedDescription)"
+                        )
                     }
                 }
                 continue
@@ -4100,13 +4112,19 @@ struct CMUXCLI {
             }
         }
 
-        for (port, artifactURLs) in portArtifacts where !isLoopbackPortReachable(port: port) {
+        for (port, artifactURLs) in portArtifacts
+        where !isRelayPortArtifactLive(port: port, relayRootURL: relayRootURL) {
             for artifactURL in artifactURLs {
                 do {
                     try FileManager.default.removeItem(at: artifactURL)
                     removedPortArtifacts += 1
                 } catch {
-                    continue
+                    if isRelayCleanupFileNotFoundError(error) {
+                        continue
+                    }
+                    throw CLIError(
+                        message: "Failed to remove stale relay metadata at \(artifactURL.path): \(error.localizedDescription)"
+                    )
                 }
             }
         }
@@ -4115,6 +4133,58 @@ struct CMUXCLI {
             removedSessionDirs: removedSessionDirs,
             removedPortArtifacts: removedPortArtifacts
         )
+    }
+
+    private func isRelayPortArtifactLive(port: Int, relayRootURL: URL) -> Bool {
+        if let relaySessionID = relaySessionIDForCleanup(port: port, relayRootURL: relayRootURL),
+           let relayPID = relaySessionPID(for: relaySessionID, relayRootURL: relayRootURL),
+           isProcessAlive(pid: relayPID) {
+            return true
+        }
+        return isLoopbackPortReachable(port: port)
+    }
+
+    private func relaySessionIDForCleanup(port: Int, relayRootURL: URL) -> String? {
+        let authURL = relayRootURL.appendingPathComponent("\(port).auth", isDirectory: false)
+        guard let authData = try? Data(contentsOf: authURL),
+              let authObject = try? JSONSerialization.jsonObject(with: authData) as? [String: Any],
+              let relaySessionID = Self.trimmedEnvValue(authObject["relay_id"] as? String),
+              isValidRelayCleanupSessionID(relaySessionID) else {
+            return nil
+        }
+        return relaySessionID
+    }
+
+    private func relaySessionPID(for relaySessionID: String, relayRootURL: URL) -> Int32? {
+        let pidURL = relayRootURL
+            .appendingPathComponent(relaySessionID, isDirectory: true)
+            .appendingPathComponent("pid", isDirectory: false)
+        guard let pidData = try? Data(contentsOf: pidURL),
+              let pidText = String(data: pidData, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = Int32(pidText),
+              pid > 0 else {
+            return nil
+        }
+        return pid
+    }
+
+    private func isValidRelayCleanupSessionID(_ sessionID: String) -> Bool {
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        return sessionID != "."
+            && sessionID != ".."
+            && sessionID.unicodeScalars.allSatisfy { allowedCharacters.contains($0) }
+    }
+
+    private func isRelayCleanupFileNotFoundError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain {
+            return nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
+        }
+        if nsError.domain == NSPOSIXErrorDomain {
+            return nsError.code == ENOENT
+        }
+        return false
     }
 
     private func isProcessAlive(pid: Int32) -> Bool {
@@ -4191,10 +4261,12 @@ struct CMUXCLI {
         return optionResult == 0 && socketError == 0
     }
 
-    private func tryLockRelaySession(at entryURL: URL) -> Int32? {
+    private func tryLockRelaySession(at entryURL: URL) throws -> Int32? {
         let lockPath = entryURL.appendingPathComponent(".lock", isDirectory: false).path
         let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
-        guard fd >= 0 else { return nil }
+        guard fd >= 0 else {
+            throw CLIError(message: "Failed to open relay lock at \(lockPath)")
+        }
         if flock(fd, LOCK_EX | LOCK_NB) != 0 {
             Darwin.close(fd)
             return nil

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1718,6 +1718,13 @@ struct CMUXCLI {
             return
         }
 
+        if command == "relay" {
+            try runRelayCommand(commandArgs: commandArgs, jsonOutput: jsonOutput)
+            return
+        }
+
+        _ = try? sweepLocalRelayState()
+
         // If the argument looks like a path (not a known command), open a workspace there.
         if looksLikePath(command) {
             try openPath(command, socketPath: resolvedSocketPath)
@@ -2031,6 +2038,8 @@ struct CMUXCLI {
 
         case "ssh":
             try runSSH(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+        case "relay":
+            try runRelayCommand(commandArgs: commandArgs, jsonOutput: jsonOutput)
         case "ssh-session-end":
             try runSSHSessionEnd(commandArgs: commandArgs, client: client)
 
@@ -3996,6 +4005,183 @@ struct CMUXCLI {
             throw CLIError(message: "failed to generate SSH relay credential")
         }
         return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private struct RelayCleanupSummary {
+        let removedSessionDirs: Int
+        let removedPortArtifacts: Int
+
+        var payload: [String: Any] {
+            [
+                "removed_session_dirs": removedSessionDirs,
+                "removed_port_artifacts": removedPortArtifacts,
+            ]
+        }
+    }
+
+    private func runRelayCommand(commandArgs: [String], jsonOutput: Bool) throws {
+        if commandArgs.isEmpty
+            || commandArgs.first == "--help"
+            || commandArgs.first == "-h" {
+            print(
+                subcommandUsage("relay")
+                    ?? """
+                    Usage: cmux relay cleanup
+                    """
+            )
+            return
+        }
+
+        guard let subcommand = commandArgs.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !subcommand.isEmpty else {
+            throw CLIError(message: "Usage: cmux relay cleanup")
+        }
+
+        switch subcommand {
+        case "cleanup":
+            guard commandArgs.count == 1 else {
+                throw CLIError(message: "relay cleanup does not accept additional arguments")
+            }
+            let summary = try sweepLocalRelayState()
+            if jsonOutput {
+                print(jsonString(summary.payload))
+            } else {
+                print(
+                    "OK removed_session_dirs=\(summary.removedSessionDirs) " +
+                    "removed_port_artifacts=\(summary.removedPortArtifacts)"
+                )
+            }
+        default:
+            throw CLIError(message: "Unknown relay subcommand '\(subcommand)'")
+        }
+    }
+
+    @discardableResult
+    private func sweepLocalRelayState() throws -> RelayCleanupSummary {
+        let relayRootURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cmux", isDirectory: true)
+            .appendingPathComponent("relay", isDirectory: true)
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: relayRootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return RelayCleanupSummary(removedSessionDirs: 0, removedPortArtifacts: 0)
+        }
+
+        var removedSessionDirs = 0
+        var removedPortArtifacts = 0
+        var portArtifacts: [Int: [URL]] = [:]
+
+        for entryURL in entries {
+            let entryName = entryURL.lastPathComponent
+            let isDirectory = (try? entryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDirectory {
+                let pidURL = entryURL.appendingPathComponent("pid", isDirectory: false)
+                if FileManager.default.fileExists(atPath: pidURL.path),
+                   let pidData = try? Data(contentsOf: pidURL),
+                   let pidText = String(data: pidData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   let pid = Int32(pidText),
+                   pid > 0,
+                   !isProcessAlive(pid: pid) {
+                    try? FileManager.default.removeItem(at: entryURL)
+                    removedSessionDirs += 1
+                }
+                continue
+            }
+
+            if let port = relayArtifactPort(from: entryName) {
+                portArtifacts[port, default: []].append(entryURL)
+            }
+        }
+
+        for (port, artifactURLs) in portArtifacts where !isLoopbackPortReachable(port: port) {
+            for artifactURL in artifactURLs {
+                try? FileManager.default.removeItem(at: artifactURL)
+                removedPortArtifacts += 1
+            }
+        }
+
+        return RelayCleanupSummary(
+            removedSessionDirs: removedSessionDirs,
+            removedPortArtifacts: removedPortArtifacts
+        )
+    }
+
+    private func isProcessAlive(pid: Int32) -> Bool {
+        if pid <= 0 {
+            return false
+        }
+        if Darwin.kill(pid, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+
+    private func relayArtifactPort(from filename: String) -> Int? {
+        let suffixes = [
+            ".auth",
+            ".daemon_path",
+            ".tty",
+            ".shell",
+            ".bootstrap.sh",
+        ]
+        for suffix in suffixes where filename.hasSuffix(suffix) {
+            let prefix = String(filename.dropLast(suffix.count))
+            if let port = Int(prefix), (1...65535).contains(port) {
+                return port
+            }
+        }
+        return nil
+    }
+
+    private func isLoopbackPortReachable(port: Int) -> Bool {
+        guard (1...65535).contains(port) else { return false }
+
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { return false }
+        defer { Darwin.close(socketFD) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.stride)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(UInt16(port).bigEndian)
+        let parsedAddress = withUnsafeMutablePointer(to: &address.sin_addr) { pointer in
+            "127.0.0.1".withCString { hostPointer in
+                inet_pton(AF_INET, hostPointer, pointer)
+            }
+        }
+        guard parsedAddress == 1 else { return false }
+
+        let previousFlags = fcntl(socketFD, F_GETFL, 0)
+        if previousFlags >= 0 {
+            _ = fcntl(socketFD, F_SETFL, previousFlags | O_NONBLOCK)
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.stride))
+            }
+        }
+        if connectResult == 0 {
+            return true
+        }
+        guard errno == EINPROGRESS else {
+            return false
+        }
+
+        var pollFD = pollfd(fd: socketFD, events: Int16(POLLOUT), revents: 0)
+        let pollResult = Darwin.poll(&pollFD, 1, 150)
+        guard pollResult > 0 else { return false }
+
+        var socketError: Int32 = 0
+        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+        let optionResult = withUnsafeMutablePointer(to: &socketError) { pointer in
+            getsockopt(socketFD, SOL_SOCKET, SO_ERROR, pointer, &socketErrorLength)
+        }
+        return optionResult == 0 && socketError == 0
     }
 
     private func runSSH(
@@ -6751,6 +6937,12 @@ struct CMUXCLI {
             Coding agents:
               Double check with the end user before sending anything. Review the message and attachments for secrets,
               private code, credentials, tokens, and other sensitive information first.
+            """
+        case "relay":
+            return """
+            Usage: cmux relay cleanup
+
+            Remove stale relay pidfiles and port metadata under ~/.cmux/relay.
             """
         case "themes":
             return """
@@ -14344,6 +14536,7 @@ struct CMUXCLI {
           list-workspaces
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
+          relay cleanup
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
           list-panes [--workspace <id|ref>]

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87391,6 +87391,57 @@
           }
         }
       }
+    },
+    "workspace.remote.connection.detail.childExited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote SSH session exited. Reconnect creates a fresh relay and shell; running processes and scrollback from the dead session are not preserved."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモート SSH セッションが終了しました。再接続すると新しいリレーとシェルが作成されます。切断されたセッションの実行中プロセスとスクロールバックは保持されません。"
+          }
+        }
+      }
+    },
+    "workspace.remote.reconnect.sidebar.relayRecreated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote relay for %@ was recreated. Fresh SSH shells are starting; process state and scrollback from the dead session are not preserved."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のリモートリレーが再作成されました。新しい SSH シェルを起動しています。切断されたセッションのプロセス状態とスクロールバックは保持されません。"
+          }
+        }
+      }
+    },
+    "workspace.remote.reconnect.warning.relayRecreated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote relay was recreated. Fresh SSH shells are starting; running processes and scrollback from the dead session are not preserved."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートリレーが再作成されました。新しい SSH シェルを起動しています。切断されたセッションの実行中プロセスとスクロールバックは保持されません。"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2480,7 +2480,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func sweepStaleRelayStateAtStartup() {
+    private static func sweepStaleRelayStateAtStartup() {
         let relayRootURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cmux", isDirectory: true)
             .appendingPathComponent("relay", isDirectory: true)
@@ -2507,6 +2507,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                       errno == ESRCH else {
                     continue
                 }
+                guard let lockFD = tryLockRelaySession(at: entryURL) else {
+                    continue
+                }
+                defer { unlockRelaySession(lockFD) }
                 try? FileManager.default.removeItem(at: entryURL)
                 continue
             }
@@ -2523,7 +2527,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func startupRelayArtifactPort(from filename: String) -> Int? {
+    private static func startupRelayArtifactPort(from filename: String) -> Int? {
         let suffixes = [
             ".auth",
             ".daemon_path",
@@ -2540,7 +2544,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
-    private func isStartupLoopbackPortReachable(port: Int) -> Bool {
+    private static func isStartupLoopbackPortReachable(port: Int) -> Bool {
         guard (1...65535).contains(port) else { return false }
 
         let socketFD = socket(AF_INET, SOCK_STREAM, 0)
@@ -2587,6 +2591,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return optionResult == 0 && socketError == 0
     }
 
+    private static func tryLockRelaySession(at entryURL: URL) -> Int32? {
+        let lockPath = entryURL.appendingPathComponent(".lock", isDirectory: false).path
+        let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else { return nil }
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            Darwin.close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    private static func unlockRelaySession(_ fd: Int32) {
+        _ = flock(fd, LOCK_UN)
+        Darwin.close(fd)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
@@ -2605,7 +2625,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .reactGrabDidCopySelection,
             object: nil
         )
-        sweepStaleRelayStateAtStartup()
+        if !isRunningUnderXCTest {
+            DispatchQueue.global(qos: .utility).async {
+                Self.sweepStaleRelayStateAtStartup()
+            }
+        }
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2480,7 +2480,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private static func sweepStaleRelayStateAtStartup() {
+    private nonisolated static func sweepStaleRelayStateAtStartup() {
         let relayRootURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cmux", isDirectory: true)
             .appendingPathComponent("relay", isDirectory: true)
@@ -2527,7 +2527,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private static func startupRelayArtifactPort(from filename: String) -> Int? {
+    private nonisolated static func startupRelayArtifactPort(from filename: String) -> Int? {
         let suffixes = [
             ".auth",
             ".daemon_path",
@@ -2544,7 +2544,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
-    private static func isStartupLoopbackPortReachable(port: Int) -> Bool {
+    private nonisolated static func isStartupLoopbackPortReachable(port: Int) -> Bool {
         guard (1...65535).contains(port) else { return false }
 
         let socketFD = socket(AF_INET, SOCK_STREAM, 0)
@@ -2591,7 +2591,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return optionResult == 0 && socketError == 0
     }
 
-    private static func tryLockRelaySession(at entryURL: URL) -> Int32? {
+    private nonisolated static func tryLockRelaySession(at entryURL: URL) -> Int32? {
         let lockPath = entryURL.appendingPathComponent(".lock", isDirectory: false).path
         let fd = open(lockPath, O_CREAT | O_RDWR, mode_t(S_IRUSR | S_IWUSR))
         guard fd >= 0 else { return nil }
@@ -2602,7 +2602,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return fd
     }
 
-    private static func unlockRelaySession(_ fd: Int32) {
+    private nonisolated static func unlockRelaySession(_ fd: Int32) {
         _ = flock(fd, LOCK_UN)
         Darwin.close(fd)
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2480,6 +2480,113 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    private func sweepStaleRelayStateAtStartup() {
+        let relayRootURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cmux", isDirectory: true)
+            .appendingPathComponent("relay", isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: relayRootURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        var portArtifacts: [Int: [URL]] = [:]
+        for entryURL in entries {
+            let isDirectory = (try? entryURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDirectory {
+                let pidURL = entryURL.appendingPathComponent("pid", isDirectory: false)
+                guard FileManager.default.fileExists(atPath: pidURL.path),
+                      let pidData = try? Data(contentsOf: pidURL),
+                      let pidText = String(data: pidData, encoding: .utf8)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines),
+                      let pid = Int32(pidText),
+                      pid > 0,
+                      Darwin.kill(pid, 0) == -1,
+                      errno == ESRCH else {
+                    continue
+                }
+                try? FileManager.default.removeItem(at: entryURL)
+                continue
+            }
+
+            if let port = startupRelayArtifactPort(from: entryURL.lastPathComponent) {
+                portArtifacts[port, default: []].append(entryURL)
+            }
+        }
+
+        for (port, artifactURLs) in portArtifacts where !isStartupLoopbackPortReachable(port: port) {
+            for artifactURL in artifactURLs {
+                try? FileManager.default.removeItem(at: artifactURL)
+            }
+        }
+    }
+
+    private func startupRelayArtifactPort(from filename: String) -> Int? {
+        let suffixes = [
+            ".auth",
+            ".daemon_path",
+            ".tty",
+            ".shell",
+            ".bootstrap.sh",
+        ]
+        for suffix in suffixes where filename.hasSuffix(suffix) {
+            let prefix = String(filename.dropLast(suffix.count))
+            if let port = Int(prefix), (1...65535).contains(port) {
+                return port
+            }
+        }
+        return nil
+    }
+
+    private func isStartupLoopbackPortReachable(port: Int) -> Bool {
+        guard (1...65535).contains(port) else { return false }
+
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { return false }
+        defer { Darwin.close(socketFD) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.stride)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(UInt16(port).bigEndian)
+        let parsedAddress = withUnsafeMutablePointer(to: &address.sin_addr) { pointer in
+            "127.0.0.1".withCString { hostPointer in
+                inet_pton(AF_INET, hostPointer, pointer)
+            }
+        }
+        guard parsedAddress == 1 else { return false }
+
+        let previousFlags = fcntl(socketFD, F_GETFL, 0)
+        if previousFlags >= 0 {
+            _ = fcntl(socketFD, F_SETFL, previousFlags | O_NONBLOCK)
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.stride))
+            }
+        }
+        if connectResult == 0 {
+            return true
+        }
+        guard errno == EINPROGRESS else {
+            return false
+        }
+
+        var pollFD = pollfd(fd: socketFD, events: Int16(POLLOUT), revents: 0)
+        let pollResult = Darwin.poll(&pollFD, 1, 150)
+        guard pollResult > 0 else { return false }
+
+        var socketError: Int32 = 0
+        var socketErrorLength = socklen_t(MemoryLayout<Int32>.size)
+        let optionResult = withUnsafeMutablePointer(to: &socketError) { pointer in
+            getsockopt(socketFD, SOL_SOCKET, SO_ERROR, pointer, &socketErrorLength)
+        }
+        return optionResult == 0 && socketError == 0
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
@@ -2498,6 +2605,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .reactGrabDidCopySelection,
             object: nil
         )
+        sweepStaleRelayStateAtStartup()
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13262,7 +13262,7 @@ private struct TabItemView: View, Equatable {
 
             Button(reconnectLabel) {
                 for workspace in remoteContextMenuWorkspaces() {
-                    workspace.reconnectRemoteConnection()
+                    workspace.requestReconnectRemoteConnection()
                 }
             }
             .disabled(allRemoteContextMenuTargetsConnecting)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4254,6 +4254,17 @@ class TabManager: ObservableObject {
     func closePanelAfterChildExited(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         guard tab.panels[surfaceId] != nil else { return }
+        if tab.handleRemoteTerminalChildExit(surfaceId: surfaceId, onClose: { [weak self] in
+            self?.finishClosePanelAfterChildExited(tabId: tabId, surfaceId: surfaceId)
+        }) {
+            return
+        }
+        finishClosePanelAfterChildExited(tabId: tabId, surfaceId: surfaceId)
+    }
+
+    private func finishClosePanelAfterChildExited(tabId: UUID, surfaceId: UUID) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        guard tab.panels[surfaceId] != nil else { return }
         let keepsRemoteWorkspaceOpen =
             tab.panels.count <= 1 && tab.shouldDemoteWorkspaceAfterChildExit(surfaceId: surfaceId)
 
@@ -4264,11 +4275,6 @@ class TabManager: ObservableObject {
             "remoteWorkspace=\(tab.isRemoteWorkspace ? 1 : 0) keepRemote=\(keepsRemoteWorkspaceOpen ? 1 : 0)"
         )
 #endif
-
-        if tab.shouldPreserveRemoteTerminalAfterChildExit(surfaceId: surfaceId) {
-            tab.preserveRemoteTerminalAfterChildExit(surfaceId: surfaceId)
-            return
-        }
 
         // Exiting the last SSH surface should demote the workspace back to a local one.
         // Route through Workspace close handling so remote teardown and replacement-panel

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4254,8 +4254,9 @@ class TabManager: ObservableObject {
     func closePanelAfterChildExited(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         guard tab.panels[surfaceId] != nil else { return }
-        if tab.handleRemoteTerminalChildExit(surfaceId: surfaceId, onClose: { [weak self] in
-            self?.finishClosePanelAfterChildExited(tabId: tabId, surfaceId: surfaceId)
+        if tab.handleRemoteTerminalChildExit(surfaceId: surfaceId, onClose: { [weak tab] in
+            let manager = tab?.owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId: tabId)
+            manager?.finishClosePanelAfterChildExited(tabId: tabId, surfaceId: surfaceId)
         }) {
             return
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4265,6 +4265,11 @@ class TabManager: ObservableObject {
         )
 #endif
 
+        if tab.shouldPreserveRemoteTerminalAfterChildExit(surfaceId: surfaceId) {
+            tab.preserveRemoteTerminalAfterChildExit(surfaceId: surfaceId)
+            return
+        }
+
         // Exiting the last SSH surface should demote the workspace back to a local one.
         // Route through Workspace close handling so remote teardown and replacement-panel
         // logic run before TabManager considers removing the workspace itself, including

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3852,6 +3852,27 @@ class TerminalController {
             }
         }
 
+        let config = WorkspaceRemoteConfiguration(
+            destination: destination,
+            port: sshPort,
+            identityFile: identityFile?.isEmpty == true ? nil : identityFile,
+            sshOptions: sshOptions,
+            localProxyPort: localProxyPort,
+            relayPort: relayPort,
+            relayID: relayID?.isEmpty == true ? nil : relayID,
+            relayToken: relayToken?.isEmpty == true ? nil : relayToken,
+            localSocketPath: localSocketPath,
+            terminalStartupCommand: terminalStartupCommand?.isEmpty == true ? nil : terminalStartupCommand,
+            foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken
+        )
+        if relayPort != nil, config.relaySessionID == nil {
+            return .err(
+                code: "invalid_params",
+                message: "relay_id must contain only letters, numbers, '.', '_', and '-'",
+                data: nil
+            )
+        }
+
 #if DEBUG
         dlog(
             "workspace.remote.configure.request workspace=\(workspaceId.uuidString.prefix(8)) " +
@@ -3873,19 +3894,6 @@ class TerminalController {
                 return
             }
 
-            let config = WorkspaceRemoteConfiguration(
-                destination: destination,
-                port: sshPort,
-                identityFile: identityFile?.isEmpty == true ? nil : identityFile,
-                sshOptions: sshOptions,
-                localProxyPort: localProxyPort,
-                relayPort: relayPort,
-                relayID: relayID?.isEmpty == true ? nil : relayID,
-                relayToken: relayToken?.isEmpty == true ? nil : relayToken,
-                localSocketPath: localSocketPath,
-                terminalStartupCommand: terminalStartupCommand?.isEmpty == true ? nil : terminalStartupCommand,
-                foregroundAuthToken: foregroundAuthToken?.isEmpty == true ? nil : foregroundAuthToken
-            )
             workspace.configureRemoteConnection(config, autoConnect: autoConnect)
 
             let windowId = v2ResolveWindowId(tabManager: owner)
@@ -3955,6 +3963,32 @@ class TerminalController {
             "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
         ])
 
+        var relayProbeController: WorkspaceRemoteSessionController?
+        var shouldReconnect = false
+        v2MainSync {
+            guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+                  let workspace = owner.tabs.first(where: { $0.id == workspaceId }) else {
+                return
+            }
+
+            guard workspace.remoteConfiguration != nil else {
+                result = .err(code: "invalid_state", message: "Remote workspace is not configured", data: [
+                    "workspace_id": workspaceId.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                ])
+                return
+            }
+
+            relayProbeController = workspace.currentRemoteRelayProbeController()
+            shouldReconnect = true
+        }
+
+        guard shouldReconnect else {
+            return result
+        }
+
+        let relayProbe = relayProbeController?.probeRelayLiveness()
+
         // Must run on main for v2MainSync because reconnect mutates TabManager/UI-owned workspace state.
         v2MainSync {
             guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
@@ -3970,7 +4004,7 @@ class TerminalController {
                 return
             }
 
-            let reconnectOutcome = workspace.reconnectRemoteConnection()
+            let reconnectOutcome = workspace.reconnectRemoteConnection(relayProbe: relayProbe)
             let windowId = v2ResolveWindowId(tabManager: owner)
             var payload: [String: Any] = [
                 "window_id": v2OrNull(windowId?.uuidString),
@@ -3981,7 +4015,10 @@ class TerminalController {
             ]
             if reconnectOutcome.relayRecreated {
                 payload["warning_code"] = "relay_recreated"
-                payload["warning"] = "Remote relay was recreated. Fresh SSH shells are starting; running processes and scrollback from the dead session are not preserved."
+                payload["warning"] = String(
+                    localized: "workspace.remote.reconnect.warning.relayRecreated",
+                    defaultValue: "Remote relay was recreated. Fresh SSH shells are starting; running processes and scrollback from the dead session are not preserved."
+                )
                 payload["replaced_surfaces"] = reconnectOutcome.replacedSurfaces.map { replacement in
                     [
                         "old_surface_id": replacement.oldSurfaceId.uuidString,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3970,15 +3970,28 @@ class TerminalController {
                 return
             }
 
-            workspace.reconnectRemoteConnection()
+            let reconnectOutcome = workspace.reconnectRemoteConnection()
             let windowId = v2ResolveWindowId(tabManager: owner)
-            result = .ok([
+            var payload: [String: Any] = [
                 "window_id": v2OrNull(windowId?.uuidString),
                 "window_ref": v2Ref(kind: .window, uuid: windowId),
                 "workspace_id": workspace.id.uuidString,
                 "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id),
                 "remote": workspace.remoteStatusPayload(),
-            ])
+            ]
+            if reconnectOutcome.relayRecreated {
+                payload["warning_code"] = "relay_recreated"
+                payload["warning"] = "Remote relay was recreated. Fresh SSH shells are starting; running processes and scrollback from the dead session are not preserved."
+                payload["replaced_surfaces"] = reconnectOutcome.replacedSurfaces.map { replacement in
+                    [
+                        "old_surface_id": replacement.oldSurfaceId.uuidString,
+                        "old_surface_ref": v2Ref(kind: .surface, uuid: replacement.oldSurfaceId),
+                        "new_surface_id": replacement.newSurfaceId.uuidString,
+                        "new_surface_ref": v2Ref(kind: .surface, uuid: replacement.newSurfaceId),
+                    ]
+                }
+            }
+            result = .ok(payload)
         }
 
         return result

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6036,6 +6036,9 @@ struct WorkspaceRemoteDaemonStatus: Equatable {
 }
 
 struct WorkspaceRemoteConfiguration: Equatable {
+    private static let relaySessionIDAllowedCharacters =
+        CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+
     let destination: String
     let port: Int?
     let identityFile: String?
@@ -6081,7 +6084,13 @@ struct WorkspaceRemoteConfiguration: Equatable {
 
     var relaySessionID: String? {
         let trimmed = relayID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({
+                  Self.relaySessionIDAllowedCharacters.contains($0)
+              }) else {
+            return nil
+        }
+        return trimmed
     }
 
     var relayLogPath: String? {
@@ -8234,14 +8243,29 @@ final class Workspace: Identifiable, ObservableObject {
         controller.start()
     }
 
+    func requestReconnectRemoteConnection(relayProbeTimeout: TimeInterval = 2.5) {
+        guard remoteConfiguration != nil else { return }
+        let relayProbeController = remoteSessionController
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let relayProbe = relayProbeController?.probeRelayLiveness(timeout: relayProbeTimeout)
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.remoteConfiguration != nil else { return }
+                _ = self.reconnectRemoteConnection(relayProbe: relayProbe)
+            }
+        }
+    }
+
+    func currentRemoteRelayProbeController() -> WorkspaceRemoteSessionController? {
+        remoteSessionController
+    }
+
     @discardableResult
-    func reconnectRemoteConnection() -> WorkspaceRemoteReconnectOutcome {
+    func reconnectRemoteConnection(relayProbe: Bool? = nil) -> WorkspaceRemoteReconnectOutcome {
         guard let configuration = remoteConfiguration else {
             return WorkspaceRemoteReconnectOutcome(relayRecreated: false, replacedSurfaces: [])
         }
 
         let pendingExitedSurfaceIds = pendingRemoteTerminalChildExitSurfaceIds
-        let relayProbe = remoteSessionController?.probeRelayLiveness()
         let replacedSurfaces = replaceExitedRemoteTerminalPanelsForReconnect()
         let relayRecreated =
             !pendingExitedSurfaceIds.isEmpty
@@ -8255,7 +8279,13 @@ final class Workspace: Identifiable, ObservableObject {
         configureRemoteConnection(configuration, autoConnect: true)
         if relayRecreated, let target = remoteDisplayTarget {
             appendSidebarLog(
-                message: "Remote relay for \(target) was recreated. Fresh SSH shells are starting; process state and scrollback from the dead session are not preserved.",
+                message: String.localizedStringWithFormat(
+                    String(
+                        localized: "workspace.remote.reconnect.sidebar.relayRecreated",
+                        defaultValue: "Remote relay for %@ was recreated. Fresh SSH shells are starting; process state and scrollback from the dead session are not preserved."
+                    ),
+                    target
+                ),
                 level: .warning,
                 source: "remote"
             )
@@ -8266,18 +8296,34 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    func shouldPreserveRemoteTerminalAfterChildExit(surfaceId: UUID) -> Bool {
+    func handleRemoteTerminalChildExit(
+        surfaceId: UUID,
+        onClose: @escaping () -> Void
+    ) -> Bool {
         guard remoteConfiguration != nil, terminalPanel(for: surfaceId) != nil else { return false }
         if remoteConnectionState != .connected || remoteDaemonStatus.state == .error {
+            preserveRemoteTerminalAfterChildExit(surfaceId: surfaceId)
             return true
         }
-        guard pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId) else {
+        guard pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId),
+              let relayProbeController = remoteSessionController else {
             return false
         }
-        if let relayAlive = remoteSessionController?.probeRelayLiveness(timeout: 0.75) {
-            return !relayAlive
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let relayAlive = relayProbeController.probeRelayLiveness(timeout: 0.75)
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.terminalPanel(for: surfaceId) != nil else { return }
+                if relayAlive == false,
+                   self.pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId),
+                   self.remoteConfiguration != nil {
+                    self.preserveRemoteTerminalAfterChildExit(surfaceId: surfaceId)
+                    return
+                }
+                self.pendingRemoteTerminalChildExitSurfaceIds.remove(surfaceId)
+                onClose()
+            }
         }
-        return false
+        return true
     }
 
     func preserveRemoteTerminalAfterChildExit(surfaceId: UUID) {
@@ -8286,7 +8332,10 @@ final class Workspace: Identifiable, ObservableObject {
         untrackRemoteTerminalSurface(surfaceId)
         applyRemoteConnectionStateUpdate(
             .error,
-            detail: "Remote SSH session exited. Reconnect creates a fresh relay and shell; running processes and scrollback from the dead session are not preserved.",
+            detail: String(
+                localized: "workspace.remote.connection.detail.childExited",
+                defaultValue: "Remote SSH session exited. Reconnect creates a fresh relay and shell; running processes and scrollback from the dead session are not preserved."
+            ),
             target: remoteDisplayTarget ?? "remote host"
         )
     }
@@ -8297,13 +8346,15 @@ final class Workspace: Identifiable, ObservableObject {
             return []
         }
 
+        let pendingSurfaceIds = pendingRemoteTerminalChildExitSurfaceIds
         let orderedPendingSurfaceIds = sidebarOrderedPanelIds().filter {
-            pendingRemoteTerminalChildExitSurfaceIds.contains($0) && terminalPanel(for: $0) != nil
+            pendingSurfaceIds.contains($0) && terminalPanel(for: $0) != nil
         }
         guard !orderedPendingSurfaceIds.isEmpty else {
             pendingRemoteTerminalChildExitSurfaceIds.removeAll(keepingCapacity: false)
             return []
         }
+        let skippedPendingSurfaceIds = pendingSurfaceIds.subtracting(Set(orderedPendingSurfaceIds))
 
         let focusedBeforeReconnect = focusedPanelId
         var focusReplacementSurfaceId: UUID?
@@ -8406,6 +8457,10 @@ final class Workspace: Identifiable, ObservableObject {
             )
         }
 
+        for surfaceId in skippedPendingSurfaceIds {
+            pendingRemoteTerminalChildExitSurfaceIds.remove(surfaceId)
+        }
+
         syncRemotePortScanTTYs()
         recomputeListeningPorts()
         scheduleTerminalGeometryReconcile()
@@ -8454,7 +8509,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         pendingRemoteForegroundAuthToken = nil
         guard remoteConnectionState == .disconnected else { return }
-        reconnectRemoteConnection()
+        requestReconnectRemoteConnection()
     }
 
     func disconnectRemoteConnection(clearConfiguration: Bool = false) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1086,7 +1086,9 @@ enum WorkspaceRemoteSSHBatchCommandBuilder {
         ]
         if let sessionID = configuration.relaySessionID {
             scriptComponents.append("--session-id \(shellSingleQuoted(sessionID))")
-            scriptComponents.append("--log \"$HOME/.cmux/relay/\(sessionID)/relay.log\"")
+            if let relayLogPath = configuration.relayLogPath {
+                scriptComponents.append("--log \"\(relayLogPath)\"")
+            }
         }
         scriptComponents.append("--invocation-reason \(shellSingleQuoted("workspace.remote.connect"))")
         let script = scriptComponents.joined(separator: " ")
@@ -4018,14 +4020,14 @@ final class WorkspaceRemoteSessionController {
 
     func probeRelayLiveness(timeout: TimeInterval = 2.5) -> Bool? {
         if DispatchQueue.getSpecific(key: queueKey) != nil {
-            return probeRelayLivenessLocked()
+            return probeRelayLivenessLocked(timeout: timeout)
         }
 
         let semaphore = DispatchSemaphore(value: 0)
         var result: Bool?
         queue.async { [weak self] in
             defer { semaphore.signal() }
-            result = self?.probeRelayLivenessLocked()
+            result = self?.probeRelayLivenessLocked(timeout: timeout)
         }
         guard semaphore.wait(timeout: .now() + timeout) == .success else {
             return nil
@@ -4033,7 +4035,7 @@ final class WorkspaceRemoteSessionController {
         return result
     }
 
-    private func probeRelayLivenessLocked() -> Bool? {
+    private func probeRelayLivenessLocked(timeout: TimeInterval) -> Bool? {
         guard let relaySessionID = configuration.relaySessionID else {
             return nil
         }
@@ -4056,8 +4058,11 @@ final class WorkspaceRemoteSessionController {
         do {
             let result = try sshExec(
                 arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command],
-                timeout: 3
+                timeout: max(0.25, timeout)
             )
+            guard result.status == 0 else {
+                return nil
+            }
             let state = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
             switch state {
             case "alive":
@@ -6085,6 +6090,8 @@ struct WorkspaceRemoteConfiguration: Equatable {
     var relaySessionID: String? {
         let trimmed = relayID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty,
+              trimmed != ".",
+              trimmed != "..",
               trimmed.unicodeScalars.allSatisfy({
                   Self.relaySessionIDAllowedCharacters.contains($0)
               }) else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1079,7 +1079,17 @@ enum WorkspaceRemoteSSHBatchCommandBuilder {
         configuration: WorkspaceRemoteConfiguration,
         remotePath: String
     ) -> [String] {
-        let script = "exec \(shellSingleQuoted(remotePath)) serve --stdio"
+        var scriptComponents = [
+            "exec \(shellSingleQuoted(remotePath))",
+            "serve",
+            "--stdio",
+        ]
+        if let sessionID = configuration.relaySessionID {
+            scriptComponents.append("--session-id \(shellSingleQuoted(sessionID))")
+            scriptComponents.append("--log \"$HOME/.cmux/relay/\(sessionID)/relay.log\"")
+        }
+        scriptComponents.append("--invocation-reason \(shellSingleQuoted("workspace.remote.connect"))")
+        let script = scriptComponents.joined(separator: " ")
         let command = "sh -c \(shellSingleQuoted(script))"
         return ["-T"]
             + batchArguments(configuration: configuration)
@@ -4006,6 +4016,63 @@ final class WorkspaceRemoteSessionController {
         }
     }
 
+    func probeRelayLiveness(timeout: TimeInterval = 2.5) -> Bool? {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return probeRelayLivenessLocked()
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Bool?
+        queue.async { [weak self] in
+            defer { semaphore.signal() }
+            result = self?.probeRelayLivenessLocked()
+        }
+        guard semaphore.wait(timeout: .now() + timeout) == .success else {
+            return nil
+        }
+        return result
+    }
+
+    private func probeRelayLivenessLocked() -> Bool? {
+        guard let relaySessionID = configuration.relaySessionID else {
+            return nil
+        }
+
+        let script = """
+        cmux_relay_pid_file="$HOME/.cmux/relay/\(relaySessionID)/pid"
+        if [ ! -r "$cmux_relay_pid_file" ]; then
+          printf 'missing'
+          exit 0
+        fi
+        cmux_relay_pid="$(tr -d '\\r\\n' < "$cmux_relay_pid_file")"
+        if [ -n "$cmux_relay_pid" ] && kill -0 "$cmux_relay_pid" 2>/dev/null; then
+          printf 'alive'
+        else
+          printf 'dead'
+        fi
+        """
+        let command = "sh -c \(Self.shellSingleQuoted(script))"
+
+        do {
+            let result = try sshExec(
+                arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command],
+                timeout: 3
+            )
+            let state = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            switch state {
+            case "alive":
+                return true
+            case "dead", "missing":
+                return false
+            default:
+                return nil
+            }
+        } catch {
+            debugLog("remote.relay.probe.failed error=\(error.localizedDescription) \(debugConfigSummary())")
+            return nil
+        }
+    }
+
     private func reverseRelayArguments(relayPort: Int, localRelayPort: Int) -> [String] {
         // Fallback standalone transport when dynamic forwarding through an existing
         // control master is unavailable.
@@ -5938,6 +6005,16 @@ enum WorkspaceRemoteDaemonState: String {
     case error
 }
 
+struct WorkspaceRemoteReconnectOutcome {
+    struct SurfaceReplacement {
+        let oldSurfaceId: UUID
+        let newSurfaceId: UUID
+    }
+
+    let relayRecreated: Bool
+    let replacedSurfaces: [SurfaceReplacement]
+}
+
 struct WorkspaceRemoteDaemonStatus: Equatable {
     var state: WorkspaceRemoteDaemonState = .unavailable
     var detail: String?
@@ -6000,6 +6077,16 @@ struct WorkspaceRemoteConfiguration: Equatable {
     var displayTarget: String {
         guard let port else { return destination }
         return "\(destination):\(port)"
+    }
+
+    var relaySessionID: String? {
+        let trimmed = relayID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var relayLogPath: String? {
+        guard let relaySessionID else { return nil }
+        return "$HOME/.cmux/relay/\(relaySessionID)/relay.log"
     }
 
     var proxyBrokerTransportKey: String {
@@ -8147,9 +8234,202 @@ final class Workspace: Identifiable, ObservableObject {
         controller.start()
     }
 
-    func reconnectRemoteConnection() {
-        guard let configuration = remoteConfiguration else { return }
+    @discardableResult
+    func reconnectRemoteConnection() -> WorkspaceRemoteReconnectOutcome {
+        guard let configuration = remoteConfiguration else {
+            return WorkspaceRemoteReconnectOutcome(relayRecreated: false, replacedSurfaces: [])
+        }
+
+        let pendingExitedSurfaceIds = pendingRemoteTerminalChildExitSurfaceIds
+        let relayProbe = remoteSessionController?.probeRelayLiveness()
+        let replacedSurfaces = replaceExitedRemoteTerminalPanelsForReconnect()
+        let relayRecreated =
+            !pendingExitedSurfaceIds.isEmpty
+            || relayProbe == false
+            || remoteConnectionState != .connected
+            || remoteDaemonStatus.state == .error
+            || remoteSessionController == nil
+
+        // Reconnect only recreates SSH shells on fresh terminal surfaces. Any PTYs,
+        // running processes, and scrollback from the dead SSH session are already gone.
         configureRemoteConnection(configuration, autoConnect: true)
+        if relayRecreated, let target = remoteDisplayTarget {
+            appendSidebarLog(
+                message: "Remote relay for \(target) was recreated. Fresh SSH shells are starting; process state and scrollback from the dead session are not preserved.",
+                level: .warning,
+                source: "remote"
+            )
+        }
+        return WorkspaceRemoteReconnectOutcome(
+            relayRecreated: relayRecreated,
+            replacedSurfaces: replacedSurfaces
+        )
+    }
+
+    func shouldPreserveRemoteTerminalAfterChildExit(surfaceId: UUID) -> Bool {
+        guard remoteConfiguration != nil, terminalPanel(for: surfaceId) != nil else { return false }
+        if remoteConnectionState != .connected || remoteDaemonStatus.state == .error {
+            return true
+        }
+        guard pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId) else {
+            return false
+        }
+        if let relayAlive = remoteSessionController?.probeRelayLiveness(timeout: 0.75) {
+            return !relayAlive
+        }
+        return false
+    }
+
+    func preserveRemoteTerminalAfterChildExit(surfaceId: UUID) {
+        guard remoteConfiguration != nil, terminalPanel(for: surfaceId) != nil else { return }
+        pendingRemoteTerminalChildExitSurfaceIds.insert(surfaceId)
+        untrackRemoteTerminalSurface(surfaceId)
+        applyRemoteConnectionStateUpdate(
+            .error,
+            detail: "Remote SSH session exited. Reconnect creates a fresh relay and shell; running processes and scrollback from the dead session are not preserved.",
+            target: remoteDisplayTarget ?? "remote host"
+        )
+    }
+
+    private func replaceExitedRemoteTerminalPanelsForReconnect() -> [WorkspaceRemoteReconnectOutcome.SurfaceReplacement] {
+        guard let remoteTerminalStartupCommand = remoteTerminalStartupCommand(),
+              !pendingRemoteTerminalChildExitSurfaceIds.isEmpty else {
+            return []
+        }
+
+        let orderedPendingSurfaceIds = sidebarOrderedPanelIds().filter {
+            pendingRemoteTerminalChildExitSurfaceIds.contains($0) && terminalPanel(for: $0) != nil
+        }
+        guard !orderedPendingSurfaceIds.isEmpty else {
+            pendingRemoteTerminalChildExitSurfaceIds.removeAll(keepingCapacity: false)
+            return []
+        }
+
+        let focusedBeforeReconnect = focusedPanelId
+        var focusReplacementSurfaceId: UUID?
+        var replacements: [WorkspaceRemoteReconnectOutcome.SurfaceReplacement] = []
+
+        for oldSurfaceId in orderedPendingSurfaceIds {
+            guard let oldPanel = terminalPanel(for: oldSurfaceId),
+                  let tabId = surfaceIdFromPanelId(oldSurfaceId) else {
+                pendingRemoteTerminalChildExitSurfaceIds.remove(oldSurfaceId)
+                continue
+            }
+
+            let paneId = bonsplitController.allPaneIds.first {
+                bonsplitController.tabs(inPane: $0).contains(where: { $0.id == tabId })
+            }
+            let inheritedConfig = inheritedTerminalConfig(
+                preferredPanelId: oldSurfaceId,
+                inPane: paneId
+            )
+            let replacementContext: ghostty_surface_context_e = {
+                if bonsplitController.allPaneIds.count <= 1 {
+                    return GHOSTTY_SURFACE_CONTEXT_TAB
+                }
+                return GHOSTTY_SURFACE_CONTEXT_SPLIT
+            }()
+
+            let replacementPanel = TerminalPanel(
+                workspaceId: id,
+                context: replacementContext,
+                configTemplate: inheritedConfig,
+                workingDirectory: remoteReconnectWorkingDirectory(for: oldSurfaceId),
+                portOrdinal: portOrdinal,
+                initialCommand: remoteTerminalStartupCommand
+            )
+            configureTerminalPanel(replacementPanel)
+            panels[replacementPanel.id] = replacementPanel
+            seedTerminalInheritanceFontPoints(panelId: replacementPanel.id, configTemplate: inheritedConfig)
+            panelTitles[replacementPanel.id] = panelTitles[oldSurfaceId] ?? replacementPanel.displayTitle
+            if let customTitle = panelCustomTitles.removeValue(forKey: oldSurfaceId) {
+                panelCustomTitles[replacementPanel.id] = customTitle
+            }
+            if pinnedPanelIds.remove(oldSurfaceId) != nil {
+                pinnedPanelIds.insert(replacementPanel.id)
+            }
+            if manualUnreadPanelIds.remove(oldSurfaceId) != nil {
+                manualUnreadPanelIds.insert(replacementPanel.id)
+            }
+            if let markedAt = manualUnreadMarkedAt.removeValue(forKey: oldSurfaceId) {
+                manualUnreadMarkedAt[replacementPanel.id] = markedAt
+            }
+
+            oldPanel.close()
+            panels.removeValue(forKey: oldSurfaceId)
+            panelDirectories.removeValue(forKey: oldSurfaceId)
+            panelGitBranches.removeValue(forKey: oldSurfaceId)
+            panelPullRequests.removeValue(forKey: oldSurfaceId)
+            panelTitles.removeValue(forKey: oldSurfaceId)
+            panelSubscriptions.removeValue(forKey: oldSurfaceId)
+            panelShellActivityStates.removeValue(forKey: oldSurfaceId)
+            surfaceListeningPorts.removeValue(forKey: oldSurfaceId)
+            surfaceTTYNames.removeValue(forKey: oldSurfaceId)
+            restoredTerminalScrollbackByPanelId.removeValue(forKey: oldSurfaceId)
+            terminalInheritanceFontPointsByPanelId.removeValue(forKey: oldSurfaceId)
+            remoteDetectedSurfaceIds.remove(oldSurfaceId)
+            PortScanner.shared.unregisterPanel(workspaceId: id, panelId: oldSurfaceId)
+            if lastTerminalConfigInheritancePanelId == oldSurfaceId {
+                lastTerminalConfigInheritancePanelId = replacementPanel.id
+            }
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: oldSurfaceId)
+
+            trackRemoteTerminalSurface(replacementPanel.id)
+            surfaceIdToPanelId[tabId] = replacementPanel.id
+            pendingRemoteTerminalChildExitSurfaceIds.remove(oldSurfaceId)
+
+            let replacementTitle = resolvedPanelTitle(
+                panelId: replacementPanel.id,
+                fallback: panelTitles[replacementPanel.id] ?? replacementPanel.displayTitle
+            )
+            bonsplitController.updateTab(
+                tabId,
+                title: replacementTitle,
+                icon: .some(replacementPanel.displayIcon),
+                iconImageData: .some(nil),
+                kind: .some(SurfaceKind.terminal),
+                hasCustomTitle: panelCustomTitles[replacementPanel.id] != nil,
+                isDirty: replacementPanel.isDirty,
+                showsNotificationBadge: manualUnreadPanelIds.contains(replacementPanel.id),
+                isLoading: false,
+                isPinned: pinnedPanelIds.contains(replacementPanel.id)
+            )
+
+            if focusedBeforeReconnect == oldSurfaceId {
+                focusReplacementSurfaceId = replacementPanel.id
+            }
+            replacements.append(
+                WorkspaceRemoteReconnectOutcome.SurfaceReplacement(
+                    oldSurfaceId: oldSurfaceId,
+                    newSurfaceId: replacementPanel.id
+                )
+            )
+        }
+
+        syncRemotePortScanTTYs()
+        recomputeListeningPorts()
+        scheduleTerminalGeometryReconcile()
+        if let focusReplacementSurfaceId {
+            focusPanel(focusReplacementSurfaceId)
+        } else {
+            scheduleFocusReconcile()
+        }
+        return replacements
+    }
+
+    private func remoteReconnectWorkingDirectory(for panelId: UUID) -> String? {
+        if let panelDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !panelDirectory.isEmpty {
+            return panelDirectory
+        }
+        if let requestedWorkingDirectory = terminalPanel(for: panelId)?
+            .requestedWorkingDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !requestedWorkingDirectory.isEmpty {
+            return requestedWorkingDirectory
+        }
+        let workspaceDirectory = currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        return workspaceDirectory.isEmpty ? nil : workspaceDirectory
     }
 
     private static func normalizedForegroundAuthToken(_ token: String?) -> String? {
@@ -8258,6 +8538,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func maybeDemoteRemoteWorkspaceAfterSSHSessionEnded() {
         guard activeRemoteTerminalSurfaceIds.isEmpty, remoteConfiguration != nil else { return }
+        guard pendingRemoteTerminalChildExitSurfaceIds.isEmpty else { return }
         let hasBrowserPanels = panels.values.contains { $0 is BrowserPanel }
         if !hasBrowserPanels {
             if remoteConnectionState == .error || remoteDaemonStatus.state == .error || remoteConnectionState == .connecting {

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -129,10 +129,6 @@ doneFlags:
 		return runRelayCommand(cmdArgs, jsonOutput)
 	}
 
-	if _, err := sweepRelayState(nil); err != nil {
-		fmt.Fprintf(os.Stderr, "cmux: relay cleanup failed: %v\n", err)
-	}
-
 	// refreshAddr is set when the address came from socket_addr file (not env/flag),
 	// allowing one stale-address refresh if another workspace has replaced socket_addr.
 	var refreshAddr func() string

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -125,6 +125,14 @@ doneFlags:
 		return 0
 	}
 
+	if cmdName == "relay" {
+		return runRelayCommand(cmdArgs, jsonOutput)
+	}
+
+	if _, err := sweepRelayState(nil); err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: relay cleanup failed: %v\n", err)
+	}
+
 	// refreshAddr is set when the address came from socket_addr file (not env/flag),
 	// allowing one stale-address refresh if another workspace has replaced socket_addr.
 	var refreshAddr func() string
@@ -180,6 +188,44 @@ doneFlags:
 	default:
 		fmt.Fprintf(os.Stderr, "cmux: internal error: unknown protocol for %q\n", cmdName)
 		return 1
+	}
+}
+
+func runRelayCommand(args []string, jsonOutput bool) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "cmux: relay requires a subcommand (try 'relay cleanup')")
+		return 2
+	}
+
+	switch args[0] {
+	case "cleanup":
+		if len(args) > 1 {
+			fmt.Fprintln(os.Stderr, "cmux: relay cleanup does not accept additional arguments")
+			return 2
+		}
+		summary, err := sweepRelayState(nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cmux: relay cleanup failed: %v\n", err)
+			return 1
+		}
+		payload := map[string]any{
+			"removed_port_artifacts": summary.removedPortArtifacts,
+			"removed_session_dirs":   summary.removedSessionDirs,
+		}
+		if jsonOutput {
+			data, _ := json.Marshal(payload)
+			fmt.Println(string(data))
+		} else {
+			fmt.Printf(
+				"OK removed_session_dirs=%d removed_port_artifacts=%d\n",
+				summary.removedSessionDirs,
+				summary.removedPortArtifacts,
+			)
+		}
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "cmux: unknown relay subcommand %q\n", args[0])
+		return 2
 	}
 }
 
@@ -778,5 +824,6 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  omo [args...]              Launch OpenCode with cmux integration")
 	fmt.Fprintln(os.Stderr, "  omx [args...]              Launch Oh My Codex with cmux integration")
 	fmt.Fprintln(os.Stderr, "  omc [args...]              Launch Oh My Claude Code with cmux integration")
+	fmt.Fprintln(os.Stderr, "  relay cleanup              Remove stale relay pidfiles and metadata")
 	fmt.Fprintln(os.Stderr, "  rpc <method> [json-params] Send arbitrary JSON-RPC")
 }

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -256,7 +256,7 @@ func (a *atomicShutdownReason) Load() string {
 func installRelaySignalWatch(
 	logger *relayLogger,
 	sessionState *relaySessionState,
-	shutdownReason *atomicShutdownReason
+	shutdownReason *atomicShutdownReason,
 ) func() {
 	signals := make(chan os.Signal, 4)
 	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM)
@@ -267,11 +267,11 @@ func installRelaySignalWatch(
 			if sig == nil {
 				return
 			}
-			signalName := strings.ToLower(strings.TrimPrefix(sig.String(), "SIG"))
+			signalName := strings.ToLower(strings.TrimSpace(sig.String()))
 			shutdownReason.Set(signalName)
 			logger.Log("info", "relay.shutdown", map[string]any{
-				"mode":       "stdio",
-				"reason":     "signal:" + signalName,
+				"mode":   "stdio",
+				"reason": "signal:" + signalName,
 				"session_id": func() string {
 					if sessionState == nil {
 						return ""

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -12,11 +12,13 @@ import (
 	"math"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -64,6 +66,7 @@ type rpcServer struct {
 	streams       map[string]*streamState
 	sessions      map[string]*sessionState
 	frameWriter   *stdioFrameWriter
+	logger        *relayLogger
 }
 
 type sessionAttachment struct {
@@ -123,6 +126,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 		fs.SetOutput(stderr)
 		stdio := fs.Bool("stdio", false, "serve over stdin/stdout")
+		logPath := fs.String("log", "", "append relay lifecycle logs to a file")
+		sessionID := fs.String("session-id", "", "relay session identifier used for pidfile state")
+		invocationReason := fs.String("invocation-reason", "", "human-readable reason for this relay start")
 		if err := fs.Parse(args[1:]); err != nil {
 			return 2
 		}
@@ -130,7 +136,84 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			_, _ = fmt.Fprintln(stderr, "serve requires --stdio")
 			return 2
 		}
-		if err := runStdioServer(stdin, stdout); err != nil {
+		resolvedLogPath := strings.TrimSpace(*logPath)
+		if resolvedLogPath == "" {
+			resolvedLogPath = strings.TrimSpace(os.Getenv("CMUX_RELAY_LOG"))
+		}
+		resolvedSessionID := strings.TrimSpace(*sessionID)
+		resolvedInvocationReason := strings.TrimSpace(*invocationReason)
+		if resolvedInvocationReason == "" {
+			resolvedInvocationReason = strings.TrimSpace(os.Getenv("CMUX_RELAY_INVOCATION_REASON"))
+		}
+		logger, err := newRelayLogger(resolvedLogPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "serve failed: %v\n", err)
+			return 1
+		}
+		defer logger.Close()
+		cleanupSummary, err := sweepRelayState(logger)
+		if err != nil {
+			logger.Log("error", "relay.cleanup.error", map[string]any{
+				"error": err,
+			})
+		} else if cleanupSummary.removedSessionDirs > 0 || cleanupSummary.removedPortArtifacts > 0 {
+			logger.Log("info", "relay.cleanup.complete", map[string]any{
+				"removed_port_artifacts": cleanupSummary.removedPortArtifacts,
+				"removed_session_dirs":   cleanupSummary.removedSessionDirs,
+			})
+		}
+
+		sessionState, err := beginRelaySession(resolvedSessionID, logger)
+		if err != nil {
+			logger.Log("error", "relay.startup.error", map[string]any{
+				"error":      err,
+				"session_id": resolvedSessionID,
+			})
+			_, _ = fmt.Fprintf(stderr, "serve failed: %v\n", err)
+			return 1
+		}
+		if sessionState != nil {
+			defer sessionState.Close()
+		}
+
+		logger.Log("info", "relay.startup", map[string]any{
+			"invocation_reason": resolvedInvocationReason,
+			"mode":              "stdio",
+			"pid":               os.Getpid(),
+			"ppid":              os.Getppid(),
+			"session_id":        resolvedSessionID,
+		})
+
+		var terminatedBySignal atomicShutdownReason
+		stopSignalWatch := installRelaySignalWatch(logger, sessionState, &terminatedBySignal)
+		defer stopSignalWatch()
+
+		shutdownReason, err := runStdioServer(stdin, stdout, logger)
+		if signalName := terminatedBySignal.Load(); signalName != "" {
+			shutdownReason = "signal:" + signalName
+			err = nil
+		}
+		if shutdownReason == "" {
+			if err == nil {
+				shutdownReason = "stdio_closed"
+			} else {
+				shutdownReason = "error"
+			}
+		}
+		logFields := map[string]any{
+			"mode":       "stdio",
+			"reason":     shutdownReason,
+			"session_id": resolvedSessionID,
+		}
+		if err != nil {
+			logFields["error"] = err
+		}
+		level := "info"
+		if err != nil {
+			level = "error"
+		}
+		logger.Log(level, "relay.shutdown", logFields)
+		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "serve failed: %v\n", err)
 			return 1
 		}
@@ -146,11 +229,72 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Usage:")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote version")
-	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --stdio")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --stdio [--log <path>] [--session-id <id>] [--invocation-reason <reason>]")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote cli <command> [args...]")
 }
 
-func runStdioServer(stdin io.Reader, stdout io.Writer) error {
+type atomicShutdownReason struct {
+	mu     sync.Mutex
+	reason string
+}
+
+func (a *atomicShutdownReason) Set(reason string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.reason != "" {
+		return
+	}
+	a.reason = strings.TrimSpace(reason)
+}
+
+func (a *atomicShutdownReason) Load() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.reason
+}
+
+func installRelaySignalWatch(
+	logger *relayLogger,
+	sessionState *relaySessionState,
+	shutdownReason *atomicShutdownReason
+) func() {
+	signals := make(chan os.Signal, 4)
+	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case sig := <-signals:
+			if sig == nil {
+				return
+			}
+			signalName := strings.ToLower(strings.TrimPrefix(sig.String(), "SIG"))
+			shutdownReason.Set(signalName)
+			logger.Log("info", "relay.shutdown", map[string]any{
+				"mode":       "stdio",
+				"reason":     "signal:" + signalName,
+				"session_id": func() string {
+					if sessionState == nil {
+						return ""
+					}
+					return sessionState.sessionID
+				}(),
+			})
+			if sessionState != nil {
+				sessionState.Close()
+			}
+			_ = logger.Close()
+			os.Exit(0)
+		case <-done:
+		}
+	}()
+
+	return func() {
+		close(done)
+		signal.Stop(signals)
+	}
+}
+
+func runStdioServer(stdin io.Reader, stdout io.Writer, logger *relayLogger) (string, error) {
 	writer := &stdioFrameWriter{
 		writer: bufio.NewWriter(stdout),
 	}
@@ -160,6 +304,7 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 		streams:       map[string]*streamState{},
 		sessions:      map[string]*sessionState{},
 		frameWriter:   writer,
+		logger:        logger,
 	}
 	defer server.closeAll()
 
@@ -170,9 +315,9 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 		line, oversized, readErr := readRPCFrame(reader, maxRPCFrameBytes)
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
-				return nil
+				return "eof", nil
 			}
-			return readErr
+			return "read_error", readErr
 		}
 		if oversized {
 			if err := writer.writeResponse(rpcResponse{
@@ -182,8 +327,13 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 					Message: "request frame exceeds maximum size",
 				},
 			}); err != nil {
-				return err
+				return "write_error", err
 			}
+			logger.Log("error", "rpc.error", map[string]any{
+				"code":    "invalid_request",
+				"message": "request frame exceeds maximum size",
+				"method":  "",
+			})
 			continue
 		}
 		line = bytes.TrimSuffix(line, []byte{'\n'})
@@ -201,14 +351,19 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 					Message: "invalid JSON request",
 				},
 			}); err != nil {
-				return err
+				return "write_error", err
 			}
+			logger.Log("error", "rpc.error", map[string]any{
+				"code":    "invalid_request",
+				"message": "invalid JSON request",
+				"method":  "",
+			})
 			continue
 		}
 
 		resp := server.handleRequest(req)
 		if err := writer.writeResponse(resp); err != nil {
-			return err
+			return "write_error", err
 		}
 	}
 }
@@ -292,7 +447,7 @@ func (w *stdioFrameWriter) writeJSONFrame(payload any) error {
 
 func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 	if req.Method == "" {
-		return rpcResponse{
+		resp := rpcResponse{
 			ID: req.ID,
 			OK: false,
 			Error: &rpcError{
@@ -300,11 +455,14 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 				Message: "method is required",
 			},
 		}
+		s.logRPC(req, resp)
+		return resp
 	}
 
+	var resp rpcResponse
 	switch req.Method {
 	case "hello":
-		return rpcResponse{
+		resp = rpcResponse{
 			ID: req.ID,
 			OK: true,
 			Result: map[string]any{
@@ -321,7 +479,7 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 			},
 		}
 	case "ping":
-		return rpcResponse{
+		resp = rpcResponse{
 			ID: req.ID,
 			OK: true,
 			Result: map[string]any{
@@ -329,27 +487,27 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 			},
 		}
 	case "proxy.open":
-		return s.handleProxyOpen(req)
+		resp = s.handleProxyOpen(req)
 	case "proxy.close":
-		return s.handleProxyClose(req)
+		resp = s.handleProxyClose(req)
 	case "proxy.write":
-		return s.handleProxyWrite(req)
+		resp = s.handleProxyWrite(req)
 	case "proxy.stream.subscribe":
-		return s.handleProxyStreamSubscribe(req)
+		resp = s.handleProxyStreamSubscribe(req)
 	case "session.open":
-		return s.handleSessionOpen(req)
+		resp = s.handleSessionOpen(req)
 	case "session.close":
-		return s.handleSessionClose(req)
+		resp = s.handleSessionClose(req)
 	case "session.attach":
-		return s.handleSessionAttach(req)
+		resp = s.handleSessionAttach(req)
 	case "session.resize":
-		return s.handleSessionResize(req)
+		resp = s.handleSessionResize(req)
 	case "session.detach":
-		return s.handleSessionDetach(req)
+		resp = s.handleSessionDetach(req)
 	case "session.status":
-		return s.handleSessionStatus(req)
+		resp = s.handleSessionStatus(req)
 	default:
-		return rpcResponse{
+		resp = rpcResponse{
 			ID: req.ID,
 			OK: false,
 			Error: &rpcError{
@@ -357,6 +515,44 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 				Message: fmt.Sprintf("unknown method %q", req.Method),
 			},
 		}
+	}
+	s.logRPC(req, resp)
+	return resp
+}
+
+func (s *rpcServer) logRPC(req rpcRequest, resp rpcResponse) {
+	if s == nil || s.logger == nil {
+		return
+	}
+
+	method := strings.TrimSpace(req.Method)
+	if resp.Error != nil {
+		s.logger.Log("error", "rpc.error", map[string]any{
+			"code":    resp.Error.Code,
+			"message": resp.Error.Message,
+			"method":  method,
+		})
+		return
+	}
+
+	switch method {
+	case "session.open", "session.close", "session.attach", "session.detach", "session.resize":
+		fields := map[string]any{"method": method}
+		if result, ok := resp.Result.(map[string]any); ok {
+			if sessionID, ok := result["session_id"]; ok {
+				fields["session_id"] = sessionID
+			}
+			if attachmentID, ok := result["attachment_id"]; ok {
+				fields["attachment_id"] = attachmentID
+			}
+		}
+		if attachmentID, ok := req.Params["attachment_id"]; ok {
+			fields["attachment_id"] = attachmentID
+		}
+		if sessionID, ok := req.Params["session_id"]; ok {
+			fields["session_id"] = sessionID
+		}
+		s.logger.Log("info", method, fields)
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/relay_state.go
+++ b/daemon/remote/cmd/cmuxd-remote/relay_state.go
@@ -146,12 +146,15 @@ type relaySessionState struct {
 }
 
 type relayCleanupSummary struct {
-	removedSessionDirs  int
+	removedSessionDirs   int
 	removedPortArtifacts int
 }
 
 func beginRelaySession(sessionID string, logger *relayLogger) (*relaySessionState, error) {
-	trimmed := strings.TrimSpace(sessionID)
+	trimmed, err := sanitizeRelaySessionID(sessionID)
+	if err != nil {
+		return nil, err
+	}
 	if trimmed == "" {
 		return nil, nil
 	}
@@ -196,13 +199,32 @@ func (s *relaySessionState) Close() {
 		return
 	}
 	_ = os.Remove(filepath.Join(s.dir, "pid"))
-	_ = os.Remove(filepath.Join(s.dir, ".lock"))
 	if s.lockFile != nil {
 		_ = syscall.Flock(int(s.lockFile.Fd()), syscall.LOCK_UN)
 		_ = s.lockFile.Close()
 		s.lockFile = nil
 	}
+	_ = os.Remove(filepath.Join(s.dir, ".lock"))
 	removeRelayDirIfEmpty(s.dir)
+}
+
+func sanitizeRelaySessionID(sessionID string) (string, error) {
+	trimmed := strings.TrimSpace(sessionID)
+	if trimmed == "" {
+		return "", nil
+	}
+	for _, r := range trimmed {
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '.' ||
+			r == '_' ||
+			r == '-' {
+			continue
+		}
+		return "", fmt.Errorf("invalid relay session id %q", trimmed)
+	}
+	return trimmed, nil
 }
 
 func removeRelayDirIfEmpty(dir string) {
@@ -333,10 +355,40 @@ func cleanupDeadRelaySessionDir(sessionID string, dir string) (removed bool, pid
 	if pidIsAlive(parsedPID) {
 		return false, parsedPID, nil
 	}
+	lockFile, locked, err := tryLockRelaySessionDir(dir)
+	if err != nil {
+		return false, parsedPID, err
+	}
+	if !locked {
+		return false, parsedPID, nil
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = lockFile.Close()
+	}()
 	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return false, parsedPID, err
 	}
 	return true, parsedPID, nil
+}
+
+func tryLockRelaySessionDir(dir string) (*os.File, bool, error) {
+	lockPath := filepath.Join(dir, ".lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lockFile.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return lockFile, true, nil
 }
 
 func pidIsAlive(pid int) bool {

--- a/daemon/remote/cmd/cmuxd-remote/relay_state.go
+++ b/daemon/remote/cmd/cmuxd-remote/relay_state.go
@@ -213,6 +213,9 @@ func sanitizeRelaySessionID(sessionID string) (string, error) {
 	if trimmed == "" {
 		return "", nil
 	}
+	if trimmed == "." || trimmed == ".." {
+		return "", fmt.Errorf("invalid relay session id %q", trimmed)
+	}
 	for _, r := range trimmed {
 		if (r >= 'a' && r <= 'z') ||
 			(r >= 'A' && r <= 'Z') ||
@@ -377,7 +380,7 @@ func tryLockRelaySessionDir(dir string) (*os.File, bool, error) {
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, true, nil
+			return nil, false, nil
 		}
 		return nil, false, err
 	}

--- a/daemon/remote/cmd/cmuxd-remote/relay_state.go
+++ b/daemon/remote/cmd/cmuxd-remote/relay_state.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type relayLogger struct {
+	mu     sync.Mutex
+	writer io.WriteCloser
+}
+
+func newRelayLogger(path string) (*relayLogger, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return &relayLogger{}, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(trimmed), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(trimmed, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &relayLogger{writer: file}, nil
+}
+
+func (l *relayLogger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.writer == nil {
+		return nil
+	}
+	err := l.writer.Close()
+	l.writer = nil
+	return err
+}
+
+func (l *relayLogger) Log(level string, event string, fields map[string]any) {
+	if l == nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.writer == nil {
+		return
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	builder.Grow(128)
+	builder.WriteString(time.Now().UTC().Format(time.RFC3339Nano))
+	builder.WriteByte(' ')
+	builder.WriteString(strings.ToLower(strings.TrimSpace(level)))
+	builder.WriteByte(' ')
+	builder.WriteString(strings.TrimSpace(event))
+	for _, key := range keys {
+		builder.WriteByte(' ')
+		builder.WriteString(key)
+		builder.WriteByte('=')
+		builder.WriteString(formatRelayLogValue(fields[key]))
+	}
+	builder.WriteByte('\n')
+	_, _ = io.WriteString(l.writer, builder.String())
+}
+
+func formatRelayLogValue(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return "null"
+	case string:
+		return quoteRelayLogString(typed)
+	case error:
+		return quoteRelayLogString(typed.Error())
+	case fmt.Stringer:
+		return quoteRelayLogString(typed.String())
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case int:
+		return strconv.Itoa(typed)
+	case int8:
+		return strconv.FormatInt(int64(typed), 10)
+	case int16:
+		return strconv.FormatInt(int64(typed), 10)
+	case int32:
+		return strconv.FormatInt(int64(typed), 10)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case uint:
+		return strconv.FormatUint(uint64(typed), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(typed), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(typed), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(typed), 10)
+	case uint64:
+		return strconv.FormatUint(typed, 10)
+	case time.Duration:
+		return quoteRelayLogString(typed.String())
+	default:
+		return quoteRelayLogString(fmt.Sprint(typed))
+	}
+}
+
+func quoteRelayLogString(value string) string {
+	if value == "" {
+		return `""`
+	}
+	for _, r := range value {
+		if !(r >= 'a' && r <= 'z') &&
+			!(r >= 'A' && r <= 'Z') &&
+			!(r >= '0' && r <= '9') &&
+			!strings.ContainsRune("._:/-@", r) {
+			return strconv.Quote(value)
+		}
+	}
+	return value
+}
+
+type relaySessionState struct {
+	sessionID string
+	dir       string
+	lockFile  *os.File
+	logger    *relayLogger
+}
+
+type relayCleanupSummary struct {
+	removedSessionDirs  int
+	removedPortArtifacts int
+}
+
+func beginRelaySession(sessionID string, logger *relayLogger) (*relaySessionState, error) {
+	trimmed := strings.TrimSpace(sessionID)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	rootDir, err := relayRootDir()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(rootDir, trimmed)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+
+	lockPath := filepath.Join(dir, ".lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lockFile.Close()
+		return nil, fmt.Errorf("failed to lock relay session %s: %w", trimmed, err)
+	}
+
+	pidPath := filepath.Join(dir, "pid")
+	pidText := strconv.Itoa(os.Getpid())
+	if err := os.WriteFile(pidPath, []byte(pidText), 0o600); err != nil {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = lockFile.Close()
+		return nil, err
+	}
+
+	return &relaySessionState{
+		sessionID: trimmed,
+		dir:       dir,
+		lockFile:  lockFile,
+		logger:    logger,
+	}, nil
+}
+
+func (s *relaySessionState) Close() {
+	if s == nil {
+		return
+	}
+	_ = os.Remove(filepath.Join(s.dir, "pid"))
+	_ = os.Remove(filepath.Join(s.dir, ".lock"))
+	if s.lockFile != nil {
+		_ = syscall.Flock(int(s.lockFile.Fd()), syscall.LOCK_UN)
+		_ = s.lockFile.Close()
+		s.lockFile = nil
+	}
+	removeRelayDirIfEmpty(s.dir)
+}
+
+func removeRelayDirIfEmpty(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 0 {
+		return
+	}
+	_ = os.Remove(dir)
+}
+
+func sweepRelayState(logger *relayLogger) (relayCleanupSummary, error) {
+	var summary relayCleanupSummary
+	rootDir, err := relayRootDir()
+	if err != nil {
+		return summary, err
+	}
+
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return summary, nil
+		}
+		return summary, err
+	}
+
+	portArtifacts := map[int][]string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		fullPath := filepath.Join(rootDir, name)
+		if sessionID, ok := relaySessionIDFromEntry(entry, fullPath); ok {
+			removed, pid, cleanupErr := cleanupDeadRelaySessionDir(sessionID, fullPath)
+			if cleanupErr != nil {
+				logger.Log("error", "relay.cleanup.error", map[string]any{
+					"error":      cleanupErr,
+					"path":       fullPath,
+					"session_id": sessionID,
+				})
+				continue
+			}
+			if removed {
+				summary.removedSessionDirs += 1
+				logger.Log("info", "relay.cleanup.removed", map[string]any{
+					"path":       fullPath,
+					"pid":        pid,
+					"reason":     "dead_pid",
+					"session_id": sessionID,
+				})
+			}
+			continue
+		}
+
+		if port, ok := relayArtifactPort(name); ok {
+			portArtifacts[port] = append(portArtifacts[port], fullPath)
+		}
+	}
+
+	for port, paths := range portArtifacts {
+		if isLoopbackPortReachable(port) {
+			continue
+		}
+		sort.Strings(paths)
+		for _, path := range paths {
+			if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				logger.Log("error", "relay.cleanup.error", map[string]any{
+					"error":  err,
+					"path":   path,
+					"port":   port,
+					"reason": "stale_port_metadata",
+				})
+				continue
+			}
+			summary.removedPortArtifacts += 1
+			logger.Log("info", "relay.cleanup.removed", map[string]any{
+				"path":   path,
+				"port":   port,
+				"reason": "stale_port_metadata",
+			})
+		}
+	}
+
+	return summary, nil
+}
+
+func relayRootDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".cmux", "relay"), nil
+}
+
+func relaySessionIDFromEntry(entry os.DirEntry, fullPath string) (string, bool) {
+	if !entry.IsDir() {
+		return "", false
+	}
+	if _, ok := relayArtifactPort(entry.Name()); ok {
+		return "", false
+	}
+	if _, err := os.Stat(filepath.Join(fullPath, "pid")); err != nil {
+		return "", false
+	}
+	return entry.Name(), true
+}
+
+func cleanupDeadRelaySessionDir(sessionID string, dir string) (removed bool, pid int, err error) {
+	pidPath := filepath.Join(dir, "pid")
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, 0, nil
+		}
+		return false, 0, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		if removeErr := os.RemoveAll(dir); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return false, 0, removeErr
+		}
+		return true, 0, nil
+	}
+	parsedPID, parseErr := strconv.Atoi(trimmed)
+	if parseErr != nil || parsedPID <= 0 {
+		if removeErr := os.RemoveAll(dir); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return false, 0, removeErr
+		}
+		return true, 0, nil
+	}
+	if pidIsAlive(parsedPID) {
+		return false, parsedPID, nil
+	}
+	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, parsedPID, err
+	}
+	return true, parsedPID, nil
+}
+
+func pidIsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func relayArtifactPort(name string) (int, bool) {
+	trimmed := strings.TrimSpace(name)
+	suffixes := []string{
+		".auth",
+		".daemon_path",
+		".tty",
+		".shell",
+		".bootstrap.sh",
+	}
+	for _, suffix := range suffixes {
+		if !strings.HasSuffix(trimmed, suffix) {
+			continue
+		}
+		prefix := strings.TrimSuffix(trimmed, suffix)
+		port, err := strconv.Atoi(prefix)
+		if err == nil && port > 0 && port <= 65535 {
+			return port, true
+		}
+	}
+	return 0, false
+}
+
+func isLoopbackPortReachable(port int) bool {
+	if port <= 0 || port > 65535 {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/2692

What shipped
- Step 2: stale relay cleanup. `cmuxd-remote serve` now writes `~/.cmux/relay/<relay-id>/pid`, sweeps dead relay state on startup, and both local `cmux relay cleanup` and remote wrapper `cmux relay cleanup` can remove stale pid/session metadata on demand. The app also does a best-effort relay sweep on startup.
- Step 3: relay lifecycle logging. `cmuxd-remote serve` now accepts `--log` / `CMUX_RELAY_LOG`, logs startup/shutdown reasons, session RPC lifecycle, and RPC errors in a grep-friendly `iso8601 level event key=value` format.
- Step 4: graceful reconnect. Remote workspaces now preserve their remote configuration when the relay/session dies, keep dead remote terminal panes around long enough for reconnect, probe relay liveness via the relay pidfile, recreate fresh SSH shells in-place, and return success with `warning_code=relay_recreated` plus old/new surface remaps instead of failing with `invalid_state`.

Deferred
- Step 5: the persistent relay daemon architecture is not in this PR. The current remote design still launches terminal SSH sessions directly from each terminal surface, so preserving PTYs / running processes / scrollback across SSH drops requires a larger daemon/socket bootstrap change than this scoped fix.
- Follow-up issue: #2696

Notes
- Reconnect now explicitly documents the limitation: when the old SSH session is dead, cmux recreates fresh shells only. PTYs, running processes, and scrollback from the dead session are not preserved.
- `--stdio` remains the only relay transport in this PR; no half-implemented socket daemon path is included.

No local tests were run, per repo policy. I verified the branch builds with `./scripts/reload.sh --tag relay-persistent-daemon`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote SSH/relay lifecycle handling (reconnect semantics, session probing, and cleanup of on-disk state), which could affect reliability of remote workspaces if edge cases are missed.
> 
> **Overview**
> Improves remote SSH resiliency by **probing relay liveness**, preserving remote workspace configuration when a terminal session exits, and making reconnect recreate fresh shells in-place (with localized warnings and `replaced_surfaces` remapping for API callers).
> 
> Adds relay hygiene tooling and automation: new `cmux relay cleanup` (and remote wrapper support) plus best-effort startup sweeps to remove stale `~/.cmux/relay` session dirs and per-port metadata using pid checks and lockfiles.
> 
> Extends `cmuxd-remote serve` with `--log`/`--session-id`/`--invocation-reason`, writes per-session pidfiles, logs relay startup/shutdown and key RPC lifecycle/errors, and passes relay session/log info through the SSH launch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaeef8a169a16d136027471550cee2cbc51e27a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds graceful SSH reconnect for remote workspaces, relay lifecycle logging, and automatic cleanup of stale relay state. This avoids orphaned artifacts and keeps workspaces usable after relay drops by recreating fresh shells in place.

- **New Features**
  - Stale relay cleanup
    - New `cmux relay cleanup` and `cmuxd-remote relay cleanup`.
    - App and `cmuxd-remote serve` sweep `~/.cmux/relay` on startup, removing dead session dirs (pid/lock guarded) and stale port artifacts.
  - Relay lifecycle logging
    - `cmuxd-remote serve` accepts `--log`/`CMUX_RELAY_LOG`, `--session-id`, and `--invocation-reason`.
    - Logs startup/shutdown (incl. signals), session RPC lifecycle, and RPC errors in `iso8601 level event key=value` format.
    - Default log: `~/.cmux/relay/<session-id>/relay.log`.
  - Graceful reconnect
    - Preserves remote config and keeps exited panes long enough to reconnect.
    - Probes relay liveness via remote pidfile; recreates SSH shells in place when needed.
    - Returns success with `warning_code=relay_recreated`, localized `warning`, and `replaced_surfaces` instead of failing.
    - Limits: PTYs, running processes, and scrollback from the dead session are not preserved.

- **Validation**
  - `relay_id` must match `[A-Za-z0-9._-]`; invalid values are rejected with `invalid_params`.

<sup>Written for commit aaeef8a169a16d136027471550cee2cbc51e27a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cmux relay cleanup` CLI command (supports JSON/plain output) to remove stale relay sessions and port artifacts.
  * App now performs automatic relay-state cleanup at startup.
  * Remote reconnect now detects relay recreation, reports warnings, and maps replaced surfaces.
  * Remote terminals are preserved after child exit to avoid unexpected workspace demotion.
  * Improved relay liveness probing and structured relay lifecycle logging.

* **Documentation**
  * Added localized strings for relay/reconnect warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->