### PR TITLE
Enable macOS Services menu on terminal right-click

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11707,6 +11707,56 @@ extension GhosttyNSView: NSTextInputClient {
     }
 }
 
+// MARK: - Services
+
+extension GhosttyNSView: NSServicesMenuRequestor {
+    override func validRequestor(
+        forSendType sendType: NSPasteboard.PasteboardType?,
+        returnType: NSPasteboard.PasteboardType?
+    ) -> Any? {
+        let supportedTypes: [NSPasteboard.PasteboardType] = [
+            .string,
+            .init("public.utf8-plain-text")
+        ]
+
+        if (returnType == nil || supportedTypes.contains(returnType!)) &&
+            (sendType == nil || supportedTypes.contains(sendType!)) {
+            if let sendType, supportedTypes.contains(sendType) {
+                guard let surface, ghostty_surface_has_selection(surface) else {
+                    return super.validRequestor(forSendType: sendType, returnType: returnType)
+                }
+            }
+
+            return self
+        }
+
+        return super.validRequestor(forSendType: sendType, returnType: returnType)
+    }
+
+    func writeSelection(
+        to pboard: NSPasteboard,
+        types: [NSPasteboard.PasteboardType]
+    ) -> Bool {
+        guard let snapshot = readSelectionSnapshot() else { return false }
+
+        pboard.declareTypes([.string], owner: nil)
+        pboard.setString(snapshot.string, forType: .string)
+        return true
+    }
+
+    func readSelection(from pboard: NSPasteboard) -> Bool {
+        guard ensureSurfaceReadyForInput() != nil else { return false }
+        guard let string = GhosttyPasteboardHelper.stringContents(from: pboard) else { return false }
+        guard !string.isEmpty else { return true }
+
+        withExternalCommittedText {
+            insertText(string, replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        return true
+    }
+}
+
 // MARK: - SwiftUI Wrapper
 
 struct GhosttyTerminalView: NSViewRepresentable {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11749,11 +11749,14 @@ extension GhosttyNSView: NSServicesMenuRequestor {
         guard let string = GhosttyPasteboardHelper.stringContents(from: pboard) else { return false }
         guard !string.isEmpty else { return true }
 
-        withExternalCommittedText {
-            insertText(string, replacementRange: NSRange(location: NSNotFound, length: 0))
+        // Services can return multiline payloads. Route them through the text/paste path
+        // so Ghostty handles them as pasted text instead of synthesizing Return/Tab keys.
+        if let terminalSurface {
+            terminalSurface.sendText(string)
+            return true
         }
 
-        return true
+        return false
     }
 }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6868,10 +6868,13 @@ final class Workspace: Identifiable, ObservableObject {
             : FileManager.default.homeDirectoryForCurrentUser.path
 
         // Configure bonsplit with keepAllAlive to preserve terminal state
-        // and keep split entry instantaneous.
+        // and keep split entry instantaneous. Use the cached Ghostty config so
+        // new workspaces inherit tab-strip sizing before the first onAppear refresh.
+        let initialSurfaceTabBarFontSize = GhosttyConfig.load().surfaceTabBarFontSize
         let appearance = Self.bonsplitAppearance(
             from: GhosttyApp.shared.defaultBackgroundColor,
-            backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity
+            backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity,
+            tabTitleFontSize: initialSurfaceTabBarFontSize
         )
         let config = BonsplitConfiguration(
             allowSplits: true,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6744,8 +6744,7 @@ final class Workspace: Identifiable, ObservableObject {
     private static func bonsplitAppearance(from config: GhosttyConfig) -> BonsplitConfiguration.Appearance {
         bonsplitAppearance(
             from: config.backgroundColor,
-            backgroundOpacity: config.backgroundOpacity,
-            tabTitleFontSize: config.surfaceTabBarFontSize
+            backgroundOpacity: config.backgroundOpacity
         )
     }
 
@@ -6766,11 +6765,9 @@ final class Workspace: Identifiable, ObservableObject {
 
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
-        backgroundOpacity: Double,
-        tabTitleFontSize: CGFloat = 11
+        backgroundOpacity: Double
     ) -> BonsplitConfiguration.Appearance {
         BonsplitConfiguration.Appearance(
-            tabTitleFontSize: tabTitleFontSize,
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
             chromeColors: .init(
@@ -6787,20 +6784,16 @@ final class Workspace: Identifiable, ObservableObject {
             backgroundColor: config.backgroundColor,
             backgroundOpacity: config.backgroundOpacity
         )
-        let nextTabTitleFontSize = config.surfaceTabBarFontSize
         let currentAppearance = bonsplitController.configuration.appearance
         let currentBackgroundHex = currentAppearance.chromeColors.backgroundHex
-        let currentTabTitleFontSize = currentAppearance.tabTitleFontSize
         let backgroundChanged = currentBackgroundHex != nextHex
-        let fontSizeChanged = abs(currentTabTitleFontSize - nextTabTitleFontSize) > 0.0001
-        let isNoOp = !backgroundChanged && !fontSizeChanged
+        let isNoOp = !backgroundChanged
 
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme apply workspace=\(id.uuidString) reason=\(reason) " +
                 "currentBg=\(currentBackgroundHex ?? "nil") nextBg=\(nextHex) " +
-                "currentTabFont=\(String(format: "%.3f", currentTabTitleFontSize)) " +
-                "nextTabFont=\(String(format: "%.3f", nextTabTitleFontSize)) noop=\(isNoOp)"
+                "noop=\(isNoOp)"
             )
         }
 
@@ -6809,15 +6802,11 @@ final class Workspace: Identifiable, ObservableObject {
         if backgroundChanged {
             bonsplitController.configuration.appearance.chromeColors.backgroundHex = nextHex
         }
-        if fontSizeChanged {
-            bonsplitController.configuration.appearance.tabTitleFontSize = nextTabTitleFontSize
-        }
 
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme applied workspace=\(id.uuidString) reason=\(reason) " +
-                "resultingBg=\(bonsplitController.configuration.appearance.chromeColors.backgroundHex ?? "nil") " +
-                "resultingTabFont=\(String(format: "%.3f", bonsplitController.configuration.appearance.tabTitleFontSize))"
+                "resultingBg=\(bonsplitController.configuration.appearance.chromeColors.backgroundHex ?? "nil")"
             )
         }
     }
@@ -6871,13 +6860,9 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Configure bonsplit with keepAllAlive to preserve terminal state
         // and keep split entry instantaneous.
-        // Use the cached Ghostty config so new workspaces inherit tab-strip sizing
-        // without paying repeated parse costs on the workspace-creation hot path.
-        let initialSurfaceTabBarFontSize = GhosttyConfig.load().surfaceTabBarFontSize
         let appearance = Self.bonsplitAppearance(
             from: GhosttyApp.shared.defaultBackgroundColor,
-            backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity,
-            tabTitleFontSize: initialSurfaceTabBarFontSize
+            backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity
         )
         let config = BonsplitConfiguration(
             allowSplits: true,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6744,7 +6744,8 @@ final class Workspace: Identifiable, ObservableObject {
     private static func bonsplitAppearance(from config: GhosttyConfig) -> BonsplitConfiguration.Appearance {
         bonsplitAppearance(
             from: config.backgroundColor,
-            backgroundOpacity: config.backgroundOpacity
+            backgroundOpacity: config.backgroundOpacity,
+            tabTitleFontSize: config.surfaceTabBarFontSize
         )
     }
 
@@ -6765,9 +6766,11 @@ final class Workspace: Identifiable, ObservableObject {
 
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
-        backgroundOpacity: Double
+        backgroundOpacity: Double,
+        tabTitleFontSize: CGFloat = 11
     ) -> BonsplitConfiguration.Appearance {
         BonsplitConfiguration.Appearance(
+            tabTitleFontSize: tabTitleFontSize,
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
             chromeColors: .init(
@@ -6780,19 +6783,20 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func applyGhosttyChrome(from config: GhosttyConfig, reason: String = "unspecified") {
-        let nextHex = Self.bonsplitChromeHex(
-            backgroundColor: config.backgroundColor,
-            backgroundOpacity: config.backgroundOpacity
-        )
+        let nextAppearance = Self.bonsplitAppearance(from: config)
         let currentAppearance = bonsplitController.configuration.appearance
+        let nextBackgroundHex = nextAppearance.chromeColors.backgroundHex
         let currentBackgroundHex = currentAppearance.chromeColors.backgroundHex
-        let backgroundChanged = currentBackgroundHex != nextHex
-        let isNoOp = !backgroundChanged
+        let backgroundChanged = currentBackgroundHex != nextBackgroundHex
+        let fontSizeChanged = abs(currentAppearance.tabTitleFontSize - nextAppearance.tabTitleFontSize) > 0.001
+        let isNoOp = !backgroundChanged && !fontSizeChanged
 
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme apply workspace=\(id.uuidString) reason=\(reason) " +
-                "currentBg=\(currentBackgroundHex ?? "nil") nextBg=\(nextHex) " +
+                "currentBg=\(currentBackgroundHex ?? "nil") nextBg=\(nextBackgroundHex ?? "nil") " +
+                "currentTabFont=\(String(format: "%.2f", currentAppearance.tabTitleFontSize)) " +
+                "nextTabFont=\(String(format: "%.2f", nextAppearance.tabTitleFontSize)) " +
                 "noop=\(isNoOp)"
             )
         }
@@ -6800,13 +6804,18 @@ final class Workspace: Identifiable, ObservableObject {
         guard !isNoOp else { return }
 
         if backgroundChanged {
-            bonsplitController.configuration.appearance.chromeColors.backgroundHex = nextHex
+            bonsplitController.configuration.appearance.chromeColors.backgroundHex = nextBackgroundHex
+        }
+
+        if fontSizeChanged {
+            bonsplitController.configuration.appearance.tabTitleFontSize = nextAppearance.tabTitleFontSize
         }
 
         if GhosttyApp.shared.backgroundLogEnabled {
             GhosttyApp.shared.logBackground(
                 "theme applied workspace=\(id.uuidString) reason=\(reason) " +
-                "resultingBg=\(bonsplitController.configuration.appearance.chromeColors.backgroundHex ?? "nil")"
+                "resultingBg=\(bonsplitController.configuration.appearance.chromeColors.backgroundHex ?? "nil") " +
+                "resultingTabFont=\(String(format: "%.2f", bonsplitController.configuration.appearance.tabTitleFontSize))"
             )
         }
     }


### PR DESCRIPTION
## Summary
- make `GhosttyNSView` conform to `NSServicesMenuRequestor` so AppKit can expose native Services for selected terminal text
- write terminal selections to the Services pasteboard and route returned strings back through the existing terminal text-input path
- remove stale `BonsplitConfiguration.Appearance.tabTitleFontSize` usage so this checkout builds against the current `vendor/bonsplit` API

## Verification
- built and launched with `./scripts/reload.sh --tag issue-2698-services-menu --launch`
- did not run local tests per repo policy

Closes #2698

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds macOS Services pasteboard integration to terminal selection/input and tweaks workspace appearance updates; regressions could affect selection availability, text insertion, or tab-strip styling but scope is limited to UI/input paths.
> 
> **Overview**
> Enables native macOS **Services** for terminal selections by making `GhosttyNSView` an `NSServicesMenuRequestor`, exporting the current selection to the Services pasteboard and accepting returned text back into the terminal via the existing `sendText`/paste path (including multiline payloads).
> 
> Updates workspace chrome application to derive the next `BonsplitConfiguration.Appearance` via `bonsplitAppearance(from: config)` and only apply background/tab-title font size when they materially change, aligning with the current bonsplit API and tightening related debug logging/thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d277da603fd884f8ec4fce0d005f5be63b310187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native macOS Services to the terminal so you can right-click selected text, run a Service, and have the result pasted back into the terminal. Also fixes tab title font sizing/divider regressions and aligns appearance updates with the current `vendor/bonsplit` API. Closes #2698.

- New Features
  - `GhosttyNSView` now conforms to `NSServicesMenuRequestor` to expose Services for selected text.
  - Selection is written to the Services pasteboard; returned text is routed through the paste path so multiline payloads are handled correctly.

- Bug Fixes
  - Restore and stabilize tab title font sizing: compute via `bonsplitAppearance(from:)`, apply only when changed, and initialize new workspaces from cached config to avoid startup mismatch.
  - Update `vendor/bonsplit` to include the divider fix.

<sup>Written for commit d277da603fd884f8ec4fce0d005f5be63b310187. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Services/Dictation integration so terminal selections can be shared with system services and incoming service-pasted text can be accepted.

* **Refactor**
  * Centralized appearance/theme application with improved change detection and clearer background/tab-size logging.

* **Chore**
  * Updated bundled appearance library to a newer vendored revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->